### PR TITLE
Make market details legible on mobile

### DIFF
--- a/ui/src/components/market/Card.tsx
+++ b/ui/src/components/market/Card.tsx
@@ -12,6 +12,7 @@ interface Props {
   info?: string | null
   right?: ReactNode
   className?: string
+  headerClassName?: string
   contentClassName?: string
   children: ReactNode
 }
@@ -21,10 +22,10 @@ interface Props {
  * Title + optional info hint + optional right slot + content. No
  * cross-panel smarts — each panel owns its own fetch and render.
  */
-export function Card({ title, info, right, className, contentClassName, children }: Props) {
+export function Card({ title, info, right, className, headerClassName, contentClassName, children }: Props) {
   return (
     <section className={`flex flex-col border border-border rounded bg-secondary/30 ${className ?? ''}`}>
-      <header className="flex items-center justify-between gap-3 px-3 py-2 border-b border-border/60">
+      <header className={`flex gap-3 border-b border-border/60 px-3 py-2 ${headerClassName ?? 'items-center justify-between'}`}>
         <div className="flex items-center gap-1.5 min-w-0">
           <h3 className="text-[13px] font-medium text-foreground truncate">{title}</h3>
           {info && (

--- a/ui/src/components/market/FinancialStatementsPanel.spec.tsx
+++ b/ui/src/components/market/FinancialStatementsPanel.spec.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FinancialStatementsPanel } from './FinancialStatementsPanel'
+
+const mocks = vi.hoisted(() => ({
+  balance: vi.fn(),
+  income: vi.fn(),
+  cashflow: vi.fn(),
+}))
+
+vi.mock('../../api/market', () => ({
+  marketApi: {
+    equity: {
+      balance: mocks.balance,
+      income: mocks.income,
+      cashflow: mocks.cashflow,
+    },
+  },
+}))
+
+const statement = {
+  period_ending: '2026-06-30',
+  fiscal_period: 'FY',
+  revenue: 416_160_000_000,
+  total_assets: 350_000_000_000,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.balance.mockResolvedValue({ results: [statement], provider: 'test' })
+  mocks.income.mockResolvedValue({ results: [statement], provider: 'test' })
+  mocks.cashflow.mockResolvedValue({ results: [statement], provider: 'test' })
+})
+
+afterEach(cleanup)
+
+describe('FinancialStatementsPanel', () => {
+  it('stacks the title above equal-width, touch-friendly tabs on narrow screens', async () => {
+    render(<FinancialStatementsPanel symbol="AAPL" />)
+
+    const heading = screen.getByRole('heading', { name: 'Financial Statements' })
+    expect(heading.closest('header')?.className).toContain('flex-col')
+    expect(heading.closest('header')?.className).toContain('sm:flex-row')
+
+    const tablist = screen.getByRole('tablist', { name: 'Financial statement type' })
+    expect(tablist.className).toContain('grid-cols-3')
+    expect(tablist.className).toContain('sm:flex')
+
+    const income = screen.getByRole('tab', { name: 'Income' })
+    expect(income.className).toContain('min-h-10')
+    expect(income.className).toContain('sm:min-h-0')
+    expect(income.getAttribute('aria-selected')).toBe('true')
+    expect(await screen.findByText('416.16B')).toBeTruthy()
+  })
+
+  it('exposes the selected statement and loads another tab on activation', async () => {
+    const user = userEvent.setup()
+    render(<FinancialStatementsPanel symbol="AAPL" />)
+
+    const balance = screen.getByRole('tab', { name: 'Balance' })
+    expect(balance.getAttribute('aria-selected')).toBe('false')
+
+    await user.click(balance)
+
+    expect(balance.getAttribute('aria-selected')).toBe('true')
+    expect(screen.getByRole('tab', { name: 'Income' }).getAttribute('aria-selected')).toBe('false')
+    expect(mocks.balance).toHaveBeenCalledWith('AAPL')
+  })
+})

--- a/ui/src/components/market/FinancialStatementsPanel.tsx
+++ b/ui/src/components/market/FinancialStatementsPanel.tsx
@@ -114,14 +114,22 @@ export function FinancialStatementsPanel({ symbol }: Props) {
     <Card
       title="Financial Statements"
       info={info}
-      contentClassName="overflow-x-auto p-0"
+      headerClassName="flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
+      contentClassName="overflow-x-auto overscroll-x-contain p-0"
       right={
-        <div className="flex border border-border rounded overflow-hidden">
+        <div
+          className="grid grid-cols-3 overflow-hidden rounded border border-border sm:flex"
+          role="tablist"
+          aria-label="Financial statement type"
+        >
           {TABS.map((t, i) => (
             <button
               key={t.key}
+              type="button"
+              role="tab"
+              aria-selected={tab === t.key}
               onClick={() => setTab(t.key)}
-              className={`px-2.5 py-1 text-[12px] transition-colors cursor-pointer ${
+              className={`min-h-10 px-2.5 py-1 text-[12px] transition-colors cursor-pointer sm:min-h-0 ${
                 i > 0 ? 'border-l border-border' : ''
               } ${tab === t.key ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
             >

--- a/ui/src/components/market/TradeableContractsPanel.spec.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.spec.tsx
@@ -65,6 +65,40 @@ describe('TradeableContractsPanel', () => {
     expect(screen.getByRole('button', { name: '收起' })).toBeTruthy()
   })
 
+  it('keeps canonical contract identity and the order action legible on narrow rows', async () => {
+    mocks.searchContracts.mockResolvedValue({
+      utasConfigured: 1,
+      results: [hit('AAPL', 'alpaca-paper|AAPL')],
+    })
+
+    render(
+      <MemoryRouter>
+        <TradeableContractsPanel symbol="AAPL" assetClass="equity" />
+      </MemoryRouter>,
+    )
+
+    const symbol = await screen.findByText('AAPL')
+    const row = symbol.closest('li')
+    expect(row?.className).toContain('grid-cols-[minmax(0,1fr)_auto]')
+    expect(row?.className).toContain('sm:flex')
+
+    const description = screen.getByText('AAPL equity · NASDAQ · USD')
+    expect(description.className).toContain('col-span-2')
+    expect(description.className).toContain('sm:flex-1')
+
+    const canonicalId = screen.getByText('alpaca-paper|AAPL')
+    expect(canonicalId.className).toContain('min-w-0')
+    expect(canonicalId.getAttribute('title')).toBe('alpaca-paper|AAPL')
+
+    const account = screen.getByText('alpaca-paper')
+    expect(account.className).toContain('hidden sm:inline')
+
+    const order = screen.getByRole('link', { name: '下单 →' })
+    expect(order.className).toContain('min-h-8')
+    expect(order.className).toContain('sm:min-h-0')
+    expect(order.getAttribute('href')).toBe('/uta/alpaca-paper?aliceId=alpaca-paper%7CAAPL')
+  })
+
   it('localizes the no-match state with the requested symbol', async () => {
     mocks.searchContracts.mockResolvedValue({ utasConfigured: 1, results: [] })
 

--- a/ui/src/components/market/TradeableContractsPanel.tsx
+++ b/ui/src/components/market/TradeableContractsPanel.tsx
@@ -133,32 +133,42 @@ function ContractRow({ hit }: { hit: ContractSearchHit }) {
   const orderHref = aliceId
     ? `/uta/${encodeURIComponent(hit.source)}?aliceId=${encodeURIComponent(aliceId)}`
     : null
+  const description = [c.description || c.localSymbol, c.primaryExchange ?? c.exchange, c.currency]
+    .filter(Boolean)
+    .join(' · ')
   return (
-    <li className="px-3 py-2 flex items-baseline gap-3 text-[12px] hover:bg-muted/40 transition-colors">
-      <span className="font-mono font-semibold text-foreground">{c.symbol ?? '—'}</span>
-      {c.secType && (
-        <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
-          {c.secType}
-        </span>
-      )}
-      <span className="text-muted-foreground/70 truncate flex-1">
-        {[c.description || c.localSymbol, c.primaryExchange ?? c.exchange, c.currency]
-          .filter(Boolean)
-          .join(' · ')}
+    <li className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1 px-3 py-2 text-[12px] transition-colors hover:bg-muted/40 sm:flex sm:items-baseline sm:gap-3">
+      <span className="flex min-w-0 items-center gap-2 sm:contents">
+        <span className="truncate font-mono font-semibold text-foreground">{c.symbol ?? '—'}</span>
+        {c.secType && (
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            {c.secType}
+          </span>
+        )}
       </span>
-      <span className="text-[10px] text-muted-foreground/60 shrink-0">{hit.source}</span>
-      {aliceId && (
-        <code
-          className="text-[10px] font-mono text-muted-foreground truncate max-w-[260px]"
-          title={aliceId}
-        >
-          {aliceId}
-        </code>
-      )}
+
+      <span className="col-span-2 min-w-0 truncate text-muted-foreground/70 sm:flex-1">
+        {description}
+      </span>
+
+      <span className="col-span-2 flex min-w-0 items-center gap-2">
+        <span className={`${aliceId ? 'hidden sm:inline' : ''} shrink-0 text-[10px] text-muted-foreground/60`}>
+          {hit.source}
+        </span>
+        {aliceId && (
+          <code
+            className="min-w-0 max-w-full truncate font-mono text-[10px] text-muted-foreground sm:max-w-[260px]"
+            title={aliceId}
+          >
+            {aliceId}
+          </code>
+        )}
+      </span>
+
       {orderHref && (
         <Link
           to={orderHref}
-          className="text-[11px] text-primary hover:underline shrink-0"
+          className="row-start-1 col-start-2 inline-flex min-h-8 shrink-0 items-center rounded-md px-2 text-[11px] text-primary hover:bg-primary/10 sm:min-h-0 sm:rounded-none sm:px-0 sm:hover:bg-transparent sm:hover:underline"
           title={t('market.tradeableOrderTitle')}
         >
           {t('market.tradeableOrder')} →


### PR DESCRIPTION
## What changed

- restructure broker contract matches into a three-level mobile row: symbol/type, contract description, then canonical `aliceId`
- keep the order action pinned to the mobile row header with a larger touch target
- stack the Financial Statements heading above three equal-width mobile tabs instead of truncating the heading
- expose statement choices as a named tablist with selected-state semantics and 40px mobile targets
- preserve compact single-line headers and rows from the `sm` breakpoint upward
- add focused responsive-structure, navigation, and tab-selection regression coverage

## Why

The market-detail page had two desktop-first compression failures at 320px:

1. Broker account and canonical contract identity collapsed into unreadable fragments such as `alpaca-d3b9a58c a`.
2. The Financial Statements heading was squeezed from 129px to 16px and rendered as `F...` beside its controls.

Both failures hid the identity of important decision surfaces immediately before users inspect broker contracts or company financials.

These changes are presentation-only. Contract search, `aliceId` values, account routing, financial data, calculations, and trading writes are unchanged.

## Verification

- `pnpm exec vitest run ui/src/components/market/TradeableContractsPanel.spec.tsx ui/src/components/market/FinancialStatementsPanel.spec.tsx`
- `pnpm --dir ui exec tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (436 files passed, 1 skipped; 3661 tests passed, 9 skipped)
- real `pnpm dev` browser checks at 320px, 390px, and 1280px on `/market/equity/AAPL`

Live-paper trading was not run because this is a presentation-only change and does not alter broker or order semantics.
