### PR TITLE
Make mobile Trading as Git list-first

### DIFF
--- a/ui/src/components/PushApprovalPanel.spec.tsx
+++ b/ui/src/components/PushApprovalPanel.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../i18n'
@@ -182,5 +182,48 @@ describe('PushApprovalPanel localization', () => {
     expect(screen.getByRole('button', { name: '确认推送' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '取消' })).toBeTruthy()
     expect(mocks.walletPush).not.toHaveBeenCalled()
+  })
+
+  it('uses a queue-to-detail drill-in on narrow layouts while preserving the desktop split view', async () => {
+    mocks.walletStatus.mockResolvedValue({
+      staged: [{
+        action: 'placeOrder',
+        contract: { symbol: 'AAPL' },
+        order: {
+          action: 'BUY',
+          orderType: 'LMT',
+          totalQuantity: '2',
+          lmtPrice: '210',
+        },
+      }],
+      pendingMessage: '调整 AAPL 仓位',
+      head: 'abc123456789',
+      commitCount: 1,
+    })
+
+    render(<PushApprovalPanel />)
+
+    const queue = await screen.findByTestId('trading-review-queue')
+    const detail = screen.getByTestId('trading-review-detail')
+    expect(queue.className).toContain('flex')
+    expect(queue.className).toContain('md:flex')
+    expect(detail.className).toContain('hidden')
+    expect(detail.className).toContain('md:block')
+
+    const queueRow = await screen.findByRole('button', { name: /调整 AAPL 仓位/ })
+    fireEvent.click(queueRow)
+
+    expect(queue.className).toContain('hidden')
+    expect(detail.className).toContain('block')
+    expect(detail.className).toContain('overflow-x-hidden')
+
+    const back = screen.getByRole('button', { name: '返回队列' })
+    expect(back.className).toContain('min-h-10')
+    await waitFor(() => expect(document.activeElement).toBe(back))
+    fireEvent.click(back)
+
+    expect(queue.className).toContain('flex')
+    expect(detail.className).toContain('hidden')
+    await waitFor(() => expect(document.activeElement).toBe(queueRow))
   })
 })

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, type Ref } from 'react'
 import type { TFunction } from 'i18next'
-import { AlertTriangle, CheckCircle2, Clock3, GitCommitHorizontal, GitPullRequest, History, RefreshCw, XCircle } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, ChevronLeft, Clock3, GitCommitHorizontal, GitPullRequest, History, RefreshCw, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { EmptyState, Skeleton } from './StateViews'
 import { formatRelativeTime, getIntlLocale } from '../lib/intl'
