### PR TITLE
Add interactive Supervisor TUI controls

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -83,10 +83,29 @@ The top-level commands and the `server` compatibility surface launch the same
 `cli-server` Guardian owner. They are presenters over one lifecycle rather than
 separate daemons.
 
-The first TypeScript TUI shell is deliberately read-only: it reports the
-selected Runtime and detaches with `q`, `Esc`, or `Ctrl+C`. Unfinished controls
-remain inside the application shell and do not change the default entry back to
-the compatibility launcher.
+The TypeScript TUI reports and polls the selected Runtime, detaches with `q`,
+`Esc`, or `Ctrl+C`, and exposes the same presentation-neutral operations as the
+explicit commands:
+
+- `s` starts the persistent Runtime when stopped;
+- `o` opens an advertised, verified Web endpoint;
+- `x` stops and `r` restarts only a `cli-server` owner, after an impact
+  confirmation;
+- `l` reads the bounded, redacted log tail;
+- `d` runs read-only Doctor checks;
+- `u` performs an advisory product-update check;
+- `?`, Tab, and the horizontal arrows expose help and detail panels.
+
+The TUI refuses to stop or restart Electron, development, incompatible, or
+otherwise foreign owners. Its stop/restart confirmation states that active Web
+and agent sessions will disconnect. Detaching never implies stopping. Update
+discovery runs in the background and cannot block lifecycle controls.
+
+The current Runtime provider is still source-backed. TUI start therefore needs
+to run from an OpenAlice checkout (or reuse a source root advertised by the
+selected Runtime) until the standalone headless Runtime artifact ships.
+Unfinished controls remain inside the application shell and do not change the
+default entry back to the compatibility launcher.
 
 ## Presentation-neutral Core
 

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -33,6 +33,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
 
     const transcript = await new Promise<string>((resolve, reject) => {
       let output = ''
+      let openedHelp = false
       let detached = false
       const timeout = setTimeout(() => {
         child.kill()
@@ -40,7 +41,10 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       }, 8_000)
       child.onData((data) => {
         output += data
-        if (!detached && output.includes('q / Esc / Ctrl+C  Detach')) {
+        if (!openedHelp && output.includes('q / Esc / Ctrl+C  Detach without stopping')) {
+          openedHelp = true
+          child.write('?')
+        } else if (!detached && output.includes('Supervisor controls')) {
           detached = true
           child.write('q')
         }
@@ -54,6 +58,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
 
     expect(transcript).toContain('OpenAlice  0.87.0-beta  development')
     expect(transcript).toContain('Runtime state: absent')
+    expect(transcript).toContain('Supervisor controls')
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
   })

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { SupervisorScreen } from './supervisor-tui.ts'
+import {
+  type SupervisorAction,
+  SupervisorScreen,
+} from './supervisor-tui.ts'
+
+const matchesKey = (data: string, key: string) => data === key
 
 describe('Supervisor TUI screen', () => {
   it('renders stable stopped-state application chrome', () => {
@@ -19,7 +24,8 @@ describe('Supervisor TUI screen', () => {
 
     expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
     expect(lines).toContain('Runtime state: absent')
-    expect(lines).toContain('q / Esc / Ctrl+C  Detach')
+    expect(lines).toContain('s Start · d Doctor · l Logs · u Update · ? Help')
+    expect(lines).toContain('q / Esc / Ctrl+C  Detach without stopping')
   })
 
   it('uses a narrow projection and sanitizes diagnostics', () => {
@@ -35,5 +41,71 @@ describe('Supervisor TUI screen', () => {
     expect(lines).toContain('Runtime: unavailable')
     expect(lines.join('\n')).not.toContain('\u001b')
     expect(lines.every((line) => line.length <= 40)).toBe(true)
+  })
+
+  it('dispatches available actions and confirms Runtime mutations', () => {
+    const actions: SupervisorAction[] = []
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: {
+        class: 'running',
+        home: '/tmp/openalice',
+        owner: { surface: 'cli-server', pid: 42 },
+        endpoints: { web: 'http://127.0.0.1:47331' },
+        components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
+      },
+    }, {
+      onAction: (action) => actions.push(action),
+    })
+
+    expect(screen.handleKey('o', matchesKey)).toBe(true)
+    expect(actions).toEqual(['open'])
+
+    expect(screen.handleKey('r', matchesKey)).toBe(true)
+    expect(screen.snapshot.confirmation).toBe('restart')
+    expect(screen.render(100).join('\n')).toContain('active Web/agent sessions reconnect or end')
+
+    expect(screen.handleKey('enter', matchesKey)).toBe(true)
+    expect(actions).toEqual(['open', 'restart'])
+  })
+
+  it('keeps foreign-owned lifecycle mutations unavailable', () => {
+    const actions: SupervisorAction[] = []
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: {
+        class: 'running',
+        owner: { surface: 'electron', pid: 7 },
+        endpoints: { web: 'http://127.0.0.1:47331' },
+      },
+    }, {
+      onAction: (action) => actions.push(action),
+    })
+
+    expect(screen.handleKey('x', matchesKey)).toBe(true)
+    expect(actions).toEqual([])
+    expect(screen.snapshot.confirmation).toBeUndefined()
+    expect(screen.snapshot.notice).toContain('electron owns this Runtime')
+  })
+
+  it('navigates detail panels and requests their read-only data', () => {
+    const actions: SupervisorAction[] = []
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: { class: 'absent' },
+    }, {
+      onAction: (action) => actions.push(action),
+    })
+
+    expect(screen.handleKey('tab', matchesKey)).toBe(true)
+    expect(screen.snapshot.panel).toBe('logs')
+    expect(actions).toEqual(['logs'])
+
+    expect(screen.handleKey('?', matchesKey)).toBe(true)
+    expect(screen.snapshot.panel).toBe('help')
+    expect(screen.render(100).join('\n')).toContain('Supervisor controls')
   })
 })

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -1,41 +1,123 @@
 import { readFileSync } from 'node:fs'
-import type { Component } from '@earendil-works/pi-tui'
+import type { Component, KeyId } from '@earendil-works/pi-tui'
 
-import { inspectRuntime } from './lifecycle.mjs'
+import { diagnoseRuntime } from './doctor.mjs'
+import {
+  inspectRuntime,
+  openRuntime,
+  startRuntime,
+  stopRuntime,
+} from './lifecycle.mjs'
+import { readRuntimeLogs } from './logs.mjs'
 import { loadPiTui } from './pi-tui-loader.ts'
+import {
+  checkForUpdate,
+  maybeNotifyUpdate,
+} from './update.mjs'
+
+const SILENT_OUTPUT = Object.freeze({ write: () => true })
 
 interface RuntimeSummary {
   class?: string
+  state?: string
   home?: string
   productVersion?: string
   runtimeVersion?: string
+  uptimeSeconds?: number
   endpoints?: { web?: string | null }
   owner?: {
     surface?: string
     pid?: number
+    launchRoot?: string
   } | null
+  provider?: {
+    kind?: string
+    root?: string
+  }
   components?: {
-    alice?: { status?: string }
-    uta?: { status?: string }
-    connector?: { status?: string }
+    alice?: string
+    uta?: string
+    connector?: string
   }
 }
+
+interface RuntimeLogs {
+  entries?: Array<{ text?: string }>
+  truncated?: boolean
+}
+
+interface DoctorReport {
+  overall?: string
+  summary?: {
+    passed?: number
+    warnings?: number
+    failures?: number
+  }
+  checks?: Array<{
+    status?: string
+    summary?: string
+    detail?: string
+  }>
+}
+
+interface UpdateResult {
+  status?: string
+  currentVersion?: string
+  latestVersion?: string
+  message?: string
+}
+
+export type SupervisorPanel = 'overview' | 'logs' | 'doctor' | 'help'
+export type SupervisorAction =
+  | 'start'
+  | 'open'
+  | 'stop'
+  | 'restart'
+  | 'logs'
+  | 'doctor'
+  | 'update'
 
 export interface SupervisorSnapshot {
   version: string
   channel: string
   runtime: RuntimeSummary | null
   diagnostic?: string
+  panel?: SupervisorPanel
+  busy?: string
+  notice?: string
+  confirmation?: 'stop' | 'restart'
+  logs?: RuntimeLogs | null
+  doctor?: DoctorReport | null
+  update?: UpdateResult | null
 }
 
 export interface SupervisorTuiDependencies {
   env?: NodeJS.ProcessEnv
   stdin?: NodeJS.ReadStream
   stdout?: NodeJS.WriteStream
-  inspect?: () => Promise<RuntimeSummary>
+  inspect?: (options?: { homeRoot?: string; waitMs?: number }) => Promise<RuntimeSummary>
+  start?: (options: Record<string, unknown>) => Promise<unknown>
+  stop?: (options: Record<string, unknown>) => Promise<unknown>
+  open?: (options: Record<string, unknown>) => Promise<unknown>
+  readLogs?: (options: Record<string, unknown>) => Promise<RuntimeLogs>
+  diagnose?: (options: Record<string, unknown>) => Promise<DoctorReport>
+  checkUpdate?: () => Promise<UpdateResult>
+  discoverUpdate?: () => Promise<UpdateResult | null>
   loadTui?: typeof loadPiTui
   version?: string
   channel?: string
+  pollIntervalMs?: number
+}
+
+interface SupervisorServices {
+  inspect: NonNullable<SupervisorTuiDependencies['inspect']>
+  start: NonNullable<SupervisorTuiDependencies['start']>
+  stop: NonNullable<SupervisorTuiDependencies['stop']>
+  open: NonNullable<SupervisorTuiDependencies['open']>
+  readLogs: NonNullable<SupervisorTuiDependencies['readLogs']>
+  diagnose: NonNullable<SupervisorTuiDependencies['diagnose']>
+  checkUpdate: NonNullable<SupervisorTuiDependencies['checkUpdate']>
+  discoverUpdate: NonNullable<SupervisorTuiDependencies['discoverUpdate']>
 }
 
 export async function runSupervisorTui(
@@ -50,30 +132,140 @@ export async function runSupervisorTui(
     )
   }
 
+  const services = createServices(dependencies)
   let runtime: RuntimeSummary | null = null
   let diagnostic: string | undefined
   try {
-    runtime = await (dependencies.inspect ?? (() => inspectRuntime()))()
+    runtime = await services.inspect()
   } catch (error: unknown) {
-    diagnostic = error instanceof Error ? error.message : String(error)
+    diagnostic = safeError(error)
   }
 
   const piTui = await (dependencies.loadTui ?? loadPiTui)(dependencies.env)
   const terminal = new piTui.ProcessTerminal()
   const ui = new piTui.TUI(terminal)
+  let active = true
+  let actionRunning = false
   const screen = new SupervisorScreen({
     version: dependencies.version ?? readCliVersion(),
     channel: dependencies.channel ?? 'development',
     runtime,
     diagnostic,
+  }, {
+    onAction: (action) => {
+      void performAction(action)
+    },
+    requestRender: () => ui.requestRender(),
   })
   ui.addChild(screen)
 
+  async function refreshRuntime(): Promise<void> {
+    if (!active || actionRunning) return
+    try {
+      const nextRuntime = await services.inspect({
+        homeRoot: screen.snapshot.runtime?.home,
+        waitMs: 1_000,
+      })
+      if (!active) return
+      screen.update({ runtime: nextRuntime, diagnostic: undefined })
+    } catch (error: unknown) {
+      if (!active) return
+      screen.update({ diagnostic: safeError(error) })
+    }
+  }
+
+  async function performAction(action: SupervisorAction): Promise<void> {
+    if (!active || actionRunning) return
+    actionRunning = true
+    const homeRoot = screen.snapshot.runtime?.home
+    const actionLabel = actionName(action)
+    screen.update({ busy: actionLabel, notice: undefined, diagnostic: undefined })
+    try {
+      if (action === 'start') {
+        await services.start({
+          prepare: true,
+          rebuild: false,
+          checkUpdates: true,
+          port: runtimeWebPort(screen.snapshot.runtime) ?? 47_331,
+          homeRoot,
+          appDir: screen.snapshot.runtime?.provider?.root,
+          waitMs: 120_000,
+          takeover: false,
+        })
+        screen.update({ notice: 'Runtime started.' })
+      } else if (action === 'open') {
+        await services.open({ homeRoot, waitMs: 2_000 })
+        screen.update({ notice: 'Opened the verified Web UI.' })
+      } else if (action === 'stop') {
+        await services.stop({ homeRoot, waitMs: 15_000 })
+        screen.update({ notice: 'Runtime stopped.', confirmation: undefined })
+      } else if (action === 'restart') {
+        const appDir = screen.snapshot.runtime?.owner?.launchRoot
+          ?? screen.snapshot.runtime?.provider?.root
+        await services.stop({ homeRoot, waitMs: 15_000 })
+        screen.update({ busy: 'Starting Runtime', confirmation: undefined })
+        await services.start({
+          prepare: true,
+          rebuild: false,
+          checkUpdates: true,
+          port: runtimeWebPort(screen.snapshot.runtime) ?? 47_331,
+          homeRoot,
+          appDir,
+          waitMs: 120_000,
+          takeover: false,
+        })
+        screen.update({ notice: 'Runtime restarted and reconnected.' })
+      } else if (action === 'logs') {
+        const logs = await services.readLogs({ homeRoot, lines: 200 })
+        screen.update({ panel: 'logs', logs, notice: undefined })
+      } else if (action === 'doctor') {
+        const doctor = await services.diagnose({ homeRoot, waitMs: 2_000 })
+        screen.update({ panel: 'doctor', doctor, notice: undefined })
+      } else {
+        const update = await services.checkUpdate()
+        screen.update({ update, notice: formatUpdateNotice(update) })
+      }
+    } catch (error: unknown) {
+      screen.update({
+        diagnostic: `${actionLabel} failed: ${safeError(error)}`,
+        confirmation: undefined,
+      })
+    } finally {
+      actionRunning = false
+      if (active) {
+        screen.update({ busy: undefined })
+        await refreshRuntime()
+      }
+    }
+  }
+
+  async function discoverUpdateInBackground(): Promise<void> {
+    try {
+      const update = await services.discoverUpdate()
+      if (!update) return
+      if (!active) return
+      screen.update({
+        update,
+        ...(update.status === 'available' ? { notice: formatUpdateNotice(update) } : {}),
+      })
+    } catch {
+      // Update discovery is advisory and must not disturb lifecycle control.
+    }
+  }
+
   return new Promise<number>((resolve) => {
     let settled = false
+    const poll = setInterval(
+      () => void refreshRuntime(),
+      dependencies.pollIntervalMs ?? 1_500,
+    )
+    poll.unref()
+
     const finish = (code = 0) => {
       if (settled) return
       settled = true
+      active = false
+      clearInterval(poll)
       removeInputListener()
       process.off('SIGTERM', onTerminate)
       process.off('SIGINT', onTerminate)
@@ -82,6 +274,10 @@ export async function runSupervisorTui(
     }
     const onTerminate = () => finish()
     const removeInputListener = ui.addInputListener((data) => {
+      if (screen.snapshot.confirmation && piTui.matchesKey(data, 'escape')) {
+        screen.cancelConfirmation()
+        return { consume: true }
+      }
       if (
         piTui.matchesKey(data, 'q')
         || piTui.matchesKey(data, 'escape')
@@ -90,54 +286,318 @@ export async function runSupervisorTui(
         finish()
         return { consume: true }
       }
-      return undefined
+      return screen.handleKey(data, piTui.matchesKey)
+        ? { consume: true }
+        : undefined
     })
 
     process.once('SIGTERM', onTerminate)
     process.once('SIGINT', onTerminate)
     ui.start()
+    void discoverUpdateInBackground()
   })
 }
 
 export class SupervisorScreen implements Component {
-  private readonly snapshot: SupervisorSnapshot
+  snapshot: SupervisorSnapshot
+  private readonly onAction?: (action: SupervisorAction) => void
+  private readonly requestRender?: () => void
 
-  constructor(snapshot: SupervisorSnapshot) {
-    this.snapshot = snapshot
+  constructor(
+    snapshot: SupervisorSnapshot,
+    callbacks: {
+      onAction?: (action: SupervisorAction) => void
+      requestRender?: () => void
+    } = {},
+  ) {
+    this.snapshot = { panel: 'overview', ...snapshot }
+    this.onAction = callbacks.onAction
+    this.requestRender = callbacks.requestRender
+  }
+
+  update(patch: Partial<SupervisorSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...patch }
+    this.requestRender?.()
+  }
+
+  cancelConfirmation(): void {
+    this.update({ confirmation: undefined, notice: 'Action cancelled.' })
+  }
+
+  handleKey(
+    data: string,
+    matchesKey: (data: string, key: KeyId) => boolean,
+  ): boolean {
+    if (this.snapshot.busy) return false
+    if (this.snapshot.confirmation) {
+      if (matchesKey(data, 'y') || matchesKey(data, 'enter')) {
+        this.onAction?.(this.snapshot.confirmation)
+        return true
+      }
+      if (matchesKey(data, 'n')) {
+        this.cancelConfirmation()
+        return true
+      }
+      return false
+    }
+    if (matchesKey(data, '?')) {
+      this.update({ panel: this.snapshot.panel === 'help' ? 'overview' : 'help' })
+      return true
+    }
+    if (matchesKey(data, 'tab') || matchesKey(data, 'right')) {
+      this.selectAdjacentPanel(1)
+      return true
+    }
+    if (matchesKey(data, 'shift+tab') || matchesKey(data, 'left')) {
+      this.selectAdjacentPanel(-1)
+      return true
+    }
+    const keyActions: Array<[KeyId, SupervisorAction]> = [
+      ['s', 'start'],
+      ['o', 'open'],
+      ['l', 'logs'],
+      ['d', 'doctor'],
+      ['u', 'update'],
+    ]
+    for (const [key, action] of keyActions) {
+      if (matchesKey(data, key)) {
+        if (this.actionAvailable(action)) this.onAction?.(action)
+        else this.update({ notice: unavailableActionMessage(action, this.snapshot.runtime) })
+        return true
+      }
+    }
+    if (matchesKey(data, 'x') || matchesKey(data, 'r')) {
+      const action = matchesKey(data, 'x') ? 'stop' : 'restart'
+      if (!this.actionAvailable(action)) {
+        this.update({ notice: unavailableActionMessage(action, this.snapshot.runtime) })
+      } else {
+        this.update({ confirmation: action })
+      }
+      return true
+    }
+    return false
   }
 
   render(width: number): string[] {
     const runtime = this.snapshot.runtime
     const narrow = width < 60
     const state = runtime?.class ?? 'unavailable'
+    const updateBadge = this.snapshot.update?.status === 'available'
+      ? ` · update ${this.snapshot.update.latestVersion ?? 'available'}`
+      : ''
     const lines = [
-      `OpenAlice  ${this.snapshot.version}  ${this.snapshot.channel}`,
+      `OpenAlice  ${this.snapshot.version}  ${this.snapshot.channel}${updateBadge}`,
       '─'.repeat(Math.max(1, Math.min(width, 80))),
-      narrow ? `Runtime: ${state}` : `Runtime state: ${state}`,
-      `Home: ${runtime?.home ?? 'default'}`,
+      renderTabs(this.snapshot.panel ?? 'overview', narrow),
+      '',
     ]
-    if (!narrow) {
+
+    if (this.snapshot.panel === 'logs') {
+      lines.push(...renderLogs(this.snapshot.logs))
+    } else if (this.snapshot.panel === 'doctor') {
+      lines.push(...renderDoctor(this.snapshot.doctor))
+    } else if (this.snapshot.panel === 'help') {
+      lines.push(...renderHelp())
+    } else {
       lines.push(
-        `Owner: ${formatOwner(runtime)}`,
-        `Web: ${runtime?.endpoints?.web ?? 'not available'}`,
-        `Components: ${formatComponents(runtime)}`,
+        narrow ? `Runtime: ${state}` : `Runtime state: ${state}`,
+        `Home: ${runtime?.home ?? 'default'}`,
       )
+      if (!narrow) {
+        lines.push(
+          `Owner: ${formatOwner(runtime)}`,
+          `Web: ${runtime?.endpoints?.web ?? 'not available'}`,
+          `Components: ${formatComponents(runtime)}`,
+        )
+        if (runtime?.provider?.kind) {
+          lines.push(`Provider: ${runtime.provider.kind}`)
+        }
+        if (Number.isInteger(runtime?.uptimeSeconds)) {
+          lines.push(`Uptime: ${formatDuration(runtime?.uptimeSeconds ?? 0)}`)
+        }
+      }
+      lines.push('', ...renderGuidance(runtime))
     }
+
+    if (this.snapshot.confirmation) {
+      lines.push('', ...renderConfirmation(this.snapshot.confirmation, runtime))
+    }
+    if (this.snapshot.busy) lines.push('', `Working: ${this.snapshot.busy}…`)
+    if (this.snapshot.notice) lines.push('', `Notice: ${sanitize(this.snapshot.notice)}`)
     if (this.snapshot.diagnostic) {
       lines.push('', `Diagnostic: ${sanitize(this.snapshot.diagnostic)}`)
     }
     lines.push(
       '',
-      state === 'absent'
-        ? 'OpenAlice is stopped. Runtime controls are coming in the next increment.'
-        : 'Open the Web UI for product interaction.',
-      '',
-      'q / Esc / Ctrl+C  Detach',
+      actionBar(runtime, narrow),
+      'q / Esc / Ctrl+C  Detach without stopping',
     )
     return lines.map((line) => truncate(line, width))
   }
 
   invalidate(): void {}
+
+  private actionAvailable(action: SupervisorAction): boolean {
+    const runtime = this.snapshot.runtime
+    if (action === 'logs' || action === 'doctor' || action === 'update') return true
+    if (action === 'start') return runtime?.class === 'absent'
+    if (action === 'open') return Boolean(runtime?.endpoints?.web)
+    return runtime?.owner?.surface === 'cli-server'
+      && runtime.class !== 'absent'
+      && runtime.class !== 'incompatible'
+  }
+
+  private selectAdjacentPanel(direction: 1 | -1): void {
+    const panels: SupervisorPanel[] = ['overview', 'logs', 'doctor', 'help']
+    const current = panels.indexOf(this.snapshot.panel ?? 'overview')
+    const panel = panels[(current + direction + panels.length) % panels.length]
+    this.update({ panel })
+    if (panel === 'logs') this.onAction?.('logs')
+    if (panel === 'doctor') this.onAction?.('doctor')
+  }
+}
+
+function createServices(dependencies: SupervisorTuiDependencies): SupervisorServices {
+  const shared = { env: dependencies.env ?? process.env }
+  return {
+    inspect: dependencies.inspect ?? ((options) => inspectRuntime(options, shared)),
+    start: dependencies.start ?? ((options) => startRuntime(options, {
+      ...shared,
+      detached: true,
+    })),
+    stop: dependencies.stop ?? ((options) => stopRuntime(options, shared)),
+    open: dependencies.open ?? ((options) => openRuntime(options, shared)),
+    readLogs: dependencies.readLogs ?? ((options) => readRuntimeLogs(options, shared)),
+    diagnose: dependencies.diagnose ?? ((options) => diagnoseRuntime(options, shared)),
+    checkUpdate: dependencies.checkUpdate ?? (() => checkForUpdate({}, shared)),
+    discoverUpdate: dependencies.discoverUpdate ?? (() => maybeNotifyUpdate(
+      { enabled: true },
+      { ...shared, interactive: true, stderr: SILENT_OUTPUT },
+    )),
+  }
+}
+
+function renderTabs(selected: SupervisorPanel, narrow: boolean): string {
+  const labels: Array<[SupervisorPanel, string]> = [
+    ['overview', narrow ? 'Home' : 'Overview'],
+    ['logs', 'Logs'],
+    ['doctor', 'Doctor'],
+    ['help', 'Help'],
+  ]
+  return labels
+    .map(([panel, label]) => panel === selected ? `[${label}]` : label)
+    .join('  ')
+}
+
+function renderGuidance(runtime: RuntimeSummary | null): string[] {
+  if (!runtime) return ['Runtime status is unavailable. Doctor may explain why.']
+  if (runtime.class === 'absent') {
+    return ['OpenAlice is stopped. Press s to start the persistent Runtime.']
+  }
+  if (runtime.class === 'incompatible') {
+    return ['The running Guardian is incompatible. Read Doctor before changing it.']
+  }
+  if (runtime.class === 'running') {
+    return ['Runtime is ready. Press o to hand product interaction to the Web UI.']
+  }
+  return [`Runtime is ${runtime.class ?? runtime.state ?? 'unknown'}; status will refresh automatically.`]
+}
+
+function renderLogs(logs: RuntimeLogs | null | undefined): string[] {
+  if (!logs) return ['Press l to load the bounded, redacted Runtime log tail.']
+  const entries = logs.entries ?? []
+  if (entries.length === 0) return ['No Runtime log entries were found.']
+  const lines = ['Runtime logs (bounded and redacted):', '']
+  lines.push(...entries.slice(-16).map((entry) => sanitize(entry.text ?? '')))
+  if (logs.truncated || entries.length > 16) {
+    lines.push('[showing the most recent visible lines]')
+  }
+  return lines
+}
+
+function renderDoctor(doctor: DoctorReport | null | undefined): string[] {
+  if (!doctor) return ['Press d to run read-only Runtime diagnostics.']
+  const summary = doctor.summary
+  const lines = [
+    `Doctor: ${doctor.overall ?? 'unknown'} · ${summary?.passed ?? 0} pass · ${summary?.warnings ?? 0} warn · ${summary?.failures ?? 0} fail`,
+    '',
+  ]
+  for (const check of (doctor.checks ?? []).slice(0, 12)) {
+    lines.push(`[${(check.status ?? 'unknown').toUpperCase()}] ${sanitize(check.summary ?? '')}`)
+    if (check.detail) lines.push(`  ${sanitize(check.detail)}`)
+  }
+  return lines
+}
+
+function renderHelp(): string[] {
+  return [
+    'Supervisor controls',
+    '',
+    's  Start persistent Runtime       o  Open verified Web UI',
+    'x  Stop (confirmation required)   r  Restart (confirmation required)',
+    'l  Bounded redacted logs          d  Read-only Doctor',
+    'u  Check for product update       ?  Toggle this help',
+    'Tab / arrows  Change panel        q / Esc  Detach only',
+    '',
+    'The Supervisor manages Runtime state. Workspaces, trading, and chat stay in the Web UI.',
+  ]
+}
+
+function renderConfirmation(
+  action: 'stop' | 'restart',
+  runtime: RuntimeSummary | null,
+): string[] {
+  const effect = action === 'stop'
+    ? 'This stops the Guardian-owned Runtime and disconnects active Web/agent sessions.'
+    : 'This stops and starts the Guardian-owned Runtime; active Web/agent sessions reconnect or end.'
+  return [
+    `${action === 'stop' ? 'Stop' : 'Restart'} Runtime owned by ${formatOwner(runtime)}?`,
+    effect,
+    'Press y / Enter to continue, n / Esc to cancel.',
+  ]
+}
+
+function actionBar(runtime: RuntimeSummary | null, narrow: boolean): string {
+  const actions = runtime?.class === 'absent'
+    ? 's Start · d Doctor · l Logs · u Update · ? Help'
+    : 'o Open · r Restart · x Stop · d Doctor · l Logs · u Update · ? Help'
+  return narrow ? actions.replaceAll(' · ', '  ') : actions
+}
+
+function unavailableActionMessage(
+  action: SupervisorAction,
+  runtime: RuntimeSummary | null,
+): string {
+  if (action === 'start') return 'Start is available only when the selected Runtime is stopped.'
+  if (action === 'open') return 'The selected Runtime has not advertised a verified Web endpoint.'
+  if (action === 'stop' || action === 'restart') {
+    return runtime?.owner
+      ? `Refusing to ${action}: ${runtime.owner.surface ?? 'another owner'} owns this Runtime.`
+      : `Refusing to ${action}: no CLI-owned Runtime is active.`
+  }
+  return `${actionName(action)} is not available in the current state.`
+}
+
+function actionName(action: SupervisorAction): string {
+  return {
+    start: 'Starting Runtime',
+    open: 'Opening Web UI',
+    stop: 'Stopping Runtime',
+    restart: 'Restarting Runtime',
+    logs: 'Loading logs',
+    doctor: 'Running Doctor',
+    update: 'Checking for updates',
+  }[action]
+}
+
+function formatUpdateNotice(update: UpdateResult): string {
+  if (update.status === 'available') {
+    return `OpenAlice ${update.latestVersion ?? 'update'} is available; use "openalice update" to review installation.`
+  }
+  if (update.status === 'current') {
+    return `OpenAlice ${update.currentVersion ?? ''} is current.`.trim()
+  }
+  return update.message ?? 'Automatic update is unavailable for this install channel.'
 }
 
 function formatOwner(runtime: RuntimeSummary | null): string {
@@ -150,10 +610,31 @@ function formatComponents(runtime: RuntimeSummary | null): string {
   const components = runtime?.components
   if (!components) return 'not reported'
   return [
-    `Alice ${components.alice?.status ?? 'unknown'}`,
-    `UTA ${components.uta?.status ?? 'optional'}`,
-    `Connector ${components.connector?.status ?? 'optional'}`,
+    `Alice ${components.alice ?? 'unknown'}`,
+    `UTA ${components.uta ?? 'optional'}`,
+    `Connector ${components.connector ?? 'optional'}`,
   ].join(' · ')
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m`
+  return `${Math.floor(seconds / 3_600)}h ${Math.floor((seconds % 3_600) / 60)}m`
+}
+
+function runtimeWebPort(runtime: RuntimeSummary | null): number | null {
+  const value = runtime?.endpoints?.web
+  if (!value) return null
+  try {
+    const port = Number(new URL(value).port)
+    return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null
+  } catch {
+    return null
+  }
+}
+
+function safeError(error: unknown): string {
+  return sanitize(error instanceof Error ? error.message : String(error))
 }
 
 function sanitize(value: string): string {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -603,6 +603,9 @@ This plan is complete only when:
   serial PR #872 after both macOS package jobs exposed the stale `0.80.6`
   digests. The real forced vendor transaction downloaded and verified both Pi
   release assets, completed `npm ci`, and assembled the macOS managed runtime.
+  The next package step then exposed a second `0.80.6` expectation in the
+  packaged-toolchain smoke; the Supervisor-controls increment replaced that
+  hardcoded version with an exact pattern derived from the packaged manifest.
 - 2026-07-30: Connected the `pi-tui` application shell to the existing
   lifecycle, logs, Doctor, and update services. Added polled lifecycle and
   update-available states, keyboard navigation, bounded detail panels,
@@ -612,7 +615,7 @@ This plan is complete only when:
   control socket, remained inside the TUI across both transitions, and restored
   the terminal on detach.
 - 2026-07-30: Verified the interactive Supervisor increment with 135 CLI
-  tests, root TypeScript, UI TypeScript, the 3,641-test root Vitest suite, and
+  tests, root TypeScript, UI TypeScript, the 3,642-test root Vitest suite, and
   the CLI package build. An isolated local installer transaction loaded the TUI
   from managed Pi, rendered installed-provenance Doctor results, then
   `uninstall --yes` removed CLI/Pi while preserving a sentinel data directory.

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -361,14 +361,14 @@ and verification before the next dependent branch starts from updated `dev`.
 - [x] Render the initial stable application chrome: product and channel header,
   selected home, lifecycle summary, detach action bar, and unavailable-state
   guidance.
-- [ ] Add navigation, help, update indicator, and selectable detail panels.
+- [x] Add navigation, help, update indicator, and selectable detail panels.
 - [x] Show unfinished product panels as unavailable within the TUI instead of
   preserving a temporary non-TUI default command.
-- [ ] Implement stopped, starting, running, degraded, incompatible, stopping,
+- [x] Implement stopped, starting, running, degraded, incompatible, stopping,
   and update-available states.
-- [ ] Add start, open, stop, restart, detach, help, and read-only detail.
+- [x] Add start, open, stop, restart, detach, help, and read-only detail.
 - [ ] Add component/instance panels and narrow fallback.
-- [ ] Keep the TUI open and reconnect across a self-owned restart.
+- [x] Keep the TUI open and reconnect across a self-owned restart.
 - [ ] Complete source-backed macOS/Linux PTY and real browser acceptance before
   merging the bare-command behavior.
 
@@ -599,3 +599,23 @@ This plan is complete only when:
   installed both launchers, ran the installed TUI through a PTY, and restored
   the terminal on detach. Docker installer smoke remained unrun because the
   local Docker/OrbStack socket was absent.
+- 2026-07-30: Repaired the managed Pi `0.83.0` desktop-vendoring hashes in
+  serial PR #872 after both macOS package jobs exposed the stale `0.80.6`
+  digests. The real forced vendor transaction downloaded and verified both Pi
+  release assets, completed `npm ci`, and assembled the macOS managed runtime.
+- 2026-07-30: Connected the `pi-tui` application shell to the existing
+  lifecycle, logs, Doctor, and update services. Added polled lifecycle and
+  update-available states, keyboard navigation, bounded detail panels,
+  CLI-owner-only start/open/stop/restart controls, and explicit mutation impact
+  confirmation. A real isolated terminal journey started Guardian and Alice,
+  observed ready components and Web endpoint, stopped the Runtime through its
+  control socket, remained inside the TUI across both transitions, and restored
+  the terminal on detach.
+- 2026-07-30: Verified the interactive Supervisor increment with 135 CLI
+  tests, root TypeScript, UI TypeScript, the 3,641-test root Vitest suite, and
+  the CLI package build. An isolated local installer transaction loaded the TUI
+  from managed Pi, rendered installed-provenance Doctor results, then
+  `uninstall --yes` removed CLI/Pi while preserving a sentinel data directory.
+  The Docker installer playground remained unavailable because this host still
+  had no reachable Docker/OrbStack daemon; the equivalent local transaction and
+  real PTY lifecycle journeys passed.

--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -34,7 +34,7 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
     command: electron,
     args: [piCli, '--version'],
     env: { ELECTRON_RUN_AS_NODE: '1' },
-    expectStdout: /\b0\.80\.6\b/,
+    expectStdout: exactLinePattern(packageResult.manifest.pi.version),
   })
 
   const searchTools = packageResult.manifest.searchTools?.[packageResult.platformArch]
@@ -216,6 +216,11 @@ const run = async (args) => {
   }
 
   return { ok: errors.length === 0, errors, commands }
+}
+
+function exactLinePattern(value) {
+  const escaped = String(value).replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped}\\s*$`)
 }
 
 export function packagedElectronExecutable(appRoot, platform) {

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -28,6 +28,7 @@ describe('buildPackagedToolchainSmokePlan', () => {
         platformArch: 'darwin-arm64',
         manifest: {
           pi: {
+            version: '0.83.0',
             cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
           },
           searchTools: {
@@ -50,6 +51,8 @@ describe('buildPackagedToolchainSmokePlan', () => {
         'managed Pi resolves packaged fd/rg without download',
         'workspace CLI payload through packaged Electron Node',
       ])
+      expect(plan.commands[1].expectStdout.test('0.83.0\n')).toBe(true)
+      expect(plan.commands[1].expectStdout.test('0x83x0\n')).toBe(false)
       expect(packagedElectronExecutable(appRoot, 'darwin')?.replaceAll('\\', '/'))
         .toContain('OpenAlice.app/Contents/MacOS/OpenAlice')
     } finally {
@@ -70,6 +73,7 @@ describe('buildPackagedToolchainSmokePlan', () => {
         platformArch: 'win32-x64',
         manifest: {
           pi: {
+            version: '0.83.0',
             cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
           },
           searchTools: {
@@ -132,6 +136,7 @@ describe('buildPackagedToolchainSmokePlan', () => {
       platformArch: null,
       manifest: {
         pi: {
+          version: '0.83.0',
           cli: 'vendor/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js',
         },
       },

--- a/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
@@ -57,6 +57,7 @@ describe('AboutOpenAliceSection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }))
 
     await waitFor(() => expect(mocks.checkVersion).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.queryByText('Checking for updates…')).toBeNull())
     expect(screen.getByText('You’re up to date.')).toBeTruthy()
   })
 


### PR DESCRIPTION
## Summary
- turn the Pi-based Supervisor shell into a polled lifecycle control surface
- add start/open/confirmed stop/restart, help, logs, Doctor, and cached background update discovery
- refuse destructive controls for Electron, development, incompatible, and foreign owners
- keep the TUI attached across self-owned restarts and detach without stopping
- derive the packaged Pi smoke expectation from the package manifest instead of a stale hardcoded version
- stabilize the existing asynchronous Web update-status test

## Verification
- `pnpm -F @traderalice/openalice-cli test` (135 tests)
- `pnpm -F @traderalice/openalice-cli build`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (434 files passed, 1 skipped; 3,642 tests passed, 9 skipped)
- `pnpm exec vitest run scripts/smoke-packaged-toolchain.spec.ts scripts/vendor-managed-runtime.spec.ts`
- real isolated PTY: stopped -> start -> running -> restart/reconnect with a new Guardian PID -> confirmed stop -> detach with terminal restoration
- real local installer: managed Pi/TUI launch, installed Doctor panel, uninstall with sentinel data preservation
- Docker installer playground not run because this host has no reachable Docker/OrbStack daemon

## Related CI repair
PR #872 proved both macOS packages contain Pi 0.83.0; its remaining failure was the toolchain smoke still matching 0.80.6. This PR removes that hardcoded expectation.