### PR TITLE
feat(autoquant): pin new desks to v0.8.31

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -30,7 +30,7 @@ the durable truth after it changes.
 
 - [[plans/auto-quant-v2-harness.md]] — Adds AutoQuant V2 as a first-class
   version-pinned Harness, then refines it into an explicitly initialized
-  default desk with Session-first daily UI and pinned `v0.8.30` source.
+  default desk with Session-first daily UI and pinned `v0.8.31` source.
 - [[plans/cli-lifecycle-quality.md]] — Aligns the computer-level CLI with the
   OpenAlice product version and adds bounded update discovery, installer-backed
   updates, and state-preserving CLI uninstall. Delivered in PR #847.

--- a/plans/auto-quant-v2-harness.md
+++ b/plans/auto-quant-v2-harness.md
@@ -19,9 +19,9 @@ quantitative assignment and open a native coding-Agent Session.
 
 - Replace the unused Classic creation template with a new `auto-quant-v2`
   template; existing Classic Workspace checkouts remain untouched.
-- Default new AutoQuant desks to V2 `v0.8.30` at commit
-  `cba95f8718e8396a3147a9cc5f5275cd44feae5f`; retain `v0.8.27` in the
-  approved catalog for reproducible explicit creation.
+- Default new AutoQuant desks to V2 `v0.8.31` at commit
+  `426d815b18450172fbcf4c6b6af77c6ae05a4967`; retain `v0.8.30` and
+  `v0.8.27` in the approved catalog for reproducible explicit creation.
 - Add a generic template-source catalog and create-time version selection.
 - Materialize the exact upstream tree into OpenAlice's fresh local Git Harness
   and commit a source receipt without installing Python dependencies.
@@ -69,8 +69,8 @@ quantitative assignment and open a native coding-Agent Session.
       selection.
 - [x] Replace the Workspace-oriented AutoQuant sidebar with the default desk's
       bounded Session history and a low-frequency Workspace control.
-- [x] Default new initialization to the immutable AutoQuant V2 `v0.8.30`
-      release while retaining the older approved catalog entry.
+- [x] Default new initialization to the immutable AutoQuant V2 `v0.8.31`
+      release while retaining the older approved catalog entries.
 - [x] Re-run full repository, demo, browser/dev, and packaged Electron
       verification for the revised entry path.
 
@@ -87,5 +87,5 @@ quantitative assignment and open a native coding-Agent Session.
 The plan completes when AutoQuant renders no research controls before a valid
 default desk exists, initialization or explicit selection establishes that
 pointer, every new assignment becomes a Session in the selected desk, and a
-fresh desk records the pinned V2 `v0.8.30` source without any Classic migration
+fresh desk records the pinned V2 `v0.8.31` source without any Classic migration
 or AutoQuant-specific orchestration service.

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -20,8 +20,8 @@ conversation, Inbox, market-data tools, and optional UTA access around the
 desk. It does not reproduce AutoQuant's Project, Study, Session, Run, Report,
 or Dossier lifecycle.
 
-The default supported source is AutoQuant V2 `v0.8.30` at commit
-`cba95f8718e8396a3147a9cc5f5275cd44feae5f`. The exact upstream source is
+The default supported source is AutoQuant V2 `v0.8.31` at commit
+`426d815b18450172fbcf4c6b6af77c6ae05a4967`. The exact upstream source is
 recorded in `.alice/harness-source.json`; the Workspace itself starts a fresh
 local Git history with no pushable upstream remote.
 

--- a/src/workspaces/templates/auto-quant-v2/template.json
+++ b/src/workspaces/templates/auto-quant-v2/template.json
@@ -8,8 +8,12 @@
   "bundledSkills": [],
   "source": {
     "repository": "https://github.com/TraderAlice/Auto-Quant-V2.git",
-    "defaultVersion": "v0.8.30",
+    "defaultVersion": "v0.8.31",
     "versions": [
+      {
+        "version": "v0.8.31",
+        "commit": "426d815b18450172fbcf4c6b6af77c6ae05a4967"
+      },
       {
         "version": "v0.8.30",
         "commit": "cba95f8718e8396a3147a9cc5f5275cd44feae5f"

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -100,8 +100,9 @@ describe('resolveTemplateSource', () => {
     bundledSkills: [],
     source: {
       repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-      defaultVersion: 'v0.8.30',
+      defaultVersion: 'v0.8.31',
       versions: [
+        { version: 'v0.8.31', commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967' },
         { version: 'v0.8.30', commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f' },
         { version: 'v0.8.27', commit: '4bf9eb45763776ab5fc2e02829b804594fc377a3' },
       ],
@@ -110,8 +111,8 @@ describe('resolveTemplateSource', () => {
 
   it('uses the catalog default when the caller omits a version', () => {
     expect(resolveTemplateSource(template)).toEqual({
-      version: 'v0.8.30',
-      commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f',
+      version: 'v0.8.31',
+      commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
     });
   });
 

--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -133,8 +133,8 @@ const demoIssueWorkspaces: Workspace[] = [
       schemaVersion: 1,
       template: 'auto-quant-v2',
       repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-      version: 'v0.8.30',
-      commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f',
+      version: 'v0.8.31',
+      commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
     },
     agents: ['codex'],
     sessions: [],
@@ -182,8 +182,12 @@ export const autoQuantTemplate: TemplateInfo = {
   hasReadme: true,
   source: {
     repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-    defaultVersion: 'v0.8.30',
+    defaultVersion: 'v0.8.31',
     versions: [
+      {
+        version: 'v0.8.31',
+        commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
+      },
       {
         version: 'v0.8.30',
         commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f',

--- a/ui/src/pages/AutoQuantSetupPage.spec.tsx
+++ b/ui/src/pages/AutoQuantSetupPage.spec.tsx
@@ -32,11 +32,17 @@ const template: TemplateInfo = {
   hasReadme: true,
   source: {
     repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-    defaultVersion: 'v0.8.30',
-    versions: [{
-      version: 'v0.8.30',
-      commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f',
-    }],
+    defaultVersion: 'v0.8.31',
+    versions: [
+      {
+        version: 'v0.8.31',
+        commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
+      },
+      {
+        version: 'v0.8.30',
+        commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f',
+      },
+    ],
   },
 }
 
@@ -109,7 +115,7 @@ describe('AutoQuant setup', () => {
     render(<AutoQuantSetupPage />)
 
     expect(screen.queryByPlaceholderText('Describe the strategy, market, hypothesis, or iteration goal…')).toBeNull()
-    expect(screen.getByText('v0.8.30')).toBeTruthy()
+    expect(screen.getByText('v0.8.31')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Initialize AutoQuant' }))
     await waitFor(() => expect(mocks.initializeAutoQuant).toHaveBeenCalledOnce())
   })


### PR DESCRIPTION
## Summary
- make AutoQuant V2 `v0.8.31` (`426d815b18450172fbcf4c6b6af77c6ae05a4967`) the default for newly initialized desks
- retain `v0.8.30` and `v0.8.27` as explicit reproducible creation choices
- update setup UI, demo lineage, template documentation, and completed integration plan
- leave existing durable AutoQuant Workspaces pinned to their recorded source

## Verification
- verified the annotated `v0.8.31` tag resolves to the pinned commit
- bootstrapped the real local AutoQuant `v0.8.31` checkout and verified its source receipt plus market-data skills
- targeted template/UI tests: 17 passed
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test -- --reporter=dot` (448 files passed, 1 skipped; 3758 tests passed, 9 skipped)
- walked the real `/auto-quant` first-run route and confirmed it renders `v0.8.31`
