### PR TITLE
feat(autoquant): preserve upstream Git history in new desks

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -447,10 +447,11 @@ POSIX shell exists.
 
 A source-backed Harness receives only repository, release, and exact commit
 values approved by its template catalog. AutoQuant V2 verifies that tuple,
-copies the exact tree, removes upstream history/remotes, starts a fresh local
-research branch, and writes `.alice/harness-source.json`. Bootstrap does not
-install Python or quantitative dependencies; the native Coding Agent owns
-environment setup and later research commits inside the Workspace.
+copies the repository, keeps its upstream ancestry and canonical `origin`,
+starts a local research branch at the approved commit, and writes
+`.alice/harness-source.json`. Bootstrap does not install Python or quantitative
+dependencies; the native Coding Agent owns environment setup, later research
+commits, and explicit fetch/merge upgrades inside the Workspace.
 
 OpenAlice copies Workspace skills into two canonical project paths:
 

--- a/plans/auto-quant-v2-harness.md
+++ b/plans/auto-quant-v2-harness.md
@@ -23,8 +23,8 @@ quantitative assignment and open a native coding-Agent Session.
   `426d815b18450172fbcf4c6b6af77c6ae05a4967`; retain `v0.8.30` and
   `v0.8.27` in the approved catalog for reproducible explicit creation.
 - Add a generic template-source catalog and create-time version selection.
-- Materialize the exact upstream tree into OpenAlice's fresh local Git Harness
-  and commit a source receipt without installing Python dependencies.
+- Materialize the exact upstream repository into a local research branch and
+  commit a source receipt without installing Python dependencies.
 - Add an AutoQuant Activity entry that reuses the Ask Alice composer, runtime,
   credential, Workspace, Session, and file surfaces.
 - Preserve AutoQuant's own `AGENTS.md`, while injecting OpenAlice collaboration,
@@ -38,9 +38,9 @@ quantitative assignment and open a native coding-Agent Session.
 - A source version is an immutable creation input, separate from the OpenAlice
   template guidance version. Floating branches and semver ranges are not
   accepted.
-- OpenAlice's initial-commit Harness rule remains authoritative: upstream Git
-  history and pushable remotes are removed, while the exact upstream
-  repository, release, and commit are retained in a tracked receipt.
+- AutoQuant retains its upstream Git history and canonical `origin`; the
+  research branch starts at the exact approved release commit and records that
+  source in a tracked receipt.
 - Dependency installation and quantitative iteration belong to the coding
   Agent inside the desk.
 - AutoQuant Workspaces are durable desks. Generic managed-context template
@@ -71,6 +71,8 @@ quantitative assignment and open a native coding-Agent Session.
       bounded Session history and a low-frequency Workspace control.
 - [x] Default new initialization to the immutable AutoQuant V2 `v0.8.31`
       release while retaining the older approved catalog entries.
+- [x] Preserve AutoQuant's upstream Git ancestry and `origin` so later upgrades
+      remain ordinary Coding Agent-managed fetch and merge work.
 - [x] Re-run full repository, demo, browser/dev, and packaged Electron
       verification for the revised entry path.
 

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -23,7 +23,8 @@ or Dossier lifecycle.
 The default supported source is AutoQuant V2 `v0.8.31` at commit
 `426d815b18450172fbcf4c6b6af77c6ae05a4967`. The exact upstream source is
 recorded in `.alice/harness-source.json`; the Workspace itself starts a fresh
-local Git history with no pushable upstream remote.
+research branch at that commit while retaining AutoQuant's upstream history and
+`origin` remote for later Coding Agent-managed fetches and merges.
 
 ## Starting work
 

--- a/src/workspaces/templates/auto-quant-v2/bootstrap.mjs
+++ b/src/workspaces/templates/auto-quant-v2/bootstrap.mjs
@@ -3,9 +3,9 @@
  *
  * OpenAlice supplies the approved repository/version/commit through the
  * template-source contract. The upstream tree is verified before it is copied,
- * then its history and remote are removed so the resulting desk follows the
- * OpenAlice Harness rule: one fresh local Git repository owned by the coding
- * Agent, with no pushable upstream remote.
+ * then the resulting desk keeps that upstream history and canonical remote.
+ * OpenAlice creates a local research branch at the approved commit so the
+ * Coding Agent can later fetch and merge another approved AutoQuant release.
  *
  * Dependency installation is intentionally absent. AutoQuant's Coding Agent
  * owns `uv`/Python setup and every later research commit inside the desk.
@@ -14,7 +14,6 @@
 import {
   existsSync,
   mkdirSync,
-  rmSync,
   writeFileSync,
 } from 'node:fs'
 import { dirname, join } from 'node:path'
@@ -69,11 +68,8 @@ if (resolved !== commit) {
 }
 
 await git(['clone', '--quiet', '--local', '--no-checkout', source, outDir], dirname(outDir))
-await git(['checkout', '--quiet', '--detach', commit], outDir)
-
-rmSync(join(outDir, '.git'), { recursive: true, force: true })
-await git(['init', '-q'], outDir)
-await git(['checkout', '-q', '-b', `research/${tag}`], outDir)
+await git(['remote', 'set-url', 'origin', repository], outDir)
+await git(['checkout', '--quiet', '-b', `research/${tag}`, commit], outDir)
 setupGitExcludes(outDir)
 
 const receiptDir = join(outDir, '.alice')

