### PR TITLE
Make the OpenAlice TUI parameter-free by default

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -86,9 +86,12 @@ separate daemons.
 
 The TypeScript TUI reports and polls the selected Runtime, detaches with `q`,
 `Esc`, or `Ctrl+C`, and exposes the same presentation-neutral operations as the
-explicit commands:
+explicit commands. Its ordinary path is intentionally parameter-free:
 
-- `s` starts the persistent Runtime when stopped;
+- Enter starts the persistent Runtime and opens the verified Web endpoint when
+  stopped, or opens the endpoint when already running;
+- `s` starts the persistent Runtime in the background without opening a
+  browser;
 - `o` opens an advertised, verified Web endpoint;
 - `x` stops and `r` restarts only a `cli-server` owner, after an impact
   confirmation;
@@ -97,8 +100,9 @@ explicit commands:
 - `u` performs an advisory product-update check;
 - `i` lists the implicit default plus registered instances, selects one without
   stopping another instance, or creates a separate named complete home;
-- `p` opens selected-instance settings for complete home, Web port, update
-  checks, and resolved source/config provenance;
+- `p` opens Setup for data home, browser port, update checks, and resolved
+  Runtime/config provenance. Setup can edit either the selected instance or
+  machine defaults inherited by instances;
 - `m` is an advanced control that confirms, prepares, remembers, and starts an installer-managed source
   aligned to the installed CLI branch/version;
 - `c` is an advanced control that chooses and remembers the selected instance's source checkout;
@@ -138,15 +142,24 @@ the Supervisor reads a versioned machine-local document at
 `<Supervisor root>/config.json`. It contains machine defaults and an instance
 map outside every selectable complete home.
 
-The `p` settings overlay atomically edits the selected instance's complete
-home, Web port, and update-check policy. A blank Home or port and the
-`Inherit` update value remove the instance override, exposing the resolved
-machine/default value immediately. Named instances must retain an explicit,
-separate complete home; only the implicit `default` may inherit its Home.
-Home and port remain read-only while the selected Runtime is active. Any value
-supplied by an environment variable or explicit CLI flag is shown with its
-resolved value and a locked provenance message; the TUI never writes a
-lower-priority value that appears to override it.
+The `p` Setup overlay atomically edits the selected instance's data home,
+browser port, and update-check policy. Its first row switches between `This
+instance` and `Machine defaults`. A blank Home or port and the `Inherit` update
+value remove that layer's override, exposing the next lower-priority value
+immediately. Named instances must retain an explicit, separate complete home;
+only the implicit `default` may inherit its Home. Home and port remain
+read-only while the selected Runtime is active when the edited layer affects
+that Runtime. A machine default may still be changed while a higher instance,
+environment, or flag layer shields the running instance.
+
+Any selected-instance value supplied by an environment variable or explicit
+CLI flag is shown with its resolved value and a locked provenance message; the
+TUI never writes a lower-priority instance value that appears to override it.
+Machine-default editing remains available because it intentionally changes the
+lower layer for future or inheriting launches. The overview reports the
+resolved field provenance, and Setup identifies the installed Runtime by the
+single OpenAlice product version plus diagnostic content identity rather than
+presenting its filesystem path as a second product concept.
 
 The `i` instance overlay reads the same atomic registry, always shows the
 implicit `default`, and adds every configured named instance. Selecting one
@@ -172,10 +185,9 @@ instead of pretending that a lower-priority selection can win.
 The `c` editor validates an OpenAlice checkout, atomically saves it as the
 selected instance's `appDir`, and starts the Runtime. If
 `OPENALICE_APP_HOME` or `--app-dir` supplied the source, the TUI reports that
-higher-priority override instead of overwriting it. Machine-default editing,
-`openalice config check`, live reload with last-known-good retention,
-registry-entry removal, and full component/instance dashboards remain later
-increments.
+higher-priority override instead of overwriting it. `openalice config check`,
+live reload with last-known-good retention, registry-entry removal, and full
+component/instance dashboards remain later increments.
 
 `OPENALICE_INSTANCE`, `OPENALICE_HOME`, `OPENALICE_WEB_PORT`,
 `OPENALICE_APP_HOME`, and `OPENALICE_NO_UPDATE_CHECK` are the corresponding

