### PR TITLE
Prefer native runtime titles for Workspace Sessions

### DIFF
--- a/docs/workspace-manager.md
+++ b/docs/workspace-manager.md
@@ -107,6 +107,11 @@ Session totals, live interactive counts, live headless counts, and a bounded
 set of recent attributable Session titles and resume identities. Those titles
 are the first-pass responsibility map; the manager must not replace the index
 with a batch crawl of every desk. Departed desks intentionally do not appear.
+Session titles follow one product-wide order: the native runtime's generated or
+user-renamed title, then OpenAlice's launch-time prompt as a fallback, then the
+sticky launcher name such as `c1` or `x1`. Runtime-specific title discovery
+belongs to each CLI adapter; SessionRegistry owns only that shared precedence
+and the durable cached projection.
 Drill into one selected desk with:
 
 ```bash

--- a/src/migrations/0029_session_native_titles.spec.ts
+++ b/src/migrations/0029_session_native_titles.spec.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { migrateSessionNativeTitles } from './0029_session_native_titles/index.js'
+
+let root: string
+let launcherRoot: string
+let backupRoot: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'session-title-migration-'))
+  launcherRoot = join(root, 'workspaces')
+  backupRoot = join(root, 'backup')
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('0029 native Session titles', () => {
+  it('moves legacy titles to fallbackTitle and backs up the original file', async () => {
+    const dir = join(launcherRoot, 'state', 'sessions')
+    await mkdir(dir, { recursive: true })
+    const path = join(dir, 'chat-calm-amber-river.json')
+    const original = {
+      version: 2,
+      records: [
+        {
+          id: 'codex-calm-amber-river',
+          name: 'x1',
+          title: 'The first user message',
+          state: 'paused',
+        },
+        {
+          id: 'claude-clear-copper-harbor',
+          name: 'c1',
+          state: 'paused',
+        },
+      ],
+    }
+    await writeFile(path, JSON.stringify(original))
+
+    await expect(migrateSessionNativeTitles(launcherRoot, { backupRoot }))
+      .resolves.toEqual({ updated: 1 })
+    expect(JSON.parse(await readFile(path, 'utf8'))).toEqual({
+      version: 3,
+      records: [
+        {
+          id: 'codex-calm-amber-river',
+          name: 'x1',
+          fallbackTitle: 'The first user message',
+          state: 'paused',
+        },
+        {
+          id: 'claude-clear-copper-harbor',
+          name: 'c1',
+          state: 'paused',
+        },
+      ],
+    })
+    expect(JSON.parse(await readFile(join(backupRoot, 'chat-calm-amber-river.json'), 'utf8')))
+      .toEqual(original)
+  })
+
+  it('is idempotent and leaves malformed or future files untouched', async () => {
+    const dir = join(launcherRoot, 'state', 'sessions')
+    await mkdir(dir, { recursive: true })
+    const current = join(dir, 'chat-ready.json')
+    const malformed = join(dir, 'chat-broken.json')
+    await writeFile(current, JSON.stringify({
+      version: 3,
+      records: [{ title: 'Native title', fallbackTitle: 'First message' }],
+    }))
+    await writeFile(malformed, '{broken')
+
+    await expect(migrateSessionNativeTitles(launcherRoot, { backupRoot }))
+      .resolves.toEqual({ updated: 0 })
+    expect(JSON.parse(await readFile(current, 'utf8'))).toEqual({
+      version: 3,
+      records: [{ title: 'Native title', fallbackTitle: 'First message' }],
+    })
+    expect(await readFile(malformed, 'utf8')).toBe('{broken')
+  })
+})

--- a/src/migrations/0029_session_native_titles/index.ts
+++ b/src/migrations/0029_session_native_titles/index.ts
@@ -1,0 +1,101 @@
+/**
+ * 0029_session_native_titles — separate native Session titles from the
+ * launch-time prompt used as a display fallback.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { cp, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import type { Migration } from '../types.js'
+
+interface MigrationOptions {
+  readonly backupRoot?: string
+}
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function writeAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const temp = join(dirname(path), `.${randomUUID()}.tmp`)
+  await writeFile(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 })
+  await rename(temp, path)
+}
+
+export async function migrateSessionNativeTitles(
+  launcherRoot: string = defaultLauncherRoot(),
+  options: MigrationOptions = {},
+): Promise<{ updated: number }> {
+  const sessionsDir = join(launcherRoot, 'state', 'sessions')
+  let names: string[]
+  try {
+    names = await readdir(sessionsDir)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { updated: 0 }
+    throw error
+  }
+
+  let updated = 0
+  for (const name of names) {
+    if (!/^[A-Za-z0-9_-]+\.json$/.test(name)) continue
+    const path = join(sessionsDir, name)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(await readFile(path, 'utf8')) as unknown
+    } catch {
+      continue
+    }
+    if (
+      !isRecord(parsed)
+      || (parsed['version'] !== 1 && parsed['version'] !== 2)
+      || !Array.isArray(parsed['records'])
+    ) continue
+
+    const records = parsed['records'].map((value) => {
+      if (!isRecord(value) || typeof value['title'] !== 'string') return value
+      const next = { ...value }
+      if (typeof next['fallbackTitle'] !== 'string') next['fallbackTitle'] = next['title']
+      delete next['title']
+      return next
+    })
+    if (options.backupRoot) {
+      await mkdir(options.backupRoot, { recursive: true })
+      await cp(path, join(options.backupRoot, name), { errorOnExist: false })
+    }
+    await writeAtomic(path, { ...parsed, version: 3, records })
+    updated += 1
+  }
+  return { updated }
+}
+
+export const migration: Migration = {
+  id: '0029_session_native_titles',
+  appVersion: '0.87.0-beta',
+  introducedAt: '2026-07-30',
+  affects: ['workspaces/state/sessions/*.json'],
+  summary: 'Treat the first Session message as a fallback and reserve the preferred title for native runtime metadata.',
+  rationale:
+    'Claude, Codex, OpenCode, and Pi can already name Sessions; OpenAlice should preserve those titles instead of permanently shadowing them with the launch prompt.',
+  up: async (ctx) => {
+    const userDataHome = resolve(ctx.configDir(), '..', '..')
+    const launcherRoot = resolve(
+      process.env['AQ_LAUNCHER_ROOT'] ?? join(userDataHome, 'workspaces'),
+    )
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    await migrateSessionNativeTitles(launcherRoot, {
+      backupRoot: join(
+        dirname(ctx.configDir()),
+        '_backup',
+        `${timestamp}-pre-0029_session_native_titles`,
+        'workspace-sessions',
+      ),
+    })
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -28,3 +28,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0026_agent_conversation_log` | 0.87.0-beta | 2026-07-29 | workspaces/state/agent-conversations.jsonl | Create the private append-only cross-Agent conversation event log. |
 | `0027_repair_snapshot_interval` | 0.87.0-beta | 2026-07-29 | snapshot.json | Repair invalid historical portfolio snapshot intervals before strict duration validation loads them. |
 | `0028_auto_quant_default_workspace` | 0.87.0-beta | 2026-07-30 | data/preferences.json | Add the explicit default Workspace pointer that defines whether AutoQuant is initialized. |
