### PR TITLE
Make mobile Inbox provenance actionable

### DIFF
--- a/ui/src/components/InboxReplyThread.spec.tsx
+++ b/ui/src/components/InboxReplyThread.spec.tsx
@@ -54,7 +54,11 @@ describe('InboxReplyThread', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Reply to this update…' }), {
       target: { value: 'Which data did you use?' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Reply' }))
+    const reply = screen.getByRole('button', { name: 'Reply' })
+    expect(reply.className).toContain('h-10')
+    expect(reply.className).toContain('w-10')
+    expect(reply.className).toContain('sm:h-8')
+    fireEvent.click(reply)
 
     await waitFor(() => expect(ask).toHaveBeenCalledWith('Which data did you use?'))
     await waitFor(() => expect(load).toHaveBeenCalledTimes(2))

--- a/ui/src/components/InboxReplyThread.tsx
+++ b/ui/src/components/InboxReplyThread.tsx
@@ -72,7 +72,7 @@ export function InboxReplyThread({
             type="button"
             onClick={() => void thread.submit()}
             disabled={thread.sending || thread.prompt.trim().length === 0}
-            className="oa-pressable inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-primary px-2.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-35 sm:px-3"
+            className="oa-pressable inline-flex h-10 w-10 shrink-0 items-center justify-center gap-1.5 rounded-lg bg-primary px-0 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-35 sm:h-8 sm:w-auto sm:px-3"
             aria-label={thread.sending ? t('inbox.replySending') : t('inbox.replyAction')}
           >
             {thread.sending

--- a/ui/src/pages/InboxPage.spec.tsx
+++ b/ui/src/pages/InboxPage.spec.tsx
@@ -156,3 +156,47 @@ describe('InboxPage deletion', () => {
     await waitFor(() => expect(screen.queryByText('Delete Inbox entry?')).toBeNull())
   })
 })
+
+describe('InboxPage responsive detail header', () => {
+  it('keeps long provenance readable and mobile actions touch-sized', async () => {
+    const entry = {
+      id: 'inbox-mobile-header',
+      ts: Date.now(),
+      workspaceId: 'ws-1',
+      workspaceLabel: 'research',
+      comments: 'A durable research update.',
+      origin: {
+        kind: 'headless' as const,
+        agent: 'pi',
+        runId: 'run-mobile-header',
+        resumeId: 'resume-plain-linen-river-2218b6',
+        issueId: 'daily-us-market-close-with-a-long-name',
+      },
+    }
+    vi.spyOn(api.inbox, 'history').mockResolvedValue({
+      entries: [entry],
+      hasMore: false,
+    })
+    useInboxSelection.getState().select(entry.id)
+
+    render(<InboxPage visible />)
+
+    const sender = await screen.findByText('from pi · @resume-plain-linen-river-2218b6')
+    expect(sender.className).toContain('break-all')
+    expect(sender.className).toContain('sm:truncate')
+
+    const issue = screen.getByRole('button', {
+      name: 'from daily-us-market-close-with-a-long-name',
+    })
+    expect(issue.className).toContain('min-h-10')
+    expect(issue.className).toContain('sm:min-h-0')
+
+    const openConversation = screen.getByRole('button', { name: 'Open conversation' })
+    expect(openConversation.className).toContain('h-10')
+    expect(openConversation.className).toContain('sm:h-8')
+
+    const deleteEntry = screen.getByRole('button', { name: 'Delete this inbox entry' })
+    expect(deleteEntry.className).toContain('h-10')
+    expect(deleteEntry.className).toContain('w-10')
+  })
+})

--- a/ui/src/pages/InboxPage.spec.tsx
+++ b/ui/src/pages/InboxPage.spec.tsx
@@ -79,6 +79,25 @@ describe('InboxAttachment', () => {
     expect(await screen.findByTitle('HTML report: research/close-report.html')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Collapse attachment close-report.html' })).toBeTruthy()
   })
+
+  it('keeps markdown asset actions touch-sized on mobile and compact on desktop', async () => {
+    render(
+      <InboxAttachment
+        workspaceId="ws-1"
+        doc={{ path: 'research/close-report.md' }}
+        defaultExpanded={false}
+      />,
+    )
+
+    const copy = await screen.findByRole('button', { name: 'Copy Markdown' })
+    const download = screen.getByRole('button', { name: 'Download Markdown' })
+    for (const action of [copy, download]) {
+      expect(action.className).toContain('h-10')
+      expect(action.className).toContain('w-10')
+      expect(action.className).toContain('sm:h-7')
+      expect(action.className).toContain('sm:w-7')
+    }
+  })
 })
 
 describe('InboxPage deletion', () => {

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -321,9 +321,9 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
     <div className="mx-auto max-w-[920px] px-4 py-6 md:px-8 md:py-8">
       {/* Provenance is identity, not a third way to open the same Session. */}
       <header className="mb-6 border-b border-border/70 pb-4">
-        <div className="flex items-start gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
           <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <div className="flex min-w-0 flex-col items-start gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
               <span
                 className={`text-[14px] font-semibold ${
                   wsAlive ? 'text-foreground' : 'text-muted-foreground/70 line-through'
@@ -334,14 +334,16 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
               </span>
               {senderLabel && (
                 <span
-                  className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground/75"
+                  className="inline-flex min-w-0 items-start gap-1.5 text-[11px] text-muted-foreground/75 sm:items-center"
                   title={t('inbox.senderIdentityTitle', { sender: senderLabel })}
                 >
                   <ChevronRight size={11} className="shrink-0 text-muted-foreground/35" aria-hidden />
                   {origin?.kind === 'interactive'
                     ? <Terminal size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />
                     : <Bot size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />}
-                  <span className="max-w-[380px] truncate">{t('inbox.fromSender', { sender: senderLabel })}</span>
+                  <span className="min-w-0 break-all sm:max-w-[380px] sm:truncate">
+                    {t('inbox.fromSender', { sender: senderLabel })}
+                  </span>
                 </span>
               )}
               {issueId && (
@@ -349,10 +351,12 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
                   type="button"
                   onClick={openIssue}
                   title={t('inbox.fromIssueTitle', { issue: issueId })}
-                  className="oa-pressable inline-flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground/75 hover:bg-primary/10 hover:text-primary"
+                  className="oa-pressable inline-flex min-h-10 w-full min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-left text-[11px] text-muted-foreground/75 hover:bg-primary/10 hover:text-primary sm:min-h-0 sm:w-auto sm:py-0.5"
                 >
                   <ListChecks size={12} strokeWidth={1.75} className="shrink-0" />
-                  <span className="max-w-[220px] truncate">{t('inbox.fromIssue', { issue: issueTitle ?? issueId })}</span>
+                  <span className="min-w-0 break-words sm:max-w-[220px] sm:truncate">
+                    {t('inbox.fromIssue', { issue: issueTitle ?? issueId })}
+                  </span>
                 </button>
               )}
             </div>
@@ -362,13 +366,13 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
               {formatRelativeTime(entry.ts)}
             </div>
           </div>
-          <div className="-mr-1 flex shrink-0 items-center gap-1">
+          <div className="flex w-full items-center gap-2 sm:-mr-1 sm:w-auto sm:shrink-0 sm:gap-1">
             {wsAlive && (
               <button
                 type="button"
                 onClick={() => void continueOrigin()}
                 disabled={continuing}
-                className="oa-pressable inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-background px-2 text-[11px] font-medium text-muted-foreground hover:border-primary/35 hover:text-primary disabled:cursor-not-allowed disabled:opacity-45 sm:px-2.5"
+                className="oa-pressable inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-lg border border-border bg-background px-2 text-[11px] font-medium text-muted-foreground hover:border-primary/35 hover:text-primary disabled:cursor-not-allowed disabled:opacity-45 sm:h-8 sm:flex-none sm:px-2.5"
                 title={canContinueOrigin ? t('inbox.openConversation') : t('inbox.openWorkspace')}
                 aria-label={canContinueOrigin ? t('inbox.openConversation') : t('inbox.openWorkspace')}
               >
@@ -390,7 +394,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
             <button
               type="button"
               onClick={onDelete}
-              className="oa-pressable inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground/45 hover:bg-destructive/10 hover:text-destructive"
+              className="oa-pressable inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground/55 hover:border-destructive/30 hover:bg-destructive/10 hover:text-destructive sm:h-8 sm:w-8 sm:border-transparent sm:bg-transparent"
               title={t('inbox.deleteEntryTitle')}
               aria-label={t('inbox.deleteEntryAriaLabel')}
             >

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -555,14 +555,14 @@ export function InboxAttachment({
           />
         </button>
         {isMarkdownPath(doc.path) && (
-          <div className="flex shrink-0 items-center gap-0.5 border-l border-border/60 px-2">
+          <div className="flex shrink-0 items-center gap-0.5 border-l border-border/60 px-1 sm:px-2">
             <button
               type="button"
               onClick={copyMarkdown}
               disabled={!markdownActionsAvailable}
               title={copied ? t('inbox.docCopiedMarkdown') : t('inbox.docCopyMarkdown')}
               aria-label={copied ? t('inbox.docCopiedMarkdown') : t('inbox.docCopyMarkdown')}
-              className="oa-pressable inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/55 hover:bg-muted hover:text-primary disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/55"
+              className="oa-pressable inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground/55 hover:bg-muted hover:text-primary disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/55 sm:h-7 sm:w-7"
             >
               {copied ? <Check size={14} strokeWidth={2} /> : <Copy size={14} strokeWidth={1.75} />}
             </button>
@@ -572,7 +572,7 @@ export function InboxAttachment({
               disabled={!markdownActionsAvailable}
               title={t('inbox.docDownloadMarkdown')}
               aria-label={t('inbox.docDownloadMarkdown')}
-              className="oa-pressable inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/55 hover:bg-muted hover:text-primary disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/55"
+              className="oa-pressable inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground/55 hover:bg-muted hover:text-primary disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/55 sm:h-7 sm:w-7"
             >
               <Download size={14} strokeWidth={1.75} />
             </button>


### PR DESCRIPTION
## Topic

Make Inbox identity, provenance, and follow-up actions usable on phones without changing desktop density or delivery semantics.

## Why

At 320 px the selected entry header kept Open chat and Delete beside the provenance block. The sender identity shrank from 229 px of content to a 111 px clipped label, the Issue source relied on truncation, and the two header actions were only 32 px high. Attachment Copy/Download actions were 28 px square and Reply was 32 px high.

Touch users could not recover the full sender from a hover title, and the controls used for follow-up were materially smaller than the surrounding mobile surface.

## Atomic increments

1. Make the mobile detail header stack identity before actions, let sender and Issue provenance wrap, and raise Open chat and Delete to 40 px while preserving the compact desktop row.
2. Raise mobile attachment Copy/Download and Reply actions to 40 px, preserving 28–32 px desktop controls.

## Real-route evidence

Verified with pnpm dev on /inbox:

- At 320×700, the full sender identity and Issue source are visible; Open chat fills the action row and Delete is a bordered 40 px target.
- At 390×844, the detail remains single-column with no clipped provenance, and the attachment plus reply controls remain usable.
- At 1280×900, the original compact single-line provenance header, attachment actions, and reply layout are retained.
- Attachment preview, collapse, reply focus, and delete confirmation were exercised. No Inbox entry was deleted and no reply was sent.

## Verification

- npx tsc --noEmit
- pnpm --dir ui exec tsc -b
- pnpm vitest run ui/src/pages/InboxPage.spec.tsx ui/src/components/InboxReplyThread.spec.tsx — 9 passed
- pnpm test — 435 files passed, 1 skipped; 3661 tests passed, 9 skipped
- git diff --check
- Real browser verification at 320×700, 390×844, and 1280×900

## Non-goals

- Changing Inbox delivery, reply dispatch, deletion, or attachment behavior
- Redesigning the Inbox sidebar
- Changing Issue detail or Workspace navigation
- Merging without maintainer acceptance