--- a/src/workspaces/workspace-creation.e2e.spec.ts
+++ b/src/workspaces/workspace-creation.e2e.spec.ts
@@ -1,9 +1,9 @@
 /**
  * End-to-end check of the create flow, exercising the real moving parts in
  * order: bootstrap.mjs (run on the bundled Node + dugite's bundled git) →
- * launcher context injection → launcher initial commit. Proves the workspace
- * is a fresh-git repo with exactly one clean commit (the "Harness rule"), and
- * — via the PATH-stripped case — that creation needs NO system git or bash.
+ * launcher context injection → launcher commit. Proves Chat starts a clean
+ * local repository, AutoQuant retains its verified upstream ancestry, and —
+ * via the PATH-stripped case — creation needs NO system git or bash.
  */
 
 import { spawn } from 'node:child_process';
@@ -138,8 +138,8 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
   });
 });
 
-describe('auto-quant workspace create: clone → scrub → commit', () => {
-  it('scrubs cloned history + remote into a fresh-git workspace with one launcher commit', async () => {
+describe('auto-quant workspace create: clone → branch → commit', () => {
+  it('retains verified upstream ancestry and origin under the local research branch', async () => {
     // fake upstream: history + an origin pointing at the public repo
     const src = join(parent, 'fake-auto-quant');
     await run('git', ['init', '-q', '-b', 'main', src]);
@@ -174,9 +174,15 @@ describe('auto-quant workspace create: clone → scrub → commit', () => {
       version: 'v0.8.27',
       commit: sourceCommit,
     });
-    // ...but history + remote are scrubbed (the Harness rule)
-    expect((await run('git', ['-C', aqDir, 'remote', '-v'])).trim()).toBe('');
-    expect((await run('git', ['-C', aqDir, 'log', '--pretty=%s'])).trim()).toBe('auto-quant-v2: aqtag');
+    // The launcher commit sits directly on the verified upstream commit, and
+    // origin remains the canonical repository for later Agent-managed updates.
+    expect((await run('git', ['-C', aqDir, 'rev-parse', 'HEAD^'])).trim()).toBe(sourceCommit);
+    expect((await run('git', ['-C', aqDir, 'remote', 'get-url', 'origin'])).trim()).toBe(
+      'https://github.com/TraderAlice/Auto-Quant-V2.git',
+    );
+    expect((await run('git', ['-C', aqDir, 'log', '--pretty=%s'])).trim()).toBe(
+      'auto-quant-v2: aqtag\nupstream history',
+    );
     expect((await run('git', ['-C', aqDir, 'status', '--porcelain'])).trim()).toBe('');
     expect((await run('git', ['-C', aqDir, 'rev-parse', '--abbrev-ref', 'HEAD'])).trim()).toBe('research/aqtag');
   });

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -247,8 +247,10 @@ export class WorkspaceCreator {
     }
 
     // Launcher-owned context injection (MCP / persona / skills, gated by the
-    // template manifest), then the initial commit. The launcher — not the
-    // bootstrap script — owns what lands in the workspace's first commit.
+    // template manifest), then the launcher commit. The launcher — not the
+    // bootstrap script — owns what lands in that commit. Snapshot templates
+    // make it the root commit; source-backed templates may append it to their
+    // retained upstream history.
     try {
       await injectWorkspaceContext({ template, wsId: id, dir });
     } catch (err) {
@@ -438,11 +440,12 @@ function insufficientStorageResult(availableBytes: number | null = null): Create
 }
 
 /**
- * The launcher's initial commit — uniform across templates (the "Harness rule":
- * every workspace is a fresh-git repo with a clean initial commit, no inherited
- * history, no pushable remote). Replaces the old per-template `commit_initial`
- * bash helper, byte-identical in message + author. The bootstrap script has
- * already run `git init` and set excludes; we just stage and commit.
+ * The launcher's workspace commit, uniform across templates. Snapshot templates
+ * initialize a fresh repository, while source-backed templates may retain an
+ * upstream repository and append this commit to it. Replaces the old
+ * per-template `commit_initial` bash helper, byte-identical in message + author.
+ * The bootstrap script has already prepared Git and its excludes; we just stage
+ * and commit.
  */
 export async function commitInitial(dir: string, message: string): Promise<void> {
   await runGit(dir, ['add', '.']);


### PR DESCRIPTION
## Summary
- keep AutoQuant's verified upstream Git ancestry instead of scrubbing `.git`
- retain canonical `origin` and create `research/<tag>` directly at the approved source commit
- append the OpenAlice launcher/context commit on top of the upstream release
- update the generic launcher-commit wording, owner guide, Harness plan, and creation E2E contract
- leave Chat and existing AutoQuant Workspaces unchanged

## Verification
- real AutoQuant `v0.8.31` bootstrap: 218 upstream commits retained, branch and origin verified
- real isolated `/auto-quant` first-run initialization: 219 commits, launcher parent exactly `426d815b18450172fbcf4c6b6af77c6ae05a4967`, clean tree, canonical origin
- targeted creator unit tests: 15 passed
- targeted Workspace creation E2E: 3 passed
- `npx tsc --noEmit`
- `pnpm test -- --reporter=dot` (448 files passed, 1 skipped; 3763 tests passed, 9 skipped)
- `pnpm test:e2e -- --reporter=dot`: Workspace suites passed; one unrelated EIA request was rate-limited with HTTP 429
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
