### PR TITLE
Let clean installs prepare their Runtime from the TUI

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -101,6 +101,8 @@ runs `npm ci --omit=dev --ignore-scripts` in the staged release.
   metadata used when managed remote reproduces the invoking CLI.
 - `packages/cli/src/supervisor-config.ts` — machine-local Supervisor and
   selected-instance configuration loading and atomic persistence.
+- `packages/cli/src/managed-source.ts` — installer-channel-aligned local source
+  selection, validated atomic clone, and collision refusal.
 - `packages/cli/src/install-layout.mjs` — strict discovery of installer-owned
   roots from immutable release paths.
 - `packages/cli/src/update.mjs` — stable manifest checks, bounded start notice,
@@ -216,6 +218,14 @@ Supervisor does not start the Runtime until the user chooses Start inside the
 TUI. For automation,
 `--yes --with-runtime-deps` is the explicit pair that approves the displayed
 Linux package command as well as the CLI transaction.
+
+When no local checkout is discoverable after installation, bare `openalice`
+opens the Supervisor and offers two explicit stopped-state paths: `m` prepares
+an installer-managed checkout aligned to the CLI's branch or version under the
+install root, while `c` selects an existing checkout. Managed preparation never
+overwrites an occupied invalid path. Its first Start can install repository
+dependencies and build the source Runtime; the installer therefore discloses
+and optionally prepares the required native build tools before consent.
 
 ### Source Runtime build tools
 
@@ -403,15 +413,18 @@ With the default installer and Runtime roots:
 │   └── <older-ref-or-content>/
 ├── .cli-install.lock/       # present only while an installer owns it
 ├── .cli-update-check.json   # best-effort stable update cache