+| `0029_session_native_titles` | 0.87.0-beta | 2026-07-30 | workspaces/state/sessions/*.json | Treat the first Session message as a fallback and reserve the preferred title for native runtime metadata. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -14,7 +14,7 @@
  * deletion + Workspace pivot turned the pre-0.40 data shapes over completely, so
  * pre-0.40 installs rebuild `data/` rather than migrate. The framework stays for
  * future upgrades. Numbering continues FORWARD from the highest id ever shipped
- * (next: 0028) — never reuse a retired id, since existing installs' journals
+ * (next: 0030) — never reuse a retired id, since existing installs' journals
  * recorded the old ones.
  */
 
@@ -40,6 +40,7 @@ import { migration as migration_0025_retire_global_compaction_config } from './0
 import { migration as migration_0026_agent_conversation_log } from './0026_agent_conversation_log/index.js'
 import { migration as migration_0027_repair_snapshot_interval } from './0027_repair_snapshot_interval/index.js'
 import { migration as migration_0028_auto_quant_default_workspace } from './0028_auto_quant_default_workspace/index.js'
+import { migration as migration_0029_session_native_titles } from './0029_session_native_titles/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -63,4 +64,5 @@ export const REGISTRY: Migration[] = [
   migration_0026_agent_conversation_log,
   migration_0027_repair_snapshot_interval,
   migration_0028_auto_quant_default_workspace,
+  migration_0029_session_native_titles,
 ]

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -33,6 +33,7 @@ import {
   makeWorkspaceResolver,
 } from '../core/workspace-tool-center.js'
 import type { IInboxStore, InboxOrigin } from '../core/inbox-store.js'
+import { sessionDisplayTitle } from '../workspaces/session-registry.js'
 import type { IEntityStore } from '../core/entity-store.js'
 import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
