### PR TITLE
feat(cli): add instance settings to supervisor TUI

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -94,6 +94,8 @@ explicit commands:
 - `l` reads the bounded, redacted log tail;
 - `d` runs read-only Doctor checks;
 - `u` performs an advisory product-update check;
+- `p` opens selected-instance settings for complete home, Web port, update
+  checks, and resolved source/config provenance;
 - `m` confirms, prepares, remembers, and starts an installer-managed source
   aligned to the installed CLI branch/version;
 - `c` chooses and remembers the selected instance's source checkout;
@@ -134,12 +136,21 @@ the Supervisor reads a versioned machine-local document at
 `<Supervisor root>/config.json`. It contains machine defaults and an instance
 map outside every selectable complete home.
 
+The `p` settings overlay atomically edits the selected instance's complete
+home, Web port, and update-check policy. A blank Home or port and the
+`Inherit` update value remove the instance override, exposing the resolved
+machine/default value immediately. Home and port remain read-only while the
+selected Runtime is active. Any value supplied by an environment variable or
+explicit CLI flag is shown with its resolved value and a locked provenance
+message; the TUI never writes a lower-priority value that appears to override
+it.
+
 The `c` editor validates an OpenAlice checkout, atomically saves it as the
 selected instance's `appDir`, and starts the Runtime. If
 `OPENALICE_APP_HOME` or `--app-dir` supplied the source, the TUI reports that
-higher-priority override instead of overwriting it. General configuration
-editing, `openalice config check`, live reload with last-known-good retention,
-and named-instance management remain later increments.
+higher-priority override instead of overwriting it. Machine-default editing,
+`openalice config check`, live reload with last-known-good retention, and
+named-instance management remain later increments.
 
 `OPENALICE_INSTANCE`, `OPENALICE_HOME`, `OPENALICE_WEB_PORT`,
 `OPENALICE_APP_HOME`, and `OPENALICE_NO_UPDATE_CHECK` are the corresponding
@@ -158,6 +169,14 @@ Consequently a Runtime started through the TUI and one started by
 `openalice up` receive the same managed-Pi environment. The transitional
 presenters still own their existing command-specific port, source, timeout,
 and output parsing until the root parser conversion is complete.
+
+The selected Web port is explicit for the source-backed built Guardian.
+Unconfigured MCP/local-tool, UTA, and Connector ports retain their independent
+probe-upward behavior, so another complete home or the desktop app can occupy
+the historical internal defaults without breaking this CLI Runtime. Explicit
+internal environment or `data/config/ports.json` values still fail visibly on
+collision. Stop and restart wait for Guardian plus Alice ownership evidence to
+clear, not merely for the control socket to disappear.
 
 ## Presentation-neutral Core
 

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -145,7 +145,9 @@ export async function startRuntime(options, dependencies = {}) {
       waitForRuntimeReady(homeRoot, options.waitMs, {
         ...dependencies,
         readStatus,
-        allowOwnerTransition: options.takeover,
+        allowOwnerTransition: true,
+        allowForeignOwnerTransition: options.takeover,
+        expectedOwnerPid: runtime.pid,
         signal: readinessAbort.signal,
       }),
       earlyFailure,
@@ -239,8 +241,20 @@ async function waitForRuntimeReady(homeRoot, timeoutMs, dependencies) {
       timeoutMs: Math.min(1_000, Math.max(100, deadline - Date.now())),
     }, dependencies)
     if (
+      Number.isInteger(dependencies.expectedOwnerPid)
+      && Number.isInteger(lastStatus.owner?.pid)
+      && lastStatus.owner.pid !== dependencies.expectedOwnerPid
+      && !dependencies.allowForeignOwnerTransition
+    ) {
+      throw lifecycleError('EOWNED', formatOwnershipRefusal(lastStatus))
+    }
+    if (
       lastStatus.class === 'running'
       && lastStatus.owner?.surface === 'cli-server'
+      && (
+        !Number.isInteger(dependencies.expectedOwnerPid)
+        || lastStatus.owner.pid === dependencies.expectedOwnerPid
+      )
       && isLoopbackWebUrl(lastStatus.endpoints?.web)
     ) {
       return lastStatus

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -93,6 +93,41 @@ describe('OpenAlice Runtime lifecycle core', () => {
     })
   })
 
