### PR TITLE
Make source-only CLI first start parameter-free

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -220,10 +220,11 @@ TUI. For automation,
 `--yes --with-runtime-deps` is the explicit pair that approves the displayed
 Linux package command as well as the CLI transaction.
 
-When no local checkout is discoverable after installation, bare `openalice`
-opens the Supervisor and offers two explicit stopped-state paths: `m` prepares
-an installer-managed checkout aligned to the CLI's branch or version under the
-install root, while `c` selects an existing checkout. Managed preparation never
+When no local checkout is discoverable after a source-only installation, bare
+`openalice` opens the Supervisor and Enter inspects the installed branch or
+version, shows the managed Runtime preparation plan, and continues through
+start plus browser open after consent. `m` opens the same managed-source plan
+explicitly, while `c` selects an existing checkout. Managed preparation never
 overwrites an occupied invalid path. Its first Start can install repository
 dependencies and build the source Runtime; the installer therefore discloses
 and optionally prepares the required native build tools before consent.
@@ -613,6 +614,8 @@ It verifies:
 - installed content identity in `openalice version --json`, so same-version
   remote payload drift is detectable;
 - runnable OpenAlice/Pi shell and CMD launchers plus managed-Pi env injection;
+- an installed bare Supervisor launched through a pseudo-TTY, including
+  install-provenance managed Runtime planning, cancellation, and detach;
 - idempotent managed PATH configuration;
 - identical-release reuse;
 - ref switching without deleting the prior release;
@@ -658,8 +661,11 @@ pnpm test:install:docker --interactive
 The playground first offers the Runtime-tool choice, stops again at the real
 combined plan, and then leaves the tester in the clean container. Its fake
 offline package manager records the exact command while still exercising the