-├── sources/                 # selector-specific managed remote checkouts
+├── sources/                 # selector-specific managed local/remote checkouts
 ├── data/                    # application state, not installer debris
 ├── workspaces/              # user work, not installer debris
 ├── provider-keys.json       # sensitive user state
 └── sealing.key              # sensitive machine-bound key
 ```
 
-`sources/` is created by approved managed-remote orchestration, not by the
-installer itself. The installer root and Runtime `OPENALICE_HOME` independently default to
+`sources/` is created only after an approved local Supervisor or managed-remote
+source action, not by the installer transaction itself. CLI-only uninstall
+preserves it deliberately because a checkout may subsequently contain user
+work; a future purge flow must inspect ownership and dirtiness rather than
+blindly deleting it. The installer root and Runtime `OPENALICE_HOME` independently default to
 `~/.openalice`. The installer does not read an `OPENALICE_HOME` override, and
 `openalice start` does not infer Runtime home from the CLI's install location.
 Either override may therefore diverge intentionally. Their default co-location

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -94,6 +94,8 @@ explicit commands:
 - `l` reads the bounded, redacted log tail;
 - `d` runs read-only Doctor checks;
 - `u` performs an advisory product-update check;
+- `m` confirms, prepares, remembers, and starts an installer-managed source
+  aligned to the installed CLI branch/version;
 - `c` chooses and remembers the selected instance's source checkout;
 - `?`, Tab, and the horizontal arrows expose help and detail panels.
 
@@ -104,9 +106,12 @@ discovery runs in the background and cannot block lifecycle controls.
 
 The current Runtime provider is still source-backed. TUI start discovers an
 OpenAlice checkout from the current directory, reuses a configured or
-owner-advertised source root, or opens the `c` path editor when discovery
-fails. Unfinished controls remain inside the application shell and do not
-change the default entry back to the compatibility launcher.
+owner-advertised source root, opens the `c` path editor when discovery fails,
+or explicitly prepares an installer-owned checkout through `m`. The managed
+path is `<install root>/sources/<install-source identity>/OpenAlice`; a branch
+install clones that branch and a version install checks out its immutable ref.
+Unfinished controls remain inside the application shell and do not change the
+default entry back to the compatibility launcher.
 
 ## TUI Launch Context
 
@@ -333,6 +338,8 @@ completion; detailed shell installation remains user-owned.
   provenance, instance roots, and managed-Pi environment projection.
 - `packages/cli/src/supervisor-config.ts` — versioned machine/instance
   configuration parsing, atomic persistence, and stored-context resolution.
+- `packages/cli/src/managed-source.ts` — local managed checkout identity,
+  validation, collision safety, and atomic preparation.
 - `packages/cli/src/supervisor-tui.ts` — `pi-tui` Supervisor application shell.
 - `packages/cli/src/pi-tui-loader.ts` — workspace and installed managed-Pi TUI
   resolution.

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -94,6 +94,12 @@ does not start the Runtime until the user chooses Start inside the TUI.
 Installation consent never implies service-start consent, and `--yes` remains
 installation-only for automation.
 
+On an installed CLI with no existing checkout, the stopped Supervisor exposes
+`m Managed`. After explicit confirmation it atomically clones the branch or
+version paired with that installed CLI under the install root, remembers the
+result for the selected instance, and enters the ordinary source preparation
+and detached-start path. `c Source` remains the existing-checkout path.
+
 `openalice run` and compatibility `openalice start` stay in the foreground and
 own the Guardian lifetime; `Ctrl+C` stops their self-owned local Runtime. The
 Supervisor TUI only detaches. A normal `up` reuses an already healthy matching

--- a/install
+++ b/install
@@ -669,6 +669,7 @@ FILES=(
   "bin/openalice.mjs"
   "src/launch-context.ts"
   "src/main.ts"
+  "src/managed-source.ts"
   "src/pi-tui-loader.ts"
   "src/supervisor-config.ts"
   "src/supervisor-tui.ts"
@@ -745,6 +746,7 @@ chmod +x "$STAGING/bin/openalice.ts"
 chmod +x "$STAGING/bin/openalice.mjs"
 node --check "$STAGING/bin/openalice.ts"
 node --check "$STAGING/bin/openalice.mjs"
+node --check "$STAGING/src/managed-source.ts"
 node --check "$STAGING/src/supervisor-config.ts"
 node --check "$STAGING/src/doctor.mjs"
 node --check "$STAGING/src/install-layout.mjs"
@@ -935,8 +937,8 @@ if [[ -n "$checkout" ]]; then
   fi
   printf '\nStart it when you are ready:\n  cd %q\n  %s\n\n' "$checkout" "$BIN_DIR/openalice"
 elif [[ "$INSTALL_CONTEXT" != "remote" ]]; then
-  printf '\n%bNext: launch from an OpenAlice checkout%b\n' "$BOLD" "$RESET"
-  printf '  git clone https://github.com/TraderAlice/OpenAlice.git\n'
-  printf '  cd OpenAlice\n'
+  printf '\n%bNext: open the OpenAlice Supervisor%b\n' "$BOLD" "$RESET"
   printf '  %s\n\n' "$BIN_DIR/openalice"
+  printf 'Press %bm%b inside the Supervisor to prepare the managed Runtime source,\n' "$BOLD" "$RESET"
+  printf 'or %bc%b to select an existing OpenAlice checkout.\n\n' "$BOLD" "$RESET"
 fi

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
     "bin/openalice.mjs",
     "src/launch-context.ts",
     "src/main.ts",
+    "src/managed-source.ts",
     "src/pi-tui-loader.ts",
     "src/supervisor-config.ts",
     "src/supervisor-tui.ts",
@@ -32,7 +33,7 @@
     "src/update.mjs"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/supervisor-config.ts && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
+    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/managed-source.ts && node --check src/supervisor-config.ts && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
@@ -83,6 +84,19 @@ export function installSourcesMatch(left, right) {
 export function formatInstallSelector(source) {
   const normalized = normalizeInstallSource(source)
   return `${normalized.selector.kind} ${normalized.selector.value}`
+}
+
+export function managedSourceKey(source) {
+  const normalized = requireInstallSource(source)
+  const readable = `${normalized.selector.kind}-${normalized.selector.value}`
+    .replaceAll(/[^A-Za-z0-9._-]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
+    .slice(0, 48) || 'source'
+  const digest = createHash('sha256')
+    .update(`${normalized.selector.kind}:${normalized.selector.value}`)
+    .digest('hex')
+    .slice(0, 8)
+  return `${readable}-${digest}`
 }
 
 function cloneInstallSource(source) {

--- a/packages/cli/src/managed-source.spec.ts
+++ b/packages/cli/src/managed-source.spec.ts
@@ -1,0 +1,171 @@
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  inspectManagedSource,
+  inspectSourceCheckout,
+  prepareManagedSource,
+} from './managed-source.ts'
+
+const temporaryPaths: string[] = []
+const branchSource = {
+  schemaVersion: 1 as const,
+  repository: 'TraderAlice/OpenAlice',
+  cliVersion: '0.87.0-beta',
+  selector: { kind: 'branch' as const, value: 'dev' },
+  installerUrl: 'https://openalice.ai/install',
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(temporaryPaths.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )))
+})
+
+describe('managed local source', () => {
+  it('atomically prepares and then reuses the branch paired with the CLI', async () => {
+    const installRoot = await temporaryInstallRoot()
+    const calls: string[][] = []
+    const runGit = vi.fn(async (args: string[]) => {
+      calls.push(args)
+      const destination = args.at(-1)
+      if (args[0] !== 'clone' || !destination) return
+      await writeValidCheckout(destination)
+    })
+
+    const first = await prepareManagedSource({
+      installSource: branchSource,
+      layout: { installRoot },
+      repositoryUrl: '/fixture/OpenAlice.git',
+    }, { runGit })
+
+    expect(first.created).toBe(true)
+    expect(first.state).toBe('present')
+    expect(first.appDir).toMatch(
+      /sources[/\\]branch-dev-[a-f0-9]{8}[/\\]OpenAlice$/,
+    )
+    expect(calls).toEqual([[
+      'clone',
+      '--branch',
+      'dev',
+      '--single-branch',
+      '/fixture/OpenAlice.git',
+      expect.stringContaining('.OpenAlice.prepare.'),
+    ]])
+
+    const reused = await prepareManagedSource({
+      installSource: branchSource,
+      layout: { installRoot },
+      repositoryUrl: '/fixture/OpenAlice.git',
+    }, { runGit })
+    expect(reused).toEqual(expect.objectContaining({
+      appDir: first.appDir,
+      created: false,
+      state: 'present',
+    }))
+    expect(runGit).toHaveBeenCalledTimes(1)
+  })
+
+  it('checks out an immutable version after cloning', async () => {
+    const installRoot = await temporaryInstallRoot()
+    const runGit = vi.fn(async (args: string[]) => {
+      if (args[0] === 'clone') {
+        const destination = args.at(-1)
+        if (destination) await writeValidCheckout(destination)
+      }
+    })
+
+    const result = await prepareManagedSource({
+      installSource: {
+        ...branchSource,
+        selector: { kind: 'version', value: 'v0.87.0' },
+      },
+      layout: { installRoot },
+      repositoryUrl: '/fixture/OpenAlice.git',
+    }, { runGit })
+
+    expect(result.created).toBe(true)
+    expect(runGit).toHaveBeenNthCalledWith(
+      1,
+      ['clone', '/fixture/OpenAlice.git', expect.any(String)],
+      expect.any(Object),
+    )
+    expect(runGit).toHaveBeenNthCalledWith(
+      2,
+      ['-C', expect.any(String), 'checkout', '--detach', 'v0.87.0'],
+      expect.any(Object),
+    )
+  })
+
+  it('refuses an occupied path that is not a checkout', async () => {
+    const installRoot = await temporaryInstallRoot()
+    const plan = await inspectManagedSource({
+      installSource: branchSource,
+      layout: { installRoot },
+    })
+    await mkdir(plan.appDir, { recursive: true })
+    await writeFile(join(plan.appDir, 'package.json'), '{"name":"other"}\n')
+
+    await expect(prepareManagedSource({
+      installSource: branchSource,
+      layout: { installRoot },
+    })).rejects.toThrow('exists but is not an OpenAlice checkout')
+  })
+
+  it('reuses a valid checkout that wins a concurrent prepare race', async () => {
+    const installRoot = await temporaryInstallRoot()
+    const plan = await inspectManagedSource({
+      installSource: branchSource,
+      layout: { installRoot },
+    })
+
+    const result = await prepareManagedSource({
+      installSource: branchSource,
+      layout: { installRoot },
+    }, {
+      runGit: async () => {
+        await writeValidCheckout(plan.appDir)
+        throw new Error('destination appeared concurrently')
+      },
+    })
+
+    expect(result).toEqual(expect.objectContaining({
+      appDir: plan.appDir,
+      created: false,
+      state: 'present',
+    }))
+  })
+
+  it('requires an installed layout and reports missing checkouts', async () => {
+    await expect(inspectManagedSource({
+      installSource: branchSource,
+      layout: null,
+    })).rejects.toThrow('available from an installed OpenAlice CLI')
+
+    const installRoot = await temporaryInstallRoot()
+    expect(await inspectSourceCheckout(join(installRoot, 'missing'))).toBe('absent')
+  })
+})
+
+async function temporaryInstallRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-managed-source-'))
+  temporaryPaths.push(root)
+  return root
+}
+
+async function writeValidCheckout(path: string): Promise<void> {
+  await mkdir(path, { recursive: true })
+  await writeFile(join(path, 'package.json'), JSON.stringify({
+    name: 'open-alice',
+    scripts: { 'build:server': 'true' },
+  }))
+}

--- a/packages/cli/src/managed-source.ts
+++ b/packages/cli/src/managed-source.ts
@@ -1,0 +1,250 @@
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import {
+  lstat,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+} from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+import { resolveInstalledLayout } from './install-layout.mjs'
+import {
+  managedSourceKey,
+  readInstallSource,
+  requireInstallSource,
+} from './install-source.mjs'
+
+const DEFAULT_REPOSITORY_URL = 'https://github.com/TraderAlice/OpenAlice.git'
+const MAX_GIT_ERROR_OUTPUT_BYTES = 64 * 1024
+
+interface InstallSource {
+  schemaVersion: 1
+  repository: string
+  cliVersion: string
+  selector: {
+    kind: 'branch' | 'version'
+    value: string
+  }
+  installerUrl: string
+}
+
+interface InstalledLayout {
+  installRoot: string
+}
+
+export interface ManagedSourcePlan {
+  appDir: string
+  installRoot: string
+  repositoryUrl: string
+  selector: InstallSource['selector']
+  state: 'absent' | 'present' | 'invalid'
+}
+
+export interface ManagedSourceResult extends ManagedSourcePlan {
+  state: 'present'
+  created: boolean
+}
+
+export interface InspectManagedSourceOptions {
+  installSource?: InstallSource
+  layout?: InstalledLayout | null
+  repositoryUrl?: string
+}
+
+export interface ManagedSourceDependencies {
+  readInstallSource?: () => Promise<InstallSource>
+  resolveLayout?: () => InstalledLayout | null
+  inspectCheckout?: (
+    appDir: string,
+  ) => Promise<ManagedSourcePlan['state']>
+  runGit?: (
+    args: string[],
+    options: { cwd?: string },
+  ) => Promise<void>
+}
+
+export async function inspectManagedSource(
+  options: InspectManagedSourceOptions = {},
+  dependencies: ManagedSourceDependencies = {},
+): Promise<ManagedSourcePlan> {
+  const source = requireInstallSource(
+    options.installSource
+      ?? await (dependencies.readInstallSource ?? readInstallSource)(),
+  ) as InstallSource
+  const layout = options.layout === undefined
+    ? (dependencies.resolveLayout ?? (() => resolveInstalledLayout(import.meta.url)))()
+    : options.layout
+  if (!layout) {
+    throw managedSourceError(
+      'EMANAGEDSOURCEUNAVAILABLE',
+      'Managed source preparation is available from an installed OpenAlice CLI. This source-run CLI should use its current checkout.',
+    )
+  }
+  const appDir = join(
+    layout.installRoot,
+    'sources',
+    managedSourceKey(source),
+    'OpenAlice',
+  )
+  const inspect = dependencies.inspectCheckout ?? inspectSourceCheckout
+  return {
+    appDir,
+    installRoot: layout.installRoot,
+    repositoryUrl: options.repositoryUrl ?? DEFAULT_REPOSITORY_URL,
+    selector: { ...source.selector },
+    state: await inspect(appDir),
+  }
+}
+
+export async function prepareManagedSource(
+  options: InspectManagedSourceOptions = {},
+  dependencies: ManagedSourceDependencies = {},
+): Promise<ManagedSourceResult> {
+  const plan = await inspectManagedSource(options, dependencies)
+  if (plan.state === 'present') {
+    return { ...plan, state: 'present', created: false }
+  }
+  if (plan.state === 'invalid') {
+    throw managedSourceError(
+      'EMANAGEDSOURCECOLLISION',
+      `The managed source path exists but is not an OpenAlice checkout: ${plan.appDir}`,
+    )
+  }
+
+  const parent = dirname(plan.appDir)
+  const temporary = join(
+    parent,
+    `.OpenAlice.prepare.${process.pid}.${randomUUID()}`,
+  )
+  await mkdir(parent, { recursive: true, mode: 0o700 })
+  const runGit = dependencies.runGit ?? runGitChecked
+  try {
+    const cloneArgs = plan.selector.kind === 'branch'
+      ? [
+          'clone',
+          '--branch',
+          plan.selector.value,
+          '--single-branch',
+          plan.repositoryUrl,
+          temporary,
+        ]
+      : ['clone', plan.repositoryUrl, temporary]
+    await runGit(cloneArgs, { cwd: parent })
+    if (plan.selector.kind === 'version') {
+      await runGit(
+        ['-C', temporary, 'checkout', '--detach', plan.selector.value],
+        { cwd: parent },
+      )
+    }
+    if (await inspectSourceCheckout(temporary) !== 'present') {
+      throw managedSourceError(
+        'EMANAGEDSOURCEINVALID',
+        'The downloaded repository is not a valid OpenAlice source checkout.',
+      )
+    }
+    await rename(temporary, plan.appDir)
+  } catch (error: unknown) {
+    await rm(temporary, { recursive: true, force: true }).catch(() => undefined)
+    if (await inspectSourceCheckout(plan.appDir) === 'present') {
+      return { ...plan, state: 'present', created: false }
+    }
+    if (isManagedSourceError(error)) throw error
+    throw managedSourceError(
+      'EMANAGEDSOURCEPREPARE',
+      `Could not prepare the managed OpenAlice source: ${errorMessage(error)}`,
+    )
+  }
+
+  return { ...plan, state: 'present', created: true }
+}
+
+export async function inspectSourceCheckout(
+  appDir: string,
+): Promise<ManagedSourcePlan['state']> {
+  try {
+    const stats = await lstat(appDir)
+    if (!stats.isDirectory() || stats.isSymbolicLink()) return 'invalid'
+  } catch (error: unknown) {
+    if (isNodeError(error, 'ENOENT')) return 'absent'
+    throw error
+  }
+
+  try {
+    const manifest = JSON.parse(
+      await readFile(join(appDir, 'package.json'), 'utf8'),
+    ) as {
+      name?: unknown
+      scripts?: Record<string, unknown>
+    }
+    return manifest.name === 'open-alice'
+      && typeof manifest.scripts?.['build:server'] === 'string'
+      ? 'present'
+      : 'invalid'
+  } catch {
+    return 'invalid'
+  }
+}
+
+function runGitChecked(
+  args: string[],
+  options: { cwd?: string },
+): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn('git', args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    let outputTail = ''
+    const rememberOutput = (chunk: Buffer | string) => {
+      outputTail = `${outputTail}${String(chunk)}`
+        .slice(-MAX_GIT_ERROR_OUTPUT_BYTES)
+    }
+    child.stdout?.on('data', rememberOutput)
+    child.stderr?.on('data', rememberOutput)
+    child.once('error', (error) => {
+      if (isNodeError(error, 'ENOENT')) {
+        rejectPromise(new Error(
+          'Git is required to prepare the managed source. Re-run the OpenAlice installer with --with-runtime-deps, or install Git and retry.',
+        ))
+      } else {
+        rejectPromise(error)
+      }
+    })
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolvePromise()
+      else {
+        const details = outputTail.trim()
+        rejectPromise(new Error(
+          `git ${args[0] ?? ''} failed (code=${String(code)}, signal=${String(signal)})${details ? `\n\n${details}` : ''}`,
+        ))
+      }
+    })
+  })
+}
+
+function managedSourceError(
+  code: string,
+  message: string,
+): Error & { code: string; exitCode: number } {
+  return Object.assign(new Error(message), { code, exitCode: 1 })
+}
+
+function isManagedSourceError(error: unknown): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && typeof error.code === 'string'
+    && error.code.startsWith('EMANAGEDSOURCE')
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === code
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -10,6 +10,7 @@ import {
   formatInstallSelector,
   installedContentIdentity,
   installSourcesMatch,
+  managedSourceKey,
   parseInstallSource,
   readInstallSource,
   requireInstallSource,
@@ -1169,19 +1170,6 @@ function contentIdentitiesMatch(localIdentity, remoteIdentity) {
 
 function normalizeContentIdentity(value) {
   return typeof value === 'string' && /^[a-f0-9]{16}$/.test(value) ? value : null
-}
-
-function managedSourceKey(source) {
-  const normalized = requireInstallSource(source)
-  const readable = `${normalized.selector.kind}-${normalized.selector.value}`
-    .replaceAll(/[^A-Za-z0-9._-]+/g, '-')
-    .replaceAll(/^-+|-+$/g, '')
-    .slice(0, 48) || 'source'
-  const digest = createHash('sha256')
-    .update(`${normalized.selector.kind}:${normalized.selector.value}`)
-    .digest('hex')
-    .slice(0, 8)
-  return `${readable}-${digest}`
 }
 
 function remoteStatePath(env, homeDir) {

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -167,4 +167,52 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
   })
+
+  it('explains when managed source is unavailable from a source-run CLI', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-managed-source-'))
+    temporaryPaths.push(isolatedHome)
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 110,
+      rows: 28,
+      cwd: isolatedHome,
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        OPENALICE_HOME: join(isolatedHome, 'state'),
+        OPENALICE_SUPERVISOR_HOME: join(isolatedHome, 'supervisor'),
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let requestedManaged = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor managed-source TUI timed out:\n${output}`))
+      }, 8_000)
+      child.onData((data) => {
+        output += data
+        if (!requestedManaged && output.includes('m Managed')) {
+          requestedManaged = true
+          child.write('m')
+        } else if (!detached && output.includes('Managed source preparation is available from an installed')) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor managed-source TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain(
+      'Managed source preparation is available from an installed',
+    )
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  })
 })

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  resolveSupervisorChannel,
   type SupervisorAction,
   SupervisorScreen,
 } from './supervisor-tui.ts'
