### PR TITLE
Make clean CLI startup self-configuring

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -99,6 +99,8 @@ runs `npm ci --omit=dev --ignore-scripts` in the staged release.
   Node 22.19+ executes its erasable types directly.
 - `packages/cli/src/install-source.mjs` — validated installation-source
   metadata used when managed remote reproduces the invoking CLI.
+- `packages/cli/src/supervisor-config.ts` — machine-local Supervisor and
+  selected-instance configuration loading and atomic persistence.
 - `packages/cli/src/install-layout.mjs` — strict discovery of installer-owned
   roots from immutable release paths.
 - `packages/cli/src/update.mjs` — stable manifest checks, bounded start notice,
@@ -205,11 +207,13 @@ before consent; no installer-owned filesystem mutation may happen there.
 | `--yes` | Approve the baseline CLI + managed Pi transaction and only the extra actions selected by flags; never implies Runtime tools and never starts the Runtime |
 | `--with-runtime-deps` | Select missing Linux build tools; does not bypass the final confirmation |
 | `--plan` | Print the same plan and exit without opening a prompt or changing files |
-| Interactive install inside a checkout | After success, separately ask `Start OpenAlice now? [y/N]` |
+| Interactive install inside a checkout | After success, separately ask `Open the OpenAlice Supervisor now? [y/N]` |
 
 The installer reads prompts from `/dev/tty`, not the curl pipe. The
-Runtime-tool selection, final plan approval, and optional service start are all
-default-no. They are intentionally different decisions. For automation,
+Runtime-tool selection, final plan approval, and optional Supervisor launch are
+all default-no. They are intentionally different decisions. Opening the
+Supervisor does not start the Runtime until the user chooses Start inside the
+TUI. For automation,
 `--yes --with-runtime-deps` is the explicit pair that approves the displayed
 Linux package command as well as the CLI transaction.
 

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -94,6 +94,7 @@ explicit commands:
 - `l` reads the bounded, redacted log tail;
 - `d` runs read-only Doctor checks;
 - `u` performs an advisory product-update check;
+- `c` chooses and remembers the selected instance's source checkout;
 - `?`, Tab, and the horizontal arrows expose help and detail panels.
 
 The TUI refuses to stop or restart Electron, development, incompatible, or
@@ -101,11 +102,11 @@ otherwise foreign owners. Its stop/restart confirmation states that active Web
 and agent sessions will disconnect. Detaching never implies stopping. Update
 discovery runs in the background and cannot block lifecycle controls.
 
-The current Runtime provider is still source-backed. TUI start therefore needs
-to run from an OpenAlice checkout (or reuse a source root advertised by the
-selected Runtime) until the standalone headless Runtime artifact ships.
-Unfinished controls remain inside the application shell and do not change the
-default entry back to the compatibility launcher.
+The current Runtime provider is still source-backed. TUI start discovers an
+OpenAlice checkout from the current directory, reuses a configured or
+owner-advertised source root, or opens the `c` path editor when discovery
+fails. Unfinished controls remain inside the application shell and do not
+change the default entry back to the compatibility launcher.
 
 ## TUI Launch Context
 
