### PR TITLE
Make mobile Tracked context legible

### DIFF
--- a/ui/src/pages/FileViewerPage.spec.tsx
+++ b/ui/src/pages/FileViewerPage.spec.tsx
@@ -72,6 +72,10 @@ describe('FileViewerPage back navigation', () => {
 
     const back = screen.getByRole('button', { name: 'Back to Semis and supply chain' })
     expect(back.getAttribute('title')).toBe('Back to Semis and supply chain')
+    expect(back.className).toContain('h-10')
+    expect(back.className).toContain('w-10')
+    expect(back.className).toContain('sm:h-7')
+    expect(screen.getByText('research/note.md').className).toContain('break-all')
     const workspaceIdentity = screen.getByText('Semis and supply chain')
     expect(workspaceIdentity.getAttribute('title')).toBe('Semis and supply chain\nchat-jul20')
     fireEvent.click(back)

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -72,27 +72,32 @@ export function FileViewerPage({ spec }: Props) {
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-secondary/30 shrink-0">
+      <div className="flex shrink-0 items-start gap-2 border-b border-border bg-secondary/30 px-4 py-2 sm:items-center">
         <button
           type="button"
           onClick={goBack}
           aria-label={backLabel}
-          className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center gap-1.5 rounded-md border border-border bg-background px-0 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground sm:h-7 sm:w-auto sm:px-2"
           title={backLabel}
         >
           <ArrowLeft size={14} strokeWidth={1.8} aria-hidden />
           <span className="hidden sm:inline">{t('fileViewer.back')}</span>
         </button>
-        <FileText size={13} strokeWidth={1.75} className="shrink-0 text-muted-foreground/70" aria-hidden />
-        <span className="font-mono text-[12px] text-foreground truncate" title={path}>
-          {path}
-        </span>
-        <span
-          className="ml-auto min-w-0 max-w-[min(35vw,20rem)] truncate text-right text-[11px] text-muted-foreground/70"
-          title={workspaceTitle}
-        >
-          {workspaceName}
-        </span>
+        <FileText size={13} strokeWidth={1.75} className="mt-1 shrink-0 text-muted-foreground/70 sm:mt-0" aria-hidden />
+        <div className="min-w-0 flex-1 sm:contents">
+          <span
+            className="block break-all font-mono text-[12px] leading-4 text-foreground sm:min-w-0 sm:flex-1 sm:truncate sm:leading-normal"
+            title={path}
+          >
+            {path}
+          </span>
+          <span
+            className="mt-1 block break-all text-[11px] text-muted-foreground/70 sm:ml-auto sm:mt-0 sm:max-w-[min(35vw,20rem)] sm:truncate sm:text-right"
+            title={workspaceTitle}
+          >
+            {workspaceName}
+          </span>
+        </div>
       </div>
       <div className="flex-1 overflow-y-auto min-h-0">
         <div className="max-w-[820px] mx-auto px-6 py-6">

--- a/ui/src/pages/TrackedPage.spec.tsx
+++ b/ui/src/pages/TrackedPage.spec.tsx
@@ -92,6 +92,10 @@ describe('TrackedPage artifact navigation', () => {
     const backlink = await screen.findByRole('button', {
       name: /research\/power\.md/,
     })
+    expect(backlink.className).toContain('min-h-10')
+    expect(within(backlink).getByText('research/power.md').className).toContain('break-all')
+    expect(within(backlink).getAllByText('power')).toHaveLength(2)
+    expect(screen.getByRole('heading', { name: 'stock-vst' }).className).toContain('break-words')
     fireEvent.click(backlink)
 
     await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -222,10 +222,12 @@ function Detail({ detail }: { detail: EntityDetail }) {
   const Icon = entity.type === 'asset' ? TrendingUp : Hash
   return (
     <div className="max-w-[820px] mx-auto py-6 px-4 md:px-8">
-      <div className="flex items-center gap-2.5 mb-2">
+      <div className="mb-2 flex items-start gap-2.5 sm:items-center">
         <Icon size={20} strokeWidth={1.75} className="shrink-0 text-muted-foreground" aria-hidden />
-        <h2 className="text-[20px] font-semibold font-mono text-foreground">{entity.name}</h2>
-        <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">
+        <h2 className="min-w-0 break-words font-mono text-[18px] font-semibold leading-snug text-foreground sm:text-[20px]">
+          {entity.name}
+        </h2>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
           {entity.type}
         </span>
       </div>
@@ -310,16 +312,25 @@ function BacklinkRow({
       type="button"
       onClick={open}
       title={issueId ? `Open issue ${issueId}` : `Open ${backlink.path}`}
-      className="group flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-muted/30 hover:bg-muted hover:border-primary/40 transition-colors text-left"
+      className="group flex min-h-10 items-start gap-2.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5 text-left transition-colors hover:border-primary/40 hover:bg-muted sm:items-center sm:py-2"
     >
       <Icon
         size={14}
         strokeWidth={1.75}
-        className="shrink-0 text-muted-foreground/70 group-hover:text-primary transition-colors"
+        className="mt-0.5 shrink-0 text-muted-foreground/70 transition-colors group-hover:text-primary sm:mt-0"
         aria-hidden
       />
-      <span className="flex-1 min-w-0 truncate font-mono text-[12px] text-foreground">{label}</span>
-      <span className="shrink-0 text-[11px] text-muted-foreground/60">{backlink.workspaceTag}</span>
+      <span className="min-w-0 flex-1">
+        <span className="block break-all font-mono text-[12px] leading-5 text-foreground sm:truncate sm:leading-normal">
+          {label}
+        </span>
+        <span className="mt-0.5 block break-all text-[11px] text-muted-foreground/60 sm:hidden">
+          {backlink.workspaceTag}
+        </span>
+      </span>
+      <span className="hidden max-w-[35%] shrink-0 truncate text-[11px] text-muted-foreground/60 sm:block">
+        {backlink.workspaceTag}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Topic

Keep Tracked entity identity, backlink provenance, and artifact return context legible and touch-friendly on phones.

## Why

The Tracked overview was readable at phone width, but long entity names used the desktop title treatment and referenced-note rows were roughly 34 px high. Each backlink truncated its file path while keeping the Workspace tag beside it.

After opening a backlink, the file viewer reduced Back to a 28 px icon and compressed the file path plus Workspace into one truncated row. The complete values existed only in hover titles, which touch users cannot recover.

## Atomic increments

1. Use a responsive Tracked title treatment, raise backlink rows to a 40 px floor, and show full file path plus Workspace provenance on mobile while preserving the compact desktop row.
2. Raise the mobile file-viewer Back action to 40 px and expose the complete path and Workspace on separate mobile lines, preserving the desktop toolbar.

## Real-route evidence

Verified with pnpm dev on /tracked and a real GLW backlink:

- At 320×700, ten-year-compounder-monitor wraps as a balanced two-line identity instead of three oversized fragments.
- Long referenced-note paths display in full with their Workspace beneath them; selecting a GLW note opens the correct artifact.
- The artifact header shows a 40 px Back action, the full research/glw-corning-deepdive.md path, and chat-jul1. Back returns to the selected stock-glw context.
- At 390×844, the file header remains compact and the article keeps its normal reading width.
- At 1280×900, the original compact Back label, single-line file path, right-aligned Workspace, and desktop Tracked sidebar remain intact.

## Verification

- npx tsc --noEmit
- pnpm --dir ui exec tsc -b
- pnpm vitest run ui/src/pages/TrackedPage.spec.tsx ui/src/pages/FileViewerPage.spec.tsx — 7 passed
- pnpm test — 435 files passed, 1 skipped; 3659 tests passed, 9 skipped
- git diff --check
- Real browser verification at 320×700, 390×844, and 1280×900

## Non-goals

- Changing Tracked entity or backlink data semantics
- Changing the mobile sidebar/drawer behavior owned by PR #861
- Changing Issue detail, file rendering, or Workspace lifecycle
- Merging without maintainer acceptance