@@ -8,6 +9,24 @@ import {
 const matchesKey = (data: string, key: string) => data === key
 
 describe('Supervisor TUI screen', () => {
+  it('labels source-run, branch, and version channels from install provenance', async () => {
+    await expect(resolveSupervisorChannel({
+      resolveLayout: () => null,
+    })).resolves.toBe('development')
+    await expect(resolveSupervisorChannel({
+      resolveLayout: () => ({}),
+      readSource: async () => ({
+        selector: { kind: 'branch', value: 'dev' },
+      }),
+    })).resolves.toBe('branch dev')
+    await expect(resolveSupervisorChannel({
+      resolveLayout: () => ({}),
+      readSource: async () => ({
+        selector: { kind: 'version', value: 'v0.87.0' },
+      }),
+    })).resolves.toBe('stable')
+  })
+
   it('renders stable stopped-state application chrome', () => {
     const screen = new SupervisorScreen({
       version: '0.87.0-beta',
@@ -24,7 +43,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
     expect(lines).toContain('Runtime state: absent')
-    expect(lines).toContain('s Start · c Source · d Doctor · l Logs · u Update · ? Help')
+    expect(lines).toContain('s Start · m Managed · c Source · d Doctor · l Logs · u Update · ? Help')
     expect(lines).toContain('q / Esc / Ctrl+C  Detach without stopping')
   })
 
@@ -112,6 +131,31 @@ describe('Supervisor TUI screen', () => {
     running.update({ runtime: { class: 'absent' } })
     expect(running.handleKey('c', matchesKey)).toBe(true)
     expect(configureRequests).toBe(1)
+  })
+
+  it('confirms managed source preparation before dispatch', () => {
+    let prepareRequests = 0
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: { class: 'absent' },
+    }, {
+      onRequestManagedSource: () => {
+        screen.update({ confirmation: 'managed-source' })
+      },
+      onPrepareManagedSource: () => {
+        prepareRequests += 1
+      },
+    })
+
+    expect(screen.handleKey('m', matchesKey)).toBe(true)
+    expect(screen.snapshot.confirmation).toBe('managed-source')
+    expect(screen.render(100).join('\n')).toContain(
+      'branch/version paired with this CLI',
+    )
+
+    expect(screen.handleKey('enter', matchesKey)).toBe(true)
+    expect(prepareRequests).toBe(1)
   })
 
   it('navigates detail panels and requests their read-only data', () => {

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -17,8 +17,16 @@ import {
   type ResolvedLaunchContext,
   type TuiLaunchFlags,
 } from './launch-context.ts'
+import { resolveInstalledLayout } from './install-layout.mjs'
+import { readInstallSource } from './install-source.mjs'
 import { findOpenAliceRoot } from './local-start.mjs'
 import { readRuntimeLogs } from './logs.mjs'
+import {
+  inspectManagedSource,
+  prepareManagedSource,
+  type ManagedSourcePlan,
+  type ManagedSourceResult,
+} from './managed-source.ts'
 import { loadPiTui } from './pi-tui-loader.ts'
 import {
   persistInstanceLaunchConfig,
@@ -100,10 +108,11 @@ export interface SupervisorSnapshot {
   panel?: SupervisorPanel
   busy?: string
   notice?: string
-  confirmation?: 'stop' | 'restart'
+  confirmation?: 'stop' | 'restart' | 'managed-source'
   logs?: RuntimeLogs | null
   doctor?: DoctorReport | null
   update?: UpdateResult | null
+  managedSource?: ManagedSourcePlan | null
 }
 
 export interface SupervisorTuiDependencies {
@@ -126,12 +135,15 @@ export interface SupervisorTuiDependencies {
     context: ResolvedLaunchContext,
     appDir: string,
   ) => Promise<ResolvedLaunchContext>
+  prepareManagedSource?: () => Promise<ManagedSourceResult>
+  inspectManagedSource?: () => Promise<ManagedSourcePlan>
   machineConfig?: MachineSupervisorConfig | null
   instanceConfig?: InstanceLaunchConfig | null
   loadTui?: typeof loadPiTui
   version?: string
   channel?: string
   pollIntervalMs?: number
+  resolveChannel?: () => Promise<string>
 }
 
 interface SupervisorServices {
@@ -182,6 +194,8 @@ export async function runSupervisorTui(
   }
 
   const piTui = await (dependencies.loadTui ?? loadPiTui)(dependencies.env)
+  const channel = dependencies.channel
+    ?? await (dependencies.resolveChannel ?? resolveSupervisorChannel)()
   const terminal = new piTui.ProcessTerminal()
   const ui = new piTui.TUI(
     terminal,
@@ -194,7 +208,7 @@ export async function runSupervisorTui(
   let closeSourcePrompt: (() => void) | null = null
   const screen = new SupervisorScreen({
     version: dependencies.version ?? readCliVersion(),
-    channel: dependencies.channel ?? 'development',
+    channel,
     runtime,
     context,
     diagnostic,
@@ -204,6 +218,12 @@ export async function runSupervisorTui(
     },
     onConfigureSource: () => {
       openSourcePrompt()
+    },
+    onRequestManagedSource: () => {
+      void requestManagedSource()
+    },
+    onPrepareManagedSource: () => {
+      void prepareManagedSourceAndStart()
     },
     requestRender: () => ui.requestRender(),
   })
@@ -219,6 +239,10 @@ export async function runSupervisorTui(
       env: dependencies.env,
     })
   })
+  const prepareManaged = dependencies.prepareManagedSource
+    ?? (() => prepareManagedSource())
+  const inspectManaged = dependencies.inspectManagedSource
+    ?? (() => inspectManagedSource())
 
   async function refreshRuntime(): Promise<void> {
     if (!active || actionRunning) return
@@ -313,6 +337,75 @@ export async function runSupervisorTui(
         if (actionFailure) screen.update({ diagnostic: actionFailure })
       }
     }
+  }
+
+  async function requestManagedSource(): Promise<void> {
+    if (actionRunning) return
+    const source = context.provenance.appDir.source
+    if (source === 'environment' || source === 'cli-flag') {
+      screen.update({
+        notice: `Source is locked by ${context.provenance.appDir.detail}; change that override and reopen the Supervisor.`,
+      })
+      return
+    }
+    actionRunning = true
+    screen.update({
+      busy: 'Inspecting managed source',
+      notice: undefined,
+      diagnostic: undefined,
+    })
+    try {
+      const managedSource = await inspectManaged()
+      if (!active) return
+      screen.update({
+        managedSource,
+        confirmation: 'managed-source',
+      })
+    } catch (error: unknown) {
+      if (!active) return
+      screen.update({
+        diagnostic: `Managed source is unavailable: ${safeError(error)}`,
+      })
+    } finally {
+      actionRunning = false
+      if (active) screen.update({ busy: undefined })
+    }
+  }
+
+  async function prepareManagedSourceAndStart(): Promise<void> {
+    if (!active || actionRunning) return
+    actionRunning = true
+    let prepared = false
+    let actionFailure: string | undefined
+    screen.update({
+      busy: 'Preparing managed source',
+      confirmation: undefined,
+      notice: undefined,
+      diagnostic: undefined,
+    })
+    try {
+      const result = await prepareManaged()
+      const nextContext = await configureSource(context, result.appDir)
+      context = nextContext
+      services = createServices(dependencies, context)
+      prepared = true
+      screen.update({
+        context,
+        notice: result.created
+          ? `Prepared and saved managed source ${result.appDir}.`
+          : `Reused and saved managed source ${result.appDir}.`,
+      })
+    } catch (error: unknown) {
+      actionFailure = `Preparing managed source failed: ${safeError(error)}`
+    } finally {
+      actionRunning = false
+      if (active) {
+        screen.update({ busy: undefined })
+        await refreshRuntime()
+        if (actionFailure) screen.update({ diagnostic: actionFailure })
+      }
+    }
+    if (prepared && active) await performAction('start')
   }
 
   function openSourcePrompt(reason?: string): void {
@@ -471,10 +564,33 @@ export async function runSupervisorTui(
   })
 }
 
+export async function resolveSupervisorChannel(
+  options: {
+    moduleUrl?: string
+    resolveLayout?: (moduleUrl?: string) => unknown
+    readSource?: () => Promise<{
+      selector?: { kind?: string; value?: string }
+    }>
+  } = {},
+): Promise<string> {
+  const moduleUrl = options.moduleUrl ?? import.meta.url
+  const layout = (
+    options.resolveLayout ?? resolveInstalledLayout
+  )(moduleUrl)
+  if (!layout) return 'development'
+  const source = await (options.readSource ?? readInstallSource)()
+  if (source.selector?.kind === 'version') return 'stable'
+  return source.selector?.value
+    ? `branch ${source.selector.value}`
+    : 'installed'
+}
+
 export class SupervisorScreen implements Component {
   snapshot: SupervisorSnapshot
   private readonly onAction?: (action: SupervisorAction) => void
   private readonly onConfigureSource?: () => void
+  private readonly onRequestManagedSource?: () => void
+  private readonly onPrepareManagedSource?: () => void
   private readonly requestRender?: () => void
 
   constructor(
@@ -482,12 +598,16 @@ export class SupervisorScreen implements Component {
     callbacks: {
       onAction?: (action: SupervisorAction) => void
       onConfigureSource?: () => void
+      onRequestManagedSource?: () => void
+      onPrepareManagedSource?: () => void
       requestRender?: () => void
     } = {},
   ) {
     this.snapshot = { panel: 'overview', ...snapshot }
     this.onAction = callbacks.onAction
     this.onConfigureSource = callbacks.onConfigureSource
+    this.onRequestManagedSource = callbacks.onRequestManagedSource
+    this.onPrepareManagedSource = callbacks.onPrepareManagedSource
     this.requestRender = callbacks.requestRender
   }
 
@@ -507,7 +627,11 @@ export class SupervisorScreen implements Component {
     if (this.snapshot.busy) return false
     if (this.snapshot.confirmation) {
       if (matchesKey(data, 'y') || matchesKey(data, 'enter')) {
-        this.onAction?.(this.snapshot.confirmation)
+        if (this.snapshot.confirmation === 'managed-source') {
+          this.onPrepareManagedSource?.()
+        } else {
+          this.onAction?.(this.snapshot.confirmation)
+        }
         return true
       }
       if (matchesKey(data, 'n')) {
@@ -527,6 +651,16 @@ export class SupervisorScreen implements Component {
     if (matchesKey(data, 'c')) {
       if (this.snapshot.runtime?.class === 'absent') {
         this.onConfigureSource?.()
+      } else {
+        this.update({
+          notice: 'Stop the selected Runtime before changing its source checkout.',
+        })
+      }
+      return true
+    }
+    if (matchesKey(data, 'm')) {
+      if (this.snapshot.runtime?.class === 'absent') {
+        this.onRequestManagedSource?.()
       } else {
         this.update({
           notice: 'Stop the selected Runtime before changing its source checkout.',
@@ -611,7 +745,11 @@ export class SupervisorScreen implements Component {
     }
 
     if (this.snapshot.confirmation) {
-      lines.push('', ...renderConfirmation(this.snapshot.confirmation, runtime))
+      lines.push('', ...renderConfirmation(
+        this.snapshot.confirmation,
+        runtime,
+        this.snapshot.managedSource,
+      ))
     }
     if (this.snapshot.busy) lines.push('', `Working: ${this.snapshot.busy}…`)
     if (this.snapshot.notice) lines.push('', `Notice: ${sanitize(this.snapshot.notice)}`)
@@ -688,7 +826,7 @@ function renderTabs(selected: SupervisorPanel, narrow: boolean): string {
 function renderGuidance(runtime: RuntimeSummary | null): string[] {
   if (!runtime) return ['Runtime status is unavailable. Doctor may explain why.']
   if (runtime.class === 'absent') {
-    return ['OpenAlice is stopped. Press s to start, or c to choose its source checkout.']
+    return ['OpenAlice is stopped. Press s to start, m for managed source, or c for an existing checkout.']
   }
   if (runtime.class === 'incompatible') {
     return ['The running Guardian is incompatible. Read Doctor before changing it.']
@@ -733,6 +871,7 @@ function renderHelp(): string[] {
     'x  Stop (confirmation required)   r  Restart (confirmation required)',
     'l  Bounded redacted logs          d  Read-only Doctor',
     'u  Check for product update       ?  Toggle this help',
+    'm  Prepare installer-managed source and start',
     'c  Choose and remember this instance\'s source checkout',
     'Tab / arrows  Change panel        q / Esc  Detach only',
     '',
@@ -741,9 +880,21 @@ function renderHelp(): string[] {
 }
 
 function renderConfirmation(
-  action: 'stop' | 'restart',
+  action: 'stop' | 'restart' | 'managed-source',
   runtime: RuntimeSummary | null,
+  managedSource?: ManagedSourcePlan | null,
 ): string[] {
+  if (action === 'managed-source') {
+    const selector = managedSource
+      ? `${managedSource.selector.kind} ${managedSource.selector.value}`
+      : 'the branch/version paired with this CLI'
+    return [
+      `Prepare and use installer-managed OpenAlice source ${selector}?`,
+      `Destination: ${managedSource?.appDir ?? 'the OpenAlice install root'}`,
+      'First start may install dependencies and build the Runtime.',
+      'Press y / Enter to continue, n / Esc to cancel.',
+    ]
+  }
   const effect = action === 'stop'
     ? 'This stops the Guardian-owned Runtime and disconnects active Web/agent sessions.'
     : 'This stops and starts the Guardian-owned Runtime; active Web/agent sessions reconnect or end.'
@@ -756,7 +907,7 @@ function renderConfirmation(
 
 function actionBar(runtime: RuntimeSummary | null, narrow: boolean): string {
   const actions = runtime?.class === 'absent'
-    ? 's Start · c Source · d Doctor · l Logs · u Update · ? Help'
+    ? 's Start · m Managed · c Source · d Doctor · l Logs · u Update · ? Help'
     : 'o Open · r Restart · x Stop · d Doctor · l Logs · u Update · ? Help'
   return narrow ? actions.replaceAll(' · ', '  ') : actions
 }

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -420,6 +420,22 @@ immediately use the selected instance's source checkout. General config
 editing, `config check`, last-known-good live reload, and named-instance
 management remain unchecked above.
 
+The clean-host follow-up reuses the managed-remote install-source identity for
+local startup. A stopped installed Supervisor now confirms `m Managed`, clones
+the exact CLI branch/version into an installer-owned collision-safe path,
+persists it for the selected instance, and continues through the normal
+prepare/build/start flow. This closes the manual `git clone` gap while the
+standalone headless artifact below remains the intended way to remove source
+toolchains from ordinary installs.
+
+The acceptance walk used a new isolated HOME and install root, installed only
+CLI 0.87.0-beta plus managed Pi 0.83.0, then launched from an unrelated empty
+directory. `m Managed` displayed the exact `branch dev` plan, cloned under the
+install root, installed dependencies, built the Runtime, and reached Alice
+ready on an isolated port. `/api/auth/status` and the root page passed, the
+0600 Supervisor config retained the managed path, detach/reattach reused the
+running Guardian, and TUI stop returned the home to absent.
+
 ### 7. Standalone headless Runtime artifact
 
 - [ ] Inventory server/UI/Guardian outputs, production dependencies, native

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -150,6 +150,8 @@ cmp /fixture/packages/cli/src/install-layout.mjs "$v1_release/src/install-layout
   || fail "downloaded install-layout module differs from the fixture"
 cmp /fixture/packages/cli/src/supervisor-config.ts "$v1_release/src/supervisor-config.ts" \
   || fail "downloaded Supervisor configuration module differs from the fixture"
+cmp /fixture/packages/cli/src/managed-source.ts "$v1_release/src/managed-source.ts" \
+  || fail "downloaded managed source module differs from the fixture"
 cmp /fixture/packages/cli/src/lifecycle-command.mjs "$v1_release/src/lifecycle-command.mjs" \
   || fail "downloaded lifecycle command module differs from the fixture"
 cmp /fixture/packages/cli/src/lifecycle.mjs "$v1_release/src/lifecycle.mjs" \


### PR DESCRIPTION
## What changed

- add a collision-safe local managed-source service keyed by the same install provenance used by managed SSH
- let a stopped installed Supervisor inspect and confirm `m Managed`, clone the exact CLI branch/version, remember it for the selected instance, and continue through ordinary prepare/build/start
- show the exact source selector and destination before mutation; source-run CLIs explain why the managed action is unavailable
- derive the TUI channel label from installed provenance (`branch dev` / `stable`)
- replace clean-host installer guidance that required a manual `git clone` with the bare Supervisor entry
- keep CLI-only uninstall conservative: managed checkouts are explicitly preserved because they may later contain user work

## Why

After #890, a user could select and persist an existing checkout inside the TUI, but a truly clean machine still could not get from curl install to a running OpenAlice without manually cloning the repository first. Managed SSH already had the correct source identity and safety model; local startup now reuses it instead of maintaining a second version-selection scheme.

## Validation

- `npx tsc --noEmit`
- `pnpm test` (443 files passed, 1 skipped; 3716 tests passed, 9 skipped)
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm -F @traderalice/openalice-cli test` (22 files, 162 tests)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `pnpm electron:smoke:pty`
- isolated macOS clean-host walk: installed only CLI 0.87.0-beta + Pi 0.83.0, launched from an unrelated empty directory, confirmed `branch dev`, cloned/installed/built via `m Managed`, reached Alice ready, verified `/api/auth/status` and HTTP 200, detached/reattached to the surviving Guardian, then stopped cleanly in the TUI
- confirmed the 0600 Supervisor config persisted the managed source and later starts reused it without recloning