### PR TITLE
Add resolved CLI launch context

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -107,6 +107,46 @@ selected Runtime) until the standalone headless Runtime artifact ships.
 Unfinished controls remain inside the application shell and do not change the
 default entry back to the compatibility launcher.
 
+## TUI Launch Context
+
+The TypeScript entry resolves launch-affecting values before starting terminal
+raw mode. Bare `openalice` and `openalice tui` accept:
+
+```text
+--instance <name>
+--home <path>
+--port <port>
+--app-dir <path>
+--no-update-check
+--update-check
+```
+
+Resolution order is defaults, machine Supervisor configuration, selected
+instance configuration, environment, then explicit CLI flags. The current
+increment implements the immutable resolver, field provenance, environment and
+flag layers, plus typed seams for the two configuration layers. Persisted
+machine configuration and the instance registry are not active yet; a named
+instance therefore needs an explicit complete home through configuration
+injection, `OPENALICE_HOME`, or `--home`.
+
+`OPENALICE_INSTANCE`, `OPENALICE_HOME`, `OPENALICE_WEB_PORT`,
+`OPENALICE_APP_HOME`, and `OPENALICE_NO_UPDATE_CHECK` are the corresponding
+environment overrides. `OPENALICE_SUPERVISOR_HOME` may relocate the
+machine-wide Supervisor root, which remains outside every selectable complete
+home.
+
+Only an installer-owned Runtime carrying `OPENALICE_MANAGED_PI_PATH` receives
+instance-private `PI_CODING_AGENT_DIR` and `PI_CODING_AGENT_SESSION_DIR`
+values. Source development and an external Pi retain their native user
+configuration and session roots.
+
+The same resolver selects homes for `up`, `run`, `down`, `status`, `open`,
+`logs`, and `doctor`; those commands also accept `--instance <name>`.
+Consequently a Runtime started through the TUI and one started by
+`openalice up` receive the same managed-Pi environment. The transitional
+presenters still own their existing command-specific port, source, timeout,
+and output parsing until the root parser conversion is complete.
+
 ## Presentation-neutral Core
 
 `packages/cli/src/lifecycle.mjs` owns:
@@ -282,6 +322,8 @@ completion; detailed shell installation remains user-owned.
 
 - `packages/cli/bin/openalice.ts` and `packages/cli/src/main.ts` — TypeScript
   application entry and default-TUI/explicit-command dispatch.
+- `packages/cli/src/launch-context.ts` — immutable launch precedence,
+  provenance, instance roots, and managed-Pi environment projection.
 - `packages/cli/src/supervisor-tui.ts` — `pi-tui` Supervisor application shell.
 - `packages/cli/src/pi-tui-loader.ts` — workspace and installed managed-Pi TUI
   resolution.

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -396,13 +396,27 @@ Do not add external-Pi version probing or upgrade UX to preserve flags used by
 the packaged runtime. Compatibility for the packaged app is maintained by
 pinning and upgrading the bundled Pi with the OpenAlice release.
 
-OpenAlice always updates trust in Pi's normal user agent directory (or an
-explicit user-provided `PI_CODING_AGENT_DIR`). Provider overrides do not change
-that directory: OpenAlice adds a namespaced provider to its `models.json` and
-uses the native Workspace `.pi/settings.json` layer to select it. This keeps
-Pi's global settings, packages, auth, resources, trust, and sessions visible.
-An old Workspace `.pi-agent/` tree is migrated into this native layout before
-launch and removed only after its configuration and session data are preserved.
+Source development and user-installed Pi update trust in Pi's normal user
+agent directory (or an explicit user-provided `PI_CODING_AGENT_DIR`). Provider
+overrides do not change that directory: OpenAlice adds a namespaced provider to
+its `models.json` and uses the native Workspace `.pi/settings.json` layer to
+select it. This keeps the user's global settings, packages, auth, resources,
+trust, and sessions visible.
+
+An installer-owned OpenAlice Runtime is a separate managed boundary. A launcher
+carrying `OPENALICE_MANAGED_PI_PATH` causes the selected complete home to set
+`PI_CODING_AGENT_DIR` and `PI_CODING_AGENT_SESSION_DIR` beneath that instance's
+complete home before Guardian starts. Managed settings, trust, resources, and
+sessions are therefore shared within one OpenAlice instance but isolated from
+another instance and from a Pi launched directly in the user's shell. The
+standalone installer-provided `pi` launcher intentionally does not set those
+overrides. The environment projection lives in the common local-Runtime
+environment builder, so TUI, lifecycle, and transitional `start`/`server`
+launch paths cannot diverge on this boundary.
+
+An old Workspace `.pi-agent/` tree is migrated into the applicable native
+agent-directory layout before launch and removed only after its configuration
+and session data are preserved.
 
 ### Codex interactive permissions
 

--- a/docs/reference/pi-herdr-cli-architecture.md
+++ b/docs/reference/pi-herdr-cli-architecture.md
@@ -29,6 +29,43 @@ normal dependency with its notices preserved. Herdr declares
 AGPL-3.0-or-later with a commercial option. OpenAlice uses Herdr as a behavioral
 and interface reference; this note does not vendor Herdr source.
 
+## Pi 0.80.3 to 0.83.0 compatibility audit
+
+OpenAlice moved its managed Pi and direct `pi-tui` dependency from the original
+`0.80.3` design baseline to `0.83.0`. The upstream range contains 371 commits
+and three published breaking-change groups:
+
+| Pi release | Upstream break | OpenAlice exposure | Outcome |
+|---|---|---|---|
+| `0.80.7` | Replaced `compat.sendSessionIdHeader` with `compat.sessionAffinityFormat` for OpenAI Responses models | OpenAlice neither emits nor owns Pi `models.json` compatibility fields | No migration required |
+| `0.80.8` | Replaced SDK `authStorage`/`modelRegistry` construction with async `modelRuntime`; removed `AuthStorage` exports and changed registry APIs | OpenAlice launches Pi as a native CLI and does not embed the Pi agent SDK | No migration required |
+| `0.83.0` | Removed deprecated bundled TypeBox aliases such as `Type.Base`, `Type.Promise`, `Type.Options`, and `Value.Mutate` | OpenAlice has no Pi extension using those aliases and its Supervisor imports only `pi-tui` | No migration required |
+
+The exact `pi-tui` surface used by the Supervisor was compared at both tags.
+`TUI.addChild()`, `start()`, `stop()`, `addInputListener()`, and
+`requestRender()`; `ProcessTerminal.start()` and `stop()`; and `matchesKey()`
+plus `KeyId` retain compatible signatures. `TUI` only gained an optional third
+`logDirectory` constructor argument, which the OpenAlice Supervisor now uses to
+keep its own diagnostics below the machine-wide Supervisor root. Both
+coding-agent releases require Node `>=22.19.0`, so the runtime floor did not
+move.
+
+The upgrade is therefore the new OpenAlice baseline rather than a compatibility
+fork. The release integration exposed two OpenAlice-owned drifts, both repaired:
+the installer/desktop vendor hashes now identify the `0.83.0` release assets,
+and the packaged-toolchain smoke derives its expected Pi version from the
+packaged manifest instead of a stale literal. Real source, installed-CLI, PTY,
+installer/uninstaller, and packaged-Electron paths have all launched Pi
+`0.83.0`.
+
+The range also contains changes that directly benefit the chosen architecture:
+`0.81.0` repairs terminal shutdown cursor restoration, and `0.82.0` makes TUI
+debug/crash logs honor a custom agent directory. The latter supports the
+instance-private `PI_CODING_AGENT_DIR` used only when OpenAlice launches its
+pinned managed Pi. Source-development and external Pi keep the user's native
+agent directory. Future Pi extensions must still be checked for removed TypeBox
+aliases before each Pi upgrade.
+
 ## Executive decision
 
 OpenAlice does not choose between a TUI-first application and a scriptable CLI.

