### PR TITLE
Move provider capabilities into runtime adapters

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -161,6 +161,26 @@ model changes future resolution but must not silently rewrite existing
 Workspace files. Existing configurations change only through their normal
 explicit apply/create paths.
 
+Runtime compatibility belongs to the runtime adapter, not to the shared
+credential or route layers. Every provider-capable adapter declares
+`capabilities.aiProvider` with:
+
+- whether native/global login is sufficient or a Workspace credential is
+  required;
+- accepted wire shapes in native preference order and the blank-form default;
+- any vendor-specific wire narrowing and narrowly scoped legacy repair;
+- which custom-model facts it registers (`contextWindow`, `reasoning`, and
+  effort variants).
+
+`src/workspaces/adapters/index.ts` is the single built-in registration point.
+The Workspace `/agents` contract serializes these declarations for UI launch,
+credential, and model controls. Adding a provider-capable runtime therefore
+means implementing its adapter, declaring these capabilities, and registering
+it once. Shared injection, readiness, config routes, and UI helpers must not
+add a second adapter-id matrix. Runtime-exclusive behavior such as a structured
+surface, transcript parser, native config format, or CLI argument spelling
+remains in the adapter or its explicitly runtime-owned UI.
+
 An upstream catalog such as Models.dev may later generate part of this table at
 build time. OpenAlice-specific overrides still own protocol quirks and runtime
 compatibility, and Workspace launch must not depend on a live catalog fetch.
@@ -257,8 +277,10 @@ contain credentials.
 - `src/ai-providers/model-semantics.ts` — exact semantic resolution and runtime-neutral binding inputs.
 - `src/ai-providers/presets.ts` — backend-to-UI preset serialization.
 - `src/core/config.ts` — credential access and creation-time Workspace defaults.
+- `src/workspaces/cli-adapter.ts` — adapter capability and provider-projection contract.
 - `src/workspaces/credential-injection.ts` — credential + selection + semantics composition.
-- `src/workspaces/adapters/` — native runtime projection and round-trip parsing.
+- `src/workspaces/adapters/index.ts` — built-in adapter registration.
+- `src/workspaces/adapters/` — declared runtime compatibility, native projection, and round-trip parsing.
 - `src/workspaces/adapters/owned-toml-config.ts` — reversible Codex project-scalar ownership.
 - `src/workspaces/schedule/scanner.ts` — Issue selection to one-run override dispatch.
 - `src/workspaces/headless-task-registry.ts` — durable requested model/effort provenance.
@@ -277,6 +299,8 @@ Tests for this subsystem must cover:
 - provider-only thinking switches never become fabricated effort values;
 - non-reasoning and unknown models do not receive fabricated capabilities;
 - model changes cannot retain a capability override for the previous id;
+- a synthetic unknown adapter works from its capability declaration without a
+  shared-layer id branch;
 - adapter write/read/write round trips preserve semantic fields;
 - reset removes only OpenAlice-owned configuration and restores prior values;
 - credential secrets never appear in logs, docs, committed fixtures, or test snapshots;

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -29,9 +29,16 @@ import type { WireShape } from '../../ai-providers/preset-catalog.js'
 import { resolveModelSemantics } from '../../ai-providers/model-semantics.js'
 import { resolveAnthropicAuthMode } from '../../core/credential-inference.js'
 import { probeByWireShape } from '../../workspaces/agent-probe.js'