@@ -276,7 +276,10 @@ export function PushApprovalPanel() {
   const [error, setError] = useState<string | null>(null)
   const [loaded, setLoaded] = useState(false)
   const [historyFilter, setHistoryFilter] = useState<string | null>(null)
+  const [mobileDetailOpen, setMobileDetailOpen] = useState(false)
   const [retryingVerification, setRetryingVerification] = useState(false)
+  const mobileBackRef = useRef<HTMLButtonElement | null>(null)
+  const activeQueueRowRef = useRef<HTMLButtonElement | null>(null)
   const [verification, setVerification] = useState<ReviewVerification>({
     total: 0,
     verified: 0,
@@ -449,12 +452,20 @@ export function PushApprovalPanel() {
   useEffect(() => {
     if (reviewItems.length === 0) {
       setSelectedId(null)
+      setMobileDetailOpen(false)
       return
     }
     if (!selectedId || !reviewItems.some((item) => item.id === selectedId)) {
       setSelectedId(reviewItems[0].id)
+      setMobileDetailOpen(false)
     }
   }, [reviewItems, selectedId])
+
+  useEffect(() => {
+    if (!mobileDetailOpen) return
+    if (typeof window.matchMedia === 'function' && !window.matchMedia('(max-width: 767px)').matches) return
+    mobileBackRef.current?.focus()
+  }, [mobileDetailOpen])
 
   const selected = reviewItems.find((item) => item.id === selectedId) ?? null
   const waitingCount = pending.length
@@ -498,7 +509,10 @@ export function PushApprovalPanel() {
         />
       )}
       <div className="grid min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border border-border bg-secondary/30 md:grid-cols-[250px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)]">
-        <div className="flex min-h-0 min-w-0 flex-col border-b border-border bg-secondary md:border-b-0 md:border-r">
+        <div
+          data-testid="trading-review-queue"
+          className={`${mobileDetailOpen ? 'hidden' : 'flex'} min-h-0 min-w-0 flex-col bg-secondary md:flex md:border-r`}
+        >
           <div className="shrink-0 border-b border-border/70 px-4 py-3">
             <div className="flex items-center gap-2 text-[12px] font-medium text-foreground">
               {verificationIncomplete || waitingCount > 0 ? (
@@ -559,7 +573,11 @@ export function PushApprovalPanel() {
                     key={item.id}
                     item={item}
                     active={item.id === selectedId}
-                    onClick={() => setSelectedId(item.id)}
+                    buttonRef={item.id === selectedId ? activeQueueRowRef : undefined}
+                    onClick={() => {
+                      setSelectedId(item.id)
+                      setMobileDetailOpen(true)
+                    }}
                   />
                 ))}
               </div>
@@ -571,7 +589,24 @@ export function PushApprovalPanel() {
           </div>
         </div>
 
-        <div className="min-h-0 min-w-0 overflow-y-auto">
+        <div
+          data-testid="trading-review-detail"
+          className={`${mobileDetailOpen ? 'block' : 'hidden'} min-h-0 min-w-0 overflow-x-hidden overflow-y-auto md:block`}
+        >
+          <div className="sticky top-0 z-10 border-b border-border bg-secondary/95 px-3 py-2 md:hidden">
+            <button
+              ref={mobileBackRef}
+              type="button"
+              onClick={() => {
+                setMobileDetailOpen(false)
+                requestAnimationFrame(() => activeQueueRowRef.current?.focus())
+              }}
+              className="oa-pressable inline-flex min-h-10 items-center gap-1.5 rounded-md px-2 text-[12px] font-medium text-primary"
+            >
+              <ChevronLeft size={15} aria-hidden />
+              {t('tradingReview.queue.backToQueue')}
+            </button>
+          </div>
           <ReviewDetail
             item={selected}
             verificationIncomplete={verificationIncomplete}
@@ -668,7 +703,17 @@ function QueueStat({ label, value, tone }: { label: string; value: number; tone:
   )
 }
 
-function QueueRow({ item, active, onClick }: { item: ReviewItem; active: boolean; onClick: () => void }) {
+function QueueRow({
+  item,
+  active,
+  buttonRef,
+  onClick,
+}: {
+  item: ReviewItem
+  active: boolean
+  buttonRef?: Ref<HTMLButtonElement>
+  onClick: () => void
+}) {
   const { t } = useTranslation()
   const ops = itemOperations(item, t)
   const timestamp = itemTimestamp(item)
@@ -683,6 +728,7 @@ function QueueRow({ item, active, onClick }: { item: ReviewItem; active: boolean
 
   return (
     <button
+      ref={buttonRef}
       type="button"
       onClick={onClick}
       className={`w-full rounded-md border px-3 py-2 text-left transition-colors ${

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1310,6 +1310,7 @@ export const en = {
       pushed: 'Pushed',
       accountFilter: 'Account filter',
       all: 'All',
+      backToQueue: 'Back to queue',
       review: 'review',
       stagedBadge: 'staged',
       operationCount_one: '{{count}} op',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1299,6 +1299,7 @@ export const ja: Resources = {
       pushed: 'プッシュ済み',
       accountFilter: '口座フィルター',
       all: 'すべて',
+      backToQueue: 'キューに戻る',
       review: '確認',
       stagedBadge: 'ステージ済み',
       operationCount_one: '{{count}} 件の操作',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1306,6 +1306,7 @@ export const zhHant: Resources = {
       pushed: '已推送',
       accountFilter: '帳戶篩選',
       all: '全部',
+      backToQueue: '返回佇列',
       review: '審閱',
       stagedBadge: '已暫存',
       operationCount_one: '{{count}} 項操作',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1298,6 +1298,7 @@ export const zh: Resources = {
       pushed: '已推送',
       accountFilter: '账户筛选',
       all: '全部',
+      backToQueue: '返回队列',
       review: '审阅',
       stagedBadge: '已暂存',
       operationCount_one: '{{count}} 项操作',


### PR DESCRIPTION
## What changed

- replace the compressed stacked queue/detail layout with a mobile list-first drill-down
- let the queue use the full review surface until a user selects an item
- show the selected review in the full surface with a sticky, 40px-tall Back to queue action
- move focus to Back to queue when entering a review and restore it to the selected row on return
- hide the inactive surface below `md` while preserving the existing desktop split view
- localize the back action in English, Simplified Chinese, Traditional Chinese, and Japanese

## Why

With 40 realistic review records at 320px, the desktop split view became two stacked nested scrollers:

- the queue had only 63px of visible height for 3312px of content
- the detail had 235px of visible height for 616px of content
- selecting a row hid the focused element without moving focus to the detail

That made routine mobile review and approval navigation unnecessarily difficult. The new hierarchy treats narrow layouts as a real master-detail flow instead of a compressed desktop view.

Broker reads, wallet state, approval checks, push/reject handlers, and trading semantics are unchanged.

## Verification

- `pnpm exec vitest run ui/src/components/PushApprovalPanel.spec.tsx`
- `pnpm --dir ui exec tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (435 files passed, 1 skipped; 3659 tests passed, 9 skipped)
- real `pnpm dev` checks with 40 review records:
  - 320px queue and detail dimensions
  - 390px detail readability and focus ring
  - 1280px desktop split view
  - queue → detail → queue focus round trip

Live-paper trading was not run because this change does not stage, approve, reject, or submit broker operations.
