### PR TITLE
feat(cli): manage named runtime instances

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -94,6 +94,8 @@ explicit commands:
 - `l` reads the bounded, redacted log tail;
 - `d` runs read-only Doctor checks;
 - `u` performs an advisory product-update check;
+- `i` lists the implicit default plus registered instances, selects one without
+  stopping another instance, or creates a separate named complete home;
 - `p` opens selected-instance settings for complete home, Web port, update
   checks, and resolved source/config provenance;
 - `m` confirms, prepares, remembers, and starts an installer-managed source
@@ -139,18 +141,41 @@ map outside every selectable complete home.
 The `p` settings overlay atomically edits the selected instance's complete
 home, Web port, and update-check policy. A blank Home or port and the
 `Inherit` update value remove the instance override, exposing the resolved
-machine/default value immediately. Home and port remain read-only while the
-selected Runtime is active. Any value supplied by an environment variable or
-explicit CLI flag is shown with its resolved value and a locked provenance
-message; the TUI never writes a lower-priority value that appears to override
-it.
+machine/default value immediately. Named instances must retain an explicit,
+separate complete home; only the implicit `default` may inherit its Home.
+Home and port remain read-only while the selected Runtime is active. Any value
+supplied by an environment variable or explicit CLI flag is shown with its
+resolved value and a locked provenance message; the TUI never writes a
+lower-priority value that appears to override it.
+
+The `i` instance overlay reads the same atomic registry, always shows the
+implicit `default`, and adds every configured named instance. Selecting one
+switches the live Supervisor view and records it as the next bare-start
+default; it does not stop, move, copy, or delete another instance. Creating an
+instance collects a validated lowercase name and separate complete home
+inside the TUI, rejects equal or nested registered homes, and selects the new
+entry atomically. An existing target must be empty or recognizable as an
+OpenAlice complete home; an unrelated non-empty directory is rejected. A new
+target is created and canonicalized when registered, so a later missing
+registered Home is never silently recreated. A bare TUI launch falls back to
+the first available instance, keeps the unavailable registry entry intact,
+and shows a persistent notice directing the user to `i Instances`; selecting
+the displayed fallback repairs the remembered default. An explicit
+environment/flag selection still fails instead of falling back because
+automation must never run against a different Home. The suggested Home is a
+sibling such as
+`~/.openalice-research` and remains editable before creation. A session whose
+instance or complete home came from `OPENALICE_INSTANCE`,
+`OPENALICE_HOME`, `--instance`, or `--home` shows the registry read-only
+instead of pretending that a lower-priority selection can win.
 
 The `c` editor validates an OpenAlice checkout, atomically saves it as the
 selected instance's `appDir`, and starts the Runtime. If
 `OPENALICE_APP_HOME` or `--app-dir` supplied the source, the TUI reports that
 higher-priority override instead of overwriting it. Machine-default editing,
-`openalice config check`, live reload with last-known-good retention, and
-named-instance management remain later increments.
+`openalice config check`, live reload with last-known-good retention,
+registry-entry removal, and full component/instance dashboards remain later
+increments.
 
 `OPENALICE_INSTANCE`, `OPENALICE_HOME`, `OPENALICE_WEB_PORT`,
 `OPENALICE_APP_HOME`, and `OPENALICE_NO_UPDATE_CHECK` are the corresponding
@@ -163,20 +188,25 @@ instance-private `PI_CODING_AGENT_DIR` and `PI_CODING_AGENT_SESSION_DIR`
 values. Source development and an external Pi retain their native user
 configuration and session roots.
 
-The same resolver selects homes for `up`, `run`, `down`, `status`, `open`,
-`logs`, and `doctor`; those commands also accept `--instance <name>`.
+The same stored resolver selects homes for `up`, `run`, `down`, `status`,
+`open`, `logs`, and `doctor`; those commands also accept
+`--instance <name>` and load a Home registered through the TUI.
 Consequently a Runtime started through the TUI and one started by
-`openalice up` receive the same managed-Pi environment. The transitional
-presenters still own their existing command-specific port, source, timeout,
-and output parsing until the root parser conversion is complete.
+`openalice up` receive the same managed-Pi environment, source, Web-port
+policy, and update-check setting unless an explicit command option overrides
+them. The transitional `start` and `server` compatibility presenters still
+own their legacy option parsing and output until the root parser conversion is
+complete.
 
-The selected Web port is explicit for the source-backed built Guardian.
-Unconfigured MCP/local-tool, UTA, and Connector ports retain their independent
-probe-upward behavior, so another complete home or the desktop app can occupy
-the historical internal defaults without breaking this CLI Runtime. Explicit
-internal environment or `data/config/ports.json` values still fail visibly on
-collision. Stop and restart wait for Guardian plus Alice ownership evidence to
-clear, not merely for the control socket to disappear.
+An inherited default Web port remains automatic for the source-backed built
+Guardian: it probes upward from 47331 together with unconfigured
+MCP/local-tool, UTA, and Connector ports. Consequently multiple complete homes
+or the desktop app may occupy historical defaults without breaking a CLI
+Runtime. A machine/instance setting, environment value, or explicit flag pins
+the Web port and fails visibly on collision, as do explicit internal
+environment or `data/config/ports.json` values. Stop and restart wait for
+Guardian plus Alice ownership evidence to clear, not merely for the control
+socket to disappear.
 
 ## Presentation-neutral Core
 

--- a/docs/data-locations.md
+++ b/docs/data-locations.md
@@ -93,6 +93,27 @@ development/CLI operation that may stop an owner of the same home. Separate
 homes are the normal choice for concurrent worktrees; takeover is recovery,
 not concurrency.
 
+Bare `openalice` exposes those separate homes through `i Instances`. The
+machine-local Supervisor registry lives outside every complete home. It always
+retains the implicit `default`, may register named homes, and remembers the
+selected name for the next bare start. Creating or selecting an entry does not
+move, copy, stop, or delete another home. Named entries require an explicit
+separate Home; equal and nested registered paths are rejected. An inherited
+existing target must be empty or recognizable as an OpenAlice home. An
+accepted target is created/canonicalized during registration; if that
+registered path later disappears, a bare Supervisor launch keeps the entry,
+falls back to an available instance, and directs the user to `i Instances` to
+repair the remembered selection. An explicit environment/flag selection fails
+instead of falling back, so automation cannot accidentally target another
+Home. The missing path is never silently recreated. An inherited Web port
+remains automatic from 47331 so concurrent instances probe upward, while a
+configured port is intentionally pinned.
+
+`OPENALICE_INSTANCE`, `OPENALICE_HOME`, `--instance`, and `--home` remain
+higher-priority one-run/automation inputs. When they fix the selected instance
+or Home, the TUI explains that instance selection is read-only rather than
+persisting a choice that cannot affect the current process.
+
 ## Switching and Failure Safety
 
 Switching never moves, copies, merges, or deletes current data. The desktop

--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -104,6 +104,15 @@ describe('ResolvedLaunchContext', () => {
       homeDir: '/home/alice',
       env: { OPENALICE_INSTANCE: 'research' },
     })).toThrow(/needs an explicit complete home/)