+  it('allows its spawned Guardian ownership transition but rejects a racing owner', async () => {
+    const child = new FakeChild()
+    child.pid = 321
+    const racingStatus = {
+      ...runningStatus(),
+      class: 'owned_elsewhere',
+      state: 'starting',
+      owner: {
+        ...runningStatus().owner,
+        pid: 999,
+      },
+      endpoints: {},
+    }
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(absentStatus())
+      .mockResolvedValue(racingStatus)
+
+    await expect(startRuntime(startOptions(), {
+      detached: true,
+      env: {},
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess: () => child,
+      openFile: async () => ({ fd: 9, close: async () => undefined }),
+      mkdirImpl: async () => undefined,
+      readStatus,
+      sleep: async () => undefined,
+    })).rejects.toMatchObject({
+      code: 'EOWNED',
+      message: expect.stringContaining('pid 999'),
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
   it('preserves Guardian takeover authority instead of signaling the old owner itself', async () => {
     const child = new FakeChild()
     const previousOwner = {
@@ -231,6 +266,7 @@ function absentStatus() {
 }
 
 class FakeChild extends EventEmitter {
+  pid = 123
   exitCode = null
   signalCode = null
   kill = vi.fn()

--- a/packages/cli/src/server-control.mjs
+++ b/packages/cli/src/server-control.mjs
@@ -265,29 +265,55 @@ function emptyRuntimeStatus(homeRoot, statusClass, state, detail) {
 }
 
 async function inspectGuardianOwner(homeRoot, options = {}) {
-  let owner
-  try {
-    owner = JSON.parse(await readFile(resolve(homeRoot, 'state', 'guardian.lock', 'owner.json'), 'utf8'))
-  } catch (error) {
-    if (error?.code === 'ENOENT') return null
-    return { active: true, publicOwner: null, detail: 'Guardian owner metadata is unreadable' }
-  }
-  if (!Number.isInteger(owner?.pid) || typeof owner?.launcher !== 'string') {
-    return { active: true, publicOwner: null, detail: 'Guardian owner metadata is invalid' }
-  }
+  const ownerPaths = [
+    resolve(homeRoot, 'state', 'guardian.lock', 'owner.json'),
+    resolve(homeRoot, 'state', 'runtime.lock', 'owner.json'),
+    resolve(homeRoot, 'workspaces', 'state', 'runtime.lock', 'owner.json'),
+  ]
   const localHostname = options.hostname ?? hostname()
-  const sameHost = typeof owner.hostname !== 'string' || owner.hostname === localHostname
   const isAlive = options.isProcessAlive ?? isProcessAlive
-  const active = !sameHost || isAlive(owner.pid)
-  return {
-    active,
-    publicOwner: {
-      surface: owner.launcher.startsWith('guardian-') ? owner.launcher.slice('guardian-'.length) : owner.launcher,
+  let staleOwner = null
+  for (const ownerPath of ownerPaths) {
+    let owner
+    try {
+      owner = JSON.parse(await readFile(ownerPath, 'utf8'))
+    } catch (error) {
+      if (error?.code === 'ENOENT') continue
+      return {
+        active: true,
+        publicOwner: null,
+        detail: `Runtime owner metadata is unreadable at ${ownerPath}`,
+      }
+    }
+    if (!Number.isInteger(owner?.pid) || typeof owner?.launcher !== 'string') {
+      return {
+        active: true,
+        publicOwner: null,
+        detail: `Runtime owner metadata is invalid at ${ownerPath}`,
+      }
+    }
+    const sameHost = typeof owner.hostname !== 'string'
+      || owner.hostname === localHostname
+    const active = !sameHost || isAlive(owner.pid)
+    const publicOwner = {
+      surface: owner.launcher.startsWith('guardian-')
+        ? owner.launcher.slice('guardian-'.length)
+        : owner.launcher,
       pid: owner.pid,
-      startedAt: typeof owner.acquiredAt === 'string' ? owner.acquiredAt : null,
-    },
-    ...(!active ? { detail: 'A stale Guardian owner record is present; the next start may recover it' } : {}),
+      startedAt: typeof owner.acquiredAt === 'string'
+        ? owner.acquiredAt
+        : null,
+    }
+    if (active) return { active: true, publicOwner }
+    staleOwner = publicOwner
   }
+  return staleOwner
+    ? {
+        active: false,
+        publicOwner: staleOwner,
+        detail: 'A stale Runtime owner record is present; the next start may recover it',
+      }
+    : null
 }
 
 function sanitizeControlOwner(owner) {

--- a/packages/cli/src/server-control.spec.mjs
+++ b/packages/cli/src/server-control.spec.mjs
@@ -221,6 +221,34 @@ describe('OpenAlice Guardian control protocol', () => {
     expect(stale.class).toBe('absent')
     expect(stale.detail).toContain('stale')
   })
+
+  it('keeps shutdown non-absent while an Alice runtime lock is still active', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'runtime.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      hostname: 'fixture-host',
+      launcher: 'cli-server',
+      acquiredAt: '2026-07-15T00:00:00.000Z',
+      token: 'do-not-expose',
+    }))
+
+    const status = await readRuntimeStatus({ homeRoot: home }, {
+      hostname: 'fixture-host',
+      isProcessAlive: () => true,
+    })
+
+    expect(status).toEqual(expect.objectContaining({
+      class: 'owned_elsewhere',
+      state: 'running',
+      owner: expect.objectContaining({
+        surface: 'cli-server',
+        pid: process.pid,
+      }),
+    }))
+    expect(JSON.stringify(status)).not.toContain('do-not-expose')
+  })
 })
 
 function runtimeStatus(home, overrides = {}) {

--- a/packages/cli/src/supervisor-config.spec.ts
+++ b/packages/cli/src/supervisor-config.spec.ts
@@ -105,6 +105,32 @@ describe('Supervisor configuration', () => {
     })
   })
 
+  it('removes an instance override when a setting returns to inheritance', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-inherit-'))
+    temporaryPaths.push(root)
+    const context = await resolveStoredLaunchContext({}, {
+      homeDir: join(root, 'user'),
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+
+    await persistInstanceLaunchConfig(context, {
+      port: 49_001,
+      updateChecks: false,
+    })
+    await persistInstanceLaunchConfig(context, {
+      port: undefined,
+    })
+
+    const saved = JSON.parse(
+      await readFile(supervisorConfigPath(context.supervisorRoot), 'utf8'),
+    )
+    expect(saved.instances.default).toEqual({
+      name: 'default',
+      updateChecks: false,
+    })
+  })
+
   it('rejects corrupt, unknown, and mismatched configuration fields', () => {
     expect(() => parseSupervisorConfig({
       schemaVersion: 2,

--- a/packages/cli/src/supervisor-config.ts
+++ b/packages/cli/src/supervisor-config.ts
@@ -60,6 +60,19 @@ export interface PersistInstanceConfigOptions {
   ) => Promise<void>
 }
 
+export async function readInstanceLaunchConfig(
+  context: ResolvedLaunchContext,
+  options: Pick<PersistInstanceConfigOptions, 'readConfig'> = {},
+): Promise<InstanceLaunchConfig> {
+  const config = await (
+    options.readConfig ?? readSupervisorConfig
+  )(context.supervisorRoot)
+  return {
+    ...config.instances?.[context.instance],
+    name: context.instance,
+  }
+}
+
 export async function resolveStoredLaunchContext(
   flags: TuiLaunchFlags = {},
   options: StoredLaunchContextOptions = {},
@@ -104,6 +117,16 @@ export async function persistInstanceLaunchConfig(
     ...existing,
     ...patch,
     name: context.instance,
+  }
+  for (const key of [
+    'home',
+    'port',
+    'appDir',
+    'updateChecks',
+  ] as const) {
+    if (Object.hasOwn(patch, key) && patch[key] === undefined) {
+      delete instance[key]
+    }
   }
   const next: SupervisorConfigDocument = {
     ...current,

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -166,6 +166,133 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('Source configuration cancelled.')
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
+  })
+
+  it('edits and persists selected-instance settings inside the TUI', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-settings-'))
+    temporaryPaths.push(isolatedHome)
+    const supervisorHome = join(isolatedHome, 'supervisor')
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 110,
+      rows: 30,
+      cwd: dirname(cliEntry),
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        OPENALICE_HOME: join(isolatedHome, 'state'),
+        OPENALICE_SUPERVISOR_HOME: supervisorHome,
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let openedSettings = false
+      let selectedPort = false
+      let submittedPort = false
+      let closedSettings = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor settings TUI timed out:\n${output}`))
+      }, 10_000)
+      child.onData((data) => {
+        output += data
+        if (!openedSettings && output.includes('p Settings')) {
+          openedSettings = true
+          child.write('p')
+        } else if (!selectedPort && output.includes('Instance settings · default')) {
+          selectedPort = true
+          child.write('\u001b[B\r')
+        } else if (!submittedPort && output.includes('Set Web port')) {
+          submittedPort = true
+          child.write('49001\r')
+        } else if (!closedSettings && output.includes('Saved Web port.')) {
+          closedSettings = true
+          child.write('\u001b')
+        } else if (
+          !detached
+          && output.includes('port (instance.default.port)')
+        ) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor settings TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    const config = JSON.parse(
+      await readFile(join(supervisorHome, 'config.json'), 'utf8'),
+    )
+    expect(config.instances.default.port).toBe(49_001)
+    expect(transcript).toContain('Instance settings · default')
+    expect(transcript).toContain('Set Web port')
+    expect(transcript).toContain('Saved Web port.')
+    expect(transcript).toContain('port (instance.default.port)')
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  })
+
+  it('shows higher-priority CLI overrides as locked settings', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-settings-lock-'))
+    temporaryPaths.push(isolatedHome)
+    const child = pty.spawn(process.execPath, [
+      cliEntry,
+      '--port', '44000',
+    ], {
+      cols: 110,
+      rows: 30,
+      cwd: dirname(cliEntry),
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        OPENALICE_HOME: join(isolatedHome, 'state'),
+        OPENALICE_SUPERVISOR_HOME: join(isolatedHome, 'supervisor'),
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let openedSettings = false
+      let selectedPort = false
+      let testedLockedPort = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor locked-settings TUI timed out:\n${output}`))
+      }, 10_000)
+      child.onData((data) => {
+        output += data
+        if (!openedSettings && output.includes('p Settings')) {
+          openedSettings = true
+          child.write('p')
+        } else if (!selectedPort && output.includes('44000 · locked')) {
+          selectedPort = true
+          child.write('\u001b[B')
+        } else if (!testedLockedPort && output.includes('Locked by --port.')) {
+          testedLockedPort = true
+          child.write('\r')
+          setTimeout(() => child.write('\u001b'), 50)
+        } else if (!detached && output.includes('Instance settings closed.')) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor locked-settings TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain('44000 · locked')
+    expect(transcript).toContain('Locked by --port.')
+    expect(transcript).not.toContain('Set Web port')
   })
 
   it('explains when managed source is unavailable from a source-run CLI', async () => {

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -43,7 +43,8 @@ describe('Supervisor TUI screen', () => {
 
     expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
     expect(lines).toContain('Runtime state: absent')
-    expect(lines).toContain('s Start · m Managed · c Source · d Doctor · l Logs · u Update · ? Help')
+    expect(lines).toContain('s Start · p Settings · m Managed · c Source')
+    expect(lines).toContain('d Doctor · l Logs · u Update · ? Help')
     expect(lines).toContain('q / Esc / Ctrl+C  Detach without stopping')
   })
 
@@ -131,6 +132,29 @@ describe('Supervisor TUI screen', () => {
     running.update({ runtime: { class: 'absent' } })
     expect(running.handleKey('c', matchesKey)).toBe(true)
     expect(configureRequests).toBe(1)
+  })
+
+  it('opens instance settings while stopped or running', () => {
+    let settingsRequests = 0
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: { class: 'absent' },
+    }, {
+      onSettings: () => {
+        settingsRequests += 1
+      },
+    })
+
+    expect(screen.handleKey('p', matchesKey)).toBe(true)
+    screen.update({
+      runtime: {
+        class: 'running',
+        owner: { surface: 'cli-server', pid: 42 },
+      },
+    })
+    expect(screen.handleKey('p', matchesKey)).toBe(true)
+    expect(settingsRequests).toBe(2)
   })
 
   it('confirms managed source preparation before dispatch', () => {

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import type { Component, KeyId } from '@earendil-works/pi-tui'
+import type {
+  Component,
+  KeyId,
+  SettingItem,
+  SettingsListTheme,
+} from '@earendil-works/pi-tui'
 
 import { diagnoseRuntime } from './doctor.mjs'
 import {
@@ -13,6 +18,7 @@ import {
   buildManagedPiEnv,
   resolveLaunchContext,
   type InstanceLaunchConfig,
+  type LaunchConfigValues,
   type MachineSupervisorConfig,
   type ResolvedLaunchContext,
   type TuiLaunchFlags,
@@ -30,6 +36,7 @@ import {
 import { loadPiTui } from './pi-tui-loader.ts'
 import {
   persistInstanceLaunchConfig,
+  readInstanceLaunchConfig,
   resolveStoredLaunchContext,
 } from './supervisor-config.ts'
 import {
@@ -38,6 +45,9 @@ import {
 } from './update.mjs'
 
 const SILENT_OUTPUT = Object.freeze({ write: () => true })
+const INHERIT_SETTING = 'Inherit'
+const ENABLED_SETTING = 'Enabled'
+const DISABLED_SETTING = 'Disabled'
 
 interface RuntimeSummary {
   class?: string
@@ -131,10 +141,13 @@ export interface SupervisorTuiDependencies {
     flags: TuiLaunchFlags,
   ) => ResolvedLaunchContext | Promise<ResolvedLaunchContext>
   findSource?: (startPath: string) => Promise<string>
-  configureSource?: (
+  configureInstance?: (
     context: ResolvedLaunchContext,
-    appDir: string,
+    patch: LaunchConfigValues,
   ) => Promise<ResolvedLaunchContext>
+  loadInstanceConfig?: (
+    context: ResolvedLaunchContext,
+  ) => Promise<InstanceLaunchConfig>
   prepareManagedSource?: () => Promise<ManagedSourceResult>
   inspectManagedSource?: () => Promise<ManagedSourcePlan>
   machineConfig?: MachineSupervisorConfig | null
@@ -205,7 +218,9 @@ export async function runSupervisorTui(
   let active = true
   let actionRunning = false
   let sourcePromptActive = false
+  let settingsActive = false
   let closeSourcePrompt: (() => void) | null = null
+  let closeSettings: (() => void) | null = null
   const screen = new SupervisorScreen({
     version: dependencies.version ?? readCliVersion(),
     channel,
@@ -219,6 +234,9 @@ export async function runSupervisorTui(
     onConfigureSource: () => {
       openSourcePrompt()
     },
+    onSettings: () => {
+      void openSettings()
+    },
     onRequestManagedSource: () => {
       void requestManagedSource()
     },
@@ -230,15 +248,17 @@ export async function runSupervisorTui(
   ui.addChild(screen)
 
   const findSource = dependencies.findSource ?? findOpenAliceRoot
-  const configureSource = dependencies.configureSource ?? (async (
+  const configureInstance = dependencies.configureInstance ?? (async (
     currentContext,
-    appDir,
+    patch,
   ) => {
-    await persistInstanceLaunchConfig(currentContext, { appDir })
+    await persistInstanceLaunchConfig(currentContext, patch)
     return resolveStoredLaunchContext(launchFlags, {
       env: dependencies.env,
     })
   })
+  const loadInstanceConfig = dependencies.loadInstanceConfig
+    ?? readInstanceLaunchConfig
   const prepareManaged = dependencies.prepareManagedSource
     ?? (() => prepareManagedSource())
   const inspectManaged = dependencies.inspectManagedSource
@@ -385,7 +405,9 @@ export async function runSupervisorTui(
     })
     try {
       const result = await prepareManaged()
-      const nextContext = await configureSource(context, result.appDir)
+      const nextContext = await configureInstance(context, {
+        appDir: result.appDir,
+      })
       context = nextContext
       services = createServices(dependencies, context)
       prepared = true
@@ -409,7 +431,7 @@ export async function runSupervisorTui(
   }
 
   function openSourcePrompt(reason?: string): void {
-    if (sourcePromptActive || actionRunning) return
+    if (sourcePromptActive || settingsActive || actionRunning) return
     const source = context.provenance.appDir.source
     if (source === 'environment' || source === 'cli-flag') {
       screen.update({
@@ -476,7 +498,7 @@ export async function runSupervisorTui(
       void (async () => {
         try {
           const appDir = await findSource(requested)
-          const nextContext = await configureSource(context, appDir)
+          const nextContext = await configureInstance(context, { appDir })
           context = nextContext
           services = createServices(dependencies, context)
           screen.update({
@@ -493,6 +515,287 @@ export async function runSupervisorTui(
         }
       })()
     }
+    overlay.focus()
+  }
+
+  async function openSettings(): Promise<void> {
+    if (settingsActive || sourcePromptActive || actionRunning) return
+    actionRunning = true
+    screen.update({
+      busy: 'Loading instance settings',
+      notice: undefined,
+      diagnostic: undefined,
+    })
+    let stored: InstanceLaunchConfig
+    try {
+      stored = await loadInstanceConfig(context)
+    } catch (error: unknown) {
+      screen.update({
+        diagnostic: `Could not load instance settings: ${safeError(error)}`,
+      })
+      return
+    } finally {
+      actionRunning = false
+      if (active) screen.update({ busy: undefined })
+    }
+    if (!active) return
+
+    settingsActive = true
+    let saving = false
+    let message = 'Changes are saved to this instance. Higher-priority overrides stay locked.'
+    const items: SettingItem[] = []
+    let settings: InstanceType<typeof piTui.SettingsList>
+
+    const setMessage = (next: string) => {
+      message = next
+      ui.requestRender()
+    }
+    const close = (notice = 'Instance settings closed.') => {
+      if (!settingsActive) return
+      settingsActive = false
+      closeSettings = null
+      overlay.hide()
+      ui.setShowHardwareCursor(false)
+      screen.update({ notice })
+    }
+    const inputSubmenu = (
+      title: string,
+      initialValue: string,
+      validate: (value: string) => string | undefined,
+      done: (selectedValue?: string) => void,
+    ): Component => {
+      const input = new (class extends piTui.Input {
+        detail = 'Leave blank to inherit from the next lower-priority layer.'
+
+        setDetail(next: string): void {
+          this.detail = next
+          this.invalidate()
+          ui.requestRender()
+        }
+
+        override render(width: number): string[] {
+          return [
+            title,
+            '',
+            ...super.render(width),
+            '',
+            sanitize(this.detail),
+            '',
+            'Enter  Save · Esc  Cancel',
+          ]
+        }
+      })()
+      input.setValue(initialValue)
+      input.focused = true
+      ui.setShowHardwareCursor(true)
+      input.onEscape = () => {
+        input.focused = false
+        ui.setShowHardwareCursor(false)
+        done()
+      }
+      input.onSubmit = (value) => {
+        const validation = validate(value.trim())
+        if (validation) {
+          input.setDetail(validation)
+          return
+        }
+        input.focused = false
+        ui.setShowHardwareCursor(false)
+        done(value.trim() || INHERIT_SETTING)
+      }
+      return input
+    }
+
+    const syncItems = () => {
+      const runtimeStopped = screen.snapshot.runtime?.class === 'absent'
+      const homeLocked = settingOverrideLock(context.provenance.home)
+      const portLocked = settingOverrideLock(context.provenance.port)
+      const updatesLocked = settingOverrideLock(context.provenance.updateChecks)
+      const homeItem: SettingItem = {
+        id: 'home',
+        label: 'Complete home',
+        currentValue: homeLocked
+          ? `${context.home} · locked`
+          : inheritedSettingValue(stored.home, context.home),
+        description: homeLocked
+          ?? (
+            runtimeStopped
+              ? 'Complete state root for this instance. Blank removes the instance override.'
+              : 'Stop the selected Runtime before changing its complete home.'
+          ),
+      }
+      if (!homeLocked && runtimeStopped) {
+        homeItem.submenu = (_currentValue, done) => inputSubmenu(
+          'Set complete home',
+          stored.home ?? '',
+          () => undefined,
+          done,
+        )
+      }
+      const portItem: SettingItem = {
+        id: 'port',
+        label: 'Web port',
+        currentValue: portLocked
+          ? `${context.port} · locked`
+          : inheritedSettingValue(stored.port, context.port),
+        description: portLocked
+          ?? (
+            runtimeStopped
+              ? 'Port for the local Web UI. Blank removes the instance override.'
+              : 'Stop the selected Runtime before changing its Web port.'
+          ),
+      }
+      if (!portLocked && runtimeStopped) {
+        portItem.submenu = (_currentValue, done) => inputSubmenu(
+          'Set Web port',
+          stored.port?.toString() ?? '',
+          validatePortSetting,
+          done,
+        )
+      }
+      const updateItem: SettingItem = {
+        id: 'updateChecks',
+        label: 'Update checks',
+        currentValue: updatesLocked
+          ? `${context.updateChecks ? ENABLED_SETTING : DISABLED_SETTING} · locked`
+          : booleanSettingValue(stored.updateChecks),
+        description: updatesLocked
+          ?? `Check for CLI/product updates when the Supervisor opens. Resolved: ${context.updateChecks ? 'enabled' : 'disabled'}.`,
+      }
+      if (!updatesLocked) {
+        updateItem.values = [
+          INHERIT_SETTING,
+          ENABLED_SETTING,
+          DISABLED_SETTING,
+        ]
+      }
+      items.splice(0, items.length,
+        homeItem,
+        portItem,
+        updateItem,
+        {
+          id: 'source',
+          label: 'Runtime source',
+          currentValue: context.appDir ?? 'current directory discovery',
+          description: 'Read-only here. Use m for installer-managed source or c for an existing checkout.',
+        },
+        {
+          id: 'config',
+          label: 'Config file',
+          currentValue: join(context.supervisorRoot, 'config.json'),
+          description: 'Machine defaults and every named instance live in this atomic JSON document.',
+        },
+      )
+    }
+    syncItems()
+
+    const applySetting = async (
+      id: string,
+      newValue: string,
+    ): Promise<void> => {
+      if (saving) return
+      const field = settingField(id)
+      if (!field) return
+      const lock = settingOverrideLock(context.provenance[field])
+      if (lock) {
+        setMessage(lock)
+        syncItems()
+        settings.updateValue(id, settingItemValue(id, stored, context))
+        return
+      }
+      if (
+        (field === 'home' || field === 'port')
+        && screen.snapshot.runtime?.class !== 'absent'
+      ) {
+        setMessage(`Stop the selected Runtime before changing its ${field === 'home' ? 'complete home' : 'Web port'}.`)
+        syncItems()
+        settings.updateValue(id, settingItemValue(id, stored, context))
+        return
+      }
+
+      const patch: LaunchConfigValues = field === 'home'
+        ? { home: newValue === INHERIT_SETTING ? undefined : newValue }
+        : field === 'port'
+          ? {
+              port: newValue === INHERIT_SETTING
+                ? undefined
+                : Number.parseInt(newValue, 10),
+            }
+          : {
+              updateChecks: newValue === INHERIT_SETTING
+                ? undefined
+                : newValue === ENABLED_SETTING,
+            }
+      saving = true
+      actionRunning = true
+      setMessage(`Saving ${settingLabel(field)}…`)
+      try {
+        context = await configureInstance(context, patch)
+        services = createServices(dependencies, context)
+        stored = await loadInstanceConfig(context)
+        syncItems()
+        for (const item of items) {
+          settings.updateValue(item.id, item.currentValue)
+        }
+        screen.update({
+          context,
+          diagnostic: undefined,
+        })
+        setMessage(`Saved ${settingLabel(field)}.`)
+      } catch (error: unknown) {
+        syncItems()
+        settings.updateValue(id, settingItemValue(id, stored, context))
+        setMessage(`Could not save ${settingLabel(field)}: ${safeError(error)}`)
+      } finally {
+        actionRunning = false
+        saving = false
+        await refreshRuntime()
+      }
+    }
+
+    const theme: SettingsListTheme = {
+      label: (text) => text,
+      value: (text) => text,
+      description: (text) => text,
+      cursor: '> ',
+      hint: (text) => text,
+    }
+    settings = new piTui.SettingsList(
+      items,
+      5,
+      theme,
+      (id, newValue) => {
+        void applySetting(id, newValue)
+      },
+      () => close(),
+    )
+    const panel = new (class implements Component {
+      render(width: number): string[] {
+        return [
+          `Instance settings · ${context.instance}`,
+          '─'.repeat(Math.max(1, width)),
+          '',
+          ...settings.render(width),
+          '',
+          sanitize(message),
+        ]
+      }
+
+      handleInput(data: string): void {
+        if (!saving) settings.handleInput(data)
+      }
+
+      invalidate(): void {
+        settings.invalidate()
+      }
+    })()
+    const overlay = ui.showOverlay(panel, {
+      width: '90%',
+      maxHeight: '90%',
+      anchor: 'center',
+      margin: 1,
+    })
+    closeSettings = () => close()
     overlay.focus()
   }
 
@@ -525,6 +828,7 @@ export async function runSupervisorTui(
       active = false
       clearInterval(poll)
       closeSourcePrompt?.()
+      closeSettings?.()
       removeInputListener()
       process.off('SIGTERM', onTerminate)
       process.off('SIGINT', onTerminate)
@@ -533,7 +837,7 @@ export async function runSupervisorTui(
     }
     const onTerminate = () => finish()
     const removeInputListener = ui.addInputListener((data) => {
-      if (sourcePromptActive) {
+      if (sourcePromptActive || settingsActive) {
         if (piTui.matchesKey(data, 'ctrl+c')) {
           finish()
           return { consume: true }
@@ -589,6 +893,7 @@ export class SupervisorScreen implements Component {
   snapshot: SupervisorSnapshot
   private readonly onAction?: (action: SupervisorAction) => void
   private readonly onConfigureSource?: () => void
+  private readonly onSettings?: () => void
   private readonly onRequestManagedSource?: () => void
   private readonly onPrepareManagedSource?: () => void
   private readonly requestRender?: () => void
@@ -598,6 +903,7 @@ export class SupervisorScreen implements Component {
     callbacks: {
       onAction?: (action: SupervisorAction) => void
       onConfigureSource?: () => void
+      onSettings?: () => void
       onRequestManagedSource?: () => void
       onPrepareManagedSource?: () => void
       requestRender?: () => void
@@ -606,6 +912,7 @@ export class SupervisorScreen implements Component {
     this.snapshot = { panel: 'overview', ...snapshot }
     this.onAction = callbacks.onAction
     this.onConfigureSource = callbacks.onConfigureSource
+    this.onSettings = callbacks.onSettings
     this.onRequestManagedSource = callbacks.onRequestManagedSource
     this.onPrepareManagedSource = callbacks.onPrepareManagedSource
     this.requestRender = callbacks.requestRender
@@ -656,6 +963,10 @@ export class SupervisorScreen implements Component {
           notice: 'Stop the selected Runtime before changing its source checkout.',
         })
       }
+      return true
+    }
+    if (matchesKey(data, 'p')) {
+      this.onSettings?.()
       return true
     }
     if (matchesKey(data, 'm')) {
@@ -758,7 +1069,7 @@ export class SupervisorScreen implements Component {
     }
     lines.push(
       '',
-      actionBar(runtime, narrow),
+      ...actionBar(runtime, width),
       'q / Esc / Ctrl+C  Detach without stopping',
     )
     return lines.map((line) => truncate(line, width))
@@ -871,6 +1182,7 @@ function renderHelp(): string[] {
     'x  Stop (confirmation required)   r  Restart (confirmation required)',
     'l  Bounded redacted logs          d  Read-only Doctor',
     'u  Check for product update       ?  Toggle this help',
+    'p  Configure selected instance settings',
     'm  Prepare installer-managed source and start',
     'c  Choose and remember this instance\'s source checkout',
     'Tab / arrows  Change panel        q / Esc  Detach only',
@@ -905,11 +1217,20 @@ function renderConfirmation(
   ]
 }
 
-function actionBar(runtime: RuntimeSummary | null, narrow: boolean): string {
-  const actions = runtime?.class === 'absent'
-    ? 's Start · m Managed · c Source · d Doctor · l Logs · u Update · ? Help'
-    : 'o Open · r Restart · x Stop · d Doctor · l Logs · u Update · ? Help'
-  return narrow ? actions.replaceAll(' · ', '  ') : actions
+function actionBar(runtime: RuntimeSummary | null, width: number): string[] {
+  const primary = runtime?.class === 'absent'
+    ? 's Start · p Settings · m Managed · c Source'
+    : 'o Open · p Settings · r Restart · x Stop'
+  const secondary = 'd Doctor · l Logs · u Update · ? Help'
+  const actions = `${primary} · ${secondary}`
+  if (actions.length <= width) return [actions]
+  if (width < 60) {
+    return [
+      primary.replaceAll(' · ', '  '),
+      secondary.replaceAll(' · ', '  '),
+    ]
+  }
+  return [primary, secondary]
 }
 
 function unavailableActionMessage(
@@ -972,6 +1293,82 @@ function formatDuration(seconds: number): string {
 
 function formatProvenance(value: { source: string; detail: string }): string {
   return value.source === 'default' ? '(default)' : `(${value.detail})`
+}
+
+type EditableSettingField = 'home' | 'port' | 'updateChecks'
+
+function settingField(id: string): EditableSettingField | undefined {
+  if (id === 'home' || id === 'port' || id === 'updateChecks') return id
+  return undefined
+}
+
+function settingLabel(field: EditableSettingField): string {
+  return {
+    home: 'complete home',
+    port: 'Web port',
+    updateChecks: 'update checks',
+  }[field]
+}
+
+function settingOverrideLock(
+  provenance: { source: string; detail: string },
+): string | undefined {
+  if (
+    provenance.source !== 'environment'
+    && provenance.source !== 'cli-flag'
+  ) {
+    return undefined
+  }
+  return `Locked by ${provenance.detail}. Change that higher-priority override and reopen the Supervisor.`
+}
+
+function inheritedSettingValue(
+  stored: string | number | undefined,
+  resolved: string | number,
+): string {
+  return stored === undefined
+    ? `${INHERIT_SETTING} → ${resolved}`
+    : String(stored)
+}
+
+function booleanSettingValue(stored: boolean | undefined): string {
+  if (stored === undefined) return INHERIT_SETTING
+  return stored ? ENABLED_SETTING : DISABLED_SETTING
+}
+
+function settingItemValue(
+  id: string,
+  stored: InstanceLaunchConfig,
+  context: ResolvedLaunchContext,
+): string {
+  if (id === 'home') {
+    return settingOverrideLock(context.provenance.home)
+      ? `${context.home} · locked`
+      : inheritedSettingValue(stored.home, context.home)
+  }
+  if (id === 'port') {
+    return settingOverrideLock(context.provenance.port)
+      ? `${context.port} · locked`
+      : inheritedSettingValue(stored.port, context.port)
+  }
+  if (id === 'updateChecks') {
+    return settingOverrideLock(context.provenance.updateChecks)
+      ? `${context.updateChecks ? ENABLED_SETTING : DISABLED_SETTING} · locked`
+      : booleanSettingValue(stored.updateChecks)
+  }
+  if (id === 'source') return context.appDir ?? 'current directory discovery'
+  return join(context.supervisorRoot, 'config.json')
+}
+
+function validatePortSetting(value: string): string | undefined {
+  if (!value) return undefined
+  if (!/^\d+$/.test(value)) {
+    return 'Web port must be a whole number from 1 to 65535.'
+  }
+  const port = Number(value)
+  return port >= 1 && port <= 65_535
+    ? undefined
+    : 'Web port must be a whole number from 1 to 65535.'
 }
 
 function safeError(error: unknown): string {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -402,6 +402,9 @@ starting the Runtime.
   flags once into `ResolvedLaunchContext`, retaining field-level provenance.
 - [ ] Add `openalice config check` plus TUI diagnostics; invalid live reload
   retains the last valid configuration.
+- [x] Add a selected-instance TUI settings overlay for complete home, Web port,
+  and update-check inheritance, with active-Runtime guards and visible
+  environment/CLI locks.
 - [x] Give OpenAlice-managed Pi an instance-local `PI_CODING_AGENT_DIR` and
   session root without changing a user-installed Pi launched externally.
 - [x] Update the managed Workspace runtime owner guide and tests for the new
@@ -414,11 +417,14 @@ starting the Runtime.
 - [ ] Test concurrent homes, ports, sockets, logs, foreign/stale owners,
   Electron ownership, and remote instances.
 
-The first persisted-configuration increment activates a versioned atomic
-`<Supervisor root>/config.json` and lets the TUI validate, remember, and
-immediately use the selected instance's source checkout. General config
-editing, `config check`, last-known-good live reload, and named-instance
-management remain unchecked above.
+The first persisted-configuration increments activate a versioned atomic
+`<Supervisor root>/config.json` and let the TUI validate, remember, and
+immediately use the selected instance's source checkout, complete home, Web
+port, and update policy. Returning a field to inheritance removes only that
+instance key. Environment and CLI provenance visibly lock lower-priority
+editing, while an active Runtime prevents its home or port from changing
+underneath it. Machine-default editing, `config check`, last-known-good live
+reload, and named-instance management remain unchecked above.
 
 The clean-host follow-up reuses the managed-remote install-source identity for
 local startup. A stopped installed Supervisor now confirms `m Managed`, clones
@@ -676,3 +682,17 @@ This plan is complete only when:
   instance/home/port selection. Persisted configuration schemas, registry
   loading, and full root-parser conversion remain in the configuration
   increment.
+- 2026-07-30: Added a Pi-style selected-instance settings overlay to the bare
+  Supervisor TUI. Humans can set or inherit complete home, Web port, and update
+  checks without launch flags; active Runtime mutations are guarded, and
+  environment/CLI overrides render their resolved values as locked. Atomic
+  persistence now removes explicit fields when they return to inheritance.
+  Real PTY journeys cover a saved/reloaded port and a `--port` lock.
+- 2026-07-30: The installed-CLI dogfood journey exposed two lifecycle gaps
+  masked by isolated unit fixtures. The built Guardian now probes unconfigured
+  internal ports, allowing a CLI Runtime on another complete home to coexist
+  with the desktop process occupying 47332. Status fallback now observes both
+  Guardian and Alice runtime locks, and spawned-start readiness accepts only
+  its expected Guardian PID. The same isolated installed CLI then completed
+  start, authenticated Web/root probes, stop/restart ownership handoff,
+  reconnect, and final stop while the desktop app remained active.

--- a/scripts/guardian/prod-ports.mjs
+++ b/scripts/guardian/prod-ports.mjs
@@ -1,0 +1,141 @@
+import { createServer } from 'node:net'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const PORT_DEFAULTS = {
+  web: 47331,
+  mcp: 47332,
+  uta: 47333,
+  connector: 47334,
+}
+
+const ENV_KEYS = {
+  web: 'OPENALICE_WEB_PORT',
+  mcp: 'OPENALICE_MCP_PORT',
+  uta: 'OPENALICE_UTA_PORT',
+  connector: 'OPENALICE_CONNECTOR_PORT',
+}
+
+export function parseProdPort(raw, origin) {
+  const port = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(
+      `[guardian/prod] invalid port ${JSON.stringify(raw)} from ${origin} — expected an integer in 1..65535`,
+    )
+  }
+  return port
+}
+
+export async function readProdPortsFile(userDataHome, options = {}) {
+  const readFileImpl = options.readFileImpl ?? readFile
+  const filePath = resolve(userDataHome, 'data', 'config', 'ports.json')
+  let raw
+  try {
+    raw = await readFileImpl(filePath, 'utf8')
+  } catch {
+    return {}
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    throw new Error(
+      `[guardian/prod] ${filePath} is not valid JSON: ${error?.message ?? error}`,
+    )
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      `[guardian/prod] ${filePath} must be a JSON object like {"web":47331,"mcp":47332,"uta":47333,"connector":47334}`,
+    )
+  }
+  const result = {}
+  for (const name of Object.keys(PORT_DEFAULTS)) {
+    if (parsed[name] !== undefined) {
+      result[name] = parseProdPort(
+        parsed[name],
+        `${filePath} ("${name}")`,
+      )
+    }
+  }
+  return result
+}
+
+export function resolveProdPortConfig(env, file) {
+  const pick = (name) => {
+    const envValue = env[ENV_KEYS[name]]
+    if (envValue !== undefined && envValue !== '') {
+      return {
+        value: parseProdPort(envValue, ENV_KEYS[name]),
+        source: 'env',
+      }
+    }
+    if (file[name] !== undefined) {
+      return { value: file[name], source: 'file' }
+    }
+    return { value: PORT_DEFAULTS[name], source: 'default' }
+  }
+  return {
+    web: pick('web'),
+    mcp: pick('mcp'),
+    uta: pick('uta'),
+    connector: pick('connector'),
+  }
+}
+
+export async function planProdPorts(
+  config,
+  options = {},
+) {
+  const probe = options.probe ?? probeFreePort
+  const claim = async (name, choice, probeStart) => {
+    if (choice.source === 'default') return probe(probeStart)
+    try {
+      return await probe(choice.value, choice.value)
+    } catch {
+      const origin = choice.source === 'env'
+        ? ENV_KEYS[name]
+        : 'data/config/ports.json'
+      throw new Error(
+        `[guardian/prod] port ${choice.value} (${name}, from ${origin}) is already in use — free it or configure another port`,
+      )
+    }
+  }
+
+  const web = await claim('web', config.web, PORT_DEFAULTS.web)
+  const mcp = await claim('mcp', config.mcp, web + 1)
+  const uta = options.skipUta
+    ? config.uta.value
+    : await claim(
+        'uta',
+        config.uta,
+        Math.max(PORT_DEFAULTS.uta, mcp + 1),
+      )
+  const connector = options.skipConnector
+    ? config.connector.value
+    : await claim(
+        'connector',
+        config.connector,
+        Math.max(PORT_DEFAULTS.connector, uta + 1),
+      )
+  return { web, mcp, uta, connector }
+}
+
+async function probeFreePort(start, max = 65_535) {
+  for (let port = start; port <= max; port += 1) {
+    if (await canListen(port)) return port
+  }
+  throw new Error(
+    `[guardian/prod] no free loopback port available from ${start} to ${max}`,
+  )
+}
+
+function canListen(port) {
+  return new Promise((resolveResult) => {
+    const server = createServer()
+    server.unref()
+    server.once('error', () => resolveResult(false))
+    server.listen(port, '127.0.0.1', () => {
+      server.close(() => resolveResult(true))
+    })
+  })
+}

--- a/scripts/guardian/prod-ports.spec.ts
+++ b/scripts/guardian/prod-ports.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  planProdPorts,
+  readProdPortsFile,
+  resolveProdPortConfig,
+} from './prod-ports.mjs'
+
+describe('built Guardian port planning', () => {
+  it('retains env, file, and default provenance', () => {
+    expect(resolveProdPortConfig(
+      { OPENALICE_WEB_PORT: '49123' },
+      { mcp: 49200 },
+    )).toEqual({
+      web: { value: 49123, source: 'env' },
+      mcp: { value: 49200, source: 'file' },
+      uta: { value: 47333, source: 'default' },
+      connector: { value: 47334, source: 'default' },
+    })
+  })
+
+  it('probes unconfigured internal ports above an explicit Web port', async () => {
+    const probe = vi.fn(async (
+      start: number,
+      max?: number,
+    ) => max === undefined ? start + 1 : start)
+    const config = resolveProdPortConfig(
+      { OPENALICE_WEB_PORT: '49123' },
+      {},
+    )
+
+    await expect(planProdPorts(config, {
+      probe,
+      skipUta: true,
+    })).resolves.toEqual({
+      web: 49123,
+      mcp: 49125,
+      uta: 47333,
+      connector: 47335,
+    })
+    expect(probe).toHaveBeenNthCalledWith(1, 49123, 49123)
+    expect(probe).toHaveBeenNthCalledWith(2, 49124)
+    expect(probe).toHaveBeenNthCalledWith(3, 47334)
+  })
+
+  it('fails loudly when an explicit internal port is occupied', async () => {
+    const config = resolveProdPortConfig({}, { mcp: 49200 })
+    const probe = vi.fn(async (start: number, max?: number) => {
+      if (start === 49200 && max === 49200) throw new Error('occupied')
+      return start
+    })
+
+    await expect(planProdPorts(config, { probe })).rejects.toThrow(
+      'port 49200 (mcp, from data/config/ports.json) is already in use',
+    )
+  })
+
+  it('reads and validates the persisted port file', async () => {
+    await expect(readProdPortsFile('/test-home', {
+      readFileImpl: async () => '{"web":49123,"connector":49126}',
+    })).resolves.toEqual({
+      web: 49123,
+      connector: 49126,
+    })
+    await expect(readProdPortsFile('/test-home', {
+      readFileImpl: async () => '{"web":"bad"}',
+    })).rejects.toThrow('expected an integer in 1..65535')
+  })
+})

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -38,6 +38,11 @@ import {
   takeoverRequested,
 } from '@traderalice/guardian-runtime'
 import { startGuardianControlServer } from './control-server.mjs'
+import {
+  planProdPorts,
+  readProdPortsFile,
+  resolveProdPortConfig,
+} from './prod-ports.mjs'
 
 const DATA_HOME = process.env.OPENALICE_HOME
   ?? process.env.OPENALICE_USER_DATA_HOME // deprecated alias, one-release courtesy
@@ -57,18 +62,6 @@ const RUNTIME_CONTENT_IDENTITY = normalizeContentIdentity(
 )
 if (!process.env.OPENALICE_HOME && process.env.OPENALICE_USER_DATA_HOME) {
   console.warn('[guardian/prod] OPENALICE_USER_DATA_HOME is deprecated — set OPENALICE_HOME instead')
-}
-
-// Port precedence: env (OPENALICE_*_PORT) > data/config/ports.json > default.
-// Mirrors scripts/guardian/shared.ts (kept inline — the runtime image ships
-// no TS tooling). Broken explicit config fails loud rather than silently
-// falling back; an in-use port fails at bind, also loud.
-function parsePort(raw, origin) {
-  const n = typeof raw === 'number' ? raw : Number(raw)
-  if (!Number.isInteger(n) || n < 1 || n > 65535) {
-    throw new Error(`[guardian/prod] invalid port ${JSON.stringify(raw)} from ${origin} — expected an integer in 1..65535`)
-  }
-  return n
 }
 
 function truthyEnv(raw) {
@@ -160,47 +153,23 @@ async function resolveTradingMode(env, userDataHome) {
   return { mode: hasUTAConfig ? 'pro' : 'lite', source: 'auto', envLocked: false, hasUTAConfig }
 }
 
-async function readPortsFile(userDataHome) {
-  const filePath = resolve(userDataHome, 'data', 'config', 'ports.json')
-  let raw
-  try {
-    raw = await readFile(filePath, 'utf8')
-  } catch {
-    return {}
-  }
-  let parsed
-  try {
-    parsed = JSON.parse(raw)
-  } catch (err) {
-    throw new Error(`[guardian/prod] ${filePath} is not valid JSON: ${err?.message ?? err}`)
-  }
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new Error(`[guardian/prod] ${filePath} must be a JSON object like {"web":47331,"mcp":47332,"uta":47333,"connector":47334}`)
-  }
-  const out = {}
-  for (const name of ['web', 'mcp', 'uta', 'connector']) {
-    if (parsed[name] !== undefined) out[name] = parsePort(parsed[name], `${filePath} ("${name}")`)
-  }
-  return out
-}
-
-const portsFile = await readPortsFile(DATA_HOME)
-const pickPort = (envKey, fileValue, fallback) => {
-  const envRaw = process.env[envKey]
-  if (envRaw !== undefined && envRaw !== '') return parsePort(envRaw, envKey)
-  return fileValue ?? fallback
-}
-const WEB_PORT = pickPort('OPENALICE_WEB_PORT', portsFile.web, 47331)
-const MCP_PORT = pickPort('OPENALICE_MCP_PORT', portsFile.mcp, 47332)
-const UTA_PORT = pickPort('OPENALICE_UTA_PORT', portsFile.uta, 47333)
-const CONNECTOR_PORT = pickPort('OPENALICE_CONNECTOR_PORT', portsFile.connector, 47334)
+// Port precedence and collision behavior mirror scripts/guardian/shared.ts:
+// explicit env/file values fail if occupied, while defaults probe upward.
+// The built Guardian keeps this logic in runnable ESM because source-backed
+// and Docker production paths do not ship a TypeScript loader.
+const portsFile = await readProdPortsFile(DATA_HOME)
+const portConfig = resolveProdPortConfig(process.env, portsFile)
+let TRADING_MODE = await resolveTradingMode(process.env, DATA_HOME)
+const LITE_MODE = TRADING_MODE.mode === 'lite'
+const plannedPorts = await planProdPorts(portConfig, { skipUta: LITE_MODE })
+const WEB_PORT = plannedPorts.web
+const MCP_PORT = plannedPorts.mcp
+const UTA_PORT = plannedPorts.uta
+const CONNECTOR_PORT = plannedPorts.connector
 const FLAG_PATH = resolve(DATA_HOME, 'data/control/restart-uta.flag')
 const CONNECTOR_FLAG_PATH = resolve(DATA_HOME, 'data/control/restart-connector.flag')
 const UTA_URL = `http://127.0.0.1:${UTA_PORT}`
 const CONNECTOR_URL = `http://127.0.0.1:${CONNECTOR_PORT}`
-let TRADING_MODE = await resolveTradingMode(process.env, DATA_HOME)
-const LITE_MODE = TRADING_MODE.mode === 'lite'
-
 let stopping = false
 let shutdownExitCode = 0
 let utaChild = null


### PR DESCRIPTION
## What changed

- add a Pi-style `p Settings` overlay to the bare OpenAlice Supervisor TUI
- let humans set or inherit the selected instance's complete home, Web port, and update-check policy
- show environment and CLI overrides as resolved, locked higher-priority values
- prevent home/port mutation while the selected Runtime is active
- remove persisted fields atomically when they return to inheritance
- make the built Guardian probe unconfigured internal ports so a CLI Runtime can coexist with Desktop or another complete home
- keep stop/restart status accurate while Guardian/Alice ownership locks are still transitioning, and require spawned-start readiness to match the expected Guardian PID
- update the CLI Supervisor owner guide and active execution plan

## Why

The shell-first product path needs to be usable by a person without memorizing launch flags. Real isolated-install dogfooding also exposed two production-only gaps: the built Guardian used fixed internal ports, and restart could briefly report an absent Runtime after the control socket disappeared but before ownership cleared.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/openalice-cli typecheck`
- CLI Vitest suite: 168 passed
- `pnpm test`: 3726 passed, 9 skipped
- `pnpm test:install:docker`
- `pnpm test:guardian-recovery`
- `pnpm electron:smoke:pty`
- `pnpm docker:smoke`
- `pnpm test:remote:docker`
- isolated local install/update using `bash install --source <checkout> --yes --no-modify-path`
- real installed-CLI PTY journey: configure source/home/port/update checks, start, authenticated Web probe, restart/reconnect, stop while Desktop remained active