### PR TITLE
Make manual order entry account-aware

### DIFF
--- a/ui/src/api/trading.contract-search.spec.ts
+++ b/ui/src/api/trading.contract-search.spec.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { tradingApi } from './trading'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('tradingApi contract search', () => {
+  it('can scope broker contract discovery to the open account', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      count: 0,
+      results: [],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await tradingApi.searchContracts('AAPL', undefined, 'alpaca-paper')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/trading/contracts/search?pattern=AAPL&source=alpaca-paper',
+      undefined,
+    )
+  })
+})

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -272,16 +272,19 @@ export const tradingApi = {
   // ==================== Contract search ====================
 
   /**
-   * Heuristic broker-side search across all configured UTAs. Used by the
-   * Market workbench to surface tradeable contracts matching a data-vendor
-   * symbol — the bridge is intentionally fuzzy / display-only.
+   * Heuristic broker-side search across configured UTAs, optionally narrowed
+   * to one account. The Market workbench searches broadly to bridge a
+   * data-vendor symbol; manual order entry scopes to its open UTA so identical
+   * symbols cannot surface a different account's canonical aliceId.
    */
   async searchContracts(
     pattern: string,
     assetClass?: 'equity' | 'crypto' | 'currency' | 'commodity',
+    source?: string,
   ): Promise<ContractSearchResponse> {
     const qs = new URLSearchParams({ pattern })
     if (assetClass) qs.set('assetClass', assetClass)
+    if (source) qs.set('source', source)
     return fetchJson(`/api/trading/contracts/search?${qs}`)
   },
 

--- a/ui/src/components/uta/OrderEntryDialog.spec.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.spec.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -43,7 +45,7 @@ function setupPlaceOrder() {
     />,
   )
 
-  fireEvent.change(screen.getByPlaceholderText('okx-test|BTC/USDT'), {
+  fireEvent.change(screen.getByRole('searchbox', { name: 'Contract' }), {
     target: { value: 'demo-paper|AAPL' },
   })
   fireEvent.change(screen.getByPlaceholderText('Why are you placing this order?'), {
@@ -64,6 +66,93 @@ function setupClosePosition() {
 }
 
 describe('OrderEntryDialog sizing', () => {
+  it('searches only the open account and submits the selected canonical contract', async () => {
+    const placeOrder = vi.spyOn(tradingApi, 'placeOrder').mockResolvedValue(pushResult)
+    const searchContracts = vi.spyOn(tradingApi, 'searchContracts').mockResolvedValue({
+      count: 2,
+      results: [
+        {
+          source: 'demo-paper',
+          contract: {
+            aliceId: 'demo-paper|AAPL',
+            symbol: 'AAPL',
+            secType: 'STK',
+            description: 'Apple Inc.',
+            primaryExchange: 'NASDAQ',
+            currency: 'USD',
+          },
+          derivativeSecTypes: [],
+        },
+        {
+          source: 'other-account',
+          contract: {
+            aliceId: 'other-account|AAPL',
+            symbol: 'AAPL',
+            secType: 'STK',
+            description: 'Wrong account',
+          },
+          derivativeSecTypes: [],
+        },
+      ],
+    })
+
+    render(
+      <OrderEntryDialog
+        utaId="demo-paper"
+        mode={{ kind: 'place' }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Contract' }), {
+      target: { value: 'AAPL' },
+    })
+
+    await waitFor(() => expect(searchContracts).toHaveBeenCalledWith('AAPL', undefined, 'demo-paper'))
+    expect(screen.queryByText('Wrong account')).toBeNull()
+    fireEvent.click(await screen.findByRole('button', { name: /AAPL.*Apple Inc.*NASDAQ.*USD/i }))
+    expect(screen.getByText('demo-paper|AAPL')).toBeTruthy()
+
+    fireEvent.change(screen.getByPlaceholderText('0.001'), { target: { value: '2' } })
+    fireEvent.change(screen.getByPlaceholderText('Why are you placing this order?'), {
+      target: { value: 'Order sizing test' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Place Order' }))
+
+    await waitFor(() => expect(placeOrder).toHaveBeenCalledWith('demo-paper', expect.objectContaining({
+      aliceId: 'demo-paper|AAPL',
+      totalQuantity: '2',
+    })))
+  })
+
+  it('preserves a Market deep link aliceId without requiring another search', async () => {
+    const placeOrder = vi.spyOn(tradingApi, 'placeOrder').mockResolvedValue(pushResult)
+    const searchContracts = vi.spyOn(tradingApi, 'searchContracts')
+
+    render(
+      <OrderEntryDialog
+        utaId="demo-paper"
+        mode={{ kind: 'place', aliceId: 'demo-paper|AAPL' }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect((screen.getByRole('searchbox', { name: 'Contract' }) as HTMLInputElement).value).toBe('AAPL')
+    expect(screen.getByText('demo-paper|AAPL')).toBeTruthy()
+    expect(searchContracts).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByPlaceholderText('0.001'), { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText('Why are you placing this order?'), {
+      target: { value: 'Market workbench follow-up' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Place Order' }))
+
+    await waitFor(() => expect(placeOrder).toHaveBeenCalledWith('demo-paper', expect.objectContaining({
+      aliceId: 'demo-paper|AAPL',
+      totalQuantity: '1',
+    })))
+  })
+
   it('clears Quantity when Cash Qty becomes authoritative', async () => {
     const placeOrder = setupPlaceOrder()
     const quantity = screen.getByPlaceholderText('0.001') as HTMLInputElement

--- a/ui/src/components/uta/OrderEntryDialog.tsx
+++ b/ui/src/components/uta/OrderEntryDialog.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 import Decimal from 'decimal.js'
+import { Check, Loader2, Search } from 'lucide-react'
 import { Field, inputClass } from '../form'
 import { Dialog } from './Dialog'
-import { tradingApi, OrderEntryError } from '../../api/trading'
+import { tradingApi, OrderEntryError, type ContractSearchHit } from '../../api/trading'
 import type { WalletPushResult, PlaceOrderRequest, ClosePositionRequest, SubAccountRef } from '../../api/types'
 
 // ==================== Modes ====================
@@ -191,14 +192,12 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
 
   return (
     <div className="space-y-4">
-      <Field label="aliceId">
-        <input
-          className={`${inputClass} font-mono text-[12px]`}
-          value={aliceId}
-          onChange={(e) => setAliceId(e.target.value)}
-          placeholder="okx-test|BTC/USDT"
-        />
-      </Field>
+      <ContractPicker
+        utaId={p.utaId}
+        value={aliceId}
+        initialAliceId={initialAliceId}
+        onChange={setAliceId}
+      />
 
       <WalletPicker subAccounts={p.subAccounts} value={subAccountId} onChange={setSubAccountId} />
 
@@ -306,6 +305,229 @@ function PlaceForm({ initialAliceId, ...p }: SharedFormProps & { initialAliceId?
         </button>
       </div>
     </div>
+  )
+}
+
+function contractLabel(hit: ContractSearchHit): string {
+  return hit.contract.symbol
+    ?? hit.contract.localSymbol
+    ?? hit.contract.aliceId?.split('|').slice(1).join('|')
+    ?? ''
+}
+
+function initialContractLabel(aliceId?: string): string {
+  if (!aliceId) return ''
+  const separator = aliceId.indexOf('|')
+  return separator >= 0 ? aliceId.slice(separator + 1) : aliceId
+}
+
+/**
+ * Resolve a broker-native contract before the form can submit. The search is
+ * intentionally scoped to the account whose dialog is open: a result from a
+ * different UTA may look identical by symbol while carrying an aliceId that
+ * the backend must reject.
+ *
+ * Exact aliceIds remain pasteable for advanced/debug workflows. Ordinary users
+ * can stay in the symbol-and-description layer and never have to construct the
+ * internal identifier themselves.
+ */
+function ContractPicker({
+  utaId,
+  value,
+  initialAliceId,
+  onChange,
+}: {
+  utaId: string
+  value: string
+  initialAliceId?: string
+  onChange: (aliceId: string) => void
+}) {
+  const resultsId = useId()
+  const [query, setQuery] = useState(() => initialContractLabel(initialAliceId))
+  const [selected, setSelected] = useState<ContractSearchHit | null>(() => (
+    initialAliceId
+      ? {
+          source: utaId,
+          derivativeSecTypes: [],
+          contract: {
+            aliceId: initialAliceId,
+            symbol: initialContractLabel(initialAliceId),
+          },
+        }
+      : null
+  ))
+  const [results, setResults] = useState<ContractSearchHit[]>([])
+  const [loading, setLoading] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+  const trimmedQuery = query.trim()
+  const hasExactAliceId = trimmedQuery.includes('|')
+  const canSearch = trimmedQuery.length >= 2 && selected === null && !hasExactAliceId
+
+  useEffect(() => {
+    if (!canSearch) {
+      setResults([])
+      setLoading(false)
+      setSearchError(null)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setSearchError(null)
+    const timeout = window.setTimeout(() => {
+      tradingApi.searchContracts(trimmedQuery, undefined, utaId)
+        .then((response) => {
+          if (cancelled) return
+          setResults(response.results.filter((hit) => hit.source === utaId && hit.contract.aliceId))
+        })
+        .catch((error) => {
+          if (cancelled) return
+          setResults([])
+          setSearchError(error instanceof Error ? error.message : String(error))
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+    }, 250)
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+    }
+  }, [canSearch, trimmedQuery, utaId])
+
+  const updateQuery = (next: string) => {
+    setQuery(next)
+    setSelected(null)
+    setResults([])
+    setSearchError(null)
+    setLoading(next.trim().length >= 2 && !next.trim().includes('|'))
+    onChange(next.trim().includes('|') ? next.trim() : '')
+  }
+
+  const chooseContract = (hit: ContractSearchHit) => {
+    const nextAliceId = hit.contract.aliceId
+    if (!nextAliceId) return
+    setSelected(hit)
+    setQuery(contractLabel(hit))
+    setResults([])
+    setSearchError(null)
+    onChange(nextAliceId)
+  }
+
+  const showResults = canSearch && (searchError !== null || results.length > 0)
+  const showNoMatches = canSearch && !loading && searchError === null && results.length === 0
+
+  return (
+    <Field label="Contract" controlId={`${resultsId}-input`}>
+      <div className="relative">
+        <Search
+          aria-hidden
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/60"
+        />
+        <input
+          id={`${resultsId}-input`}
+          type="search"
+          className={`${inputClass} pl-9 pr-9`}
+          value={query}
+          onChange={(event) => updateQuery(event.target.value)}
+          placeholder="Search this account — AAPL, BTC, EUR…"
+          autoComplete="off"
+          aria-controls={resultsId}
+          aria-expanded={showResults || showNoMatches}
+          aria-describedby={`${resultsId}-help`}
+        />
+        {loading && (
+          <Loader2
+            aria-label="Searching contracts"
+            className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground"
+          />
+        )}
+      </div>
+
+      <p id={`${resultsId}-help`} className="mt-1 text-[11px] text-muted-foreground/70">
+        Search tradeable contracts on this account, or paste an exact aliceId.
+      </p>
+
+      {selected && value && (
+        <div className="mt-2 flex min-w-0 items-start gap-2 rounded-lg border border-primary/30 bg-primary/[0.06] px-3 py-2">
+          <Check aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-1.5 text-[12px] font-medium text-foreground">
+              <span>{contractLabel(selected)}</span>
+              {selected.contract.secType && (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {selected.contract.secType}
+                </span>
+              )}
+            </div>
+            <div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground" title={value}>
+              {value}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showResults && (
+        <div
+          id={resultsId}
+          role="group"
+          aria-label="Matching contracts"
+          className="mt-2 max-h-52 overflow-y-auto rounded-lg border border-border bg-background p-1 shadow-sm"
+        >
+          {searchError !== null ? (
+            <div className="px-2 py-2 text-[12px] text-destructive">
+              Could not search this account: {searchError}
+            </div>
+          ) : results.map((hit) => {
+            const aliceId = hit.contract.aliceId
+            const details = [
+              hit.contract.description,
+              hit.contract.primaryExchange ?? hit.contract.exchange,
+              hit.contract.currency,
+            ].filter(Boolean).join(' · ')
+            return (
+              <button
+                key={aliceId}
+                type="button"
+                onClick={() => chooseContract(hit)}
+                className="oa-pressable flex min-h-11 w-full min-w-0 items-center gap-2 rounded-md px-2.5 py-2 text-left hover:bg-muted"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="flex flex-wrap items-center gap-1.5">
+                    <span className="font-mono text-[13px] font-semibold text-foreground">
+                      {contractLabel(hit)}
+                    </span>
+                    {hit.contract.secType && (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-muted-foreground">
+                        {hit.contract.secType}
+                      </span>
+                    )}
+                  </span>
+                  {details && (
+                    <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                      {details}
+                    </span>
+                  )}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {showNoMatches && (
+        <div id={resultsId} role="status" className="mt-2 rounded-lg border border-border bg-secondary/40 px-3 py-2 text-[12px] text-muted-foreground">
+          No matching tradeable contract on this account.
+        </div>
+      )}
+
+      {hasExactAliceId && selected === null && value && (
+        <div id={resultsId} role="status" className="mt-2 rounded-lg border border-border bg-secondary/40 px-3 py-2 text-[11px] text-muted-foreground">
+          Exact aliceId entered. It will still be validated by the account before the order is staged.
+        </div>
+      )}
+    </Field>
   )
 }
 


### PR DESCRIPTION
## Summary

- replace the raw `aliceId`-first order field with broker contract search scoped to the UTA whose account page is open
- show symbol, security type, description, venue, currency, and the selected canonical `aliceId` before order sizing
- keep exact `aliceId` paste support for advanced workflows and preserve Market workbench deep links
- keep the existing stage → commit → push path unchanged

## Why

The manual Place Order dialog previously showed an OKX-specific `okx-test|BTC/USDT` placeholder even on an Alpaca account and required users to construct an internal identifier themselves. Searching every UTA would still be unsafe because identical symbols can return canonical IDs belonging to another account. The existing broker search endpoint already supports a `source` constraint, so the UI now uses that account boundary.

## Verification

- `pnpm --dir ui exec vitest run src/components/uta/OrderEntryDialog.spec.tsx src/api/trading.contract-search.spec.ts`
- `pnpm --dir ui exec tsc -b`
- `npx tsc --noEmit`
- `pnpm test` — 435 files passed, 1 skipped; 3642 tests passed, 9 skipped
- real `pnpm dev` route at `/settings/uta/alpaca-d3b9a58c`
  - 320px: searched `AAPL`, inspected the account-scoped result list, and selected `alpaca-d3b9a58c|AAPL`
  - 390px: verified `?aliceId=alpaca-d3b9a58c%7CAAPL` still opens with the contract selected
  - 1280px: verified the desktop dialog layout remains intact

No order was submitted. Live-paper acceptance was not run because this change only adds a read-only contract lookup and selection layer; it does not alter the trading write request or backend order pipeline.