--- a/install
+++ b/install
@@ -667,6 +667,7 @@ FILES=(
   "package.json"
   "bin/openalice.ts"
   "bin/openalice.mjs"
+  "src/launch-context.ts"
   "src/main.ts"
   "src/pi-tui-loader.ts"
   "src/supervisor-tui.ts"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,6 +9,7 @@
   "files": [
     "bin/openalice.ts",
     "bin/openalice.mjs",
+    "src/launch-context.ts",
     "src/main.ts",
     "src/pi-tui-loader.ts",
     "src/supervisor-tui.ts",

--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildManagedPiEnv,
+  parseTuiLaunchArgs,
+  resolveLaunchContext,
+} from './launch-context.ts'
+
+describe('ResolvedLaunchContext', () => {
+  it('resolves defaults < machine < instance < env < CLI with field provenance', () => {
+    const context = resolveLaunchContext({
+      homeDir: '/Users/alice',
+      cwd: '/repo',
+      platform: 'darwin',
+      machineConfig: {
+        defaultInstance: 'desk',
+        defaults: {
+          home: '/machine-home',
+          port: 41_000,
+          appDir: '/machine-app',
+          updateChecks: false,
+        },
+      },
+      instanceConfig: {
+        name: 'desk',
+        home: '/instance-home',
+        port: 42_000,
+        appDir: '/instance-app',
+        updateChecks: true,
+      },
+      env: {
+        OPENALICE_HOME: '/env-home',
+        OPENALICE_WEB_PORT: '43000',
+        OPENALICE_APP_HOME: '/env-app',
+        OPENALICE_NO_UPDATE_CHECK: '1',
+      },
+      flags: {
+        instance: 'desk',
+        home: './flag-home',
+        port: 44_000,
+        appDir: './flag-app',
+        updateChecks: true,
+      },
+    })
+
+    expect(context).toMatchObject({
+      instance: 'desk',
+      home: '/repo/flag-home',
+      port: 44_000,
+      appDir: '/repo/flag-app',
+      updateChecks: true,
+      supervisorRoot: '/Users/alice/Library/Application Support/OpenAlice/Supervisor',
+      managedPi: {
+        codingAgentDir: '/repo/flag-home/runtime/pi',
+        sessionDir: '/repo/flag-home/runtime/pi/sessions',
+      },
+      provenance: {
+        instance: { source: 'cli-flag', detail: '--instance' },
+        home: { source: 'cli-flag', detail: '--home' },
+        port: { source: 'cli-flag', detail: '--port' },
+        appDir: { source: 'cli-flag', detail: '--app-dir' },
+        updateChecks: { source: 'cli-flag', detail: '--update-check' },
+      },
+    })
+    expect(Object.isFrozen(context)).toBe(true)
+    expect(Object.isFrozen(context.provenance)).toBe(true)
+  })
+
+  it('uses environment values above both configuration layers', () => {
+    const context = resolveLaunchContext({
+      homeDir: '/home/alice',
+      cwd: '/repo',
+      platform: 'linux',
+      machineConfig: {
+        defaultInstance: 'research',
+        defaults: { port: 41_000, updateChecks: true },
+      },
+      instanceConfig: {
+        name: 'research',
+        home: '/instance-home',
+        port: 42_000,
+        updateChecks: true,
+      },
+      env: {
+        OPENALICE_INSTANCE: 'research',
+        OPENALICE_HOME: '~/env-home',
+        OPENALICE_WEB_PORT: '43000',
+        OPENALICE_NO_UPDATE_CHECK: 'true',
+        XDG_CONFIG_HOME: '/xdg',
+      },
+    })
+
+    expect(context.home).toBe('/home/alice/env-home')
+    expect(context.port).toBe(43_000)
+    expect(context.updateChecks).toBe(false)
+    expect(context.supervisorRoot).toBe('/xdg/openalice')
+    expect(context.provenance.home.detail).toBe('OPENALICE_HOME')
+  })
+
+  it('requires a complete home for a named non-default instance', () => {
+    expect(() => resolveLaunchContext({
+      homeDir: '/home/alice',
+      env: { OPENALICE_INSTANCE: 'research' },
+    })).toThrow(/needs an explicit complete home/)
+  })
+
+  it('rejects malformed instance, port, and boolean environment values', () => {
+    expect(() => resolveLaunchContext({
+      env: { OPENALICE_INSTANCE: '../escape', OPENALICE_HOME: '/tmp/home' },
+    })).toThrow(/Invalid OpenAlice instance/)
+    expect(() => resolveLaunchContext({
+      env: { OPENALICE_WEB_PORT: 'nope' },
+    })).toThrow(/integer between 1 and 65535/)
+    expect(() => resolveLaunchContext({
+      env: { OPENALICE_NO_UPDATE_CHECK: 'sometimes' },
+    })).toThrow(/must be one of/)
+  })
+
+  it('projects instance-private Pi roots without mutating the caller environment', () => {
+    const base = {
+      PATH: '/bin',
+      OPENALICE_MANAGED_PI_PATH: '/managed/pi/cli.js',
+      PI_CODING_AGENT_DIR: '/native/pi',
+    }
+    const context = resolveLaunchContext({
+      homeDir: '/home/alice',
+      env: {},
+    })
+
+    const managed = buildManagedPiEnv(context, base)
+
+    expect(base.PI_CODING_AGENT_DIR).toBe('/native/pi')
+    expect(managed).toMatchObject({
+      PATH: '/bin',
+      PI_CODING_AGENT_DIR: '/home/alice/.openalice/runtime/pi',
+      PI_CODING_AGENT_SESSION_DIR: '/home/alice/.openalice/runtime/pi/sessions',
+    })
+  })
+
+  it('preserves native Pi state when the Runtime has no managed Pi', () => {
+    const context = resolveLaunchContext({
+      homeDir: '/home/alice',
+      env: {},
+    })
+
+    expect(buildManagedPiEnv(context, {
+      PATH: '/bin',
+      PI_CODING_AGENT_DIR: '/native/pi',
+      PI_CODING_AGENT_SESSION_DIR: '/native/pi/sessions',
+    })).toEqual({
+      PATH: '/bin',
+      PI_CODING_AGENT_DIR: '/native/pi',
+      PI_CODING_AGENT_SESSION_DIR: '/native/pi/sessions',
+    })
+  })
+})
+
+describe('TUI launch flags', () => {
+  it('parses the launch-affecting flags before terminal startup', () => {
+    expect(parseTuiLaunchArgs([
+      '--instance', 'research',
+      '--home', './state',
+      '--port', '44000',
+      '--app-dir', './checkout',
+      '--no-update-check',
+    ])).toEqual({
+      instance: 'research',
+      home: './state',
+      port: 44_000,
+      appDir: './checkout',
+      updateChecks: false,
+    })
+  })
+
+  it('rejects unknown flags before terminal startup', () => {
+    expect(() => parseTuiLaunchArgs(['--wat'])).toThrow(/Unknown TUI option/)
+  })
+})

--- a/packages/cli/src/launch-context.ts
+++ b/packages/cli/src/launch-context.ts
@@ -1,0 +1,380 @@
+import { homedir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+
+const INSTANCE_NAME_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/
+const DEFAULT_PORT = 47_331
+
+export type LaunchValueSource =
+  | 'default'
+  | 'machine-config'
+  | 'instance-config'
+  | 'environment'
+  | 'cli-flag'
+  | 'derived'
+
+export interface LaunchValueProvenance {
+  source: LaunchValueSource
+  detail: string
+}
+
+export interface LaunchConfigValues {
+  home?: string
+  port?: number
+  appDir?: string | null
+  updateChecks?: boolean
+}
+
+export interface MachineSupervisorConfig {
+  defaultInstance?: string
+  defaults?: LaunchConfigValues
+}
+
+export interface InstanceLaunchConfig extends LaunchConfigValues {
+  name?: string
+}
+
+export interface TuiLaunchFlags extends LaunchConfigValues {
+  instance?: string
+}
+
+export interface ResolvedLaunchContext {
+  instance: string
+  home: string
+  port: number
+  appDir: string | null
+  updateChecks: boolean
+  supervisorRoot: string
+  managedPi: {
+    codingAgentDir: string
+    sessionDir: string
+  }
+  provenance: {
+    instance: LaunchValueProvenance
+    home: LaunchValueProvenance
+    port: LaunchValueProvenance
+    appDir: LaunchValueProvenance
+    updateChecks: LaunchValueProvenance
+    supervisorRoot: LaunchValueProvenance
+    managedPi: LaunchValueProvenance
+  }
+}
+
+export interface ResolveLaunchContextOptions {
+  flags?: TuiLaunchFlags
+  machineConfig?: MachineSupervisorConfig | null
+  instanceConfig?: InstanceLaunchConfig | null
+  env?: NodeJS.ProcessEnv
+  cwd?: string
+  homeDir?: string
+  platform?: NodeJS.Platform
+}
+
+interface Candidate<T> {
+  value: T
+  provenance: LaunchValueProvenance
+}
+
+export function resolveLaunchContext(
+  options: ResolveLaunchContextOptions = {},
+): ResolvedLaunchContext {
+  const env = options.env ?? process.env
+  const cwd = options.cwd ?? process.cwd()
+  const homeDir = options.homeDir ?? homedir()
+  const platform = options.platform ?? process.platform
+  const flags = options.flags ?? {}
+  const machine = options.machineConfig ?? {}
+  const instanceConfig = options.instanceConfig ?? {}
+
+  const instance = resolveInstance(flags, env, machine)
+  if (instanceConfig.name !== undefined && instanceConfig.name !== instance.value) {
+    throw launchContextError(
+      'EINSTANCECONFIG',
+      `Instance config "${instanceConfig.name}" does not match selected instance "${instance.value}".`,
+    )
+  }
+
+  const supervisorRoot = resolveSupervisorRoot(env, homeDir, platform, cwd)
+  const home = resolveField<string>(
+    candidate(join(homeDir, '.openalice'), 'default', '~/.openalice'),
+    pathCandidate(machine.defaults?.home, 'machine-config', 'machine.defaults.home', cwd, homeDir),
+    pathCandidate(instanceConfig.home, 'instance-config', `instance.${instance.value}.home`, cwd, homeDir),
+    pathCandidate(env['OPENALICE_HOME'], 'environment', 'OPENALICE_HOME', cwd, homeDir),
+    pathCandidate(flags.home, 'cli-flag', '--home', cwd, homeDir),
+  )
+  if (instance.value !== 'default' && home.provenance.source === 'default') {
+    throw launchContextError(
+      'EINSTANCEHOME',
+      `Instance "${instance.value}" needs an explicit complete home in instance config, OPENALICE_HOME, or --home.`,
+    )
+  }
+
+  const port = resolveField<number>(
+    candidate(DEFAULT_PORT, 'default', String(DEFAULT_PORT)),
+    numberCandidate(machine.defaults?.port, 'machine-config', 'machine.defaults.port'),
+    numberCandidate(instanceConfig.port, 'instance-config', `instance.${instance.value}.port`),
+    env['OPENALICE_WEB_PORT'] === undefined
+      ? undefined
+      : candidate(parsePort(env['OPENALICE_WEB_PORT'], 'OPENALICE_WEB_PORT'), 'environment', 'OPENALICE_WEB_PORT'),
+    numberCandidate(flags.port, 'cli-flag', '--port'),
+  )
+  const appDir = resolveField<string | null>(
+    candidate(null, 'default', 'current working directory discovery'),
+    nullablePathCandidate(machine.defaults?.appDir, 'machine-config', 'machine.defaults.appDir', cwd, homeDir),
+    nullablePathCandidate(instanceConfig.appDir, 'instance-config', `instance.${instance.value}.appDir`, cwd, homeDir),
+    nullablePathCandidate(env['OPENALICE_APP_HOME'], 'environment', 'OPENALICE_APP_HOME', cwd, homeDir),
+    nullablePathCandidate(flags.appDir, 'cli-flag', '--app-dir', cwd, homeDir),
+  )
+  const updateChecks = resolveField<boolean>(
+    candidate(true, 'default', 'enabled'),
+    booleanCandidate(machine.defaults?.updateChecks, 'machine-config', 'machine.defaults.updateChecks'),
+    booleanCandidate(instanceConfig.updateChecks, 'instance-config', `instance.${instance.value}.updateChecks`),
+    env['OPENALICE_NO_UPDATE_CHECK'] === undefined
+      ? undefined
+      : candidate(
+          !parseBoolean(env['OPENALICE_NO_UPDATE_CHECK'], 'OPENALICE_NO_UPDATE_CHECK'),
+          'environment',
+          'OPENALICE_NO_UPDATE_CHECK',
+        ),
+    booleanCandidate(flags.updateChecks, 'cli-flag', flags.updateChecks ? '--update-check' : '--no-update-check'),
+  )
+
+  const managedPiRoot = join(home.value, 'runtime', 'pi')
+  return deepFreeze({
+    instance: instance.value,
+    home: home.value,
+    port: port.value,
+    appDir: appDir.value,
+    updateChecks: updateChecks.value,
+    supervisorRoot: supervisorRoot.value,
+    managedPi: {
+      codingAgentDir: managedPiRoot,
+      sessionDir: join(managedPiRoot, 'sessions'),
+    },
+    provenance: {
+      instance: instance.provenance,
+      home: home.provenance,
+      port: port.provenance,
+      appDir: appDir.provenance,
+      updateChecks: updateChecks.provenance,
+      supervisorRoot: supervisorRoot.provenance,
+      managedPi: {
+        source: 'derived',
+        detail: 'selected complete home/runtime/pi',
+      },
+    },
+  })
+}
+
+export function buildManagedPiEnv(
+  context: ResolvedLaunchContext,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return buildManagedPiEnvForHome(context.home, baseEnv)
+}
+
+export function buildManagedPiEnvForHome(
+  home: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  if (!baseEnv['OPENALICE_MANAGED_PI_PATH']?.trim()) {
+    return { ...baseEnv }
+  }
+  const managedPiRoot = join(home, 'runtime', 'pi')
+  return {
+    ...baseEnv,
+    PI_CODING_AGENT_DIR: managedPiRoot,
+    PI_CODING_AGENT_SESSION_DIR: join(managedPiRoot, 'sessions'),
+  }
+}
+
+export function parseTuiLaunchArgs(argv: string[]): TuiLaunchFlags {
+  const flags: TuiLaunchFlags = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--instance') {
+      flags.instance = requireValue(argv, ++index, arg)
+    } else if (arg === '--home') {
+      flags.home = requireValue(argv, ++index, arg)
+    } else if (arg === '--port') {
+      flags.port = parsePort(requireValue(argv, ++index, arg), arg)
+    } else if (arg === '--app-dir') {
+      flags.appDir = requireValue(argv, ++index, arg)
+    } else if (arg === '--no-update-check') {
+      flags.updateChecks = false
+    } else if (arg === '--update-check') {
+      flags.updateChecks = true
+    } else {
+      throw launchContextError(
+        'EUSAGE',
+        arg?.startsWith('-') ? `Unknown TUI option: ${arg}` : `Unexpected TUI argument: ${arg}`,
+        2,
+      )
+    }
+  }
+  return flags
+}
+
+function resolveInstance(
+  flags: TuiLaunchFlags,
+  env: NodeJS.ProcessEnv,
+  machine: MachineSupervisorConfig,
+): Candidate<string> {
+  const selected = resolveField<string>(
+    candidate('default', 'default', 'implicit default instance'),
+    stringCandidate(machine.defaultInstance, 'machine-config', 'machine.defaultInstance'),
+    stringCandidate(env['OPENALICE_INSTANCE'], 'environment', 'OPENALICE_INSTANCE'),
+    stringCandidate(flags.instance, 'cli-flag', '--instance'),
+  )
+  if (!INSTANCE_NAME_PATTERN.test(selected.value)) {
+    throw launchContextError(
+      'EINSTANCENAME',
+      `Invalid OpenAlice instance "${selected.value}". Use a lowercase name beginning with a letter and containing only letters, numbers, "_" or "-".`,
+    )
+  }
+  return selected
+}
+
+function resolveSupervisorRoot(
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+  platform: NodeJS.Platform,
+  cwd: string,
+): Candidate<string> {
+  if (env['OPENALICE_SUPERVISOR_HOME']) {
+    return candidate(
+      resolveUserPath(env['OPENALICE_SUPERVISOR_HOME'], cwd, homeDir),
+      'environment',
+      'OPENALICE_SUPERVISOR_HOME',
+    )
+  }
+  if (platform === 'win32') {
+    const localAppData = env['LOCALAPPDATA']
+    const root = localAppData
+      ? resolveUserPath(localAppData, cwd, homeDir)
+      : join(homeDir, 'AppData', 'Local')
+    return candidate(join(root, 'OpenAlice', 'Supervisor'), 'default', 'platform user config directory')
+  }
+  if (platform === 'darwin') {
+    return candidate(
+      join(homeDir, 'Library', 'Application Support', 'OpenAlice', 'Supervisor'),
+      'default',
+      'platform user config directory',
+    )
+  }
+  const xdg = env['XDG_CONFIG_HOME']
+    ? resolveUserPath(env['XDG_CONFIG_HOME'], cwd, homeDir)
+    : join(homeDir, '.config')
+  return candidate(join(xdg, 'openalice'), 'default', 'platform user config directory')
+}
+
+function resolveField<T>(
+  fallback: Candidate<T>,
+  ...overrides: Array<Candidate<T> | undefined>
+): Candidate<T> {
+  return overrides.reduce<Candidate<T>>(
+    (resolved, next) => next ?? resolved,
+    fallback,
+  )
+}
+
+function candidate<T>(
+  value: T,
+  source: LaunchValueSource,
+  detail: string,
+): Candidate<T> {
+  return { value, provenance: { source, detail } }
+}
+
+function stringCandidate(
+  value: string | undefined,
+  source: LaunchValueSource,
+  detail: string,
+): Candidate<string> | undefined {
+  return value === undefined ? undefined : candidate(value, source, detail)
+}
+
+function numberCandidate(
+  value: number | undefined,
+  source: LaunchValueSource,
+  detail: string,
+): Candidate<number> | undefined {
+  return value === undefined ? undefined : candidate(parsePort(value, detail), source, detail)
+}
+
+function booleanCandidate(
+  value: boolean | undefined,
+  source: LaunchValueSource,
+  detail: string,
+): Candidate<boolean> | undefined {
+  return value === undefined ? undefined : candidate(value, source, detail)
+}
+
+function pathCandidate(
+  value: string | undefined,
+  source: LaunchValueSource,
+  detail: string,
+  cwd: string,
+  homeDir: string,
+): Candidate<string> | undefined {
+  return value === undefined
+    ? undefined
+    : candidate(resolveUserPath(value, cwd, homeDir), source, detail)
+}
+
+function nullablePathCandidate(
+  value: string | null | undefined,
+  source: LaunchValueSource,
+  detail: string,
+  cwd: string,
+  homeDir: string,
+): Candidate<string | null> | undefined {
+  if (value === undefined) return undefined
+  return candidate(value === null ? null : resolveUserPath(value, cwd, homeDir), source, detail)
+}
+
+function resolveUserPath(value: string, cwd: string, homeDir: string): string {
+  if (value === '~') return homeDir
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return resolve(homeDir, value.slice(2))
+  }
+  return isAbsolute(value) ? resolve(value) : resolve(cwd, value)
+}
+
+function parsePort(value: string | number, label: string): number {
+  const port = typeof value === 'number' ? value : Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw launchContextError('EPORT', `${label} must be an integer between 1 and 65535.`)
+  }
+  return port
+}
+
+function parseBoolean(value: string, label: string): boolean {
+  if (value === '1' || value === 'true') return true
+  if (value === '0' || value === 'false') return false
+  throw launchContextError('EBOOLEAN', `${label} must be one of 1, 0, true, or false.`)
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index]
+  if (!value || value.startsWith('--')) {
+    throw launchContextError('EUSAGE', `${flag} requires a value`, 2)
+  }
+  return value
+}
+
+function launchContextError(
+  code: string,
+  message: string,
+  exitCode = 1,
+): Error & { code: string; exitCode: number } {
+  return Object.assign(new Error(message), { code, exitCode })
+}
+
+function deepFreeze<T extends object>(value: T): T {
+  for (const child of Object.values(value)) {
+    if (child && typeof child === 'object' && !Object.isFrozen(child)) {
+      deepFreeze(child)
+    }
+  }
+  return Object.freeze(value)
+}

