### PR TITLE
Fix Windows CLI path expectations

### DIFF
--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -1,3 +1,5 @@
+import { join, resolve } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -45,14 +47,14 @@ describe('ResolvedLaunchContext', () => {
 
     expect(context).toMatchObject({
       instance: 'desk',
-      home: '/repo/flag-home',
+      home: resolve('/repo', 'flag-home'),
       port: 44_000,
-      appDir: '/repo/flag-app',
+      appDir: resolve('/repo', 'flag-app'),
       updateChecks: true,
-      supervisorRoot: '/Users/alice/Library/Application Support/OpenAlice/Supervisor',
+      supervisorRoot: join('/Users/alice', 'Library', 'Application Support', 'OpenAlice', 'Supervisor'),
       managedPi: {
-        codingAgentDir: '/repo/flag-home/runtime/pi',
-        sessionDir: '/repo/flag-home/runtime/pi/sessions',
+        codingAgentDir: join(resolve('/repo', 'flag-home'), 'runtime', 'pi'),
+        sessionDir: join(resolve('/repo', 'flag-home'), 'runtime', 'pi', 'sessions'),
       },
       provenance: {
         instance: { source: 'cli-flag', detail: '--instance' },
@@ -90,10 +92,10 @@ describe('ResolvedLaunchContext', () => {
       },
     })
 
-    expect(context.home).toBe('/home/alice/env-home')
+    expect(context.home).toBe(resolve('/home/alice', 'env-home'))
     expect(context.port).toBe(43_000)
     expect(context.updateChecks).toBe(false)
-    expect(context.supervisorRoot).toBe('/xdg/openalice')
+    expect(context.supervisorRoot).toBe(join(resolve('/xdg'), 'openalice'))
     expect(context.provenance.home.detail).toBe('OPENALICE_HOME')
   })
 
@@ -132,8 +134,8 @@ describe('ResolvedLaunchContext', () => {
     expect(base.PI_CODING_AGENT_DIR).toBe('/native/pi')
     expect(managed).toMatchObject({
       PATH: '/bin',
-      PI_CODING_AGENT_DIR: '/home/alice/.openalice/runtime/pi',
-      PI_CODING_AGENT_SESSION_DIR: '/home/alice/.openalice/runtime/pi/sessions',
+      PI_CODING_AGENT_DIR: join('/home/alice', '.openalice', 'runtime', 'pi'),
+      PI_CODING_AGENT_SESSION_DIR: join('/home/alice', '.openalice', 'runtime', 'pi', 'sessions'),
     })
   })
 

--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -1,3 +1,5 @@
+import { join, resolve } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -139,12 +141,12 @@ describe('OpenAlice top-level lifecycle commands', () => {
     expect(startRuntime).toHaveBeenCalledWith(
       expect.objectContaining({
         instance: 'research',
-        homeRoot: '/tmp/research-home',
+        homeRoot: resolve('/tmp/research-home'),
       }),
       expect.objectContaining({
         env: expect.objectContaining({
-          PI_CODING_AGENT_DIR: '/tmp/research-home/runtime/pi',
-          PI_CODING_AGENT_SESSION_DIR: '/tmp/research-home/runtime/pi/sessions',
+          PI_CODING_AGENT_DIR: join(resolve('/tmp/research-home'), 'runtime', 'pi'),
+          PI_CODING_AGENT_SESSION_DIR: join(resolve('/tmp/research-home'), 'runtime', 'pi', 'sessions'),
         }),
       }),
     )
@@ -161,7 +163,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
     })).resolves.toBe(0)
 
     expect(inspectRuntime).toHaveBeenCalledWith(
-      expect.objectContaining({ homeRoot: '/tmp/source-home' }),
+      expect.objectContaining({ homeRoot: resolve('/tmp/source-home') }),
       expect.objectContaining({
         env: expect.objectContaining({ PI_CODING_AGENT_DIR: '/native/pi' }),
       }),

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -165,8 +165,8 @@ describe('OpenAlice local Runtime launcher', () => {
     })
 
     expect(runtimeEnv).toEqual(expect.objectContaining({
-      PI_CODING_AGENT_DIR: '/tmp/alice-home/runtime/pi',
-      PI_CODING_AGENT_SESSION_DIR: '/tmp/alice-home/runtime/pi/sessions',
+      PI_CODING_AGENT_DIR: join('/tmp/alice-home', 'runtime', 'pi'),
+      PI_CODING_AGENT_SESSION_DIR: join('/tmp/alice-home', 'runtime', 'pi', 'sessions'),
     }))
   })
 

--- a/packages/cli/src/observability-command.spec.mjs
+++ b/packages/cli/src/observability-command.spec.mjs
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -90,7 +92,7 @@ describe('observability command presenter', () => {
     expect(readLogs).toHaveBeenCalledWith(
       expect.objectContaining({
         instance: 'research',
-        homeRoot: '/tmp/research',
+        homeRoot: resolve('/tmp/research'),
       }),
       expect.any(Object),
     )


### PR DESCRIPTION
## Summary
- replace POSIX-only path expectations in four CLI test files with Node path helpers
- preserve the runtime behavior while making the same assertions valid on macOS, Linux, and Windows
- repair the seven deterministic failures reported by PR #886's Windows cross-platform job

## Root cause
The CLI correctly resolves complete-home and managed-Pi paths with the host platform's native path module. The tests compared those results with hard-coded `/tmp/...` strings, so Windows returned canonical `D:\\tmp\\...` or `\\tmp\\...` paths and failed otherwise-correct assertions.

## Verification
- `pnpm vitest run packages/cli/src/launch-context.spec.ts packages/cli/src/lifecycle-command.spec.mjs packages/cli/src/local-start.spec.mjs packages/cli/src/observability-command.spec.mjs` (34 passed)
- `pnpm -F @traderalice/openalice-cli typecheck`
- `npx tsc --noEmit`
- `pnpm test -- --reporter=dot` (440 files passed, 1 skipped; 3698 tests passed, 9 skipped)

## Acceptance
The `cross-platform-test (windows-latest)` GitHub Actions job must pass before merge.