@@ -122,12 +123,18 @@ raw mode. Bare `openalice` and `openalice tui` accept:
 ```
 
 Resolution order is defaults, machine Supervisor configuration, selected
-instance configuration, environment, then explicit CLI flags. The current
-increment implements the immutable resolver, field provenance, environment and
-flag layers, plus typed seams for the two configuration layers. Persisted
-machine configuration and the instance registry are not active yet; a named
-instance therefore needs an explicit complete home through configuration
-injection, `OPENALICE_HOME`, or `--home`.
+instance configuration, environment, then explicit CLI flags. The immutable
+resolver retains field provenance for every layer. Before terminal raw mode,
+the Supervisor reads a versioned machine-local document at
+`<Supervisor root>/config.json`. It contains machine defaults and an instance
+map outside every selectable complete home.
+
+The `c` editor validates an OpenAlice checkout, atomically saves it as the
+selected instance's `appDir`, and starts the Runtime. If
+`OPENALICE_APP_HOME` or `--app-dir` supplied the source, the TUI reports that
+higher-priority override instead of overwriting it. General configuration
+editing, `openalice config check`, live reload with last-known-good retention,
+and named-instance management remain later increments.
 
 `OPENALICE_INSTANCE`, `OPENALICE_HOME`, `OPENALICE_WEB_PORT`,
 `OPENALICE_APP_HOME`, and `OPENALICE_NO_UPDATE_CHECK` are the corresponding
@@ -324,6 +331,8 @@ completion; detailed shell installation remains user-owned.
   application entry and default-TUI/explicit-command dispatch.
 - `packages/cli/src/launch-context.ts` — immutable launch precedence,
   provenance, instance roots, and managed-Pi environment projection.
+- `packages/cli/src/supervisor-config.ts` — versioned machine/instance
+  configuration parsing, atomic persistence, and stored-context resolution.
 - `packages/cli/src/supervisor-tui.ts` — `pi-tui` Supervisor application shell.
 - `packages/cli/src/pi-tui-loader.ts` — workspace and installed managed-Pi TUI
   resolution.

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -88,9 +88,11 @@ adapter workspaces for development, but `build:server` excludes those wrappers
 from UTA Core and no live SDK is evaluated at startup.
 
 When an interactive install is run from inside an OpenAlice checkout, the
-installer presents a separate, default-no `Start OpenAlice now?` prompt after
-the CLI is complete. Installation consent never implies service-start consent,
-and `--yes` remains installation-only for automation.
+installer presents a separate, default-no `Open the OpenAlice Supervisor now?`
+prompt after the CLI is complete. The Supervisor opens inside the checkout but
+does not start the Runtime until the user chooses Start inside the TUI.
+Installation consent never implies service-start consent, and `--yes` remains
+installation-only for automation.
 
 `openalice run` and compatibility `openalice start` stay in the foreground and
 own the Guardian lifetime; `Ctrl+C` stops their self-owned local Runtime. The

--- a/install
+++ b/install
@@ -670,6 +670,7 @@ FILES=(
   "src/launch-context.ts"
   "src/main.ts"
   "src/pi-tui-loader.ts"
+  "src/supervisor-config.ts"
   "src/supervisor-tui.ts"
   "src/doctor.mjs"
   "src/install-layout.mjs"
@@ -744,6 +745,7 @@ chmod +x "$STAGING/bin/openalice.ts"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.ts"
 node --check "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/src/supervisor-config.ts"
 node --check "$STAGING/src/doctor.mjs"
 node --check "$STAGING/src/install-layout.mjs"
 node --check "$STAGING/src/install-source.mjs"
@@ -919,15 +921,16 @@ if [[ -n "$checkout" ]]; then
   printf '\n%bReady to launch%b\n' "$BOLD" "$RESET"
   printf '  Checkout     %s\n' "$checkout"
   printf '  Local UI     http://127.0.0.1:47331\n'
-  printf '  Runtime      Stays attached to this terminal; Ctrl+C stops it\n'
+  printf '  Supervisor   Starts and manages a persistent background Runtime\n'
   if [[ "$TTY_OPEN" -eq 1 ]]; then
     start_status=0
-    prompt_yes_no "Start OpenAlice now? Dependency preparation may take a few minutes." || start_status=$?
+    prompt_yes_no "Open the OpenAlice Supervisor now?" || start_status=$?
     if [[ "$start_status" -eq 0 ]]; then
       exec 3>&- 3<&-
       TTY_OPEN=0
-      printf '\nStarting OpenAlice...\n\n'
-      exec "$BIN_DIR/openalice" start "$checkout"
+      printf '\nOpening the OpenAlice Supervisor...\n\n'
+      cd "$checkout"
+      exec "$BIN_DIR/openalice"
     fi
   fi
   printf '\nStart it when you are ready:\n  cd %q\n  %s\n\n' "$checkout" "$BIN_DIR/openalice"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "src/launch-context.ts",
     "src/main.ts",
     "src/pi-tui-loader.ts",
+    "src/supervisor-config.ts",
     "src/supervisor-tui.ts",
     "src/doctor.mjs",
     "src/install-layout.mjs",
@@ -31,7 +32,7 @@
     "src/update.mjs"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
+    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/supervisor-config.ts && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -242,7 +242,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(result.exitCode).toBe(0)
     expect(result.output).toContain('Continue with this install?')
     expect(result.output).toContain('OpenAlice and Pi are ready')
-    expect(result.output).toContain('Start OpenAlice now?')
+    expect(result.output).toContain('Open the OpenAlice Supervisor now?')
     expect(result.output).toContain('Start it when you are ready')
     await expect(access(join(installRoot, 'bin', 'openalice'))).resolves.toBeUndefined()
   })
@@ -296,7 +296,7 @@ function runInstallerInPty(args, { home, reply }) {
         replied = true
         terminal.write(reply)
       }
-      if (!declinedStart && output.includes('Start OpenAlice now?')) {
+      if (!declinedStart && output.includes('Open the OpenAlice Supervisor now?')) {
         declinedStart = true
         terminal.write('n\r')
       }

--- a/packages/cli/src/launch-context.ts
+++ b/packages/cli/src/launch-context.ts
@@ -69,6 +69,13 @@ export interface ResolveLaunchContextOptions {
   platform?: NodeJS.Platform
 }
 
+export interface ResolveSupervisorRootOptions {
+  env?: NodeJS.ProcessEnv
+  cwd?: string
+  homeDir?: string
+  platform?: NodeJS.Platform
+}
+
 interface Candidate<T> {
   value: T
   provenance: LaunchValueProvenance
@@ -93,7 +100,7 @@ export function resolveLaunchContext(
     )
   }
 
-  const supervisorRoot = resolveSupervisorRoot(env, homeDir, platform, cwd)
+  const supervisorRoot = resolveSupervisorRootCandidate(env, homeDir, platform, cwd)
   const home = resolveField<string>(
     candidate(join(homeDir, '.openalice'), 'default', '~/.openalice'),
     pathCandidate(machine.defaults?.home, 'machine-config', 'machine.defaults.home', cwd, homeDir),
@@ -165,6 +172,17 @@ export function resolveLaunchContext(
   })
 }
 
+export function resolveSupervisorRootPath(
+  options: ResolveSupervisorRootOptions = {},
+): string {
+  return resolveSupervisorRootCandidate(
+    options.env ?? process.env,
+    options.homeDir ?? homedir(),
+    options.platform ?? process.platform,
+    options.cwd ?? process.cwd(),
+  ).value
+}
+
 export function buildManagedPiEnv(
   context: ResolvedLaunchContext,
   baseEnv: NodeJS.ProcessEnv = process.env,
@@ -234,7 +252,7 @@ function resolveInstance(
   return selected
 }
 
-function resolveSupervisorRoot(
+function resolveSupervisorRootCandidate(
   env: NodeJS.ProcessEnv,
   homeDir: string,
   platform: NodeJS.Platform,

--- a/packages/cli/src/supervisor-config.spec.ts
+++ b/packages/cli/src/supervisor-config.spec.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  parseSupervisorConfig,
+  persistInstanceLaunchConfig,
+  resolveStoredLaunchContext,
+  supervisorConfigPath,
+} from './supervisor-config.ts'
+
+const temporaryPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )))
+})
+
+describe('Supervisor configuration', () => {
+  it('loads machine and selected-instance layers below environment and flags', async () => {
+    const context = await resolveStoredLaunchContext({
+      port: 44_000,
+    }, {
+      homeDir: '/home/alice',
+      cwd: '/repo',
+      platform: 'linux',
+      env: {
+        XDG_CONFIG_HOME: '/xdg',
+        OPENALICE_HOME: '/env-home',
+      },
+      readConfig: async () => ({
+        schemaVersion: 1,
+        defaultInstance: 'research',
+        defaults: {
+          home: '/machine-home',
+          port: 41_000,
+          appDir: '/machine-app',
+        },
+        instances: {
+          research: {
+            name: 'research',
+            home: '/instance-home',
+            port: 42_000,
+            appDir: '/instance-app',
+          },
+        },
+      }),
+    })
+
+    expect(context).toMatchObject({
+      instance: 'research',
+      home: '/env-home',
+      port: 44_000,
+      appDir: '/instance-app',
+      provenance: {
+        instance: { source: 'machine-config' },
+        home: { source: 'environment' },
+        port: { source: 'cli-flag' },
+        appDir: { source: 'instance-config' },
+      },
+    })
+  })
+
+  it('persists an instance source atomically outside the selected home', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-config-'))
+    temporaryPaths.push(root)
+    const context = await resolveStoredLaunchContext({}, {
+      homeDir: join(root, 'user'),
+      cwd: '/repo',
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+
+    await persistInstanceLaunchConfig(context, {
+      appDir: '/srv/OpenAlice',
+    })
+
+    const saved = JSON.parse(
+      await readFile(supervisorConfigPath(context.supervisorRoot), 'utf8'),
+    )
+    expect(saved).toEqual({
+      schemaVersion: 1,
+      instances: {
+        default: {
+          name: 'default',
+          appDir: '/srv/OpenAlice',
+        },
+      },
+    })
+    expect(context.supervisorRoot.startsWith(context.home)).toBe(false)
+
+    const resolved = await resolveStoredLaunchContext({}, {
+      homeDir: join(root, 'user'),
+      cwd: '/elsewhere',
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+    expect(resolved.appDir).toBe(resolve('/srv/OpenAlice'))
+    expect(resolved.provenance.appDir).toEqual({
+      source: 'instance-config',
+      detail: 'instance.default.appDir',
+    })
+  })
+
+  it('rejects corrupt, unknown, and mismatched configuration fields', () => {
+    expect(() => parseSupervisorConfig({
+      schemaVersion: 2,
+    })).toThrow(/schemaVersion must be 1/)
+    expect(() => parseSupervisorConfig({
+      schemaVersion: 1,
+      surprise: true,
+    })).toThrow(/unknown field "surprise"/)
+    expect(() => parseSupervisorConfig({
+      schemaVersion: 1,
+      instances: {
+        research: { name: 'other' },
+      },
+    })).toThrow(/must match its registry key/)
+  })
+})

--- a/packages/cli/src/supervisor-config.ts
+++ b/packages/cli/src/supervisor-config.ts
@@ -1,0 +1,325 @@
+import { randomUUID } from 'node:crypto'
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { join } from 'node:path'
+
+import {
+  resolveLaunchContext,
+  resolveSupervisorRootPath,
+  type InstanceLaunchConfig,
+  type LaunchConfigValues,
+  type MachineSupervisorConfig,
+  type ResolvedLaunchContext,
+  type ResolveSupervisorRootOptions,
+  type TuiLaunchFlags,
+} from './launch-context.ts'
+
+const CONFIG_SCHEMA_VERSION = 1
+const INSTANCE_NAME_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/
+const CONFIG_FILE_NAME = 'config.json'
+const CONFIG_KEYS = new Set([
+  'schemaVersion',
+  'defaultInstance',
+  'defaults',
+  'instances',
+])
+const LAUNCH_VALUE_KEYS = new Set([
+  'name',
+  'home',
+  'port',
+  'appDir',
+  'updateChecks',
+])
+
+export interface SupervisorConfigDocument {
+  schemaVersion: 1
+  defaultInstance?: string
+  defaults?: LaunchConfigValues
+  instances?: Record<string, InstanceLaunchConfig>
+}
+
+export interface StoredLaunchContextOptions
+  extends ResolveSupervisorRootOptions {
+  readConfig?: (
+    supervisorRoot: string,
+  ) => Promise<SupervisorConfigDocument>
+}
+
+export interface PersistInstanceConfigOptions {
+  readConfig?: (
+    supervisorRoot: string,
+  ) => Promise<SupervisorConfigDocument>
+  writeConfig?: (
+    supervisorRoot: string,
+    config: SupervisorConfigDocument,
+  ) => Promise<void>
+}
+
+export async function resolveStoredLaunchContext(
+  flags: TuiLaunchFlags = {},
+  options: StoredLaunchContextOptions = {},
+): Promise<ResolvedLaunchContext> {
+  const env = options.env ?? process.env
+  const supervisorRoot = resolveSupervisorRootPath(options)
+  const config = await (
+    options.readConfig ?? readSupervisorConfig
+  )(supervisorRoot)
+  const selectedInstance = flags.instance
+    ?? env['OPENALICE_INSTANCE']
+    ?? config.defaultInstance
+    ?? 'default'
+  const machineConfig: MachineSupervisorConfig = {
+    defaultInstance: config.defaultInstance,
+    defaults: config.defaults,
+  }
+
+  return resolveLaunchContext({
+    flags,
+    machineConfig,
+    instanceConfig: config.instances?.[selectedInstance],
+    env,
+    cwd: options.cwd,
+    homeDir: options.homeDir,
+    platform: options.platform,
+  })
+}
+
+export async function persistInstanceLaunchConfig(
+  context: ResolvedLaunchContext,
+  patch: LaunchConfigValues,
+  options: PersistInstanceConfigOptions = {},
+): Promise<void> {
+  const readConfig = options.readConfig ?? readSupervisorConfig
+  const writeConfig = options.writeConfig ?? writeSupervisorConfig
+  const current = await readConfig(context.supervisorRoot)
+  const existing = current.instances?.[context.instance] ?? {
+    name: context.instance,
+  }
+  const instance: InstanceLaunchConfig = {
+    ...existing,
+    ...patch,
+    name: context.instance,
+  }
+  const next: SupervisorConfigDocument = {
+    ...current,
+    schemaVersion: CONFIG_SCHEMA_VERSION,
+    instances: {
+      ...current.instances,
+      [context.instance]: instance,
+    },
+  }
+  await writeConfig(context.supervisorRoot, next)
+}
+
+export async function readSupervisorConfig(
+  supervisorRoot: string,
+): Promise<SupervisorConfigDocument> {
+  const path = supervisorConfigPath(supervisorRoot)
+  let text: string
+  try {
+    text = await readFile(path, 'utf8')
+  } catch (error: unknown) {
+    if (isNodeError(error, 'ENOENT')) {
+      return { schemaVersion: CONFIG_SCHEMA_VERSION }
+    }
+    throw configError(`Could not read Supervisor configuration at ${path}: ${errorMessage(error)}`)
+  }
+
+  try {
+    return parseSupervisorConfig(JSON.parse(text) as unknown)
+  } catch (error: unknown) {
+    if (isConfigError(error)) throw error
+    throw configError(`Invalid Supervisor configuration at ${path}: ${errorMessage(error)}`)
+  }
+}
+
+export async function writeSupervisorConfig(
+  supervisorRoot: string,
+  config: SupervisorConfigDocument,
+): Promise<void> {
+  const validated = parseSupervisorConfig(config)
+  const path = supervisorConfigPath(supervisorRoot)
+  const temporary = join(
+    supervisorRoot,
+    `.${CONFIG_FILE_NAME}.${process.pid}.${randomUUID()}.tmp`,
+  )
+  await mkdir(supervisorRoot, { recursive: true, mode: 0o700 })
+  try {
+    await writeFile(
+      temporary,
+      `${JSON.stringify(validated, null, 2)}\n`,
+      { encoding: 'utf8', mode: 0o600, flag: 'wx' },
+    )
+    await rename(temporary, path)
+  } catch (error: unknown) {
+    await rm(temporary, { force: true }).catch(() => undefined)
+    throw configError(`Could not save Supervisor configuration at ${path}: ${errorMessage(error)}`)
+  }
+}
+
+export function parseSupervisorConfig(
+  value: unknown,
+): SupervisorConfigDocument {
+  const root = requireRecord(value, 'Supervisor configuration')
+  rejectUnknownKeys(root, CONFIG_KEYS, 'Supervisor configuration')
+  if (root['schemaVersion'] !== CONFIG_SCHEMA_VERSION) {
+    throw configError(
+      `Supervisor configuration schemaVersion must be ${CONFIG_SCHEMA_VERSION}.`,
+    )
+  }
+
+  const defaultInstance = optionalInstanceName(
+    root['defaultInstance'],
+    'defaultInstance',
+  )
+  const defaults = root['defaults'] === undefined
+    ? undefined
+    : parseLaunchValues(root['defaults'], 'defaults', false)
+  let instances: Record<string, InstanceLaunchConfig> | undefined
+  if (root['instances'] !== undefined) {
+    const rawInstances = requireRecord(root['instances'], 'instances')
+    instances = {}
+    for (const [name, entry] of Object.entries(rawInstances)) {
+      requireInstanceName(name, `instances.${name}`)
+      const parsed = parseLaunchValues(
+        entry,
+        `instances.${name}`,
+        true,
+      ) as InstanceLaunchConfig
+      if (parsed.name !== undefined && parsed.name !== name) {
+        throw configError(
+          `instances.${name}.name must match its registry key.`,
+        )
+      }
+      instances[name] = { ...parsed, name }
+    }
+  }
+
+  return {
+    schemaVersion: CONFIG_SCHEMA_VERSION,
+    ...(defaultInstance === undefined ? {} : { defaultInstance }),
+    ...(defaults === undefined ? {} : { defaults }),
+    ...(instances === undefined ? {} : { instances }),
+  }
+}
+
+export function supervisorConfigPath(supervisorRoot: string): string {
+  return join(supervisorRoot, CONFIG_FILE_NAME)
+}
+
+function parseLaunchValues(
+  value: unknown,
+  label: string,
+  allowName: boolean,
+): LaunchConfigValues | InstanceLaunchConfig {
+  const record = requireRecord(value, label)
+  rejectUnknownKeys(
+    record,
+    allowName
+      ? LAUNCH_VALUE_KEYS
+      : new Set([...LAUNCH_VALUE_KEYS].filter((key) => key !== 'name')),
+    label,
+  )
+  const result: InstanceLaunchConfig = {}
+  if (allowName && record['name'] !== undefined) {
+    result.name = requireInstanceName(record['name'], `${label}.name`)
+  }
+  if (record['home'] !== undefined) {
+    result.home = requireNonEmptyString(record['home'], `${label}.home`)
+  }
+  if (record['appDir'] !== undefined) {
+    result.appDir = record['appDir'] === null
+      ? null
+      : requireNonEmptyString(record['appDir'], `${label}.appDir`)
+  }
+  if (record['port'] !== undefined) {
+    const port = record['port']
+    if (!Number.isInteger(port) || Number(port) < 1 || Number(port) > 65_535) {
+      throw configError(`${label}.port must be an integer between 1 and 65535.`)
+    }
+    result.port = Number(port)
+  }
+  if (record['updateChecks'] !== undefined) {
+    if (typeof record['updateChecks'] !== 'boolean') {
+      throw configError(`${label}.updateChecks must be a boolean.`)
+    }
+    result.updateChecks = record['updateChecks']
+  }
+  return result
+}
+
+function optionalInstanceName(
+  value: unknown,
+  label: string,
+): string | undefined {
+  return value === undefined ? undefined : requireInstanceName(value, label)
+}
+
+function requireInstanceName(value: unknown, label: string): string {
+  const name = requireNonEmptyString(value, label)
+  if (!INSTANCE_NAME_PATTERN.test(name)) {
+    throw configError(
+      `${label} must begin with a lowercase letter and contain only lowercase letters, numbers, "_" or "-".`,
+    )
+  }
+  return name
+}
+
+function requireNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw configError(`${label} must be a non-empty string.`)
+  }
+  return value
+}
+
+function requireRecord(
+  value: unknown,
+  label: string,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw configError(`${label} must be a JSON object.`)
+  }
+  return value as Record<string, unknown>
+}
+
+function rejectUnknownKeys(
+  value: Record<string, unknown>,
+  allowed: Set<string>,
+  label: string,
+): void {
+  const unknown = Object.keys(value).find((key) => !allowed.has(key))
+  if (unknown) {
+    throw configError(`${label} contains unknown field "${unknown}".`)
+  }
+}
+
+function configError(message: string): Error & {
+  code: string
+  exitCode: number
+} {
+  return Object.assign(new Error(message), {
+    code: 'ESUPERVISORCONFIG',
+    exitCode: 2,
+  })
+}
+
+function isConfigError(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === 'ESUPERVISORCONFIG'
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === code
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -111,4 +111,60 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
   })
+
+  it('opens an in-TUI source prompt when startup has no checkout', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-source-prompt-'))
+    temporaryPaths.push(isolatedHome)
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 100,
+      rows: 28,
+      cwd: isolatedHome,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        OPENALICE_HOME: join(isolatedHome, 'state'),
+        OPENALICE_SUPERVISOR_HOME: join(isolatedHome, 'supervisor'),
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let requestedStart = false
+      let submittedInvalidPath = false
+      let cancelledPrompt = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor source prompt timed out:\n${output}`))
+      }, 8_000)
+      child.onData((data) => {
+        output += data
+        if (!requestedStart && output.includes('c Source')) {
+          requestedStart = true
+          child.write('s')
+        } else if (!submittedInvalidPath && output.includes('Configure Runtime source')) {
+          submittedInvalidPath = true
+          child.write('\u0005\u0015/definitely/not/openalice\r')
+        } else if (!cancelledPrompt && output.includes('Could not use that checkout')) {
+          cancelledPrompt = true
+          child.write('\u001b')
+        } else if (!detached && output.includes('Source configuration cancelled.')) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor source prompt exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain('Configure Runtime source')
+    expect(transcript).toContain('Could not use that checkout')
+    expect(transcript).toContain('Source configuration cancelled.')
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  })
 })

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -24,7 +24,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
     expect(lines).toContain('Runtime state: absent')