--- a/packages/cli/src/supervisor-config.spec.ts
+++ b/packages/cli/src/supervisor-config.spec.ts
@@ -17,7 +17,9 @@ import {
   createSupervisorInstance,
   parseSupervisorConfig,
   persistInstanceLaunchConfig,
+  persistMachineLaunchConfig,
   persistSelectedSupervisorInstance,
+  readMachineLaunchConfig,
   readSupervisorInstanceRegistry,
   resolveAvailableStoredLaunchContext,
   resolveStoredLaunchContext,
@@ -183,6 +185,69 @@ describe('Supervisor configuration', () => {
       name: 'default',
       updateChecks: false,
     })
+  })
+
+  it('persists machine defaults below instance, environment, and CLI layers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-supervisor-machine-'))
+    temporaryPaths.push(root)
+    const homeDir = join(root, 'user')
+    const context = await resolveStoredLaunchContext({}, {
+      homeDir,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+
+    await persistMachineLaunchConfig(context, {
+      home: join(root, 'machine-home'),
+      port: 48_001,
+      updateChecks: false,
+    }, {
+      homeDir,
+      platform: 'linux',
+    })
+
+    await expect(readMachineLaunchConfig(context)).resolves.toEqual({
+      home: await realpath(join(root, 'machine-home')),
+      port: 48_001,
+      updateChecks: false,
+    })
+    const inherited = await resolveStoredLaunchContext({}, {
+      homeDir,
+      platform: 'linux',
+      env: { XDG_CONFIG_HOME: join(root, 'config') },
+    })
+    expect(inherited).toMatchObject({
+      home: await realpath(join(root, 'machine-home')),
+      port: 48_001,
+      updateChecks: false,
+      provenance: {
+        home: { source: 'machine-config' },
+        port: { source: 'machine-config' },
+        updateChecks: { source: 'machine-config' },
+      },
+    })
+
+    await persistInstanceLaunchConfig(inherited, { port: 48_002 })
+    const overridden = await resolveStoredLaunchContext({ port: 48_004 }, {
+      homeDir,
+      platform: 'linux',
+      env: {
+        XDG_CONFIG_HOME: join(root, 'config'),
+        OPENALICE_WEB_PORT: '48003',
+      },
+    })
+    expect(overridden.port).toBe(48_004)
+    expect(overridden.provenance.port.source).toBe('cli-flag')
+
+    await persistMachineLaunchConfig(overridden, {
+      home: undefined,
+      port: undefined,
+      updateChecks: undefined,
+    }, {
+      homeDir,
+      platform: 'linux',
+    })
+    await expect(readMachineLaunchConfig(context)).resolves.toEqual({})
   })
 
   it('creates, lists, selects, and remembers named complete-home instances', async () => {

--- a/packages/cli/src/supervisor-config.ts
+++ b/packages/cli/src/supervisor-config.ts
@@ -122,6 +122,16 @@ export async function readInstanceLaunchConfig(
   }
 }
 
+export async function readMachineLaunchConfig(
+  context: Pick<ResolvedLaunchContext, 'supervisorRoot'>,
+  options: Pick<PersistInstanceConfigOptions, 'readConfig'> = {},
+): Promise<LaunchConfigValues> {
+  const config = await (
+    options.readConfig ?? readSupervisorConfig
+  )(context.supervisorRoot)
+  return { ...config.defaults }
+}
+
 export async function resolveStoredLaunchContext(
   flags: TuiLaunchFlags = {},
   options: StoredLaunchContextOptions = {},
@@ -256,6 +266,46 @@ export async function persistInstanceLaunchConfig(
     await mkdir(normalizedPatch.home, { recursive: true, mode: 0o700 })
     await assertHomeCandidateUsable(normalizedPatch.home)
     instance.home = await realpath(normalizedPatch.home)
+    await assertRegistryHomesSeparate(next, options)
+  }
+  await writeConfig(context.supervisorRoot, next)
+}
+
+export async function persistMachineLaunchConfig(
+  context: Pick<ResolvedLaunchContext, 'supervisorRoot'>,
+  patch: LaunchConfigValues,
+  options: PersistInstanceConfigOptions = {},
+): Promise<void> {
+  const readConfig = options.readConfig ?? readSupervisorConfig
+  const writeConfig = options.writeConfig ?? writeSupervisorConfig
+  const current = await readConfig(context.supervisorRoot)
+  const defaults: LaunchConfigValues = {
+    ...current.defaults,
+    ...patch,
+  }
+  for (const key of [
+    'home',
+    'port',
+    'appDir',
+    'updateChecks',
+  ] as const) {
+    if (Object.hasOwn(patch, key) && patch[key] === undefined) {
+      delete defaults[key]
+    }
+  }
+  if (typeof patch.home === 'string') {
+    defaults.home = resolveConfiguredHome('default', patch.home, options)
+  }
+  const next: SupervisorConfigDocument = {
+    ...current,
+    schemaVersion: CONFIG_SCHEMA_VERSION,
+    defaults: Object.keys(defaults).length > 0 ? defaults : undefined,
+  }
+  await assertRegistryHomesSeparate(next, options)
+  if (typeof defaults.home === 'string' && Object.hasOwn(patch, 'home')) {
+    await mkdir(defaults.home, { recursive: true, mode: 0o700 })
+    await assertHomeCandidateUsable(defaults.home)
+    defaults.home = await realpath(defaults.home)
     await assertRegistryHomesSeparate(next, options)
   }
   await writeConfig(context.supervisorRoot, next)

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -208,16 +208,19 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       }, 10_000)
       child.onData((data) => {
         output += data
-        if (!openedSettings && output.includes('p Settings')) {
+        if (!openedSettings && output.includes('p Setup')) {
           openedSettings = true
           child.write('p')
-        } else if (!selectedPort && output.includes('Instance settings · default')) {
+        } else if (!selectedPort && output.includes('OpenAlice setup · default')) {
           selectedPort = true
-          child.write('\u001b[B\r')
-        } else if (!submittedPort && output.includes('Set Web port')) {
+          child.write('\u001b[B\u001b[B\r')
+        } else if (!submittedPort && output.includes('Set instance browser port')) {
           submittedPort = true
           child.write('49001\r')
-        } else if (!closedSettings && output.includes('Saved Web port.')) {
+        } else if (
+          !closedSettings
+          && output.includes('Saved browser port for instance "default".')
+        ) {
           closedSettings = true
           child.write('\u001b')
         } else if (
@@ -239,13 +242,99 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       await readFile(join(supervisorHome, 'config.json'), 'utf8'),
     )
     expect(config.instances.default.port).toBe(49_001)
-    expect(transcript).toContain('Instance settings · default')
-    expect(transcript).toContain('Set Web port')
-    expect(transcript).toContain('Saved Web port.')
+    expect(transcript).toContain('OpenAlice setup · default')
+    expect(transcript).toContain('Set instance browser port')
+    expect(transcript).toContain('Saved browser port for instance "default".')
     expect(transcript).toContain('port (instance.default.port)')
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
-  })
+  }, 15_000)
+
+  it('switches setup scope and persists machine defaults inside the TUI', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-machine-settings-'))
+    temporaryPaths.push(isolatedHome)
+    const supervisorHome = join(isolatedHome, 'supervisor')
+    const childEnv = { ...process.env }
+    delete childEnv.OPENALICE_HOME
+    delete childEnv.OPENALICE_INSTANCE
+    const child = pty.spawn(process.execPath, [cliEntry], {
+      cols: 110,
+      rows: 30,
+      cwd: dirname(cliEntry),
+      env: {
+        ...childEnv,
+        HOME: isolatedHome,
+        OPENALICE_SUPERVISOR_HOME: supervisorHome,
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let openedSetup = false
+      let selectedMachineScope = false
+      let selectedPort = false
+      let submittedPort = false
+      let closedSetup = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Supervisor machine settings timed out:\n${output}`))
+      }, 10_000)
+      child.onData((data) => {
+        output += data
+        if (!openedSetup && output.includes('p Setup')) {
+          openedSetup = true
+          child.write('p')
+        } else if (
+          !selectedMachineScope
+          && output.includes('Editing')
+          && output.includes('This instance')
+        ) {
+          selectedMachineScope = true
+          child.write('\r')
+        } else if (
+          !selectedPort
+          && output.includes('Editing machine defaults.')
+        ) {
+          selectedPort = true
+          child.write('\u001b[B\u001b[B\r')
+        } else if (
+          !submittedPort
+          && output.includes('Set machine-default browser port')
+        ) {
+          submittedPort = true
+          child.write('49002\r')
+        } else if (
+          !closedSetup
+          && output.includes('Saved browser port for machine default.')
+        ) {
+          closedSetup = true
+          child.write('\u001b')
+        } else if (
+          !detached
+          && output.includes('port (machine.defaults.port)')
+        ) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Supervisor machine settings exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    const config = JSON.parse(
+      await readFile(join(supervisorHome, 'config.json'), 'utf8'),
+    )
+    expect(config.defaults.port).toBe(49_002)
+    expect(transcript).toContain('Editing machine defaults.')
+    expect(transcript).toContain('Set machine-default browser port')
+    expect(transcript).toContain('Saved browser port for machine default.')
+    expect(transcript).toContain('port (machine.defaults.port)')
+  }, 15_000)
 
   it('creates, selects, remembers, and switches named instances inside the TUI', async () => {
     const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-instances-'))
@@ -296,7 +385,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
         } else if (
           !acceptedHome
           && output.includes('Create instance · research')
-          && output.includes('Complete home')
+          && output.includes('Data home')
         ) {
           acceptedHome = true
           child.write('\r')
@@ -458,17 +547,17 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       }, 10_000)
       child.onData((data) => {
         output += data
-        if (!openedSettings && output.includes('p Settings')) {
+        if (!openedSettings && output.includes('p Setup')) {
           openedSettings = true
           child.write('p')
         } else if (!selectedPort && output.includes('44000 · locked')) {
           selectedPort = true
-          child.write('\u001b[B')
+          child.write('\u001b[B\u001b[B')
         } else if (!testedLockedPort && output.includes('Locked by --port.')) {
           testedLockedPort = true
           child.write('\r')
           setTimeout(() => child.write('\u001b'), 50)
-        } else if (!detached && output.includes('Instance settings closed.')) {
+        } else if (!detached && output.includes('Setup closed.')) {
           detached = true
           child.write('q')
         }
@@ -482,7 +571,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
 
     expect(transcript).toContain('44000 · locked')
     expect(transcript).toContain('Locked by --port.')
-    expect(transcript).not.toContain('Set Web port')
+    expect(transcript).not.toContain('Set browser port')
   })
 
   it('shows CLI-selected instances as read-only instead of pretending to switch them', async () => {

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import { resolveLaunchContext } from './launch-context.ts'
 import {
   resolveSupervisorChannel,
+  runSupervisorTui,
   type SupervisorAction,
   SupervisorScreen,
 } from './supervisor-tui.ts'
@@ -43,7 +45,9 @@ describe('Supervisor TUI screen', () => {
 
     expect(lines).toContain('OpenAlice  0.87.0-beta  dev')
     expect(lines).toContain('Runtime state: absent')
-    expect(lines).toContain('s Start · i Instances · p Settings · m Managed · c Source')
+    expect(lines).toContain(
+      'Enter Start & open · s Background · p Setup · i Instances · m Managed · c Source',
+    )
     expect(lines).toContain('d Doctor · l Logs · u Update · ? Help')
     expect(lines).toContain('q / Esc / Ctrl+C  Detach without stopping')
   })
@@ -61,6 +65,35 @@ describe('Supervisor TUI screen', () => {
     expect(lines).toContain('Runtime: unavailable')
     expect(lines.join('\n')).not.toContain('\u001b')
     expect(lines.every((line) => line.length <= 40)).toBe(true)
+  })
+
+  it('shows the installed Runtime as a product identity instead of a long path', () => {
+    const context = resolveLaunchContext({
+      cwd: '/tmp',
+      homeDir: '/home/alice',
+      env: {
+        OPENALICE_MANAGED_RUNTIME_PATH: '/opt/openalice/releases/runtime',
+        OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY: '1234567890abcdef',
+      },
+    })
+    const screen = new SupervisorScreen({
+      version: '0.87.0-beta',
+      channel: 'stable',
+      runtime: {
+        class: 'absent',
+        home: context.home,
+        owner: null,
+        endpoints: {},
+      },
+      context,
+    })
+
+    const output = screen.render(100).join('\n')
+    expect(output).toContain('Provider: bundle (installed)')
+    expect(output).toContain(
+      'Runtime: OpenAlice 0.87.0-beta · bundle 1234567890abcdef',
+    )
+    expect(output).not.toContain('/opt/openalice/releases/runtime')
   })
 
   it('dispatches available actions and confirms Runtime mutations', () => {
@@ -88,6 +121,101 @@ describe('Supervisor TUI screen', () => {
 
     expect(screen.handleKey('enter', matchesKey)).toBe(true)
     expect(actions).toEqual(['open', 'restart'])
+  })
+
+  it('uses Enter as the human-first start-and-open or open action', () => {
+    const actions: SupervisorAction[] = []
+    const screen = new SupervisorScreen({
+      version: 'dev',
+      channel: 'development',
+      runtime: { class: 'absent', endpoints: {} },
+    }, {
+      onAction: (action) => actions.push(action),
+    })
+
+    expect(screen.handleKey('enter', matchesKey)).toBe(true)
+    expect(actions).toEqual(['start-open'])
+    expect(screen.render(100).join('\n')).toContain(
+      'Press Enter to start and open the browser',
+    )
+
+    screen.update({
+      runtime: {
+        class: 'running',
+        owner: { surface: 'cli-server', pid: 42 },
+        endpoints: { web: 'http://127.0.0.1:47331' },
+      },
+    })
+    expect(screen.handleKey('enter', matchesKey)).toBe(true)
+    expect(actions).toEqual(['start-open', 'open'])
+    expect(screen.render(100).join('\n')).toContain(
+      'Press Enter or o to open the Web UI',
+    )
+  })
+
+  it('starts the Runtime and opens the browser from one Enter key', async () => {
+    const calls: string[] = []
+    let runtime: {
+      class: string
+      owner: { surface: string; pid: number } | null
+      endpoints: { web?: string }
+    } = {
+      class: 'absent',
+      owner: null,
+      endpoints: {},
+    }
+    let inputListener: ((data: string) => unknown) | undefined
+    class FakeTui {
+      addChild(): void {}
+      addInputListener(listener: (data: string) => unknown): () => void {
+        inputListener = listener
+        return () => undefined
+      }
+      requestRender(): void {}
+      setShowHardwareCursor(): void {}
+      start(): void {
+        queueMicrotask(() => inputListener?.('enter'))
+      }
+      stop(): void {}
+    }
+    const fakePiTui = {
+      ProcessTerminal: class {},
+      TUI: FakeTui,
+      matchesKey,
+    }
+    const context = resolveLaunchContext({
+      cwd: '/tmp',
+      homeDir: '/home/alice',
+      env: {
+        OPENALICE_MANAGED_RUNTIME_PATH: '/opt/openalice/runtime',
+        OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY: '1234567890abcdef',
+      },
+    })
+
+    await expect(runSupervisorTui({}, {
+      stdin: { isTTY: true } as NodeJS.ReadStream,
+      stdout: { isTTY: true } as NodeJS.WriteStream,
+      resolveContext: () => context,
+      inspect: async () => runtime,
+      start: async () => {
+        calls.push('start')
+        runtime = {
+          class: 'running',
+          owner: { surface: 'cli-server', pid: 42 },
+          endpoints: { web: 'http://127.0.0.1:47331' },
+        }
+      },
+      open: async () => {
+        calls.push('open')
+        queueMicrotask(() => inputListener?.('q'))
+      },
+      discoverUpdate: async () => null,
+      loadTui: async () => fakePiTui as never,
+      version: '0.87.0-beta',
+      channel: 'stable',
+    })).resolves.toBe(0)
+
+    expect(calls).toEqual(['start', 'open'])
   })
 
   it('keeps foreign-owned lifecycle mutations unavailable', () => {

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -42,8 +42,10 @@ import { loadPiTui } from './pi-tui-loader.ts'
 import {
   createSupervisorInstance,
   persistInstanceLaunchConfig,
+  persistMachineLaunchConfig,
   persistSelectedSupervisorInstance,
   readInstanceLaunchConfig,
+  readMachineLaunchConfig,
   readSupervisorInstanceRegistry,
   isStoredHomeUnavailableError,
   resolveAvailableStoredLaunchContext,
@@ -60,6 +62,8 @@ const SILENT_OUTPUT = Object.freeze({ write: () => true })
 const INHERIT_SETTING = 'Inherit'
 const ENABLED_SETTING = 'Enabled'
 const DISABLED_SETTING = 'Disabled'
+const INSTANCE_SCOPE = 'This instance'
+const MACHINE_SCOPE = 'Machine defaults'
 
 interface RuntimeSummary {
   class?: string
@@ -114,6 +118,7 @@ interface UpdateResult {
 export type SupervisorPanel = 'overview' | 'logs' | 'doctor' | 'help'
 export type SupervisorAction =
   | 'start'
+  | 'start-open'
   | 'open'
   | 'stop'
   | 'restart'
@@ -157,9 +162,16 @@ export interface SupervisorTuiDependencies {
     context: ResolvedLaunchContext,
     patch: LaunchConfigValues,
   ) => Promise<ResolvedLaunchContext>
+  configureMachine?: (
+    context: ResolvedLaunchContext,
+    patch: LaunchConfigValues,
+  ) => Promise<ResolvedLaunchContext>
   loadInstanceConfig?: (
     context: ResolvedLaunchContext,
   ) => Promise<InstanceLaunchConfig>
+  loadMachineConfig?: (
+    context: ResolvedLaunchContext,
+  ) => Promise<LaunchConfigValues>
   loadInstanceRegistry?: (
     context: ResolvedLaunchContext,
   ) => Promise<SupervisorInstanceRegistry>
@@ -312,6 +324,17 @@ export async function runSupervisorTui(
   })
   const loadInstanceConfig = dependencies.loadInstanceConfig
     ?? readInstanceLaunchConfig
+  const loadMachineConfig = dependencies.loadMachineConfig
+    ?? readMachineLaunchConfig
+  const configureMachine = dependencies.configureMachine ?? (async (
+    currentContext,
+    patch,
+  ) => {
+    await persistMachineLaunchConfig(currentContext, patch)
+    return resolveStoredLaunchContext(launchFlags, {
+      env: dependencies.env,
+    })
+  })
   const loadInstanceRegistry = dependencies.loadInstanceRegistry
     ?? readSupervisorInstanceRegistry
   const selectInstance = dependencies.selectInstance ?? (async (
@@ -355,7 +378,7 @@ export async function runSupervisorTui(
 
   async function requestAction(action: SupervisorAction): Promise<void> {
     if (
-      action === 'start'
+      (action === 'start' || action === 'start-open')
       && context.appDir === null
     ) {
       try {
@@ -376,7 +399,7 @@ export async function runSupervisorTui(
     const actionLabel = actionName(action)
     screen.update({ busy: actionLabel, notice: undefined, diagnostic: undefined })
     try {
-      if (action === 'start') {
+      if (action === 'start' || action === 'start-open') {
         await services.start({
           prepare: true,
           rebuild: false,
@@ -388,7 +411,19 @@ export async function runSupervisorTui(
           waitMs: 120_000,
           takeover: false,
         })
-        screen.update({ notice: 'Runtime started.' })
+        if (action === 'start-open') {
+          screen.update({ notice: 'Runtime started.' })
+          try {
+            await services.open({ homeRoot, waitMs: 2_000 })
+            screen.update({
+              notice: 'OpenAlice started and opened in your browser.',
+            })
+          } catch (error: unknown) {
+            actionFailure = `OpenAlice is running, but the browser did not open: ${safeError(error)}`
+          }
+        } else {
+          screen.update({ notice: 'Runtime started in the background.' })
+        }
       } else if (action === 'open') {
         await services.open({ homeRoot, waitMs: 2_000 })
         screen.update({ notice: 'Opened the verified Web UI.' })
@@ -612,9 +647,13 @@ export async function runSupervisorTui(
       notice: undefined,
       diagnostic: undefined,
     })
-    let stored: InstanceLaunchConfig
+    let storedInstance: InstanceLaunchConfig
+    let storedMachine: LaunchConfigValues
     try {
-      stored = await loadInstanceConfig(context)
+      ;[storedInstance, storedMachine] = await Promise.all([
+        loadInstanceConfig(context),
+        loadMachineConfig(context),
+      ])
     } catch (error: unknown) {
       screen.update({
         diagnostic: `Could not load instance settings: ${safeError(error)}`,
@@ -628,7 +667,8 @@ export async function runSupervisorTui(
 
     settingsActive = true
     let saving = false
-    let message = 'Changes are saved to this instance. Higher-priority overrides stay locked.'
+    let scope: typeof INSTANCE_SCOPE | typeof MACHINE_SCOPE = INSTANCE_SCOPE
+    let message = 'Changes apply to this instance. Env vars and command options remain locked.'
     const items: SettingItem[] = []
     let settings: InstanceType<typeof piTui.SettingsList>
 
@@ -636,7 +676,7 @@ export async function runSupervisorTui(
       message = next
       ui.requestRender()
     }
-    const close = (notice = 'Instance settings closed.') => {
+    const close = (notice = 'Setup closed.') => {
       if (!settingsActive) return
       settingsActive = false
       closeSettings = null
@@ -694,58 +734,83 @@ export async function runSupervisorTui(
     }
 
     const syncItems = () => {
+      const stored = scope === INSTANCE_SCOPE ? storedInstance : storedMachine
+      const editingMachine = scope === MACHINE_SCOPE
       const runtimeStopped = screen.snapshot.runtime?.class === 'absent'
-      const homeLocked = settingOverrideLock(context.provenance.home)
-      const portLocked = settingOverrideLock(context.provenance.port)
-      const updatesLocked = settingOverrideLock(context.provenance.updateChecks)
+      const homeLocked = editingMachine
+        ? undefined
+        : settingOverrideLock(context.provenance.home)
+      const portLocked = editingMachine
+        ? undefined
+        : settingOverrideLock(context.provenance.port)
+      const updatesLocked = editingMachine
+        ? undefined
+        : settingOverrideLock(context.provenance.updateChecks)
+      const homeAffectsRunning = !editingMachine
+        || machineDefaultAffectsCurrent('home', context)
+      const portAffectsRunning = !editingMachine
+        || machineDefaultAffectsCurrent('port', context)
+      const homeEditable = !homeLocked
+        && (runtimeStopped || !homeAffectsRunning)
+      const portEditable = !portLocked
+        && (runtimeStopped || !portAffectsRunning)
+      const layerDescription = editingMachine
+        ? 'Default for instances that do not set their own value.'
+        : `Overrides machine defaults for instance "${context.instance}".`
       const homeItem: SettingItem = {
         id: 'home',
-        label: 'Complete home',
+        label: 'Data home',
         currentValue: homeLocked
           ? `${context.home} · locked`
-          : inheritedSettingValue(stored.home, context.home),
+          : editingMachine
+            ? machineHomeSettingValue(stored.home)
+            : inheritedSettingValue(stored.home, context.home),
         description: homeLocked
           ?? (
-            runtimeStopped
+            homeEditable
               ? (
-                  context.instance === 'default'
-                    ? 'Complete state root for this instance. Blank removes the instance override.'
-                    : 'Complete state root for this named instance. Named instances require a separate explicit home.'
+                  editingMachine
+                    ? 'Default data home for the implicit "default" instance. Blank uses ~/.openalice.'
+                    : context.instance === 'default'
+                    ? 'Where this instance keeps settings, credentials, and local state. Blank uses the inherited location.'
+                    : 'Where this named instance keeps its separate settings, credentials, and local state.'
                 )
-              : 'Stop the selected Runtime before changing its complete home.'
+              : 'Stop OpenAlice before changing the data-home layer used by this running instance.'
           ),
       }
-      if (!homeLocked && runtimeStopped) {
+      if (homeEditable) {
         homeItem.submenu = (_currentValue, done) => inputSubmenu(
-          'Set complete home',
+          editingMachine ? 'Set machine-default data home' : 'Set instance data home',
           stored.home ?? '',
           (value) => (
-            context.instance !== 'default' && value === ''
-              ? 'Named instances require an explicit complete home.'
+            !editingMachine && context.instance !== 'default' && value === ''
+              ? 'Named instances require an explicit data home.'
               : undefined
           ),
           done,
-          context.instance === 'default'
+          editingMachine || context.instance === 'default'
             ? 'Leave blank to inherit from the next lower-priority layer.'
-            : 'Named instances require a separate explicit complete home.',
+            : 'Named instances require a separate data home.',
         )
       }
       const portItem: SettingItem = {
         id: 'port',
-        label: 'Web port',
+        label: 'Browser port',
         currentValue: portLocked
           ? `${context.port} · locked`
-          : portSettingValue(stored.port, context),
+          : editingMachine
+            ? machinePortSettingValue(stored.port)
+            : portSettingValue(stored.port, context),
         description: portLocked
           ?? (
-            runtimeStopped
-              ? 'Port for the local Web UI. Blank removes the instance override.'
-              : 'Stop the selected Runtime before changing its Web port.'
+            portEditable
+              ? `${layerDescription} Blank chooses an available port automatically.`
+              : 'Stop OpenAlice before changing the browser-port layer used by this running instance.'
           ),
       }
-      if (!portLocked && runtimeStopped) {
+      if (portEditable) {
         portItem.submenu = (_currentValue, done) => inputSubmenu(
-          'Set Web port',
+          editingMachine ? 'Set machine-default browser port' : 'Set instance browser port',
           stored.port?.toString() ?? '',
           validatePortSetting,
           done,
@@ -756,9 +821,11 @@ export async function runSupervisorTui(
         label: 'Update checks',
         currentValue: updatesLocked
           ? `${context.updateChecks ? ENABLED_SETTING : DISABLED_SETTING} · locked`
-          : booleanSettingValue(stored.updateChecks),
+          : editingMachine
+            ? machineBooleanSettingValue(stored.updateChecks)
+            : booleanSettingValue(stored.updateChecks),
         description: updatesLocked
-          ?? `Check for CLI/product updates when the Supervisor opens. Resolved: ${context.updateChecks ? 'enabled' : 'disabled'}.`,
+          ?? `${layerDescription} Current instance resolves to ${context.updateChecks ? 'enabled' : 'disabled'}.`,
       }
       if (!updatesLocked) {
         updateItem.values = [
@@ -767,47 +834,90 @@ export async function runSupervisorTui(
           DISABLED_SETTING,
         ]
       }
+      const runtimeItem: SettingItem = context.runtimeProvider.kind === 'bundle'
+        ? {
+            id: 'source',
+            label: 'Installed Runtime',
+            currentValue: `OpenAlice ${screen.snapshot.version} · ${context.runtimeProvider.contentIdentity ?? 'verified'}`,
+            description: `Managed by the installer at ${context.appDir ?? 'an unavailable path'}. No source checkout is needed.`,
+          }
+        : {
+            id: 'source',
+            label: 'Source checkout',
+            currentValue: context.appDir ?? 'current directory discovery',
+            description: 'Advanced development provider. Use m for managed source or c to choose a checkout.',
+          }
       items.splice(0, items.length,
+        {
+          id: 'scope',
+          label: 'Editing',
+          currentValue: scope,
+          values: [INSTANCE_SCOPE, MACHINE_SCOPE],
+          description: editingMachine
+            ? 'Machine defaults are inherited by instances without their own value.'
+            : 'Instance values override machine defaults. Env vars and command options remain higher priority.',
+        },
         homeItem,
         portItem,
         updateItem,
-        {
-          id: 'source',
-          label: 'Runtime source',
-          currentValue: context.appDir ?? 'current directory discovery',
-          description: 'Read-only here. Use m for installer-managed source or c for an existing checkout.',
-        },
+        runtimeItem,
         {
           id: 'config',
-          label: 'Config file',
+          label: 'Advanced config',
           currentValue: join(context.supervisorRoot, 'config.json'),
-          description: 'Machine defaults and every named instance live in this atomic JSON document.',
+          description: 'Read-only location for machine defaults and named-instance settings.',
         },
       )
     }
     syncItems()
+    const updateDisplayedValues = () => {
+      for (const item of items) {
+        settings.updateValue(item.id, item.currentValue)
+      }
+    }
+    const restoreDisplayedValue = (id: string) => {
+      syncItems()
+      const item = items.find((candidate) => candidate.id === id)
+      if (item) settings.updateValue(id, item.currentValue)
+    }
 
     const applySetting = async (
       id: string,
       newValue: string,
     ): Promise<void> => {
       if (saving) return
+      if (id === 'scope') {
+        scope = newValue === MACHINE_SCOPE ? MACHINE_SCOPE : INSTANCE_SCOPE
+        syncItems()
+        updateDisplayedValues()
+        setMessage(
+          scope === MACHINE_SCOPE
+            ? 'Editing machine defaults. Instance, env, and command layers remain above them.'
+            : `Editing instance "${context.instance}". Env and command layers remain above it.`,
+        )
+        return
+      }
       const field = settingField(id)
       if (!field) return
-      const lock = settingOverrideLock(context.provenance[field])
+      const editingMachine = scope === MACHINE_SCOPE
+      const lock = editingMachine
+        ? undefined
+        : settingOverrideLock(context.provenance[field])
       if (lock) {
         setMessage(lock)
-        syncItems()
-        settings.updateValue(id, settingItemValue(id, stored, context))
+        restoreDisplayedValue(id)
         return
       }
       if (
         (field === 'home' || field === 'port')
         && screen.snapshot.runtime?.class !== 'absent'
+        && (
+          !editingMachine
+          || machineDefaultAffectsCurrent(field, context)
+        )
       ) {
-        setMessage(`Stop the selected Runtime before changing its ${field === 'home' ? 'complete home' : 'Web port'}.`)
-        syncItems()
-        settings.updateValue(id, settingItemValue(id, stored, context))
+        setMessage(`Stop OpenAlice before changing its ${field === 'home' ? 'data home' : 'browser port'}.`)
+        restoreDisplayedValue(id)
         return
       }
 
@@ -826,23 +936,26 @@ export async function runSupervisorTui(
             }
       saving = true
       actionRunning = true
-      setMessage(`Saving ${settingLabel(field)}…`)
+      const layerLabel = editingMachine ? 'machine default' : `instance "${context.instance}"`
+      setMessage(`Saving ${settingLabel(field)} for ${layerLabel}…`)
       try {
-        context = await configureInstance(context, patch)
+        context = editingMachine
+          ? await configureMachine(context, patch)
+          : await configureInstance(context, patch)
         services = createServices(dependencies, context)
-        stored = await loadInstanceConfig(context)
+        ;[storedInstance, storedMachine] = await Promise.all([
+          loadInstanceConfig(context),
+          loadMachineConfig(context),
+        ])
         syncItems()
-        for (const item of items) {
-          settings.updateValue(item.id, item.currentValue)
-        }
+        updateDisplayedValues()
         screen.update({
           context,
           diagnostic: undefined,
         })
-        setMessage(`Saved ${settingLabel(field)}.`)
+        setMessage(`Saved ${settingLabel(field)} for ${layerLabel}.`)
       } catch (error: unknown) {
-        syncItems()
-        settings.updateValue(id, settingItemValue(id, stored, context))
+        restoreDisplayedValue(id)
         setMessage(`Could not save ${settingLabel(field)}: ${safeError(error)}`)
       } finally {
         actionRunning = false
@@ -860,7 +973,7 @@ export async function runSupervisorTui(
     }
     settings = new piTui.SettingsList(
       items,
-      5,
+      6,
       theme,
       (id, newValue) => {
         void applySetting(id, newValue)
@@ -870,7 +983,7 @@ export async function runSupervisorTui(
     const panel = new (class implements Component {
       render(width: number): string[] {
         return [
-          `Instance settings · ${context.instance}`,
+          `OpenAlice setup · ${context.instance}`,
           '─'.repeat(Math.max(1, width)),
           '',
           ...settings.render(width),
@@ -957,7 +1070,7 @@ export async function runSupervisorTui(
       items.push({
         value: createValue,
         label: '+ Create instance…',
-        description: 'Register a separate complete home and select it.',
+        description: 'Register a separate data home and select it.',
       })
     }
 
@@ -1030,7 +1143,7 @@ export async function runSupervisorTui(
         `.openalice-${name}`,
       )
       const input = new (class extends piTui.Input {
-        detail = 'Use a separate complete home. An empty directory is prepared when registered.'
+        detail = 'Use a separate data home. An empty directory is prepared when registered.'
 
         setDetail(next: string): void {
           this.detail = next
@@ -1042,7 +1155,7 @@ export async function runSupervisorTui(
           return [
             `Create instance · ${name}`,
             '',
-            'Complete home',
+            'Data home',
             ...super.render(width),
             '',
             sanitize(this.detail),
@@ -1061,7 +1174,7 @@ export async function runSupervisorTui(
       input.onSubmit = (value) => {
         const home = value.trim()
         if (!home) {
-          input.setDetail('Enter a complete home for this instance.')
+          input.setDetail('Enter a data home for this instance.')
           return
         }
         void activateContext(
@@ -1328,6 +1441,17 @@ export class SupervisorScreen implements Component {
       this.update({ panel: this.snapshot.panel === 'help' ? 'overview' : 'help' })
       return true
     }
+    if (matchesKey(data, 'enter')) {
+      const action = primaryAction(this.snapshot.runtime)
+      if (action && this.actionAvailable(action)) {
+        this.onAction?.(action)
+      } else {
+        this.update({
+          notice: 'No primary action is available in the current Runtime state.',
+        })
+      }
+      return true
+    }
     if (matchesKey(data, 'tab') || matchesKey(data, 'right')) {
       this.selectAdjacentPanel(1)
       return true
@@ -1422,18 +1546,23 @@ export class SupervisorScreen implements Component {
           `Web: ${runtime?.endpoints?.web ?? 'not available'}`,
           `Components: ${formatComponents(runtime)}`,
         )
-        if (runtime?.provider?.kind) {
-          lines.push(`Provider: ${runtime.provider.kind}`)
+        const provider = runtime?.provider?.kind
+          ?? this.snapshot.context?.runtimeProvider.kind
+        if (provider) {
+          lines.push(`Provider: ${provider}${runtime?.class === 'absent' && provider === 'bundle' ? ' (installed)' : ''}`)
         }
         if (Number.isInteger(runtime?.uptimeSeconds)) {
           lines.push(`Uptime: ${formatDuration(runtime?.uptimeSeconds ?? 0)}`)
         }
         if (this.snapshot.context) {
           lines.push(`Resolved: home ${formatProvenance(this.snapshot.context.provenance.home)} · port ${formatPortResolution(this.snapshot.context)}`)
-          const runtimeLabel = this.snapshot.context.runtimeProvider.kind === 'bundle'
-            ? 'Runtime'
-            : 'Source'
-          lines.push(`${runtimeLabel}: ${this.snapshot.context.appDir ?? runtime?.provider?.root ?? 'current directory discovery'} ${formatProvenance(this.snapshot.context.provenance.appDir)}`)
+          if (this.snapshot.context.runtimeProvider.kind === 'bundle') {
+            lines.push(
+              `Runtime: OpenAlice ${this.snapshot.version} · bundle ${this.snapshot.context.runtimeProvider.contentIdentity ?? 'verified'}`,
+            )
+          } else {
+            lines.push(`Source: ${this.snapshot.context.appDir ?? runtime?.provider?.root ?? 'current directory discovery'} ${formatProvenance(this.snapshot.context.provenance.appDir)}`)
+          }
         }
       }
       lines.push('', ...renderGuidance(runtime, this.snapshot.context))
@@ -1464,7 +1593,9 @@ export class SupervisorScreen implements Component {
   private actionAvailable(action: SupervisorAction): boolean {
     const runtime = this.snapshot.runtime
     if (action === 'logs' || action === 'doctor' || action === 'update') return true
-    if (action === 'start') return runtime?.class === 'absent'
+    if (action === 'start' || action === 'start-open') {
+      return runtime?.class === 'absent'
+    }
     if (action === 'open') return Boolean(runtime?.endpoints?.web)
     return runtime?.owner?.surface === 'cli-server'
       && runtime.class !== 'absent'
@@ -1525,15 +1656,21 @@ function renderGuidance(
   if (!runtime) return ['Runtime status is unavailable. Doctor may explain why.']
   if (runtime.class === 'absent') {
     if (context?.runtimeProvider.kind === 'bundle') {
-      return ['OpenAlice is stopped. Press s to start the installed Runtime.']
+      return [
+        'OpenAlice is ready to start.',
+        'Press Enter to start and open the browser, or p to review setup first.',
+      ]
     }
-    return ['OpenAlice is stopped. Press s to start, m for managed source, or c for an existing checkout.']
+    return [
+      'OpenAlice is stopped. Press Enter to start and open the browser.',
+      'Source development: m prepares managed source; c chooses a checkout.',
+    ]
   }
   if (runtime.class === 'incompatible') {
     return ['The running Guardian is incompatible. Read Doctor before changing it.']
   }
   if (runtime.class === 'running') {
-    return ['Runtime is ready. Press o to hand product interaction to the Web UI.']
+    return ['OpenAlice is ready. Press Enter or o to open the Web UI.']
   }
   return [`Runtime is ${runtime.class ?? runtime.state ?? 'unknown'}; status will refresh automatically.`]
 }
@@ -1568,12 +1705,13 @@ function renderHelp(): string[] {
   return [
     'Supervisor controls',
     '',
-    's  Start persistent Runtime       o  Open verified Web UI',
+    'Enter  Start and open / open Web UI',
+    's  Start in background            o  Open verified Web UI',
     'x  Stop (confirmation required)   r  Restart (confirmation required)',
     'l  Bounded redacted logs          d  Read-only Doctor',
     'u  Check for product update       ?  Toggle this help',
     'i  Select or create an instance',
-    'p  Configure selected instance settings',
+    'p  Review setup for this instance',
     'm  Advanced: prepare installer-managed source and start',
     'c  Advanced: choose and remember a source checkout',
     'Tab / arrows  Change panel        q / Esc  Detach only',
@@ -1615,9 +1753,9 @@ function actionBar(
 ): string[] {
   const primary = runtime?.class === 'absent'
     ? context?.runtimeProvider.kind === 'bundle'
-      ? 's Start · i Instances · p Settings'
-      : 's Start · i Instances · p Settings · m Managed · c Source'
-    : 'o Open · i Instances · p Settings · r Restart · x Stop'
+      ? 'Enter Start & open · s Background · p Setup · i Instances'
+      : 'Enter Start & open · s Background · p Setup · i Instances · m Managed · c Source'
+    : 'Enter / o Open · i Instances · p Setup · r Restart · x Stop'
   const secondary = 'd Doctor · l Logs · u Update · ? Help'
   const actions = `${primary} · ${secondary}`
   if (actions.length <= width) return [actions]
@@ -1647,6 +1785,7 @@ function unavailableActionMessage(
 function actionName(action: SupervisorAction): string {
   return {
     start: 'Starting Runtime',
+    'start-open': 'Starting and opening OpenAlice',
     open: 'Opening Web UI',
     stop: 'Stopping Runtime',
     restart: 'Restarting Runtime',
@@ -1654,6 +1793,14 @@ function actionName(action: SupervisorAction): string {
     doctor: 'Running Doctor',
     update: 'Checking for updates',
   }[action]
+}
+
+function primaryAction(
+  runtime: RuntimeSummary | null,
+): SupervisorAction | undefined {
+  if (runtime?.class === 'absent') return 'start-open'
+  if (runtime?.endpoints?.web) return 'open'
+  return undefined
 }
 
 function formatUpdateNotice(update: UpdateResult): string {
@@ -1715,8 +1862,8 @@ function settingField(id: string): EditableSettingField | undefined {
 
 function settingLabel(field: EditableSettingField): string {
   return {
-    home: 'complete home',
-    port: 'Web port',
+    home: 'data home',
+    port: 'browser port',
     updateChecks: 'update checks',
   }[field]
 }
@@ -1740,7 +1887,7 @@ function instanceSelectionOverrideLock(
   if (instanceLock) return `Instance selection is read-only. ${instanceLock}`
   const homeLock = settingOverrideLock(context.provenance.home)
   if (homeLock) {
-    return `Instance selection is read-only while this session's complete home is fixed. ${homeLock}`
+    return `Instance selection is read-only while this session's data home is fixed. ${homeLock}`
   }
   return undefined
 }
@@ -1769,39 +1916,38 @@ function booleanSettingValue(stored: boolean | undefined): string {
   return stored ? ENABLED_SETTING : DISABLED_SETTING
 }
 
-function settingItemValue(
-  id: string,
-  stored: InstanceLaunchConfig,
+function machineHomeSettingValue(stored: string | undefined): string {
+  return stored ?? `${INHERIT_SETTING} → ~/.openalice`
+}
+
+function machinePortSettingValue(stored: number | undefined): string {
+  return stored?.toString()
+    ?? `${INHERIT_SETTING} → automatic from 47331`
+}
+
+function machineBooleanSettingValue(stored: boolean | undefined): string {
+  return stored === undefined
+    ? INHERIT_SETTING
+    : stored ? ENABLED_SETTING : DISABLED_SETTING
+}
+
+function machineDefaultAffectsCurrent(
+  field: 'home' | 'port',
   context: ResolvedLaunchContext,
-): string {
-  if (id === 'home') {
-    return settingOverrideLock(context.provenance.home)
-      ? `${context.home} · locked`
-      : inheritedSettingValue(stored.home, context.home)
-  }
-  if (id === 'port') {
-    return settingOverrideLock(context.provenance.port)
-      ? `${context.port} · locked`
-      : portSettingValue(stored.port, context)
-  }
-  if (id === 'updateChecks') {
-    return settingOverrideLock(context.provenance.updateChecks)
-      ? `${context.updateChecks ? ENABLED_SETTING : DISABLED_SETTING} · locked`
-      : booleanSettingValue(stored.updateChecks)
-  }
-  if (id === 'source') return context.appDir ?? 'current directory discovery'
-  return join(context.supervisorRoot, 'config.json')
+): boolean {
+  return context.provenance[field].source === 'default'
+    || context.provenance[field].source === 'machine-config'
 }
 
 function validatePortSetting(value: string): string | undefined {
   if (!value) return undefined
   if (!/^\d+$/.test(value)) {
-    return 'Web port must be a whole number from 1 to 65535.'
+    return 'Browser port must be a whole number from 1 to 65535.'
   }
   const port = Number(value)
   return port >= 1 && port <= 65_535
     ? undefined
-    : 'Web port must be a whole number from 1 to 65535.'
+    : 'Browser port must be a whole number from 1 to 65535.'
 }
 
 function safeError(error: unknown): string {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -201,6 +201,7 @@ Configuration resolves exactly once with observable provenance:
 
 ```text
 defaults
+  < installed Runtime provider
   < machine-wide Supervisor config
   < selected instance config
   < environment variables
@@ -405,6 +406,8 @@ starting the Runtime.
 - [x] Add a selected-instance TUI settings overlay for complete home, Web port,
   and update-check inheritance, with active-Runtime guards and visible
   environment/CLI locks.
+- [x] Let parameter-free Setup switch between selected-instance values and
+  machine defaults while preserving environment and explicit CLI priority.
 - [x] Give OpenAlice-managed Pi an instance-local `PI_CODING_AGENT_DIR` and
   session root without changing a user-installed Pi launched externally.
 - [x] Update the managed Workspace runtime owner guide and tests for the new
@@ -423,8 +426,11 @@ immediately use the selected instance's source checkout, complete home, Web
 port, and update policy. Returning a field to inheritance removes only that
 instance key. Environment and CLI provenance visibly lock lower-priority
 editing, while an active Runtime prevents its home or port from changing
-underneath it. Machine-default editing, `config check`, last-known-good live
-reload, and named-instance management remain unchecked above.
+underneath it. Setup now switches in place to machine defaults, persists their
+Home, port, and update policy atomically, and immediately re-resolves the
+selected instance. Higher-priority instance, environment, and explicit command
+layers continue to win. `config check`, last-known-good live reload, and
+registry deletion remain unchecked above.
 
 The clean-host follow-up reuses the managed-remote install-source identity for
 local startup. A stopped installed Supervisor now confirms `m Managed`, clones
@@ -753,3 +759,12 @@ This plan is complete only when:
   Supervisor keeps the unavailable entry, opens on an available fallback,
   explains the recovery, and lets `i Instances` atomically repair the
   remembered default. Unit and real-PTY coverage preserve that distinction.
+- 2026-07-30: Refined the parameter-free installed experience around the bare
+  TUI. Enter now starts a stopped Runtime and opens its verified browser
+  endpoint in one action, while `s` remains the explicit background-only
+  start. Setup uses ordinary product vocabulary, identifies the installed
+  Runtime by OpenAlice version and content identity, and edits either the
+  current instance or inherited machine defaults without weakening
+  environment/CLI precedence. Real PTY coverage exercises both persisted
+  layers, and an installed bundle dogfood launch reached Alice, opened the Web
+  UI, detached, reattached, and stopped cleanly.


### PR DESCRIPTION
## What changed

- make Enter the bare-TUI primary action: start the installed Runtime and open its verified Web endpoint, or open an already-running Runtime
- keep `s` as the explicit background-only start
- replace developer-facing setup vocabulary with data home, browser port, installed Runtime, and advanced config
- let Setup edit either the selected instance or inherited machine defaults while preserving CLI and environment precedence
- persist machine defaults atomically and report installed Runtime product/content identity without exposing a long path
- add unit and real-PTY coverage for Enter dispatch, start-and-open sequencing, instance settings, and machine-default settings
- update the Shell Supervisor owner guide and active execution plan

## Why

Humans should be able to install OpenAlice, run `openalice` without flags, and finish setup interactively. Explicit flags remain the simplest deterministic interface for agents, scripts, CI, and SSH automation.

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 3,763 passed, 9 skipped
- targeted Supervisor config/TUI/PTY suite — 32 passed
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm test:install:docker`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- real isolated installed-bundle TUI dogfood: Setup machine-default persistence, terminal restoration, start/open, reattach, and stop