+    expect(() => resolveLaunchContext({
+      homeDir: '/home/alice',
+      machineConfig: {
+        defaultInstance: 'research',
+        defaults: { home: '/shared-machine-home' },
+      },
+      instanceConfig: { name: 'research' },
+      env: {},
+    })).toThrow(/needs an explicit complete home/)
   })
 
   it('rejects malformed instance, port, and boolean environment values', () => {

--- a/packages/cli/src/launch-context.ts
+++ b/packages/cli/src/launch-context.ts
@@ -108,7 +108,12 @@ export function resolveLaunchContext(
     pathCandidate(env['OPENALICE_HOME'], 'environment', 'OPENALICE_HOME', cwd, homeDir),
     pathCandidate(flags.home, 'cli-flag', '--home', cwd, homeDir),
   )
-  if (instance.value !== 'default' && home.provenance.source === 'default') {
+  if (
+    instance.value !== 'default'
+    && home.provenance.source !== 'instance-config'
+    && home.provenance.source !== 'environment'
+    && home.provenance.source !== 'cli-flag'
+  ) {
     throw launchContextError(
       'EINSTANCEHOME',
       `Instance "${instance.value}" needs an explicit complete home in instance config, OPENALICE_HOME, or --home.`,

--- a/packages/cli/src/lifecycle-command.mjs
+++ b/packages/cli/src/lifecycle-command.mjs
@@ -1,8 +1,8 @@
 import { parseLocalStartArgs } from './local-start.mjs'
 import {
   buildManagedPiEnv,
-  resolveLaunchContext,
 } from './launch-context.ts'
+import { resolveStoredLaunchContext } from './supervisor-config.ts'
 import {
   inspectRuntime,
   lifecycleError,
@@ -89,19 +89,52 @@ export async function runLifecycleCommand(action, options, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const stderr = dependencies.stderr ?? process.stderr
   try {
+    const startAction = action === 'up' || action === 'run'
     const context = await (
       dependencies.resolveContext
-      ?? ((flags) => resolveLaunchContext({
-        flags,
+      ?? ((flags) => resolveStoredLaunchContext(flags, {
         env: dependencies.env,
+        cwd: dependencies.cwd,
+        homeDir: dependencies.homeDir,
+        platform: dependencies.platform,
+        readConfig: dependencies.readSupervisorConfig,
+        checkStoredHome: dependencies.checkStoredHome,
       }))
     )({
       instance: options.instance ?? undefined,
       home: options.homeRoot ?? undefined,
+      ...(startAction && options._appDirSpecified
+        ? { appDir: options.appDir ?? undefined }
+        : {}),
+      ...(startAction && options._portSpecified
+        ? { port: options.port }
+        : {}),
+      ...(startAction && options._updateChecksSpecified
+        ? { updateChecks: options.checkUpdates }
+        : {}),
     })
+    const {
+      _appDirSpecified,
+      _portSpecified,
+      _updateChecksSpecified,
+      ...publicOptions
+    } = options
     const resolvedOptions = {
-      ...options,
+      ...publicOptions,
       homeRoot: context.home,
+      ...(startAction
+        ? {
+            appDir: _appDirSpecified
+              ? options.appDir
+              : context.appDir,
+            port: _portSpecified
+              ? options.port
+              : runtimeStartPort(context),
+            checkUpdates: _updateChecksSpecified
+              ? options.checkUpdates
+              : context.updateChecks,
+          }
+        : {}),
     }
     const runtimeDependencies = {
       ...dependencies,
@@ -191,7 +224,7 @@ Options:
   --instance <name>  Select a named complete-home instance
   --app-dir <path>   OpenAlice checkout (default: current directory or parent)
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
-  --port <port>      Local Web port (default: 47331)
+  --port <port>      Pin the local Web port (default: automatic from 47331)
   --log <path>       Runtime log (default: <home>/logs/server.log)
   --rebuild          Reinstall dependencies and rebuild server artifacts
   --skip-prepare     Fail instead of installing/building missing artifacts
@@ -214,7 +247,7 @@ Options:
   --instance <name>  Select a named complete-home instance
   --app-dir <path>   OpenAlice checkout (default: current directory or parent)
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
-  --port <port>      Local Web port (default: 47331)
+  --port <port>      Pin the local Web port (default: automatic from 47331)
   --rebuild          Reinstall dependencies and rebuild server artifacts
   --skip-prepare     Fail instead of installing/building missing artifacts
   --takeover         Replace the recorded Guardian owner tree
@@ -326,6 +359,8 @@ function parseStartArgs(action, argv) {
   let openRequested = false
   let noOpenRequested = false
   let logFile = null
+  let portSpecified = false
+  let updateChecksSpecified = false
   const startArgv = []
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -345,6 +380,8 @@ function parseStartArgs(action, argv) {
       continue
     }
     if (arg === '--no-open') noOpenRequested = true
+    if (arg === '--port') portSpecified = true
+    if (arg === '--no-update-check') updateChecksSpecified = true
     if (arg === '--log') {
       if (action === 'run') throw usageError('openalice run does not support --log')
       if (logFile !== null) throw usageError('--log may only be provided once')
@@ -362,11 +399,20 @@ function parseStartArgs(action, argv) {
   }
   return {
     ...parsed,
+    _appDirSpecified: parsed.appDir !== null,
+    _portSpecified: portSpecified,
+    _updateChecksSpecified: updateChecksSpecified,
     instance,
     openBrowser: action === 'up' && openRequested,
     json,
     logFile,
   }
+}
+
+function runtimeStartPort(context) {
+  return context.provenance.port.source === 'default'
+    ? undefined
+    : context.port
 }
 
 function formatStartedRuntime(result) {

--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -152,6 +152,99 @@ describe('OpenAlice top-level lifecycle commands', () => {
     )
   })
 
+  it('loads a TUI-registered named home for explicit lifecycle commands', async () => {
+    const inspectRuntime = vi.fn(async () => absentStatus())
+    await expect(runLifecycleCommand(
+      'status',
+      parseLifecycleArgs('status', ['--instance', 'research']),
+      {
+        env: {},
+        homeDir: '/home/alice',
+        platform: 'linux',
+        readSupervisorConfig: async () => ({
+          schemaVersion: 1,
+          instances: {
+            research: {
+              name: 'research',
+              home: '/srv/openalice-research',
+            },
+          },
+        }),
+        checkStoredHome: async () => {},
+        inspectRuntime,
+        stdout: output(),
+      },
+    )).resolves.toBe(0)
+
+    expect(inspectRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: 'research',
+        homeRoot: '/srv/openalice-research',
+      }),
+      expect.any(Object),
+    )
+  })
+
+  it('inherits stored start settings and leaves an unconfigured Web port automatic', async () => {
+    const automaticStart = vi.fn(async () => startedResult())
+    await expect(runLifecycleCommand(
+      'up',
+      parseLifecycleArgs('up', []),
+      {
+        env: {},
+        homeDir: '/home/alice',
+        platform: 'linux',
+        readSupervisorConfig: async () => ({ schemaVersion: 1 }),
+        startRuntime: automaticStart,
+        stdout: output(),
+      },
+    )).resolves.toBe(0)
+    expect(automaticStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appDir: null,
+        homeRoot: '/home/alice/.openalice',
+        port: undefined,
+        checkUpdates: true,
+      }),
+      expect.any(Object),
+    )
+
+    const configuredStart = vi.fn(async () => startedResult())
+    await expect(runLifecycleCommand(
+      'up',
+      parseLifecycleArgs('up', ['--instance', 'research']),
+      {
+        env: {},
+        homeDir: '/home/alice',
+        platform: 'linux',
+        readSupervisorConfig: async () => ({
+          schemaVersion: 1,
+          instances: {
+            research: {
+              name: 'research',
+              home: '/srv/openalice-research',
+              appDir: '/srv/OpenAlice',
+              port: 49_001,
+              updateChecks: false,
+            },
+          },
+        }),
+        checkStoredHome: async () => {},
+        startRuntime: configuredStart,
+        stdout: output(),
+      },
+    )).resolves.toBe(0)
+    expect(configuredStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appDir: '/srv/OpenAlice',
+        homeRoot: '/srv/openalice-research',
+        port: 49_001,
+        checkUpdates: false,
+      }),
+      expect.any(Object),
+    )
+  })
+
   it('does not redirect external Pi during source lifecycle commands', async () => {
     const inspectRuntime = vi.fn(async () => absentStatus())
     await expect(runLifecycleCommand('status', parseLifecycleArgs('status', [

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -197,10 +197,14 @@ export function buildLocalRuntimeEnv(env, options) {
     OPENALICE_HOME: options.homeRoot,
     OPENALICE_APP_HOME: options.appDir,
     OPENALICE_BIND_HOST: LOOPBACK,
-    OPENALICE_WEB_PORT: String(options.port),
     OPENALICE_WEB_TRANSPORT: 'http',
     OPENALICE_LAUNCHER: 'cli',
     OPENALICE_NODE_BINARY: options.nodeBinary,
+  }
+  if (options.port === undefined || options.port === null) {
+    delete runtimeEnv.OPENALICE_WEB_PORT
+  } else {
+    runtimeEnv.OPENALICE_WEB_PORT = String(options.port)
   }
   delete runtimeEnv.OPENALICE_DISABLE_AUTH
   delete runtimeEnv.OPENALICE_TAKEOVER

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -152,6 +152,20 @@ describe('OpenAlice local Runtime launcher', () => {
     expect(runtimeEnv).not.toHaveProperty('OPENALICE_TAKEOVER')
   })
 
+  it('leaves the Web port unpinned when the Supervisor selected an automatic port', () => {
+    const runtimeEnv = buildLocalRuntimeEnv({
+      OPENALICE_WEB_PORT: '41000',
+    }, {
+      appDir: '/tmp/OpenAlice',
+      homeRoot: '/tmp/alice-home',
+      nodeBinary: '/test/node',
+      port: undefined,
+      takeover: false,
+    })
+
+    expect(runtimeEnv).not.toHaveProperty('OPENALICE_WEB_PORT')
+  })
+
   it('isolates managed Pi for every local Guardian launch path', () => {
     const runtimeEnv = buildLocalRuntimeEnv({
       OPENALICE_MANAGED_PI_PATH: '/managed/pi/cli.js',

--- a/packages/cli/src/observability-command.mjs
+++ b/packages/cli/src/observability-command.mjs
@@ -1,9 +1,9 @@
 import { diagnoseRuntime } from './doctor.mjs'
 import {
   buildManagedPiEnv,
-  resolveLaunchContext,
 } from './launch-context.ts'
 import { readRuntimeLogs } from './logs.mjs'
+import { resolveStoredLaunchContext } from './supervisor-config.ts'
 
 export function parseObservabilityArgs(action, argv) {
   if (!['logs', 'doctor'].includes(action)) throw usageError(`Unknown observability command: ${String(action)}`)
@@ -48,9 +48,13 @@ export async function runObservabilityCommand(action, options, dependencies = {}
   try {
     const context = await (
       dependencies.resolveContext
-      ?? ((flags) => resolveLaunchContext({
-        flags,
+      ?? ((flags) => resolveStoredLaunchContext(flags, {
         env: dependencies.env,
+        cwd: dependencies.cwd,
+        homeDir: dependencies.homeDir,
+        platform: dependencies.platform,
+        readConfig: dependencies.readSupervisorConfig,
+        checkStoredHome: dependencies.checkStoredHome,
       }))
     )({
       instance: options.instance ?? undefined,

--- a/packages/cli/src/observability-command.spec.mjs
+++ b/packages/cli/src/observability-command.spec.mjs
@@ -97,6 +97,46 @@ describe('observability command presenter', () => {
       expect.any(Object),
     )
   })
+
+  it('loads a TUI-registered named home for logs and Doctor', async () => {
+    const readLogs = vi.fn(async () => ({
+      home: '/srv/openalice-research',
+      component: 'runtime',
+      lineLimit: 200,
+      truncated: false,
+      files: [],
+      entries: [],
+    }))
+    await runObservabilityCommand(
+      'logs',
+      parseObservabilityArgs('logs', ['--instance', 'research']),
+      {
+        env: {},
+        homeDir: '/home/alice',
+        platform: 'linux',
+        readSupervisorConfig: async () => ({
+          schemaVersion: 1,
+          instances: {
+            research: {
+              name: 'research',
+              home: '/srv/openalice-research',
+            },
+          },
+        }),
+        checkStoredHome: async () => {},
+        readLogs,
+        stdout: sink(),
+      },
+    )
+
+    expect(readLogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance: 'research',
+        homeRoot: '/srv/openalice-research',
+      }),
+      expect.any(Object),
+    )
+  })
 })
 
 function sink() {

--- a/packages/cli/src/supervisor-config.spec.ts
+++ b/packages/cli/src/supervisor-config.spec.ts
@@ -1,12 +1,25 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
+  createSupervisorInstance,
   parseSupervisorConfig,
   persistInstanceLaunchConfig,
+  persistSelectedSupervisorInstance,
+  readSupervisorInstanceRegistry,
+  resolveAvailableStoredLaunchContext,
   resolveStoredLaunchContext,
   supervisorConfigPath,
 } from './supervisor-config.ts'
@@ -60,6 +73,47 @@ describe('Supervisor configuration', () => {
         home: { source: 'environment' },
         port: { source: 'cli-flag' },
         appDir: { source: 'instance-config' },
+      },
+    })
+  })
+
+  it('falls back to an available instance only after a stored default home becomes unavailable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-recovery-'))
+    temporaryPaths.push(root)
+    const config = {
+      schemaVersion: 1 as const,
+      defaultInstance: 'missing',
+      instances: {
+        missing: {
+          name: 'missing',
+          home: join(root, 'disconnected-home'),
+        },
+      },
+    }
+    const options = {
+      homeDir: join(root, 'user'),
+      cwd: root,
+      platform: 'linux' as const,
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+      readConfig: async () => config,
+    }
+
+    await expect(resolveStoredLaunchContext({}, options)).rejects.toMatchObject({
+      code: 'ESTOREDHOMEMISSING',
+    })
+
+    const fallback = await resolveAvailableStoredLaunchContext(options)
+    expect(fallback).toMatchObject({
+      instance: 'default',
+      home: resolve(root, 'user/.openalice'),
+      provenance: {
+        instance: {
+          source: 'machine-config',
+          detail: 'machine.defaultInstance',
+        },
+        home: {
+          source: 'default',
+        },
       },
     })
   })
@@ -131,6 +185,179 @@ describe('Supervisor configuration', () => {
     })
   })
 
+  it('creates, lists, selects, and remembers named complete-home instances', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-instances-'))
+    temporaryPaths.push(root)
+    const homeDir = join(root, 'user')
+    const configRoot = join(root, 'config')
+    const context = await resolveStoredLaunchContext({}, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: configRoot },
+    })
+
+    await createSupervisorInstance(
+      context,
+      'research',
+      './research-home',
+      { homeDir, cwd: root, platform: 'linux' },
+    )
+    const researchHome = await realpath(resolve(root, 'research-home'))
+
+    const registry = await readSupervisorInstanceRegistry(context, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+    })
+    expect(registry).toEqual({
+      defaultInstance: 'research',
+      instances: [
+        {
+          name: 'default',
+          home: resolve(homeDir, '.openalice'),
+          port: 47_331,
+          portAutomatic: true,
+          isDefault: false,
+        },
+        {
+          name: 'research',
+          home: researchHome,
+          port: 47_331,
+          portAutomatic: true,
+          isDefault: true,
+        },
+      ],
+    })
+
+    const selected = await resolveStoredLaunchContext({}, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: configRoot },
+    })
+    expect(selected).toMatchObject({
+      instance: 'research',
+      home: researchHome,
+    })
+
+    await persistSelectedSupervisorInstance(context, 'default')
+    const saved = JSON.parse(
+      await readFile(supervisorConfigPath(context.supervisorRoot), 'utf8'),
+    )
+    expect(saved.defaultInstance).toBeUndefined()
+    expect(saved.instances.research.home).toBe(researchHome)
+    expect((await stat(researchHome)).isDirectory()).toBe(true)
+
+    await rm(researchHome, {
+      recursive: true,
+      force: true,
+    })
+    await expect(persistSelectedSupervisorInstance(
+      context,
+      'research',
+      { homeDir, cwd: root, platform: 'linux' },
+    )).rejects.toThrow(/Registered complete home .* is missing/)
+    expect(JSON.parse(
+      await readFile(supervisorConfigPath(context.supervisorRoot), 'utf8'),
+    ).defaultInstance).toBeUndefined()
+    await expect(resolveStoredLaunchContext({ instance: 'research' }, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: configRoot },
+    })).rejects.toThrow(/Registered complete home .* is missing/)
+  })
+
+  it('rejects duplicate, overlapping, and home-less named instances', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-collision-'))
+    temporaryPaths.push(root)
+    const homeDir = join(root, 'user')
+    const context = await resolveStoredLaunchContext({}, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+
+    await expect(createSupervisorInstance(
+      context,
+      'nested',
+      join(context.home, 'child'),
+      { homeDir, cwd: root, platform: 'linux' },
+    )).rejects.toThrow(/overlaps instance "default"/)
+
+    await createSupervisorInstance(
+      context,
+      'paper',
+      join(root, 'paper-home'),
+      { homeDir, cwd: root, platform: 'linux' },
+    )
+    await expect(createSupervisorInstance(
+      context,
+      'paper',
+      join(root, 'another-home'),
+      { homeDir, cwd: root, platform: 'linux' },
+    )).rejects.toThrow(/already registered/)
+
+    const unrelated = join(root, 'unrelated')
+    await mkdir(unrelated)
+    await writeFile(join(unrelated, 'notes.txt'), 'not OpenAlice')
+    await expect(createSupervisorInstance(
+      context,
+      'unsafe',
+      unrelated,
+      { homeDir, cwd: root, platform: 'linux' },
+    )).rejects.toThrow(/non-empty and is not an existing OpenAlice home/)
+
+    const selected = await resolveStoredLaunchContext({}, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+    await expect(persistInstanceLaunchConfig(
+      selected,
+      { home: undefined },
+    )).rejects.toThrow(/must keep an explicit complete home/)
+  })
+
+  it('resolves symlinked ancestors before checking nested-home collisions', async ({ skip }) => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-symlink-'))
+    temporaryPaths.push(root)
+    const homeDir = join(root, 'user')
+    const context = await resolveStoredLaunchContext({}, {
+      homeDir,
+      cwd: root,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+    const actual = join(root, 'actual')
+    const alias = join(root, 'alias')
+    await mkdir(actual)
+    try {
+      await symlink(actual, alias, 'dir')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+        skip('symlinks unavailable on this runner')
+        return
+      }
+      throw error
+    }
+
+    await persistInstanceLaunchConfig(
+      context,
+      { home: join(actual, 'default-home') },
+      { homeDir, cwd: root, platform: 'linux' },
+    )
+    await expect(createSupervisorInstance(
+      context,
+      'nested',
+      join(alias, 'default-home', 'nested'),
+      { homeDir, cwd: root, platform: 'linux' },
+    )).rejects.toThrow(/overlaps instance "default"/)
+  })
+
   it('rejects corrupt, unknown, and mismatched configuration fields', () => {
     expect(() => parseSupervisorConfig({
       schemaVersion: 2,
@@ -145,5 +372,9 @@ describe('Supervisor configuration', () => {
         research: { name: 'other' },
       },
     })).toThrow(/must match its registry key/)
+    expect(() => parseSupervisorConfig({
+      schemaVersion: 1,
+      defaultInstance: 'missing',
+    })).toThrow(/not present in instances/)
   })
 })

--- a/packages/cli/src/supervisor-config.ts
+++ b/packages/cli/src/supervisor-config.ts
@@ -1,12 +1,24 @@
 import { randomUUID } from 'node:crypto'
+import { constants } from 'node:fs'
 import {
+  access,
   mkdir,
+  readdir,
   readFile,
+  realpath,
   rename,
   rm,
+  stat,
   writeFile,
 } from 'node:fs/promises'
-import { join } from 'node:path'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from 'node:path'
 
 import {
   resolveLaunchContext,
@@ -22,6 +34,22 @@ import {
 const CONFIG_SCHEMA_VERSION = 1
 const INSTANCE_NAME_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/
 const CONFIG_FILE_NAME = 'config.json'
+const IGNORED_HOME_ENTRIES = new Set([
+  '.DS_Store',
+  'Thumbs.db',
+  'desktop.ini',
+])
+const OPENALICE_HOME_ENTRIES = new Set([
+  'provider-keys.json',
+  'sealing.key',
+])
+const OPENALICE_HOME_MARKERS = [
+  ['data', 'config'],
+  ['workspaces', 'workspaces.json'],
+  ['state', 'guardian.lock'],
+  ['state', 'runtime.lock'],
+  ['runtime', 'broker-packs'],
+] as const
 const CONFIG_KEYS = new Set([
   'schemaVersion',
   'defaultInstance',
@@ -45,12 +73,20 @@ export interface SupervisorConfigDocument {
 
 export interface StoredLaunchContextOptions
   extends ResolveSupervisorRootOptions {
+  selectedInstance?: string
+  checkStoredHome?: (
+    path: string,
+    instance: string,
+  ) => Promise<void>
   readConfig?: (
     supervisorRoot: string,
   ) => Promise<SupervisorConfigDocument>
 }
 
 export interface PersistInstanceConfigOptions {
+  cwd?: string
+  homeDir?: string
+  platform?: NodeJS.Platform
   readConfig?: (
     supervisorRoot: string,
   ) => Promise<SupervisorConfigDocument>
@@ -58,6 +94,19 @@ export interface PersistInstanceConfigOptions {
     supervisorRoot: string,
     config: SupervisorConfigDocument,
   ) => Promise<void>
+}
+
+export interface SupervisorInstanceSummary {
+  name: string
+  home: string
+  port: number
+  portAutomatic: boolean
+  isDefault: boolean
+}
+
+export interface SupervisorInstanceRegistry {
+  defaultInstance: string
+  instances: SupervisorInstanceSummary[]
 }
 
 export async function readInstanceLaunchConfig(
@@ -84,14 +133,15 @@ export async function resolveStoredLaunchContext(
   )(supervisorRoot)
   const selectedInstance = flags.instance
     ?? env['OPENALICE_INSTANCE']
+    ?? options.selectedInstance
     ?? config.defaultInstance
     ?? 'default'
   const machineConfig: MachineSupervisorConfig = {
-    defaultInstance: config.defaultInstance,
+    defaultInstance: options.selectedInstance ?? config.defaultInstance,
     defaults: config.defaults,
   }
 
-  return resolveLaunchContext({
+  const context = resolveLaunchContext({
     flags,
     machineConfig,
     instanceConfig: config.instances?.[selectedInstance],
@@ -100,6 +150,54 @@ export async function resolveStoredLaunchContext(
     homeDir: options.homeDir,
     platform: options.platform,
   })
+  if (context.provenance.home.source === 'instance-config') {
+    await (
+      options.checkStoredHome ?? assertStoredHomePresent
+    )(context.home, context.instance)
+  }
+  return context
+}
+
+export async function resolveAvailableStoredLaunchContext(
+  options: StoredLaunchContextOptions = {},
+): Promise<ResolvedLaunchContext> {
+  const supervisorRoot = resolveSupervisorRootPath(options)
+  const config = await (
+    options.readConfig ?? readSupervisorConfig
+  )(supervisorRoot)
+  const candidates = [
+    'default',
+    ...Object.keys(config.instances ?? {})
+      .filter((name) => name !== 'default')
+      .sort(),
+  ]
+  let unavailable: unknown
+  for (const name of candidates) {
+    try {
+      return await resolveStoredLaunchContext({}, {
+        ...options,
+        selectedInstance: name,
+        readConfig: async () => config,
+      })
+    } catch (error: unknown) {
+      if (!isStoredHomeUnavailableError(error)) throw error
+      unavailable = error
+    }
+  }
+  throw unavailable ?? configError(
+    'No available OpenAlice instance could be selected.',
+  )
+}
+
+export function isStoredHomeUnavailableError(
+  error: unknown,
+): boolean {
+  return error instanceof Error
+    && 'code' in error
+    && (
+      error.code === 'ESTOREDHOMEMISSING'
+      || error.code === 'ESTOREDHOMEUNAVAILABLE'
+    )
 }
 
 export async function persistInstanceLaunchConfig(
@@ -113,9 +211,26 @@ export async function persistInstanceLaunchConfig(
   const existing = current.instances?.[context.instance] ?? {
     name: context.instance,
   }
+  if (
+    context.instance !== 'default'
+    && Object.hasOwn(patch, 'home')
+    && patch.home === undefined
+  ) {
+    throw configError(
+      `Instance "${context.instance}" must keep an explicit complete home.`,
+    )
+  }
+  const normalizedPatch = { ...patch }
+  if (typeof patch.home === 'string') {
+    normalizedPatch.home = resolveConfiguredHome(
+      context.instance,
+      patch.home,
+      options,
+    )
+  }
   const instance: InstanceLaunchConfig = {
     ...existing,
-    ...patch,
+    ...normalizedPatch,
     name: context.instance,
   }
   for (const key of [
@@ -136,6 +251,105 @@ export async function persistInstanceLaunchConfig(
       [context.instance]: instance,
     },
   }
+  await assertRegistryHomesSeparate(next, options)
+  if (typeof normalizedPatch.home === 'string') {
+    await mkdir(normalizedPatch.home, { recursive: true, mode: 0o700 })
+    await assertHomeCandidateUsable(normalizedPatch.home)
+    instance.home = await realpath(normalizedPatch.home)
+    await assertRegistryHomesSeparate(next, options)
+  }
+  await writeConfig(context.supervisorRoot, next)
+}
+
+export async function readSupervisorInstanceRegistry(
+  context: Pick<ResolvedLaunchContext, 'supervisorRoot'>,
+  options: StoredLaunchContextOptions = {},
+): Promise<SupervisorInstanceRegistry> {
+  const config = await (
+    options.readConfig ?? readSupervisorConfig
+  )(context.supervisorRoot)
+  await assertRegistryHomesSeparate(config, options)
+  return buildInstanceRegistry(config, options)
+}
+
+export async function persistSelectedSupervisorInstance(
+  context: Pick<ResolvedLaunchContext, 'supervisorRoot'>,
+  name: string,
+  options: PersistInstanceConfigOptions = {},
+): Promise<void> {
+  requireInstanceName(name, 'instance')
+  const readConfig = options.readConfig ?? readSupervisorConfig
+  const writeConfig = options.writeConfig ?? writeSupervisorConfig
+  const current = await readConfig(context.supervisorRoot)
+  if (name !== 'default' && !current.instances?.[name]) {
+    throw configError(`Instance "${name}" is not registered.`)
+  }
+  if (name !== 'default' && !current.instances?.[name]?.home) {
+    throw configError(
+      `Instance "${name}" needs an explicit complete home before it can become the default.`,
+    )
+  }
+  await assertRegistryHomesSeparate(current, options)
+  if (name !== 'default' || current.instances?.default?.home) {
+    const selected = buildInstanceRegistry(current, options)
+      .instances
+      .find((entry) => entry.name === name)
+    if (!selected) {
+      throw configError(`Instance "${name}" is not registered.`)
+    }
+    await assertStoredHomePresent(selected.home, name)
+  }
+  await writeConfig(context.supervisorRoot, {
+    ...current,
+    schemaVersion: CONFIG_SCHEMA_VERSION,
+    defaultInstance: name === 'default' ? undefined : name,
+  })
+}
+
+export async function createSupervisorInstance(
+  context: Pick<ResolvedLaunchContext, 'supervisorRoot'>,
+  name: string,
+  home: string,
+  options: PersistInstanceConfigOptions = {},
+): Promise<void> {
+  requireInstanceName(name, 'instance')
+  if (name === 'default') {
+    throw configError('The implicit "default" instance already exists.')
+  }
+  const readConfig = options.readConfig ?? readSupervisorConfig
+  const writeConfig = options.writeConfig ?? writeSupervisorConfig
+  const current = await readConfig(context.supervisorRoot)
+  if (current.instances?.[name]) {
+    throw configError(`Instance "${name}" is already registered.`)
+  }
+  let normalizedHome = resolveConfiguredHome(name, home, options)
+  const candidate: SupervisorConfigDocument = {
+    ...current,
+    schemaVersion: CONFIG_SCHEMA_VERSION,
+    defaultInstance: name,
+    instances: {
+      ...current.instances,
+      [name]: {
+        name,
+        home: normalizedHome,
+      },
+    },
+  }
+  await assertRegistryHomesSeparate(candidate, options)
+  await mkdir(normalizedHome, { recursive: true, mode: 0o700 })
+  await assertHomeCandidateUsable(normalizedHome)
+  normalizedHome = await realpath(normalizedHome)
+  const next: SupervisorConfigDocument = {
+    ...candidate,
+    instances: {
+      ...candidate.instances,
+      [name]: {
+        name,
+        home: normalizedHome,
+      },
+    },
+  }
+  await assertRegistryHomesSeparate(next, options)
   await writeConfig(context.supervisorRoot, next)
 }
 
@@ -222,6 +436,15 @@ export function parseSupervisorConfig(
       instances[name] = { ...parsed, name }
     }
   }
+  if (
+    defaultInstance !== undefined
+    && defaultInstance !== 'default'
+    && !instances?.[defaultInstance]
+  ) {
+    throw configError(
+      `defaultInstance "${defaultInstance}" is not present in instances.`,
+    )
+  }
 
   return {
     schemaVersion: CONFIG_SCHEMA_VERSION,
@@ -233,6 +456,203 @@ export function parseSupervisorConfig(
 
 export function supervisorConfigPath(supervisorRoot: string): string {
   return join(supervisorRoot, CONFIG_FILE_NAME)
+}
+
+export function validateSupervisorInstanceName(
+  value: string,
+): string | undefined {
+  if (!INSTANCE_NAME_PATTERN.test(value)) {
+    return 'Use 1-32 lowercase letters, numbers, "_" or "-", beginning with a letter.'
+  }
+  if (value === 'default') {
+    return 'The implicit "default" instance already exists.'
+  }
+  return undefined
+}
+
+function buildInstanceRegistry(
+  config: SupervisorConfigDocument,
+  options: ResolveSupervisorRootOptions,
+): SupervisorInstanceRegistry {
+  const defaultInstance = config.defaultInstance ?? 'default'
+  const names = [
+    'default',
+    ...Object.keys(config.instances ?? {})
+      .filter((name) => name !== 'default')
+      .sort(),
+  ]
+  const machineConfig: MachineSupervisorConfig = {
+    defaultInstance: config.defaultInstance,
+    defaults: config.defaults,
+  }
+  return {
+    defaultInstance,
+    instances: names.map((name) => {
+      const resolved = resolveLaunchContext({
+        flags: { instance: name },
+        machineConfig,
+        instanceConfig: config.instances?.[name],
+        env: {},
+        cwd: options.cwd,
+        homeDir: options.homeDir,
+        platform: options.platform,
+      })
+      return {
+        name,
+        home: resolved.home,
+        port: resolved.port,
+        portAutomatic: resolved.provenance.port.source === 'default',
+        isDefault: name === defaultInstance,
+      }
+    }),
+  }
+}
+
+function resolveConfiguredHome(
+  instance: string,
+  home: string,
+  options: Pick<PersistInstanceConfigOptions, 'cwd' | 'homeDir' | 'platform'>,
+): string {
+  return resolveLaunchContext({
+    flags: { instance, home },
+    env: {},
+    cwd: options.cwd,
+    homeDir: options.homeDir,
+    platform: options.platform,
+  }).home
+}
+
+async function assertRegistryHomesSeparate(
+  config: SupervisorConfigDocument,
+  options: Pick<PersistInstanceConfigOptions, 'cwd' | 'homeDir' | 'platform'>,
+): Promise<void> {
+  const registry = buildInstanceRegistry(config, options)
+  const homes = await Promise.all(registry.instances.map(async (entry) => ({
+    ...entry,
+    physicalHome: await physicalPath(entry.home),
+  })))
+  for (let leftIndex = 0; leftIndex < homes.length; leftIndex += 1) {
+    const left = homes[leftIndex]
+    if (!left) continue
+    for (let rightIndex = leftIndex + 1; rightIndex < homes.length; rightIndex += 1) {
+      const right = homes[rightIndex]
+      if (!right) continue
+      if (
+        normalizedPathKey(left.physicalHome, options.platform)
+          === normalizedPathKey(right.physicalHome, options.platform)
+        || pathContains(left.physicalHome, right.physicalHome)
+        || pathContains(right.physicalHome, left.physicalHome)
+      ) {
+        throw configError(
+          `Complete home ${right.home} for instance "${right.name}" overlaps instance "${left.name}" at ${left.home}. Choose a separate directory.`,
+        )
+      }
+    }
+  }
+}
+
+async function physicalPath(path: string): Promise<string> {
+  const absolute = resolve(path)
+  let current = absolute
+  const suffix: string[] = []
+  while (true) {
+    try {
+      return resolve(await realpath(current), ...suffix)
+    } catch (error: unknown) {
+      if (!isNodeError(error, 'ENOENT')) return absolute
+      const parent = dirname(current)
+      if (parent === current) return absolute
+      suffix.unshift(basename(current))
+      current = parent
+    }
+  }
+}
+
+async function assertHomeCandidateUsable(path: string): Promise<void> {
+  let info
+  try {
+    info = await stat(path)
+  } catch (error: unknown) {
+    if (isNodeError(error, 'ENOENT')) return
+    throw configError(
+      `Complete home ${path} is unavailable: ${errorMessage(error)}`,
+    )
+  }
+  if (!info.isDirectory()) {
+    throw configError(`Complete home ${path} is not a directory.`)
+  }
+  try {
+    await access(path, constants.R_OK | constants.W_OK)
+    const entries = (await readdir(path))
+      .filter((entry) => !IGNORED_HOME_ENTRIES.has(entry))
+    if (entries.length === 0) return
+    if (
+      entries.some((entry) => OPENALICE_HOME_ENTRIES.has(entry))
+      || await hasOpenAliceHomeMarker(path)
+    ) return
+  } catch (error: unknown) {
+    if (isConfigError(error)) throw error
+    throw configError(
+      `Complete home ${path} is unavailable or not writable: ${errorMessage(error)}`,
+    )
+  }
+  throw configError(
+    `Complete home ${path} is non-empty and is not an existing OpenAlice home. Choose an empty directory or an OpenAlice home.`,
+  )
+}
+
+async function assertStoredHomePresent(
+  path: string,
+  instance: string,
+): Promise<void> {
+  try {
+    const info = await stat(path)
+    if (!info.isDirectory()) {
+      throw configError(
+        `Registered complete home ${path} for instance "${instance}" is not a directory.`,
+        'ESTOREDHOMEUNAVAILABLE',
+      )
+    }
+    await access(path, constants.R_OK | constants.W_OK)
+  } catch (error: unknown) {
+    if (isConfigError(error)) throw error
+    const missing = isNodeError(error, 'ENOENT')
+      ? 'is missing'
+      : 'is unavailable or not writable'
+    throw configError(
+      `Registered complete home ${path} for instance "${instance}" ${missing}. Reconnect it or choose another instance.`,
+      isNodeError(error, 'ENOENT')
+        ? 'ESTOREDHOMEMISSING'
+        : 'ESTOREDHOMEUNAVAILABLE',
+    )
+  }
+}
+
+async function hasOpenAliceHomeMarker(path: string): Promise<boolean> {
+  for (const parts of OPENALICE_HOME_MARKERS) {
+    try {
+      await access(join(path, ...parts))
+      return true
+    } catch {
+      // Keep checking known complete-home markers.
+    }
+  }
+  return false
+}
+
+function normalizedPathKey(
+  path: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const normalized = resolve(path)
+  return platform === 'win32'
+    ? normalized.toLocaleLowerCase('en-US')
+    : normalized
+}
+
+function pathContains(parent: string, child: string): boolean {
+  const rel = relative(parent, child)
+  return rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel)
 }
 
 function parseLaunchValues(
@@ -321,12 +741,15 @@ function rejectUnknownKeys(
   }
 }
 
-function configError(message: string): Error & {
+function configError(
+  message: string,
+  code = 'ESUPERVISORCONFIG',
+): Error & {
   code: string
   exitCode: number
 } {
   return Object.assign(new Error(message), {
-    code: 'ESUPERVISORCONFIG',
+    code,
     exitCode: 2,
   })
 }

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -172,12 +179,15 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-settings-'))
     temporaryPaths.push(isolatedHome)
     const supervisorHome = join(isolatedHome, 'supervisor')
+    const childEnv = { ...process.env }
+    delete childEnv.OPENALICE_HOME
+    delete childEnv.OPENALICE_INSTANCE
     const child = pty.spawn(process.execPath, [cliEntry], {
       cols: 110,
       rows: 30,
       cwd: dirname(cliEntry),
       env: {
-        ...process.env,
+        ...childEnv,
         HOME: isolatedHome,
         OPENALICE_HOME: join(isolatedHome, 'state'),
         OPENALICE_SUPERVISOR_HOME: supervisorHome,
@@ -237,6 +247,186 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('\u001b[?2004l')
   })
 
+  it('creates, selects, remembers, and switches named instances inside the TUI', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-instances-'))
+    temporaryPaths.push(isolatedHome)
+    const supervisorHome = join(isolatedHome, 'supervisor')
+    const childEnv = { ...process.env }
+    delete childEnv.OPENALICE_HOME
+    delete childEnv.OPENALICE_INSTANCE
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 110,
+      rows: 32,
+      cwd: dirname(cliEntry),
+      env: {
+        ...childEnv,
+        HOME: isolatedHome,
+        OPENALICE_SUPERVISOR_HOME: supervisorHome,
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let openedInstances = false
+      let requestedCreate = false
+      let submittedName = false
+      let acceptedHome = false
+      let reopenedInstances = false
+      let selectedDefault = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor instances TUI timed out:\n${output}`))
+      }, 12_000)
+      child.onData((data) => {
+        output += data
+        if (!openedInstances && output.includes('i Instances')) {
+          openedInstances = true
+          child.write('i')
+        } else if (!requestedCreate && output.includes('+ Create instance')) {
+          requestedCreate = true
+          child.write('\u001b[B\r')
+        } else if (
+          !submittedName
+          && output.includes('Instance name')
+        ) {
+          submittedName = true
+          child.write('research\r')
+        } else if (
+          !acceptedHome
+          && output.includes('Create instance · research')
+          && output.includes('Complete home')
+        ) {
+          acceptedHome = true
+          child.write('\r')
+        } else if (
+          !reopenedInstances
+          && output.includes('Created and selected instance research.')
+          && output.includes('Instance: research')
+        ) {
+          reopenedInstances = true
+          child.write('i')
+        } else if (
+          reopenedInstances
+          && !selectedDefault
+          && output.includes('research · current · default')
+        ) {
+          selectedDefault = true
+          child.write('\u001b[A\r')
+        } else if (
+          !detached
+          && output.includes('Selected instance default; future bare starts use it.')
+          && output.includes('Instance: default')
+        ) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor instances TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    const config = JSON.parse(
+      await readFile(join(supervisorHome, 'config.json'), 'utf8'),
+    )
+    expect(config.defaultInstance).toBeUndefined()
+    expect(config.instances.research).toEqual({
+      name: 'research',
+      home: await realpath(join(isolatedHome, '.openalice-research')),
+    })
+    expect(transcript).toContain('OpenAlice instances')
+    expect(transcript).toContain('Created and selected instance research.')
+    expect(transcript).toContain('Selected instance default; future bare starts use it.')
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  }, 15_000)
+
+  it('recovers in the instance picker when the remembered complete home is missing', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-instance-recovery-'))
+    temporaryPaths.push(isolatedHome)
+    const supervisorHome = join(isolatedHome, 'supervisor')
+    await mkdir(supervisorHome, { recursive: true })
+    await writeFile(join(supervisorHome, 'config.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      defaultInstance: 'missing',
+      instances: {
+        missing: {
+          name: 'missing',
+          home: join(isolatedHome, 'disconnected-home'),
+        },
+      },
+    }, null, 2)}\n`)
+    const childEnv = { ...process.env }
+    delete childEnv.OPENALICE_HOME
+    delete childEnv.OPENALICE_INSTANCE
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 120,
+      rows: 32,
+      cwd: dirname(cliEntry),
+      env: {
+        ...childEnv,
+        HOME: isolatedHome,
+        OPENALICE_SUPERVISOR_HOME: supervisorHome,
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let openedInstances = false
+      let repairedDefault = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor instance recovery timed out:\n${output}`))
+      }, 10_000)
+      child.onData((data) => {
+        output += data
+        if (
+          !openedInstances
+          && output.includes('Using "default"; press i Instances to recover.')
+          && output.includes('Instance: default')
+        ) {
+          openedInstances = true
+          child.write('i')
+        } else if (
+          openedInstances
+          && !repairedDefault
+          && output.includes('default · current')
+          && output.includes('+ Create instance')
+        ) {
+          repairedDefault = true
+          child.write('\r')
+        } else if (
+          !detached
+          && output.includes('Selected instance default; future bare starts use it.')
+        ) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor instance recovery exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    const config = JSON.parse(
+      await readFile(join(supervisorHome, 'config.json'), 'utf8'),
+    )
+    expect(config.defaultInstance).toBeUndefined()
+    expect(config.instances.missing.home).toBe(join(isolatedHome, 'disconnected-home'))
+    expect(transcript).toContain('Instance "missing" is missing.')
+    expect(transcript).toContain('Using "default"; press i Instances to recover.')
+    expect(transcript).toContain('+ Create instance')
+    expect(transcript).toContain('Selected instance default; future bare starts use it.')
+  }, 15_000)
+
   it('shows higher-priority CLI overrides as locked settings', async () => {
     const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-settings-lock-'))
     temporaryPaths.push(isolatedHome)
@@ -293,6 +483,67 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('44000 · locked')
     expect(transcript).toContain('Locked by --port.')
     expect(transcript).not.toContain('Set Web port')
+  })
+
+  it('shows CLI-selected instances as read-only instead of pretending to switch them', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-instance-lock-'))
+    temporaryPaths.push(isolatedHome)
+    const instanceHome = join(isolatedHome, 'research-home')
+    const child = pty.spawn(process.execPath, [
+      cliEntry,
+      '--instance', 'research',
+      '--home', instanceHome,
+    ], {
+      cols: 110,
+      rows: 30,
+      cwd: dirname(cliEntry),
+      env: {
+        ...process.env,
+        HOME: isolatedHome,
+        OPENALICE_SUPERVISOR_HOME: join(isolatedHome, 'supervisor'),
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let openedInstances = false
+      let closedInstances = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor instance-lock TUI timed out:\n${output}`))
+      }, 10_000)
+      child.onData((data) => {
+        output += data
+        if (!openedInstances && output.includes('i Instances')) {
+          openedInstances = true
+          child.write('i')
+        } else if (
+          !closedInstances
+          && output.includes('Instance selection is read-only.')
+          && output.includes('research · current')
+        ) {
+          closedInstances = true
+          child.write('\u001b')
+        } else if (
+          !detached
+          && output.includes('Instance selection closed.')
+        ) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor instance-lock TUI exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain('Locked by --instance.')
+    expect(transcript).toContain('research · current')
+    expect(transcript).not.toContain('+ Create instance')
   })
 
   it('explains when managed source is unavailable from a source-run CLI', async () => {

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -43,7 +43,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
     expect(lines).toContain('Runtime state: absent')
-    expect(lines).toContain('s Start · p Settings · m Managed · c Source')
+    expect(lines).toContain('s Start · i Instances · p Settings · m Managed · c Source')
     expect(lines).toContain('d Doctor · l Logs · u Update · ? Help')
     expect(lines).toContain('q / Esc / Ctrl+C  Detach without stopping')
   })
@@ -155,6 +155,29 @@ describe('Supervisor TUI screen', () => {
     })
     expect(screen.handleKey('p', matchesKey)).toBe(true)
     expect(settingsRequests).toBe(2)
+  })
+
+  it('opens instance selection while stopped or running', () => {
+    let instanceRequests = 0
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: { class: 'absent' },
+    }, {
+      onInstances: () => {
+        instanceRequests += 1
+      },
+    })
+
+    expect(screen.handleKey('i', matchesKey)).toBe(true)
+    screen.update({
+      runtime: {
+        class: 'running',
+        owner: { surface: 'cli-server', pid: 42 },
+      },
+    })
+    expect(screen.handleKey('i', matchesKey)).toBe(true)
+    expect(instanceRequests).toBe(2)
   })
 
   it('confirms managed source preparation before dispatch', () => {

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -1,8 +1,13 @@
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import {
+  dirname,
+  join,
+} from 'node:path'
 import type {
   Component,
   KeyId,
+  SelectItem,
+  SelectListTheme,
   SettingItem,
   SettingsListTheme,
 } from '@earendil-works/pi-tui'
@@ -35,9 +40,16 @@ import {
 } from './managed-source.ts'
 import { loadPiTui } from './pi-tui-loader.ts'
 import {
+  createSupervisorInstance,
   persistInstanceLaunchConfig,
+  persistSelectedSupervisorInstance,
   readInstanceLaunchConfig,
+  readSupervisorInstanceRegistry,
+  isStoredHomeUnavailableError,
+  resolveAvailableStoredLaunchContext,
   resolveStoredLaunchContext,
+  validateSupervisorInstanceName,
+  type SupervisorInstanceRegistry,
 } from './supervisor-config.ts'
 import {
   checkForUpdate,
@@ -148,6 +160,18 @@ export interface SupervisorTuiDependencies {
   loadInstanceConfig?: (
     context: ResolvedLaunchContext,
   ) => Promise<InstanceLaunchConfig>
+  loadInstanceRegistry?: (
+    context: ResolvedLaunchContext,
+  ) => Promise<SupervisorInstanceRegistry>
+  selectInstance?: (
+    context: ResolvedLaunchContext,
+    name: string,
+  ) => Promise<ResolvedLaunchContext>
+  createInstance?: (
+    context: ResolvedLaunchContext,
+    name: string,
+    home: string,
+  ) => Promise<ResolvedLaunchContext>
   prepareManagedSource?: () => Promise<ManagedSourceResult>
   inspectManagedSource?: () => Promise<ManagedSourcePlan>
   machineConfig?: MachineSupervisorConfig | null
@@ -183,9 +207,8 @@ export async function runSupervisorTui(
     )
   }
 
-  let context = await (
-    dependencies.resolveContext
-    ?? ((flags) => {
+  const resolveContext = dependencies.resolveContext
+    ?? ((flags: TuiLaunchFlags) => {
       if (dependencies.machineConfig || dependencies.instanceConfig) {
         return resolveLaunchContext({
           flags,
@@ -196,7 +219,31 @@ export async function runSupervisorTui(
       }
       return resolveStoredLaunchContext(flags, { env: dependencies.env })
     })
-  )(launchFlags)
+  let context: ResolvedLaunchContext
+  let startupNotice: string | undefined
+  try {
+    context = await resolveContext(launchFlags)
+  } catch (error: unknown) {
+    const env = dependencies.env ?? process.env
+    const explicitSelection = launchFlags.instance !== undefined
+      || launchFlags.home !== undefined
+      || env['OPENALICE_INSTANCE'] !== undefined
+      || env['OPENALICE_HOME'] !== undefined
+    const customResolution = dependencies.resolveContext !== undefined
+      || dependencies.machineConfig !== undefined
+      || dependencies.instanceConfig !== undefined
+    if (
+      explicitSelection
+      || customResolution
+      || !isStoredHomeUnavailableError(error)
+    ) {
+      throw error
+    }
+    context = await resolveAvailableStoredLaunchContext({
+      env: dependencies.env,
+    })
+    startupNotice = storedHomeRecoveryNotice(error, context.instance)
+  }
   let services = createServices(dependencies, context)
   let runtime: RuntimeSummary | null = null
   let diagnostic: string | undefined
@@ -219,14 +266,17 @@ export async function runSupervisorTui(
   let actionRunning = false
   let sourcePromptActive = false
   let settingsActive = false
+  let instancesActive = false
   let closeSourcePrompt: (() => void) | null = null
   let closeSettings: (() => void) | null = null
+  let closeInstances: (() => void) | null = null
   const screen = new SupervisorScreen({
     version: dependencies.version ?? readCliVersion(),
     channel,
     runtime,
     context,
     diagnostic,
+    notice: startupNotice,
   }, {
     onAction: (action) => {
       void requestAction(action)
@@ -236,6 +286,9 @@ export async function runSupervisorTui(
     },
     onSettings: () => {
       void openSettings()
+    },
+    onInstances: () => {
+      void openInstances()
     },
     onRequestManagedSource: () => {
       void requestManagedSource()
@@ -259,6 +312,27 @@ export async function runSupervisorTui(
   })
   const loadInstanceConfig = dependencies.loadInstanceConfig
     ?? readInstanceLaunchConfig
+  const loadInstanceRegistry = dependencies.loadInstanceRegistry
+    ?? readSupervisorInstanceRegistry
+  const selectInstance = dependencies.selectInstance ?? (async (
+    currentContext,
+    name,
+  ) => {
+    await persistSelectedSupervisorInstance(currentContext, name)
+    return resolveStoredLaunchContext(launchFlags, {
+      env: dependencies.env,
+    })
+  })
+  const createInstance = dependencies.createInstance ?? (async (
+    currentContext,
+    name,
+    home,
+  ) => {
+    await createSupervisorInstance(currentContext, name, home)
+    return resolveStoredLaunchContext(launchFlags, {
+      env: dependencies.env,
+    })
+  })
   const prepareManaged = dependencies.prepareManagedSource
     ?? (() => prepareManagedSource())
   const inspectManaged = dependencies.inspectManagedSource
@@ -307,7 +381,7 @@ export async function runSupervisorTui(
           prepare: true,
           rebuild: false,
           checkUpdates: context.updateChecks,
-          port: context.port,
+          port: runtimeStartPort(context),
           homeRoot,
           appDir: context.appDir ?? screen.snapshot.runtime?.provider?.root,
           waitMs: 120_000,
@@ -329,7 +403,7 @@ export async function runSupervisorTui(
           prepare: true,
           rebuild: false,
           checkUpdates: context.updateChecks,
-          port: context.port,
+          port: runtimeStartPort(context),
           homeRoot,
           appDir,
           waitMs: 120_000,
@@ -431,7 +505,12 @@ export async function runSupervisorTui(
   }
 
   function openSourcePrompt(reason?: string): void {
-    if (sourcePromptActive || settingsActive || actionRunning) return
+    if (
+      sourcePromptActive
+      || settingsActive
+      || instancesActive
+      || actionRunning
+    ) return
     const source = context.provenance.appDir.source
     if (source === 'environment' || source === 'cli-flag') {
       screen.update({
@@ -519,7 +598,12 @@ export async function runSupervisorTui(
   }
 
   async function openSettings(): Promise<void> {
-    if (settingsActive || sourcePromptActive || actionRunning) return
+    if (
+      settingsActive
+      || sourcePromptActive
+      || instancesActive
+      || actionRunning
+    ) return
     actionRunning = true
     screen.update({
       busy: 'Loading instance settings',
@@ -563,9 +647,10 @@ export async function runSupervisorTui(
       initialValue: string,
       validate: (value: string) => string | undefined,
       done: (selectedValue?: string) => void,
+      initialDetail = 'Leave blank to inherit from the next lower-priority layer.',
     ): Component => {
       const input = new (class extends piTui.Input {
-        detail = 'Leave blank to inherit from the next lower-priority layer.'
+        detail = initialDetail
 
         setDetail(next: string): void {
           this.detail = next
@@ -620,7 +705,11 @@ export async function runSupervisorTui(
         description: homeLocked
           ?? (
             runtimeStopped
-              ? 'Complete state root for this instance. Blank removes the instance override.'
+              ? (
+                  context.instance === 'default'
+                    ? 'Complete state root for this instance. Blank removes the instance override.'
+                    : 'Complete state root for this named instance. Named instances require a separate explicit home.'
+                )
               : 'Stop the selected Runtime before changing its complete home.'
           ),
       }
@@ -628,8 +717,15 @@ export async function runSupervisorTui(
         homeItem.submenu = (_currentValue, done) => inputSubmenu(
           'Set complete home',
           stored.home ?? '',
-          () => undefined,
+          (value) => (
+            context.instance !== 'default' && value === ''
+              ? 'Named instances require an explicit complete home.'
+              : undefined
+          ),
           done,
+          context.instance === 'default'
+            ? 'Leave blank to inherit from the next lower-priority layer.'
+            : 'Named instances require a separate explicit complete home.',
         )
       }
       const portItem: SettingItem = {
@@ -637,7 +733,7 @@ export async function runSupervisorTui(
         label: 'Web port',
         currentValue: portLocked
           ? `${context.port} · locked`
-          : inheritedSettingValue(stored.port, context.port),
+          : portSettingValue(stored.port, context),
         description: portLocked
           ?? (
             runtimeStopped
@@ -799,6 +895,281 @@ export async function runSupervisorTui(
     overlay.focus()
   }
 
+  async function openInstances(): Promise<void> {
+    if (
+      instancesActive
+      || sourcePromptActive
+      || settingsActive
+      || actionRunning
+    ) return
+    actionRunning = true
+    screen.update({
+      busy: 'Loading instances',
+      notice: undefined,
+      diagnostic: undefined,
+    })
+    let registry: SupervisorInstanceRegistry
+    try {
+      registry = await loadInstanceRegistry(context)
+    } catch (error: unknown) {
+      screen.update({
+        diagnostic: `Could not load instances: ${safeError(error)}`,
+      })
+      return
+    } finally {
+      actionRunning = false
+      if (active) screen.update({ busy: undefined })
+    }
+    if (!active) return
+
+    instancesActive = true
+    let changing = false
+    let message = 'Selecting an instance also makes it the next bare-start default.'
+    const lock = instanceSelectionOverrideLock(context)
+    if (lock) message = lock
+    const createValue = '__create_instance__'
+    const visibleInstances = registry.instances.some(
+      (entry) => entry.name === context.instance,
+    )
+      ? registry.instances
+      : [
+          ...registry.instances,
+          {
+            name: context.instance,
+            home: context.home,
+            port: context.port,
+            portAutomatic: context.provenance.port.source === 'default',
+            isDefault: false,
+          },
+        ]
+    const items: SelectItem[] = visibleInstances.map((entry) => ({
+      value: entry.name,
+      label: [
+        entry.name,
+        entry.name === context.instance ? 'current' : undefined,
+        entry.isDefault ? 'default' : undefined,
+      ].filter(Boolean).join(' · '),
+      description: `${entry.home} · Web ${entry.portAutomatic ? `auto from ${entry.port}` : entry.port}`,
+    }))
+    if (!lock) {
+      items.push({
+        value: createValue,
+        label: '+ Create instance…',
+        description: 'Register a separate complete home and select it.',
+      })
+    }
+
+    const theme: SelectListTheme = {
+      selectedPrefix: (text) => text,
+      selectedText: (text) => text,
+      description: (text) => text,
+      scrollInfo: (text) => text,
+      noMatch: (text) => text,
+    }
+    const list = new piTui.SelectList(items, 8, theme, {
+      minPrimaryColumnWidth: 20,
+      maxPrimaryColumnWidth: 32,
+    })
+    const selectedIndex = items.findIndex(
+      (item) => item.value === context.instance,
+    )
+    list.setSelectedIndex(Math.max(0, selectedIndex))
+    let component: Component = list
+
+    const setMessage = (next: string) => {
+      message = next
+      ui.requestRender()
+    }
+    const close = (notice = 'Instance selection closed.') => {
+      if (!instancesActive) return
+      instancesActive = false
+      closeInstances = null
+      overlay.hide()
+      ui.setShowHardwareCursor(false)
+      screen.update({ notice })
+    }
+    const showList = () => {
+      ui.setShowHardwareCursor(false)
+      component = list
+      setMessage(lock ?? 'Selecting an instance also makes it the next bare-start default.')
+    }
+    const activateContext = async (
+      operation: () => Promise<ResolvedLaunchContext>,
+      notice: (next: ResolvedLaunchContext) => string,
+    ) => {
+      if (changing) return
+      changing = true
+      actionRunning = true
+      setMessage('Switching instance…')
+      try {
+        const next = await operation()
+        context = next
+        services = createServices(dependencies, context)
+        screen.update({
+          context,
+          runtime: null,
+          diagnostic: undefined,
+        })
+        close(notice(next))
+      } catch (error: unknown) {
+        setMessage(`Could not switch instance: ${safeError(error)}`)
+      } finally {
+        actionRunning = false
+        changing = false
+        await refreshRuntime()
+      }
+    }
+    const showCreateHomeInput = (name: string) => {
+      const defaultHome = registry.instances.find(
+        (entry) => entry.name === 'default',
+      )?.home ?? context.home
+      const suggestedHome = join(
+        dirname(defaultHome),
+        `.openalice-${name}`,
+      )
+      const input = new (class extends piTui.Input {
+        detail = 'Use a separate complete home. An empty directory is prepared when registered.'
+
+        setDetail(next: string): void {
+          this.detail = next
+          this.invalidate()
+          ui.requestRender()
+        }
+
+        override render(width: number): string[] {
+          return [
+            `Create instance · ${name}`,
+            '',
+            'Complete home',
+            ...super.render(width),
+            '',
+            sanitize(this.detail),
+            '',
+            'Enter  Create and select · Esc  Back',
+          ]
+        }
+      })()
+      input.setValue(suggestedHome)
+      input.focused = true
+      ui.setShowHardwareCursor(true)
+      input.onEscape = () => {
+        input.focused = false
+        showList()
+      }
+      input.onSubmit = (value) => {
+        const home = value.trim()
+        if (!home) {
+          input.setDetail('Enter a complete home for this instance.')
+          return
+        }
+        void activateContext(
+          () => createInstance(context, name, home),
+          (next) => `Created and selected instance ${next.instance}.`,
+        )
+      }
+      component = input
+      setMessage('The new instance owns only its registry entry; its data is never copied or deleted.')
+    }
+    const showCreateNameInput = () => {
+      const input = new (class extends piTui.Input {
+        detail = 'Use a short lowercase name such as research or paper.'
+
+        setDetail(next: string): void {
+          this.detail = next
+          this.invalidate()
+          ui.requestRender()
+        }
+
+        override render(width: number): string[] {
+          return [
+            'Create instance',
+            '',
+            'Instance name',
+            ...super.render(width),
+            '',
+            sanitize(this.detail),
+            '',
+            'Enter  Continue · Esc  Back',
+          ]
+        }
+      })()
+      input.focused = true
+      ui.setShowHardwareCursor(true)
+      input.onEscape = () => {
+        input.focused = false
+        showList()
+      }
+      input.onSubmit = (value) => {
+        const name = value.trim()
+        const validation = validateSupervisorInstanceName(name)
+        if (validation) {
+          input.setDetail(validation)
+          return
+        }
+        if (registry.instances.some((entry) => entry.name === name)) {
+          input.setDetail(`Instance "${name}" is already registered.`)
+          return
+        }
+        input.focused = false
+        showCreateHomeInput(name)
+      }
+      component = input
+      setMessage('Create a named instance without leaving the Supervisor.')
+    }
+
+    list.onCancel = () => close()
+    list.onSelect = (item) => {
+      if (item.value === createValue) {
+        showCreateNameInput()
+        return
+      }
+      if (lock) {
+        setMessage(lock)
+        return
+      }
+      if (
+        item.value === context.instance
+        && item.value === registry.defaultInstance
+      ) {
+        close(`Instance ${context.instance} is already selected.`)
+        return
+      }
+      void activateContext(
+        () => selectInstance(context, item.value),
+        (next) => `Selected instance ${next.instance}; future bare starts use it.`,
+      )
+    }
+
+    const panel = new (class implements Component {
+      render(width: number): string[] {
+        return [
+          'OpenAlice instances',
+          '─'.repeat(Math.max(1, width)),
+          '',
+          ...component.render(width),
+          '',
+          sanitize(message),
+        ]
+      }
+
+      handleInput(data: string): void {
+        if (!changing) component.handleInput?.(data)
+      }
+
+      invalidate(): void {
+        component.invalidate()
+      }
+    })()
+    const overlay = ui.showOverlay(panel, {
+      width: '92%',
+      maxHeight: '90%',
+      anchor: 'center',
+      margin: 1,
+    })
+    closeInstances = () => close()
+    overlay.focus()
+  }
+
   async function discoverUpdateInBackground(): Promise<void> {
     if (!context.updateChecks) return
     try {
@@ -829,6 +1200,7 @@ export async function runSupervisorTui(
       clearInterval(poll)
       closeSourcePrompt?.()
       closeSettings?.()
+      closeInstances?.()
       removeInputListener()
       process.off('SIGTERM', onTerminate)
       process.off('SIGINT', onTerminate)
@@ -837,7 +1209,7 @@ export async function runSupervisorTui(
     }
     const onTerminate = () => finish()
     const removeInputListener = ui.addInputListener((data) => {
-      if (sourcePromptActive || settingsActive) {
+      if (sourcePromptActive || settingsActive || instancesActive) {
         if (piTui.matchesKey(data, 'ctrl+c')) {
           finish()
           return { consume: true }
@@ -894,6 +1266,7 @@ export class SupervisorScreen implements Component {
   private readonly onAction?: (action: SupervisorAction) => void
   private readonly onConfigureSource?: () => void
   private readonly onSettings?: () => void
+  private readonly onInstances?: () => void
   private readonly onRequestManagedSource?: () => void
   private readonly onPrepareManagedSource?: () => void
   private readonly requestRender?: () => void
@@ -904,6 +1277,7 @@ export class SupervisorScreen implements Component {
       onAction?: (action: SupervisorAction) => void
       onConfigureSource?: () => void
       onSettings?: () => void
+      onInstances?: () => void
       onRequestManagedSource?: () => void
       onPrepareManagedSource?: () => void
       requestRender?: () => void
@@ -913,6 +1287,7 @@ export class SupervisorScreen implements Component {
     this.onAction = callbacks.onAction
     this.onConfigureSource = callbacks.onConfigureSource
     this.onSettings = callbacks.onSettings
+    this.onInstances = callbacks.onInstances
     this.onRequestManagedSource = callbacks.onRequestManagedSource
     this.onPrepareManagedSource = callbacks.onPrepareManagedSource
     this.requestRender = callbacks.requestRender
@@ -967,6 +1342,10 @@ export class SupervisorScreen implements Component {
     }
     if (matchesKey(data, 'p')) {
       this.onSettings?.()
+      return true
+    }
+    if (matchesKey(data, 'i')) {
+      this.onInstances?.()
       return true
     }
     if (matchesKey(data, 'm')) {
@@ -1048,7 +1427,7 @@ export class SupervisorScreen implements Component {
           lines.push(`Uptime: ${formatDuration(runtime?.uptimeSeconds ?? 0)}`)
         }
         if (this.snapshot.context) {
-          lines.push(`Resolved: home ${formatProvenance(this.snapshot.context.provenance.home)} · port ${formatProvenance(this.snapshot.context.provenance.port)}`)
+          lines.push(`Resolved: home ${formatProvenance(this.snapshot.context.provenance.home)} · port ${formatPortResolution(this.snapshot.context)}`)
           lines.push(`Source: ${this.snapshot.context.appDir ?? runtime?.provider?.root ?? 'current directory discovery'} ${formatProvenance(this.snapshot.context.provenance.appDir)}`)
         }
       }
@@ -1182,6 +1561,7 @@ function renderHelp(): string[] {
     'x  Stop (confirmation required)   r  Restart (confirmation required)',
     'l  Bounded redacted logs          d  Read-only Doctor',
     'u  Check for product update       ?  Toggle this help',
+    'i  Select or create an instance',
     'p  Configure selected instance settings',
     'm  Prepare installer-managed source and start',
     'c  Choose and remember this instance\'s source checkout',
@@ -1219,8 +1599,8 @@ function renderConfirmation(
 
 function actionBar(runtime: RuntimeSummary | null, width: number): string[] {
   const primary = runtime?.class === 'absent'
-    ? 's Start · p Settings · m Managed · c Source'
-    : 'o Open · p Settings · r Restart · x Stop'
+    ? 's Start · i Instances · p Settings · m Managed · c Source'
+    : 'o Open · i Instances · p Settings · r Restart · x Stop'
   const secondary = 'd Doctor · l Logs · u Update · ? Help'
   const actions = `${primary} · ${secondary}`
   if (actions.length <= width) return [actions]
@@ -1269,6 +1649,14 @@ function formatUpdateNotice(update: UpdateResult): string {
   return update.message ?? 'Automatic update is unavailable for this install channel.'
 }
 
+function runtimeStartPort(
+  context: ResolvedLaunchContext,
+): number | undefined {
+  return context.provenance.port.source === 'default'
+    ? undefined
+    : context.port
+}
+
 function formatOwner(runtime: RuntimeSummary | null): string {
   if (!runtime?.owner) return 'none'
   const pid = runtime.owner.pid === undefined ? '' : ` pid ${runtime.owner.pid}`
@@ -1293,6 +1681,12 @@ function formatDuration(seconds: number): string {
 
 function formatProvenance(value: { source: string; detail: string }): string {
   return value.source === 'default' ? '(default)' : `(${value.detail})`
+}
+
+function formatPortResolution(context: ResolvedLaunchContext): string {
+  return context.provenance.port.source === 'default'
+    ? `(automatic from ${context.port})`
+    : formatProvenance(context.provenance.port)
 }
 
 type EditableSettingField = 'home' | 'port' | 'updateChecks'
@@ -1322,6 +1716,18 @@ function settingOverrideLock(
   return `Locked by ${provenance.detail}. Change that higher-priority override and reopen the Supervisor.`
 }
 
+function instanceSelectionOverrideLock(
+  context: ResolvedLaunchContext,
+): string | undefined {
+  const instanceLock = settingOverrideLock(context.provenance.instance)
+  if (instanceLock) return `Instance selection is read-only. ${instanceLock}`
+  const homeLock = settingOverrideLock(context.provenance.home)
+  if (homeLock) {
+    return `Instance selection is read-only while this session's complete home is fixed. ${homeLock}`
+  }
+  return undefined
+}
+
 function inheritedSettingValue(
   stored: string | number | undefined,
   resolved: string | number,
@@ -1329,6 +1735,16 @@ function inheritedSettingValue(
   return stored === undefined
     ? `${INHERIT_SETTING} → ${resolved}`
     : String(stored)
+}
+
+function portSettingValue(
+  stored: number | undefined,
+  context: ResolvedLaunchContext,
+): string {
+  if (stored !== undefined) return String(stored)
+  return context.provenance.port.source === 'default'
+    ? `${INHERIT_SETTING} → automatic from ${context.port}`
+    : `${INHERIT_SETTING} → ${context.port}`
 }
 
 function booleanSettingValue(stored: boolean | undefined): string {
@@ -1349,7 +1765,7 @@ function settingItemValue(
   if (id === 'port') {
     return settingOverrideLock(context.provenance.port)
       ? `${context.port} · locked`
-      : inheritedSettingValue(stored.port, context.port)
+      : portSettingValue(stored.port, context)
   }
   if (id === 'updateChecks') {
     return settingOverrideLock(context.provenance.updateChecks)
@@ -1373,6 +1789,20 @@ function validatePortSetting(value: string): string | undefined {
 
 function safeError(error: unknown): string {
   return sanitize(error instanceof Error ? error.message : String(error))
+}
+
+function storedHomeRecoveryNotice(
+  error: unknown,
+  fallbackInstance: string,
+): string {
+  const message = error instanceof Error ? error.message : String(error)
+  const match = message.match(/for instance "([^"]+)" (is missing|is unavailable or not writable)/)
+  const unavailable = match
+    ? `Instance "${match[1]}" ${match[2]}.`
+    : 'The remembered instance home is unavailable.'
+  return sanitize(
+    `${unavailable} Using "${fallbackInstance}"; press i Instances to recover.`,
+  )
 }
 
 function sanitize(value: string): string {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -398,7 +398,7 @@ starting the Runtime.
 
 - [x] Define machine-wide Supervisor and selected-instance schemas outside
   `OPENALICE_HOME`.
-- [ ] Resolve defaults, machine config, instance config, environment, and CLI
+- [x] Resolve defaults, machine config, instance config, environment, and CLI
   flags once into `ResolvedLaunchContext`, retaining field-level provenance.
 - [ ] Add `openalice config check` plus TUI diagnostics; invalid live reload
   retains the last valid configuration.
@@ -409,10 +409,10 @@ starting the Runtime.
   session root without changing a user-installed Pi launched externally.
 - [x] Update the managed Workspace runtime owner guide and tests for the new
   managed-Pi isolation boundary.
-- [ ] Define a versioned atomic CLI-owned registry mapping names to complete
+- [x] Define a versioned atomic CLI-owned registry mapping names to complete
   homes; never store the registry inside a selected home.
-- [ ] Preserve implicit `default` without moving existing data.
-- [ ] Add `--instance`, list, TUI selection, and collision checks.
+- [x] Preserve implicit `default` without moving existing data.
+- [x] Add `--instance`, list, TUI selection, and collision checks.
 - [ ] Make deletion remove registry ownership only by default.
 - [ ] Test concurrent homes, ports, sockets, logs, foreign/stale owners,
   Electron ownership, and remote instances.
@@ -696,3 +696,24 @@ This plan is complete only when:
   its expected Guardian PID. The same isolated installed CLI then completed
   start, authenticated Web/root probes, stop/restart ownership handoff,
   reconnect, and final stop while the desktop app remained active.
+- 2026-07-30: Added `i Instances` as a first-class Supervisor path. The TUI
+  now lists the implicit default and registered instances, creates a validated
+  named entry with a separate complete home, switches the live view without
+  stopping another Runtime, and remembers the selection for the next bare
+  start. Environment/CLI-selected instance or Home overrides make the list
+  visibly read-only. Named homes cannot be cleared, duplicated, or nested
+  under another registered home.
+- 2026-07-30: Real multi-instance dogfood created `paper` entirely inside the
+  TUI, started it on 47331, switched to the implicit default while it remained
+  active, and started a second Runtime that automatically selected 47334 after
+  the first instance's Web and internal ports. Both auth-status probes passed;
+  switching back found the first live owner, and each Runtime stopped from its
+  own TUI view. The journey exposed that explicit lifecycle/observability
+  commands still bypassed the stored registry; `up`, `run`, `down`, `status`,
+  `open`, `logs`, and `doctor` now resolve TUI-registered named homes before
+  dispatch.
+- 2026-07-30: A missing registered complete Home now fails explicit
+  automation selection but no longer strands a bare interactive launch. The
+  Supervisor keeps the unavailable entry, opens on an available fallback,
+  explains the recovery, and lets `i Instances` atomically repair the
+  remembered default. Unit and real-PTY coverage preserve that distinction.


### PR DESCRIPTION
## What changed

- add an `i Instances` flow to the Supervisor TUI for listing, creating, selecting, and remembering isolated complete-home instances
- validate and canonicalize instance homes, reject equal/nested or unrelated non-empty targets, and keep named instances from inheriting the implicit default home
- make lifecycle, logs, and Doctor commands resolve the same persisted instance registry as the TUI
- let unpinned Web ports probe automatically so two complete-home Runtimes can coexist
- recover a bare interactive TUI when the remembered home disappears while keeping explicit environment/flag selection fail-closed
- document the registry, precedence, recovery, and remaining headless-bundle boundary

## Why

Shell and SSH users need a real Runtime supervisor, not a development-only launcher. Named instances must isolate state and ports, command and TUI entry points must agree, and a disconnected mount must not strand the interactive Supervisor or silently redirect automation.

## Validation

- `pnpm -F @traderalice/openalice-cli typecheck`
- `pnpm -F @traderalice/openalice-cli test` (180 passed)
- `npx tsc --noEmit`
- `pnpm test` (3748 passed, 9 skipped)
- `pnpm test:guardian-recovery`
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `pnpm electron:smoke:pty`
- real installed-CLI PTY recovery against an unavailable remembered home
- real two-instance dogfood: both Runtimes healthy concurrently on automatically selected ports, then independently stopped