-    expect(lines).toContain('s Start · d Doctor · l Logs · u Update · ? Help')
+    expect(lines).toContain('s Start · c Source · d Doctor · l Logs · u Update · ? Help')
     expect(lines).toContain('q / Esc / Ctrl+C  Detach without stopping')
   })
 
@@ -88,6 +88,30 @@ describe('Supervisor TUI screen', () => {
     expect(actions).toEqual([])
     expect(screen.snapshot.confirmation).toBeUndefined()
     expect(screen.snapshot.notice).toContain('electron owns this Runtime')
+  })
+
+  it('changes source only while the selected Runtime is stopped', () => {
+    let configureRequests = 0
+    const running = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: {
+        class: 'running',
+        owner: { surface: 'cli-server', pid: 42 },
+      },
+    }, {
+      onConfigureSource: () => {
+        configureRequests += 1
+      },
+    })
+
+    expect(running.handleKey('c', matchesKey)).toBe(true)
+    expect(configureRequests).toBe(0)
+    expect(running.snapshot.notice).toContain('Stop the selected Runtime')
+
+    running.update({ runtime: { class: 'absent' } })
+    expect(running.handleKey('c', matchesKey)).toBe(true)
+    expect(configureRequests).toBe(1)
   })
 
   it('navigates detail panels and requests their read-only data', () => {

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -17,8 +17,13 @@ import {
   type ResolvedLaunchContext,
   type TuiLaunchFlags,
 } from './launch-context.ts'
+import { findOpenAliceRoot } from './local-start.mjs'
 import { readRuntimeLogs } from './logs.mjs'
 import { loadPiTui } from './pi-tui-loader.ts'
+import {
+  persistInstanceLaunchConfig,
+  resolveStoredLaunchContext,
+} from './supervisor-config.ts'
 import {
   checkForUpdate,
   maybeNotifyUpdate,
@@ -116,6 +121,11 @@ export interface SupervisorTuiDependencies {
   resolveContext?: (
     flags: TuiLaunchFlags,
   ) => ResolvedLaunchContext | Promise<ResolvedLaunchContext>
+  findSource?: (startPath: string) => Promise<string>
+  configureSource?: (
+    context: ResolvedLaunchContext,
+    appDir: string,
+  ) => Promise<ResolvedLaunchContext>
   machineConfig?: MachineSupervisorConfig | null
   instanceConfig?: InstanceLaunchConfig | null
   loadTui?: typeof loadPiTui
@@ -148,16 +158,21 @@ export async function runSupervisorTui(
     )
   }
 
-  const context = await (
+  let context = await (
     dependencies.resolveContext
-    ?? ((flags) => resolveLaunchContext({
-      flags,
-      machineConfig: dependencies.machineConfig,
-      instanceConfig: dependencies.instanceConfig,
-      env: dependencies.env,
-    }))
+    ?? ((flags) => {
+      if (dependencies.machineConfig || dependencies.instanceConfig) {
+        return resolveLaunchContext({
+          flags,
+          env: dependencies.env,
+          machineConfig: dependencies.machineConfig,
+          instanceConfig: dependencies.instanceConfig,
+        })
+      }
+      return resolveStoredLaunchContext(flags, { env: dependencies.env })
+    })
   )(launchFlags)
-  const services = createServices(dependencies, context)
+  let services = createServices(dependencies, context)
   let runtime: RuntimeSummary | null = null
   let diagnostic: string | undefined
   try {
@@ -175,6 +190,8 @@ export async function runSupervisorTui(
   )
   let active = true
   let actionRunning = false
+  let sourcePromptActive = false
+  let closeSourcePrompt: (() => void) | null = null
   const screen = new SupervisorScreen({
     version: dependencies.version ?? readCliVersion(),
     channel: dependencies.channel ?? 'development',
@@ -183,11 +200,25 @@ export async function runSupervisorTui(
     diagnostic,
   }, {
     onAction: (action) => {
-      void performAction(action)
+      void requestAction(action)
+    },
+    onConfigureSource: () => {
+      openSourcePrompt()
     },
     requestRender: () => ui.requestRender(),
   })
   ui.addChild(screen)
+
+  const findSource = dependencies.findSource ?? findOpenAliceRoot
+  const configureSource = dependencies.configureSource ?? (async (
+    currentContext,
+    appDir,
+  ) => {
+    await persistInstanceLaunchConfig(currentContext, { appDir })
+    return resolveStoredLaunchContext(launchFlags, {
+      env: dependencies.env,
+    })
+  })
 
   async function refreshRuntime(): Promise<void> {
     if (!active || actionRunning) return
@@ -204,9 +235,25 @@ export async function runSupervisorTui(
     }
   }
 
+  async function requestAction(action: SupervisorAction): Promise<void> {
+    if (
+      action === 'start'
+      && context.appDir === null
+    ) {
+      try {
+        await findSource(process.cwd())
+      } catch (error: unknown) {
+        openSourcePrompt(safeError(error))
+        return
+      }
+    }
+    await performAction(action)
+  }
+
   async function performAction(action: SupervisorAction): Promise<void> {
     if (!active || actionRunning) return
     actionRunning = true
+    let actionFailure: string | undefined
     const homeRoot = context.home
     const actionLabel = actionName(action)
     screen.update({ busy: actionLabel, notice: undefined, diagnostic: undefined })
@@ -256,17 +303,104 @@ export async function runSupervisorTui(
         screen.update({ update, notice: formatUpdateNotice(update) })
       }
     } catch (error: unknown) {
-      screen.update({
-        diagnostic: `${actionLabel} failed: ${safeError(error)}`,
-        confirmation: undefined,
-      })
+      actionFailure = `${actionLabel} failed: ${safeError(error)}`
+      screen.update({ confirmation: undefined })
     } finally {
       actionRunning = false
       if (active) {
         screen.update({ busy: undefined })
         await refreshRuntime()
+        if (actionFailure) screen.update({ diagnostic: actionFailure })
       }
     }
+  }
+
+  function openSourcePrompt(reason?: string): void {
+    if (sourcePromptActive || actionRunning) return
+    const source = context.provenance.appDir.source
+    if (source === 'environment' || source === 'cli-flag') {
+      screen.update({
+        notice: `Source is locked by ${context.provenance.appDir.detail}; change that override and reopen the Supervisor.`,
+      })
+      return
+    }
+
+    sourcePromptActive = true
+    let saving = false
+    const input = new (class extends piTui.Input {
+      detail = reason
+        ? `Start needs an OpenAlice source checkout. ${reason}`
+        : 'Choose the OpenAlice source checkout for this instance.'
+
+      setDetail(detail: string): void {
+        this.detail = detail
+        this.invalidate()
+        ui.requestRender()
+      }
+
+      override render(width: number): string[] {
+        return [
+          'Configure Runtime source',
+          '',
+          sanitize(this.detail),
+          '',
+          ...super.render(width),
+          '',
+          'Enter  Save for this instance and start',
+          'Esc    Cancel',
+        ]
+      }
+    })()
+    input.setValue(context.appDir ?? process.cwd())
+    input.handleInput('\u0005')
+    const overlay = ui.showOverlay(input, {
+      width: '80%',
+      maxHeight: 10,
+      anchor: 'center',
+      margin: 1,
+    })
+    ui.setShowHardwareCursor(true)
+
+    const close = (notice?: string) => {
+      if (!sourcePromptActive) return
+      sourcePromptActive = false
+      closeSourcePrompt = null
+      overlay.hide()
+      ui.setShowHardwareCursor(false)
+      if (notice) screen.update({ notice })
+    }
+    closeSourcePrompt = () => close('Source configuration cancelled.')
+    input.onEscape = closeSourcePrompt
+    input.onSubmit = (value) => {
+      if (saving) return
+      const requested = value.trim()
+      if (!requested) {
+        input.setDetail('Enter a source checkout path.')
+        return
+      }
+      saving = true
+      input.setDetail('Validating and saving the source checkout…')
+      void (async () => {
+        try {
+          const appDir = await findSource(requested)
+          const nextContext = await configureSource(context, appDir)
+          context = nextContext
+          services = createServices(dependencies, context)
+          screen.update({
+            context,
+            diagnostic: undefined,
+            notice: `Saved source checkout ${appDir}.`,
+          })
+          close()
+          await performAction('start')
+        } catch (error: unknown) {
+          input.setDetail(`Could not use that checkout: ${safeError(error)}`)
+        } finally {
+          saving = false
+        }
+      })()
+    }
+    overlay.focus()
   }
 
   async function discoverUpdateInBackground(): Promise<void> {
@@ -297,6 +431,7 @@ export async function runSupervisorTui(
       settled = true
       active = false
       clearInterval(poll)
+      closeSourcePrompt?.()
       removeInputListener()
       process.off('SIGTERM', onTerminate)
       process.off('SIGINT', onTerminate)
@@ -305,6 +440,13 @@ export async function runSupervisorTui(
     }
     const onTerminate = () => finish()
     const removeInputListener = ui.addInputListener((data) => {
+      if (sourcePromptActive) {
+        if (piTui.matchesKey(data, 'ctrl+c')) {
+          finish()
+          return { consume: true }
+        }
+        return undefined
+      }
       if (screen.snapshot.confirmation && piTui.matchesKey(data, 'escape')) {
         screen.cancelConfirmation()
         return { consume: true }
@@ -332,17 +474,20 @@ export async function runSupervisorTui(
 export class SupervisorScreen implements Component {
   snapshot: SupervisorSnapshot
   private readonly onAction?: (action: SupervisorAction) => void
+  private readonly onConfigureSource?: () => void
   private readonly requestRender?: () => void
 
   constructor(
     snapshot: SupervisorSnapshot,
     callbacks: {
       onAction?: (action: SupervisorAction) => void
+      onConfigureSource?: () => void
       requestRender?: () => void
     } = {},
   ) {
     this.snapshot = { panel: 'overview', ...snapshot }
     this.onAction = callbacks.onAction
+    this.onConfigureSource = callbacks.onConfigureSource
     this.requestRender = callbacks.requestRender
   }
 
@@ -377,6 +522,16 @@ export class SupervisorScreen implements Component {
     }
     if (matchesKey(data, 'tab') || matchesKey(data, 'right')) {
       this.selectAdjacentPanel(1)
+      return true
+    }
+    if (matchesKey(data, 'c')) {
+      if (this.snapshot.runtime?.class === 'absent') {
+        this.onConfigureSource?.()
+      } else {
+        this.update({
+          notice: 'Stop the selected Runtime before changing its source checkout.',
+        })
+      }
       return true
     }
     if (matchesKey(data, 'shift+tab') || matchesKey(data, 'left')) {
@@ -449,6 +604,7 @@ export class SupervisorScreen implements Component {
         }
         if (this.snapshot.context) {
           lines.push(`Resolved: home ${formatProvenance(this.snapshot.context.provenance.home)} · port ${formatProvenance(this.snapshot.context.provenance.port)}`)
+          lines.push(`Source: ${this.snapshot.context.appDir ?? runtime?.provider?.root ?? 'current directory discovery'} ${formatProvenance(this.snapshot.context.provenance.appDir)}`)
         }
       }
       lines.push('', ...renderGuidance(runtime))
@@ -532,7 +688,7 @@ function renderTabs(selected: SupervisorPanel, narrow: boolean): string {
 function renderGuidance(runtime: RuntimeSummary | null): string[] {
   if (!runtime) return ['Runtime status is unavailable. Doctor may explain why.']
   if (runtime.class === 'absent') {
-    return ['OpenAlice is stopped. Press s to start the persistent Runtime.']
+    return ['OpenAlice is stopped. Press s to start, or c to choose its source checkout.']
   }
   if (runtime.class === 'incompatible') {
     return ['The running Guardian is incompatible. Read Doctor before changing it.']
@@ -577,6 +733,7 @@ function renderHelp(): string[] {
     'x  Stop (confirmation required)   r  Restart (confirmation required)',
     'l  Bounded redacted logs          d  Read-only Doctor',
     'u  Check for product update       ?  Toggle this help',
+    'c  Choose and remember this instance\'s source checkout',
     'Tab / arrows  Change panel        q / Esc  Detach only',
     '',
     'The Supervisor manages Runtime state. Workspaces, trading, and chat stay in the Web UI.',
@@ -599,7 +756,7 @@ function renderConfirmation(
 
 function actionBar(runtime: RuntimeSummary | null, narrow: boolean): string {
   const actions = runtime?.class === 'absent'
-    ? 's Start · d Doctor · l Logs · u Update · ? Help'
+    ? 's Start · c Source · d Doctor · l Logs · u Update · ? Help'
     : 'o Open · r Restart · x Stop · d Doctor · l Logs · u Update · ? Help'
   return narrow ? actions.replaceAll(' · ', '  ') : actions
 }

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -369,8 +369,20 @@ and verification before the next dependent branch starts from updated `dev`.
 - [x] Add start, open, stop, restart, detach, help, and read-only detail.
 - [ ] Add component/instance panels and narrow fallback.
 - [x] Keep the TUI open and reconnect across a self-owned restart.
-- [ ] Complete source-backed macOS/Linux PTY and real browser acceptance before
+- [x] Complete source-backed macOS/Linux PTY and real browser acceptance before
   merging the bare-command behavior.
+
+Dogfood follow-up on 2026-07-30 installed the CLI and managed Pi into an
+isolated root, launched bare `openalice` through a real macOS PTY, started a
+detached source Runtime, exercised Logs/Doctor/Help, verified
+`/api/auth/status` plus the rendered Ask Alice route in a real browser,
+detached the TUI, and reattached to the surviving Guardian. Repeating the
+journey from an unrelated directory exposed and fixed the missing-source setup
+and disappearing-action-diagnostic paths. The same increment then passed the
+clean-container installer, managed SSH install/start/tunnel/reconnect/repair
+smoke, and Electron PTY smoke; an interactive installer walk confirmed its
+default-no post-install handoff opens the Supervisor without implicitly
+starting the Runtime.
 
 ### 5. Logs, Doctor, and update UX
 
@@ -384,7 +396,7 @@ and verification before the next dependent branch starts from updated `dev`.
 
 ### 6. Configuration and instance model
 
-- [ ] Define machine-wide Supervisor and selected-instance schemas outside
+- [x] Define machine-wide Supervisor and selected-instance schemas outside
   `OPENALICE_HOME`.
 - [ ] Resolve defaults, machine config, instance config, environment, and CLI
   flags once into `ResolvedLaunchContext`, retaining field-level provenance.
@@ -401,6 +413,12 @@ and verification before the next dependent branch starts from updated `dev`.
 - [ ] Make deletion remove registry ownership only by default.
 - [ ] Test concurrent homes, ports, sockets, logs, foreign/stale owners,
   Electron ownership, and remote instances.
+
+The first persisted-configuration increment activates a versioned atomic
+`<Supervisor root>/config.json` and lets the TUI validate, remember, and
+immediately use the selected instance's source checkout. General config
+editing, `config check`, last-known-good live reload, and named-instance
+management remain unchecked above.
 
 ### 7. Standalone headless Runtime artifact
 

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -148,6 +148,8 @@ cmp /fixture/packages/cli/src/install-source.mjs "$v1_release/src/install-source
   || fail "downloaded install-source module differs from the fixture"
 cmp /fixture/packages/cli/src/install-layout.mjs "$v1_release/src/install-layout.mjs" \
   || fail "downloaded install-layout module differs from the fixture"
+cmp /fixture/packages/cli/src/supervisor-config.ts "$v1_release/src/supervisor-config.ts" \
+  || fail "downloaded Supervisor configuration module differs from the fixture"
 cmp /fixture/packages/cli/src/lifecycle-command.mjs "$v1_release/src/lifecycle-command.mjs" \
   || fail "downloaded lifecycle command module differs from the fixture"
 cmp /fixture/packages/cli/src/lifecycle.mjs "$v1_release/src/lifecycle.mjs" \


### PR DESCRIPTION
## What changed

- add a versioned machine-local Supervisor config with atomic persistence and the intended defaults < machine < instance < environment < CLI precedence
- let a stopped Supervisor choose, validate, remember, and immediately start from an OpenAlice source checkout
- preserve failed-action diagnostics instead of clearing them during the next status refresh
- update the installer’s post-install handoff to open the Supervisor, without implicitly starting the Runtime
- include the new config module in the distributed payload and document the current source-backed boundary

## Why

A freshly installed CLI could open its TUI from an arbitrary directory, but Start then failed because no source checkout was discoverable. The subsequent status refresh also erased that error, making the key appear to do nothing. Users should be able to install first and finish the source selection inside the TUI while automation retains higher-priority environment and flag injection.

## Validation

- `npx tsc --noEmit`
- `pnpm test` (442 files passed, 1 skipped; 3708 tests passed, 9 skipped)
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm -F @traderalice/openalice-cli test` (154 passed)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `pnpm electron:smoke:pty`
- real macOS PTY dogfood from isolated install roots, including source prompt/config reuse, persistent detached Runtime, Logs/Doctor/Help, and failure persistence
- real browser check of `/api/auth/status` and the rendered Ask Alice route
- interactive installer walk through the default-no post-install Supervisor prompt