### PR TITLE
feat(cli): install standalone runtime bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,82 @@ jobs:
       - name: Exercise candidate installer through managed SSH remote
         run: node scripts/remote-ssh-smoke.mjs
 
+  build-headless-runtime:
+    name: Build headless Runtime (${{ matrix.platform }}-${{ matrix.arch }})
+    needs: release
+    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            platform: darwin
+            arch: arm64
+          - os: macos-15-intel
+            platform: darwin
+            arch: x64
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build platform headless Runtime
+        run: pnpm build:headless-runtime
+
+      - name: Install and boot the candidate outside the checkout
+        shell: bash
+        run: |
+          metadata=$(find dist/headless -maxdepth 1 -name 'openalice-runtime-*.json' -print -quit)
+          archive=$(node -p "require('./${metadata}').archive.file")
+          sha256=$(node -p "require('./${metadata}').archive.sha256")
+          ./install \
+            --source "$GITHUB_WORKSPACE" \
+            --runtime-archive "$GITHUB_WORKSPACE/dist/headless/$archive" \
+            --runtime-sha256 "$sha256" \
+            --install-dir "$RUNNER_TEMP/openalice-cli" \
+            --no-modify-path \
+            --yes
+          "$RUNNER_TEMP/openalice-cli/bin/openalice" up \
+            --home "$RUNNER_TEMP/openalice-home" \
+            --no-update-check \
+            --wait 120 \
+            --json
+          "$RUNNER_TEMP/openalice-cli/bin/openalice" doctor \
+            --home "$RUNNER_TEMP/openalice-home" \
+            --json
+          "$RUNNER_TEMP/openalice-cli/bin/openalice" down \
+            --home "$RUNNER_TEMP/openalice-home" \
+            --json
+
+      - name: Preserve accepted headless Runtime
+        uses: actions/upload-artifact@v4
+        with:
+          name: headless-runtime-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            dist/headless/*.json
+            dist/headless/*.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
   build-linux-broker-packs:
     name: Build Linux Broker Packs
     needs: release
@@ -287,8 +363,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, build-linux-broker-packs, cli-installer-acceptance]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.build-linux-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
+    needs: [release, build-desktop, build-headless-runtime, build-linux-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.build-headless-runtime.result == 'success' && needs.build-linux-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -312,6 +388,12 @@ jobs:
           path: dist/release-broker-packs
           merge-multiple: true
 
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: headless-runtime-*
+          path: dist/release-headless-runtime
+          merge-multiple: true
+
       - name: Create tag and GitHub Release from accepted candidates
         uses: softprops/action-gh-release@v2
         with:
@@ -330,6 +412,8 @@ jobs:
             dist/release-assets/*.exe
             dist/release-broker-packs/*.json
             dist/release-broker-packs/*.tgz
+            dist/release-headless-runtime/*.json
+            dist/release-headless-runtime/*.tar.gz
 
   mirror-release-assets:
     needs: [release, publish-release]
@@ -369,6 +453,16 @@ jobs:
           test "$CLI_PACKAGE_VERSION" = "$VERSION"
           bash -n install
           cp install "dist/r2-upload/OpenAlice-${VERSION}-install"
+          node - "$VERSION" "dist/r2-upload/OpenAlice-${VERSION}-install" <<'NODE'
+          const { readFileSync, writeFileSync } = require('node:fs')
+          const [version, path] = process.argv.slice(2)
+          const source = 'OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"'
+          const target = `OPENALICE_INSTALLER_RELEASE_VERSION="\${OPENALICE_INSTALLER_RELEASE_VERSION:-${version}}"`
+          const input = readFileSync(path, 'utf8')
+          if (!input.includes(source)) throw new Error('installer release-version placeholder is missing')
+          writeFileSync(path, input.replace(source, target))
+          NODE
+          bash -n "dist/r2-upload/OpenAlice-${VERSION}-install"
 
       - name: Prepare CDN download aliases
         env:

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -15,12 +15,12 @@ non-authoritative and lives in
 
 ## Product Boundary
 
-The installer always makes the `openalice` command and OpenAlice's pinned Pi
-runtime available. Pi is installed inside the immutable OpenAlice release, not
-into npm's system or user-global prefix. On Linux, the installer can also
-install the source Runtime's native build tools, but only after the user
-selects that option and approves the exact system command. By default it does
-not:
+The stable installer makes the `openalice` command, pinned Pi, and the matching
+platform headless Runtime available. Pi and Runtime are installed inside the
+same immutable OpenAlice release, not into a system or user-global prefix.
+Development/source-only channels can still offer Linux source-build tools, but
+only after the user selects that option and approves the exact system command.
+By default it does not:
 
 - clone the OpenAlice repository;
 - install or modify Electron;
@@ -36,15 +36,14 @@ compile native Node modules such as `node-pty`. It does not install Node,
 additional Agent CLIs, broker SDKs, credentials, Docker, or Electron. Managed
 Pi is part of the baseline OpenAlice transaction, not a Runtime-tool option.
 
-The current browser-local distribution remains source-backed:
+The stable browser-local distribution is bundle-backed:
 
 ```text
 curl installer
-  └── immutable OpenAlice CLI + managed Pi
-        ├── openalice command injects managed Pi into Guardian
+  └── immutable OpenAlice CLI + managed Pi + platform Runtime
+        ├── openalice command injects managed Pi and Runtime into Guardian
         ├── pi command exposes the same pinned runtime directly
-        └── user-owned OpenAlice checkout
-              └── localhost Runtime
+        └── localhost Runtime independent of cwd
 ```
 
 The install script targets macOS, Linux, WSL, and Git Bash. Native Windows
@@ -67,7 +66,9 @@ The main-site route proxies that release-owned alias and refuses non-script
 upstream content.
 
 The script requires Node.js 22.19.0 or newer, matching the pinned Pi runtime's
-engine floor. With no selector, it targets the stable `master` branch.
+engine floor. A release-owned installer embeds its OpenAlice version and
+selects that immutable tag; the raw development installer uses its explicit
+branch selector.
 
 The independently active development channel deliberately uses GitHub's raw
 branch endpoint rather than the release CDN. Both layers must select `dev`:
@@ -266,11 +267,12 @@ Downloads first land in a temporary `openalice-cli.*` directory outside the
 visible command path. A failed or interrupted download therefore leaves the
 previous installed command untouched.
 
-Managed Pi is installed under `managed/pi/` in that same staging tree. npm
-never receives `--global` and never writes OpenAlice's Pi into a host prefix.
-The pinned lockfile supplies registry integrity values for the dependency tree;
-install scripts are disabled. A failure leaves the previous content-addressed
-OpenAlice and Pi release visible.
+Managed Pi is installed under `managed/pi/` and the expanded platform Runtime
+under `managed/runtime/` in that same staging tree. npm never receives
+`--global`. The Runtime archive SHA-256 comes from release-owned metadata; its
+internal manifest then verifies platform, architecture, product version,
+entrypoint, every file hash, safe symlinks, and a 16-character content
+identity. A failure leaves the previous content-addressed release visible.
 
 ### Validation and content identity
 
@@ -283,20 +285,24 @@ Before a release becomes visible, the installer:
    package manifest;
 4. verifies the Pi install manifest and lockfile against the SHA-256 values
    pinned in the installer, then requires the staged Pi CLI to report `0.83.0`;
-5. writes `install-source.json` with the CLI version, selected branch/tag/commit,
+5. verifies and expands the matching headless Runtime when the selected release
+   supplies one, then requires its product version to equal the CLI version;
+6. writes `install-source.json` with the CLI version, selected branch/tag/commit,
    and installer URL that produced this CLI;
-6. hashes the ordered OpenAlice payload, install-source metadata, and both Pi
-   install files with SHA-256 and uses the first 16 hex characters as its
-   content identity.
+7. hashes the ordered OpenAlice CLI payload, install-source metadata, and both
+   Pi install files with SHA-256 and uses the first 16 hex characters as the
+   cross-platform CLI install content identity.
 
 That metadata is returned by `openalice version --json` together with the
 16-character identity derived from the immutable installed release directory.
 Managed `openalice remote` compares both provenance and content identity before
 deciding that a remote CLI matches, then invokes the same ordinary installer
 source and selector when it does not. This catches changed payload bytes even
-when the product version and branch name are unchanged. The CLI package version
-must equal the root OpenAlice version; tests and the release workflow reject a
-mismatch. `remote` has no independent branch/version option.
+when the product version and branch name are unchanged. The platform Runtime
+keeps a separate manifest identity so a macOS CLI can match the same release's
+Linux CLI while each host still verifies its own Runtime bytes. The CLI package
+version must equal the root OpenAlice version; tests and the release workflow
+reject a mismatch. `remote` has no independent branch/version option.
 
 The resulting directory is:
 
@@ -305,7 +311,8 @@ The resulting directory is:
 ```
 
 Installing identical content for the same ref reuses the existing directory
-only when both the content hash and executable Pi version still match. If a
+only when the content hash, executable Pi version, and full Runtime manifest
+verification still match. If a
 directory claims that identity but its files no longer hash correctly or its
 managed Pi runtime is missing/damaged, it is preserved as
 `<release>.damaged.<pid>` and replaced with the validated staging tree. The
@@ -317,9 +324,11 @@ The installer writes temporary `openalice`, `openalice.cmd`, `pi`, and `pi.cmd`
 launchers in the target bin directory. All point to the complete immutable
 release. It executes both temporary shell launchers before replacing any
 visible command, then moves the launchers into place within the same directory.
-The OpenAlice launchers export `OPENALICE_MANAGED_PI_PATH` and
-`OPENALICE_MANAGED_PI_NODE_PATH`; foreground and detached Guardian trees
-therefore inherit the pinned runtime without relying on shell-profile reloads.
+The OpenAlice launchers export `OPENALICE_MANAGED_PI_PATH`,
+`OPENALICE_MANAGED_PI_NODE_PATH`, `OPENALICE_MANAGED_RUNTIME_PATH`, and
+`OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY`; foreground and detached Guardian
+trees therefore inherit the pinned agent and application Runtime without
+relying on cwd or shell-profile reloads.
 
 This gives updates a simple safety property: a visible launcher points to the
 complete old release or the complete new release, never to a half-written
@@ -406,9 +415,11 @@ With the default installer and Runtime roots:
 │   ├── pi
 │   └── pi.cmd
 ├── cli-versions/
-│   ├── master-<content-id>/
+│   ├── v<version>-<content-id>/
 │   │   ├── install-source.json
-│   │   └── managed/pi/     # pinned npm runtime inside the immutable release
+│   │   └── managed/
+│   │       ├── pi/         # pinned npm agent runtime
+│   │       └── runtime/    # verified platform headless Runtime
 │   ├── dev-<content-id>/   # only after an explicit --branch dev install
 │   └── <older-ref-or-content>/
 ├── .cli-install.lock/       # present only while an installer owns it
@@ -484,6 +495,8 @@ Development-only option:
 | Option | Meaning |
 |---|---|
 | `--source <checkout>` | Copy CLI payload files from a local OpenAlice checkout |
+| `--runtime-archive <path>` | Install a locally built platform Runtime archive |
+| `--runtime-sha256 <hex>` | Require an exact SHA-256 for the local Runtime archive |
 
 Environment inputs:
 
@@ -497,6 +510,9 @@ Environment inputs:
 | `OPENALICE_NPM_BIN` | Use a single alternate npm executable in installer tests |
 | `OPENALICE_INSTALL_CONTEXT` | Internal managed-remote context; returns control without local checkout/start guidance |
 | `OPENALICE_EXPECTED_CLI_VERSION` | Internal verified-update guard; rejects a payload whose CLI/product version differs from the release manifest |
+| `OPENALICE_RUNTIME_RELEASE_BASE_URL` | Release/test override for Runtime metadata and archive downloads |
+| `OPENALICE_INSTALLER_RELEASE_VERSION` | Embedded by the release workflow; binds the installer to one OpenAlice tag and Runtime set |
+| `OPENALICE_RUNTIME_ARCHIVE`, `OPENALICE_RUNTIME_ARCHIVE_SHA256` | Local/CI equivalents of the development Runtime archive flags |
 | `NO_COLOR` | Disable installer color output |
 | `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |
 
@@ -518,11 +534,11 @@ then protects update layout and detects accidental or local modification.
 `openalice update` improves consistency by fetching the versioned installer URL
 from that manifest and verifying the recorded SHA-256 before execution.
 
-This is still not a cryptographic signature. The installer downloads the CLI
-payload as individual files from the selected raw GitHub ref, and the R2
-manifest belongs to the same release control plane as the mirrored script.
-Even when that payload ref is an immutable commit, a hash published beside the
-download is not an independent trust anchor.
+This is still not a cryptographic signature. The release Runtime archive has
+both a release-metadata SHA-256 and an internal file manifest, while the CLI
+payload still comes from the selected immutable GitHub tag. Those hashes and
+the mirrored installer belong to the same release control plane rather than an
+independent trust anchor.
 
 Do not describe the CLI path as signed. A future archive/signature path should
 establish this chain:
@@ -756,9 +772,9 @@ Likely follow-up stages, in dependency order:
 2. move durable install logic behind a shared cross-platform core before adding
    a native PowerShell bootstrap;
 3. add explicit CLI rollback, garbage collection, and surgical uninstall;
-4. replace the source/build requirement with a standalone headless Runtime
-   asset while retaining the same localhost and consent contracts;
-5. layer remote transports around a loopback Runtime rather than opening the
+4. add independent signature/authenticity verification for the published
+   headless Runtime and CLI payload;
+5. layer additional remote transports around a loopback Runtime rather than opening the
    Runtime itself to the network.
 
 Do not implement a later stage by weakening the current consent, data ownership,

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -63,17 +63,18 @@ when no owner exists. Ordinary start never signals another owner. `--takeover`
 delegates replacement to Guardian's established discover, TERM, grace, KILL,
 wait, then acquire ordering.
 
-The current Runtime provider remains source-backed. `up` and `run` therefore
-accept the checkout, preparation, rebuild, home, port, wait, and takeover
-options documented in [[docs/local-runtime.md]]. `up` is browserless by default;
-`--open` performs a separate verified browser open after readiness.
+Stable installs use the verified bundle provider. `up` and `run` remain
+browserless lifecycle commands and accept home, port, wait, and takeover
+options; `--app-dir` is an advanced source override with the preparation and
+rebuild options documented in [[docs/local-runtime.md]]. `--open` performs a
+separate verified browser open after readiness.
 
 ## Default and Compatibility Surface
 
 - bare `openalice` enters the local Supervisor TUI;
 - `openalice tui` is the explicit equivalent for tests and scripts;
-- `openalice start` retains the existing foreground, browser-oriented source
-  launcher;
+- `openalice start` retains the existing foreground, browser-oriented
+  compatibility launcher and also selects the installed bundle by default;
 - `openalice server run|start|status|stop` remains available for managed remote
   and existing scripts;
 - new code uses `run|up|status|down`;
@@ -98,9 +99,9 @@ explicit commands:
   stopping another instance, or creates a separate named complete home;
 - `p` opens selected-instance settings for complete home, Web port, update
   checks, and resolved source/config provenance;
-- `m` confirms, prepares, remembers, and starts an installer-managed source
+- `m` is an advanced control that confirms, prepares, remembers, and starts an installer-managed source
   aligned to the installed CLI branch/version;
-- `c` chooses and remembers the selected instance's source checkout;
+- `c` is an advanced control that chooses and remembers the selected instance's source checkout;
 - `?`, Tab, and the horizontal arrows expose help and detail panels.
 
 The TUI refuses to stop or restart Electron, development, incompatible, or
@@ -108,14 +109,12 @@ otherwise foreign owners. Its stop/restart confirmation states that active Web
 and agent sessions will disconnect. Detaching never implies stopping. Update
 discovery runs in the background and cannot block lifecycle controls.
 
-The current Runtime provider is still source-backed. TUI start discovers an
-OpenAlice checkout from the current directory, reuses a configured or
-owner-advertised source root, opens the `c` path editor when discovery fails,
-or explicitly prepares an installer-owned checkout through `m`. The managed
-path is `<install root>/sources/<install-source identity>/OpenAlice`; a branch
-install clones that branch and a version install checks out its immutable ref.
-Unfinished controls remain inside the application shell and do not change the
-default entry back to the compatibility launcher.
+The installed Runtime is the default provider below stored configuration and
+above cwd discovery. TUI start therefore works from any directory and shows a
+small ordinary action bar. A configured instance source,
+`OPENALICE_APP_HOME`, or `--app-dir` overrides the bundle; `m` and `c` remain
+advanced source controls. The managed source path is
+`<install root>/sources/<install-source identity>/OpenAlice`.
 
 ## TUI Launch Context
 
@@ -131,8 +130,9 @@ raw mode. Bare `openalice` and `openalice tui` accept:
 --update-check
 ```
 
-Resolution order is defaults, machine Supervisor configuration, selected
-instance configuration, environment, then explicit CLI flags. The immutable
+Resolution order is defaults, installed Runtime, machine Supervisor
+configuration, selected instance configuration, environment, then explicit CLI
+flags. The immutable
 resolver retains field provenance for every layer. Before terminal raw mode,
 the Supervisor reads a versioned machine-local document at
 `<Supervisor root>/config.json`. It contains machine defaults and an instance
@@ -181,7 +181,10 @@ increments.
 `OPENALICE_APP_HOME`, and `OPENALICE_NO_UPDATE_CHECK` are the corresponding
 environment overrides. `OPENALICE_SUPERVISOR_HOME` may relocate the
 machine-wide Supervisor root, which remains outside every selectable complete
-home.
+home. Installer launchers supply the lower-priority internal pair
+`OPENALICE_MANAGED_RUNTIME_PATH` and
+`OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY`; ordinary users do not need to set
+them.
 
 Only an installer-owned Runtime carrying `OPENALICE_MANAGED_PI_PATH` receives
 instance-private `PI_CODING_AGENT_DIR` and `PI_CODING_AGENT_SESSION_DIR`

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -1,8 +1,8 @@
 # Local Runtime and CLI Bootstrap
 
 This guide owns the browser-local OpenAlice entry after CLI installation and
-the boundary between dependency bootstrap, source-backed Runtime startup,
-Electron distribution, and later downloadable Runtime bundles. Installer
+the boundary between the installed headless Runtime, explicit source-backed
+development, and Electron distribution. Installer
 consent, installed layout, PATH integration, updates, and installer release
 checks belong to [[docs/cli-installer.md]].
 
@@ -18,9 +18,9 @@ The local browser path is a first-class OpenAlice distribution surface:
 
 ```text
 installed openalice CLI
-  └── local OpenAlice source checkout
-        └── built-runtime Guardian
-              ├── Alice + normal Web UI on 127.0.0.1:47331
+  └── platform-specific headless Runtime bundle
+        └── Guardian
+              ├── Alice + normal Web UI on an available 127.0.0.1 port
               ├── optional UTA on local internal ports
               └── optional Connector Service on local internal ports
 ```
@@ -44,17 +44,13 @@ curl -fsSL https://openalice.ai/install | bash
 ```
 
 Development dogfooding can opt into `dev` explicitly with `--branch dev`. The
-installer requires Node.js 22.19.0 or newer and always installs the small CLI
-plus OpenAlice's pinned Pi runtime inside the same immutable install release;
-the two visible commands are `openalice` and `pi`. The installed CLI reports
-the same version as the OpenAlice product release; there is no independent CLI
-version sequence.
-When explicitly selected,
-it can also install missing Linux Git/Python/make/C++ tools needed to build the
-source Runtime. It does not clone OpenAlice, write application state, install
-Electron, configure a provider credential, or start a service without separate
-consent. Managed `openalice remote` can separately plan and clone a private
-remote checkout after installation; that orchestration belongs to
+installer requires Node.js 22.19.0 or newer and installs the CLI, pinned Pi,
+and matching macOS/Linux headless Runtime inside one immutable release. The two
+visible commands are `openalice` and `pi`; CLI and Runtime report the same
+OpenAlice product version. It does not clone OpenAlice, write application
+state, install Electron, configure a provider credential, or start a service
+without separate consent. Managed `openalice remote` installs or reuses the
+same platform Runtime on the SSH host; that orchestration belongs to
 [[docs/remote-access.md]]. The curl entry targets macOS, Linux, WSL, and Git Bash; native Windows
 desktop distribution remains the signed Electron installer. The complete
 consent, update, filesystem, PATH, authenticity, and test contract lives in
@@ -64,41 +60,37 @@ Installer flags, non-interactive consent, development seams, the clean Docker
 fixture, and the manual prompt playground are documented only in
 [[docs/cli-installer.md]].
 
-Until release assets include a standalone headless Runtime, users keep an
-OpenAlice source checkout and run the CLI from inside it:
+After installation, startup is independent of the current directory:
 
 ```bash
-git clone https://github.com/TraderAlice/OpenAlice.git
-cd OpenAlice
+openalice
 openalice up
 openalice open
 ```
 
-`openalice up` finds the checkout, installs the locked workspace dependencies
-without `@traderalice/desktop`, runs `pnpm build:server`, starts
-`scripts/guardian/prod.mjs` on `127.0.0.1`, and leaves it running after the
-shell exits. `openalice open` verifies and opens the normal Web UI. Bare
-`openalice` enters the Supervisor TUI; `openalice start` preserves the legacy
-foreground-and-browser path. If `pnpm` is absent but Corepack is available,
-preparation uses Corepack with the pnpm version pinned by the repository.
+`openalice up` selects the installed bundle, starts
+`scripts/guardian/prod.mjs` on loopback, and leaves it running after the shell
+exits. `openalice open` verifies and opens the normal Web UI. Bare `openalice`
+enters the Supervisor TUI; `openalice run` is the foreground form. A source
+checkout remains an advanced override through instance configuration,
+`OPENALICE_APP_HOME`, or `--app-dir`; missing source artifacts may then use the
+locked pnpm preparation path.
 
 Live broker engines are still activated through the Trading UI and
 `<OPENALICE_HOME>/runtime/broker-packs/`. The source checkout contains their
 adapter workspaces for development, but `build:server` excludes those wrappers
 from UTA Core and no live SDK is evaluated at startup.
 
-When an interactive install is run from inside an OpenAlice checkout, the
+When an interactive stable install completes, the
 installer presents a separate, default-no `Open the OpenAlice Supervisor now?`
-prompt after the CLI is complete. The Supervisor opens inside the checkout but
-does not start the Runtime until the user chooses Start inside the TUI.
+prompt after the CLI is complete. The Supervisor can open from any directory
+but does not start the Runtime until the user chooses Start inside the TUI.
 Installation consent never implies service-start consent, and `--yes` remains
 installation-only for automation.
 
-On an installed CLI with no existing checkout, the stopped Supervisor exposes
-`m Managed`. After explicit confirmation it atomically clones the branch or
-version paired with that installed CLI under the install root, remembers the
-result for the selected instance, and enters the ordinary source preparation
-and detached-start path. `c Source` remains the existing-checkout path.
+The stopped Supervisor offers `s Start` for the installed Runtime. `m Managed`
+and `c Source` remain advanced source-development controls and are hidden from
+the ordinary stopped action bar when a bundle is available.
 
 `openalice run` and compatibility `openalice start` stay in the foreground and
 own the Guardian lifetime; `Ctrl+C` stops their self-owned local Runtime. The

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -15,27 +15,30 @@ this guide is the OpenAlice contract.
 
 ## Status
 
-The repository now contains the source-backed Stage 0 through Stage 2 path:
+The repository now contains the bundle-backed Stage 0 through Stage 2 path,
+with source checkout support retained as an explicit development fallback:
 
-- `openalice start` prepares a source checkout, runs Guardian in the
-  foreground, and optionally opens the local browser;
+- `openalice up|run` prefers the installer-owned headless Runtime bundle and
+  starts Guardian without requiring a checkout or a current working directory;
+- `openalice start` remains a compatibility entry point and follows the same
+  installed-Runtime preference;
 - `openalice up|run|status|open|down` provides the canonical local Shell
   lifecycle and presentation over the same `cli-server` Guardian owner;
 - `openalice ssh <target>` creates a loopback SSH tunnel to an already-running
   remote OpenAlice Runtime;
 - `openalice server run|start|status|stop` provides a browserless foreground or
   detached Runtime lifecycle backed by Guardian's local control endpoint;
-- `openalice remote <target>` probes, plans, installs the ordinary CLI when
-  approved, installs missing Linux source-build tools, atomically creates or
-  fast-forwards a managed checkout when needed, starts or reuses the remote
-  Server, and opens the same loopback tunnel;
+- `openalice remote <target>` probes, plans, installs the ordinary CLI plus its
+  matching Runtime bundle when approved, starts or reuses the remote Server,
+  and opens the same loopback tunnel; explicit source providers still prepare
+  build tools and checkouts when needed;
 - Electron remains a complete local desktop distribution.
 
-These commands are source-backed behavior distributed by the selected CLI
-lane, not a standalone headless release. The clean Docker SSH acceptance covers the
-management and tunnel loop; real long-latency Agent TUI measurements remain a
-separate release observation rather than a reason to invent a new terminal
-protocol preemptively.
+The release-owned installer advances CLI, managed Pi, and the platform Runtime
+as one OpenAlice version. The clean Docker SSH acceptance covers bundle
+download, install, management, and the tunnel loop. Real long-latency Agent TUI
+measurements remain a separate release observation rather than a reason to
+invent a new terminal protocol preemptively.
 
 ## Product Decision
 
@@ -100,7 +103,9 @@ protocol is deferred until the local/server boundary is stable.
 9. Remote bootstrap reuses the invoking local CLI's recorded ordinary
    installer source, selector, and installed content identity. It does not
    carry a second SSH-only installer or upload the full OpenAlice Runtime
-   through SSH. A missing managed checkout clones directly on the remote host.
+   through SSH. The ordinary installer downloads the matching platform Runtime
+   directly on the remote host. An explicitly selected source provider clones
+   directly on that host when its checkout is missing.
 10. Shared Runtime facts use presentation-neutral names and versioned schemas.
     Browser layout, Electron chrome, modal state, and other client UI state do
     not become server truth.
@@ -206,9 +211,9 @@ openalice remote <target>
 
 1. verify ordinary SSH connectivity and host-key policy;
 2. detect remote platform, home, and an installed `openalice` CLI;
-3. select the explicit `--app-dir` or a selector-specific managed checkout
-   beneath remote `OPENALICE_HOME`;
-4. probe `openalice server status --json`, source state, and protocol
+3. select a compatible installed Runtime bundle, or the explicit `--app-dir`
+   or selector-specific managed checkout used by a source provider;
+4. probe `openalice server status --json`, Runtime provider state, and protocol
    compatibility;
 5. compare the remote CLI version, installer source/selector, and immutable
    installed content identity with the invoking local CLI;
@@ -216,9 +221,11 @@ openalice remote <target>
    separately before calling the normal installer on the remote host;
 7. re-probe and re-plan after installation so a newly visible owner can block
    or require a second explicit takeover decision;
-8. clone a missing managed checkout atomically, or fast-forward a clean managed
-   branch checkout and rebuild after the plan names that update;
-9. run `openalice server start --app-dir ...` remotely and wait for readiness;
+8. when an explicit source provider is selected, clone a missing managed
+   checkout atomically, or fast-forward a clean managed branch checkout and
+   rebuild after the plan names that update;
+9. run `openalice server start` with the selected installed Runtime or explicit
+   source root and wait for readiness;
 10. create the same loopback tunnel used by `openalice ssh`;
 11. reuse the last successful local port for this target and remote home when it
    is available, so an existing browser tab can reconnect to the same origin;
@@ -240,15 +247,15 @@ openalice remote <target> --stop
 
 Neither command conflates “disconnect” with “stop my remote work.”
 
-When `--app-dir` is absent, the source-backed phase selects a private managed
-checkout beneath the remote home. A missing checkout is cloned only after the
-visible plan is approved. A clean managed branch checkout is compared with its
-selected upstream; an available fast-forward is planned together with a Server
-restart and rebuild. Tracked changes block that update. An explicit
+When `--app-dir` is absent, managed remote prefers the verified Runtime bundle
+installed with the matching CLI. No Git checkout or compiler is needed. On a
+lane or platform without that artifact it can fall back to a private managed
+checkout beneath the remote home. A missing fallback checkout is cloned only
+after the visible plan is approved. A clean managed branch checkout is compared
+with its selected upstream; an available fast-forward is planned together with
+a Server restart and rebuild. Tracked changes block that update. An explicit
 `--app-dir` is user-owned: it may be cloned when wholly absent, but existing
-source is never fetched, switched, reset, or overwritten. A future headless
-release bundle can remove the source-checkout requirement without changing the
-command or lifecycle contract.
+source is never fetched, switched, reset, or overwritten.
 
 `--yes` may approve the displayed install/update/start plan for automation, but
 it never implies `--takeover`. Non-interactive execution without a sufficient
@@ -549,9 +556,11 @@ The read-only plan reports:
 - detected OpenAlice CLI path, version, and whether its install source and
   content identity match the invoking local CLI;
 - control protocol compatibility;
-- Server state and source/bundle root;
-- whether the selected source checkout already has complete Runtime artifacts;
-- whether source will be cloned, is user-owned, or has a safe managed
+- Server state, Runtime provider, bundle identity, and source/bundle root;
+- whether an installed bundle matches the CLI product version, platform, and
+  architecture;
+- for a source provider, whether its checkout already has complete Runtime
+  artifacts and whether it will be cloned, is user-owned, or has a safe managed
   fast-forward available;
 - missing Git, Python 3, make, or C++ tools and the package-manager action that
   would provide them;
@@ -562,9 +571,12 @@ The read-only plan reports:
 
 Apply rules:
 
-1. no matching compatible CLI: ask before invoking the normal installer with
-   the local CLI's recorded branch/tag/commit selector;
-2. source artifacts absent and Linux build tools missing: include
+1. no matching compatible CLI or Runtime: ask before invoking the normal
+   installer with the local CLI's recorded branch/tag/commit selector and
+   expected product version; the installer obtains the matching platform
+   Runtime from the same release;
+2. an explicitly selected source provider with absent artifacts and missing
+   Linux build tools: include
    `--with-runtime-deps` in that same normal installer invocation after plan
    consent;
 3. complete source artifacts: do not modify system packages merely because a
@@ -643,13 +655,14 @@ Runtime model.
 - stop is structured and self-owned;
 - Electron behavior remains unchanged.
 
-### Stage 2 — managed source-backed remote (implemented baseline)
+### Stage 2 — managed bundle-backed remote (implemented baseline)
 
 - `openalice remote` plan/apply orchestration;
-- probe and bootstrap the existing CLI plus pinned managed Pi with explicit
-  consent;
-- choose, atomically clone, and safely fast-forward selector-specific managed
-  source without requiring manual SSH setup;
+- probe and bootstrap the existing CLI, pinned managed Pi, and matching
+  headless Runtime with explicit consent;
+- prefer the installed release Runtime without Git or build tools;
+- retain source-provider selection, atomic clone, and safe fast-forward for
+  development and unsupported release lanes;
 - when an older healthy CLI Server lacks managed Pi, infer its recorded source
   root, install Pi, stop that self-owned Server through `runtime.stop`, and
   restart it so the Guardian tree inherits the managed runtime;
@@ -658,6 +671,17 @@ Runtime model.
 - leave the Server alive after disconnect;
 - remaining release observation: validate ordinary Agent TUI interaction under
   representative network shaping before deciding whether Stage 3 is useful.
+
+#### Bundle-backed Linux SSH observation — 2026-07-30
+
+The disposable OrbStack Docker SSH fixture exercised an ordinary Linux arm64
+remote with no source checkout. The remote plan detected the missing CLI, the
+normal installer downloaded and verified the matching Runtime archive, and the
+refreshed plan selected `provider=bundle` beneath `cli-versions/` without Git,
+Python, make, or a compiler. Detached readiness, `/api/auth/status`, tunnel
+disconnect persistence, managed Pi repair with a self-owned restart, same-port
+reconnect, status, and structured stop all passed. The fixture also asserted
+that no managed source checkout was created.
 
 #### Railway cold-host observation — 2026-07-15
 
@@ -762,10 +786,12 @@ permission to reclaim a shared volume.
 - consider relay/device enrollment only after direct SSH is operationally
   understood.
 
-### Stage 5 — standalone headless Runtime bundle
+### Stage 5 — standalone headless Runtime hardening (in progress)
 
-- replace source checkout preparation with signed, content-addressed release
-  assets where supported;
+- the initial content-addressed platform archive, hashed manifest, installer
+  integration, and managed-remote selection are implemented;
+- add release signature/provenance verification and reproducible-build
+  evidence before describing the asset as cryptographically authenticated;
 - retain the same `server` and `remote` commands, status schema, state root, and
   consent model;
 - keep source-backed development as a supported diagnostic path.
@@ -798,7 +824,9 @@ permission to reclaim a shared volume.
 | missing remote CLI, interactive | shows plan; default no leaves host unchanged |
 | missing remote CLI, non-interactive | fails unless explicit approval is present |
 | incompatible running Server | explains process impact before update/restart |
-| managed remote source missing | plan names the exact clone destination and selector; default no leaves it absent |
+| matching installed Runtime bundle | plan selects it without a checkout or build-tool mutation |
+| missing remote CLI and Runtime | ordinary installer obtains matching platform artifacts; default no leaves the host unchanged |
+| managed remote source fallback missing | plan names the exact clone destination and selector; default no leaves it absent |
 | explicit source path missing | plan may clone only that exact path; an occupied non-OpenAlice path is refused |
 | managed branch advanced | clean checkout fast-forwards, rebuilds, and restarts; tracked changes block without overwrite |
 | source artifacts missing, build tools missing | plan names the tools and normal installer command; default no leaves packages untouched |

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -40,13 +40,14 @@ On the remote host:
 - Linux or macOS;
 - Node.js `22.19.0` or newer;
 - `curl`;
-- enough disk and memory for the source Runtime.
+- enough disk and memory for the installed Runtime.
 
-The remote plan can install missing Git, Python 3, make, and C++ tools on
-supported Linux hosts after showing the exact package-manager command. On
-macOS, install Command Line Tools locally with `xcode-select --install` when
-the plan asks for them. OpenAlice does not install Node.js or configure SSH
-keys for you.
+The release Runtime does not require Git or source-build tools. If you
+explicitly select a source checkout, the remote plan can install missing Git,
+Python 3, make, and C++ tools on supported Linux hosts after showing the exact
+package-manager command. On macOS, install Command Line Tools locally with
+`xcode-select --install` when that source plan asks for them. OpenAlice does
+not install Node.js or configure SSH keys for you.
 
 ## 1. Install the CLI on Your Laptop
 
@@ -95,19 +96,17 @@ openalice remote openalice-box --plan
 ```
 
 The read-only plan reports the remote platform, Node.js, CLI and Pi, Runtime
-owner, source location, build tools, ports, and every proposed change. On a
-new host it normally includes:
+owner and provider, ports, and every proposed change. On a new supported host
+it normally includes:
 
-1. install the matching OpenAlice CLI and managed Pi;
-2. install missing Linux source-build tools, when needed;
-3. clone a matching managed source checkout;
-4. build and start the detached OpenAlice Server;
-5. open a local loopback tunnel.
+1. install the matching OpenAlice CLI, managed Pi, and platform Runtime;
+2. verify and start the detached OpenAlice Server from that immutable Runtime;
+3. open a local loopback tunnel.
 
-The managed checkout lives below the selected remote `OPENALICE_HOME`, under a
-selector-specific `sources/` directory. You do not need to SSH in, clone the
-repository, find its absolute path, or repeat `--app-dir` on later connections.
-Nothing changes until you approve the plan.
+The installed Runtime lives in the installer's immutable `cli-versions/`
+release directory. You do not need to SSH in, clone the repository, install a
+compiler, find an absolute source path, or repeat `--app-dir` on later
+connections. Nothing changes until you approve the plan.
 
 ## 4. Connect
 
@@ -155,15 +154,16 @@ platform-neutral message. Raw platform diagnostics are shown only when the
 connection finally fails, so a provider's temporary SSH control-plane noise
 does not become the normal OpenAlice experience.
 
-## Managed and User-Owned Source
+## Installed Runtime and User-Owned Source
 
-The default managed checkout is maintained by OpenAlice:
+The default installed Runtime is maintained by the ordinary OpenAlice
+installer:
 
-- a missing checkout is cloned atomically after consent;
-- a clean branch checkout is compared with its selected upstream on reconnect;
-- an available fast-forward is shown in the plan, then applied with a Server
-  restart and source rebuild;
-- tracked local changes block the managed update instead of being overwritten.
+- the CLI, managed Pi, and Runtime carry the same OpenAlice product version;
+- archives are selected for the remote platform and architecture;
+- the archive checksum and internal file manifest are verified before
+  activation;
+- reconnect reuses a compatible healthy Runtime without mutation.
 
 For development or a deliberately pinned checkout, pass your own absolute
 path:
@@ -191,7 +191,7 @@ openalice remote openalice-box --no-open
 openalice remote alice@server.example.com \
   --identity ~/.ssh/id_ed25519
 
-# Put durable state and the managed source on a mounted volume.
+# Put durable state on a mounted volume.
 openalice remote openalice-box \
   --home /data/openalice-home
 ```
@@ -204,7 +204,7 @@ openalice remote openalice-box \
 - Provider credentials, Workspace history, files, and Agent state live under
   the remote home; the browser is not a backup.
 - For an ephemeral VM or container, place `--home` on persistent storage. The
-  managed source then follows that home onto the same volume.
+  Runtime can be reinstalled; the home is the durable state that must survive.
 - A platform replacement can reattach a volume whose Guardian lock names the
   removed machine. OpenAlice refuses cross-machine takeover automatically;
   confirm the previous instance is gone before following the operator recovery

--- a/install
+++ b/install
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPOSITORY="TraderAlice/OpenAlice"
 DEFAULT_BRANCH="master"
+OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"
 PUBLIC_INSTALLER_URL="https://openalice.ai/install"
 VERSION=""
 REF_KIND=""
@@ -16,6 +17,17 @@ PI_LOCK_SHA256="f5cb41dcfc60561ba54490b49c17beecec202900f73eb5f104b34f8b2a79a0af
 PI_ASSET_SOURCE_DIR="${OPENALICE_PI_SOURCE_DIR:-}"
 NPM_BIN="${OPENALICE_NPM_BIN:-npm}"
 SOURCE_DIR=""
+RUNTIME_ARCHIVE="${OPENALICE_RUNTIME_ARCHIVE:-}"
+RUNTIME_ARCHIVE_SHA256="${OPENALICE_RUNTIME_ARCHIVE_SHA256:-}"
+RUNTIME_CONTENT_IDENTITY=""
+RUNTIME_PRODUCT_VERSION=""
+RUNTIME_PLATFORM=""
+RUNTIME_ARCH=""
+RUNTIME_AUTO_DOWNLOAD=0
+RUNTIME_RELEASE_BASE_URL=""
+RUNTIME_ARCHIVE_FILE=""
+RUNTIME_ARCHIVE_SIZE=0
+RUNTIME_ARCHIVE_SIZE_LABEL=""
 MODIFY_PATH=1
 ASSUME_YES=0
 PLAN_ONLY=0
@@ -114,6 +126,10 @@ Options:
   --version <git-ref>   Git tag or commit to install
   --install-dir <path>  OpenAlice user root (default: ~/.openalice)
   --source <path>       Install CLI files from a local checkout (development)
+  --runtime-archive <path>
+                        Install a local platform Runtime archive (development)
+  --runtime-sha256 <hex>
+                        Require this SHA-256 for --runtime-archive
   --with-runtime-deps   Install missing Linux source-build tools after consent
   --no-modify-path      Do not update the shell profile
   --plan                Show the install plan and exit without changing files
@@ -394,6 +410,16 @@ while [[ $# -gt 0 ]]; do
       SOURCE_DIR="$2"
       shift 2
       ;;
+    --runtime-archive)
+      [[ $# -ge 2 ]] || { echo "openalice install: --runtime-archive requires a value" >&2; exit 1; }
+      RUNTIME_ARCHIVE="$2"
+      shift 2
+      ;;
+    --runtime-sha256)
+      [[ $# -ge 2 ]] || { echo "openalice install: --runtime-sha256 requires a value" >&2; exit 1; }
+      RUNTIME_ARCHIVE_SHA256="$2"
+      shift 2
+      ;;
     --no-modify-path)
       MODIFY_PATH=0
       shift
@@ -423,8 +449,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$VERSION" ]]; then
-  VERSION="$DEFAULT_BRANCH"
-  REF_KIND="branch"
+  if [[ -n "$OPENALICE_INSTALLER_RELEASE_VERSION" ]]; then
+    VERSION="v$OPENALICE_INSTALLER_RELEASE_VERSION"
+    REF_KIND="version"
+  else
+    VERSION="$DEFAULT_BRANCH"
+    REF_KIND="branch"
+  fi
 fi
 
 if [[ ${#VERSION} -gt 128 || "$VERSION" == *".."* || ! "$VERSION" =~ ^[A-Za-z0-9._/-]+$ ]]; then
@@ -447,6 +478,33 @@ if [[ -n "$SOURCE_DIR" ]]; then
   if ! SOURCE_DIR="$(cd "$SOURCE_DIR" 2>/dev/null && pwd)"; then
     die "Local source checkout not found: $source_argument"
   fi
+fi
+
+if [[ -n "$RUNTIME_ARCHIVE" ]]; then
+  runtime_archive_argument="$RUNTIME_ARCHIVE"
+  runtime_archive_dir="$(dirname "$RUNTIME_ARCHIVE")"
+  runtime_archive_name="$(basename "$RUNTIME_ARCHIVE")"
+  if ! runtime_archive_dir="$(cd "$runtime_archive_dir" 2>/dev/null && pwd)"; then
+    die "Runtime archive directory not found: $runtime_archive_argument"
+  fi
+  RUNTIME_ARCHIVE="$runtime_archive_dir/$runtime_archive_name"
+  [[ -f "$RUNTIME_ARCHIVE" ]] || die "Runtime archive not found: $runtime_archive_argument"
+fi
+if [[ -n "$RUNTIME_ARCHIVE_SHA256" && -z "$RUNTIME_ARCHIVE" ]]; then
+  die "--runtime-sha256 requires --runtime-archive."
+fi
+if [[ -n "$RUNTIME_ARCHIVE_SHA256" && ! "$RUNTIME_ARCHIVE_SHA256" =~ ^[a-fA-F0-9]{64}$ ]]; then
+  die "--runtime-sha256 must be exactly 64 hexadecimal characters."
+fi
+runtime_release_version="$OPENALICE_INSTALLER_RELEASE_VERSION"
+if [[ -z "$runtime_release_version" && -n "${OPENALICE_EXPECTED_CLI_VERSION:-}" ]]; then
+  runtime_release_version="$OPENALICE_EXPECTED_CLI_VERSION"
+fi
+if [[ -z "$RUNTIME_ARCHIVE" && -n "$runtime_release_version" ]]; then
+  RUNTIME_AUTO_DOWNLOAD=1
+  runtime_release_tag="v$runtime_release_version"
+  RUNTIME_RELEASE_BASE_URL="${OPENALICE_RUNTIME_RELEASE_BASE_URL:-https://github.com/$REPOSITORY/releases/download/$runtime_release_tag}"
+  RUNTIME_RELEASE_BASE_URL="${RUNTIME_RELEASE_BASE_URL%/}"
 fi
 
 path_present=0
@@ -510,6 +568,12 @@ if ! node_version_supported; then
   die "Node.js $MINIMUM_NODE_VERSION or newer is required for OpenAlice and managed Pi (found $(node --version))."
 fi
 ok "Node.js $(node --version)"
+RUNTIME_PLATFORM="$(node -p 'process.platform')"
+RUNTIME_ARCH="$(node -p 'process.arch')"
+case "$RUNTIME_PLATFORM-$RUNTIME_ARCH" in
+  darwin-arm64|darwin-x64|linux-arm64|linux-x64) ;;
+  *) RUNTIME_AUTO_DOWNLOAD=0 ;;
+esac
 
 if ! node -e '
   const url = new URL(process.argv[1]);
@@ -528,11 +592,18 @@ elif ! command -v "$NPM_BIN" >/dev/null 2>&1; then
 fi
 ok "npm is available for managed Pi"
 
-if [[ ( -z "$SOURCE_DIR" || -z "$PI_ASSET_SOURCE_DIR" ) ]] && ! command -v curl >/dev/null 2>&1; then
-  die "curl is required to download the OpenAlice and managed Pi files."
-fi
 if [[ -n "$SOURCE_DIR" ]]; then
   [[ -f "$SOURCE_DIR/packages/cli/package.json" ]] || die "OpenAlice CLI sources are missing under $SOURCE_DIR"
+  source_cli_version="$(node -e '
+    const manifest = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+    if (manifest.name !== "@traderalice/openalice-cli" || typeof manifest.version !== "string") process.exit(1);
+    process.stdout.write(manifest.version);
+  ' "$SOURCE_DIR/packages/cli/package.json")" \
+    || die "The local package manifest is not an OpenAlice CLI package"
+  if [[ -n "${OPENALICE_EXPECTED_CLI_VERSION:-}" \
+    && "$source_cli_version" != "$OPENALICE_EXPECTED_CLI_VERSION" ]]; then
+    die "The downloaded CLI reported $source_cli_version instead of expected release $OPENALICE_EXPECTED_CLI_VERSION"
+  fi
   ok "Local checkout is readable"
   install_source="Local checkout: $SOURCE_DIR"
 else
@@ -546,6 +617,42 @@ else
   else
     install_source="GitHub ref: $REPOSITORY@$VERSION"
   fi
+fi
+
+if [[ ( -z "$SOURCE_DIR" || -z "$PI_ASSET_SOURCE_DIR" || "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ) ]] && ! command -v curl >/dev/null 2>&1; then
+  die "curl is required to download the OpenAlice and managed Pi files."
+fi
+if [[ "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ]]; then
+  runtime_metadata_file="openalice-runtime-${runtime_release_version}-${RUNTIME_PLATFORM}-${RUNTIME_ARCH}.json"
+  runtime_metadata_json="$(curl --fail --silent --show-error --location --retry 3 --connect-timeout 15 \
+    "$RUNTIME_RELEASE_BASE_URL/$runtime_metadata_file")" \
+    || die "Could not download OpenAlice Runtime release metadata"
+  RUNTIME_ARCHIVE_FILE="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    const [version, platform, arch] = process.argv.slice(2);
+    if (value.schemaVersion !== 1
+      || value.productVersion !== version
+      || value.platform !== platform
+      || value.arch !== arch
+      || typeof value.archive?.file !== "string"
+      || !/^openalice-runtime-[0-9A-Za-z.+_-]+-(darwin|linux)-(arm64|x64)-[a-f0-9]{16}\.tar\.gz$/.test(value.archive.file)
+      || !Number.isSafeInteger(value.archive.size)
+      || value.archive.size <= 0
+      || !/^[a-f0-9]{64}$/.test(value.archive.sha256 ?? "")) process.exit(1);
+    process.stdout.write(value.archive.file);
+  ' "$runtime_metadata_json" "$runtime_release_version" "$RUNTIME_PLATFORM" "$RUNTIME_ARCH")" \
+    || die "OpenAlice Runtime release metadata is invalid"
+  RUNTIME_ARCHIVE_SHA256="$(node -e '
+    process.stdout.write(JSON.parse(process.argv[1]).archive.sha256);
+  ' "$runtime_metadata_json")"
+  RUNTIME_ARCHIVE_SIZE="$(node -e '
+    process.stdout.write(String(JSON.parse(process.argv[1]).archive.size));
+  ' "$runtime_metadata_json")"
+  RUNTIME_ARCHIVE_SIZE_LABEL="$(node -e '
+    const bytes = Number(process.argv[1]);
+    const mib = bytes / 1024 / 1024;
+    process.stdout.write(`${mib.toFixed(mib >= 100 ? 0 : 1)} MiB`);
+  ' "$RUNTIME_ARCHIVE_SIZE")"
 fi
 
 if [[ -n "$PI_ASSET_SOURCE_DIR" ]]; then
@@ -564,7 +671,14 @@ probe_runtime_deps
 runtime_deps_ready=0
 [[ ${#RUNTIME_MISSING[@]} -gt 0 ]] || runtime_deps_ready=1
 resolve_runtime_deps_plan || true
-if [[ "$runtime_deps_ready" -eq 1 ]]; then
+if [[ -n "$RUNTIME_ARCHIVE" || "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ]]; then
+  runtime_deps_ready=1
+  RUNTIME_MISSING=()
+  RUNTIME_DEPS_BLOCKER=""
+fi
+if [[ -n "$RUNTIME_ARCHIVE" || "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ]]; then
+  ok "Prebuilt Runtime selected; source build tools are not needed"
+elif [[ "$runtime_deps_ready" -eq 1 ]]; then
   ok "Source Runtime build tools are available"
 else
   warn "Source Runtime build tools are missing: $(runtime_missing_text)"
@@ -582,7 +696,9 @@ if [[ "$WITH_RUNTIME_DEPS" -eq 0 && "$PLAN_ONLY" -eq 0 && "$ASSUME_YES" -eq 0 \
   fi
 fi
 
-if [[ "$runtime_deps_ready" -eq 1 ]]; then
+if [[ -n "$RUNTIME_ARCHIVE" || "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ]]; then
+  runtime_setup="Not needed (prebuilt Runtime)"
+elif [[ "$runtime_deps_ready" -eq 1 ]]; then
   runtime_setup="Already ready"
 elif [[ "$WITH_RUNTIME_DEPS" -eq 1 && -z "$RUNTIME_DEPS_BLOCKER" ]]; then
   runtime_setup="Install $(runtime_missing_text)"
@@ -605,6 +721,11 @@ printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-14s %s\n' "Managed agent" "Pi $PI_VERSION -> $BIN_DIR/pi"
 printf '  %-14s %s\n' "Pi source" "$pi_install_source"
 printf '  %-14s %s\n' "Pi install" "$NPM_BIN ci --omit=dev --ignore-scripts --no-audit --no-fund"
+if [[ -n "$RUNTIME_ARCHIVE" ]]; then
+  printf '  %-14s %s\n' "Runtime" "$RUNTIME_ARCHIVE"
+elif [[ "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ]]; then
+  printf '  %-14s %s\n' "Runtime" "OpenAlice $runtime_release_version ($RUNTIME_PLATFORM-$RUNTIME_ARCH, $RUNTIME_ARCHIVE_SIZE_LABEL)"
+fi
 printf '  %-14s %s\n' "Shell setup" "$shell_setup"
 printf '  %-14s %s\n' "Runtime tools" "$runtime_setup"
 if [[ "$WITH_RUNTIME_DEPS" -eq 1 && "$runtime_deps_ready" -eq 0 && -n "$RUNTIME_DEPS_COMMAND" ]]; then
@@ -683,6 +804,7 @@ FILES=(
   "src/observability-command.mjs"
   "src/remote.mjs"
   "src/runtime-deps.mjs"
+  "src/runtime-bundle.mjs"
   "src/runtime-client.mjs"
   "src/server.mjs"
   "src/server-control.mjs"
@@ -725,6 +847,64 @@ fi
   || die "Managed Pi package-lock.json failed SHA-256 verification"
 ok "Pinned Pi $PI_VERSION assets passed SHA-256 verification"
 
+if [[ "$RUNTIME_AUTO_DOWNLOAD" -eq 1 ]]; then
+  RUNTIME_ARCHIVE="$STAGING/$RUNTIME_ARCHIVE_FILE"
+  curl --fail --silent --show-error --location --retry 3 --connect-timeout 15 \
+    "$RUNTIME_RELEASE_BASE_URL/$RUNTIME_ARCHIVE_FILE" \
+    --output "$RUNTIME_ARCHIVE"
+  [[ "$(node -p "require('node:fs').statSync(process.argv[1]).size" "$RUNTIME_ARCHIVE")" == "$RUNTIME_ARCHIVE_SIZE" ]] \
+    || die "OpenAlice Runtime archive size does not match release metadata"
+fi
+
+if [[ -n "$RUNTIME_ARCHIVE" ]]; then
+  runtime_archive_actual_sha256="$(file_sha256 "$RUNTIME_ARCHIVE")"
+  runtime_archive_expected_sha256="$(printf '%s' "$RUNTIME_ARCHIVE_SHA256" | tr 'A-F' 'a-f')"
+  if [[ -n "$RUNTIME_ARCHIVE_SHA256" \
+    && "$runtime_archive_actual_sha256" != "$runtime_archive_expected_sha256" ]]; then
+    die "OpenAlice Runtime archive failed SHA-256 verification"
+  fi
+  mkdir -p "$STAGING/managed/runtime"
+  if ! tar -tzf "$RUNTIME_ARCHIVE" | node -e '
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { input += chunk; });
+    process.stdin.on("end", () => {
+      const entries = input.split(/\r?\n/).filter(Boolean);
+      if (entries.length === 0) process.exit(1);
+      for (const entry of entries) {
+        const normalized = entry.replace(/^\.\//, "");
+        if (normalized !== "openalice-runtime"
+          && normalized !== "openalice-runtime/"
+          && !normalized.startsWith("openalice-runtime/")) process.exit(1);
+        if (normalized.split("/").includes("..") || normalized.startsWith("/")) process.exit(1);
+      }
+    });
+  '; then
+    die "OpenAlice Runtime archive contains an unsafe or unexpected path"
+  fi
+  tar -xzf "$RUNTIME_ARCHIVE" \
+    -C "$STAGING/managed/runtime" \
+    --strip-components 1
+  runtime_manifest_json="$(node "$STAGING/src/runtime-bundle.mjs" verify \
+    "$STAGING/managed/runtime" \
+    --platform "$RUNTIME_PLATFORM" \
+    --arch "$RUNTIME_ARCH")" \
+    || die "OpenAlice Runtime bundle verification failed"
+  RUNTIME_CONTENT_IDENTITY="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (!/^[a-f0-9]{16}$/.test(value.contentIdentity ?? "")) process.exit(1);
+    process.stdout.write(value.contentIdentity);
+  ' "$runtime_manifest_json")" \
+    || die "OpenAlice Runtime bundle did not report a valid content identity"
+  RUNTIME_PRODUCT_VERSION="$(node -e '
+    const value = JSON.parse(process.argv[1]);
+    if (typeof value.productVersion !== "string") process.exit(1);
+    process.stdout.write(value.productVersion);
+  ' "$runtime_manifest_json")" \
+    || die "OpenAlice Runtime bundle did not report a product version"
+  ok "OpenAlice Runtime $RUNTIME_PLATFORM-$RUNTIME_ARCH passed verification ($RUNTIME_CONTENT_IDENTITY)"
+fi
+
 step 4 "Installing the managed Pi runtime"
 (
   cd "$STAGING/managed/pi"
@@ -758,6 +938,7 @@ node --check "$STAGING/src/logs.mjs"
 node --check "$STAGING/src/observability-command.mjs"
 node --check "$STAGING/src/remote.mjs"
 node --check "$STAGING/src/runtime-deps.mjs"
+node --check "$STAGING/src/runtime-bundle.mjs"
 node --check "$STAGING/src/runtime-client.mjs"
 node --check "$STAGING/src/server.mjs"
 node --check "$STAGING/src/server-control.mjs"
@@ -773,6 +954,9 @@ CLI_VERSION="$(node -e '
 if [[ -n "${OPENALICE_EXPECTED_CLI_VERSION:-}" \
   && "$CLI_VERSION" != "$OPENALICE_EXPECTED_CLI_VERSION" ]]; then
   die "The downloaded CLI reported $CLI_VERSION instead of expected release $OPENALICE_EXPECTED_CLI_VERSION"
+fi
+if [[ -n "$RUNTIME_PRODUCT_VERSION" && "$RUNTIME_PRODUCT_VERSION" != "$CLI_VERSION" ]]; then
+  die "The Runtime bundle reports OpenAlice $RUNTIME_PRODUCT_VERSION, but the CLI reports $CLI_VERSION"
 fi
 STAGED_VERSION="$(node "$STAGING/bin/openalice.ts" --version)"
 [[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
@@ -803,6 +987,8 @@ node "$STAGING/bin/openalice.ts" version --json | node -e '
 ' "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$CLI_VERSION" \
   || die "The downloaded CLI did not preserve its installation source"
 CONTENT_FILES=("${FILES[@]}" "install-source.json" "managed/pi/package.json" "managed/pi/package-lock.json")
+# Keep the CLI identity stable across operating systems. The platform-specific
+# Runtime has its own manifest identity and is verified independently below.
 CONTENT_ID="$(content_id "$STAGING" "${CONTENT_FILES[@]}")"
 ok "OpenAlice CLI $CLI_VERSION passed validation ($CONTENT_ID)"
 
@@ -813,7 +999,22 @@ if [[ -e "$DESTINATION" ]]; then
   destination_pi_version="$(node "$DESTINATION/$PI_RELATIVE_ENTRY" --version 2>/dev/null || true)"
   if [[ -d "$DESTINATION" \
     && "$(content_id "$DESTINATION" "${CONTENT_FILES[@]}" 2>/dev/null || true)" == "$CONTENT_ID" \
-    && "$destination_pi_version" == "$PI_VERSION" ]]; then
+    && "$destination_pi_version" == "$PI_VERSION" \
+    && ( -z "$RUNTIME_CONTENT_IDENTITY" \
+      || "$(node "$DESTINATION/src/runtime-bundle.mjs" verify \
+        "$DESTINATION/managed/runtime" \
+        --platform "$RUNTIME_PLATFORM" \
+        --arch "$RUNTIME_ARCH" 2>/dev/null \
+        | node -e '
+          let input = "";
+          process.stdin.setEncoding("utf8");
+          process.stdin.on("data", (chunk) => { input += chunk; });
+          process.stdin.on("end", () => {
+            try {
+              process.stdout.write(JSON.parse(input).contentIdentity ?? "");
+            } catch {}
+          });
+        ')" == "$RUNTIME_CONTENT_IDENTITY" ) ]]; then
     rm -rf "$STAGING"
     STAGING=""
     ok "Reusing the already-verified OpenAlice and Pi release"
@@ -831,14 +1032,21 @@ fi
 
 CLI_ENTRY="$DESTINATION/bin/openalice.ts"
 PI_ENTRY="$DESTINATION/$PI_RELATIVE_ENTRY"
+RUNTIME_ENTRY="$DESTINATION/managed/runtime"
 printf -v quoted_cli_entry '%q' "$CLI_ENTRY"
 printf -v quoted_pi_entry '%q' "$PI_ENTRY"
+printf -v quoted_runtime_entry '%q' "$RUNTIME_ENTRY"
 SHELL_LAUNCHER_TEMP="$BIN_DIR/.openalice.$$.tmp"
 CMD_LAUNCHER_TEMP="$BIN_DIR/.openalice.$$.cmd.tmp"
 PI_SHELL_LAUNCHER_TEMP="$BIN_DIR/.pi.$$.tmp"
 PI_CMD_LAUNCHER_TEMP="$BIN_DIR/.pi.$$.cmd.tmp"
-printf '#!/usr/bin/env bash\n# OpenAlice CLI launcher with managed Pi\nnode_binary="$(command -v node)" || { printf "OpenAlice requires Node.js.\\n" >&2; exit 1; }\nexport OPENALICE_MANAGED_PI_PATH=%s\nexport OPENALICE_MANAGED_PI_NODE_PATH="$node_binary"\nexec "$node_binary" %s "$@"\n' \
-  "$quoted_pi_entry" "$quoted_cli_entry" > "$SHELL_LAUNCHER_TEMP"
+if [[ -n "$RUNTIME_CONTENT_IDENTITY" ]]; then
+  printf '#!/usr/bin/env bash\n# OpenAlice CLI launcher with managed Pi and Runtime\nnode_binary="$(command -v node)" || { printf "OpenAlice requires Node.js.\\n" >&2; exit 1; }\nexport OPENALICE_MANAGED_PI_PATH=%s\nexport OPENALICE_MANAGED_PI_NODE_PATH="$node_binary"\nexport OPENALICE_MANAGED_RUNTIME_PATH=%s\nexport OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY=%q\nexec "$node_binary" %s "$@"\n' \
+    "$quoted_pi_entry" "$quoted_runtime_entry" "$RUNTIME_CONTENT_IDENTITY" "$quoted_cli_entry" > "$SHELL_LAUNCHER_TEMP"
+else
+  printf '#!/usr/bin/env bash\n# OpenAlice CLI launcher with managed Pi\nnode_binary="$(command -v node)" || { printf "OpenAlice requires Node.js.\\n" >&2; exit 1; }\nexport OPENALICE_MANAGED_PI_PATH=%s\nexport OPENALICE_MANAGED_PI_NODE_PATH="$node_binary"\nexec "$node_binary" %s "$@"\n' \
+    "$quoted_pi_entry" "$quoted_cli_entry" > "$SHELL_LAUNCHER_TEMP"
+fi
 chmod +x "$SHELL_LAUNCHER_TEMP"
 printf '#!/usr/bin/env bash\n# OpenAlice-managed Pi launcher\nnode_binary="$(command -v node)" || { printf "Pi requires Node.js.\\n" >&2; exit 1; }\nexec "$node_binary" %s "$@"\n' \
   "$quoted_pi_entry" > "$PI_SHELL_LAUNCHER_TEMP"
@@ -897,6 +1105,10 @@ printf '  %-12s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-12s %s\n' "CLI version" "$CLI_VERSION"
 printf '  %-12s %s\n' "Agent" "$BIN_DIR/pi"
 printf '  %-12s %s\n' "Pi version" "$PI_VERSION"
+if [[ -n "$RUNTIME_CONTENT_IDENTITY" ]]; then
+  printf '  %-12s %s\n' "Runtime" "$RUNTIME_PRODUCT_VERSION ($RUNTIME_PLATFORM-$RUNTIME_ARCH)"
+  printf '  %-12s %s\n' "Runtime ID" "$RUNTIME_CONTENT_IDENTITY"
+fi
 if [[ "$REF_KIND" == "branch" ]]; then
   printf '  %-12s %s\n' "Branch" "$VERSION"
 else
@@ -914,12 +1126,27 @@ if [[ -n "$existing_command" && "$existing_command" != "$BIN_DIR/openalice" ]]; 
 fi
 
 checkout=""
-if [[ "$INSTALL_CONTEXT" == "remote" ]]; then
+if [[ -n "$RUNTIME_CONTENT_IDENTITY" && "$INSTALL_CONTEXT" != "remote" ]]; then
+  printf '\n%bReady to launch%b\n' "$BOLD" "$RESET"
+  printf '  Local UI     Starts on an available loopback port\n'
+  printf '  Supervisor   Starts and manages the installed Runtime\n'
+  if [[ "$TTY_OPEN" -eq 1 ]]; then
+    start_status=0
+    prompt_yes_no "Open the OpenAlice Supervisor now?" || start_status=$?
+    if [[ "$start_status" -eq 0 ]]; then
+      exec 3>&- 3<&-
+      TTY_OPEN=0
+      printf '\nOpening the OpenAlice Supervisor...\n\n'
+      exec "$BIN_DIR/openalice"
+    fi
+  fi
+  printf '\nStart it when you are ready from any directory:\n  %s\n\n' "$BIN_DIR/openalice"
+elif [[ "$INSTALL_CONTEXT" == "remote" ]]; then
   printf '\nReturning to the approved remote setup plan.\n\n'
 else
   checkout="$(find_openalice_checkout 2>/dev/null || true)"
 fi
-if [[ -n "$checkout" ]]; then
+if [[ -z "$RUNTIME_CONTENT_IDENTITY" && -n "$checkout" ]]; then
   printf '\n%bReady to launch%b\n' "$BOLD" "$RESET"
   printf '  Checkout     %s\n' "$checkout"
   printf '  Local UI     http://127.0.0.1:47331\n'
@@ -936,7 +1163,7 @@ if [[ -n "$checkout" ]]; then
     fi
   fi
   printf '\nStart it when you are ready:\n  cd %q\n  %s\n\n' "$checkout" "$BIN_DIR/openalice"
-elif [[ "$INSTALL_CONTEXT" != "remote" ]]; then
+elif [[ -z "$RUNTIME_CONTENT_IDENTITY" && "$INSTALL_CONTEXT" != "remote" ]]; then
   printf '\n%bNext: open the OpenAlice Supervisor%b\n' "$BOLD" "$RESET"
   printf '  %s\n\n' "$BIN_DIR/openalice"
   printf 'Press %bm%b inside the Supervisor to prepare the managed Runtime source,\n' "$BOLD" "$RESET"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "turbo run build && tsup src/main.ts --format esm --dts",
     "prebuild:server": "tsx scripts/build-migration-index.ts",
     "build:server": "turbo run build --filter=!@traderalice/desktop --filter=!./packages/uta-broker-* && tsup src/main.ts --format esm --dts",
+    "build:headless-runtime": "tsx scripts/build-headless-runtime.ts",
     "build:migration-index": "tsx scripts/build-migration-index.ts",
     "broker-packs:build": "turbo run build --filter=./packages/uta-broker-* && tsx scripts/build-broker-packs.ts && pnpm broker-packs:verify",
     "broker-packs:upgrade-smoke": "tsx scripts/broker-pack-upgrade-smoke.ts",

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -30,10 +30,12 @@ export async function main(argv = process.argv.slice(2)) {
     return 0
   }
   if (command === 'version' && args[0] === '--json') {
+    const version = readVersion()
     process.stdout.write(`${JSON.stringify({
-      version: readVersion(),
+      version,
       installSource: await readInstallSource(),
       contentIdentity: installedContentIdentity(),
+      managedRuntime: installedRuntimeInfo(version),
     })}\n`)
     return 0
   }
@@ -127,6 +129,21 @@ Prints a completion script to stdout without modifying shell configuration.
   error.code = 'EUSAGE'
   error.exitCode = 2
   throw error
+}
+
+function installedRuntimeInfo(productVersion) {
+  const path = process.env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
+  const contentIdentity = process.env[
+    'OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY'
+  ]?.trim()
+  if (!path || !contentIdentity) return null
+  return {
+    productVersion,
+    platform: process.platform,
+    arch: process.arch,
+    path,
+    contentIdentity,
+  }
 }
 
 function readVersion() {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "src/observability-command.mjs",
     "src/remote.mjs",
     "src/runtime-deps.mjs",
+    "src/runtime-bundle.mjs",
     "src/runtime-client.mjs",
     "src/server.mjs",
     "src/server-control.mjs",
@@ -33,7 +34,7 @@
     "src/update.mjs"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/managed-source.ts && node --check src/supervisor-config.ts && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
+    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/managed-source.ts && node --check src/supervisor-config.ts && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-bundle.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -145,6 +145,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
         selector: { kind: 'version', value: 'test/ref' },
         installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/test/ref/install',
       },
+      managedRuntime: null,
     })
     await expect(access(join(installRoot, 'cli-versions', releases[0], 'install-source.json'))).resolves.toBeUndefined()
     const pi = await execFileAsync(join(installRoot, 'bin', 'pi'), ['--version'])

--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -99,6 +99,52 @@ describe('ResolvedLaunchContext', () => {
     expect(context.provenance.home.detail).toBe('OPENALICE_HOME')
   })
 
+  it('uses the installed Runtime below stored and explicit source overrides', () => {
+    const installed = resolveLaunchContext({
+      homeDir: '/home/alice',
+      cwd: '/repo',
+      platform: 'linux',
+      env: {
+        OPENALICE_MANAGED_RUNTIME_PATH: '/installed/runtime',
+        OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY: '0123456789abcdef',
+      },
+    })
+
+    expect(installed.appDir).toBe('/installed/runtime')
+    expect(installed.runtimeProvider).toEqual({
+      kind: 'bundle',
+      contentIdentity: '0123456789abcdef',
+    })
+    expect(installed.provenance.appDir).toEqual({
+      source: 'installed-runtime',
+      detail: 'installed OpenAlice Runtime',
+    })
+
+    const configured = resolveLaunchContext({
+      homeDir: '/home/alice',
+      cwd: '/repo',
+      platform: 'linux',
+      machineConfig: { defaults: { appDir: '/configured/source' } },
+      env: {
+        OPENALICE_MANAGED_RUNTIME_PATH: '/installed/runtime',
+        OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY: '0123456789abcdef',
+      },
+    })
+    expect(configured.appDir).toBe('/configured/source')
+    expect(configured.runtimeProvider).toEqual({
+      kind: 'source',
+      contentIdentity: null,
+    })
+  })
+
+  it('refuses an installed Runtime without its paired content identity', () => {
+    expect(() => resolveLaunchContext({
+      env: {
+        OPENALICE_MANAGED_RUNTIME_PATH: '/installed/runtime',
+      },
+    })).toThrow(/CONTENT_IDENTITY/)
+  })
+
   it('requires a complete home for a named non-default instance', () => {
     expect(() => resolveLaunchContext({
       homeDir: '/home/alice',

--- a/packages/cli/src/launch-context.ts
+++ b/packages/cli/src/launch-context.ts
@@ -6,6 +6,7 @@ const DEFAULT_PORT = 47_331
 
 export type LaunchValueSource =
   | 'default'
+  | 'installed-runtime'
   | 'machine-config'
   | 'instance-config'
   | 'environment'
@@ -42,6 +43,10 @@ export interface ResolvedLaunchContext {
   home: string
   port: number
   appDir: string | null
+  runtimeProvider: {
+    kind: 'source' | 'bundle'
+    contentIdentity: string | null
+  }
   updateChecks: boolean
   supervisorRoot: string
   managedPi: {
@@ -131,6 +136,13 @@ export function resolveLaunchContext(
   )
   const appDir = resolveField<string | null>(
     candidate(null, 'default', 'current working directory discovery'),
+    nullablePathCandidate(
+      env['OPENALICE_MANAGED_RUNTIME_PATH'],
+      'installed-runtime',
+      'installed OpenAlice Runtime',
+      cwd,
+      homeDir,
+    ),
     nullablePathCandidate(machine.defaults?.appDir, 'machine-config', 'machine.defaults.appDir', cwd, homeDir),
     nullablePathCandidate(instanceConfig.appDir, 'instance-config', `instance.${instance.value}.appDir`, cwd, homeDir),
     nullablePathCandidate(env['OPENALICE_APP_HOME'], 'environment', 'OPENALICE_APP_HOME', cwd, homeDir),
@@ -151,11 +163,23 @@ export function resolveLaunchContext(
   )
 
   const managedPiRoot = join(home.value, 'runtime', 'pi')
+  const runtimeProvider = appDir.provenance.source === 'installed-runtime'
+    ? {
+        kind: 'bundle' as const,
+        contentIdentity: parseRuntimeContentIdentity(
+          env['OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY'],
+        ),
+      }
+    : {
+        kind: 'source' as const,
+        contentIdentity: null,
+      }
   return deepFreeze({
     instance: instance.value,
     home: home.value,
     port: port.value,
     appDir: appDir.value,
+    runtimeProvider,
     updateChecks: updateChecks.value,
     supervisorRoot: supervisorRoot.value,
     managedPi: {
@@ -375,6 +399,17 @@ function parseBoolean(value: string, label: string): boolean {
   if (value === '1' || value === 'true') return true
   if (value === '0' || value === 'false') return false
   throw launchContextError('EBOOLEAN', `${label} must be one of 1, 0, true, or false.`)
+}
+
+function parseRuntimeContentIdentity(value: string | undefined): string {
+  const identity = value?.trim()
+  if (!identity || !/^[a-f0-9]{16}$/.test(identity)) {
+    throw launchContextError(
+      'ERUNTIMEIDENTITY',
+      'OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY must be the 16-character lowercase identity paired with OPENALICE_MANAGED_RUNTIME_PATH.',
+    )
+  }
+  return identity
 }
 
 function requireValue(argv: string[], index: number, flag: string): string {

--- a/packages/cli/src/lifecycle-command.mjs
+++ b/packages/cli/src/lifecycle-command.mjs
@@ -133,6 +133,7 @@ export async function runLifecycleCommand(action, options, dependencies = {}) {
             checkUpdates: _updateChecksSpecified
               ? options.checkUpdates
               : context.updateChecks,
+            runtimeProvider: context.runtimeProvider,
           }
         : {}),
     }
@@ -216,13 +217,13 @@ export function formatLifecycleHelp(action) {
     return `Usage:
   openalice up [path] [options]
 
-Starts a persistent background Runtime from an OpenAlice source checkout, waits
-for Guardian control and Alice HTTP readiness, then returns. The Runtime
-survives this shell.
+Starts the installed OpenAlice Runtime in the background, waits for Guardian
+control and Alice HTTP readiness, then returns. The Runtime survives this shell.
+A source checkout is used only when selected by configuration or --app-dir.
 
 Options:
   --instance <name>  Select a named complete-home instance
-  --app-dir <path>   OpenAlice checkout (default: current directory or parent)
+  --app-dir <path>   Advanced: override the installed Runtime with a source checkout
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --port <port>      Pin the local Web port (default: automatic from 47331)
   --log <path>       Runtime log (default: <home>/logs/server.log)
@@ -240,12 +241,12 @@ Options:
     return `Usage:
   openalice run [path] [options]
 
-Runs a source-backed OpenAlice Runtime in the foreground without opening a
+Runs the installed OpenAlice Runtime in the foreground without opening a
 browser. Ctrl+C stops the self-owned Guardian process tree.
 
 Options:
   --instance <name>  Select a named complete-home instance
-  --app-dir <path>   OpenAlice checkout (default: current directory or parent)
+  --app-dir <path>   Advanced: override the installed Runtime with a source checkout
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --port <port>      Pin the local Web port (default: automatic from 47331)
   --rebuild          Reinstall dependencies and rebuild server artifacts

--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -277,7 +277,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
     for (const command of ['up', 'run', 'down', 'status', 'logs', 'doctor', 'open', 'completion']) {
       expect(help).toContain(command)
     }
-    expect(formatLifecycleHelp('up')).toContain('persistent background Runtime')
+    expect(formatLifecycleHelp('up')).toContain('installed OpenAlice Runtime in the background')
     expect(formatLifecycleHelp('run')).toContain('foreground')
     expect(formatShellCompletion('bash')).toContain('complete -F _openalice_completion openalice')
     expect(formatShellCompletion('zsh')).toContain('#compdef openalice')

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -67,8 +67,14 @@ export async function startRuntime(options, dependencies = {}) {
     throw lifecycleError('EOWNED', formatOwnershipRefusal(status))
   }
 
+  const requestedAppDir = options.appDir
+    ?? env['OPENALICE_APP_HOME']?.trim()
+    ?? env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
+    ?? dependencies.cwd
+    ?? process.cwd()
   const resolveRoot = dependencies.resolveRoot ?? findOpenAliceRoot
-  const appDir = await resolveRoot(options.appDir ?? dependencies.cwd ?? process.cwd())
+  const appDir = await resolveRoot(requestedAppDir)
+  const runtimeProvider = resolveRuntimeProvider(options.runtimeProvider, appDir, env)
   const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
   emit({ type: 'preparing', appDir, homeRoot })
   await prepareSource(appDir, options, {
@@ -86,7 +92,11 @@ export async function startRuntime(options, dependencies = {}) {
   })
   runtimeEnv.OPENALICE_LAUNCHER = 'cli-server'
   runtimeEnv.OPENALICE_SERVER_MODE = detached ? 'detached' : 'foreground'
-  runtimeEnv.OPENALICE_RUNTIME_PROVIDER = 'source'
+  runtimeEnv.OPENALICE_RUNTIME_PROVIDER = runtimeProvider.kind
+  delete runtimeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY
+  if (runtimeProvider.contentIdentity) {
+    runtimeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY = runtimeProvider.contentIdentity
+  }
 
   const logPath = resolve(options.logFile ?? resolve(homeRoot, 'logs', 'server.log'))
   runtimeEnv.OPENALICE_SERVER_LOG = logPath
@@ -187,6 +197,39 @@ export async function startRuntime(options, dependencies = {}) {
     }
     throw error
   }
+}
+
+function resolveRuntimeProvider(explicit, appDir, env) {
+  if (explicit?.kind === 'bundle') {
+    return {
+      kind: 'bundle',
+      contentIdentity: requireRuntimeContentIdentity(explicit.contentIdentity),
+    }
+  }
+  if (explicit?.kind === 'source') {
+    return { kind: 'source', contentIdentity: null }
+  }
+  const managedPath = env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
+  if (managedPath && resolve(managedPath) === resolve(appDir)) {
+    return {
+      kind: 'bundle',
+      contentIdentity: requireRuntimeContentIdentity(
+        env['OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY'],
+      ),
+    }
+  }
+  return { kind: 'source', contentIdentity: null }
+}
+
+function requireRuntimeContentIdentity(value) {
+  const identity = String(value ?? '').trim()
+  if (!/^[a-f0-9]{16}$/.test(identity)) {
+    throw lifecycleError(
+      'ERUNTIMEIDENTITY',
+      'The installed OpenAlice Runtime is missing its valid 16-character content identity. Reinstall or update OpenAlice.',
+    )
+  }
+  return identity
 }
 
 export async function stopRuntime(options = {}, dependencies = {}) {

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -119,8 +119,14 @@ export async function startLocal(options, dependencies = {}) {
     return 0
   }
 
+  const requestedAppDir = options.appDir
+    ?? env['OPENALICE_APP_HOME']?.trim()
+    ?? env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
+    ?? dependencies.cwd
+    ?? process.cwd()
   const resolveRoot = dependencies.resolveRoot ?? findOpenAliceRoot
-  const appDir = await resolveRoot(options.appDir ?? dependencies.cwd ?? process.cwd())
+  const appDir = await resolveRoot(requestedAppDir)
+  const runtimeProvider = resolveLocalRuntimeProvider(appDir, env)
   const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
   await prepareSource(appDir, options, { stdout, env })
 
@@ -134,6 +140,11 @@ export async function startLocal(options, dependencies = {}) {
     port: options.port,
     takeover: options.takeover,
   })
+  runtimeEnv.OPENALICE_RUNTIME_PROVIDER = runtimeProvider.kind
+  delete runtimeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY
+  if (runtimeProvider.contentIdentity) {
+    runtimeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY = runtimeProvider.contentIdentity
+  }
   const runtime = spawnProcess(nodeBinary, ['scripts/guardian/prod.mjs'], {
     cwd: appDir,
     env: runtimeEnv,
@@ -174,6 +185,22 @@ export async function startLocal(options, dependencies = {}) {
     runtime.kill('SIGTERM')
     throw error
   }
+}
+
+function resolveLocalRuntimeProvider(appDir, env) {
+  const managedPath = env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
+  if (!managedPath || resolve(managedPath) !== resolve(appDir)) {
+    return { kind: 'source', contentIdentity: null }
+  }
+  const contentIdentity = env[
+    'OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY'
+  ]?.trim()
+  if (!contentIdentity || !/^[a-f0-9]{16}$/.test(contentIdentity)) {
+    throw new Error(
+      'The installed OpenAlice Runtime is missing its valid 16-character content identity. Reinstall or update OpenAlice.',
+    )
+  }
+  return { kind: 'bundle', contentIdentity }
 }
 
 export async function readHomeWebPort(homeRoot, options = {}) {

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -438,7 +438,9 @@ function formatManagedRemoteStatus(destination, remote) {
     `Runtime: ${status?.class ?? 'unknown'}${status?.owner?.surface ? ` (${status.owner.surface})` : ''}`,
   ]
   if (status?.home) lines.push(`Home:    ${status.home}`)
-  if (status?.owner?.launchRoot) lines.push(`Source:  ${status.owner.launchRoot}`)
+  if (status?.owner?.launchRoot) {
+    lines.push(`${status.provider?.kind === 'bundle' ? 'Runtime' : 'Source'}:  ${status.owner.launchRoot}`)
+  }
   if (status?.endpoints?.web) lines.push(`Web:     ${status.endpoints.web}`)
   return `${lines.join('\n')}\n\n`
 }
@@ -459,7 +461,11 @@ export function createRemotePlan(options, remote, install = {}) {
   let rebuildSource = false
   let startServer = false
   let restartServer = false
-  let serverAppDir = options.appDir || remote.managedAppDir || ''
+  const bundledRuntime = !options.appDir
+    && remote.managedRuntime?.compatible === true
+  let serverAppDir = options.appDir
+    || (bundledRuntime ? remote.managedRuntime.path : remote.managedAppDir)
+    || ''
   let remotePort = options.remotePort
 
   if (!['linux', 'darwin'].includes(remote.platform?.os)) {
@@ -530,7 +536,7 @@ export function createRemotePlan(options, remote, install = {}) {
     }
   }
 
-  if (!blocker && !options.appDir && remote.sourceCheckoutState === 'present' && remote.sourceUpdateAvailable === true) {
+  if (!blocker && !bundledRuntime && !options.appDir && remote.sourceCheckoutState === 'present' && remote.sourceUpdateAvailable === true) {
     if (remote.sourceDirty) {
       blocker = `${serverAppDir} has tracked local changes, so OpenAlice will not update the managed checkout. Preserve the changes with a separate checkout and pass --app-dir.`
     } else {
@@ -545,7 +551,7 @@ export function createRemotePlan(options, remote, install = {}) {
     }
   }
 
-  if (!blocker && startServer) {
+  if (!blocker && startServer && !bundledRuntime) {
     if (remote.sourceCheckoutState === 'invalid') {
       blocker = `${serverAppDir} exists but is not an OpenAlice source checkout. Choose another --app-dir or move the existing path.`
     } else if (remote.sourceCheckoutState === 'absent') {
@@ -555,7 +561,7 @@ export function createRemotePlan(options, remote, install = {}) {
   }
 
   const runtimeBuildToolsMissing = remote.runtimeBuildToolsMissing ?? []
-  if (!blocker && startServer && remote.sourceArtifactsReady !== true && runtimeBuildToolsMissing.length > 0) {
+  if (!blocker && startServer && !bundledRuntime && remote.sourceArtifactsReady !== true && runtimeBuildToolsMissing.length > 0) {
     if (remote.platform?.os === 'linux') {
       installRuntimeDeps = true
     } else {
@@ -587,7 +593,15 @@ export function createRemotePlan(options, remote, install = {}) {
     appDir: serverAppDir || 'not selected',
     serverAppDir,
     remoteHome: options.remoteHome || '~/.openalice (remote default)',
-    sourceMode: options.appDir ? 'user-selected' : 'managed',
+    sourceMode: options.appDir
+      ? 'user-selected'
+      : bundledRuntime
+        ? 'installed-bundle'
+        : 'managed',
+    bundledRuntime,
+    runtimeContentIdentity: bundledRuntime
+      ? remote.managedRuntime.contentIdentity
+      : null,
     sourceCheckoutState: remote.sourceCheckoutState ?? null,
     remotePort,
     localPort: options.localPort || (options.preferredLocalPort ? `${options.preferredLocalPort} (remembered)` : 'auto'),
@@ -618,7 +632,9 @@ export function formatRemotePlan(plan) {
   const actions = plan.mutations.length > 0
     ? [...plan.mutations, 'open local SSH tunnel']
     : ['reuse compatible remote CLI Server', 'open local SSH tunnel']
-  const buildTools = plan.sourceArtifactsReady === true
+  const buildTools = plan.bundledRuntime
+    ? 'Not needed (installed Runtime)'
+    : plan.sourceArtifactsReady === true
     ? 'Not needed (built artifacts present)'
     : plan.runtimeBuildToolsMissing.length > 0
       ? `Missing: ${formatMissingRuntimeBuildTools(plan.runtimeBuildToolsMissing)}`
@@ -628,7 +644,9 @@ export function formatRemotePlan(plan) {
   const cliState = plan.cliCompatible && plan.cliMatchesLocal
     ? ', compatible and matches local CLI'
     : ', install/update required'
-  const sourceState = plan.cloneSource
+  const sourceState = plan.bundledRuntime
+    ? `, content ${plan.runtimeContentIdentity}`
+    : plan.cloneSource
     ? ', will clone'
     : plan.updateSource
       ? ', update available'
@@ -726,6 +744,7 @@ export async function probeRemoteHost(options, dependencies = {}) {
   let cliVersion = null
   let remoteInstallSource = null
   let cliContentIdentity = null
+  let managedRuntime = null
   let status = null
   let cliCompatible = false
   try {
@@ -735,6 +754,11 @@ export async function probeRemoteHost(options, dependencies = {}) {
       if (versionInfo.version === cliVersion) {
         remoteInstallSource = versionInfo.installSource
         cliContentIdentity = versionInfo.contentIdentity
+        managedRuntime = normalizeRemoteManagedRuntime(
+          versionInfo.managedRuntime,
+          cliVersion,
+          platform,
+        )
       }
     } catch {
       remoteInstallSource = null
@@ -745,7 +769,7 @@ export async function probeRemoteHost(options, dependencies = {}) {
   } catch {
     cliCompatible = false
   }
-  return { platform, shellHome, managedAppDir, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, sourceUpdateAvailable, sourceDirty, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath, cliVersion, cliContentIdentity, installSource: remoteInstallSource, cliCompatible, status }
+  return { platform, shellHome, managedAppDir, managedRuntime, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, sourceUpdateAvailable, sourceDirty, runtimeBuildToolsMissing, piPath, piVersion, piCompatible, cliPath, cliVersion, cliContentIdentity, installSource: remoteInstallSource, cliCompatible, status }
 }
 
 async function probeRemoteControl(options, dependencies) {
@@ -853,14 +877,13 @@ export function buildRemoteStatusCommand(options, cliPath) {
 }
 
 export function buildRemoteServerStartCommand(options, cliPath) {
-  if (!options.appDir) throw new Error('--app-dir is required to start the remote Server')
   const args = [
     shellQuote(cliPath),
     'server', 'start',
-    '--app-dir', shellQuote(options.appDir),
     '--port', String(options.remotePort),
     '--wait', String(Math.ceil(options.waitMs / 1_000)),
   ]
+  if (options.appDir) args.push('--app-dir', shellQuote(options.appDir))
   if (options.remoteHome) args.push('--home', shellQuote(options.remoteHome))
   if (options.rebuild) args.push('--rebuild')
   if (options.takeover) args.push('--takeover')
@@ -881,6 +904,7 @@ export function buildRemoteInstallCommand(installSource, installBaseUrl = '', wi
   const installEnv = [
     `OPENALICE_INSTALL_URL=${url}`,
     'OPENALICE_INSTALL_CONTEXT=remote',
+    `OPENALICE_EXPECTED_CLI_VERSION=${shellQuote(source.cliVersion)}`,
     installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)}` : '',
   ].filter(Boolean).join(' ')
   const runtimeDepsFlag = withRuntimeDeps ? ' --with-runtime-deps' : ''
@@ -1025,13 +1049,13 @@ export function formatRemoteHelp() {
   return `Usage:
   openalice remote <user@host> [options]
 
-Plans and, after explicit consent, prepares a source-backed OpenAlice Server on
-the SSH host. It then opens the normal loopback browser tunnel. Disconnecting
-closes only the tunnel; the remote Server keeps running.
+Plans and, after explicit consent, installs or reuses the matching OpenAlice
+Runtime on the SSH host. It then opens the normal loopback browser tunnel.
+Disconnecting closes only the tunnel; the remote Server keeps running.
 
-When --app-dir is omitted, OpenAlice selects a private managed checkout under
-the remote OPENALICE_HOME and clones it when needed. Pass an absolute checkout
-path to keep source ownership manual.
+When --app-dir is omitted, OpenAlice prefers the installed platform Runtime and
+falls back to a private managed checkout only for older/source-only installs.
+Pass an absolute checkout path to keep source ownership manual.
 
 Options:
   --app-dir <path>        Existing or new checkout path (default: managed)
@@ -1066,7 +1090,37 @@ function parseRemoteVersionInfo(output) {
     version: value.version,
     installSource,
     contentIdentity: normalizeContentIdentity(value.contentIdentity),
+    managedRuntime: value.managedRuntime ?? null,
   }
+}
+
+function normalizeRemoteManagedRuntime(value, cliVersion, platform) {
+  if (
+    !value
+    || typeof value !== 'object'
+    || value.productVersion !== cliVersion
+    || value.platform !== platform.os
+    || value.arch !== normalizeRemoteArchitecture(platform.architecture)
+  ) {
+    return null
+  }
+  const path = normalizeRemoteExecutablePath(value.path, 'managed Runtime')
+  const contentIdentity = normalizeContentIdentity(value.contentIdentity)
+  if (!contentIdentity) return null
+  return {
+    path,
+    contentIdentity,
+    productVersion: value.productVersion,
+    platform: value.platform,
+    arch: value.arch,
+    compatible: true,
+  }
+}
+
+function normalizeRemoteArchitecture(value) {
+  if (value === 'x86_64' || value === 'amd64') return 'x64'
+  if (value === 'arm64' || value === 'aarch64') return 'arm64'
+  return 'unsupported'
 }
 
 function parseRemoteStatus(output) {

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -19,6 +19,7 @@ import {
   buildRemoteSshArgs,
   connectRemote,
   createRemotePlan,
+  formatRemotePlan,
   parseRemoteArgs,
   probeRemoteHost,
   readRememberedRemotePort,
@@ -224,6 +225,40 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.serverAppDir).toBe(remote.managedAppDir)
     expect(plan.cloneSource).toBe(true)
     expect(plan.mutations).toContain('clone OpenAlice source (branch master)')
+  })
+
+  it('starts an installed Runtime bundle without cloning source or build tools', () => {
+    const remote = {
+      ...compatibleRemote({
+        class: 'absent',
+        state: 'absent',
+        owner: null,
+        endpoints: {},
+      }),
+      managedRuntime: {
+        path: '/home/alice/.openalice/cli-versions/release/managed/runtime',
+        contentIdentity: '0123456789abcdef',
+        productVersion: CLI_VERSION,
+        platform: 'linux',
+        arch: 'x64',
+        compatible: true,
+      },
+      managedAppDir: '/home/alice/.openalice/sources/branch-master/OpenAlice',
+      sourceCheckoutState: 'absent',
+      sourceCheckoutPresent: false,
+      sourceArtifactsReady: false,
+      runtimeBuildToolsMissing: ['git', 'python3', 'make', 'cxx'],
+    }
+
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+
+    expect(plan.sourceMode).toBe('installed-bundle')
+    expect(plan.bundledRuntime).toBe(true)
+    expect(plan.serverAppDir).toBe(remote.managedRuntime.path)
+    expect(plan.cloneSource).toBe(false)
+    expect(plan.installRuntimeDeps).toBe(false)
+    expect(plan.mutations).toEqual(['start remote OpenAlice Server'])
+    expect(formatRemotePlan(plan)).toContain('Not needed (installed Runtime)')
   })
 
   it('refuses to overwrite an occupied non-OpenAlice source path', () => {

--- a/packages/cli/src/runtime-bundle.mjs
+++ b/packages/cli/src/runtime-bundle.mjs
@@ -1,0 +1,617 @@
+import { createHash } from 'node:crypto'
+import {
+  createReadStream,
+} from 'node:fs'
+import {
+  lstat,
+  link,
+  readFile,
+  readdir,
+  readlink,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import {
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path'
+
+export const RUNTIME_BUNDLE_SCHEMA_VERSION = 1
+export const RUNTIME_BUNDLE_DIRECTORY = 'openalice-runtime'
+export const RUNTIME_BUNDLE_MANIFEST = 'runtime-manifest.json'
+export const RUNTIME_BUNDLE_ENTRYPOINT = 'scripts/guardian/prod.mjs'
+export const RUNTIME_BUNDLE_MINIMUM_NODE_VERSION = '22.19.0'
+
+const SUPPORTED_PLATFORMS = new Set(['darwin', 'linux'])
+const SUPPORTED_ARCHITECTURES = new Set(['arm64', 'x64'])
+const REQUIRED_PATHS = [
+  'dist/main.js',
+  'ui/dist/index.html',
+  'default/persona.default.md',
+  'src/workspaces/templates',
+  'src/workspaces/cli/bin/openalice-cli.cjs',
+  'services/uta/dist/uta.js',
+  'services/connector/dist/connector.cjs',
+  'packages/guardian-runtime/dist/index.js',
+  RUNTIME_BUNDLE_ENTRYPOINT,
+  'scripts/guardian/control-server.mjs',
+  'scripts/guardian/prod-ports.mjs',
+  'node_modules',
+  'package.json',
+]
+
+export async function createRuntimeBundleManifest(
+  root,
+  options,
+) {
+  const platform = requireSupportedPlatform(
+    options?.platform ?? process.platform,
+  )
+  const arch = requireSupportedArchitecture(
+    options?.arch ?? process.arch,
+  )
+  const productVersion = requireVersion(options?.productVersion)
+  await assertRuntimeLayout(root)
+  const files = await collectRuntimeEntries(root)
+  const unsigned = {
+    schemaVersion: RUNTIME_BUNDLE_SCHEMA_VERSION,
+    productVersion,
+    platform,
+    arch,
+    node: {
+      minimumVersion: RUNTIME_BUNDLE_MINIMUM_NODE_VERSION,
+    },
+    entrypoint: RUNTIME_BUNDLE_ENTRYPOINT,
+    files,
+  }
+  return {
+    ...unsigned,
+    contentIdentity: manifestContentIdentity(unsigned),
+  }
+}
+
+export async function writeRuntimeBundleManifest(
+  root,
+  options,
+) {
+  const manifest = await createRuntimeBundleManifest(root, options)
+  await writeFile(
+    join(root, RUNTIME_BUNDLE_MANIFEST),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    { encoding: 'utf8', mode: 0o644 },
+  )
+  return manifest
+}
+
+export async function readRuntimeBundleManifest(root) {
+  let parsed
+  try {
+    parsed = JSON.parse(
+      await readFile(join(root, RUNTIME_BUNDLE_MANIFEST), 'utf8'),
+    )
+  } catch (error) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `Could not read ${RUNTIME_BUNDLE_MANIFEST} under ${root}: ${errorMessage(error)}`,
+    )
+  }
+  return parseRuntimeBundleManifest(parsed)
+}
+
+export function parseRuntimeBundleManifest(value) {
+  const record = requireRecord(value, 'Runtime bundle manifest')
+  rejectUnknownKeys(record, new Set([
+    'schemaVersion',
+    'productVersion',
+    'platform',
+    'arch',
+    'node',
+    'entrypoint',
+    'files',
+    'contentIdentity',
+  ]), 'Runtime bundle manifest')
+  if (record.schemaVersion !== RUNTIME_BUNDLE_SCHEMA_VERSION) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `Runtime bundle schemaVersion must be ${RUNTIME_BUNDLE_SCHEMA_VERSION}.`,
+    )
+  }
+  const productVersion = requireVersion(record.productVersion)
+  const platform = requireSupportedPlatform(record.platform)
+  const arch = requireSupportedArchitecture(record.arch)
+  const node = requireRecord(record.node, 'Runtime bundle node')
+  rejectUnknownKeys(
+    node,
+    new Set(['minimumVersion']),
+    'Runtime bundle node',
+  )
+  if (node.minimumVersion !== RUNTIME_BUNDLE_MINIMUM_NODE_VERSION) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `Runtime bundle minimum Node.js version must be ${RUNTIME_BUNDLE_MINIMUM_NODE_VERSION}.`,
+    )
+  }
+  if (record.entrypoint !== RUNTIME_BUNDLE_ENTRYPOINT) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `Runtime bundle entrypoint must be ${RUNTIME_BUNDLE_ENTRYPOINT}.`,
+    )
+  }
+  if (!Array.isArray(record.files) || record.files.length === 0) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      'Runtime bundle files must be a non-empty array.',
+    )
+  }
+  const files = record.files.map((entry, index) => (
+    parseRuntimeEntry(entry, index)
+  ))
+  const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path))
+  if (files.some((entry, index) => entry.path !== sorted[index].path)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      'Runtime bundle files must be sorted by path.',
+    )
+  }
+  if (new Set(files.map((entry) => entry.path)).size !== files.length) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      'Runtime bundle files contain duplicate paths.',
+    )
+  }
+  const contentIdentity = requireContentIdentity(record.contentIdentity)
+  const unsigned = {
+    schemaVersion: RUNTIME_BUNDLE_SCHEMA_VERSION,
+    productVersion,
+    platform,
+    arch,
+    node: {
+      minimumVersion: RUNTIME_BUNDLE_MINIMUM_NODE_VERSION,
+    },
+    entrypoint: RUNTIME_BUNDLE_ENTRYPOINT,
+    files,
+  }
+  if (manifestContentIdentity(unsigned) !== contentIdentity) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      'Runtime bundle content identity does not match its manifest.',
+    )
+  }
+  return {
+    ...unsigned,
+    contentIdentity,
+  }
+}
+
+export async function verifyRuntimeBundle(
+  root,
+  options = {},
+) {
+  const manifest = await readRuntimeBundleManifest(root)
+  if (
+    options.productVersion !== undefined
+    && manifest.productVersion !== options.productVersion
+  ) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEVERSION',
+      `Runtime bundle reports ${manifest.productVersion}, expected ${options.productVersion}.`,
+    )
+  }
+  const platform = options.platform ?? process.platform
+  if (manifest.platform !== platform) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEPLATFORM',
+      `Runtime bundle targets ${manifest.platform}, not ${platform}.`,
+    )
+  }
+  const arch = options.arch ?? process.arch
+  if (manifest.arch !== arch) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEARCH',
+      `Runtime bundle targets ${manifest.arch}, not ${arch}.`,
+    )
+  }
+  await assertRuntimeLayout(root)
+  const actualEntries = await collectRuntimeEntries(root)
+  if (JSON.stringify(actualEntries) !== JSON.stringify(manifest.files)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEINTEGRITY',
+      `Runtime bundle files under ${root} do not match ${RUNTIME_BUNDLE_MANIFEST}.`,
+    )
+  }
+  return manifest
+}
+
+export async function deduplicateRuntimeTree(root) {
+  const candidates = []
+  await walkRuntimeTree(root, async (path, info) => {
+    if (info.isFile() && info.size >= 4_096 && info.nlink === 1) {
+      candidates.push({
+        path,
+        size: info.size,
+        mode: info.mode & 0o777,
+      })
+    }
+  })
+  const byShape = new Map()
+  for (const candidate of candidates) {
+    const key = `${candidate.size}:${candidate.mode}`
+    const entries = byShape.get(key) ?? []
+    entries.push(candidate.path)
+    byShape.set(key, entries)
+  }
+
+  let filesLinked = 0
+  let bytesDeduplicated = 0
+  for (const entries of byShape.values()) {
+    if (entries.length < 2) continue
+    const byHash = new Map()
+    for (const path of entries.sort()) {
+      const hash = await fileSha256(path)
+      const source = byHash.get(hash)
+      if (!source) {
+        byHash.set(hash, path)
+        continue
+      }
+      const temporary = `${path}.openalice-dedup-${process.pid}`
+      await rename(path, temporary)
+      try {
+        await link(source, path)
+        await rm(temporary, { force: true })
+      } catch (error) {
+        await rm(path, { force: true }).catch(() => undefined)
+        await rename(temporary, path)
+        throw runtimeBundleError(
+          'ERUNTIMEBUNDLEBUILD',
+          `Could not deduplicate ${path}: ${errorMessage(error)}`,
+        )
+      }
+      filesLinked += 1
+      bytesDeduplicated += (await stat(path)).size
+    }
+  }
+  return { filesLinked, bytesDeduplicated }
+}
+
+export async function fileSha256(path) {
+  return new Promise((resolveHash, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(path)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('error', reject)
+    stream.on('end', () => resolveHash(hash.digest('hex')))
+  })
+}
+
+async function collectRuntimeEntries(root) {
+  const entries = []
+  await walkRuntimeTree(root, async (path, info) => {
+    const relativePath = runtimeRelativePath(root, path)
+    if (relativePath === RUNTIME_BUNDLE_MANIFEST) return
+    if (info.isFile()) {
+      entries.push({
+        path: relativePath,
+        kind: 'file',
+        size: info.size,
+        mode: info.mode & 0o777,
+        sha256: await fileSha256(path),
+      })
+      return
+    }
+    if (info.isSymbolicLink()) {
+      const target = await readlink(path)
+      await assertSafeRuntimeSymlink(root, path, target)
+      entries.push({
+        path: relativePath,
+        kind: 'symlink',
+        target: target.split(sep).join('/'),
+      })
+    }
+  })
+  return entries.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+async function walkRuntimeTree(root, visit) {
+  const walk = async (directory) => {
+    const names = (await readdir(directory)).sort()
+    for (const name of names) {
+      const path = join(directory, name)
+      const info = await lstat(path)
+      if (info.isDirectory()) {
+        await walk(path)
+      } else if (info.isFile() || info.isSymbolicLink()) {
+        await visit(path, info)
+      } else {
+        throw runtimeBundleError(
+          'ERUNTIMEBUNDLELAYOUT',
+          `Runtime bundle contains unsupported filesystem entry ${path}.`,
+        )
+      }
+    }
+  }
+  await walk(root)
+}
+
+async function assertSafeRuntimeSymlink(root, path, target) {
+  if (isAbsolute(target)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLELAYOUT',
+      `Runtime bundle symlink ${path} has an absolute target.`,
+    )
+  }
+  const lexicalTarget = resolve(dirname(path), target)
+  if (!pathInside(root, lexicalTarget)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLELAYOUT',
+      `Runtime bundle symlink ${path} escapes the bundle root.`,
+    )
+  }
+  try {
+    const physicalTarget = await realpath(lexicalTarget)
+    if (!pathInside(await realpath(root), physicalTarget)) {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLELAYOUT',
+        `Runtime bundle symlink ${path} resolves outside the bundle root.`,
+      )
+    }
+  } catch (error) {
+    if (isRuntimeBundleError(error)) throw error
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLELAYOUT',
+      `Runtime bundle symlink ${path} is broken: ${errorMessage(error)}`,
+    )
+  }
+}
+
+async function assertRuntimeLayout(root) {
+  for (const relativePath of REQUIRED_PATHS) {
+    const path = join(root, relativePath)
+    try {
+      await lstat(path)
+    } catch {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLELAYOUT',
+        `Runtime bundle is missing ${relativePath}.`,
+      )
+    }
+  }
+}
+
+function parseRuntimeEntry(value, index) {
+  const label = `Runtime bundle files[${index}]`
+  const record = requireRecord(value, label)
+  const path = requireRuntimePath(record.path, `${label}.path`)
+  if (record.kind === 'file') {
+    rejectUnknownKeys(
+      record,
+      new Set(['path', 'kind', 'size', 'mode', 'sha256']),
+      label,
+    )
+    if (!Number.isSafeInteger(record.size) || record.size < 0) {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLEMANIFEST',
+        `${label}.size must be a non-negative safe integer.`,
+      )
+    }
+    if (
+      !Number.isInteger(record.mode)
+      || record.mode < 0
+      || record.mode > 0o777
+    ) {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLEMANIFEST',
+        `${label}.mode must be a permission mode from 0 to 0777.`,
+      )
+    }
+    if (
+      typeof record.sha256 !== 'string'
+      || !/^[a-f0-9]{64}$/.test(record.sha256)
+    ) {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLEMANIFEST',
+        `${label}.sha256 must be a lowercase SHA-256 value.`,
+      )
+    }
+    return {
+      path,
+      kind: 'file',
+      size: record.size,
+      mode: record.mode,
+      sha256: record.sha256,
+    }
+  }
+  if (record.kind === 'symlink') {
+    rejectUnknownKeys(
+      record,
+      new Set(['path', 'kind', 'target']),
+      label,
+    )
+    if (
+      typeof record.target !== 'string'
+      || record.target === ''
+      || isAbsolute(record.target)
+    ) {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLEMANIFEST',
+        `${label}.target must be a non-empty relative path.`,
+      )
+    }
+    return {
+      path,
+      kind: 'symlink',
+      target: record.target,
+    }
+  }
+  throw runtimeBundleError(
+    'ERUNTIMEBUNDLEMANIFEST',
+    `${label}.kind must be "file" or "symlink".`,
+  )
+}
+
+function requireRuntimePath(value, label) {
+  if (
+    typeof value !== 'string'
+    || value === ''
+    || value.startsWith('/')
+    || value.includes('\\')
+    || value.split('/').some((part) => part === '' || part === '.' || part === '..')
+  ) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `${label} must be a normalized relative POSIX path.`,
+    )
+  }
+  return value
+}
+
+function manifestContentIdentity(unsigned) {
+  return createHash('sha256')
+    .update(JSON.stringify(unsigned))
+    .digest('hex')
+    .slice(0, 16)
+}
+
+function requireSupportedPlatform(value) {
+  if (typeof value !== 'string' || !SUPPORTED_PLATFORMS.has(value)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEPLATFORM',
+      `Unsupported Runtime bundle platform: ${String(value)}.`,
+    )
+  }
+  return value
+}
+
+function requireSupportedArchitecture(value) {
+  if (typeof value !== 'string' || !SUPPORTED_ARCHITECTURES.has(value)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEARCH',
+      `Unsupported Runtime bundle architecture: ${String(value)}.`,
+    )
+  }
+  return value
+}
+
+function requireVersion(value) {
+  if (
+    typeof value !== 'string'
+    || !/^[0-9A-Za-z][0-9A-Za-z.+_-]{0,127}$/.test(value)
+  ) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEVERSION',
+      `Invalid Runtime bundle product version: ${String(value)}.`,
+    )
+  }
+  return value
+}
+
+function requireContentIdentity(value) {
+  if (typeof value !== 'string' || !/^[a-f0-9]{16}$/.test(value)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      'Runtime bundle contentIdentity must be 16 lowercase hexadecimal characters.',
+    )
+  }
+  return value
+}
+
+function requireRecord(value, label) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `${label} must be a JSON object.`,
+    )
+  }
+  return value
+}
+
+function rejectUnknownKeys(value, allowed, label) {
+  const unknown = Object.keys(value).find((key) => !allowed.has(key))
+  if (unknown) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEMANIFEST',
+      `${label} contains unknown field "${unknown}".`,
+    )
+  }
+}
+
+function runtimeRelativePath(root, path) {
+  return relative(root, path).split(sep).join('/')
+}
+
+function pathInside(root, target) {
+  const rel = relative(resolve(root), resolve(target))
+  return rel === '' || (
+    !rel.startsWith('..')
+    && !isAbsolute(rel)
+  )
+}
+
+function runtimeBundleError(code, message) {
+  return Object.assign(new Error(message), {
+    code,
+    exitCode: 2,
+  })
+}
+
+function isRuntimeBundleError(error) {
+  return error instanceof Error
+    && 'code' in error
+    && String(error.code).startsWith('ERUNTIMEBUNDLE')
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function runRuntimeBundleCommand(argv) {
+  const [command, root, ...args] = argv
+  if (command !== 'verify' || !root) {
+    throw runtimeBundleError(
+      'ERUNTIMEBUNDLEUSAGE',
+      'Usage: node runtime-bundle.mjs verify <root> [--platform <name>] [--arch <name>] [--product-version <version>]',
+    )
+  }
+  const options = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    const value = args[index + 1]
+    if (
+      !['--platform', '--arch', '--product-version'].includes(arg)
+      || !value
+      || value.startsWith('--')
+    ) {
+      throw runtimeBundleError(
+        'ERUNTIMEBUNDLEUSAGE',
+        `Unknown or incomplete Runtime bundle option: ${String(arg)}.`,
+      )
+    }
+    if (arg === '--platform') options.platform = value
+    if (arg === '--arch') options.arch = value
+    if (arg === '--product-version') options.productVersion = value
+    index += 1
+  }
+  const manifest = await verifyRuntimeBundle(resolve(root), options)
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: manifest.schemaVersion,
+    productVersion: manifest.productVersion,
+    platform: manifest.platform,
+    arch: manifest.arch,
+    minimumNodeVersion: manifest.node.minimumVersion,
+    contentIdentity: manifest.contentIdentity,
+    files: manifest.files.length,
+  })}\n`)
+}
+
+if (process.argv[2] === 'verify') {
+  runRuntimeBundleCommand(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`openalice runtime bundle: ${errorMessage(error)}\n`)
+    process.exitCode = Number.isInteger(error?.exitCode) ? error.exitCode : 1
+  })
+}

--- a/packages/cli/src/runtime-bundle.spec.mjs
+++ b/packages/cli/src/runtime-bundle.spec.mjs
@@ -1,0 +1,155 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  createRuntimeBundleManifest,
+  deduplicateRuntimeTree,
+  parseRuntimeBundleManifest,
+  readRuntimeBundleManifest,
+  verifyRuntimeBundle,
+  writeRuntimeBundleManifest,
+} from './runtime-bundle.mjs'
+
+const temporaryPaths = []
+const TEST_PLATFORM = process.platform === 'win32'
+  ? 'linux'
+  : process.platform
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => (
+    rm(path, { recursive: true, force: true })
+  )))
+})
+
+describe('headless Runtime bundles', () => {
+  it('writes and verifies a platform-specific content manifest', async () => {
+    const root = await createFixture()
+    const manifest = await writeRuntimeBundleManifest(root, {
+      productVersion: '1.2.3',
+      platform: TEST_PLATFORM,
+      arch: process.arch,
+    })
+
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      productVersion: '1.2.3',
+      platform: TEST_PLATFORM,
+      arch: process.arch,
+      entrypoint: 'scripts/guardian/prod.mjs',
+      contentIdentity: expect.stringMatching(/^[a-f0-9]{16}$/),
+    })
+    expect(manifest.files.map((entry) => entry.path)).toEqual(
+      [...manifest.files.map((entry) => entry.path)].sort(),
+    )
+    await expect(verifyRuntimeBundle(root, {
+      productVersion: '1.2.3',
+      platform: TEST_PLATFORM,
+      arch: process.arch,
+    })).resolves.toEqual(manifest)
+
+    const saved = JSON.parse(
+      await readFile(join(root, 'runtime-manifest.json'), 'utf8'),
+    )
+    expect(parseRuntimeBundleManifest(saved)).toEqual(manifest)
+    expect(await readRuntimeBundleManifest(root)).toEqual(manifest)
+  })
+
+  it('rejects tampering, a mismatched platform, and a forged identity', async () => {
+    const root = await createFixture()
+    const manifest = await writeRuntimeBundleManifest(root, {
+      productVersion: '1.2.3',
+      platform: TEST_PLATFORM,
+      arch: process.arch,
+    })
+
+    await expect(verifyRuntimeBundle(root, {
+      platform: process.platform === 'darwin' ? 'linux' : 'darwin',
+    })).rejects.toMatchObject({ code: 'ERUNTIMEBUNDLEPLATFORM' })
+
+    await writeFile(join(root, 'dist/main.js'), 'tampered\n')
+    await expect(verifyRuntimeBundle(root, {
+      platform: TEST_PLATFORM,
+    })).rejects.toMatchObject({
+      code: 'ERUNTIMEBUNDLEINTEGRITY',
+    })
+
+    await writeFile(
+      join(root, 'runtime-manifest.json'),
+      `${JSON.stringify({
+        ...manifest,
+        contentIdentity: '0000000000000000',
+      })}\n`,
+    )
+    await expect(readRuntimeBundleManifest(root)).rejects.toMatchObject({
+      code: 'ERUNTIMEBUNDLEMANIFEST',
+    })
+  })
+
+  it('restores hard links for identical production files without changing content', async () => {
+    const root = await createFixture()
+    const first = join(root, 'node_modules/a/repeated.bin')
+    const second = join(root, 'node_modules/b/repeated.bin')
+    const payload = Buffer.alloc(8_192, 7)
+    await writeFixtureFile(first, payload)
+    await writeFixtureFile(second, payload)
+
+    expect((await stat(first)).ino).not.toBe((await stat(second)).ino)
+    const result = await deduplicateRuntimeTree(root)
+
+    expect(result.filesLinked).toBeGreaterThanOrEqual(1)
+    expect(result.bytesDeduplicated).toBeGreaterThanOrEqual(payload.length)
+    expect((await stat(first)).ino).toBe((await stat(second)).ino)
+    expect(await readFile(second)).toEqual(payload)
+  })
+
+  it.skipIf(process.platform === 'win32')('rejects symlinks that escape the Runtime root', async () => {
+    const root = await createFixture()
+    await symlink('../../../../outside', join(root, 'node_modules/escape'))
+
+    await expect(createRuntimeBundleManifest(root, {
+      productVersion: '1.2.3',
+      platform: TEST_PLATFORM,
+      arch: process.arch,
+    })).rejects.toMatchObject({ code: 'ERUNTIMEBUNDLELAYOUT' })
+  })
+})
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-runtime-bundle-'))
+  temporaryPaths.push(root)
+  const files = {
+    'dist/main.js': 'main\n',
+    'ui/dist/index.html': '<html></html>\n',
+    'default/persona.default.md': 'persona\n',
+    'src/workspaces/templates/chat/bootstrap.mjs': 'export {}\n',
+    'src/workspaces/cli/bin/openalice-cli.cjs': 'module.exports = {}\n',
+    'services/uta/dist/uta.js': 'uta\n',
+    'services/connector/dist/connector.cjs': 'connector\n',
+    'packages/guardian-runtime/dist/index.js': 'guardian runtime\n',
+    'scripts/guardian/prod.mjs': 'guardian\n',
+    'scripts/guardian/control-server.mjs': 'control\n',
+    'scripts/guardian/prod-ports.mjs': 'ports\n',
+    'node_modules/example/index.js': 'dependency\n',
+    'package.json': '{"name":"open-alice","version":"1.2.3"}\n',
+  }
+  for (const [path, contents] of Object.entries(files)) {
+    await writeFixtureFile(join(root, path), contents)
+  }
+  return root
+}
+
+async function writeFixtureFile(path, contents) {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, contents)
+}

--- a/packages/cli/src/server.mjs
+++ b/packages/cli/src/server.mjs
@@ -68,7 +68,7 @@ export async function startRuntimeServer(options, dependencies = {}) {
     emit: (event) => {
       if (event.type !== 'ready') return
       const ready = event.result
-      stdout.write(`OpenAlice source: ${ready.appDir}\n`)
+      stdout.write(`OpenAlice ${ready.status.provider?.kind === 'bundle' ? 'Runtime' : 'source'}: ${ready.appDir}\n`)
       stdout.write(`OpenAlice home: ${ready.homeRoot}\n`)
       stdout.write(`OpenAlice Server: ${ready.status.endpoints.web}\n`)
       if (detached) {
@@ -119,7 +119,7 @@ top-level "openalice run|up|status|down" commands in new scripts.
 Alice are ready.
 
 Run/start options:
-  --app-dir <path>   OpenAlice checkout (default: current directory or parent)
+  --app-dir <path>   Advanced source override (default: installed Runtime)
   --home <path>      User-state root (default: OPENALICE_HOME or ~/.openalice)
   --port <port>      Local web port (default: 47331)
   --log <path>       Detached Server log (default: <home>/logs/server.log)

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -381,6 +381,7 @@ export async function runSupervisorTui(
           prepare: true,
           rebuild: false,
           checkUpdates: context.updateChecks,
+          runtimeProvider: context.runtimeProvider,
           port: runtimeStartPort(context),
           homeRoot,
           appDir: context.appDir ?? screen.snapshot.runtime?.provider?.root,
@@ -403,6 +404,7 @@ export async function runSupervisorTui(
           prepare: true,
           rebuild: false,
           checkUpdates: context.updateChecks,
+          runtimeProvider: context.runtimeProvider,
           port: runtimeStartPort(context),
           homeRoot,
           appDir,
@@ -1428,10 +1430,13 @@ export class SupervisorScreen implements Component {
         }
         if (this.snapshot.context) {
           lines.push(`Resolved: home ${formatProvenance(this.snapshot.context.provenance.home)} · port ${formatPortResolution(this.snapshot.context)}`)
-          lines.push(`Source: ${this.snapshot.context.appDir ?? runtime?.provider?.root ?? 'current directory discovery'} ${formatProvenance(this.snapshot.context.provenance.appDir)}`)
+          const runtimeLabel = this.snapshot.context.runtimeProvider.kind === 'bundle'
+            ? 'Runtime'
+            : 'Source'
+          lines.push(`${runtimeLabel}: ${this.snapshot.context.appDir ?? runtime?.provider?.root ?? 'current directory discovery'} ${formatProvenance(this.snapshot.context.provenance.appDir)}`)
         }
       }
-      lines.push('', ...renderGuidance(runtime))
+      lines.push('', ...renderGuidance(runtime, this.snapshot.context))
     }
 
     if (this.snapshot.confirmation) {
@@ -1448,7 +1453,7 @@ export class SupervisorScreen implements Component {
     }
     lines.push(
       '',
-      ...actionBar(runtime, width),
+      ...actionBar(runtime, this.snapshot.context, width),
       'q / Esc / Ctrl+C  Detach without stopping',
     )
     return lines.map((line) => truncate(line, width))
@@ -1513,9 +1518,15 @@ function renderTabs(selected: SupervisorPanel, narrow: boolean): string {
     .join('  ')
 }
 
-function renderGuidance(runtime: RuntimeSummary | null): string[] {
+function renderGuidance(
+  runtime: RuntimeSummary | null,
+  context?: ResolvedLaunchContext,
+): string[] {
   if (!runtime) return ['Runtime status is unavailable. Doctor may explain why.']
   if (runtime.class === 'absent') {
+    if (context?.runtimeProvider.kind === 'bundle') {
+      return ['OpenAlice is stopped. Press s to start the installed Runtime.']
+    }
     return ['OpenAlice is stopped. Press s to start, m for managed source, or c for an existing checkout.']
   }
   if (runtime.class === 'incompatible') {
@@ -1563,8 +1574,8 @@ function renderHelp(): string[] {
     'u  Check for product update       ?  Toggle this help',
     'i  Select or create an instance',
     'p  Configure selected instance settings',
-    'm  Prepare installer-managed source and start',
-    'c  Choose and remember this instance\'s source checkout',
+    'm  Advanced: prepare installer-managed source and start',
+    'c  Advanced: choose and remember a source checkout',
     'Tab / arrows  Change panel        q / Esc  Detach only',
     '',
     'The Supervisor manages Runtime state. Workspaces, trading, and chat stay in the Web UI.',
@@ -1597,9 +1608,15 @@ function renderConfirmation(
   ]
 }
 
-function actionBar(runtime: RuntimeSummary | null, width: number): string[] {
+function actionBar(
+  runtime: RuntimeSummary | null,
+  context: ResolvedLaunchContext | undefined,
+  width: number,
+): string[] {
   const primary = runtime?.class === 'absent'
-    ? 's Start · i Instances · p Settings · m Managed · c Source'
+    ? context?.runtimeProvider.kind === 'bundle'
+      ? 's Start · i Instances · p Settings'
+      : 's Start · i Instances · p Settings · m Managed · c Source'
     : 'o Open · i Instances · p Settings · r Restart · x Stop'
   const secondary = 'd Doctor · l Logs · u Update · ? Help'
   const actions = `${primary} · ${secondary}`

--- a/packages/cli/src/uninstall.mjs
+++ b/packages/cli/src/uninstall.mjs
@@ -54,7 +54,7 @@ export async function runUninstallCommand(argv, dependencies = {}) {
     profiles,
     processKill: dependencies.processKill,
   })
-  stdout.write('\nOpenAlice CLI and managed Pi were removed.\n')
+  stdout.write('\nOpenAlice CLI, managed Pi, and installed Runtime were removed.\n')
   stdout.write(`Preserved application data and user work under ${layout.installRoot}.\n`)
   if (result.profilesChanged.length > 0) {
     stdout.write(`Removed managed PATH configuration from: ${result.profilesChanged.join(', ')}\n`)
@@ -141,9 +141,10 @@ export function formatUninstallHelp() {
   openalice uninstall --plan
   openalice uninstall [--yes]
 
-Removes the installed OpenAlice CLI, managed Pi, immutable CLI releases, and
-matching managed PATH blocks. It preserves OpenAlice data, Workspaces, source
-checkouts, credentials, keys, and the shared install root.
+Removes the installed OpenAlice CLI, managed Pi, installed Runtime, immutable
+release directories, and matching managed PATH blocks. It preserves OpenAlice
+data, Workspaces, source checkouts, credentials, keys, and the shared install
+root.
 
 Options:
   --plan     Show exact ownership boundaries without changing files

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -444,25 +444,57 @@ running Guardian, and TUI stop returned the home to absent.
 
 ### 7. Standalone headless Runtime artifact
 
-- [ ] Inventory server/UI/Guardian outputs, production dependencies, native
+- [x] Inventory server/UI/Guardian outputs, production dependencies, native
   modules, Broker Pack boundary, and managed Pi injection.
 - [ ] Produce deterministic platform/architecture archives.
 - [ ] Define authenticated manifest, version, compatibility, Node requirement,
   file hashes, and content identity.
-- [ ] Install immutable Runtime versions and validate without a checkout.
-- [ ] Add providers for bundle, source-development, Docker, Electron, and
+- [x] Install immutable Runtime versions and validate without a checkout.
+- [x] Add providers for bundle, source-development, Docker, Electron, and
   managed remote.
 - [ ] Prove clean-host Alice, optional components, Web, Workspace PTY, and Pi.
-- [ ] Re-run unsigned Electron package acceptance for shared build changes.
+- [x] Re-run unsigned Electron package acceptance for shared build changes.
 
 ### 8. Installer integration and source-development split
 
-- [ ] Add the Runtime bytes and size to installer plan/consent.
-- [ ] Make normal `up` select the bundle independent of cwd.
+- [x] Add the Runtime identity/platform to installer plan/consent.
+- [x] Make normal `up` select the bundle independent of cwd.
 - [ ] Move checkout preparation/rebuild to explicit development provider.
-- [ ] Make managed remote reuse the release artifact and trust chain.
-- [ ] Distinguish installer-owned Runtime releases from preserved data and
+- [x] Make managed remote reuse the release artifact and trust chain.
+- [x] Distinguish installer-owned Runtime releases from preserved data and
   sources during uninstall.
+
+The first bundle increment on 2026-07-30 produced a 107 MiB darwin-arm64
+archive from three production dependency closures. Content-aware hard-link
+deduplication removed 500 MiB from the expanded tree before compression. The
+34,613-entry manifest verifies product version, Node floor, platform,
+architecture, modes, hashes, symlinks, required Guardian/Alice/UI/UTA/Connector
+layout, and content identity. A release matrix now builds darwin/linux on arm64
+and x64, installs each archive outside the checkout, boots it, runs Doctor, and
+stops it before publication.
+
+The installer places CLI, Pi, and Runtime beneath the same immutable
+`cli-versions/<ref>-<content-id>` directory and atomically switches one launcher
+that exports both managed providers. Stable versioned installers download
+release metadata plus the matching archive, verify both archive SHA-256 and
+the internal manifest, and bind CLI and Runtime to one OpenAlice version.
+Local development can pass `--runtime-archive` and `--runtime-sha256`.
+
+Dogfood installed the candidate into a fresh temporary root, launched
+`openalice up` from `/tmp` with no checkout, reached Alice at loopback, passed
+Doctor with zero failures, opened the bare `pi-tui` Supervisor against the
+surviving Runtime, detached without stopping it, and stopped it cleanly.
+Guardian reported `provider=bundle`, product/runtime `0.87.0-beta`, and content
+`d4a8e69b270f3cd1`. The OrbStack Linux arm64 SSH fixture then installed the
+matching bundle through the ordinary remote installer, launched and tunneled
+without a checkout or build tools, survived disconnect, repaired managed Pi,
+reconnected, and stopped through Guardian. Remaining work in this increment is
+reproducibility/authenticity hardening. The unsigned packaged-Electron Workspace
+acceptance passed its real Electron PTY, Shell, managed Pi response, scheduled
+Issue, and cleanup checks. The interactive clean-container installer playground
+also passed manual review of consent, plan copy, command/version JSON,
+completion, update policy, uninstall preservation, managed Pi, PATH, and
+source-tool planning.
 
 ### 9. Atomic Runtime update, activation, and rollback
 
@@ -608,6 +640,10 @@ This plan is complete only when:
   smoke, real isolated background `up/status/down`, foreground PTY Ctrl+C,
   clean installer upgrade/uninstall Docker smoke, managed remote SSH smoke, UI
   typecheck, server build, and Electron PTY smoke.
+- 2026-07-30: Built the first standalone headless Runtime increment. A clean
+  macOS install booted outside any checkout and the OrbStack Linux arm64 SSH
+  fixture installed, started, tunneled, repaired, reconnected, and stopped the
+  release bundle without creating a managed source checkout.
 - 2026-07-30: Published increment 1 as serial PR #853 targeting `dev`.
 - 2026-07-30: Completed increment 2 implementation and local verification:
   additive control API/capability negotiation, expanded product/provider/status

--- a/scripts/build-headless-runtime.ts
+++ b/scripts/build-headless-runtime.ts
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import {
+  join,
+  resolve,
+} from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import {
+  deduplicateRuntimeTree,
+  fileSha256,
+  RUNTIME_BUNDLE_DIRECTORY,
+  writeRuntimeBundleManifest,
+} from '../packages/cli/src/runtime-bundle.mjs'
+
+interface BuildOptions {
+  outputDir: string
+  skipBuild: boolean
+  keepStage: boolean
+}
+
+interface RootPackage {
+  name?: string
+  version?: string
+  engines?: {
+    node?: string
+  }
+}
+
+const REPOSITORY_ROOT = resolve(import.meta.dirname, '..')
+const DEFAULT_OUTPUT_DIR = resolve(REPOSITORY_ROOT, 'dist', 'headless')
+const RUNTIME_RESOURCES = [
+  ['dist', 'dist'],
+  ['ui/dist', 'ui/dist'],
+  ['default', 'default'],
+  ['src/workspaces/templates', 'src/workspaces/templates'],
+  ['src/workspaces/cli/bin', 'src/workspaces/cli/bin'],
+  ['services/uta/dist', 'services/uta/dist'],
+  ['services/uta/package.json', 'services/uta/package.json'],
+  ['services/connector/dist', 'services/connector/dist'],
+  ['services/connector/package.json', 'services/connector/package.json'],
+  ['packages/guardian-runtime/dist', 'packages/guardian-runtime/dist'],
+  ['packages/guardian-runtime/package.json', 'packages/guardian-runtime/package.json'],
+  ['scripts/guardian/prod.mjs', 'scripts/guardian/prod.mjs'],
+  ['scripts/guardian/control-server.mjs', 'scripts/guardian/control-server.mjs'],
+  ['scripts/guardian/prod-ports.mjs', 'scripts/guardian/prod-ports.mjs'],
+  ['package.json', 'package.json'],
+  ['LICENSE', 'LICENSE'],
+  ['THIRD_PARTY_NOTICES.md', 'THIRD_PARTY_NOTICES.md'],
+] as const
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+  if (!['darwin', 'linux'].includes(process.platform)) {
+    throw new Error(
+      `Headless Runtime bundles currently support macOS and Linux, not ${process.platform}.`,
+    )
+  }
+  if (!['arm64', 'x64'].includes(process.arch)) {
+    throw new Error(
+      `Headless Runtime bundles currently support arm64 and x64, not ${process.arch}.`,
+    )
+  }
+  const rootPackage = JSON.parse(
+    await readFile(join(REPOSITORY_ROOT, 'package.json'), 'utf8'),
+  ) as RootPackage
+  if (
+    rootPackage.name !== 'open-alice'
+    || typeof rootPackage.version !== 'string'
+  ) {
+    throw new Error('The repository package manifest is not OpenAlice.')
+  }
+  const productVersion = rootPackage.version
+  if (!options.skipBuild) {
+    run('build the server Runtime', ['build:server'])
+  }
+  await assertBuiltArtifacts()
+
+  const temporaryRoot = await mkdtemp(
+    join(tmpdir(), 'openalice-headless-runtime-'),
+  )
+  const deploymentsRoot = join(temporaryRoot, 'deployments')
+  const archiveParent = join(temporaryRoot, 'archive')
+  const runtimeRoot = join(archiveParent, RUNTIME_BUNDLE_DIRECTORY)
+  try {
+    await mkdir(deploymentsRoot, { recursive: true })
+    deployProductionPackage(
+      'open-alice',
+      join(deploymentsRoot, 'root'),
+    )
+    deployProductionPackage(
+      '@traderalice/uta-service',
+      join(deploymentsRoot, 'uta'),
+    )
+    deployProductionPackage(
+      '@traderalice/connector-service',
+      join(deploymentsRoot, 'connector'),
+    )
+
+    await mkdir(runtimeRoot, { recursive: true })
+    for (const [source, destination] of RUNTIME_RESOURCES) {
+      await copyRuntimeResource(source, destination, runtimeRoot)
+    }
+    await moveDeploymentClosure(
+      join(deploymentsRoot, 'root', 'node_modules'),
+      join(runtimeRoot, 'node_modules'),
+    )
+    await moveDeploymentClosure(
+      join(deploymentsRoot, 'uta', 'node_modules'),
+      join(runtimeRoot, 'services', 'uta', 'node_modules'),
+    )
+    await moveDeploymentClosure(
+      join(deploymentsRoot, 'connector', 'node_modules'),
+      join(runtimeRoot, 'services', 'connector', 'node_modules'),
+    )
+
+    const deduplicated = await deduplicateRuntimeTree(runtimeRoot)
+    const manifest = await writeRuntimeBundleManifest(runtimeRoot, {
+      productVersion,
+      platform: process.platform,
+      arch: process.arch,
+    })
+    await mkdir(options.outputDir, { recursive: true })
+    const stem = [
+      'openalice-runtime',
+      productVersion,
+      process.platform,
+      process.arch,
+      manifest.contentIdentity,
+    ].join('-')
+    const archiveName = `${stem}.tar.gz`
+    const archivePath = join(options.outputDir, archiveName)
+    const metadataPath = join(
+      options.outputDir,
+      `openalice-runtime-${productVersion}-${process.platform}-${process.arch}.json`,
+    )
+    await rm(archivePath, { force: true })
+    createArchive(archiveParent, archivePath)
+    verifyArchive(archivePath)
+    const archiveInfo = await stat(archivePath)
+    const archiveSha256 = await fileSha256(archivePath)
+    const metadata = {
+      schemaVersion: 1,
+      productVersion,
+      platform: process.platform,
+      arch: process.arch,
+      node: {
+        minimumVersion: '22.19.0',
+      },
+      runtimeContentIdentity: manifest.contentIdentity,
+      archive: {
+        file: archiveName,
+        size: archiveInfo.size,
+        sha256: archiveSha256,
+      },
+    }
+    await writeFile(
+      metadataPath,
+      `${JSON.stringify(metadata, null, 2)}\n`,
+      { encoding: 'utf8', mode: 0o644 },
+    )
+    process.stdout.write([
+      '',
+      'OpenAlice headless Runtime bundle ready',
+      `  Runtime   ${productVersion} ${process.platform}-${process.arch}`,
+      `  Identity  ${manifest.contentIdentity}`,
+      `  Files     ${manifest.files.length}`,
+      `  Dedup     ${deduplicated.filesLinked} files (${formatBytes(deduplicated.bytesDeduplicated)})`,
+      `  Archive   ${archivePath} (${formatBytes(archiveInfo.size)})`,
+      `  SHA-256   ${archiveSha256}`,
+      `  Metadata  ${metadataPath}`,
+      '',
+    ].join('\n'))
+    if (options.keepStage) {
+      const keptStage = join(options.outputDir, `${stem}.stage`)
+      await rm(keptStage, { recursive: true, force: true })
+      await rename(runtimeRoot, keptStage)
+      process.stdout.write(`  Stage     ${keptStage}\n`)
+    }
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+}
+
+function parseArgs(argv: string[]): BuildOptions {
+  const options: BuildOptions = {
+    outputDir: DEFAULT_OUTPUT_DIR,
+    skipBuild: false,
+    keepStage: false,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '--output-dir') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('-')) {
+        throw new Error('--output-dir requires a path.')
+      }
+      options.outputDir = resolve(value)
+      index += 1
+      continue
+    }
+    if (arg === '--skip-build') {
+      options.skipBuild = true
+      continue
+    }
+    if (arg === '--keep-stage') {
+      options.keepStage = true
+      continue
+    }
+    if (arg === '--help' || arg === '-h') {
+      process.stdout.write(`Usage:
+  pnpm build:headless-runtime [options]
+
+Build a platform-specific OpenAlice Runtime archive from production dependency
+closures. The archive does not contain Electron or source-build tooling.
+
+Options:
+  --output-dir <path>  Artifact directory (default: dist/headless)
+  --skip-build         Reuse existing server build artifacts
+  --keep-stage         Preserve the verified expanded Runtime beside the archive
+  -h, --help           Show this help
+`)
+      process.exit(0)
+    }
+    throw new Error(`Unknown option: ${arg}`)
+  }
+  return options
+}
+
+function deployProductionPackage(
+  packageName: string,
+  destination: string,
+): void {
+  run(`deploy ${packageName}`, [
+    '--config.inject-workspace-packages=true',
+    '--filter',
+    packageName,
+    'deploy',
+    '--prod',
+    destination,
+  ])
+}
+
+function run(label: string, args: string[]): void {
+  process.stdout.write(`\n[headless-runtime] ${label}\n`)
+  const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  const result = spawnSync(command, args, {
+    cwd: REPOSITORY_ROOT,
+    env: process.env,
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit code ${String(result.status)}.`)
+  }
+}
+
+function createArchive(
+  archiveParent: string,
+  archivePath: string,
+): void {
+  process.stdout.write('\n[headless-runtime] create archive\n')
+  const result = spawnSync('tar', [
+    '-czf',
+    archivePath,
+    '-C',
+    archiveParent,
+    RUNTIME_BUNDLE_DIRECTORY,
+  ], {
+    cwd: REPOSITORY_ROOT,
+    env: {
+      ...process.env,
+      COPYFILE_DISABLE: '1',
+    },
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `Creating the Runtime archive failed with exit code ${String(result.status)}.`,
+    )
+  }
+}
+
+function verifyArchive(archivePath: string): void {
+  const result = spawnSync('tar', ['-tzf', archivePath], {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `Verifying the Runtime archive failed with exit code ${String(result.status)}.`,
+    )
+  }
+  const entries = result.stdout.split(/\r?\n/).filter(Boolean)
+  if (
+    entries.length === 0
+    || entries.some((entry) => (
+      entry !== RUNTIME_BUNDLE_DIRECTORY
+      && entry !== `${RUNTIME_BUNDLE_DIRECTORY}/`
+      && !entry.startsWith(`${RUNTIME_BUNDLE_DIRECTORY}/`)
+    ))
+  ) {
+    throw new Error('The Runtime archive contains an unexpected path.')
+  }
+}
+
+async function copyRuntimeResource(
+  source: string,
+  destination: string,
+  runtimeRoot: string,
+): Promise<void> {
+  const sourcePath = join(REPOSITORY_ROOT, source)
+  const destinationPath = join(runtimeRoot, destination)
+  await mkdir(resolve(destinationPath, '..'), { recursive: true })
+  await cp(sourcePath, destinationPath, {
+    recursive: true,
+    force: true,
+    preserveTimestamps: true,
+  })
+}
+
+async function moveDeploymentClosure(
+  source: string,
+  destination: string,
+): Promise<void> {
+  await mkdir(resolve(destination, '..'), { recursive: true })
+  await rename(source, destination)
+}
+
+async function assertBuiltArtifacts(): Promise<void> {
+  for (const path of [
+    'dist/main.js',
+    'ui/dist/index.html',
+    'services/uta/dist/uta.js',
+    'services/connector/dist/connector.cjs',
+    'packages/guardian-runtime/dist/index.js',
+  ]) {
+    try {
+      await stat(join(REPOSITORY_ROOT, path))
+    } catch {
+      throw new Error(
+        `Missing ${path}; run pnpm build:server before --skip-build.`,
+      )
+    }
+  }
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB']
+  let value = bytes
+  let unit = units[0]
+  for (let index = 1; index < units.length && value >= 1_024; index += 1) {
+    value /= 1_024
+    unit = units[index]
+  }
+  return `${value.toFixed(value >= 10 || unit === 'B' ? 0 : 1)} ${unit}`
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `[headless-runtime] ${error instanceof Error ? error.message : String(error)}\n`,
+  )
+  process.exitCode = 1
+})

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -122,7 +122,7 @@ const value = JSON.parse(process.argv[1]);
 if (value.schemaVersion !== 1 || value.command !== "doctor" || value.ok !== true) process.exit(1);
 if (value.result?.doctor?.summary?.failures !== 0 || value.result?.doctor?.runtime?.class !== "absent") process.exit(1);
 ' "$doctor_status" || fail "installed CLI Doctor envelope check failed"
-"$bin_dir/openalice" up --help | grep -Fq "persistent background Runtime" \
+"$bin_dir/openalice" up --help | grep -Fq "installed OpenAlice Runtime" \
   || fail "installed CLI up help check failed"
 "$bin_dir/openalice" completion bash | grep -Fq "complete -F _openalice_completion openalice" \
   || fail "installed CLI completion check failed"
@@ -152,6 +152,8 @@ cmp /fixture/packages/cli/src/supervisor-config.ts "$v1_release/src/supervisor-c
   || fail "downloaded Supervisor configuration module differs from the fixture"
 cmp /fixture/packages/cli/src/managed-source.ts "$v1_release/src/managed-source.ts" \
   || fail "downloaded managed source module differs from the fixture"
+cmp /fixture/packages/cli/src/runtime-bundle.mjs "$v1_release/src/runtime-bundle.mjs" \
+  || fail "downloaded Runtime bundle module differs from the fixture"
 cmp /fixture/packages/cli/src/lifecycle-command.mjs "$v1_release/src/lifecycle-command.mjs" \
   || fail "downloaded lifecycle command module differs from the fixture"
 cmp /fixture/packages/cli/src/lifecycle.mjs "$v1_release/src/lifecycle.mjs" \

--- a/scripts/remote-smoke/Dockerfile
+++ b/scripts/remote-smoke/Dockerfile
@@ -16,6 +16,7 @@ COPY scripts/install-smoke/pi-assets /fixture/pi-assets
 COPY scripts/guardian/control-server.mjs /fixture/OpenAlice/scripts/guardian/control-server.mjs
 COPY scripts/remote-smoke/fixture-guardian.mjs /fixture/OpenAlice/scripts/guardian/prod.mjs
 COPY scripts/remote-smoke/fixture-package.json /fixture/OpenAlice/package.json
+COPY scripts/remote-smoke/build-runtime-fixture.mjs /fixture/scripts/remote-smoke/build-runtime-fixture.mjs
 COPY scripts/remote-smoke/entrypoint.sh /fixture/entrypoint.sh
 
 RUN mkdir -p \
@@ -40,6 +41,7 @@ RUN mkdir -p \
   && git -C /fixture/OpenAlice add --force . \
   && git -C /fixture/OpenAlice commit -m 'remote smoke fixture' \
   && git -C /fixture/OpenAlice tag remote-smoke \
+  && node /fixture/scripts/remote-smoke/build-runtime-fixture.mjs \
   && chmod +x /fixture/entrypoint.sh /fixture/fake-npm.sh \
   && chown -R smoke:smoke /fixture/OpenAlice /home/smoke
 

--- a/scripts/remote-smoke/build-runtime-fixture.mjs
+++ b/scripts/remote-smoke/build-runtime-fixture.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+import {
+  fileSha256,
+  writeRuntimeBundleManifest,
+} from '../../packages/cli/src/runtime-bundle.mjs'
+
+const fixtureRoot = '/fixture'
+const runtimeAssets = join(fixtureRoot, 'runtime-assets')
+const archiveParent = join(runtimeAssets, 'archive')
+const runtimeRoot = join(archiveParent, 'openalice-runtime')
+const productVersion = JSON.parse(
+  await readFile(join(fixtureRoot, 'packages/cli/package.json'), 'utf8'),
+).version
+
+for (const path of [
+  'dist',
+  'ui/dist',
+  'default',
+  'src/workspaces/templates',
+  'src/workspaces/cli/bin',
+  'services/uta/dist',
+  'services/connector/dist',
+  'packages/guardian-runtime/dist',
+  'scripts/guardian',
+  'node_modules',
+]) {
+  await mkdir(join(runtimeRoot, path), { recursive: true })
+}
+
+const files = new Map([
+  ['dist/main.js', 'export {}\n'],
+  ['ui/dist/index.html', '<!doctype html><title>OpenAlice remote fixture</title>\n'],
+  ['default/persona.default.md', '# OpenAlice\n'],
+  ['src/workspaces/templates/.keep', 'fixture\n'],
+  ['src/workspaces/cli/bin/openalice-cli.cjs', 'module.exports = {}\n'],
+  ['services/uta/dist/uta.js', 'export {}\n'],
+  ['services/connector/dist/connector.cjs', 'module.exports = {}\n'],
+  ['packages/guardian-runtime/dist/index.js', 'export {}\n'],
+  ['scripts/guardian/prod-ports.mjs', 'export {}\n'],
+  ['node_modules/.keep', 'fixture\n'],
+  ['package.json', JSON.stringify({
+    name: 'open-alice',
+    version: productVersion,
+    type: 'module',
+    scripts: { 'build:server': 'true' },
+  }) + '\n'],
+])
+for (const [path, content] of files) {
+  await writeFile(join(runtimeRoot, path), content)
+}
+await writeFile(
+  join(runtimeRoot, 'scripts/guardian/prod.mjs'),
+  await readFile(join(fixtureRoot, 'OpenAlice/scripts/guardian/prod.mjs')),
+)
+await writeFile(
+  join(runtimeRoot, 'scripts/guardian/control-server.mjs'),
+  await readFile(join(fixtureRoot, 'OpenAlice/scripts/guardian/control-server.mjs')),
+)
+
+const manifest = await writeRuntimeBundleManifest(runtimeRoot, {
+  productVersion,
+  platform: process.platform,
+  arch: process.arch,
+})
+const archiveName = [
+  'openalice-runtime',
+  productVersion,
+  process.platform,
+  process.arch,
+  manifest.contentIdentity,
+].join('-') + '.tar.gz'
+const archivePath = join(runtimeAssets, archiveName)
+const tar = spawnSync('tar', [
+  '-czf',
+  archivePath,
+  '-C',
+  archiveParent,
+  'openalice-runtime',
+], { stdio: 'inherit' })
+if (tar.error) throw tar.error
+if (tar.status !== 0) throw new Error(`tar exited ${String(tar.status)}`)
+const archiveSha256 = await fileSha256(archivePath)
+const archiveSize = await stat(archivePath)
+await writeFile(
+  join(
+    runtimeAssets,
+    `openalice-runtime-${productVersion}-${process.platform}-${process.arch}.json`,
+  ),
+  JSON.stringify({
+    schemaVersion: 1,
+    productVersion,
+    platform: process.platform,
+    arch: process.arch,
+    node: { minimumVersion: '22.19.0' },
+    runtimeContentIdentity: manifest.contentIdentity,
+    archive: {
+      file: archiveName,
+      size: archiveSize.size,
+      sha256: archiveSha256,
+    },
+  }, null, 2) + '\n',
+)

--- a/scripts/remote-smoke/entrypoint.sh
+++ b/scripts/remote-smoke/entrypoint.sh
@@ -6,6 +6,7 @@ install -m 0600 -o smoke -g smoke /tmp/authorized_keys /home/smoke/.ssh/authoriz
 printf '%s\n' \
   'OPENALICE_NPM_BIN=/fixture/fake-npm.sh' \
   'OPENALICE_PI_RELEASE_BASE_URL=http://127.0.0.1:18080/pi-assets' \
+  'OPENALICE_RUNTIME_RELEASE_BASE_URL=http://127.0.0.1:18080/runtime-assets' \
   > /home/smoke/.ssh/environment
 chown smoke:smoke /home/smoke/.ssh/environment
 chmod 0600 /home/smoke/.ssh/environment

--- a/scripts/remote-smoke/fixture-guardian.mjs
+++ b/scripts/remote-smoke/fixture-guardian.mjs
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 import { createServer } from 'node:http'
 
 import { startGuardianControlServer } from './control-server.mjs'
@@ -8,6 +9,9 @@ const port = Number(process.env.OPENALICE_WEB_PORT ?? 47331)
 const surface = process.env.OPENALICE_LAUNCHER ?? 'cli-server'
 const startedAt = new Date().toISOString()
 const instanceId = randomUUID()
+const productVersion = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+).version
 let stopping = false
 let control
 
@@ -31,7 +35,8 @@ control = await startGuardianControlServer({
   allowStop: surface === 'cli-server',
   getStatus: () => ({
     protocol: 1,
-    runtimeVersion: '0.0.0-remote-smoke',
+    productVersion,
+    runtimeVersion: productVersion,
     state: stopping ? 'stopping' : 'running',
     home,
     owner: {
@@ -43,6 +48,11 @@ control = await startGuardianControlServer({
       mode: process.env.OPENALICE_SERVER_MODE ?? 'detached',
     },
     endpoints: { web: `http://127.0.0.1:${port}` },
+    provider: {
+      kind: process.env.OPENALICE_RUNTIME_PROVIDER ?? 'source',
+      root: process.cwd(),
+      contentIdentity: process.env.OPENALICE_RUNTIME_CONTENT_IDENTITY ?? null,
+    },
     components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
     capabilities: surface === 'cli-server' ? ['runtime.stop'] : [],
   }),

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -120,10 +120,12 @@ try {
   const piVersion = run('ssh', [remoteTarget, '"$HOME/.openalice/bin/pi" --version'], { env: smokeEnv }).trim()
   if (piVersion !== '0.83.0') throw new Error(`Remote managed Pi version mismatch: ${piVersion}`)
   const launchRoot = running.owner?.launchRoot
-  if (typeof launchRoot !== 'string' || !launchRoot.includes('/.openalice/sources/')) {
-    throw new Error(`Remote Server did not use a managed checkout: ${JSON.stringify(launchRoot)}`)
+  if (typeof launchRoot !== 'string' || !launchRoot.includes('/.openalice/cli-versions/')) {
+    throw new Error(`Remote Server did not use an installed Runtime: ${JSON.stringify(launchRoot)}`)
   }
-  run('ssh', [remoteTarget, `test -d ${shellQuote(join(launchRoot, '.git'))}`], { env: smokeEnv })
+  if (running.provider?.kind !== 'bundle') {
+    throw new Error(`Remote Server did not report the bundle provider: ${JSON.stringify(running.provider)}`)
+  }
 
   console.log('[remote-ssh-smoke] repairing a legacy CLI Server with its managed Pi launcher missing')
   run('ssh', [remoteTarget, 'rm -f "$HOME/.openalice/bin/pi" "$HOME/.openalice/bin/pi.cmd"'], { env: smokeEnv })


### PR DESCRIPTION
## What changed

- builds content-addressed macOS/Linux headless Runtime archives for arm64 and x64
- publishes Runtime metadata and archives as release assets after boot/Doctor/stop acceptance
- installs CLI, managed Pi, and the matching platform Runtime as one OpenAlice version
- makes local lifecycle commands and the Supervisor prefer the installed Runtime from any working directory
- makes `openalice remote` install and reuse the remote platform Runtime without cloning or compiling source
- keeps explicit source checkout behavior as an advanced development fallback
- removes installer-owned Runtime releases during uninstall while preserving homes, Workspaces, credentials, and sources
- documents and tests the clean-machine and SSH-machine paths

## Why

Shell-first OpenAlice should work as a product distribution, not require a repository checkout or `pnpm dev`. A programmer should be able to install OpenAlice on a clean local machine or an SSH host, leave Guardian running after disconnect, and use the browser as the full product UI.

CLI/Pi content identity is deliberately cross-platform; the platform Runtime keeps its own manifest identity. This lets a macOS controller recognize the matching Linux remote CLI while still verifying every platform-specific Runtime file.

## Verification

- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh scripts/remote-smoke/entrypoint.sh`
- `npx tsc --noEmit`
- `pnpm test` — 447 files passed, 3755 tests passed, 9 skipped
- `pnpm test:install:docker` — clean install/update/reuse/uninstall passed
- `pnpm test:install:docker --interactive` — manual consent, plan, PATH, version, completion, update and uninstall review passed
- `pnpm test:remote:docker` — Linux arm64 SSH install/start/tunnel/reconnect/repair/stop passed without a checkout
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` — packaged Electron PTY, Shell, managed Pi and scheduled Issue acceptance passed
- real 107 MiB darwin-arm64 Runtime archive installed outside the checkout; `up`, Web auth, Doctor, Supervisor detach, and `down` passed
- plain and Runtime-bearing installs produced the same cross-platform CLI content identity while the Runtime retained its own identity