+import { createBuiltinAdapterRegistry } from '../../workspaces/adapters/index.js'
+import {
+  isAgentRuntime,
+  type AdapterRegistry,
+  type CliAdapter,
+} from '../../workspaces/cli-adapter.js'
 
 interface ConfigRouteOpts {
   ctx?: EngineContext
+  adapterRegistry?: AdapterRegistry
 }
 
 export const ONBOARDING_TEST_CREDENTIAL = {
@@ -75,6 +82,15 @@ function maybeHandleOnboardingMockCredentialTest(body: {
 /** Config routes: GET /, PUT /:section, profile CRUD, presets, test */
 export function createConfigRoutes(opts?: ConfigRouteOpts) {
   const app = new Hono()
+  const adapters = opts?.adapterRegistry ?? createBuiltinAdapterRegistry()
+  const runtimeAdapters = adapters.list().filter(isAgentRuntime)
+  const providerAdapters = runtimeAdapters.filter(
+    (adapter): adapter is CliAdapter & {
+      capabilities: CliAdapter['capabilities'] & {
+        aiProvider: NonNullable<CliAdapter['capabilities']['aiProvider']>
+      }
+    } => adapter.capabilities.aiProvider !== undefined,
+  )
 
   app.get('/', async (c) => {
     try {
@@ -170,7 +186,9 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
       const defaults = await readWorkspaceCredentialDefaults()
       for (const [agentId, def] of Object.entries(defaults)) {
         if (def.credentialSlug !== slug) continue
-        if (!pickAgentWire(credentialWires(cred), agentId, def.wireShape)) {
+        const adapter = adapters.get(agentId)
+        const capabilities = adapter?.capabilities.aiProvider
+        if (!capabilities || !pickAgentWire(credentialWires(cred), capabilities, def.wireShape)) {
           return c.json({
             error: `This credential is the ${agentId} Workspace default. Choose a compatible default protocol before removing its current wire.`,
           }, 400)
@@ -229,8 +247,6 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   // into each new workspace's file-based AI config at create time — sparing the
   // user the per-workspace AI-config modal. References the vault above.
 
-  const DEFAULTABLE_AGENTS = ['claude', 'codex', 'opencode', 'pi'] as const
-
   /**
    * GET /workspace-credential-defaults — the current per-agent defaults plus,
    * for the picker, the vault slugs each agent can actually be driven by (the
@@ -243,8 +259,8 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
         readCredentials(),
       ])
       const compatibleByAgent: Record<string, string[]> = {}
-      for (const agent of DEFAULTABLE_AGENTS) {
-        compatibleByAgent[agent] = compatibleCredentials(creds, agent).map(([slug]) => slug)
+      for (const adapter of providerAdapters) {
+        compatibleByAgent[adapter.id] = compatibleCredentials(creds, adapter).map(([slug]) => slug)
       }
       return c.json({ defaults, compatibleByAgent })
     } catch (err) {
@@ -265,7 +281,10 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
       const credentials = await readCredentials()
       const incoming = body.defaults ?? {}
       const next: Record<string, WorkspaceCredentialDefault> = {}
-      for (const agent of DEFAULTABLE_AGENTS) {
+      for (const adapter of providerAdapters) {
+        const agent = adapter.id
+        const capabilities = adapter.capabilities.aiProvider
+        const registration = capabilities.modelRegistration
         const def = incoming[agent]
         if (def && typeof def.credentialSlug === 'string' && def.credentialSlug) {
           const parsedWire = credentialWireShapeEnum.safeParse(def.wireShape)
@@ -274,7 +293,10 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
           }
           if (parsedWire.success) {
             const credential = credentials[def.credentialSlug]
-            if (credential && !pickAgentWire(credentialWires(credential), agent, parsedWire.data)) {
+            if (
+              credential &&
+              !pickAgentWire(credentialWires(credential), capabilities, parsedWire.data)
+            ) {
               return c.json({ error: `${agent} cannot use ${parsedWire.data} from ${def.credentialSlug}` }, 400)
             }
           }
@@ -297,10 +319,10 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
             credentialSlug: def.credentialSlug,
             ...(typeof def.model === 'string' && def.model ? { model: def.model } : {}),
             ...(parsedWire.success ? { wireShape: parsedWire.data } : {}),
-            ...((agent === 'pi' || agent === 'opencode') && def.contextWindow !== undefined
+            ...(registration?.contextWindow && def.contextWindow !== undefined
               ? { contextWindow: def.contextWindow }
               : {}),
-            ...((agent === 'pi' || agent === 'opencode') &&
+            ...(registration?.reasoning &&
               !reasoningIsRegistered &&
               typeof selectedModel === 'string' &&
               typeof def.reasoning === 'boolean'
@@ -327,9 +349,10 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   app.put('/workspace-default-agent', async (c) => {
     try {
       const body = await c.req.json<{ agent?: string | null }>()
-      const agent = typeof body.agent === 'string' && DEFAULTABLE_AGENTS.includes(body.agent as typeof DEFAULTABLE_AGENTS[number])
-        ? body.agent
-        : null
+      const agent = typeof body.agent === 'string' &&
+        runtimeAdapters.some((adapter) => adapter.id === body.agent)
+          ? body.agent
+          : null
       await writeWorkspaceDefaultAgent(agent)
       return c.json({ agent })
     } catch (err) {
@@ -348,9 +371,10 @@ export function createConfigRoutes(opts?: ConfigRouteOpts) {
   app.put('/issue-default-agent', async (c) => {
     try {
       const body = await c.req.json<{ agent?: string | null }>()
-      const agent = typeof body.agent === 'string' && DEFAULTABLE_AGENTS.includes(body.agent as typeof DEFAULTABLE_AGENTS[number])
-        ? body.agent
-        : null
+      const agent = typeof body.agent === 'string' &&
+        runtimeAdapters.some((adapter) => adapter.id === body.agent)
+          ? body.agent
+          : null
       await writeIssueDefaultAgent(agent)
       return c.json({ agent })
     } catch (err) {

--- a/src/webui/routes/preferences.spec.ts
+++ b/src/webui/routes/preferences.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createPreferencesRoutes } from './preferences.js'
+import { AdapterRegistry, type CliAdapter } from '../../workspaces/cli-adapter.js'
 
 const unusedShellStatus = vi.fn(async () => ({ supported: false as const }))
 const unusedShellSave = vi.fn(async () => ({ supported: false as const }))
@@ -52,6 +53,46 @@ describe('preferences routes', () => {
     })
     expect(response.status).toBe(200)
     expect(remember).toHaveBeenCalledWith('pi', 'minimax-1')
+  })
+
+  it('accepts a future workspace-required adapter without changing the route schema', async () => {
+    const futureAdapter: CliAdapter = {
+      id: 'future',
+      displayName: 'Future Runtime',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: false,
+        resumeById: false,
+        transcriptDiscovery: 'none',
+        aiProvider: {
+          credentialSource: 'workspace-required',
+          wirePreference: ['openai-chat'],
+        },
+      },
+      composeCommand: (base) => base,
+    }
+    const registry = new AdapterRegistry()
+    registry.register(futureAdapter, { default: true })
+    const remember = vi.fn(async (agent: string, credentialSlug: string | null) => ({
+      lastCredentialByAgent: { [agent]: credentialSlug! },
+      recentChatWorkspaceId: null,
+    }))
+    const app = createPreferencesRoutes({
+      readQuickChatPreferences: vi.fn(),
+      rememberQuickChatCredential: remember,
+      rememberRecentChatWorkspace: unusedRecentWorkspace,
+      getWorkspaceShellStatus: unusedShellStatus,
+      saveWorkspaceShellPreference: unusedShellSave,
+    }, registry)
+
+    const response = await app.request('/quick-chat', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agent: 'future', credentialSlug: 'future-1' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(remember).toHaveBeenCalledWith('future', 'future-1')
   })
 
   it('rejects unknown runtimes and empty slugs without writing', async () => {

--- a/src/webui/routes/preferences.ts
+++ b/src/webui/routes/preferences.ts
@@ -13,11 +13,11 @@ import {
   saveWindowsWorkspaceShellPreference,
   type WindowsWorkspaceShellStatus,
 } from '../../core/windows-workspace-shell.js'
-
-const LOGINLESS_AGENTS = ['opencode', 'pi'] as const
+import type { AdapterRegistry } from '../../workspaces/cli-adapter.js'
+import { createBuiltinAdapterRegistry } from '../../workspaces/adapters/index.js'
 
 const quickChatPreferenceUpdateSchema = z.object({
-  agent: z.enum(LOGINLESS_AGENTS),
+  agent: z.string().trim().min(1).max(128),
   credentialSlug: z.string().trim().min(1).max(128).nullable(),
 })
 
@@ -50,7 +50,10 @@ const defaultDeps: PreferenceRouteDeps = {
   saveWorkspaceShellPreference: (input) => saveWindowsWorkspaceShellPreference(input),
 }
 
-export function createPreferencesRoutes(deps: PreferenceRouteDeps = defaultDeps) {
+export function createPreferencesRoutes(
+  deps: PreferenceRouteDeps = defaultDeps,
+  adapterRegistry: AdapterRegistry = createBuiltinAdapterRegistry(),
+) {
   const app = new Hono()
 
   app.get('/quick-chat', async (c) => {
@@ -64,6 +67,10 @@ export function createPreferencesRoutes(deps: PreferenceRouteDeps = defaultDeps)
   app.put('/quick-chat', async (c) => {
     const parsed = quickChatPreferenceUpdateSchema.safeParse(await c.req.json().catch(() => null))
     if (!parsed.success) {
+      return c.json({ error: 'invalid_quick_chat_preference' }, 400)
+    }
+    const adapter = adapterRegistry.get(parsed.data.agent)
+    if (adapter?.capabilities.aiProvider?.credentialSource !== 'workspace-required') {
       return c.json({ error: 'invalid_quick_chat_preference' }, 400)
     }
     try {

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -22,6 +22,7 @@ import {
   ChatWorkspaceResolver,
   TemplateWorkspaceResolver,
 } from '../../workspaces/chat-workspace-resolver.js';
+import { createBuiltinAdapterRegistry } from '../../workspaces/adapters/index.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -50,6 +51,7 @@ function build(opts: {
   opencodeRuntimeSource?: 'global-config' | 'global-login' | 'managed-runtime';
   runtimeWorkspace?: any;
 } = {}) {
+  const builtinAdapters = createBuiltinAdapterRegistry();
   const META = {
     id: 'ws-1',
     dir: '/w',
@@ -61,16 +63,23 @@ function build(opts: {
   const opencode = {
     id: 'opencode',
     namePrefix: 'o',
+    capabilities: builtinAdapters.get('opencode')!.capabilities,
     writeAiConfig: vi.fn(async () => {}),
     readAiConfig: vi.fn(async () => opts.opencodeConfig ?? null),
   };
   const claude = {
     id: 'claude',
     namePrefix: 'c',
+    capabilities: builtinAdapters.get('claude')!.capabilities,
     readAiConfig: vi.fn(async () => opts.claudeConfig ?? null),
     readInteractiveSetupStatus: vi.fn(async () => opts.claudeInteractiveSetupStatus ?? 'ready'),
   };
-  const shell = { id: 'shell', kind: 'utility', namePrefix: 'sh' };
+  const shell = {
+    id: 'shell',
+    kind: 'utility',
+    namePrefix: 'sh',
+    capabilities: builtinAdapters.get('shell')!.capabilities,
+  };
   const adapters: Record<string, any> = { opencode, claude, shell };
   const spawn = vi.fn((_wsId: string, ctx: any) => ({
     recordId: ctx.recordId,

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -2158,11 +2158,14 @@ export function createWorkspaceRoutes(
       // mode; the dropdown receives only presentation/injection metadata, while
       // the unfiltered Workspace modal keeps the key-bearing response.
       const agent = c.req.query('agent');
-      const entries = agent ? compatibleCredentials(credentials, agent) : Object.entries(credentials);
+      const adapter = agent ? svc.adapters.get(agent) : undefined;
+      const entries = agent
+        ? adapter ? compatibleCredentials(credentials, adapter) : []
+        : Object.entries(credentials);
       const list = entries.map(([slug, cred]) => {
         const resolvedModel = resolveInjectionModel(cred);
-        const projected = agent && resolvedModel
-          ? credentialToWorkspaceAiCred(cred, agent, { model: resolvedModel })
+        const projected = adapter && resolvedModel
+          ? credentialToWorkspaceAiCred(cred, adapter, { model: resolvedModel })
           : null;
         const reasoningMode = resolveModelSemantics(cred.vendor, resolvedModel)?.reasoning?.mode;
         return {
@@ -2232,13 +2235,14 @@ export function createWorkspaceRoutes(
     const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
     if (!meta) return c.json({ error: 'not_found' }, 404);
     try {
-      const [claude, codex, opencode, pi] = await Promise.all([
-        svc.adapters.get('claude')?.readAiConfig?.(meta.dir) ?? null,
-        svc.adapters.get('codex')?.readAiConfig?.(meta.dir) ?? null,
-        svc.adapters.get('opencode')?.readAiConfig?.(meta.dir) ?? null,
-        svc.adapters.get('pi')?.readAiConfig?.(meta.dir) ?? null,
-      ]);
-      return c.json({ claude, codex, opencode, pi });
+      const configurable = svc.adapters.list().filter(
+        (adapter) => adapter.capabilities.aiProvider && adapter.readAiConfig,
+      );
+      const entries = await Promise.all(configurable.map(async (adapter) => [
+        adapter.id,
+        await adapter.readAiConfig!(meta.dir),
+      ] as const));
+      return c.json(Object.fromEntries(entries));
     } catch (err) {
       if (err instanceof PathTraversal) return c.json({ error: 'invalid_path' }, 400);
       launcherLogger.warn('agent_config.read_failed', { id, err });
@@ -2331,7 +2335,8 @@ export function createWorkspaceRoutes(
     const id = c.req.param('id');
     const agent = c.req.param('agent');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
-    if (agent !== 'claude' && agent !== 'codex' && agent !== 'opencode' && agent !== 'pi') {
+    const adapter = svc.adapters.get(agent);
+    if (!adapter?.capabilities.aiProvider || !adapter.writeAiConfig) {
       return c.json({ error: 'unknown_agent' }, 400);
     }
     const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
@@ -2340,8 +2345,6 @@ export function createWorkspaceRoutes(
     const body = (await safeJson(c)) as WorkspaceAiCred | null;
     const cfg = body && typeof body === 'object' ? body : {};
     try {
-      const adapter = svc.adapters.get(agent);
-      if (!adapter?.writeAiConfig) return c.json({ error: 'unknown_agent' }, 400);
       const credentials = cfg.apiKey ? await readCredentials() : {};
       const slug = matchCredentialByApiKey(credentials, cfg.apiKey);
       const vendor = slug
@@ -2351,7 +2354,11 @@ export function createWorkspaceRoutes(
             baseUrl: cfg.baseUrl ?? undefined,
             wireShape: cfg.wireShape ?? undefined,
           });
-      const projected = applyRegisteredModelSemantics(cfg, agent, vendor);
+      const projected = applyRegisteredModelSemantics(
+        cfg,
+        adapter.capabilities.aiProvider,
+        vendor,
+      );
       await adapter.writeAiConfig(meta.dir, projected);
       // Remember an explicit model choice on the originating vault credential
       // (matched by apiKey) so quick-chat can reuse it without re-prompting.
@@ -2379,7 +2386,7 @@ export function createWorkspaceRoutes(
     const id = c.req.param('id');
     const agent = c.req.param('agent');
     if (!validId(id)) return c.json({ ok: false, error: 'invalid_id' }, 400);
-    if (agent !== 'claude' && agent !== 'codex' && agent !== 'opencode' && agent !== 'pi') {
+    if (!svc.adapters.get(agent)?.capabilities.aiProvider) {
       return c.json({ ok: false, error: 'unknown_agent' }, 400);
     }
 

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -620,7 +620,7 @@ describe('opencodeAdapter AI-config', () => {
         anthropic: 'https://api.minimax.io/anthropic',
         'openai-chat': 'https://api.minimax.io/v1',
       },
-    }, 'opencode', { model: 'MiniMax-M2.5' })!;
+    }, opencodeAdapter, { model: 'MiniMax-M2.5' })!;
 
     await opencodeAdapter.writeAiConfig!(dir, cred);
     const config = JSON.parse(await read('opencode.json'));

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -188,6 +188,11 @@ export const claudeAdapter: CliAdapter = {
     resumeById: true,
     transcriptDiscovery: 'fs-watch',
     headless: true,
+    aiProvider: {
+      credentialSource: 'runtime-or-workspace',
+      wirePreference: ['anthropic'],
+      defaultWire: 'anthropic',
+    },
   },
 
   readInteractiveSetupStatus: readClaudeInteractiveSetupStatus,

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -129,6 +129,11 @@ export const codexAdapter: CliAdapter = {
     // resumeHint. Then `codex resume <id>` (composeCommand) resumes by id.
     transcriptDiscovery: 'subprocess',
     headless: true,
+    aiProvider: {
+      credentialSource: 'runtime-or-workspace',
+      wirePreference: ['openai-responses'],
+      defaultWire: 'openai-responses',
+    },
   },
 
   /**

--- a/src/workspaces/adapters/index.spec.ts
+++ b/src/workspaces/adapters/index.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { BUILTIN_ADAPTERS, createBuiltinAdapterRegistry } from './index.js';
+
+describe('built-in adapter provider capabilities', () => {
+  it('keeps provider semantics on each native runtime adapter', () => {
+    const registry = createBuiltinAdapterRegistry();
+
+    expect(registry.resolve(null).id).toBe('claude');
+    expect(registry.list()).toEqual(BUILTIN_ADAPTERS);
+    expect(registry.get('claude')?.capabilities.aiProvider).toMatchObject({
+      credentialSource: 'runtime-or-workspace',
+      wirePreference: ['anthropic'],
+    });
+    expect(registry.get('codex')?.capabilities.aiProvider).toMatchObject({
+      credentialSource: 'runtime-or-workspace',
+      wirePreference: ['openai-responses'],
+    });
+    expect(registry.get('opencode')?.capabilities.aiProvider).toMatchObject({
+      credentialSource: 'workspace-required',
+      defaultWire: 'openai-chat',
+      modelRegistration: {
+        contextWindow: true,
+        reasoning: true,
+        effortVariants: true,
+      },
+    });
+    expect(registry.get('pi')?.capabilities.aiProvider).toMatchObject({
+      credentialSource: 'workspace-required',
+      defaultWire: 'openai-chat',
+      modelRegistration: {
+        contextWindow: true,
+        reasoning: true,
+      },
+    });
+    expect(registry.get('shell')?.capabilities.aiProvider).toBeUndefined();
+  });
+});

--- a/src/workspaces/adapters/index.ts
+++ b/src/workspaces/adapters/index.ts
@@ -1,0 +1,27 @@
+import { AdapterRegistry } from '../cli-adapter.js';
+import { claudeAdapter } from './claude.js';
+import { codexAdapter } from './codex.js';
+import { opencodeAdapter } from './opencode.js';
+import { piAdapter } from './pi.js';
+import { shellAdapter } from './shell.js';
+
+/**
+ * One registration point for the native runtimes shipped with OpenAlice.
+ * Adding an adapter here makes its declared capabilities available to the
+ * launcher, config routes, and serialized `/agents` metadata.
+ */
+export const BUILTIN_ADAPTERS = [
+  claudeAdapter,
+  codexAdapter,
+  opencodeAdapter,
+  piAdapter,
+  shellAdapter,
+] as const;
+
+export function createBuiltinAdapterRegistry(): AdapterRegistry {
+  const registry = new AdapterRegistry();
+  for (const adapter of BUILTIN_ADAPTERS) {
+    registry.register(adapter, { default: adapter === claudeAdapter });
+  }
+  return registry;
+}

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -326,6 +326,22 @@ export const opencodeAdapter: CliAdapter = {
     // `opencode --session <id>` (composeCommand) resumes by id.
     transcriptDiscovery: 'subprocess',
     headless: true,
+    aiProvider: {
+      credentialSource: 'workspace-required',
+      wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+      defaultWire: 'openai-chat',
+      vendorPolicies: {
+        minimax: {
+          wirePreference: ['anthropic'],
+          legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' },
+        },
+      },
+      modelRegistration: {
+        contextWindow: true,
+        reasoning: true,
+        effortVariants: true,
+      },
+    },
   },
 
   lifecycle: {

--- a/src/workspaces/adapters/pi.ts
+++ b/src/workspaces/adapters/pi.ts
@@ -250,6 +250,21 @@ export const piAdapter: CliAdapter = {
     // immune to pi's lazy transcript write.
     assignsSessionId: true,
     headless: true,
+    aiProvider: {
+      credentialSource: 'workspace-required',
+      wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+      defaultWire: 'openai-chat',
+      vendorPolicies: {
+        minimax: {
+          wirePreference: ['anthropic'],
+          legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' },
+        },
+      },
+      modelRegistration: {
+        contextWindow: true,
+        reasoning: true,
+      },
+    },
   },
 
   lifecycle: {

--- a/src/workspaces/agent-credential-readiness.spec.ts
+++ b/src/workspaces/agent-credential-readiness.spec.ts
@@ -47,6 +47,15 @@ function adapter(id: string, cfg: WorkspaceAiCred | null = null) {
       resumeLast: true,
       resumeById: true,
       transcriptDiscovery: 'none',
+      aiProvider: {
+        credentialSource: id === 'opencode' || id === 'pi'
+          ? 'workspace-required'
+          : 'runtime-or-workspace',
+        wirePreference: id === 'claude' ? ['anthropic'] : ['openai-chat'],
+        ...(id === 'opencode' || id === 'pi'
+          ? { modelRegistration: { contextWindow: true, reasoning: true } }
+          : {}),
+      },
     },
     composeCommand: () => [id],
     readAiConfig: vi.fn(async () => cfg),

--- a/src/workspaces/agent-credential-readiness.ts
+++ b/src/workspaces/agent-credential-readiness.ts
@@ -13,13 +13,6 @@ import type { CliAdapter, WorkspaceAiCred } from './cli-adapter.js'
 import type { Logger } from './logger.js'
 import type { WorkspaceMeta } from './workspace-registry.js'
 
-/**
- * Provider-agnostic runtimes that cannot rely on a first-party CLI login in
- * OpenAlice's launch path. They need either a usable workspace AI config file
- * or an Alice vault credential we can inject before spawn/headless dispatch.
- */
-export const LOGINLESS_AGENTS = new Set(['opencode', 'pi'])
-
 export type AgentCredentialSource =
   | 'runtime-login'
   | 'workspace-config'
@@ -61,6 +54,10 @@ export class AgentCredentialError extends Error {
   }
 }
 
+function requiresWorkspaceCredential(adapter: CliAdapter | undefined): boolean {
+  return adapter?.capabilities.aiProvider?.credentialSource === 'workspace-required'
+}
+
 function trimString(value: string | null | undefined): string {
   return typeof value === 'string' ? value.trim() : ''
 }
@@ -71,22 +68,25 @@ function trimString(value: string | null | undefined): string {
  * first-party OpenAI/Anthropic-compatible defaults; apiKey + model are the
  * load-bearing fields for OpenAlice-managed opencode/Pi configs.
  */
-export function isUsableWorkspaceAiCred(agentId: string, cred: WorkspaceAiCred | null | undefined): boolean {
-  if (!LOGINLESS_AGENTS.has(agentId)) return true
+export function isUsableWorkspaceAiCred(
+  adapter: CliAdapter,
+  cred: WorkspaceAiCred | null | undefined,
+): boolean {
+  if (!requiresWorkspaceCredential(adapter)) return true
   return trimString(cred?.apiKey).length > 0 && trimString(cred?.model).length > 0
 }
 
 function injectableCredentials(
   credentials: Record<string, Credential>,
-  agentId: string,
+  adapter: CliAdapter,
 ): Array<[string, Credential, WorkspaceAiCred]> {
   const out: Array<[string, Credential, WorkspaceAiCred]> = []
-  for (const [slug, credential] of compatibleCredentials(credentials, agentId)) {
+  for (const [slug, credential] of compatibleCredentials(credentials, adapter)) {
     const model = resolveInjectionModel(credential)
-    const wsCred = credentialToWorkspaceAiCred(credential, agentId, {
+    const wsCred = credentialToWorkspaceAiCred(credential, adapter, {
       ...(model ? { model } : {}),
     })
-    if (wsCred && isUsableWorkspaceAiCred(agentId, wsCred)) out.push([slug, credential, wsCred])
+    if (wsCred && isUsableWorkspaceAiCred(adapter, wsCred)) out.push([slug, credential, wsCred])
   }
   return out
 }
@@ -121,7 +121,7 @@ export async function getAgentCredentialReadiness(opts: {
     return {
       agent: agentId,
       ready: false,
-      requiresCredential: LOGINLESS_AGENTS.has(agentId),
+      requiresCredential: requiresWorkspaceCredential(adapter),
       source: 'disabled-agent',
       hasWorkspaceConfig: false,
       hasUsableWorkspaceConfig: false,
@@ -131,7 +131,7 @@ export async function getAgentCredentialReadiness(opts: {
       message: `agent "${agentId}" is not enabled on this workspace`,
     }
   }
-  if (!LOGINLESS_AGENTS.has(agentId)) {
+  if (!requiresWorkspaceCredential(adapter)) {
     return {
       agent: agentId,
       ready: true,
@@ -148,9 +148,9 @@ export async function getAgentCredentialReadiness(opts: {
   const credentials = opts.credentials ?? await readCredentials()
   const cfg = await readWorkspaceConfig(meta, adapter)
   const detectedCredentialSlug = matchCredentialByApiKey(credentials, cfg?.apiKey)
-  const compatible = compatibleCredentials(credentials, agentId)
-  const injectable = injectableCredentials(credentials, agentId)
-  const hasUsableWorkspaceConfig = isUsableWorkspaceAiCred(agentId, cfg)
+  const compatible = compatibleCredentials(credentials, adapter)
+  const injectable = injectableCredentials(credentials, adapter)
+  const hasUsableWorkspaceConfig = isUsableWorkspaceAiCred(adapter, cfg)
 
   if (hasUsableWorkspaceConfig) {
     return {
@@ -204,7 +204,7 @@ export async function ensureAgentCredentialReady(opts: {
   readonly logger?: Logger
 }): Promise<AgentCredentialReadiness> {
   const { meta, agentId, adapter, pickedCredentialSlug, logger } = opts
-  if (!LOGINLESS_AGENTS.has(agentId)) {
+  if (!requiresWorkspaceCredential(adapter)) {
     return getAgentCredentialReadiness({ meta, agentId, adapter })
   }
   if (!adapter?.writeAiConfig) {
@@ -213,8 +213,8 @@ export async function ensureAgentCredentialReady(opts: {
 
   const credentials = await readCredentials()
   const cfg = await readWorkspaceConfig(meta, adapter)
-  const compatible = compatibleCredentials(credentials, agentId)
-  const injectable = injectableCredentials(credentials, agentId)
+  const compatible = compatibleCredentials(credentials, adapter)
+  const injectable = injectableCredentials(credentials, adapter)
   const injectableMap = new Map(injectable.map(([slug, credential, wsCred]) => [slug, { credential, wsCred }]))
   const detectedCredentialSlug = matchCredentialByApiKey(credentials, cfg?.apiKey)
   const picked = pickedCredentialSlug && injectableMap.has(pickedCredentialSlug) ? pickedCredentialSlug : null
@@ -224,7 +224,7 @@ export async function ensureAgentCredentialReady(opts: {
   // auth mode, model, and context window; Quick Chat sends the visible provider
   // pill on every turn, including immediately after creation-time defaults were
   // injected.
-  if ((!picked || picked === detectedCredentialSlug) && isUsableWorkspaceAiCred(agentId, cfg)) {
+  if ((!picked || picked === detectedCredentialSlug) && isUsableWorkspaceAiCred(adapter, cfg)) {
     return {
       agent: agentId,
       ready: true,

--- a/src/workspaces/agent-runtime-readiness.ts
+++ b/src/workspaces/agent-runtime-readiness.ts
@@ -159,7 +159,7 @@ export function failedRuntimeReadinessRow(opts: {
     source: opts.source ?? 'unknown',
     checkedAt: new Date().toISOString(),
     durationMs: opts.result.durationMs,
-    repairTarget: repairTargetForStatus(status, opts.adapter.id),
+    repairTarget: repairTargetForStatus(status, opts.adapter),
     message: summarizeRuntimeReadinessFailure(opts.result, status),
   };
 }
@@ -187,10 +187,12 @@ export function runtimeProbeSucceeded(result: HeadlessTaskResult): boolean {
 
 function repairTargetForStatus(
   status: AgentRuntimeReadinessStatus,
-  agentId: string,
+  adapter: CliAdapter,
 ): AgentRuntimeRepairTarget {
   if (status === 'auth_required') {
-    return agentId === 'claude' || agentId === 'codex' ? 'cli-login' : 'ai-provider';
+    return adapter.capabilities.aiProvider?.credentialSource === 'runtime-or-workspace'
+      ? 'cli-login'
+      : 'ai-provider';
   }
   if (status === 'provider_required') return 'ai-provider';
   if (status === 'not_installed') return 'runtime-install';

--- a/src/workspaces/cli-adapter.ts
+++ b/src/workspaces/cli-adapter.ts
@@ -75,6 +75,39 @@ export interface AgentRuntimeWorkspaceContext {
   readonly launcherRepoRoot: string;
 }
 
+export interface AgentProviderVendorPolicy {
+  /** Vendor-specific narrowing of the runtime's normal wire preference. */
+  readonly wirePreference: readonly WireShape[];
+  /**
+   * Narrow compatibility repair for a previously valid saved selection.
+   * The target still has to be present (or provider-inferable) on the credential.
+   */
+  readonly legacyRequestedWireFallbacks?: Readonly<Partial<Record<WireShape, WireShape>>>;
+}
+
+export interface AgentProviderCapabilities {
+  /**
+   * Whether the runtime can start from its own native/global login, or needs a
+   * concrete Workspace provider binding before OpenAlice launches it.
+   */
+  readonly credentialSource: 'runtime-or-workspace' | 'workspace-required';
+  /** Wire protocols this runtime can consume, in native preference order. */
+  readonly wirePreference: readonly WireShape[];
+  /** Protocol preselected for a blank manual binding form. */
+  readonly defaultWire?: WireShape;
+  /** Provider-specific compatibility constraints and legacy repairs. */
+  readonly vendorPolicies?: Readonly<Record<string, AgentProviderVendorPolicy>>;
+  /**
+   * Custom-model facts this runtime registers in provider metadata. Runtimes
+   * that only select a model id leave this absent and preserve native fallback.
+   */
+  readonly modelRegistration?: {
+    readonly contextWindow?: boolean;
+    readonly reasoning?: boolean;
+    readonly effortVariants?: boolean;
+  };
+}
+
 /**
  * Shared lifecycle surface for native agent runtimes. Hooks are invoked by the
  * launcher rather than by individual HTTP/headless/Web adapters, so every
@@ -200,6 +233,12 @@ export interface CliAdapter {
      * set this; `shell` does not (no agent-turn concept).
      */
     readonly headless?: boolean;
+    /**
+     * Native AI-provider projection contract. Shared credential/model logic
+     * consumes this declaration instead of branching on adapter ids. Omit for
+     * utility adapters that cannot accept a Workspace AI binding.
+     */
+    readonly aiProvider?: AgentProviderCapabilities;
   };
 
   /** Runtime-specific hooks executed through the shared launcher lifecycle. */

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
-  credentialToWorkspaceAiCred,
+  credentialToWorkspaceAiCred as projectCredentialToWorkspace,
   injectWorkspaceCredentials,
-  compatibleCredentials,
+  compatibleCredentials as listCompatibleCredentials,
   matchCredentialByApiKey,
   resolveInjectionModel,
 } from './credential-injection.js'
 import { AdapterRegistry, type CliAdapter, type WorkspaceAiCred } from './cli-adapter.js'
+import { createBuiltinAdapterRegistry } from './adapters/index.js'
 import type { Credential } from '@/core/config.js'
 import type { Logger } from './logger.js'
 
@@ -27,7 +28,65 @@ const longcatKey: Credential = {
   wires: { 'openai-chat': 'https://api.longcat.chat/openai' },
 }
 
+const builtinAdapters = createBuiltinAdapterRegistry()
+
+function builtinAdapter(agentId: string): CliAdapter {
+  const adapter = builtinAdapters.get(agentId)
+  if (!adapter) throw new Error(`missing test adapter: ${agentId}`)
+  return adapter
+}
+
+function credentialToWorkspaceAiCred(
+  credential: Parameters<typeof projectCredentialToWorkspace>[0],
+  agentId: string,
+  overrides?: Parameters<typeof projectCredentialToWorkspace>[2],
+): ReturnType<typeof projectCredentialToWorkspace> {
+  return projectCredentialToWorkspace(credential, builtinAdapter(agentId), overrides)
+}
+
+function compatibleCredentials(
+  credentials: Parameters<typeof listCompatibleCredentials>[0],
+  agentId: string,
+): ReturnType<typeof listCompatibleCredentials> {
+  return listCompatibleCredentials(credentials, builtinAdapter(agentId))
+}
+
 describe('credentialToWorkspaceAiCred', () => {
+  it('supports a newly registered adapter entirely from its capability declaration', () => {
+    const futureAdapter: CliAdapter = {
+      id: 'future',
+      displayName: 'Future Runtime',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: false,
+        resumeById: false,
+        transcriptDiscovery: 'none',
+        aiProvider: {
+          credentialSource: 'workspace-required',
+          wirePreference: ['google-generative-ai'],
+          modelRegistration: {
+            contextWindow: true,
+            reasoning: true,
+            effortVariants: true,
+          },
+        },
+      },
+      composeCommand: (base) => base,
+    }
+
+    expect(projectCredentialToWorkspace(googleKey, futureAdapter, {
+      model: 'gemini-3.1-flash-lite',
+    })).toMatchObject({
+      apiKey: 'AQ.google',
+      baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      wireShape: 'google-generative-ai',
+      contextWindow: 1_048_576,
+      reasoning: true,
+      reasoningEffort: 'minimal',
+    })
+    expect(projectCredentialToWorkspace(openaiKey, futureAdapter)).toBeNull()
+  })
+
   it('picks the agent\'s wire (claude → anthropic) + apiKey; model from overrides', () => {
     const cred = credentialToWorkspaceAiCred(minimaxIntl, 'claude', { model: 'MiniMax-M3' })!
     expect(cred.apiKey).toBe('mm-key')
@@ -207,10 +266,17 @@ describe('credentialToWorkspaceAiCred', () => {
 interface WriteCall { id: string; dir: string; cred: WorkspaceAiCred }
 
 function stubAdapter(id: string, calls: WriteCall[], writeable = true): CliAdapter {
+  const aiProvider = builtinAdapters.get(id)?.capabilities.aiProvider
   const adapter: CliAdapter = {
     id,
     displayName: id,
-    capabilities: { parallelPerCwd: true, resumeLast: false, resumeById: false, transcriptDiscovery: 'none' },
+    capabilities: {
+      parallelPerCwd: true,
+      resumeLast: false,
+      resumeById: false,
+      transcriptDiscovery: 'none',
+      ...(aiProvider ? { aiProvider } : {}),
+    },
     composeCommand: (base) => base,
   }
   if (writeable) {

--- a/src/workspaces/credential-injection.ts
+++ b/src/workspaces/credential-injection.ts
@@ -23,41 +23,31 @@ import {
 } from '@/core/config.js'
 import { DEFAULT_MODEL_BY_VENDOR } from '@/ai-providers/preset-catalog.js'
 import { modelSupportsReasoning, resolveModelSemantics } from '@/ai-providers/model-semantics.js'
-import type { AdapterRegistry, WorkspaceAiCred } from './cli-adapter.js'
+import type {
+  AdapterRegistry,
+  AgentProviderCapabilities,
+  CliAdapter,
+  WorkspaceAiCred,
+} from './cli-adapter.js'
 import type { Logger } from './logger.js'
 import type { AgentCredentialDecl } from './template-registry.js'
 
 /**
- * The wire shapes each agent can speak, in preference order. The injector picks
- * the first one a credential actually has — so a credential serves an agent only
- * if it declares a compatible wire (codex's Responses-only lock means most
- * credentials can't drive it, which is the intended funnel toward pi/opencode).
- */
-export const AGENT_WIRE_PREFERENCE: Record<string, CredentialWireShape[]> = {
-  claude: ['anthropic'],
-  codex: ['openai-responses'],
-  opencode: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
-  pi: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
-}
-
-/**
- * Provider-specific support inside an agent's wire set.
+ * Provider-specific support inside an adapter's declared wire set.
  *
- * MiniMax is the deliberate exception to the generic OpenAI-compatible set:
+ * MiniMax is currently the deliberate exception to the generic OpenAI-compatible set:
  * its Anthropic endpoint is the documented coding-agent path and returns
  * native thinking blocks. The OpenAI endpoint requires `reasoning_split` and
  * returns an array-shaped `reasoning_details` extension that Pi and opencode's
- * generic OpenAI transports do not parse losslessly. Do not expose a protocol
- * choice that silently turns reasoning into visible `<think>` text or drops it.
+ * generic OpenAI transports do not parse losslessly. The affected adapters
+ * declare that vendor policy; this shared layer only applies the declaration.
  */
 export function agentWirePreference(
-  agentId: string,
+  capabilities: AgentProviderCapabilities,
   vendor?: string | null,
-): CredentialWireShape[] {
-  const preference = AGENT_WIRE_PREFERENCE[agentId]
-    ?? ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses']
-  if (vendor !== 'minimax' || (agentId !== 'opencode' && agentId !== 'pi')) return preference
-  return ['anthropic']
+): readonly CredentialWireShape[] {
+  return (vendor ? capabilities.vendorPolicies?.[vendor]?.wirePreference : undefined)
+    ?? capabilities.wirePreference
 }
 
 function inferredMinimaxAnthropicEndpoint(
@@ -95,10 +85,12 @@ function wireEndpoint(
  */
 export function compatibleCredentials(
   credentials: Record<string, Credential>,
-  agentId: string,
+  adapter: CliAdapter,
 ): Array<[string, Credential]> {
+  const capabilities = adapter.capabilities.aiProvider
+  if (!capabilities) return []
   return Object.entries(credentials).filter(
-    ([, cred]) => pickAgentWire(credentialWires(cred), agentId, undefined, cred.vendor) !== null,
+    ([, cred]) => pickAgentWire(credentialWires(cred), capabilities, undefined, cred.vendor) !== null,
   )
 }
 
@@ -133,26 +125,26 @@ export function resolveInjectionModel(cred: Pick<Credential, 'vendor' | 'lastMod
 /** Pick the wire an agent should use from a credential's capabilities (null = none compatible). */
 export function pickAgentWire(
   wires: Partial<Record<CredentialWireShape, string>>,
-  agentId: string,
+  capabilities: AgentProviderCapabilities,
   requestedShape?: CredentialWireShape,
   vendor?: string | null,
 ): { shape: CredentialWireShape; baseUrl: string } | null {
-  const pref = agentWirePreference(agentId, vendor)
+  const pref = agentWirePreference(capabilities, vendor)
   if (requestedShape !== undefined) {
     const requestedEndpoint = wireEndpoint(wires, requestedShape, vendor)
     if (pref.includes(requestedShape) && requestedEndpoint !== undefined) {
       return { shape: requestedShape, baseUrl: requestedEndpoint }
     }
-    // Heal Workspace defaults saved before MiniMax's native-thinking boundary
-    // was registered. This is intentionally narrower than a generic fallback:
-    // other explicit protocol mismatches remain loud incompatibilities.
-    if (
-      vendor === 'minimax' &&
-      (agentId === 'opencode' || agentId === 'pi') &&
-      requestedShape === 'openai-chat' &&
-      wireEndpoint(wires, 'anthropic', vendor) !== undefined
-    ) {
-      return { shape: 'anthropic', baseUrl: wireEndpoint(wires, 'anthropic', vendor)! }
+    // Heal Workspace defaults through the adapter's narrowly declared legacy
+    // fallback. Other explicit protocol mismatches remain loud incompatibilities.
+    const fallbackShape = vendor
+      ? capabilities.vendorPolicies?.[vendor]?.legacyRequestedWireFallbacks?.[requestedShape]
+      : undefined
+    if (fallbackShape) {
+      const fallbackEndpoint = wireEndpoint(wires, fallbackShape, vendor)
+      if (fallbackEndpoint !== undefined) {
+        return { shape: fallbackShape, baseUrl: fallbackEndpoint }
+      }
     }
     return null
   }
@@ -188,11 +180,13 @@ export interface CredentialInjectionOverrides {
  */
 export function credentialToWorkspaceAiCred(
   credential: Pick<Credential, 'vendor' | 'apiKey' | 'baseUrl' | 'wireShape' | 'wires'>,
-  agentId: string,
+  adapter: CliAdapter,
   overrides: CredentialInjectionOverrides = {},
 ): WorkspaceAiCred | null {
+  const capabilities = adapter.capabilities.aiProvider
+  if (!capabilities) return null
   const wires = credentialWires(credential as Credential)
-  const picked = pickAgentWire(wires, agentId, overrides.wireShape, credential.vendor)
+  const picked = pickAgentWire(wires, capabilities, overrides.wireShape, credential.vendor)
   if (!picked) return null
 
   const cred: WorkspaceAiCred = {
@@ -204,9 +198,12 @@ export function credentialToWorkspaceAiCred(
     wireShape: picked.shape,
   }
 
-  if (agentId === 'opencode' || agentId === 'pi') {
+  const registration = capabilities.modelRegistration
+  if (registration?.contextWindow) {
     const explicitContextWindow = positiveNumber(overrides.contextWindow)
     if (explicitContextWindow !== null) cred.contextWindow = explicitContextWindow
+  }
+  if (registration?.reasoning) {
     if (typeof overrides.reasoning === 'boolean') cred.reasoning = overrides.reasoning
   }
   if (overrides.reasoningEffort) cred.reasoningEffort = overrides.reasoningEffort
@@ -217,11 +214,9 @@ export function credentialToWorkspaceAiCred(
       baseUrl: picked.baseUrl,
     })
   }
-  if (agentId === 'codex') {
-    if (overrides.wireApi) cred.wireApi = overrides.wireApi
-  }
+  if (overrides.wireApi) cred.wireApi = overrides.wireApi
 
-  return applyRegisteredModelSemantics(cred, agentId, credential.vendor)
+  return applyRegisteredModelSemantics(cred, capabilities, credential.vendor)
 }
 
 /**
@@ -235,14 +230,15 @@ export function credentialToWorkspaceAiCred(
  */
 export function applyRegisteredModelSemantics(
   cred: WorkspaceAiCred,
-  agentId: string,
+  capabilities: AgentProviderCapabilities,
   vendor: string | null | undefined,
 ): WorkspaceAiCred {
   const semantics = resolveModelSemantics(vendor, cred.model)
   if (!semantics) return cred
 
   const next: WorkspaceAiCred = { ...cred }
-  if (agentId === 'opencode' || agentId === 'pi') {
+  const registration = capabilities.modelRegistration
+  if (registration?.contextWindow) {
     const registeredContext = positiveNumber(semantics.contextWindow)
     const configuredContext = positiveNumber(cred.contextWindow)
     if (registeredContext !== null) {
@@ -250,6 +246,8 @@ export function applyRegisteredModelSemantics(
         ? registeredContext
         : Math.min(configuredContext, registeredContext)
     }
+  }
+  if (registration?.reasoning) {
     const reasoning = modelSupportsReasoning(semantics)
     if (reasoning !== null) next.reasoning = reasoning
   }
@@ -310,7 +308,7 @@ export async function injectWorkspaceCredentials(opts: {
       // stable pair even in config written before reasoningModel existed.
       (decl.reasoningModel === undefined && decl.model === selectedModel)
     )
-    const wsCred = credentialToWorkspaceAiCred(credential, agentId, {
+    const wsCred = credentialToWorkspaceAiCred(credential, adapter, {
       ...(selectedModel !== null ? { model: selectedModel } : {}),
       ...(decl.wireShape !== undefined ? { wireShape: decl.wireShape } : {}),
       ...(decl.contextWindow !== undefined

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -25,15 +25,12 @@ import {
   rememberRecentChatWorkspace,
 } from '@/core/preferences.js';
 
-import { claudeAdapter } from './adapters/claude.js';
-import { codexAdapter } from './adapters/codex.js';
-import { opencodeAdapter } from './adapters/opencode.js';
+import { createBuiltinAdapterRegistry } from './adapters/index.js';
 import { piAdapter } from './adapters/pi.js';
-import { shellAdapter } from './adapters/shell.js';
 import {
-  AdapterRegistry,
   isAgentRuntime,
   prepareAgentRuntimeWorkspace,
+  type AdapterRegistry,
   type CliAdapter,
   type HeadlessRunOverrides,
 } from './cli-adapter.js';
@@ -761,12 +758,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     });
   }
 
-  const adapters = new AdapterRegistry();
-  adapters.register(claudeAdapter, { default: true });
-  adapters.register(codexAdapter);
-  adapters.register(opencodeAdapter);
-  adapters.register(piAdapter);
-  adapters.register(shellAdapter);
+  const adapters = createBuiltinAdapterRegistry();
   const sessionTitleResolver = new NativeSessionTitleResolver({
     sessionRegistry,
     resumeRegistry,
@@ -984,7 +976,9 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     adapter: CliAdapter,
     availability?: AgentAvailability,
   ): AgentRuntimeReadinessSource => {
-    if (adapter.id === 'claude' || adapter.id === 'codex') return 'global-login';
+    if (adapter.capabilities.aiProvider?.credentialSource === 'runtime-or-workspace') {
+      return 'global-login';
+    }
     const binaryPath = availability?.path ?? '';
     if (
       adapter.id === 'pi' &&
@@ -1051,13 +1045,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   ): Promise<boolean> => {
     if (!adapter.writeAiConfig) return false;
     const credentials = await readCredentials();
-    const [, credential] = compatibleCredentials(credentials, adapter.id)[0] ?? [];
+    const [, credential] = compatibleCredentials(credentials, adapter)[0] ?? [];
     if (!credential) return false;
 
     const model = resolveInjectionModel(credential);
     const workspaceCredential = credentialToWorkspaceAiCred(
       credential,
-      adapter.id,
+      adapter,
       model ? { model } : {},
     );
     if (!workspaceCredential) return false;

--- a/ui/src/api/preferences.ts
+++ b/ui/src/api/preferences.ts
@@ -23,7 +23,7 @@ export const preferencesApi = {
   },
 
   rememberQuickChatCredential(
-    agent: 'opencode' | 'pi',
+    agent: string,
     credentialSlug: string | null,
   ): Promise<QuickChatPreferences> {
     return fetchJson('/api/preferences/quick-chat', {

--- a/ui/src/components/FirstRunGuide.tsx
+++ b/ui/src/components/FirstRunGuide.tsx
@@ -739,6 +739,7 @@ export function FirstRunGuide() {
         <CredentialModal
           mode="add"
           presets={apiKeyPresets}
+          agents={agents}
           initialPresetId={ONBOARDING_TEST_MODE && MOCK_CREDENTIAL_TEST ? ONBOARDING_TEST_PRESET_ID : undefined}
           initialApiKey={ONBOARDING_TEST_MODE && MOCK_CREDENTIAL_TEST ? ONBOARDING_TEST_API_KEY : undefined}
           onClose={() => setShowCredentialForm(false)}

--- a/ui/src/components/credentials/CredentialModal.spec.tsx
+++ b/ui/src/components/credentials/CredentialModal.spec.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Preset } from '../../api/types'
 import { api } from '../../api'
 import { i18n } from '../../i18n'
+import type { AgentInfo } from '../workspace/api'
 import { CredentialModal } from './CredentialModal'
 
 vi.mock('../../api', () => ({
@@ -122,6 +123,36 @@ const customPreset: Preset = {
   },
 }
 
+const agents: AgentInfo[] = [
+  {
+    id: 'claude',
+    displayName: 'Claude Code',
+    capabilities: {
+      parallelPerCwd: true, resumeLast: false, resumeById: true, transcriptDiscovery: 'fs-watch',
+      aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['anthropic'] },
+    },
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex',
+    capabilities: {
+      parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess',
+      aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['openai-responses'] },
+    },
+  },
+  ...['opencode', 'pi'].map((id): AgentInfo => ({
+    id,
+    displayName: id === 'pi' ? 'Pi' : 'opencode',
+    capabilities: {
+      parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess',
+      aiProvider: {
+        credentialSource: 'workspace-required',
+        wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+      },
+    },
+  })),
+]
+
 function setup() {
   const onClose = vi.fn()
   const onSaved = vi.fn().mockResolvedValue(undefined)
@@ -129,6 +160,7 @@ function setup() {
     <CredentialModal
       mode="add"
       presets={[openAiPreset]}
+      agents={agents}
       onClose={onClose}
       onSaved={onSaved}
     />,
@@ -153,6 +185,7 @@ describe('CredentialModal', () => {
       <CredentialModal
         mode="add"
         presets={[geminiPreset]}
+        agents={agents}
         initialPresetId={geminiPreset.id}
         onClose={vi.fn()}
         onSaved={vi.fn()}
@@ -174,6 +207,7 @@ describe('CredentialModal', () => {
       <CredentialModal
         mode="add"
         presets={[customPreset]}
+        agents={agents}
         initialPresetId={customPreset.id}
         onClose={vi.fn()}
         onSaved={vi.fn()}
@@ -195,6 +229,7 @@ describe('CredentialModal', () => {
       <CredentialModal
         mode="add"
         presets={[openAiPreset]}
+        agents={agents}
         initialPresetId={openAiPreset.id}
         initialApiKey="sk-prefilled"
         onClose={vi.fn()}
@@ -245,6 +280,7 @@ describe('CredentialModal', () => {
       <CredentialModal
         mode="add"
         presets={[onboardingTestPreset]}
+        agents={agents}
         initialPresetId={onboardingTestPreset.id}
         initialApiKey="oa_test_ok"
         onClose={vi.fn()}
@@ -284,6 +320,7 @@ describe('CredentialModal', () => {
           lastModel: 'gpt-account-specific',
         }}
         presets={[openAiPreset]}
+        agents={agents}
         onClose={vi.fn()}
         onSaved={onSaved}
       />,

--- a/ui/src/components/credentials/CredentialModal.tsx
+++ b/ui/src/components/credentials/CredentialModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { api, type Preset, type WireShape } from '../../api'
 import type { CredentialSummary } from '../../api/config'
+import type { AgentInfo } from '../workspace/api'
 import { Field, inputClass } from '../form'
 import {
   VENDOR_BY_PRESET,
@@ -46,10 +47,11 @@ function agentNames(ids: readonly string[]): string {
   return ids.map((id) => AGENT_LABELS[id] ?? id).join(', ')
 }
 
-export function CredentialModal({ mode, cred, presets, initialPresetId, initialApiKey, onClose, onSaved }: {
+export function CredentialModal({ mode, cred, presets, agents, initialPresetId, initialApiKey, onClose, onSaved }: {
   mode: 'add' | 'edit'
   cred?: CredentialSummary
   presets: Preset[]
+  agents: readonly AgentInfo[]
   initialPresetId?: string
   initialApiKey?: string
   onClose: () => void
@@ -102,7 +104,7 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
   const primaryShape = shapes[0]
   const primaryUrl = primaryShape ? (wires[primaryShape] ?? '') : ''
   const compatibilityWires = isCustom ? { [customShape]: customUrl.trim() } : wires
-  const compatibleAgents = compatibleAgentIds(compatibilityWires)
+  const compatibleAgents = compatibleAgentIds(compatibilityWires, agents)
 
   const pickPreset = (next: Preset) => {
     setPreset(next)
@@ -253,7 +255,9 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                       <span className="mt-0.5 block truncate text-[10px] text-muted-foreground/75">
                         {item.category === 'custom'
                           ? t('aiProvider.credentialModal.chooseMode')
-                          : t('aiProvider.credentialModal.worksWith', { agents: agentNames(presetCompatibleAgentIds(item)) })}
+                          : t('aiProvider.credentialModal.worksWith', {
+                              agents: agentNames(presetCompatibleAgentIds(item, agents)),
+                            })}
                       </span>
                     </span>
                     {item.category === 'custom' && (
@@ -301,7 +305,9 @@ export function CredentialModal({ mode, cred, presets, initialPresetId, initialA
                     <select className={inputClass} value={customShape} onChange={(event) => { setCustomShape(event.target.value as WireShape); gate.reset() }}>
                       {SHAPE_ORDER.map((shape) => (
                         <option key={shape} value={shape}>
-                          {WIRE_SHAPE_GUIDANCE[shape]} — {agentNames(compatibleAgentIds({ [shape]: '' }))}
+                          {WIRE_SHAPE_GUIDANCE[shape]} — {
+                            agentNames(compatibleAgentIds({ [shape]: '' }, agents))
+                          }
                         </option>
                       ))}
                     </select>

--- a/ui/src/components/first-run-guide-model.ts
+++ b/ui/src/components/first-run-guide-model.ts
@@ -1,16 +1,7 @@
 import type { TradingServiceStatus } from '../api/trading'
-import type { UTAConfig, WireShape } from '../api/types'
+import type { UTAConfig } from '../api/types'
 import type { CredentialSummary } from '../api/config'
 import type { AgentInfo, AgentRuntimeReadinessSnapshot } from './workspace/api'
-
-const AGENT_WIRE_PREFERENCE: Record<string, WireShape[]> = {
-  claude: ['anthropic'],
-  codex: ['openai-responses'],
-  opencode: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
-  pi: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
-}
-
-const LOGIN_RUNTIME_AGENTS = new Set(['claude', 'codex'])
 
 export const FIRST_RUN_STEP_KEYS = ['language', 'lite', 'ai', 'broker', 'finish'] as const
 export type FirstRunStepKey = typeof FIRST_RUN_STEP_KEYS[number]
@@ -53,7 +44,10 @@ export function buildFirstRunGuideAccess(input: {
 }
 
 export function buildFirstRunGuideModel(input: {
-  agents: readonly Pick<AgentInfo, 'id' | 'displayName' | 'kind' | 'installed'>[]
+  agents: readonly (
+    Pick<AgentInfo, 'id' | 'displayName' | 'kind' | 'installed'>
+    & Partial<Pick<AgentInfo, 'capabilities'>>
+  )[]
   runtimeReadiness: AgentRuntimeReadinessSnapshot | null
   credentials: readonly Pick<CredentialSummary, 'wires'>[]
   tradingStatus: TradingServiceStatus | null
@@ -72,11 +66,13 @@ export function buildFirstRunGuideModel(input: {
   const runtimeRows = agentRuntimes.map((agent) => {
     const readiness = input.runtimeReadiness?.agents[agent.id] ?? null
     const installed = readiness?.installed ?? agent.installed !== false
-    const compatibleCredentialCount = input.credentials.filter((credential) =>
-      (AGENT_WIRE_PREFERENCE[agent.id] ?? ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'])
-        .some((shape) => shape in credential.wires),
-    ).length
-    const loginRuntime = LOGIN_RUNTIME_AGENTS.has(agent.id)
+    const providerCapabilities = agent.capabilities?.aiProvider
+    const compatibleCredentialCount = providerCapabilities
+      ? input.credentials.filter((credential) =>
+          providerCapabilities.wirePreference.some((shape) => shape in credential.wires),
+        ).length
+      : 0
+    const loginRuntime = providerCapabilities?.credentialSource === 'runtime-or-workspace'
     const status = readiness?.status ?? (installed ? 'unknown' : 'not_installed')
     const chainReady = readiness?.ready === true
     const accessLabel = status === 'ready'

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
@@ -59,6 +59,82 @@ beforeEach(async () => {
       agents: ['pi'],
       sessions: [],
     }],
+    agents: [
+      {
+        id: 'claude',
+        displayName: 'Claude Code',
+        capabilities: {
+          parallelPerCwd: true,
+          resumeLast: false,
+          resumeById: true,
+          transcriptDiscovery: 'fs-watch',
+          aiProvider: {
+            credentialSource: 'runtime-or-workspace',
+            wirePreference: ['anthropic'],
+          },
+        },
+      },
+      {
+        id: 'codex',
+        displayName: 'Codex',
+        capabilities: {
+          parallelPerCwd: true,
+          resumeLast: true,
+          resumeById: true,
+          transcriptDiscovery: 'subprocess',
+          aiProvider: {
+            credentialSource: 'runtime-or-workspace',
+            wirePreference: ['openai-responses'],
+          },
+        },
+      },
+      {
+        id: 'opencode',
+        displayName: 'opencode',
+        capabilities: {
+          parallelPerCwd: true,
+          resumeLast: true,
+          resumeById: true,
+          transcriptDiscovery: 'subprocess',
+          aiProvider: {
+            credentialSource: 'workspace-required',
+            wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+            vendorPolicies: {
+              minimax: {
+                wirePreference: ['anthropic'],
+                legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' },
+              },
+            },
+            modelRegistration: {
+              contextWindow: true,
+              reasoning: true,
+              effortVariants: true,
+            },
+          },
+        },
+      },
+      {
+        id: 'pi',
+        displayName: 'Pi',
+        capabilities: {
+          parallelPerCwd: true,
+          resumeLast: true,
+          resumeById: true,
+          transcriptDiscovery: 'none',
+          aiProvider: {
+            credentialSource: 'workspace-required',
+            wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+            vendorPolicies: {
+              minimax: {
+                wirePreference: ['anthropic'],
+                legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' },
+              },
+            },
+            modelRegistration: { contextWindow: true, reasoning: true },
+          },
+        },
+      },
+    ],
     refresh: vi.fn(),
     saveWorkspaceMetadata: vi.fn(),
   })

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from 'vitest'
 
 import { configToForm, connectionFieldsChanged, formToConfig } from './WorkspaceAIConfigModal'
+import type { AgentProviderCapabilities } from './api'
+
+const nativeCapabilities: AgentProviderCapabilities = {
+  credentialSource: 'runtime-or-workspace',
+  wirePreference: ['anthropic'],
+}
+
+const registeredModelCapabilities: AgentProviderCapabilities = {
+  credentialSource: 'workspace-required',
+  wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic'],
+  defaultWire: 'openai-chat',
+  modelRegistration: {
+    contextWindow: true,
+    reasoning: true,
+  },
+}
 
 describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
   it.each([true, false])('round-trips reasoning=%s for Pi', (reasoning) => {
@@ -11,10 +27,10 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
       contextWindow: 512_000,
       wireShape: 'openai-chat',
       reasoning,
-    }, 'pi')
+    }, registeredModelCapabilities)
 
     expect(form.reasoning).toBe(reasoning)
-    expect(formToConfig(form, 'pi')).toMatchObject({
+    expect(formToConfig(form, 'pi', registeredModelCapabilities)).toMatchObject({
       model: 'reasoning-model',
       contextWindow: 512_000,
       reasoning,
@@ -22,9 +38,10 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
   })
 
   it('shares an explicit unknown-model capability with opencode', () => {
-    const form = configToForm(null, 'opencode')
+    const form = configToForm(null, registeredModelCapabilities)
+    expect(form.wireShape).toBe('openai-chat')
     form.reasoning = true
-    expect(formToConfig(form, 'opencode').reasoning).toBe(true)
+    expect(formToConfig(form, 'opencode', registeredModelCapabilities).reasoning).toBe(true)
   })
 
   it('round-trips a Workspace reasoning effort for every runtime', () => {
@@ -34,22 +51,30 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
         apiKey: 'secret',
         model: 'reasoning-model',
         reasoningEffort: 'high',
-      }, agent)
+      }, agent === 'claude' || agent === 'codex'
+        ? nativeCapabilities
+        : registeredModelCapabilities)
       expect(form.reasoningEffort).toBe('high')
-      expect(formToConfig(form, agent)).toMatchObject({ reasoningEffort: 'high' })
+      expect(formToConfig(
+        form,
+        agent,
+        agent === 'claude' || agent === 'codex'
+          ? nativeCapabilities
+          : registeredModelCapabilities,
+      )).toMatchObject({ reasoningEffort: 'high' })
     }
   })
 
   it('omits unknown-model reasoning when the runtime should decide', () => {
-    const form = configToForm(null, 'pi')
+    const form = configToForm(null, registeredModelCapabilities)
     expect(form.reasoning).toBeNull()
-    expect(formToConfig(form, 'pi').reasoning).toBeUndefined()
+    expect(formToConfig(form, 'pi', registeredModelCapabilities).reasoning).toBeUndefined()
   })
 
   it('omits context when the model registry or native runtime should decide', () => {
-    const form = configToForm(null, 'opencode')
+    const form = configToForm(null, registeredModelCapabilities)
     expect(form.contextWindow).toBeNull()
-    expect(formToConfig(form, 'opencode').contextWindow).toBeUndefined()
+    expect(formToConfig(form, 'opencode', registeredModelCapabilities).contextWindow).toBeUndefined()
   })
 
   it('does not invalidate a connection test for local context or reasoning metadata', () => {
@@ -61,12 +86,12 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
       wireShape: 'openai-chat' as const,
       reasoning: null,
     }
-    const form = configToForm(saved, 'pi')
+    const form = configToForm(saved, registeredModelCapabilities)
     form.contextWindow = 512_000
     form.reasoning = true
     form.reasoningEffort = 'high'
 
-    expect(connectionFieldsChanged(saved, form, 'pi')).toBe(false)
+    expect(connectionFieldsChanged(saved, form, registeredModelCapabilities)).toBe(false)
   })
 
   it.each([
@@ -82,20 +107,20 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
       contextWindow: 256_000,
       wireShape: 'openai-chat' as const,
     }
-    const form = configToForm(saved, 'pi')
+    const form = configToForm(saved, registeredModelCapabilities)
     Object.assign(form, { [field]: value })
 
-    expect(connectionFieldsChanged(saved, form, 'pi')).toBe(true)
+    expect(connectionFieldsChanged(saved, form, registeredModelCapabilities)).toBe(true)
   })
 
   it.each(['codex', 'claude'] as const)(
     'lets %s native-login model and effort changes save without an HTTP probe',
     (agent) => {
-      const form = configToForm(null, agent)
+      const form = configToForm(null, nativeCapabilities)
       form.model = agent === 'codex' ? 'gpt-5.6' : 'claude-opus-4-8'
       form.reasoningEffort = 'high'
 
-      expect(connectionFieldsChanged(null, form, agent)).toBe(false)
+      expect(connectionFieldsChanged(null, form, nativeCapabilities)).toBe(false)
     },
   )
 })

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -21,12 +21,14 @@ import {
   type AgentConfig,
   type AgentConfigBundle,
   type AgentId,
+  type AgentInfo,
+  type AgentProviderCapabilities,
   type SavedCredential,
 } from './api'
 import { api, type ModelReasoningEffort, type Preset, type WireShape } from '../../api'
 import {
-  AGENT_WIRE_PREFERENCE,
   WIRE_SHAPE_GUIDANCE,
+  agentWirePreference,
   agentWireShapes,
   anthropicAuthModeForBaseUrl,
   baseUrlToVendor,
@@ -154,12 +156,15 @@ export interface FormState {
   authMode: 'x-api-key' | 'bearer'
 }
 
-/** The wire shape each agent defaults to when nothing else specifies one. */
-const DEFAULT_WIRE_BY_TAB: Record<Tab, WireShape> = {
-  claude: 'anthropic',
-  codex: 'openai-responses', // codex is Responses-only (hard-rejects chat)
-  opencode: 'openai-chat',
-  pi: 'openai-chat',
+function providerCapabilities(
+  agents: readonly AgentInfo[],
+  agent: string,
+): AgentProviderCapabilities | undefined {
+  return agents.find((candidate) => candidate.id === agent)?.capabilities.aiProvider
+}
+
+function defaultWire(capabilities: AgentProviderCapabilities | undefined): WireShape {
+  return capabilities?.defaultWire ?? capabilities?.wirePreference[0] ?? 'anthropic'
 }
 
 const EMPTY_FORM: FormState = {
@@ -184,8 +189,11 @@ function formatContextWindow(value: number): string {
   return String(value)
 }
 
-export function configToForm(cfg: AgentConfig | null, tab: Tab): FormState {
-  if (!cfg) return { ...EMPTY_FORM, wireShape: DEFAULT_WIRE_BY_TAB[tab] }
+export function configToForm(
+  cfg: AgentConfig | null,
+  capabilities?: AgentProviderCapabilities,
+): FormState {
+  if (!cfg) return { ...EMPTY_FORM, wireShape: defaultWire(capabilities) }
   return {
     baseUrl: cfg.baseUrl ?? '',
     apiKey: cfg.apiKey ?? '',
@@ -193,13 +201,17 @@ export function configToForm(cfg: AgentConfig | null, tab: Tab): FormState {
     contextWindow: normalizeContextWindow(cfg.contextWindow),
     reasoning: typeof cfg.reasoning === 'boolean' ? cfg.reasoning : null,
     reasoningEffort: cfg.reasoningEffort ?? null,
-    wireShape: cfg.wireShape ?? DEFAULT_WIRE_BY_TAB[tab],
+    wireShape: cfg.wireShape ?? defaultWire(capabilities),
     wireApi: 'responses',
     authMode: cfg.authMode === 'bearer' ? 'bearer' : 'x-api-key',
   }
 }
 
-export function formToConfig(form: FormState, agent: AgentId): AgentConfig {
+export function formToConfig(
+  form: FormState,
+  agent: AgentId,
+  capabilities?: AgentProviderCapabilities,
+): AgentConfig {
   const cfg: AgentConfig = {
     baseUrl: form.baseUrl.trim() || null,
     apiKey: form.apiKey.trim() || null,
@@ -207,11 +219,16 @@ export function formToConfig(form: FormState, agent: AgentId): AgentConfig {
     wireShape: form.wireShape,
     ...(form.reasoningEffort ? { reasoningEffort: form.reasoningEffort } : {}),
   }
-  if (agent === 'opencode' || agent === 'pi') {
+  const registration = capabilities?.modelRegistration
+  if (registration?.contextWindow || registration?.reasoning) {
     return {
       ...cfg,
-      ...(form.contextWindow !== null ? { contextWindow: form.contextWindow } : {}),
-      ...(typeof form.reasoning === 'boolean' ? { reasoning: form.reasoning } : {}),
+      ...(registration.contextWindow && form.contextWindow !== null
+        ? { contextWindow: form.contextWindow }
+        : {}),
+      ...(registration.reasoning && typeof form.reasoning === 'boolean'
+        ? { reasoning: form.reasoning }
+        : {}),
       ...(form.wireShape === 'anthropic' ? { authMode: form.authMode } : {}),
     }
   }
@@ -221,7 +238,6 @@ export function formToConfig(form: FormState, agent: AgentId): AgentConfig {
   if (agent === 'claude') {
     return { ...cfg, authMode: form.authMode }
   }
-  // opencode / pi: baseUrl/apiKey/model + wireShape.
   return cfg
 }
 
@@ -248,19 +264,19 @@ function testKey(form: FormState): string {
 export function connectionFieldsChanged(
   saved: AgentConfig | null,
   form: FormState,
-  tab: Tab,
+  capabilities?: AgentProviderCapabilities,
 ): boolean {
   // Codex and Claude Code can inherit their native login while a project file
   // selects only model/effort. With no OpenAlice-managed endpoint or key there
   // is no credential-bearing HTTP connection for this modal to probe.
   if (
-    (tab === 'codex' || tab === 'claude') &&
+    capabilities?.credentialSource === 'runtime-or-workspace' &&
     !form.baseUrl.trim() &&
     !form.apiKey.trim()
   ) {
     return false
   }
-  return testKey(configToForm(saved, tab)) !== testKey(form)
+  return testKey(configToForm(saved, capabilities)) !== testKey(form)
 }
 
 export function WorkspaceAIConfigModal({
@@ -276,7 +292,12 @@ export function WorkspaceAIConfigModal({
   const onCloseRef = useRef(onClose)
   const dialogTitleId = useId()
   const dialogDescriptionId = useId()
-  const { workspaces, refresh, saveWorkspaceMetadata } = useWorkspaces()
+  const {
+    workspaces,
+    agents = [],
+    refresh,
+    saveWorkspaceMetadata,
+  } = useWorkspaces()
   const workspace = workspaces.find((w) => w.id === wsId) ?? null
   const workspaceLabel = workspace?.displayName?.trim() || workspace?.tag || wsId
   const [section, setSection] = useState<Section>(initialSection)
@@ -385,18 +406,20 @@ export function WorkspaceAIConfigModal({
       .then(([creds, b]) => {
         setCredentials(creds)
         setBundle(b)
-        setClaudeForm(configToForm(b.claude, 'claude'))
-        setCodexForm(configToForm(b.codex, 'codex'))
-        setOpencodeForm(configToForm(b.opencode, 'opencode'))
-        setPiForm(configToForm(b.pi, 'pi'))
+        setClaudeForm(configToForm(b.claude, providerCapabilities(agents, 'claude')))
+        setCodexForm(configToForm(b.codex, providerCapabilities(agents, 'codex')))
+        setOpencodeForm(configToForm(b.opencode, providerCapabilities(agents, 'opencode')))
+        setPiForm(configToForm(b.pi, providerCapabilities(agents, 'pi')))
       })
       .catch((err: Error) => setError(err.message))
     // Presets drive the model-id suggestions (anti-typo) — load once.
     void api.config.getPresets().then(({ presets: p }) => setPresets(p)).catch(() => {})
-  }, [wsId])
+  }, [agents, wsId])
 
   const form = { claude: claudeForm, codex: codexForm, opencode: opencodeForm, pi: piForm }[tab]
   const setForm = { claude: setClaudeForm, codex: setCodexForm, opencode: setOpencodeForm, pi: setPiForm }[tab]
+  const tabProviderCapabilities = providerCapabilities(agents, tab)
+  const modelRegistration = tabProviderCapabilities?.modelRegistration
   const formCredentialByKey = useMemo(() => credentials.find((credential) => (
     !!credential.apiKey && credential.apiKey === form.apiKey.trim()
   )) ?? null, [credentials, form.apiKey])
@@ -405,20 +428,21 @@ export function WorkspaceAIConfigModal({
     return selected?.vendor ?? formCredentialByKey?.vendor ?? null
   }, [credentials, formCredentialByKey, pickedCredential])
   const formWireOptions = useMemo(() => {
-    if (tab !== 'opencode' && tab !== 'pi') return []
-    return formCredentialByKey?.vendor === 'minimax'
-      ? agentWireShapes(formCredentialByKey.wires, tab, formCredentialByKey.vendor)
-      : AGENT_WIRE_PREFERENCE[tab] ?? []
-  }, [formCredentialByKey, tab])
+    return formCredentialByKey?.vendor &&
+      tabProviderCapabilities?.vendorPolicies?.[formCredentialByKey.vendor]
+      ? agentWireShapes(formCredentialByKey.wires, agents, tab, formCredentialByKey.vendor)
+      : agentWirePreference(agents, tab)
+  }, [agents, formCredentialByKey, tab, tabProviderCapabilities])
 
   useEffect(() => {
     if (
-      (tab !== 'opencode' && tab !== 'pi') ||
-      formCredentialByKey?.vendor !== 'minimax'
+      !formCredentialByKey ||
+      !tabProviderCapabilities?.vendorPolicies?.[formCredentialByKey.vendor]
     ) return
     if (formWireOptions.includes(form.wireShape)) return
     const repaired = pickAgentWire(
       formCredentialByKey.wires,
+      agents,
       tab,
       form.wireShape,
       formCredentialByKey.vendor,
@@ -432,7 +456,7 @@ export function WorkspaceAIConfigModal({
         ? { authMode: anthropicAuthModeForBaseUrl(repaired.baseUrl) }
         : {}),
     })
-  }, [form, formCredentialByKey, formWireOptions, setForm, tab])
+  }, [agents, form, formCredentialByKey, formWireOptions, setForm, tab, tabProviderCapabilities])
   // Model-id suggestions for the current field: infer the provider vendor from
   // the matched vault credential first, then its entered baseUrl (api.z.ai →
   // glm, …), with the tab as fallback. Official endpoints may intentionally be
@@ -468,25 +492,25 @@ export function WorkspaceAIConfigModal({
   const dirty = useMemo(() => {
     if (!bundle) return false
     const saved = bundle[tab]
-    const savedForm = configToForm(saved, tab)
+    const savedForm = configToForm(saved, tabProviderCapabilities)
     return (
       savedForm.baseUrl !== form.baseUrl ||
       savedForm.apiKey !== form.apiKey ||
       savedForm.model !== form.model ||
       savedForm.wireShape !== form.wireShape ||
-      ((tab === 'opencode' || tab === 'pi') && savedForm.contextWindow !== form.contextWindow) ||
-      ((tab === 'opencode' || tab === 'pi') && savedForm.reasoning !== form.reasoning) ||
+      (modelRegistration?.contextWindow === true && savedForm.contextWindow !== form.contextWindow) ||
+      (modelRegistration?.reasoning === true && savedForm.reasoning !== form.reasoning) ||
       savedForm.reasoningEffort !== form.reasoningEffort ||
       (form.wireShape === 'anthropic' && savedForm.authMode !== form.authMode)
     )
-  }, [bundle, form, tab])
+  }, [bundle, form, modelRegistration, tab, tabProviderCapabilities])
   const enteredApiKey = form.apiKey.trim()
   const offerSaveCred = !!enteredApiKey &&
     !credentials.some((credential) => credential.apiKey === enteredApiKey) &&
     dismissedCredentialKey !== enteredApiKey
   const connectionDirty = useMemo(
-    () => !!bundle && connectionFieldsChanged(bundle[tab], form, tab),
-    [bundle, form, tab],
+    () => !!bundle && connectionFieldsChanged(bundle[tab], form, tabProviderCapabilities),
+    [bundle, form, tab, tabProviderCapabilities],
   )
   // The primary footer button morphs Test → Save off this: an unsaved change
   // to connection fields has to clear the probe before it can be saved. Local
@@ -498,7 +522,7 @@ export function WorkspaceAIConfigModal({
     if (!cred) return
     // Pick the wire this tab's agent speaks from the credential's capabilities.
     // (The picker only lists compatible credentials, so this is non-null.)
-    const picked = pickAgentWire(cred.wires, tab, pickedWireShape || undefined, cred.vendor)
+    const picked = pickAgentWire(cred.wires, agents, tab, pickedWireShape || undefined, cred.vendor)
     if (!picked) return
     // Prefer the model this credential last used. A newly-created credential
     // falls back to the catalog's explicit default, not list order: catalogs
@@ -524,7 +548,7 @@ export function WorkspaceAIConfigModal({
     setError(null)
     setSaving(true)
     try {
-      await saveAgentConfig(wsId, tab, formToConfig(form, tab))
+      await saveAgentConfig(wsId, tab, formToConfig(form, tab, tabProviderCapabilities))
       notifyConfigChanged()
       onAiSaved?.({
         agent: tab,
@@ -568,7 +592,7 @@ export function WorkspaceAIConfigModal({
       await saveAgentConfig(wsId, tab, { baseUrl: null, apiKey: null, model: null })
       const fresh = await getAgentConfig(wsId)
       setBundle(fresh)
-      setForm({ ...EMPTY_FORM, wireShape: DEFAULT_WIRE_BY_TAB[tab] })
+      setForm({ ...EMPTY_FORM, wireShape: defaultWire(tabProviderCapabilities) })
       notifyConfigChanged()
       setSavedFlash(true)
       setTimeout(() => setSavedFlash(false), 1800)
@@ -865,10 +889,11 @@ export function WorkspaceAIConfigModal({
               // Only credentials that declare a wire THIS agent speaks. Codex is
               // Responses-only, so most credentials won't list here — the funnel
               // toward pi/opencode is by design.
-              const compatible = credentials.filter((c) => pickAgentWire(c.wires, tab, undefined, c.vendor))
+              const compatible = credentials.filter((c) =>
+                pickAgentWire(c.wires, agents, tab, undefined, c.vendor))
               const selectedCredential = compatible.find((c) => c.slug === pickedCredential)
               const selectedWireOptions = selectedCredential
-                ? agentWireShapes(selectedCredential.wires, tab, selectedCredential.vendor)
+                ? agentWireShapes(selectedCredential.wires, agents, tab, selectedCredential.vendor)
                 : []
               return (
                 <>
@@ -880,7 +905,9 @@ export function WorkspaceAIConfigModal({
                         const slug = e.target.value
                         const cred = compatible.find((candidate) => candidate.slug === slug)
                         setPickedCredential(slug)
-                        setPickedWireShape(cred ? (agentWireShapes(cred.wires, tab, cred.vendor)[0] ?? '') : '')
+                        setPickedWireShape(
+                          cred ? (agentWireShapes(cred.wires, agents, tab, cred.vendor)[0] ?? '') : '',
+                        )
                       }}
                       className={inputClass + ' flex-1'}
                       disabled={compatible.length === 0}
@@ -891,7 +918,7 @@ export function WorkspaceAIConfigModal({
                           : t('workspaceSettings.ai.selectCredential')}
                       </option>
                       {compatible.map((cred) => {
-                        const shapes = agentWireShapes(cred.wires, tab, cred.vendor)
+                        const shapes = agentWireShapes(cred.wires, agents, tab, cred.vendor)
                         return (
                           <option key={cred.slug} value={cred.slug}>
                             {(cred.label?.trim() || cred.slug)}{shapes.length > 1 ? ` · ${t('workspaceSettings.ai.protocolCount', { count: shapes.length })}` : ''}
@@ -930,7 +957,7 @@ export function WorkspaceAIConfigModal({
           </div>
 
           {/* Manual fields */}
-          {(tab === 'opencode' || tab === 'pi') && (
+          {(tabProviderCapabilities?.wirePreference.length ?? 0) > 1 && (
             <div>
               <label className="block text-xs font-medium text-muted-foreground mb-1">{t('workspaceSettings.ai.apiProtocol')}</label>
               <select
@@ -1115,7 +1142,7 @@ export function WorkspaceAIConfigModal({
                 </div>
               )}
 
-            {(tab === 'opencode' || tab === 'pi') && !selectedModelSemantics?.reasoning && (
+            {modelRegistration?.reasoning === true && !selectedModelSemantics?.reasoning && (
               <details className="mt-2 rounded-md border border-border bg-secondary/40 px-3 py-2">
                 <summary className="cursor-pointer text-[11px] font-medium text-muted-foreground">
                   {t('aiProvider.advancedReasoning')}
@@ -1143,7 +1170,7 @@ export function WorkspaceAIConfigModal({
 
           </div>
 
-          {(tab === 'opencode' || tab === 'pi') && (
+          {modelRegistration?.contextWindow === true && (
             <div>
               <label className="block text-xs font-medium text-muted-foreground mb-1">{t('workspaceSettings.ai.contextWindow')}</label>
               <select

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -423,6 +423,22 @@ export interface AgentCapabilities {
   readonly transcriptDiscovery: 'fs-watch' | 'subprocess' | 'none';
   readonly assignsSessionId?: boolean;
   readonly headless?: boolean;
+  readonly aiProvider?: AgentProviderCapabilities;
+}
+
+export interface AgentProviderCapabilities {
+  readonly credentialSource: 'runtime-or-workspace' | 'workspace-required';
+  readonly wirePreference: readonly WireShape[];
+  readonly defaultWire?: WireShape;
+  readonly vendorPolicies?: Readonly<Record<string, {
+    readonly wirePreference: readonly WireShape[];
+    readonly legacyRequestedWireFallbacks?: Readonly<Partial<Record<WireShape, WireShape>>>;
+  }>>;
+  readonly modelRegistration?: {
+    readonly contextWindow?: boolean;
+    readonly reasoning?: boolean;
+    readonly effortVariants?: boolean;
+  };
 }
 
 export interface AgentInfo {

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -700,10 +700,10 @@ export const workspacesHandlers = [
       // probe, so present everything as installed (a clean showcase, not a
       // "go install things" prompt).
       agents: [
-        { id: 'claude', displayName: 'Claude Code', installed: true, binPath: '/usr/local/bin/claude', capabilities: { parallelPerCwd: true, resumeLast: false, resumeById: true, transcriptDiscovery: 'fs-watch' } },
-        { id: 'codex', displayName: 'Codex', installed: true, binPath: '/usr/local/bin/codex', capabilities: { parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess' } },
-        { id: 'opencode', displayName: 'opencode', installed: true, binPath: '/usr/local/bin/opencode', capabilities: { parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess' } },
-        { id: 'pi', displayName: 'Pi', installed: true, binPath: '/usr/local/bin/pi', capabilities: { parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'none' } },
+        { id: 'claude', displayName: 'Claude Code', installed: true, binPath: '/usr/local/bin/claude', capabilities: { parallelPerCwd: true, resumeLast: false, resumeById: true, transcriptDiscovery: 'fs-watch', aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['anthropic'], defaultWire: 'anthropic' } } },
+        { id: 'codex', displayName: 'Codex', installed: true, binPath: '/usr/local/bin/codex', capabilities: { parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess', aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['openai-responses'], defaultWire: 'openai-responses' } } },
+        { id: 'opencode', displayName: 'opencode', installed: true, binPath: '/usr/local/bin/opencode', capabilities: { parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess', aiProvider: { credentialSource: 'workspace-required', wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'], defaultWire: 'openai-chat', vendorPolicies: { minimax: { wirePreference: ['anthropic'], legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' } } }, modelRegistration: { contextWindow: true, reasoning: true, effortVariants: true } } } },
+        { id: 'pi', displayName: 'Pi', installed: true, binPath: '/usr/local/bin/pi', capabilities: { parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'none', aiProvider: { credentialSource: 'workspace-required', wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'], defaultWire: 'openai-chat', vendorPolicies: { minimax: { wirePreference: ['anthropic'], legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' } } }, modelRegistration: { contextWindow: true, reasoning: true } } } },
       ],
     }),
   ),

--- a/ui/src/hooks/useAgentLaunchConfig.ts
+++ b/ui/src/hooks/useAgentLaunchConfig.ts
@@ -16,7 +16,7 @@ import {
   type SavedCredential,
   type WorkspaceCredentialDetection,
 } from '../components/workspace/api'
-import { isLoginlessAgent, resolveAgentRuntime, type LoginlessAgentId } from '../lib/agentRuntime'
+import { requiresWorkspaceCredential, resolveAgentRuntime } from '../lib/agentRuntime'
 import {
   WORKSPACE_AGENT_CONFIG_CHANGED_EVENT,
   WORKSPACE_DEFAULTS_CHANGED_EVENT,
@@ -202,7 +202,7 @@ export interface AgentLaunchPreferencesState {
   readonly lastCredentialByAgent: Readonly<Record<string, string>>
   readonly recentChatWorkspaceId: string | null
   readonly loaded: boolean
-  rememberCredential(agent: LoginlessAgentId, credentialSlug: string | null): Promise<void>
+  rememberCredential(agent: string, credentialSlug: string | null): Promise<void>
   adoptRecentChatWorkspace(workspaceId: string | null): void
 }
 
@@ -241,7 +241,7 @@ export function useAgentLaunchPreferences(): AgentLaunchPreferencesState {
   }, [])
 
   const rememberCredential = useCallback(async (
-    agent: LoginlessAgentId,
+    agent: string,
     credentialSlug: string | null,
   ): Promise<void> => {
     setPreferences((current) => ({
@@ -352,7 +352,7 @@ export function useAgentLaunchConfig({
     selectedRuntimeReadiness.source === 'managed-runtime' ||
     selectedRuntimeReadiness.source === 'global-login'
   )
-  const needsCredential = isLoginlessAgent(effectiveAgent)
+  const needsCredential = requiresWorkspaceCredential(selectedAgent)
   const credentials = credentialList?.agent === effectiveAgent
     ? credentialList.credentials
     : null
@@ -505,10 +505,10 @@ export function useAgentLaunchConfig({
   }, [setDefaultAgent])
 
   const selectCredential = useCallback((credentialSlug: string) => {
-    if (!isLoginlessAgent(effectiveAgent)) return
+    if (!needsCredential || effectiveAgent === null) return
     setPickedCredential({ agent: effectiveAgent, workspaceId, slug: credentialSlug })
     void preferences.rememberCredential(effectiveAgent, credentialSlug)
-  }, [effectiveAgent, preferences, workspaceId])
+  }, [effectiveAgent, needsCredential, preferences, workspaceId])
 
   const resetCredentialSelection = useCallback(() => setPickedCredential(null), [])
 

--- a/ui/src/lib/agentRuntime.ts
+++ b/ui/src/lib/agentRuntime.ts
@@ -1,12 +1,10 @@
 import type { AgentId, AgentInfo, AgentRuntimeReadinessSnapshot } from '../components/workspace/api'
 
-/** Agent runtimes without a first-party login flow need an injected provider. */
-export type LoginlessAgentId = 'opencode' | 'pi'
-
-export const LOGINLESS_AGENT_IDS = new Set<LoginlessAgentId>(['opencode', 'pi'])
-
-export function isLoginlessAgent(agentId: string | null): agentId is LoginlessAgentId {
-  return agentId !== null && LOGINLESS_AGENT_IDS.has(agentId as LoginlessAgentId)
+/** Whether this adapter must receive a concrete Workspace provider binding. */
+export function requiresWorkspaceCredential(
+  agent: Pick<AgentInfo, 'capabilities'> | null,
+): boolean {
+  return agent?.capabilities.aiProvider?.credentialSource === 'workspace-required'
 }
 
 const WORKSPACE_AI_AGENT_IDS = new Set<AgentId>(['claude', 'codex', 'opencode', 'pi'])

--- a/ui/src/lib/presetHelpers.spec.ts
+++ b/ui/src/lib/presetHelpers.spec.ts
@@ -10,11 +10,40 @@ import {
   savedCredentialModel,
 } from './presetHelpers'
 import type { Preset } from '../api'
+import type { AgentInfo } from '../components/workspace/api'
 
 const multiWire = {
   anthropic: 'https://provider.example/anthropic',
   'openai-chat': 'https://provider.example/v1',
 } as const
+
+const agents: AgentInfo[] = [
+  {
+    id: 'codex',
+    displayName: 'Codex',
+    capabilities: {
+      parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess',
+      aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['openai-responses'] },
+    },
+  },
+  ...['opencode', 'pi'].map((id): AgentInfo => ({
+    id,
+    displayName: id,
+    capabilities: {
+      parallelPerCwd: true, resumeLast: true, resumeById: true, transcriptDiscovery: 'subprocess',
+      aiProvider: {
+        credentialSource: 'workspace-required',
+        wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+        vendorPolicies: {
+          minimax: {
+            wirePreference: ['anthropic'],
+            legacyRequestedWireFallbacks: { 'openai-chat': 'anthropic' },
+          },
+        },
+      },
+    },
+  })),
+]
 
 const modelPreset: Preset = {
   id: 'test',
@@ -50,35 +79,35 @@ const modelPreset: Preset = {
 
 describe('agent wire selection', () => {
   it('lists every compatible Pi/opencode protocol in runtime preference order', () => {
-    expect(agentWireShapes(multiWire, 'pi')).toEqual(['openai-chat', 'anthropic'])
-    expect(agentWireShapes(multiWire, 'opencode')).toEqual(['openai-chat', 'anthropic'])
+    expect(agentWireShapes(multiWire, agents, 'pi')).toEqual(['openai-chat', 'anthropic'])
+    expect(agentWireShapes(multiWire, agents, 'opencode')).toEqual(['openai-chat', 'anthropic'])
   })
 
   it('only exposes MiniMax Anthropic to coding CLIs without changing generic providers', () => {
-    expect(agentWireShapes(multiWire, 'pi', 'minimax')).toEqual(['anthropic'])
-    expect(agentWireShapes(multiWire, 'opencode', 'minimax')).toEqual(['anthropic'])
-    expect(pickAgentWire(multiWire, 'opencode', undefined, 'minimax')?.shape).toBe('anthropic')
+    expect(agentWireShapes(multiWire, agents, 'pi', 'minimax')).toEqual(['anthropic'])
+    expect(agentWireShapes(multiWire, agents, 'opencode', 'minimax')).toEqual(['anthropic'])
+    expect(pickAgentWire(multiWire, agents, 'opencode', undefined, 'minimax')?.shape).toBe('anthropic')
   })
 
   it('derives the native endpoint for an old official MiniMax OpenAI-only credential', () => {
     const oldCredential = { 'openai-chat': 'https://api.minimaxi.com/v1' } as const
-    expect(agentWireShapes(oldCredential, 'pi', 'minimax')).toEqual(['anthropic'])
-    expect(pickAgentWire(oldCredential, 'pi', 'openai-chat', 'minimax')).toEqual({
+    expect(agentWireShapes(oldCredential, agents, 'pi', 'minimax')).toEqual(['anthropic'])
+    expect(pickAgentWire(oldCredential, agents, 'pi', 'openai-chat', 'minimax')).toEqual({
       shape: 'anthropic',
       baseUrl: 'https://api.minimaxi.com/anthropic',
     })
   })
 
   it('repairs an old MiniMax OpenAI default and rejects other incompatible protocols', () => {
-    expect(pickAgentWire(multiWire, 'pi', 'anthropic')).toEqual({
+    expect(pickAgentWire(multiWire, agents, 'pi', 'anthropic')).toEqual({
       shape: 'anthropic',
       baseUrl: 'https://provider.example/anthropic',
     })
-    expect(pickAgentWire(multiWire, 'pi', 'openai-chat', 'minimax')).toEqual({
+    expect(pickAgentWire(multiWire, agents, 'pi', 'openai-chat', 'minimax')).toEqual({
       shape: 'anthropic',
       baseUrl: 'https://provider.example/anthropic',
     })
-    expect(pickAgentWire(multiWire, 'codex', 'anthropic')).toBeNull()
+    expect(pickAgentWire(multiWire, agents, 'codex', 'anthropic')).toBeNull()
   })
 })
 

--- a/ui/src/lib/presetHelpers.ts
+++ b/ui/src/lib/presetHelpers.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ModelSemantics, Preset, PresetModel, SerializedRegion, WireShape } from '../api'
+import type { AgentInfo, AgentProviderCapabilities } from '../components/workspace/api'
 
 export interface LabeledOption {
   id: string
@@ -59,28 +60,25 @@ export function regionShapes(region: SerializedRegion | undefined): WireShape[] 
   return SHAPE_ORDER.filter((s) => s in region.wires)
 }
 
-/**
- * The wire shapes each agent can speak, in preference order — mirrors the
- * backend `AGENT_WIRE_PREFERENCE` (credential-injection.ts). A credential serves
- * an agent only if it declares a compatible wire (codex = Responses-only, so few
- * credentials can drive it — the intended funnel toward pi/opencode).
- */
-export const AGENT_WIRE_PREFERENCE: Record<string, WireShape[]> = {
-  claude: ['anthropic'],
-  codex: ['openai-responses'],
-  opencode: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
-  pi: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+type AgentProviderInfo = Pick<AgentInfo, 'id' | 'capabilities'>
+
+function agentProviderCapabilities(
+  agents: readonly AgentProviderInfo[],
+  agentId: string,
+): AgentProviderCapabilities | undefined {
+  return agents.find((agent) => agent.id === agentId)?.capabilities.aiProvider
 }
 
-/** Keep provider-aware runtime support aligned with the backend injector. */
-export function agentWirePreference(agentId: string, vendor?: string | null): WireShape[] {
-  const preference = AGENT_WIRE_PREFERENCE[agentId] ?? SHAPE_ORDER
-  if (vendor !== 'minimax' || (agentId !== 'opencode' && agentId !== 'pi')) return preference
-  // MiniMax OpenAI Chat emits its separated thinking as the non-standard
-  // `reasoning_details[]` extension. Neither runtime's generic OpenAI adapter
-  // consumes it losslessly; both runtimes' native MiniMax integrations use the
-  // Anthropic endpoint instead.
-  return ['anthropic']
+/** Read provider-aware runtime support from the backend adapter declaration. */
+export function agentWirePreference(
+  agents: readonly AgentProviderInfo[],
+  agentId: string,
+  vendor?: string | null,
+): readonly WireShape[] {
+  const capabilities = agentProviderCapabilities(agents, agentId)
+  if (!capabilities) return []
+  return (vendor ? capabilities.vendorPolicies?.[vendor]?.wirePreference : undefined)
+    ?? capabilities.wirePreference
 }
 
 function inferredMinimaxAnthropicEndpoint(
@@ -112,11 +110,14 @@ function wireEndpoint(
 /** Pick the wire an agent should use from a credential's capabilities (null = none compatible). */
 export function pickAgentWire(
   wires: Partial<Record<WireShape, string>>,
+  agents: readonly AgentProviderInfo[],
   agentId: string,
   requestedShape?: WireShape,
   vendor?: string | null,
 ): { shape: WireShape; baseUrl: string } | null {
-  const pref = agentWirePreference(agentId, vendor)
+  const capabilities = agentProviderCapabilities(agents, agentId)
+  if (!capabilities) return null
+  const pref = agentWirePreference(agents, agentId, vendor)
   if (requestedShape !== undefined) {
     const requestedEndpoint = wireEndpoint(wires, requestedShape, vendor)
     if (pref.includes(requestedShape) && requestedEndpoint !== undefined) {
@@ -124,13 +125,14 @@ export function pickAgentWire(
     }
     // Transparently repair an old MiniMax OpenAI default when the credential
     // still carries the native Anthropic endpoint.
-    if (
-      vendor === 'minimax' &&
-      (agentId === 'opencode' || agentId === 'pi') &&
-      requestedShape === 'openai-chat' &&
-      wireEndpoint(wires, 'anthropic', vendor) !== undefined
-    ) {
-      return { shape: 'anthropic', baseUrl: wireEndpoint(wires, 'anthropic', vendor)! }
+    const fallbackShape = vendor
+      ? capabilities.vendorPolicies?.[vendor]?.legacyRequestedWireFallbacks?.[requestedShape]
+      : undefined
+    if (fallbackShape) {
+      const fallbackEndpoint = wireEndpoint(wires, fallbackShape, vendor)
+      if (fallbackEndpoint !== undefined) {
+        return { shape: fallbackShape, baseUrl: fallbackEndpoint }
+      }
     }
     return null
   }
@@ -144,23 +146,33 @@ export function pickAgentWire(
 /** All declared wire shapes this agent can speak, in runtime preference order. */
 export function agentWireShapes(
   wires: Partial<Record<WireShape, string>>,
+  agents: readonly AgentProviderInfo[],
   agentId: string,
   vendor?: string | null,
 ): WireShape[] {
-  const pref = agentWirePreference(agentId, vendor)
+  const pref = agentWirePreference(agents, agentId, vendor)
   return pref.filter((shape) => wireEndpoint(wires, shape, vendor) !== undefined)
 }
 
 /** Agent runtimes that can consume at least one declared wire shape. */
-export function compatibleAgentIds(wires: Partial<Record<WireShape, string>>): string[] {
-  return Object.keys(AGENT_WIRE_PREFERENCE).filter((agentId) => pickAgentWire(wires, agentId) !== null)
+export function compatibleAgentIds(
+  wires: Partial<Record<WireShape, string>>,
+  agents: readonly AgentProviderInfo[],
+): string[] {
+  return agents
+    .filter((agent) => agent.capabilities.aiProvider)
+    .filter((agent) => pickAgentWire(wires, agents, agent.id) !== null)
+    .map((agent) => agent.id)
 }
 
 /** Compatibility summary for a preset before a region has been selected. */
-export function presetCompatibleAgentIds(preset: Preset): string[] {
+export function presetCompatibleAgentIds(
+  preset: Preset,
+  agents: readonly AgentProviderInfo[],
+): string[] {
   const wires: Partial<Record<WireShape, string>> = {}
   for (const region of presetRegions(preset)) Object.assign(wires, region.wires)
-  return compatibleAgentIds(wires)
+  return compatibleAgentIds(wires, agents)
 }
 
 function schemaProps(schema: Preset['schema']): Record<string, Record<string, unknown>> {

--- a/ui/src/pages/AIProviderPage.loading.spec.tsx
+++ b/ui/src/pages/AIProviderPage.loading.spec.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   getCredentials: vi.fn(),
   getPresets: vi.fn(),
   getWorkspaceCredentialDefaults: vi.fn(),
+  listAgents: vi.fn(),
 }))
 
 vi.mock('../api', () => ({
@@ -22,6 +23,11 @@ vi.mock('../api', () => ({
   },
 }))
 
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return { ...actual, listAgents: mocks.listAgents }
+})
+
 beforeEach(async () => {
   vi.clearAllMocks()
   await i18n.changeLanguage('en')
@@ -30,6 +36,7 @@ beforeEach(async () => {
     defaults: {},
     compatibleByAgent: {},
   })
+  mocks.listAgents.mockResolvedValue([])
 })
 
 afterEach(cleanup)

--- a/ui/src/pages/AIProviderPage.spec.tsx
+++ b/ui/src/pages/AIProviderPage.spec.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   getWorkspaceCredentialDefaults: vi.fn(),
   setWorkspaceCredentialDefaults: vi.fn(),
   deleteCredential: vi.fn(),
+  listAgents: vi.fn(),
 }))
 
 vi.mock('../api', () => ({
@@ -25,6 +26,11 @@ vi.mock('../api', () => ({
     },
   },
 }))
+
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return { ...actual, listAgents: mocks.listAgents }
+})
 
 beforeEach(async () => {
   vi.clearAllMocks()
@@ -50,6 +56,23 @@ beforeEach(async () => {
     defaults,
   }))
   mocks.deleteCredential.mockResolvedValue(undefined)
+  mocks.listAgents.mockResolvedValue([
+    {
+      id: 'pi',
+      displayName: 'Pi',
+      capabilities: {
+        parallelPerCwd: true,
+        resumeLast: true,
+        resumeById: true,
+        transcriptDiscovery: 'none',
+        aiProvider: {
+          credentialSource: 'workspace-required',
+          wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+          modelRegistration: { contextWindow: true, reasoning: true },
+        },
+      },
+    },
+  ])
 })
 
 afterEach(cleanup)

--- a/ui/src/pages/AIProviderPage.tsx
+++ b/ui/src/pages/AIProviderPage.tsx
@@ -39,6 +39,7 @@ import {
   vendorPreset,
 } from '../lib/presetHelpers'
 import { notifyWorkspaceDefaultsChanged } from '../lib/workspaceAiEvents'
+import { listAgents, type AgentInfo } from '../components/workspace/api'
 
 function credentialLabel(cred: Pick<CredentialSummary, 'slug' | 'vendor' | 'label'>): string {
   return cred.label?.trim() || cred.slug
@@ -93,6 +94,7 @@ const AGENT_RUNTIMES: RuntimeInfo[] = [
 
 export function AIProviderPage() {
   const { t } = useTranslation()
+  const [agents, setAgents] = useState<AgentInfo[]>([])
   const [credentials, setCredentials] = useState<CredentialSummary[] | null>(null)
   const [credentialsLoadError, setCredentialsLoadError] = useState(false)
   const [presets, setPresets] = useState<Preset[]>([])
@@ -113,6 +115,7 @@ export function AIProviderPage() {
   useEffect(() => {
     void reload()
     api.config.getPresets().then(({ presets: p }) => setPresets(p)).catch(() => {})
+    void listAgents().then(setAgents).catch(() => setAgents([]))
   }, [reload])
 
   const apiKeyPresets = useMemo(() => presets.filter(isApiKeyPreset), [presets])
@@ -176,7 +179,7 @@ export function AIProviderPage() {
 
             <div className="space-y-2.5">
               {credentials.map((cred) => {
-                const compatibleAgents = compatibleAgentIds(cred.wires)
+                const compatibleAgents = compatibleAgentIds(cred.wires, agents)
                 return (
                   <div key={cred.slug} className="flex min-w-0 flex-col gap-3 rounded-lg border border-border bg-background px-4 py-3 sm:flex-row sm:items-center">
                     <div className="flex-1 min-w-0">
@@ -243,7 +246,7 @@ export function AIProviderPage() {
           </section>
 
           {/* ============== Default workspace credentials ============== */}
-          <WorkspaceDefaultsSection credentials={credentials} presets={presets} />
+          <WorkspaceDefaultsSection credentials={credentials} presets={presets} agents={agents} />
         </div>
 
         {/* Runtime descriptions are reference material, not a prerequisite for
@@ -290,6 +293,7 @@ export function AIProviderPage() {
           mode={modal.mode}
           cred={modal.mode === 'edit' ? modal.cred : undefined}
           presets={apiKeyPresets}
+          agents={agents}
           onClose={() => setModal(null)}
           onSaved={async () => { await reload(); setModal(null) }}
         />
@@ -335,7 +339,15 @@ const ADVANCED_DEFAULT_AGENTS = [
   { id: 'codex', name: 'Codex' },
 ] as const
 
-function WorkspaceDefaultsSection({ credentials, presets }: { credentials: CredentialSummary[]; presets: Preset[] }) {
+function WorkspaceDefaultsSection({
+  credentials,
+  presets,
+  agents,
+}: {
+  credentials: CredentialSummary[]
+  presets: Preset[]
+  agents: readonly AgentInfo[]
+}) {
   const { t } = useTranslation()
   const [data, setData] = useState<WorkspaceCredentialDefaultsResponse | null>(null)
   const [showAdvanced, setShowAdvanced] = useState(false)
@@ -387,7 +399,7 @@ function WorkspaceDefaultsSection({ credentials, presets }: { credentials: Crede
     const nextDefaults = { ...data.defaults }
     if (slug) {
       const cred = credentials.find((candidate) => candidate.slug === slug)
-      const wireShape = cred ? agentWireShapes(cred.wires, agentId, cred.vendor)[0] : undefined
+      const wireShape = cred ? agentWireShapes(cred.wires, agents, agentId, cred.vendor)[0] : undefined
       nextDefaults[agentId] = { credentialSlug: slug, ...(wireShape ? { wireShape } : {}) }
     } else {
       delete nextDefaults[agentId]
@@ -434,7 +446,7 @@ function WorkspaceDefaultsSection({ credentials, presets }: { credentials: Crede
     const current = data?.defaults[agent.id]?.credentialSlug ?? ''
     const selectedCredential = credentials.find((candidate) => candidate.slug === current)
     const wireShapes = selectedCredential
-      ? agentWireShapes(selectedCredential.wires, agent.id, selectedCredential.vendor)
+      ? agentWireShapes(selectedCredential.wires, agents, agent.id, selectedCredential.vendor)
       : []
     const configuredWire = data?.defaults[agent.id]?.wireShape
     const selectedWire = configuredWire && wireShapes.includes(configuredWire)

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -68,6 +68,11 @@ const piAgent: AgentInfo = {
     resumeLast: true,
     resumeById: true,
     transcriptDiscovery: 'fs-watch',
+    aiProvider: {
+      credentialSource: 'workspace-required',
+      wirePreference: ['google-generative-ai', 'openai-chat', 'anthropic', 'openai-responses'],
+      modelRegistration: { contextWindow: true, reasoning: true },
+    },
   },
 }
 

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -91,6 +91,21 @@ const runtimeAgents: AgentInfo[] = [
     resumeLast: true,
     resumeById: true,
     transcriptDiscovery: 'none',
+    ...(id !== 'shell' ? {
+      aiProvider: {
+        credentialSource: id === 'opencode' || id === 'pi'
+          ? 'workspace-required' as const
+          : 'runtime-or-workspace' as const,
+        wirePreference: id === 'claude'
+          ? ['anthropic' as const]
+          : id === 'codex'
+            ? ['openai-responses' as const]
+            : ['google-generative-ai' as const, 'openai-chat' as const, 'anthropic' as const, 'openai-responses' as const],
+        ...(id === 'opencode' || id === 'pi'
+          ? { modelRegistration: { contextWindow: true, reasoning: true } }
+          : {}),
+      },
+    } : {}),
   },
 }))
 


### PR DESCRIPTION
## What changed

- added an adapter-owned AI provider capability contract for credential source, wire preference/default, vendor-specific compatibility, and custom-model registration
- centralized built-in adapter registration and removed shared Claude/Codex/opencode/Pi allowlists from injection, readiness, config, and Quick Chat preference paths
- serialized the adapter declarations through `/api/workspaces/agents` and made credential/default/model UI consume that contract
- added synthetic future-adapter coverage and documented the ownership boundary

## Why

Adding another native agent runtime previously required updating several backend and frontend ID matrices. The adapter now declares its provider semantics once; shared layers consume the declaration while native config/CLI behavior remains adapter-owned.

## Validation

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 3,751 passed, 9 skipped
- real `dev:demo` browser walk of AI Provider and Workspace AI settings; verified dynamic protocol/model controls and no console warnings/errors