@@ -102,6 +103,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
         ...(svc ? {
           workspaceInventory: async () => Promise.all(svc.registry.list().map(async (meta) => {
             await svc.sessionRegistry.ensureLoaded(meta.id)
+            void svc.refreshSessionTitles?.(meta)
             const sessions = svc.sessionRegistry.listFor(meta.id)
             const activity = svc.workspaceRuntimeActivity(meta.id)
             return {
@@ -120,7 +122,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
                   .map((session) => ({
                     resumeId: session.resumeId,
                     agent: session.agent,
-                    title: session.title?.trim() || session.name,
+                    title: sessionDisplayTitle(session),
                     state: session.state,
                     lastActiveAt: session.lastActiveAt,
                   })),

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -18,6 +18,7 @@ import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
 import { registerCliRoutes } from './cli.js'
 import { resolveInboxOrigin } from './inbox-origin.js'
 import { createWorkspaceConversationControl } from '../workspaces/conversation-control.js'
+import { sessionDisplayTitle } from '../workspaces/session-registry.js'
 
 /**
  * MCP Plugin — exposes OpenAlice tools via Streamable HTTP, plus the CLI gateway.
@@ -112,6 +113,7 @@ export class McpPlugin implements Plugin {
         ...(svc ? {
           workspaceInventory: async () => Promise.all(svc.registry.list().map(async (meta) => {
             await svc.sessionRegistry.ensureLoaded(meta.id)
+            void svc.refreshSessionTitles?.(meta)
             const sessions = svc.sessionRegistry.listFor(meta.id)
             const activity = svc.workspaceRuntimeActivity(meta.id)
             return {
@@ -130,7 +132,7 @@ export class McpPlugin implements Plugin {
                   .map((session) => ({
                     resumeId: session.resumeId,
                     agent: session.agent,
-                    title: session.title?.trim() || session.name,
+                    title: sessionDisplayTitle(session),
                     state: session.state,
                     lastActiveAt: session.lastActiveAt,
                   })),

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -758,7 +758,7 @@ describe('POST /:id/headless/:taskId/session', () => {
     expect(Array.from(records.values())[0]).toMatchObject({
       sourceRunId: 'run-1',
       resumeId: 'resume-run-1',
-      title: 'Investigate the earnings anomaly',
+      fallbackTitle: 'Investigate the earnings anomaly',
       resumeHint: { kind: 'agent-session-id', value: '019eb75e-0b1b-7fa2' },
     });
   });

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -24,7 +24,11 @@ import { listDir, PathTraversal, readWorkspaceFile } from '../../workspaces/file
 import { gitLog, gitStatus } from '../../workspaces/git-service.js';
 import { logger as launcherLogger } from '../../workspaces/logger.js';
 import { readWorkspaceMetadata, workspaceMetadataSchema, writeWorkspaceMetadata } from '../../workspaces/workspace-metadata.js';
-import type { SessionRecord } from '../../workspaces/session-registry.js';
+import {
+  normalizeSessionTitle,
+  sessionPreferredTitle,
+  type SessionRecord,
+} from '../../workspaces/session-registry.js';
 import type { WorkspaceMeta } from '../../workspaces/workspace-registry.js';
 import { HeadlessCapacityError, HeadlessResumeError, resumeFromRecord, type SessionFactoryContext, type WorkspaceService } from '../../workspaces/service.js';
 import {
@@ -148,9 +152,6 @@ function redactLaunchCommand(argv: readonly string[]): readonly string[] {
   return out;
 }
 
-/** Max stored length of a session title (the seed message); the row truncates further. */
-const MAX_SESSION_TITLE = 200;
-
 /** The 201 body both `/:id/sessions/spawn` and `/quick-chat` return. */
 interface SpawnedSessionBody {
   readonly sessionId: string;
@@ -160,7 +161,7 @@ interface SpawnedSessionBody {
   readonly agent: string;
   readonly resumeId: string;
   readonly startedAt: number;
-  /** The seed message, when the session was seeded — its sidebar title. */
+  /** Native Session title, falling back to the launch-time prompt. */
   readonly title: string | null;
 }
 
@@ -339,8 +340,7 @@ export function createWorkspaceRoutes(
     });
     const recordName = svc.sessionRegistry.nextName(id, adapter.id, prefix);
     const nowIso = new Date().toISOString();
-    const titleSource = opts.title?.trim() || initialPrompt;
-    const title = titleSource ? titleSource.slice(0, MAX_SESSION_TITLE) : undefined;
+    const fallbackTitle = normalizeSessionTitle(opts.title) ?? normalizeSessionTitle(initialPrompt);
     const claimedResume = opts.resumeId
       ? (svc.claimResume?.(opts.resumeId) ?? true)
       : false;
@@ -372,7 +372,7 @@ export function createWorkspaceRoutes(
       lastActiveAt: nowIso,
       state: 'running',
       surface: 'terminal',
-      ...(title !== undefined ? { title } : {}),
+      ...(fallbackTitle !== undefined ? { fallbackTitle } : {}),
       ...(opts.sourceRunId ? { sourceRunId: opts.sourceRunId } : {}),
       ...(resume && resume !== 'last'
         ? { resumeHint: { kind: 'agent-session-id' as const, value: resume.sessionId } }
@@ -414,7 +414,7 @@ export function createWorkspaceRoutes(
           agent: adapter.id,
           resumeId: identity.resumeId,
           startedAt: session.startedAt,
-          title: title ?? null,
+          title: sessionPreferredTitle(record) ?? null,
         },
       };
     } catch (err) {
@@ -443,7 +443,7 @@ export function createWorkspaceRoutes(
       resumeId: record.resumeId,
       pid: terminal?.pid ?? browser?.pid ?? null,
       startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
-      title: record.title ?? null,
+      title: sessionPreferredTitle(record) ?? null,
       sourceRunId: record.sourceRunId ?? null,
     };
   };
@@ -537,6 +537,7 @@ export function createWorkspaceRoutes(
   const publicManager = async () => {
     const meta = svc.managerWorkspace;
     await svc.sessionRegistry.ensureLoaded(meta.id);
+    void svc.refreshSessionTitles?.(meta);
     return {
       id: meta.id,
       tag: meta.tag,
@@ -1702,7 +1703,7 @@ export function createWorkspaceRoutes(
           pid: session.pid,
           agent: adapter.id,
           startedAt: session.startedAt,
-          title: record.title ?? null,
+          title: sessionPreferredTitle(record) ?? null,
         });
       } catch (err) {
         launcherLogger.error('workspace.session_resume_failed', { id, token, err });

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -12,10 +12,15 @@ import { basename, dirname, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { claudeAdapter } from './claude.js';
+import { claudeAdapter, readClaudeSessionTitleFile } from './claude.js';
 import { codexAdapter } from './codex.js';
-import { opencodeAdapter } from './opencode.js';
-import { piAdapter, syncPiProjectTrust, syncPiWindowsShellPath } from './pi.js';
+import { openCodeSessionTitle, opencodeAdapter } from './opencode.js';
+import {
+  piAdapter,
+  readPiSessionTitleFile,
+  syncPiProjectTrust,
+  syncPiWindowsShellPath,
+} from './pi.js';
 import { migrateLegacyPiAgentDir, piWorkspaceProviderId } from './pi-config.js';
 import { prepareAgentRuntimeWorkspace } from '../cli-adapter.js';
 import { credentialToWorkspaceAiCred } from '../credential-injection.js';
@@ -51,6 +56,16 @@ describe('claudeAdapter AI-config', () => {
   it('composeCommand: "last" resume throws (intentionally unsupported)', () => {
     expect(() => claudeAdapter.composeCommand(['claude'], { cwd: dir, env: {}, resume: 'last' }))
       .toThrow(/"last" resume not supported/);
+  });
+
+  it('prefers Claude custom titles over generated titles', async () => {
+    const transcript = join(dir, 'claude-session.jsonl');
+    await writeFile(transcript, [
+      JSON.stringify({ type: 'ai-title', aiTitle: 'Generated title', sessionId: 'native-1' }),
+      JSON.stringify({ type: 'custom-title', customTitle: '  User renamed title  ', sessionId: 'native-1' }),
+      '',
+    ].join('\n'));
+    expect(await readClaudeSessionTitleFile(transcript)).toBe('User renamed title');
   });
 
   it('writes full x-api-key config byte-exact', async () => {
@@ -375,10 +390,30 @@ describe('codexAdapter AI-config', () => {
   it('listOnDisk returns [] when there are no sessions', async () => {
     expect(await codexAdapter.listOnDisk!(dir)).toEqual([]);
   });
+
+  it('reads Codex native titles from its session index', async () => {
+    await codexAdapter.writeAiConfig!(dir, { baseUrl: 'https://oai.test/v1', model: 'gpt-x' });
+    const home = join(dir, '.codex', 'openalice-home');
+    await mkdir(home, { recursive: true });
+    await writeFile(join(home, 'session_index.jsonl'), [
+      JSON.stringify({ id: 'native-1', thread_name: '  Native Codex title  ', updated_at: '2026-07-30' }),
+      '{"partially-written":',
+      '',
+    ].join('\n'));
+    expect(await codexAdapter.readSessionTitle!(dir, 'native-1')).toBe('Native Codex title');
+    expect(await codexAdapter.readSessionTitle!(dir, 'missing')).toBeNull();
+  });
 });
 
 describe('opencodeAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
+
+  it('uses the title returned by OpenCode session list', () => {
+    expect(openCodeSessionTitle([
+      { id: 'ses_1', title: '  Native OpenCode title  ' },
+    ], 'ses_1')).toBe('Native OpenCode title');
+    expect(openCodeSessionTitle([], 'ses_1')).toBeNull();
+  });
 
   it('prepares OpenCode to derive its theme from the terminal palette', async () => {
     await mkdir(join(dir, '.git/info'), { recursive: true });
@@ -852,6 +887,17 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
 
 describe('piAdapter AI-config', () => {
   const mcpEnv = { OPENALICE_MCP_URL: 'http://127.0.0.1:47332/mcp', AQ_WS_ID: 'ws-abc' };
+
+  it('uses the latest explicit Pi session name', async () => {
+    const transcript = join(dir, 'pi-session.jsonl');
+    await writeFile(transcript, [
+      JSON.stringify({ type: 'session', id: 'native-1', cwd: dir }),
+      JSON.stringify({ type: 'session_info', name: 'First name' }),
+      JSON.stringify({ type: 'session_info', name: '  Renamed in Pi  ' }),
+      '',
+    ].join('\n'));
+    expect(await readPiSessionTitleFile(transcript)).toBe('Renamed in Pi');
+  });
   let previousPiAgentDir: string | undefined;
 
   beforeEach(() => {

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -1,6 +1,8 @@
+import { createReadStream } from 'node:fs';
 import { readFile, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
 
 import type {
   AgentInteractiveSetupStatus,
@@ -27,6 +29,33 @@ const CLAUDE_OWNED_PATHS = [
 
 const CLAUDE_PROJECT_EFFORTS = new Set<ModelReasoningEffort>(['low', 'medium', 'high', 'xhigh']);
 const CLAUDE_RUN_EFFORTS = new Set<ModelReasoningEffort>(['low', 'medium', 'high', 'max']);
+
+export async function readClaudeSessionTitleFile(path: string): Promise<string | null> {
+  let customTitle: string | undefined;
+  let aiTitle: string | undefined;
+  try {
+    const lines = createInterface({
+      input: createReadStream(path, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+    for await (const line of lines) {
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (entry['type'] === 'custom-title' && typeof entry['customTitle'] === 'string') {
+        customTitle = entry['customTitle'].trim() || undefined;
+      } else if (entry['type'] === 'ai-title' && typeof entry['aiTitle'] === 'string') {
+        aiTitle = entry['aiTitle'].trim() || undefined;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return customTitle ?? aiTitle ?? null;
+}
 
 function claudeProjectEffort(value: unknown): ModelReasoningEffort | null {
   return typeof value === 'string' && CLAUDE_PROJECT_EFFORTS.has(value as ModelReasoningEffort)
@@ -389,5 +418,10 @@ export const claudeAdapter: CliAdapter = {
   extractSessionId(filename: string): string | null {
     const m = SESSION_FILE_RE.exec(filename);
     return m && m[1] ? m[1] : null;
+  },
+  readSessionTitle(cwd: string, sessionId: string): Promise<string | null> {
+    return readClaudeSessionTitleFile(
+      join(homedir(), '.claude', 'projects', projectKey(cwd), `${sessionId}.jsonl`),
+    );
   },
 };

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -32,6 +32,42 @@ const CODEX_INTERACTIVE_PERMISSION_ARGS = [
   'never',
 ] as const;
 
+function codexHome(cwd: string): string {
+  const relativeHome = isolatedHomePath(cwd);
+  return relativeHome ? join(cwd, relativeHome) : join(homedir(), '.codex');
+}
+
+const codexTitleIndexInFlight = new Map<string, Promise<ReadonlyMap<string, string>>>();
+
+function readCodexSessionTitleIndex(cwd: string): Promise<ReadonlyMap<string, string>> {
+  const home = codexHome(cwd);
+  const existing = codexTitleIndexInFlight.get(home);
+  if (existing) return existing;
+  const read = (async () => {
+    let raw: string;
+    try {
+      raw = await readFile(join(home, 'session_index.jsonl'), 'utf8');
+    } catch {
+      return new Map<string, string>();
+    }
+    const titles = new Map<string, string>();
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        const row = JSON.parse(line) as Record<string, unknown>;
+        const id = typeof row['id'] === 'string' ? row['id'] : null;
+        const title = typeof row['thread_name'] === 'string' ? row['thread_name'].trim() : '';
+        if (id && title) titles.set(id, title);
+      } catch {
+        // A partially-written tail must not hide the rest of the index.
+      }
+    }
+    return titles;
+  })().finally(() => codexTitleIndexInFlight.delete(home));
+  codexTitleIndexInFlight.set(home, read);
+  return read;
+}
+
 /**
  * OpenAI Codex CLI (Rust rewrite, `codex-cli`).
  *
@@ -483,10 +519,7 @@ export const codexAdapter: CliAdapter = {
    * newest dated leaves since a just-spawned session is today's.
    */
   async listOnDisk(cwd: string): Promise<readonly OnDiskSession[]> {
-    const relativeHome = isolatedHomePath(cwd);
-    const root = relativeHome
-      ? join(cwd, relativeHome, 'sessions')
-      : join(homedir(), '.codex', 'sessions');
+    const root = join(codexHome(cwd), 'sessions');
     const target = resolve(cwd);
     const out: OnDiskSession[] = [];
     for (const leaf of await recentDatedLeaves(root, 2)) {
@@ -516,6 +549,10 @@ export const codexAdapter: CliAdapter = {
       }
     }
     return out;
+  },
+
+  async readSessionTitle(cwd: string, sessionId: string): Promise<string | null> {
+    return (await readCodexSessionTitleIndex(cwd)).get(sessionId) ?? null;
   },
 };
 

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -34,6 +34,52 @@ const OPENCODE_OWNED_PATHS = [
 ] as const;
 const DEFAULT_OUTPUT_TOKENS = 16_384;
 
+const openCodeSessionRowsInFlight = new Map<string, Promise<readonly Record<string, unknown>[]>>();
+
+function readOpenCodeSessionRows(cwd: string): Promise<readonly Record<string, unknown>[]> {
+  const existing = openCodeSessionRowsInFlight.get(cwd);
+  if (existing) return existing;
+  const read = (async () => {
+    let stdout: string;
+    try {
+      const res = await execFileAsync('opencode', ['session', 'list', '--format', 'json'], {
+        cwd,
+        env: {
+          ...process.env,
+          OPENCODE_DISABLE_MODELS_FETCH: '1',
+          OPENCODE_DISABLE_AUTOUPDATE: '1',
+          OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
+        },
+        timeout: 10_000,
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      stdout = res.stdout;
+    } catch {
+      return [];
+    }
+    try {
+      const rows: unknown = JSON.parse(stdout);
+      return Array.isArray(rows)
+        ? rows.filter((row): row is Record<string, unknown> =>
+            typeof row === 'object' && row !== null && !Array.isArray(row))
+        : [];
+    } catch {
+      return [];
+    }
+  })().finally(() => openCodeSessionRowsInFlight.delete(cwd));
+  openCodeSessionRowsInFlight.set(cwd, read);
+  return read;
+}
+
+export function openCodeSessionTitle(
+  rows: readonly Record<string, unknown>[],
+  sessionId: string,
+): string | null {
+  const row = rows.find((candidate) => candidate['id'] === sessionId);
+  const title = typeof row?.['title'] === 'string' ? row['title'].trim() : '';
+  return title || null;
+}
+
 function opencodeRunModel(cwd: string, model: string): string {
   if (model.includes('/')) return model;
   try {
@@ -569,32 +615,8 @@ export const opencodeAdapter: CliAdapter = {
    * `--continue`.
    */
   async listOnDisk(cwd: string): Promise<readonly OnDiskSession[]> {
-    let stdout: string;
-    try {
-      const res = await execFileAsync('opencode', ['session', 'list', '--format', 'json'], {
-        cwd,
-        env: {
-          ...process.env,
-          OPENCODE_DISABLE_MODELS_FETCH: '1',
-          OPENCODE_DISABLE_AUTOUPDATE: '1',
-          OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
-        },
-        timeout: 10_000,
-        maxBuffer: 8 * 1024 * 1024,
-      });
-      stdout = res.stdout;
-    } catch {
-      return [];
-    }
-    let rows: unknown;
-    try {
-      rows = JSON.parse(stdout);
-    } catch {
-      return [];
-    }
-    if (!Array.isArray(rows)) return [];
     const out: OnDiskSession[] = [];
-    for (const r of rows as Array<Record<string, unknown>>) {
+    for (const r of await readOpenCodeSessionRows(cwd)) {
       const id = r['id'];
       if (typeof id !== 'string') continue;
       const ts = r['updated'] ?? r['created'];
@@ -602,5 +624,9 @@ export const opencodeAdapter: CliAdapter = {
       out.push({ sessionId: id, file: '', mtime, sizeBytes: 0 });
     }
     return out;
+  },
+
+  async readSessionTitle(cwd: string, sessionId: string): Promise<string | null> {
+    return openCodeSessionTitle(await readOpenCodeSessionRows(cwd), sessionId);
   },
 };

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, readFile, realpath, rename, writeFile } from 'node:fs/promises';
+import { createReadStream, existsSync, readFileSync } from 'node:fs';
+import { mkdir, readFile, readdir, realpath, rename, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
+import { createInterface } from 'node:readline';
 
 import { runtimeProfileFromEnv } from '@/core/runtime-profile.js';
 import { resolveBashPath } from '@/core/shell-resolver.js';
@@ -27,6 +28,39 @@ import {
 const PI_TRUST_FILENAME = 'trust.json';
 
 let piTrustWriteQueue: Promise<void> = Promise.resolve();
+
+export async function readPiSessionTitleFile(path: string): Promise<string | null> {
+  let title: string | undefined;
+  try {
+    const lines = createInterface({
+      input: createReadStream(path, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+    for await (const line of lines) {
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (entry['type'] === 'session_info') {
+        title = typeof entry['name'] === 'string' ? entry['name'].trim() || undefined : undefined;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return title ?? null;
+}
+
+function piSessionDir(cwd: string): string {
+  const configured = process.env['PI_CODING_AGENT_SESSION_DIR']?.trim();
+  if (configured) {
+    return resolve(configured.replace(/^~(?=$|[/\\])/, process.env['HOME']?.trim() || ''));
+  }
+  const safeCwd = resolve(cwd).replace(/^[/\\]/, '').replace(/[/\\:]/g, '-');
+  return join(resolvePiAgentDir(process.env), 'sessions', `--${safeCwd}--`);
+}
 
 function piRunModel(cwd: string, model: string): string {
   try {
@@ -252,6 +286,19 @@ export const piAdapter: CliAdapter = {
     if (ctx.resume === undefined) return [...head, ...seed];
     if (ctx.resume === 'last') return [...head, '--continue', ...seed];
     return [...head, '--session-id', ctx.resume.sessionId, ...seed];
+  },
+
+  async readSessionTitle(cwd: string, sessionId: string): Promise<string | null> {
+    let files: string[];
+    try {
+      files = await readdir(piSessionDir(cwd));
+    } catch {
+      return null;
+    }
+    const filename = files.find((name) => name.endsWith(`_${sessionId}.jsonl`));
+    return filename
+      ? readPiSessionTitleFile(join(piSessionDir(cwd), filename))
+      : null;
   },
 
   // WebPi is a second VIEW over the same Pi session, not another runtime.

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -334,6 +334,13 @@ export interface CliAdapter {
 
   /** Subprocess discovery (capabilities.transcriptDiscovery === 'subprocess'). */
   listOnDisk?(cwd: string): Promise<readonly OnDiskSession[]>;
+
+  /**
+   * Read the runtime's current human-facing title for one native Session.
+   * This is best-effort presentation metadata: callers keep the launch prompt
+   * as a fallback when the runtime has not named the Session yet.
+   */
+  readSessionTitle?(cwd: string, sessionId: string): Promise<string | null>;
 }
 
 /** Execute the common pre-use lifecycle without coupling callers to an

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -307,7 +307,12 @@ export function launchEnvironmentDisclosure(
 }
 import { ScrollbackStore } from './scrollback-store.js';
 import { SessionPool, type SessionFactoryContext } from './session-pool.js';
-import { SessionRegistry, type SessionRecord } from './session-registry.js';
+import {
+  SessionRegistry,
+  sessionPreferredTitle,
+  type SessionRecord,
+} from './session-registry.js';
+import { NativeSessionTitleResolver } from './session-title-resolver.js';
 import { buildCliPath, buildSpawnEnv } from './spawn-env.js';
 import { TemplateRegistry } from './template-registry.js';
 import { TemplateUpgradeManager } from './template-upgrade.js';
@@ -395,6 +400,8 @@ export interface WorkspaceService {
       approveProject?: boolean;
     },
   ): Promise<WebPiSnapshot>;
+  /** Best-effort background reconciliation of native runtime Session titles. */
+  refreshSessionTitles?(meta: WorkspaceMeta): Promise<void>;
   publicMeta(w: WorkspaceMeta): Promise<unknown>;
   /**
    * Probe the host PATH for each registered adapter's CLI binary. Keyed by
@@ -760,6 +767,14 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   adapters.register(opencodeAdapter);
   adapters.register(piAdapter);
   adapters.register(shellAdapter);
+  const sessionTitleResolver = new NativeSessionTitleResolver({
+    sessionRegistry,
+    resumeRegistry,
+    adapters,
+    logger: launcherLogger.child({ scope: 'session-title' }),
+  });
+  const refreshSessionTitles = (meta: WorkspaceMeta): Promise<void> =>
+    sessionTitleResolver.refreshWorkspace(meta);
   const managerWorkspace = createManagerWorkspaceMeta(
     config.launcherRoot,
     adapters.list().filter(isAgentRuntime).map((adapter) => adapter.id),
@@ -2021,6 +2036,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     const ws = registry.get(wsId);
     if (!ws) return null;
     await sessionRegistry.ensureLoaded(wsId);
+    void refreshSessionTitles(ws);
     return buildWorkspaceSessionDirectory({
       workspace: { id: ws.id, tag: ws.tag },
       identities: resumeRegistry.list({ wsId, limit }),
@@ -2318,6 +2334,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     const metadata = await readWorkspaceMetadata(w.dir);
     const harnessSource = await readHarnessSource(w.dir);
     await sessionRegistry.ensureLoaded(w.id).catch(() => undefined);
+    void refreshSessionTitles(w);
     const sessions = sessionRegistry.listFor(w.id).map((r) => {
       const terminal = pool.get(r.id);
       const browser = webPi.get(r.id);
@@ -2333,7 +2350,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         resumeId: r.resumeId,
         pid: terminal?.pid ?? browser?.pid ?? null,
         startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
-        title: r.title ?? null,
+        title: sessionPreferredTitle(r) ?? null,
         sourceRunId: r.sourceRunId ?? null,
       };
     });
@@ -2410,6 +2427,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     resolveDefaultAgentId,
     resolveAdapter,
     startWebPiSession,
+    refreshSessionTitles,
     publicMeta,
     detectAgents,
     getAgentRuntimeReadiness: getAgentRuntimeReadinessMethod,

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -1,6 +1,6 @@
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from './headless-task-registry.js'
 import type { ResumeIdentityRecord } from './resume-registry.js'
-import type { SessionRecord } from './session-registry.js'
+import { sessionPreferredTitle, type SessionRecord } from './session-registry.js'
 
 export interface WorkspaceSessionDirectoryEntry {
   resumeId: string
@@ -48,6 +48,7 @@ export function buildWorkspaceSessionDirectory(input: {
     sessions: input.identities.map((identity) => {
       const execution = input.latestExecutionFor(identity.resumeId)
       const interactive = input.interactiveFor(identity.resumeId)
+      const interactiveTitle = interactive ? sessionPreferredTitle(interactive) : undefined
       return {
         resumeId: identity.resumeId,
         agent: identity.agent,
@@ -76,7 +77,7 @@ export function buildWorkspaceSessionDirectory(input: {
           ? {
               interactive: {
                 name: interactive.name,
-                ...(interactive.title ? { title: interactive.title } : {}),
+                ...(interactiveTitle ? { title: interactiveTitle } : {}),
                 state: interactive.state,
                 lastActiveAt: interactive.lastActiveAt,
               },

--- a/src/workspaces/session-registry.spec.ts
+++ b/src/workspaces/session-registry.spec.ts
@@ -1,10 +1,14 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { SessionRegistry, type SessionRecord } from './session-registry.js'
+import {
+  SessionRegistry,
+  sessionDisplayTitle,
+  type SessionRecord,
+} from './session-registry.js'
 import type { Logger } from './logger.js'
 
 const noopLogger = {
@@ -45,19 +49,17 @@ function rec(over: Partial<SessionRecord> = {}): SessionRecord {
 }
 
 describe('SessionRegistry persistence', () => {
-  // Regression: parseRecords rebuilt each record field-by-field and dropped
-  // `title`, so the chat-sidebar title reverted to the `c1` name on every
-  // server restart / registry reload even though flush had written it to disk.
-  it('round-trips the session title across a reload', async () => {
+  it('round-trips native and fallback titles across a reload', async () => {
     const reg = await SessionRegistry.load(root, noopLogger)
     await reg.create(rec({
       id: 'claude-calm-amber-river',
       title: "What's moving in semiconductors today?",
+      fallbackTitle: 'Tell me about semiconductors.',
     }))
     await reg.create(rec({
       id: 'claude-clear-copper-harbor',
       name: 'c2',
-      title: '解释一下美债收益率曲线倒挂',
+      fallbackTitle: '解释一下美债收益率曲线倒挂',
     }))
     await reg.create(rec({ id: 'claude-quiet-silver-meadow', name: 'c3' })) // unseeded — no title
 
@@ -69,10 +71,35 @@ describe('SessionRegistry persistence', () => {
     expect(byId.get('claude-calm-amber-river')?.title).toBe(
       "What's moving in semiconductors today?",
     )
-    expect(byId.get('claude-clear-copper-harbor')?.title).toBe(
+    expect(byId.get('claude-calm-amber-river')?.fallbackTitle).toBe(
+      'Tell me about semiconductors.',
+    )
+    expect(byId.get('claude-clear-copper-harbor')?.fallbackTitle).toBe(
       '解释一下美债收益率曲线倒挂',
     ) // CJK survives
     expect(byId.get('claude-quiet-silver-meadow')?.title).toBeUndefined() // unseeded stays nameless
+  })
+
+  it('loads pre-v3 titles as fallbacks so a native title can replace them', async () => {
+    const sessionsDir = join(root, 'sessions')
+    await mkdir(sessionsDir, { recursive: true })
+    await writeFile(join(sessionsDir, `${WS}.json`), JSON.stringify({
+      version: 2,
+      records: [rec({
+        state: 'paused',
+        title: 'The old first message',
+      })],
+    }))
+
+    const reg = await SessionRegistry.load(root, noopLogger)
+    await reg.ensureLoaded(WS)
+    const loaded = reg.listFor(WS)[0]!
+    expect(loaded.title).toBeUndefined()
+    expect(loaded.fallbackTitle).toBe('The old first message')
+    expect(sessionDisplayTitle(loaded)).toBe('The old first message')
+
+    await reg.update(WS, loaded.id, { title: 'Native runtime title' })
+    expect(sessionDisplayTitle(reg.get(WS, loaded.id)!)).toBe('Native runtime title')
   })
 
   // The exact path the user hit: a reload both flips orphaned running→paused

--- a/src/workspaces/session-registry.ts
+++ b/src/workspaces/session-registry.ts
@@ -38,12 +38,16 @@ export interface SessionRecord {
   resumeHint?: { kind: 'agent-session-id'; value: string };
   scrollbackFile?: string;
   /**
-   * The user's first message, captured when the session is seeded (quick-chat).
-   * Surfaced as a human-readable title in the chat sidebar instead of the sticky
-   * `c1` name. Only present for seeded sessions; absent ones fall back to `name`.
-   * Stored capped — we don't need the whole prompt for a one-line title.
+   * Preferred title discovered from the native runtime. This intentionally
+   * stays separate from `fallbackTitle`: a runtime-generated or user-renamed
+   * title must win over the prompt OpenAlice happened to use at launch.
    */
   readonly title?: string;
+  /**
+   * OpenAlice's launch-time title candidate, normally the first user message.
+   * Used only until the native runtime exposes a better title.
+   */
+  readonly fallbackTitle?: string;
   /**
    * The headless run this launcher-owned Session was materialized from.
    * Optional in the v2 registry because ordinary interactive Sessions have no
@@ -56,11 +60,29 @@ export interface SessionRecord {
 }
 
 interface FileShape {
-  readonly version: 2;
+  readonly version: 3;
   readonly records: SessionRecord[];
 }
 
 const SESSION_FILE_RE = /^[A-Za-z0-9_-]+\.json$/;
+export const MAX_SESSION_TITLE = 200;
+
+/** Native title → launch-time prompt. */
+export function sessionPreferredTitle(
+  record: Pick<SessionRecord, 'title' | 'fallbackTitle'>,
+): string | undefined {
+  return record.title?.trim() || record.fallbackTitle?.trim() || undefined;
+}
+
+/** Preferred title → sticky launcher name. */
+export function sessionDisplayTitle(record: Pick<SessionRecord, 'title' | 'fallbackTitle' | 'name'>): string {
+  return sessionPreferredTitle(record) || record.name;
+}
+
+export function normalizeSessionTitle(value: string | null | undefined): string | undefined {
+  const title = value?.trim();
+  return title ? title.slice(0, MAX_SESSION_TITLE) : undefined;
+}
 
 /**
  * Per-workspace persistent registry of SessionRecords. Each workspace gets
@@ -273,7 +295,7 @@ export class SessionRegistry {
     const records = this.byWs.get(wsId);
     if (!records) return;
     const payload: FileShape = {
-      version: 2,
+      version: 3,
       records: Array.from(records.values()),
     };
     const path = join(this.dir, `${wsId}.json`);
@@ -293,7 +315,7 @@ function validateFile(value: unknown): SessionRecord[] {
     throw new Error('sessions.json: root must be an object');
   }
   const v = value as Record<string, unknown>;
-  if (v['version'] !== 1 && v['version'] !== 2) {
+  if (v['version'] !== 1 && v['version'] !== 2 && v['version'] !== 3) {
     throw new Error(`sessions.json: unsupported version ${String(v['version'])}`);
   }
   if (!Array.isArray(v['records'])) {
@@ -329,10 +351,14 @@ function validateFile(value: unknown): SessionRecord[] {
       ...(r['surface'] === 'terminal' || r['surface'] === 'webpi'
         ? { surface: r['surface'] }
         : {}),
-      // Carry the session title (the captured first message) across reloads —
-      // it's written to disk by `flush`, so it must be read back here too, or
-      // every server restart / registry reload reverts the row to the `c1` name.
-      ...(typeof r['title'] === 'string' ? { title: r['title'] } : {}),
+      // Before v3 `title` meant "the launch prompt". Treat it as a fallback so
+      // a native runtime title discovered after upgrade can replace it.
+      ...(v['version'] === 3 && typeof r['title'] === 'string' ? { title: r['title'] } : {}),
+      ...(typeof r['fallbackTitle'] === 'string'
+        ? { fallbackTitle: r['fallbackTitle'] }
+        : v['version'] !== 3 && typeof r['title'] === 'string'
+          ? { fallbackTitle: r['title'] }
+          : {}),
       ...(typeof r['sourceRunId'] === 'string' ? { sourceRunId: r['sourceRunId'] } : {}),
     };
     const hint = r['resumeHint'];

--- a/src/workspaces/session-title-resolver.spec.ts
+++ b/src/workspaces/session-title-resolver.spec.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AdapterRegistry, type CliAdapter } from './cli-adapter.js'
+import type { Logger } from './logger.js'
+import type { ResumeRegistry } from './resume-registry.js'
+import { SessionRegistry, sessionDisplayTitle } from './session-registry.js'
+import { NativeSessionTitleResolver } from './session-title-resolver.js'
+import type { WorkspaceMeta } from './workspace-registry.js'
+
+const noopLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  event() {},
+  child() {
+    return noopLogger
+  },
+} as unknown as Logger
+
+let root: string
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'session-title-'))
+})
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('NativeSessionTitleResolver', () => {
+  it('refreshes a cached native title without losing the launch prompt fallback', async () => {
+    const sessionRegistry = await SessionRegistry.load(root, noopLogger)
+    await sessionRegistry.create({
+      id: 'codex-calm-amber-river',
+      resumeId: 'resume-calm-amber-river-a1b2c3',
+      wsId: 'chat-calm-amber-river',
+      agent: 'codex',
+      name: 'x1',
+      createdAt: '2026-07-30T00:00:00.000Z',
+      lastActiveAt: '2026-07-30T00:00:00.000Z',
+      state: 'paused',
+      title: 'Stale native title',
+      fallbackTitle: 'Please investigate this.',
+      resumeHint: { kind: 'agent-session-id', value: 'native-session' },
+    })
+    const readSessionTitle = vi.fn(async () => 'Runtime-generated investigation title')
+    const adapter: CliAdapter = {
+      id: 'codex',
+      displayName: 'Codex',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: true,
+        resumeById: true,
+        transcriptDiscovery: 'none',
+      },
+      composeCommand: (base) => base,
+      readSessionTitle,
+    }
+    const adapters = new AdapterRegistry()
+    adapters.register(adapter)
+    const resolver = new NativeSessionTitleResolver({
+      sessionRegistry,
+      resumeRegistry: { get: () => undefined } as unknown as ResumeRegistry,
+      adapters,
+      logger: noopLogger,
+      retryMs: 0,
+    })
+    const meta = {
+      id: 'chat-calm-amber-river',
+      dir: '/workspace/chat',
+    } as WorkspaceMeta
+
+    await resolver.refreshWorkspace(meta)
+
+    const record = sessionRegistry.get(meta.id, 'codex-calm-amber-river')!
+    expect(readSessionTitle).toHaveBeenCalledWith('/workspace/chat', 'native-session')
+    expect(record.fallbackTitle).toBe('Please investigate this.')
+    expect(record.title).toBe('Runtime-generated investigation title')
+    expect(sessionDisplayTitle(record)).toBe('Runtime-generated investigation title')
+  })
+
+  it('keeps the fallback and retries later when the runtime has no title yet', async () => {
+    const sessionRegistry = await SessionRegistry.load(root, noopLogger)
+    await sessionRegistry.create({
+      id: 'pi-clear-copper-harbor',
+      resumeId: 'resume-clear-copper-harbor-a1b2c3',
+      wsId: 'chat-clear-copper-harbor',
+      agent: 'pi',
+      name: 'p1',
+      createdAt: '2026-07-30T00:00:00.000Z',
+      lastActiveAt: '2026-07-30T00:00:00.000Z',
+      state: 'paused',
+      fallbackTitle: 'Original request',
+      resumeHint: { kind: 'agent-session-id', value: 'native-pi' },
+    })
+    const readSessionTitle = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('Named in Pi')
+    const adapters = new AdapterRegistry()
+    adapters.register({
+      id: 'pi',
+      displayName: 'Pi',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: true,
+        resumeById: true,
+        transcriptDiscovery: 'none',
+      },
+      composeCommand: (base) => base,
+      readSessionTitle,
+    })
+    const resolver = new NativeSessionTitleResolver({
+      sessionRegistry,
+      resumeRegistry: { get: () => undefined } as unknown as ResumeRegistry,
+      adapters,
+      logger: noopLogger,
+      retryMs: 0,
+    })
+    const meta = { id: 'chat-clear-copper-harbor', dir: '/workspace/chat' } as WorkspaceMeta
+
+    await resolver.refreshWorkspace(meta)
+    expect(sessionDisplayTitle(sessionRegistry.listFor(meta.id)[0]!)).toBe('Original request')
+    await resolver.refreshWorkspace(meta)
+    expect(sessionDisplayTitle(sessionRegistry.listFor(meta.id)[0]!)).toBe('Named in Pi')
+  })
+
+  it('does not deduplicate same-named records across workspaces', async () => {
+    const sessionRegistry = await SessionRegistry.load(root, noopLogger)
+    for (const wsId of ['chat-one', 'chat-two']) {
+      await sessionRegistry.create({
+        id: 'codex-shared-record-id',
+        resumeId: `resume-${wsId}`,
+        wsId,
+        agent: 'codex',
+        name: 'x1',
+        createdAt: '2026-07-30T00:00:00.000Z',
+        lastActiveAt: '2026-07-30T00:00:00.000Z',
+        state: 'paused',
+        resumeHint: { kind: 'agent-session-id', value: `native-${wsId}` },
+      })
+    }
+    const readSessionTitle = vi.fn(async (cwd: string) => `Title for ${cwd}`)
+    const adapters = new AdapterRegistry()
+    adapters.register({
+      id: 'codex',
+      displayName: 'Codex',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: true,
+        resumeById: true,
+        transcriptDiscovery: 'none',
+      },
+      composeCommand: (base) => base,
+      readSessionTitle,
+    })
+    const resolver = new NativeSessionTitleResolver({
+      sessionRegistry,
+      resumeRegistry: { get: () => undefined } as unknown as ResumeRegistry,
+      adapters,
+      logger: noopLogger,
+    })
+
+    await Promise.all([
+      resolver.refreshWorkspace({ id: 'chat-one', dir: '/workspace/one' } as WorkspaceMeta),
+      resolver.refreshWorkspace({ id: 'chat-two', dir: '/workspace/two' } as WorkspaceMeta),
+    ])
+
+    expect(readSessionTitle).toHaveBeenCalledTimes(2)
+    expect(sessionRegistry.get('chat-one', 'codex-shared-record-id')?.title)
+      .toBe('Title for /workspace/one')
+    expect(sessionRegistry.get('chat-two', 'codex-shared-record-id')?.title)
+      .toBe('Title for /workspace/two')
+  })
+})

--- a/src/workspaces/session-title-resolver.ts
+++ b/src/workspaces/session-title-resolver.ts
@@ -1,0 +1,79 @@
+import type { AdapterRegistry } from './cli-adapter.js';
+import type { Logger } from './logger.js';
+import type { ResumeRegistry } from './resume-registry.js';
+import {
+  normalizeSessionTitle,
+  type SessionRecord,
+  type SessionRegistry,
+} from './session-registry.js';
+import type { WorkspaceMeta } from './workspace-registry.js';
+
+const DEFAULT_RETRY_MS = 30_000;
+const RESOLVED_REFRESH_MS = 5 * 60_000;
+
+/**
+ * Best-effort bridge from launcher-owned Session records to the native
+ * runtime's presentation metadata. Reads run in the background; callers keep
+ * rendering the launch prompt until a native title is available.
+ */
+export class NativeSessionTitleResolver {
+  private readonly attemptedAt = new Map<string, number>();
+  private readonly inFlight = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly deps: {
+      sessionRegistry: SessionRegistry;
+      resumeRegistry: ResumeRegistry;
+      adapters: AdapterRegistry;
+      logger: Logger;
+      retryMs?: number;
+    },
+  ) {}
+
+  async refreshWorkspace(meta: WorkspaceMeta): Promise<void> {
+    await this.deps.sessionRegistry.ensureLoaded(meta.id);
+    await Promise.all(
+      this.deps.sessionRegistry.listFor(meta.id).map((record) => this.refreshRecord(meta, record)),
+    );
+  }
+
+  private async refreshRecord(meta: WorkspaceMeta, record: SessionRecord): Promise<void> {
+    const recordKey = `${meta.id}\0${record.id}`;
+    const existing = this.inFlight.get(recordKey);
+    if (existing) return existing;
+
+    const adapter = this.deps.adapters.get(record.agent);
+    if (!adapter?.readSessionTitle) return;
+    const nativeSessionId = this.deps.resumeRegistry.get(record.resumeId)?.agentSessionId
+      ?? record.resumeHint?.value;
+    if (!nativeSessionId) return;
+
+    const now = Date.now();
+    const retryMs = this.deps.retryMs
+      ?? (normalizeSessionTitle(record.title) ? RESOLVED_REFRESH_MS : DEFAULT_RETRY_MS);
+    if (now - (this.attemptedAt.get(recordKey) ?? 0) < retryMs) return;
+    this.attemptedAt.set(recordKey, now);
+
+    const refresh = (async () => {
+      try {
+        const title = normalizeSessionTitle(
+          await adapter.readSessionTitle!(meta.dir, nativeSessionId),
+        );
+        if (!title) return;
+        if (title === normalizeSessionTitle(record.title)) return;
+        await this.deps.sessionRegistry.update(meta.id, record.id, { title });
+      } catch (error) {
+        this.deps.logger.warn('session_title.refresh_failed', {
+          wsId: meta.id,
+          recordId: record.id,
+          agent: record.agent,
+          error,
+        });
+      }
+    })().finally(() => {
+      this.inFlight.delete(recordKey);
+    });
+    this.inFlight.set(recordKey, refresh);
+    return refresh;
+  }
+}

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -652,7 +652,7 @@ export function SessionRow(props: SessionRowProps): ReactElement {
   const { t } = useTranslation();
   const s = props.session;
   const isPaused = s.state === 'paused';
-  // Title: the captured first message (seeded sessions), else the sticky name.
+  // The server resolves native title → launch prompt → sticky name.
   const display = s.title?.trim() || s.name;
   const resumeLabel = t('workspace.resumeSession', { title: display });
   const stopLabel = t('workspace.stopSession', { title: display });

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -642,7 +642,7 @@ export interface SessionRecord {
   readonly surface?: 'terminal' | 'webpi';
   readonly pid: number | null;
   readonly startedAt: number | null;
-  /** First message (seeded sessions) — the sidebar title; null → fall back to `name`. */
+  /** Resolved native/fallback sidebar title; null for an unseeded, unnamed Session. */
   readonly title: string | null;
   /** Headless run this stable Alice Session was materialized from. */
   readonly sourceRunId?: string | null;


### PR DESCRIPTION
## Summary
- add runtime-owned Session title discovery to the Claude, Codex, OpenCode, and Pi adapters
- resolve display titles with native title first, launch-time prompt second, and sticky launcher name last
- refresh native titles in the background across UI, CLI, MCP, and Session directory projections
- migrate legacy v1/v2 Session registries so their captured first message becomes `fallbackTitle`

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3,726 passed, 9 skipped)
- targeted adapter, registry, resolver, route, and migration specs
- `pnpm build:migration-index`
- real demo `/chat` route exercised in the in-app browser
- read-only native title discovery smoke against installed Codex and OpenCode runtimes

## Boundary touch
Persisted Workspace Session state and agent-runtime adapters. Migration 0029 is idempotent, preserves backups, and skips malformed or future-version files.

## Non-goals
- no native title writes or renames from OpenAlice
- no synchronous runtime crawl on the UI response path