--- a/packages/cli/src/lifecycle-command.mjs
+++ b/packages/cli/src/lifecycle-command.mjs
@@ -1,5 +1,9 @@
 import { parseLocalStartArgs } from './local-start.mjs'
 import {
+  buildManagedPiEnv,
+  resolveLaunchContext,
+} from './launch-context.ts'
+import {
   inspectRuntime,
   lifecycleError,
   openRuntime,
@@ -30,18 +34,18 @@ export const ROOT_COMMANDS = Object.freeze([
 
 const LIFECYCLE_OPTIONS = Object.freeze({
   up: [
-    '--app-dir', '--home', '--port', '--log', '--wait', '--rebuild',
+    '--instance', '--app-dir', '--home', '--port', '--log', '--wait', '--rebuild',
     '--skip-prepare', '--takeover', '--open', '--no-open', '--no-update-check', '--json',
   ],
   run: [
-    '--app-dir', '--home', '--port', '--wait', '--rebuild',
+    '--instance', '--app-dir', '--home', '--port', '--wait', '--rebuild',
     '--skip-prepare', '--takeover', '--no-update-check',
   ],
-  down: ['--home', '--wait', '--json'],
-  status: ['--home', '--wait', '--json'],
-  logs: ['--home', '--lines', '--json'],
-  doctor: ['--home', '--wait', '--json'],
-  open: ['--home', '--wait'],
+  down: ['--instance', '--home', '--wait', '--json'],
+  status: ['--instance', '--home', '--wait', '--json'],
+  logs: ['--instance', '--home', '--lines', '--json'],
+  doctor: ['--instance', '--home', '--wait', '--json'],
+  open: ['--instance', '--home', '--wait'],
 })
 
 export function parseLifecycleArgs(action, argv) {
@@ -51,6 +55,7 @@ export function parseLifecycleArgs(action, argv) {
   }
 
   const options = {
+    instance: null,
     homeRoot: null,
     json: false,
     waitMs: action === 'down' ? 15_000 : 2_000,
@@ -67,6 +72,10 @@ export function parseLifecycleArgs(action, argv) {
       options.homeRoot = requireValue(argv, ++index, arg)
       continue
     }
+    if (arg === '--instance') {
+      options.instance = requireValue(argv, ++index, arg)
+      continue
+    }
     if (arg === '--wait') {
       options.waitMs = parseWait(requireValue(argv, ++index, arg))
       continue
@@ -80,10 +89,28 @@ export async function runLifecycleCommand(action, options, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const stderr = dependencies.stderr ?? process.stderr
   try {
+    const context = await (
+      dependencies.resolveContext
+      ?? ((flags) => resolveLaunchContext({
+        flags,
+        env: dependencies.env,
+      }))
+    )({
+      instance: options.instance ?? undefined,
+      home: options.homeRoot ?? undefined,
+    })
+    const resolvedOptions = {
+      ...options,
+      homeRoot: context.home,
+    }
+    const runtimeDependencies = {
+      ...dependencies,
+      env: buildManagedPiEnv(context, dependencies.env ?? process.env),
+    }
     if (action === 'up' || action === 'run') {
       const humanOutput = !options.json
-      const result = await (dependencies.startRuntime ?? startRuntime)(options, {
-        ...dependencies,
+      const result = await (dependencies.startRuntime ?? startRuntime)(resolvedOptions, {
+        ...runtimeDependencies,
         detached: action === 'up',
         progressOutput: humanOutput ? stdout : undefined,
         emit: humanOutput
@@ -97,7 +124,7 @@ export async function runLifecycleCommand(action, options, dependencies = {}) {
         opened = await (dependencies.openRuntime ?? openRuntime)({
           homeRoot: result.homeRoot,
           waitMs: options.waitMs,
-        }, dependencies)
+        }, runtimeDependencies)
       }
       if (options.json) {
         writeJson(stdout, successEnvelope(action, {
@@ -112,14 +139,20 @@ export async function runLifecycleCommand(action, options, dependencies = {}) {
     }
 
     if (action === 'status') {
-      const status = await (dependencies.inspectRuntime ?? inspectRuntime)(options, dependencies)
+      const status = await (dependencies.inspectRuntime ?? inspectRuntime)(
+        resolvedOptions,
+        runtimeDependencies,
+      )
       if (options.json) writeJson(stdout, successEnvelope(action, { status }))
       else stdout.write(formatLifecycleStatus(status))
       return 0
     }
 
     if (action === 'down') {
-      const result = await (dependencies.stopRuntime ?? stopRuntime)(options, dependencies)
+      const result = await (dependencies.stopRuntime ?? stopRuntime)(
+        resolvedOptions,
+        runtimeDependencies,
+      )
       if (options.json) writeJson(stdout, successEnvelope(action, result))
       else if (result.stopped) stdout.write(`OpenAlice Runtime stopped (${result.status.home})\n`)
       else stdout.write(`OpenAlice Runtime is not running (${result.status.home})\n`)
@@ -127,7 +160,10 @@ export async function runLifecycleCommand(action, options, dependencies = {}) {
     }
 
     if (action === 'open') {
-      const result = await (dependencies.openRuntime ?? openRuntime)(options, dependencies)
+      const result = await (dependencies.openRuntime ?? openRuntime)(
+        resolvedOptions,
+        runtimeDependencies,
+      )
       stdout.write(`Opened OpenAlice Web UI: ${result.url}\n`)
       return 0
     }
@@ -152,6 +188,7 @@ for Guardian control and Alice HTTP readiness, then returns. The Runtime
 survives this shell.
 
 Options:
+  --instance <name>  Select a named complete-home instance
   --app-dir <path>   OpenAlice checkout (default: current directory or parent)
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --port <port>      Local Web port (default: 47331)
@@ -174,6 +211,7 @@ Runs a source-backed OpenAlice Runtime in the foreground without opening a
 browser. Ctrl+C stops the self-owned Guardian process tree.
 
 Options:
+  --instance <name>  Select a named complete-home instance
   --app-dir <path>   OpenAlice checkout (default: current directory or parent)
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --port <port>      Local Web port (default: 47331)
@@ -283,6 +321,7 @@ ${fishCompletionOptions()}
 }
 
 function parseStartArgs(action, argv) {
+  let instance = null
   let json = false
   let openRequested = false
   let noOpenRequested = false
@@ -290,6 +329,11 @@ function parseStartArgs(action, argv) {
   const startArgv = []
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
+    if (arg === '--instance') {
+      if (instance !== null) throw usageError('--instance may only be provided once')
+      instance = requireValue(argv, ++index, arg)
+      continue
+    }
     if (arg === '--json') {
       if (action === 'run') throw usageError('openalice run does not support --json')
       json = true
@@ -318,6 +362,7 @@ function parseStartArgs(action, argv) {
   }
   return {
     ...parsed,
+    instance,
     openBrowser: action === 'up' && openRequested,
     json,
     logFile,
@@ -435,6 +480,7 @@ function formatControlHelp(action, description, defaultWaitSeconds, json) {
 ${description}
 
 Options:
+  --instance <name>  Select a named complete-home instance
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --wait <seconds>   Control timeout, 1-600 (default: ${defaultWaitSeconds})
 ${json ? '  --json             Print a versioned machine-readable result\n' : ''}  -h, --help         Show this help

--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -12,6 +12,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
   it('parses background startup independently from browser opening', () => {
     expect(parseLifecycleArgs('up', [
       '/tmp/OpenAlice',
+      '--instance', 'research',
       '--home', '/tmp/alice-home',
       '--port', '41000',
       '--log', '/tmp/openalice.log',
@@ -20,6 +21,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
       '--json',
     ])).toEqual(expect.objectContaining({
       appDir: '/tmp/OpenAlice',
+      instance: 'research',
       homeRoot: '/tmp/alice-home',
       port: 41000,
       logFile: '/tmp/openalice.log',
@@ -45,11 +47,13 @@ describe('OpenAlice top-level lifecycle commands', () => {
 
   it('uses explicit control timeouts and exit-code-2 usage errors', () => {
     expect(parseLifecycleArgs('status', ['--home', '/tmp/alice-home', '--wait', '3', '--json'])).toEqual({
+      instance: null,
       homeRoot: '/tmp/alice-home',
       json: true,
       waitMs: 3_000,
     })
     expect(parseLifecycleArgs('down', [])).toEqual({
+      instance: null,
       homeRoot: null,
       json: false,
       waitMs: 15_000,
@@ -116,6 +120,52 @@ describe('OpenAlice top-level lifecycle commands', () => {
     expect(stdout.text()).toContain('keep running')
     expect(stdout.text()).toContain('Opened OpenAlice Web UI')
     expect(openRuntime).toHaveBeenCalledOnce()
+  })
+
+  it('shares named-home and managed-Pi isolation with noninteractive startup', async () => {
+    const startRuntime = vi.fn(async () => startedResult())
+    await expect(runLifecycleCommand('up', parseLifecycleArgs('up', [
+      '--instance', 'research',
+      '--home', '/tmp/research-home',
+    ]), {
+      env: {
+        OPENALICE_MANAGED_PI_PATH: '/managed/pi/cli.js',
+        PI_CODING_AGENT_DIR: '/native/pi',
+      },
+      startRuntime,
+      stdout: output(),
+    })).resolves.toBe(0)
+
+    expect(startRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: 'research',
+        homeRoot: '/tmp/research-home',
+      }),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          PI_CODING_AGENT_DIR: '/tmp/research-home/runtime/pi',
+          PI_CODING_AGENT_SESSION_DIR: '/tmp/research-home/runtime/pi/sessions',
+        }),
+      }),
+    )
+  })
+
+  it('does not redirect external Pi during source lifecycle commands', async () => {
+    const inspectRuntime = vi.fn(async () => absentStatus())
+    await expect(runLifecycleCommand('status', parseLifecycleArgs('status', [
+      '--home', '/tmp/source-home',
+    ]), {
+      env: { PI_CODING_AGENT_DIR: '/native/pi' },
+      inspectRuntime,
+      stdout: output(),
+    })).resolves.toBe(0)
+
+    expect(inspectRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ homeRoot: '/tmp/source-home' }),
+      expect.objectContaining({
+        env: expect.objectContaining({ PI_CODING_AGENT_DIR: '/native/pi' }),
+      }),
+    )
   })
 
   it('keeps already-absent down idempotent', async () => {

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -3,6 +3,7 @@ import { access, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
+import { buildManagedPiEnvForHome } from './launch-context.ts'
 import {
   LOOPBACK,
   createStartupSignalGuard,
@@ -192,7 +193,7 @@ function configuredLocalUrl(port) {
 
 export function buildLocalRuntimeEnv(env, options) {
   const runtimeEnv = {
-    ...env,
+    ...buildManagedPiEnvForHome(options.homeRoot, env),
     OPENALICE_HOME: options.homeRoot,
     OPENALICE_APP_HOME: options.appDir,
     OPENALICE_BIND_HOST: LOOPBACK,

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -152,6 +152,24 @@ describe('OpenAlice local Runtime launcher', () => {
     expect(runtimeEnv).not.toHaveProperty('OPENALICE_TAKEOVER')
   })
 
+  it('isolates managed Pi for every local Guardian launch path', () => {
+    const runtimeEnv = buildLocalRuntimeEnv({
+      OPENALICE_MANAGED_PI_PATH: '/managed/pi/cli.js',
+      PI_CODING_AGENT_DIR: '/native/pi',
+    }, {
+      appDir: '/tmp/OpenAlice',
+      homeRoot: '/tmp/alice-home',
+      nodeBinary: '/test/node',
+      port: 41_000,
+      takeover: false,
+    })
+
+    expect(runtimeEnv).toEqual(expect.objectContaining({
+      PI_CODING_AGENT_DIR: '/tmp/alice-home/runtime/pi',
+      PI_CODING_AGENT_SESSION_DIR: '/tmp/alice-home/runtime/pi/sessions',
+    }))
+  })
+
   it('starts the built Guardian on loopback and preserves explicit takeover', async () => {
     const child = new FakeChild()
     const spawnProcess = vi.fn(() => child)

--- a/packages/cli/src/main.spec.ts
+++ b/packages/cli/src/main.spec.ts
@@ -8,7 +8,7 @@ describe('OpenAlice TypeScript application entry', () => {
 
     await expect(main([], { runTui })).resolves.toBe(0)
 
-    expect(runTui).toHaveBeenCalledOnce()
+    expect(runTui).toHaveBeenCalledWith({})
   })
 
   it('keeps the explicit tui alias', async () => {
@@ -16,7 +16,25 @@ describe('OpenAlice TypeScript application entry', () => {
 
     await expect(main(['tui'], { runTui })).resolves.toBe(0)
 
-    expect(runTui).toHaveBeenCalledOnce()
+    expect(runTui).toHaveBeenCalledWith({})
+  })
+
+  it('resolves TUI launch flags before terminal startup', async () => {
+    const runTui = vi.fn(async () => 0)
+
+    await expect(main([
+      '--instance', 'research',
+      '--home', './isolated',
+      '--port', '44000',
+      '--no-update-check',
+    ], { runTui })).resolves.toBe(0)
+
+    expect(runTui).toHaveBeenCalledWith({
+      instance: 'research',
+      home: './isolated',
+      port: 44_000,
+      updateChecks: false,
+    })
   })
 
   it('rejects unknown tui options before terminal startup', async () => {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,8 +1,14 @@
 import { main as runLegacyCommand } from '../bin/openalice.mjs'
+import {
+  parseTuiLaunchArgs,
+  type TuiLaunchFlags,
+} from './launch-context.ts'
 import { runSupervisorTui } from './supervisor-tui.ts'
 
 export interface CliDependencies {
-  runTui?: typeof runSupervisorTui
+  runTui?: (
+    flags?: TuiLaunchFlags,
+  ) => Promise<number>
 }
 
 export async function main(
@@ -13,19 +19,27 @@ export async function main(
   if (command === 'tui') {
     if (args.includes('--help') || args.includes('-h')) {
       process.stdout.write(`Usage:
-  openalice tui
+  openalice tui [options]
 
 Open the local OpenAlice Supervisor TUI. Detaching never stops the Runtime.
+
+Options:
+  --instance <name>  Select a named complete-home instance
+  --home <path>      Override the selected complete home
+  --port <port>      Runtime Web port for a start/restart
+  --app-dir <path>   Source Runtime checkout
+  --no-update-check  Disable background update discovery
+  --update-check     Enable background update discovery
 `)
       return 0
     }
-    if (args.length > 0) {
-      throw usageError(`Unknown tui option: ${args[0]}`)
-    }
-    return (dependencies.runTui ?? runSupervisorTui)()
+    return (dependencies.runTui ?? runSupervisorTui)(parseTuiLaunchArgs(args))
   }
   if (command === undefined) {
-    return (dependencies.runTui ?? runSupervisorTui)()
+    return (dependencies.runTui ?? runSupervisorTui)({})
+  }
+  if (command.startsWith('-') && !['--help', '-h', '--version'].includes(command)) {
+    return (dependencies.runTui ?? runSupervisorTui)(parseTuiLaunchArgs(argv))
   }
   return runLegacyCommand(argv)
 }

--- a/packages/cli/src/observability-command.mjs
+++ b/packages/cli/src/observability-command.mjs
@@ -1,9 +1,14 @@
 import { diagnoseRuntime } from './doctor.mjs'
+import {
+  buildManagedPiEnv,
+  resolveLaunchContext,
+} from './launch-context.ts'
 import { readRuntimeLogs } from './logs.mjs'
 
 export function parseObservabilityArgs(action, argv) {
   if (!['logs', 'doctor'].includes(action)) throw usageError(`Unknown observability command: ${String(action)}`)
   const options = {
+    instance: null,
     homeRoot: null,
     json: false,
     waitMs: 2_000,
@@ -18,6 +23,10 @@ export function parseObservabilityArgs(action, argv) {
     }
     if (arg === '--home') {
       options.homeRoot = requireValue(argv, ++index, arg)
+      continue
+    }
+    if (arg === '--instance') {
+      options.instance = requireValue(argv, ++index, arg)
       continue
     }
     if (arg === '--wait' && action === 'doctor') {
@@ -37,14 +46,38 @@ export async function runObservabilityCommand(action, options, dependencies = {}
   const stdout = dependencies.stdout ?? process.stdout
   const stderr = dependencies.stderr ?? process.stderr
   try {
+    const context = await (
+      dependencies.resolveContext
+      ?? ((flags) => resolveLaunchContext({
+        flags,
+        env: dependencies.env,
+      }))
+    )({
+      instance: options.instance ?? undefined,
+      home: options.homeRoot ?? undefined,
+    })
+    const resolvedOptions = {
+      ...options,
+      homeRoot: context.home,
+    }
+    const runtimeDependencies = {
+      ...dependencies,
+      env: buildManagedPiEnv(context, dependencies.env ?? process.env),
+    }
     if (action === 'logs') {
-      const logs = await (dependencies.readLogs ?? readRuntimeLogs)(options, dependencies)
+      const logs = await (dependencies.readLogs ?? readRuntimeLogs)(
+        resolvedOptions,
+        runtimeDependencies,
+      )
       if (options.json) writeJson(stdout, successEnvelope(action, { logs }))
       else stdout.write(formatRuntimeLogs(logs))
       return 0
     }
     if (action === 'doctor') {
-      const doctor = await (dependencies.diagnose ?? diagnoseRuntime)(options, dependencies)
+      const doctor = await (dependencies.diagnose ?? diagnoseRuntime)(
+        resolvedOptions,
+        runtimeDependencies,
+      )
       if (options.json) writeJson(stdout, successEnvelope(action, { doctor }))
       else stdout.write(formatDoctor(doctor))
       return doctor.summary.failures > 0 ? 1 : 0
@@ -68,6 +101,7 @@ Prints a bounded, redacted tail of the selected Runtime log. Only regular
 server.log rotation files inside the selected OpenAlice home are read.
 
 Options:
+  --instance <name>  Select a named complete-home instance
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --lines <count>    Last 1-5000 lines (default: 200)
   --json             Print a versioned machine-readable result
@@ -83,6 +117,7 @@ compatibility, Web readiness, components, provider artifacts, update metadata,
 and safe log discovery.
 
 Options:
+  --instance <name>  Select a named complete-home instance
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --wait <seconds>   Control timeout, 1-600 (default: 2)
   --json             Print a versioned machine-readable result

--- a/packages/cli/src/observability-command.spec.mjs
+++ b/packages/cli/src/observability-command.spec.mjs
@@ -8,13 +8,15 @@ import {
 
 describe('observability command presenter', () => {
   it('parses bounded logs and Doctor options', () => {
-    expect(parseObservabilityArgs('logs', ['--home', '/tmp/alice', '--lines', '50', '--json'])).toEqual({
+    expect(parseObservabilityArgs('logs', ['--instance', 'research', '--home', '/tmp/alice', '--lines', '50', '--json'])).toEqual({
+      instance: 'research',
       homeRoot: '/tmp/alice',
       json: true,
       waitMs: 2_000,
       lines: 50,
     })
     expect(parseObservabilityArgs('doctor', ['--wait', '3', '--json'])).toEqual({
+      instance: null,
       homeRoot: null,
       json: true,
       waitMs: 3_000,
@@ -65,6 +67,33 @@ describe('observability command presenter', () => {
     expect(exitCode).toBe(1)
     expect(stdout.value).toContain('[FAIL] Web is unavailable')
     expect(formatObservabilityHelp('doctor')).toContain('read-only checks')
+  })
+
+  it('uses the same selected home for logs and Doctor', async () => {
+    const readLogs = vi.fn(async () => ({
+      home: '/tmp/research',
+      component: 'runtime',
+      lineLimit: 200,
+      truncated: false,
+      files: [],
+      entries: [],
+    }))
+    await runObservabilityCommand(
+      'logs',
+      parseObservabilityArgs('logs', [
+        '--instance', 'research',
+        '--home', '/tmp/research',
+      ]),
+      { readLogs, stdout: sink() },
+    )
+
+    expect(readLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: 'research',
+        homeRoot: '/tmp/research',
+      }),
+      expect.any(Object),
+    )
   })
 })
 

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -62,4 +62,53 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
   })
+
+  it('renders an explicitly selected launch context before detach', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-context-'))
+    temporaryPaths.push(isolatedHome)
+    const instanceHome = join(isolatedHome, 'research')
+    const child = pty.spawn(process.execPath, [
+      cliEntry,
+      '--instance', 'research',
+      '--home', instanceHome,
+      '--port', '44000',
+      '--no-update-check',
+    ], {
+      cols: 120,
+      rows: 28,
+      cwd: dirname(cliEntry),
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor launch-context TUI timed out:\n${output}`))
+      }, 8_000)
+      child.onData((data) => {
+        output += data
+        if (!detached && output.includes('Resolved: home (--home) · port (--port)')) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor launch-context TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain('Instance: research')
+    expect(transcript).toContain(`Home: ${instanceHome}`)
+    expect(transcript).toContain('Resolved: home (--home) · port (--port)')
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  })
 })

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import type { Component, KeyId } from '@earendil-works/pi-tui'
 
 import { diagnoseRuntime } from './doctor.mjs'
@@ -8,6 +9,14 @@ import {
   startRuntime,
   stopRuntime,
 } from './lifecycle.mjs'
+import {
+  buildManagedPiEnv,
+  resolveLaunchContext,
+  type InstanceLaunchConfig,
+  type MachineSupervisorConfig,
+  type ResolvedLaunchContext,
+  type TuiLaunchFlags,
+} from './launch-context.ts'
 import { readRuntimeLogs } from './logs.mjs'
 import { loadPiTui } from './pi-tui-loader.ts'
 import {
@@ -81,6 +90,7 @@ export interface SupervisorSnapshot {
   version: string
   channel: string
   runtime: RuntimeSummary | null
+  context?: ResolvedLaunchContext
   diagnostic?: string
   panel?: SupervisorPanel
   busy?: string
@@ -103,6 +113,11 @@ export interface SupervisorTuiDependencies {
   diagnose?: (options: Record<string, unknown>) => Promise<DoctorReport>
   checkUpdate?: () => Promise<UpdateResult>
   discoverUpdate?: () => Promise<UpdateResult | null>
+  resolveContext?: (
+    flags: TuiLaunchFlags,
+  ) => ResolvedLaunchContext | Promise<ResolvedLaunchContext>
+  machineConfig?: MachineSupervisorConfig | null
+  instanceConfig?: InstanceLaunchConfig | null
   loadTui?: typeof loadPiTui
   version?: string
   channel?: string
@@ -121,6 +136,7 @@ interface SupervisorServices {
 }
 
 export async function runSupervisorTui(
+  launchFlags: TuiLaunchFlags = {},
   dependencies: SupervisorTuiDependencies = {},
 ): Promise<number> {
   const stdin = dependencies.stdin ?? process.stdin
@@ -132,24 +148,38 @@ export async function runSupervisorTui(
     )
   }
 
-  const services = createServices(dependencies)
+  const context = await (
+    dependencies.resolveContext
+    ?? ((flags) => resolveLaunchContext({
+      flags,
+      machineConfig: dependencies.machineConfig,
+      instanceConfig: dependencies.instanceConfig,
+      env: dependencies.env,
+    }))
+  )(launchFlags)
+  const services = createServices(dependencies, context)
   let runtime: RuntimeSummary | null = null
   let diagnostic: string | undefined
   try {
-    runtime = await services.inspect()
+    runtime = await services.inspect({ homeRoot: context.home, waitMs: 2_000 })
   } catch (error: unknown) {
     diagnostic = safeError(error)
   }
 
   const piTui = await (dependencies.loadTui ?? loadPiTui)(dependencies.env)
   const terminal = new piTui.ProcessTerminal()
-  const ui = new piTui.TUI(terminal)
+  const ui = new piTui.TUI(
+    terminal,
+    undefined,
+    join(context.supervisorRoot, 'logs'),
+  )
   let active = true
   let actionRunning = false
   const screen = new SupervisorScreen({
     version: dependencies.version ?? readCliVersion(),
     channel: dependencies.channel ?? 'development',
     runtime,
+    context,
     diagnostic,
   }, {
     onAction: (action) => {
@@ -163,7 +193,7 @@ export async function runSupervisorTui(
     if (!active || actionRunning) return
     try {
       const nextRuntime = await services.inspect({
-        homeRoot: screen.snapshot.runtime?.home,
+        homeRoot: context.home,
         waitMs: 1_000,
       })
       if (!active) return
@@ -177,7 +207,7 @@ export async function runSupervisorTui(
   async function performAction(action: SupervisorAction): Promise<void> {
     if (!active || actionRunning) return
     actionRunning = true
-    const homeRoot = screen.snapshot.runtime?.home
+    const homeRoot = context.home
     const actionLabel = actionName(action)
     screen.update({ busy: actionLabel, notice: undefined, diagnostic: undefined })
     try {
@@ -185,10 +215,10 @@ export async function runSupervisorTui(
         await services.start({
           prepare: true,
           rebuild: false,
-          checkUpdates: true,
-          port: runtimeWebPort(screen.snapshot.runtime) ?? 47_331,
+          checkUpdates: context.updateChecks,
+          port: context.port,
           homeRoot,
-          appDir: screen.snapshot.runtime?.provider?.root,
+          appDir: context.appDir ?? screen.snapshot.runtime?.provider?.root,
           waitMs: 120_000,
           takeover: false,
         })
@@ -207,8 +237,8 @@ export async function runSupervisorTui(
         await services.start({
           prepare: true,
           rebuild: false,
-          checkUpdates: true,
-          port: runtimeWebPort(screen.snapshot.runtime) ?? 47_331,
+          checkUpdates: context.updateChecks,
+          port: context.port,
           homeRoot,
           appDir,
           waitMs: 120_000,
@@ -240,6 +270,7 @@ export async function runSupervisorTui(
   }
 
   async function discoverUpdateInBackground(): Promise<void> {
+    if (!context.updateChecks) return
     try {
       const update = await services.discoverUpdate()
       if (!update) return
@@ -401,7 +432,8 @@ export class SupervisorScreen implements Component {
     } else {
       lines.push(
         narrow ? `Runtime: ${state}` : `Runtime state: ${state}`,
-        `Home: ${runtime?.home ?? 'default'}`,
+        `Instance: ${this.snapshot.context?.instance ?? 'default'}`,
+        `Home: ${this.snapshot.context?.home ?? runtime?.home ?? 'default'}`,
       )
       if (!narrow) {
         lines.push(
@@ -414,6 +446,9 @@ export class SupervisorScreen implements Component {
         }
         if (Number.isInteger(runtime?.uptimeSeconds)) {
           lines.push(`Uptime: ${formatDuration(runtime?.uptimeSeconds ?? 0)}`)
+        }
+        if (this.snapshot.context) {
+          lines.push(`Resolved: home ${formatProvenance(this.snapshot.context.provenance.home)} · port ${formatProvenance(this.snapshot.context.provenance.port)}`)
         }
       }
       lines.push('', ...renderGuidance(runtime))
@@ -457,8 +492,13 @@ export class SupervisorScreen implements Component {
   }
 }
 
-function createServices(dependencies: SupervisorTuiDependencies): SupervisorServices {
-  const shared = { env: dependencies.env ?? process.env }
+function createServices(
+  dependencies: SupervisorTuiDependencies,
+  context: ResolvedLaunchContext,
+): SupervisorServices {
+  const shared = {
+    env: buildManagedPiEnv(context, dependencies.env ?? process.env),
+  }
   return {
     inspect: dependencies.inspect ?? ((options) => inspectRuntime(options, shared)),
     start: dependencies.start ?? ((options) => startRuntime(options, {
@@ -622,15 +662,8 @@ function formatDuration(seconds: number): string {
   return `${Math.floor(seconds / 3_600)}h ${Math.floor((seconds % 3_600) / 60)}m`
 }
 
-function runtimeWebPort(runtime: RuntimeSummary | null): number | null {
-  const value = runtime?.endpoints?.web
-  if (!value) return null
-  try {
-    const port = Number(new URL(value).port)
-    return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null
-  } catch {
-    return null
-  }
+function formatProvenance(value: { source: string; detail: string }): string {
+  return value.source === 'default' ? '(default)' : `(${value.detail})`
 }
 
 function safeError(error: unknown): string {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -390,9 +390,9 @@ and verification before the next dependent branch starts from updated `dev`.
   flags once into `ResolvedLaunchContext`, retaining field-level provenance.
 - [ ] Add `openalice config check` plus TUI diagnostics; invalid live reload
   retains the last valid configuration.
-- [ ] Give OpenAlice-managed Pi an instance-local `PI_CODING_AGENT_DIR` and
+- [x] Give OpenAlice-managed Pi an instance-local `PI_CODING_AGENT_DIR` and
   session root without changing a user-installed Pi launched externally.
-- [ ] Update the managed Workspace runtime owner guide and tests for the new
+- [x] Update the managed Workspace runtime owner guide and tests for the new
   managed-Pi isolation boundary.
 - [ ] Define a versioned atomic CLI-owned registry mapping names to complete
   homes; never store the registry inside a selected home.
@@ -622,3 +622,23 @@ This plan is complete only when:
   The Docker installer playground remained unavailable because this host still
   had no reachable Docker/OrbStack daemon; the equivalent local transaction and
   real PTY lifecycle journeys passed.
+- 2026-07-30: Audited the full Pi `0.80.3` to `0.83.0` range (371 commits)
+  against OpenAlice's actual imports, generated configuration, managed runtime,
+  and installer/package paths. None of the three upstream breaking-change
+  groups are reachable from OpenAlice. The exact Supervisor `pi-tui` API
+  surface and Node floor remain compatible; `0.83.0` is the accepted baseline
+  without a compatibility fork. Recorded the break matrix and future extension
+  guardrail in [[docs/reference/pi-herdr-cli-architecture.md]].
+- 2026-07-30: Added the immutable launch-context foundation for the TUI:
+  default/machine/instance/environment/flag precedence, field provenance,
+  named complete-home selection, source root, port, update policy, and a
+  machine-wide Supervisor root outside selectable data homes. Installed
+  managed Pi now receives instance-private agent and session roots, while
+  source development, external Pi, and the standalone installed `pi` launcher
+  preserve native user state. TUI and lifecycle/observability commands now use
+  the same selected home, preventing `openalice up` from creating a different
+  managed-Pi environment than a TUI start. Added source and installed-payload
+  regression coverage plus a real PTY journey for explicit
+  instance/home/port selection. Persisted configuration schemas, registry
+  loading, and full root-parser conversion remain in the configuration
+  increment.


### PR DESCRIPTION
## Summary
- audit Pi 0.80.3 through 0.83.0 and accept 0.83.0 as the compatible OpenAlice baseline
- resolve immutable instance/home/port/source/update launch context before TUI startup, with field provenance and named-instance flags
- share selected-home semantics across TUI, lifecycle, logs, and Doctor commands
- isolate installer-managed Pi state per OpenAlice complete home without changing external/source Pi behavior
- include the new module in the direct installer payload and use Pi 0.83's Supervisor log-directory seam

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm -F @traderalice/openalice-cli test` (149 passed)
- `pnpm test` (3,658 passed, 9 skipped)
- real PTY launch-context selection and terminal restoration
- real local installer payload regression in the CLI suite

## Residual
- `pnpm test:install:docker` could not run locally because the configured OrbStack Docker socket is absent. The equivalent local installer and real PTY paths passed.
