### PR TITLE
Make account positions actionable on mobile

### DIFF
--- a/ui/src/pages/UTADetailPage.positions.spec.tsx
+++ b/ui/src/pages/UTADetailPage.positions.spec.tsx
@@ -1,4 +1,6 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Position } from '../api/types'
@@ -26,8 +28,8 @@ function position(symbol: string): Position {
 
 afterEach(cleanup)
 
-describe('UTADetailPage positions table', () => {
-  it('identifies each close action by its contract', () => {
+describe('UTADetailPage responsive positions', () => {
+  it('keeps the comparison table for desktop and identifies each close action', () => {
     const aapl = position('AAPL')
     const nvda = position('NVDA')
     const onCloseClick = vi.fn()
@@ -39,11 +41,49 @@ describe('UTADetailPage positions table', () => {
       />,
     )
 
-    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Close AAPL position' })).toBeTruthy()
+    const desktop = screen.getByTestId('uta-positions-desktop')
+    expect(desktop.className).toContain('hidden')
+    expect(desktop.className).toContain('md:block')
+    expect(within(desktop).getByRole('columnheader', { name: 'Actions' })).toBeTruthy()
+    expect(within(desktop).getByRole('button', { name: 'Close AAPL position' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close NVDA position' }))
+    fireEvent.click(within(desktop).getByRole('button', { name: 'Close NVDA position' }))
 
     expect(onCloseClick).toHaveBeenCalledWith(nvda)
+  })
+
+  it('keeps value and PnL visible in mobile summaries before revealing a safe close action', () => {
+    const aapl = position('AAPL')
+    const onCloseClick = vi.fn()
+
+    render(
+      <PositionsSection
+        positions={[aapl]}
+        onCloseClick={onCloseClick}
+      />,
+    )
+
+    const mobile = screen.getByTestId('uta-positions-mobile')
+    expect(mobile.className).toContain('md:hidden')
+    const summary = within(mobile).getByLabelText(
+      'AAPL long position, market value $1,100.00, PnL +$100.00, +10.00%. Expand for position details.',
+    )
+    expect(summary.textContent).toContain('AAPL')
+    expect(summary.textContent).toContain('$1,100.00')
+    expect(summary.textContent).toContain('+$100.00')
+    expect(summary.textContent).toContain('+10.00%')
+
+    const details = summary.closest('details')
+    expect(details?.open).toBe(false)
+    fireEvent.click(summary)
+    expect(details?.open).toBe(true)
+    expect(within(details as HTMLElement).getByText('Quantity')).toBeTruthy()
+    expect(within(details as HTMLElement).getByText('Average cost')).toBeTruthy()
+    expect(within(details as HTMLElement).getByText('Current price')).toBeTruthy()
+
+    const close = within(details as HTMLElement).getByRole('button', { name: 'Close AAPL position' })
+    expect(close.className).toContain('min-h-10')
+    fireEvent.click(close)
+    expect(onCloseClick).toHaveBeenCalledWith(aapl)
   })
 })

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { ChevronDown } from 'lucide-react'
 import type { ViewSpec } from '../tabs/types'
 import { api } from '../api'
 import { getIntlLocale } from '../lib/intl'
@@ -619,7 +620,50 @@ export function PositionsSection({ positions, onCloseClick }: {
 
   return (
     <Section title={`Positions (${positions.length})`}>
-      <div className="border border-border rounded-lg overflow-x-auto">
+      <div
+        data-testid="uta-positions-mobile"
+        className="overflow-hidden rounded-lg border border-border md:hidden"
+      >
+        {groups.map((g) => {
+          const sumValue = g.positions.reduce((sum, position) => sum + Number(position.marketValue), 0)
+          const sumPnl = g.positions.reduce((sum, position) => sum + Number(position.unrealizedPnL), 0)
+          const currencies = new Set(g.positions.map(position => position.currency))
+          const groupCcy = currencies.size === 1 ? [...currencies][0] : undefined
+          return (
+            <div key={g.class} className="border-t border-border first:border-t-0">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 bg-muted/40 px-3 py-2 text-[11px]">
+                <div className="flex items-center gap-1.5">
+                  <span className="font-semibold text-foreground">{assetClassLabel(g.class)}</span>
+                  <span className="text-muted-foreground/60">·</span>
+                  <span className="text-muted-foreground">
+                    {g.positions.length} position{g.positions.length > 1 ? 's' : ''}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 tabular-nums">
+                  <span className="text-foreground">
+                    {groupCcy ? fmt(sumValue, groupCcy) : `$${sumValue.toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+                  </span>
+                  <span className={sumPnl >= 0 ? 'text-success' : 'text-destructive'}>
+                    {groupCcy ? fmtPnl(sumPnl, groupCcy) : `${sumPnl >= 0 ? '+' : ''}${sumPnl.toLocaleString(getIntlLocale(), { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+                  </span>
+                </div>
+              </div>
+              {g.positions.map((position, index) => (
+                <PositionMobileRow
+                  key={`${g.class}-${index}`}
+                  position={position}
+                  onClose={() => onCloseClick(position)}
+                />
+              ))}
+            </div>
+          )
+        })}
+      </div>
+
+      <div
+        data-testid="uta-positions-desktop"
+        className="hidden overflow-x-auto rounded-lg border border-border md:block"
+      >
         <table className="w-full text-[13px]">
           <thead>
             <tr className="bg-secondary text-muted-foreground text-left">
@@ -673,6 +717,82 @@ export function PositionsSection({ positions, onCloseClick }: {
         </table>
       </div>
     </Section>
+  )
+}
+
+function PositionMetric({
+  label,
+  value,
+  valueClassName = 'text-foreground',
+}: {
+  label: string
+  value: string
+  valueClassName?: string
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className={`mt-0.5 truncate text-[12px] tabular-nums ${valueClassName}`} title={value}>{value}</dd>
+    </div>
+  )
+}
+
+function PositionMobileRow({ position: p, onClose }: { position: Position; onClose: () => void }) {
+  const ccy = p.currency ?? 'USD'
+  const cost = Number(p.avgCost) * Number(p.quantity)
+  const pnl = Number(p.unrealizedPnL)
+  const pct = cost > 0 ? (pnl / cost) * 100 : 0
+  const pnlTone = pnl >= 0 ? 'text-success' : 'text-destructive'
+  const name = contractPrimary(p.contract)
+
+  return (
+    <details className="group border-t border-border">
+      <summary
+        aria-label={`${name} ${p.side} position, market value ${fmt(p.marketValue, ccy)}, PnL ${fmtPnl(pnl, ccy)}, ${fmtPctSigned(pct)}. Expand for position details.`}
+        className="list-none px-3 py-3 outline-none transition-colors hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary [&::-webkit-details-marker]:hidden"
+      >
+        <div className="grid grid-cols-[minmax(0,1fr)_auto_16px] items-start gap-2">
+          <div className="min-w-0">
+            <ContractCell contract={p.contract} />
+            <span className={`mt-1 inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium ${p.side === 'long' ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'}`}>
+              {p.side}
+            </span>
+          </div>
+          <div className="shrink-0 text-right">
+            <div className="text-[13px] font-semibold tabular-nums text-foreground">{fmt(p.marketValue, ccy)}</div>
+            <div className={`mt-1 text-[11px] tabular-nums ${pnlTone}`}>
+              {fmtPnl(pnl, ccy)} · {fmtPctSigned(pct)}
+            </div>
+          </div>
+          <ChevronDown
+            size={14}
+            aria-hidden
+            className="mt-1 text-muted-foreground transition-transform group-open:rotate-180"
+          />
+        </div>
+      </summary>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-3 border-t border-border bg-secondary/35 px-3 py-3">
+        <PositionMetric label="Quantity" value={fmtNum(p.quantity)} />
+        <PositionMetric label="Average cost" value={fmt(p.avgCost, ccy)} />
+        <PositionMetric label="Current price" value={fmt(p.marketPrice, ccy)} />
+        <PositionMetric
+          label="Unrealized PnL"
+          value={fmtPnl(pnl, ccy)}
+          valueClassName={pnlTone}
+        />
+      </dl>
+      <div className="flex items-center justify-between gap-3 border-t border-border bg-secondary/20 px-3 py-2">
+        <span className="text-[11px] text-muted-foreground">Position action</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={`Close ${name} position`}
+          className="oa-pressable inline-flex min-h-10 items-center justify-center rounded-md border border-destructive/30 px-3 text-[12px] font-medium text-destructive transition-colors hover:bg-destructive/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
+        >
+          Close position
+        </button>
+      </div>
+    </details>
   )
 }
 


### PR DESCRIPTION
## Summary

- replace the individual-account positions table with scan-first disclosure rows below the desktop breakpoint
- keep contract identity, side, market value, absolute PnL, and PnL percentage visible in every phone summary
- reveal quantity, average cost, current price, and a touch-friendly Close action only after explicit expansion
- preserve the existing grouped seven-column comparison table on desktop
- add focused regression coverage for both responsive branches and close-action routing

Closes #873

## Why

The aggregate Portfolio was already responsive, but an individual UTA account still squeezed its seven-column desktop table into a 282px pane at 320px. Market value, PnL, and Close were pushed outside the initial viewport behind horizontal scrolling, separating the decision-critical values and a destructive action from the position identity.

## User impact

Phone users can now scan position risk without horizontal scrolling. Secondary execution metrics remain one disclosure away, while Close is isolated in a labelled action row with a 40px target instead of living off-screen in the same dense row.

## Verification

- `pnpm --dir ui exec vitest run src/pages/UTADetailPage.positions.spec.tsx` — 2 passed
- `pnpm --dir ui exec tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 434 files passed, 1 skipped; 3639 tests passed, 9 skipped
- real `pnpm dev` paper-account route at `/settings/uta/alpaca-d3b9a58c`, verified at 320×700, 390×844, and 1280×900
- expanded AAPL disclosure verified without activating Close; no live-paper run because order, confirmation, broker, and UTA behavior are unchanged

## Design review

- removes routine horizontal scrolling from the phone decision path
- strengthens identity → market value/PnL → execution details → destructive action hierarchy
- reuses native `<details>`, existing financial colors, `ContractCell`, and `oa-pressable`
- preserves desktop comparison density and introduces no new visual dialect

## Safety boundary

Presentation only. The existing `onCloseClick(position)` confirmation/write path is unchanged. No order or position was submitted, modified, or closed during verification.