-non-root plus `sudo` branch. Review both choices, copy, and spacing, approve
-with an explicit `y`, and run at least:
+non-root plus `sudo` branch. The fixture supplies a minimal offline `pi-tui`
+adapter so the automated Docker lane can execute the installed TUI state
+machine; the repository's real-PTY suite remains the renderer/terminal
+acceptance boundary. Review both choices, copy, and spacing, approve with an
+explicit `y`, and run at least:
 
 ```bash
 command -v openalice

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -120,6 +120,14 @@ small ordinary action bar. A configured instance source,
 advanced source controls. The managed source path is
 `<install root>/sources/<install-source identity>/OpenAlice`.
 
+For an older or development install without a bundled Runtime, Enter still
+owns the ordinary path. If current-directory source discovery fails, it reads
+the installed branch/version provenance and opens the same managed-source
+confirmation as `m`; accepting prepares and remembers that source, starts
+OpenAlice, and opens the browser. `c` remains the explicit manual-checkout
+path. A source-run CLI with no installed provenance falls back to the source
+path editor instead of pretending it can manage an install root.
+
 ## TUI Launch Context
 
 The TypeScript entry resolves launch-affecting values before starting terminal

--- a/install
+++ b/install
@@ -1166,6 +1166,6 @@ if [[ -z "$RUNTIME_CONTENT_IDENTITY" && -n "$checkout" ]]; then
 elif [[ -z "$RUNTIME_CONTENT_IDENTITY" && "$INSTALL_CONTEXT" != "remote" ]]; then
   printf '\n%bNext: open the OpenAlice Supervisor%b\n' "$BOLD" "$RESET"
   printf '  %s\n\n' "$BIN_DIR/openalice"
-  printf 'Press %bm%b inside the Supervisor to prepare the managed Runtime source,\n' "$BOLD" "$RESET"
-  printf 'or %bc%b to select an existing OpenAlice checkout.\n\n' "$BOLD" "$RESET"
+  printf 'Press %bEnter%b inside the Supervisor to prepare, start, and open OpenAlice.\n' "$BOLD" "$RESET"
+  printf 'Use %bc%b only if you want to select an existing checkout instead.\n\n' "$BOLD" "$RESET"
 fi

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -1,9 +1,11 @@
 import {
+  cp,
   mkdir,
   mkdtemp,
   readFile,
   realpath,
   rm,
+  symlink,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -14,6 +16,7 @@ import * as pty from 'node-pty'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const cliEntry = join(dirname(fileURLToPath(import.meta.url)), '../bin/openalice.ts')
+const cliPackageRoot = dirname(dirname(cliEntry))
 const temporaryPaths: string[] = []
 
 afterEach(async () => {
@@ -171,6 +174,84 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
     expect(transcript).toContain('Configure Runtime source')
     expect(transcript).toContain('Could not use that checkout')
     expect(transcript).toContain('Source configuration cancelled.')
+    expect(transcript).toContain('\u001b[?25h')
+    expect(transcript).toContain('\u001b[?2004l')
+  })
+
+  it('uses installed provenance to offer managed Runtime setup from Enter', async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), 'openalice-cli-installed-enter-'))
+    temporaryPaths.push(isolatedHome)
+    const installRoot = join(isolatedHome, 'install')
+    const releaseRoot = join(
+      installRoot,
+      'cli-versions',
+      'dev-fixture-1234567890abcdef',
+    )
+    await mkdir(releaseRoot, { recursive: true })
+    await Promise.all([
+      cp(join(cliPackageRoot, 'bin'), join(releaseRoot, 'bin'), { recursive: true }),
+      cp(join(cliPackageRoot, 'src'), join(releaseRoot, 'src'), { recursive: true }),
+      cp(join(cliPackageRoot, 'package.json'), join(releaseRoot, 'package.json')),
+      symlink(join(cliPackageRoot, 'node_modules'), join(releaseRoot, 'node_modules')),
+      writeFile(join(releaseRoot, 'install-source.json'), JSON.stringify({
+        schemaVersion: 1,
+        repository: 'TraderAlice/OpenAlice',
+        cliVersion: '0.87.0-beta',
+        selector: { kind: 'branch', value: 'dev' },
+        installerUrl: 'https://openalice.ai/install',
+      })),
+    ])
+    const installedEntry = join(releaseRoot, 'bin', 'openalice.ts')
+    const unrelatedCwd = join(isolatedHome, 'empty')
+    await mkdir(unrelatedCwd)
+    const child = pty.spawn(process.execPath, [installedEntry], {
+      cols: 100,
+      rows: 28,
+      cwd: unrelatedCwd,
+      env: {
+        ...process.env,
+        HOME: join(isolatedHome, 'home'),
+        OPENALICE_HOME: join(isolatedHome, 'state'),
+        OPENALICE_SUPERVISOR_HOME: join(isolatedHome, 'supervisor'),
+        TERM: 'xterm-256color',
+      },
+    })
+
+    const transcript = await new Promise<string>((resolve, reject) => {
+      let output = ''
+      let requestedStart = false
+      let cancelledPlan = false
+      let detached = false
+      const timeout = setTimeout(() => {
+        child.kill()
+        reject(new Error(`Installed Supervisor first start timed out:\n${output}`))
+      }, 8_000)
+      child.onData((data) => {
+        output += data
+        if (!requestedStart && output.includes('Enter prepares anything missing')) {
+          requestedStart = true
+          child.write('\r')
+        } else if (
+          !cancelledPlan
+          && output.includes('installer-managed OpenAlice source branch dev')
+        ) {
+          cancelledPlan = true
+          child.write('n')
+        } else if (!detached && output.includes('Action cancelled.')) {
+          detached = true
+          child.write('q')
+        }
+      })
+      child.onExit(({ exitCode }) => {
+        clearTimeout(timeout)
+        if (exitCode === 0) resolve(output)
+        else reject(new Error(`Installed Supervisor first start exited ${exitCode}:\n${output}`))
+      })
+    })
+
+    expect(transcript).toContain('OpenAlice  0.87.0-beta  branch dev')
+    expect(transcript).toContain('installer-managed OpenAlice source branch dev')
+    expect(transcript).not.toContain('Configure Runtime source')
     expect(transcript).toContain('\u001b[?25h')
     expect(transcript).toContain('\u001b[?2004l')
   })

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -84,6 +84,7 @@ describe('Supervisor TUI screen', () => {
         home: context.home,
         owner: null,
         endpoints: {},
+        provider: { kind: 'unknown' },
       },
       context,
     })
@@ -136,7 +137,7 @@ describe('Supervisor TUI screen', () => {
     expect(screen.handleKey('enter', matchesKey)).toBe(true)
     expect(actions).toEqual(['start-open'])
     expect(screen.render(100).join('\n')).toContain(
-      'Press Enter to start and open the browser',
+      'Enter prepares anything missing and opens the browser',
     )
 
     screen.update({
@@ -216,6 +217,109 @@ describe('Supervisor TUI screen', () => {
     })).resolves.toBe(0)
 
     expect(calls).toEqual(['start', 'open'])
+  })
+
+  it('uses installed provenance to prepare missing source before Enter starts and opens', async () => {
+    const calls: string[] = []
+    let runtime: {
+      class: string
+      owner: { surface: string; pid: number } | null
+      endpoints: { web?: string }
+    } = {
+      class: 'absent',
+      owner: null,
+      endpoints: {},
+    }
+    let inputListener: ((data: string) => unknown) | undefined
+    class FakeTui {
+      addChild(): void {}
+      addInputListener(listener: (data: string) => unknown): () => void {
+        inputListener = listener
+        return () => undefined
+      }
+      requestRender(): void {}
+      setShowHardwareCursor(): void {}
+      start(): void {
+        queueMicrotask(() => inputListener?.('enter'))
+      }
+      stop(): void {}
+    }
+    const fakePiTui = {
+      ProcessTerminal: class {},
+      TUI: FakeTui,
+      matchesKey,
+    }
+    const initialContext = resolveLaunchContext({
+      cwd: '/tmp/empty',
+      homeDir: '/home/alice',
+      env: {},
+    })
+    const preparedContext = resolveLaunchContext({
+      cwd: '/tmp/empty',
+      homeDir: '/home/alice',
+      flags: { appDir: '/opt/openalice/managed-source' },
+      env: {},
+    })
+
+    await expect(runSupervisorTui({}, {
+      stdin: { isTTY: true } as NodeJS.ReadStream,
+      stdout: { isTTY: true } as NodeJS.WriteStream,
+      resolveContext: () => initialContext,
+      inspect: async () => runtime,
+      findSource: async () => {
+        throw new Error('No OpenAlice checkout was found.')
+      },
+      inspectManagedSource: async () => {
+        calls.push('inspect-managed')
+        setTimeout(() => inputListener?.('enter'), 0)
+        return {
+          appDir: '/opt/openalice/managed-source',
+          installRoot: '/opt/openalice',
+          repositoryUrl: 'https://github.com/TraderAlice/OpenAlice.git',
+          selector: { kind: 'branch', value: 'dev' },
+          state: 'absent',
+        }
+      },
+      prepareManagedSource: async () => {
+        calls.push('prepare-managed')
+        return {
+          appDir: '/opt/openalice/managed-source',
+          installRoot: '/opt/openalice',
+          repositoryUrl: 'https://github.com/TraderAlice/OpenAlice.git',
+          selector: { kind: 'branch', value: 'dev' },
+          state: 'present',
+          created: true,
+        }
+      },
+      configureInstance: async () => {
+        calls.push('configure-instance')
+        return preparedContext
+      },
+      start: async () => {
+        calls.push('start')
+        runtime = {
+          class: 'running',
+          owner: { surface: 'cli-server', pid: 42 },
+          endpoints: { web: 'http://127.0.0.1:47331' },
+        }
+      },
+      open: async () => {
+        calls.push('open')
+        queueMicrotask(() => inputListener?.('q'))
+      },
+      discoverUpdate: async () => null,
+      loadTui: async () => fakePiTui as never,
+      version: '0.87.0-beta',
+      channel: 'branch dev',
+    })).resolves.toBe(0)
+
+    expect(calls).toEqual([
+      'inspect-managed',
+      'prepare-managed',
+      'configure-instance',
+      'start',
+      'open',
+    ])
   })
 
   it('keeps foreign-owned lifecycle mutations unavailable', () => {

--- a/packages/cli/src/supervisor-tui.ts
+++ b/packages/cli/src/supervisor-tui.ts
@@ -279,6 +279,7 @@ export async function runSupervisorTui(
   let sourcePromptActive = false
   let settingsActive = false
   let instancesActive = false
+  let managedStartAction: 'start' | 'start-open' = 'start'
   let closeSourcePrompt: (() => void) | null = null
   let closeSettings: (() => void) | null = null
   let closeInstances: (() => void) | null = null
@@ -303,7 +304,7 @@ export async function runSupervisorTui(
       void openInstances()
     },
     onRequestManagedSource: () => {
-      void requestManagedSource()
+      void requestManagedSource('start')
     },
     onPrepareManagedSource: () => {
       void prepareManagedSourceAndStart()
@@ -384,7 +385,7 @@ export async function runSupervisorTui(
       try {
         await findSource(process.cwd())
       } catch (error: unknown) {
-        openSourcePrompt(safeError(error))
+        await requestManagedSource(action, safeError(error))
         return
       }
     }
@@ -470,7 +471,10 @@ export async function runSupervisorTui(
     }
   }
 
-  async function requestManagedSource(): Promise<void> {
+  async function requestManagedSource(
+    startAction: 'start' | 'start-open',
+    sourceFailure?: string,
+  ): Promise<void> {
     if (actionRunning) return
     const source = context.provenance.appDir.source
     if (source === 'environment' || source === 'cli-flag') {
@@ -480,6 +484,7 @@ export async function runSupervisorTui(
       return
     }
     actionRunning = true
+    let sourceFallback: string | undefined
     screen.update({
       busy: 'Inspecting managed source',
       notice: undefined,
@@ -488,23 +493,34 @@ export async function runSupervisorTui(
     try {
       const managedSource = await inspectManaged()
       if (!active) return
+      managedStartAction = startAction
       screen.update({
         managedSource,
         confirmation: 'managed-source',
       })
     } catch (error: unknown) {
       if (!active) return
-      screen.update({
-        diagnostic: `Managed source is unavailable: ${safeError(error)}`,
-      })
+      if (sourceFailure) {
+        sourceFallback = [
+          sourceFailure,
+          `Automatic Runtime setup is unavailable: ${safeError(error)}`,
+        ].join(' ')
+      } else {
+        screen.update({
+          diagnostic: `Managed source is unavailable: ${safeError(error)}`,
+        })
+      }
     } finally {
       actionRunning = false
       if (active) screen.update({ busy: undefined })
     }
+    if (sourceFallback) openSourcePrompt(sourceFallback)
   }
 
   async function prepareManagedSourceAndStart(): Promise<void> {
     if (!active || actionRunning) return
+    const startAction = managedStartAction
+    managedStartAction = 'start'
     actionRunning = true
     let prepared = false
     let actionFailure: string | undefined
@@ -538,7 +554,7 @@ export async function runSupervisorTui(
         if (actionFailure) screen.update({ diagnostic: actionFailure })
       }
     }
-    if (prepared && active) await performAction('start')
+    if (prepared && active) await performAction(startAction)
   }
 
   function openSourcePrompt(reason?: string): void {
@@ -1546,8 +1562,10 @@ export class SupervisorScreen implements Component {
           `Web: ${runtime?.endpoints?.web ?? 'not available'}`,
           `Components: ${formatComponents(runtime)}`,
         )
-        const provider = runtime?.provider?.kind
-          ?? this.snapshot.context?.runtimeProvider.kind
+        const reportedProvider = runtime?.provider?.kind
+        const provider = reportedProvider && reportedProvider !== 'unknown'
+          ? reportedProvider
+          : this.snapshot.context?.runtimeProvider.kind
         if (provider) {
           lines.push(`Provider: ${provider}${runtime?.class === 'absent' && provider === 'bundle' ? ' (installed)' : ''}`)
         }
@@ -1662,8 +1680,8 @@ function renderGuidance(
       ]
     }
     return [
-      'OpenAlice is stopped. Press Enter to start and open the browser.',
-      'Source development: m prepares managed source; c chooses a checkout.',
+      'OpenAlice is ready to start.',
+      'Enter prepares anything missing and opens the browser; c chooses a checkout.',
     ]
   }
   if (runtime.class === 'incompatible') {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -768,3 +768,15 @@ This plan is complete only when:
   environment/CLI precedence. Real PTY coverage exercises both persisted
   layers, and an installed bundle dogfood launch reached Alice, opened the Web
   UI, detached, reattached, and stopped cleanly.
+- 2026-07-30: Removed the remaining source-only first-start detour. When Enter
+  cannot discover a checkout, an installed CLI now derives the managed source
+  plan from its own branch/version provenance, asks for consent in the TUI,
+  then preserves the original start-and-open intent after preparation. `c`
+  remains the manual checkout escape hatch, while a non-installed source-run
+  CLI still falls back to the path editor. Stopped bundle views also ignore an
+  uninformative `provider=unknown` observation and show the verified installed
+  provider from launch context. Manual clean-container review exposed that the
+  offline installer fixture did not include Pi's TUI dependency and therefore
+  had never executed bare `openalice`; the fixture now supplies a minimal
+  adapter and the Docker acceptance itself drives Enter, verifies the
+  install-provenance plan, cancels, and detaches.

--- a/scripts/install-smoke/Dockerfile
+++ b/scripts/install-smoke/Dockerfile
@@ -15,6 +15,7 @@ COPY --chown=smoke:smoke scripts/install-smoke/interactive.sh /fixture/interacti
 COPY --chown=smoke:smoke scripts/install-smoke/run.sh /fixture/run.sh
 COPY --chown=smoke:smoke scripts/install-smoke/fake-package-manager.sh /fixture/fake-package-manager.sh
 COPY --chown=smoke:smoke scripts/install-smoke/fake-npm.sh /fixture/fake-npm.sh
+COPY --chown=smoke:smoke scripts/install-smoke/fake-pi-tui.mjs /fixture/fake-pi-tui.mjs
 COPY --chown=smoke:smoke scripts/install-smoke/pi-assets /fixture/pi-assets
 COPY --chown=smoke:smoke scripts/install-smoke/static-server.mjs /fixture/static-server.mjs
 

--- a/scripts/install-smoke/fake-npm.sh
+++ b/scripts/install-smoke/fake-npm.sh
@@ -15,8 +15,14 @@ for index in "${!expected[@]}"; do
 done
 
 cli_dir="$PWD/node_modules/@earendil-works/pi-coding-agent/dist"
+tui_dir="$PWD/node_modules/@earendil-works/pi-tui"
 mkdir -p "$cli_dir"
+mkdir -p "$tui_dir"
 printf '%s\n' \
   '#!/usr/bin/env node' \
   "if (process.argv.includes('--version') || process.argv.includes('-v')) console.log('0.83.0')" \
   > "$cli_dir/cli.js"
+cp /fixture/fake-pi-tui.mjs "$tui_dir/index.js"
+printf '%s\n' \
+  '{"name":"@earendil-works/pi-tui","version":"0.83.0","type":"module","main":"index.js"}' \
+  > "$tui_dir/package.json"

--- a/scripts/install-smoke/fake-pi-tui.mjs
+++ b/scripts/install-smoke/fake-pi-tui.mjs
@@ -1,0 +1,75 @@
+export class ProcessTerminal {}
+
+export class TUI {
+  #children = []
+  #inputHandlers = new Set()
+  #started = false
+
+  addChild(component) {
+    this.#children.push(component)
+  }
+
+  addInputListener(listener) {
+    const handler = (chunk) => {
+      listener(String(chunk))
+    }
+    this.#inputHandlers.add(handler)
+    process.stdin.on('data', handler)
+    return () => {
+      this.#inputHandlers.delete(handler)
+      process.stdin.off('data', handler)
+    }
+  }
+
+  requestRender() {
+    if (this.#started) this.#render()
+  }
+
+  setShowHardwareCursor() {}
+
+  start() {
+    this.#started = true
+    process.stdin.setEncoding('utf8')
+    if (process.stdin.isTTY) process.stdin.setRawMode(true)
+    process.stdin.resume()
+    this.#render()
+  }
+
+  stop() {
+    this.#started = false
+    for (const handler of this.#inputHandlers) {
+      process.stdin.off('data', handler)
+    }
+    this.#inputHandlers.clear()
+    if (process.stdin.isTTY) process.stdin.setRawMode(false)
+    process.stdin.pause()
+    process.stdout.write('\u001b[?25h\u001b[?2004l\n')
+  }
+
+  #render() {
+    const width = process.stdout.columns || 100
+    const lines = this.#children.flatMap((component) => (
+      component.render?.(width) ?? []
+    ))
+    process.stdout.write(`\u001b[2J\u001b[H${lines.join('\n')}\n`)
+  }
+}
+
+export class Input {}
+export class SelectList {}
+export class SettingsList {}
+
+export function matchesKey(data, key) {
+  const keys = {
+    enter: ['\r', '\n'],
+    escape: ['\u001b'],
+    'ctrl+c': ['\u0003'],
+    tab: ['\t'],
+    'shift+tab': ['\u001b[Z'],
+    up: ['\u001b[A'],
+    down: ['\u001b[B'],
+    left: ['\u001b[D'],
+    right: ['\u001b[C'],
+  }
+  return keys[key]?.includes(data) ?? data === key
+}

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -15,6 +15,7 @@ fi
 server_log="$(mktemp)"
 refusal_log="$(mktemp)"
 runtime_deps_log="$(mktemp)"
+tui_log="$(mktemp)"
 runtime_fixture_bin="$(mktemp -d)"
 cp /fixture/fake-package-manager.sh "$runtime_fixture_bin/fake-package-manager"
 chmod +x "$runtime_fixture_bin/fake-package-manager"
@@ -31,7 +32,7 @@ cleanup() {
   kill "$server_pid" >/dev/null 2>&1 || true
   wait "$server_pid" >/dev/null 2>&1 || true
   rm -rf "$runtime_fixture_bin"
-  rm -f "$server_log" "$refusal_log" "$runtime_deps_log"
+  rm -f "$server_log" "$refusal_log" "$runtime_deps_log" "$tui_log"
 }
 trap cleanup EXIT
 
@@ -83,7 +84,14 @@ install_branch_with_runtime_deps() {
 
 mkdir -p "$HOME/.openalice/.cli-install.lock"
 printf '99999999\n' > "$HOME/.openalice/.cli-install.lock/pid"
-install_branch smoke-v1
+first_install_output="$(install_branch smoke-v1)"
+printf '%s\n' "$first_install_output"
+grep -Fq "Press Enter inside the Supervisor to prepare, start, and open OpenAlice." \
+  <<<"$first_install_output" \
+  || fail "source-only install did not explain the parameter-free first start"
+grep -Fq "Use c only if you want to select an existing checkout instead." \
+  <<<"$first_install_output" \
+  || fail "source-only install did not keep manual checkout selection secondary"
 
 bin_dir="$HOME/.openalice/bin"
 versions_dir="$HOME/.openalice/cli-versions"
@@ -99,6 +107,21 @@ if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") proc
 ' "$install_source" "$cli_version" || fail "installed CLI did not preserve its install source"
 [[ "$($bin_dir/pi --version)" == "0.83.0" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
+{
+  sleep 0.2
+  printf '\r'
+  sleep 0.2
+  printf 'n'
+  sleep 0.2
+  printf 'q'
+} | script -qec "$bin_dir/openalice" "$tui_log" >/dev/null
+grep -Fq "installer-managed OpenAlice source branch smoke-v1" "$tui_log" \
+  || fail "installed bare TUI did not derive managed Runtime setup from install provenance"
+grep -Fq "Action cancelled." "$tui_log" \
+  || fail "installed bare TUI did not return from the managed Runtime confirmation"
+if grep -Fq "Configure Runtime source" "$tui_log"; then
+  fail "installed bare TUI fell back to the manual checkout path"
+fi
 server_status="$($bin_dir/openalice server status --home "$HOME/openalice-server-smoke" --json)"
 node -e '
 const status = JSON.parse(process.argv[1]);


### PR DESCRIPTION
## What changed

- make bare-TUI Enter fall back from current-directory discovery to the installed branch/version managed Runtime plan
- preserve the original start-and-open intent after managed source preparation; `m` remains background preparation and `c` remains manual checkout selection
- fall back from an uninformative stopped `provider=unknown` observation to the verified installed Runtime provider
- update installer completion copy so source-only installs teach Enter as the primary path
- add unit sequencing and real-PTY coverage for installed-layout first start
- extend the clean Docker installer acceptance to actually launch the installed bare TUI, drive Enter, verify install provenance, cancel, and detach

## Why

The source-only/dev installation path still asked humans to know the `m` shortcut or type a checkout path. Bare `openalice` should own setup interactively, while explicit command flags and `c` remain the automation and development escape hatches.

Manual clean-container review also showed that the offline npm fixture omitted Pi's TUI dependency, so the Docker “installed CLI” smoke had never executed the default command. The fixture now provides a minimal offline adapter for application-state acceptance; the real `pi-tui` renderer remains covered by the host PTY suite.

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 3,765 passed, 9 skipped
- targeted Supervisor unit/PTY suite — 25 passed
- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/fake-npm.sh`
- `node --check scripts/install-smoke/fake-pi-tui.mjs`
- `pnpm test:install:docker`
- manual isolated local install plus real installed `pi-tui` Enter/cancel/detach
- manual clean-container installer copy review
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
