### PR TITLE
fix(installer): verify managed TUI dependency

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -285,7 +285,9 @@ Before a release becomes visible, the installer:
 3. executes the staged CLI with `--version` and compares its result with the
    package manifest;
 4. verifies the Pi install manifest and lockfile against the SHA-256 values
-   pinned in the installer, then requires the staged Pi CLI to report `0.83.0`;
+   pinned in the installer, requires the staged Pi CLI to report `0.83.0`, and
+   resolves the pinned `@earendil-works/pi-tui` dependency from that exact
+   managed Pi closure;
 5. verifies and expands the matching headless Runtime when the selected release
    supplies one, then requires its product version to equal the CLI version;
 6. writes `install-source.json` with the CLI version, selected branch/tag/commit,
@@ -312,10 +314,10 @@ The resulting directory is:
 ```
 
 Installing identical content for the same ref reuses the existing directory
-only when the content hash, executable Pi version, and full Runtime manifest
-verification still match. If a
-directory claims that identity but its files no longer hash correctly or its
-managed Pi runtime is missing/damaged, it is preserved as
+only when the content hash, executable Pi version, managed `pi-tui` dependency,
+and full Runtime manifest verification still match. If a directory claims that
+identity but its files no longer hash correctly or its managed Pi runtime is
+missing/damaged, it is preserved as
 `<release>.damaged.<pid>` and replaced with the validated staging tree. The
 installer does not silently destroy the damaged evidence.
 
@@ -618,6 +620,8 @@ It verifies:
   install-provenance managed Runtime planning, cancellation, and detach;
 - idempotent managed PATH configuration;
 - identical-release reuse;
+- damaged-release preservation and repair when Pi remains runnable but its TUI
+  dependency is missing;
 - ref switching without deleting the prior release;
 - development-channel update guidance without a stable-channel network check;
 - installed uninstall execution that removes CLI assets and PATH integration

--- a/install
+++ b/install
@@ -917,6 +917,11 @@ step 4 "Installing the managed Pi runtime"
 PI_RELATIVE_ENTRY="managed/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js"
 PI_STAGED_ENTRY="$STAGING/$PI_RELATIVE_ENTRY"
 [[ -f "$PI_STAGED_ENTRY" ]] || die "npm completed without the managed Pi CLI"
+node -e '
+  const { createRequire } = require("node:module");
+  createRequire(process.argv[1]).resolve("@earendil-works/pi-tui");
+' "$PI_STAGED_ENTRY" \
+  || die "npm completed without the managed Pi TUI dependency"
 PI_STAGED_VERSION="$(node "$PI_STAGED_ENTRY" --version)"
 [[ "$PI_STAGED_VERSION" == "$PI_VERSION" ]] || die "Managed Pi reported $PI_STAGED_VERSION instead of $PI_VERSION"
 ok "Managed Pi $PI_VERSION is ready"
@@ -997,9 +1002,17 @@ mkdir -p "$BIN_DIR" "$VERSIONS_DIR"
 DESTINATION="$VERSIONS_DIR/${SAFE_VERSION}-${CONTENT_ID}"
 if [[ -e "$DESTINATION" ]]; then
   destination_pi_version="$(node "$DESTINATION/$PI_RELATIVE_ENTRY" --version 2>/dev/null || true)"
+  destination_pi_tui_ready=0
+  if node -e '
+    const { createRequire } = require("node:module");
+    createRequire(process.argv[1]).resolve("@earendil-works/pi-tui");
+  ' "$DESTINATION/$PI_RELATIVE_ENTRY" >/dev/null 2>&1; then
+    destination_pi_tui_ready=1
+  fi
   if [[ -d "$DESTINATION" \
     && "$(content_id "$DESTINATION" "${CONTENT_FILES[@]}" 2>/dev/null || true)" == "$CONTENT_ID" \
     && "$destination_pi_version" == "$PI_VERSION" \
+    && "$destination_pi_tui_ready" -eq 1 \
     && ( -z "$RUNTIME_CONTENT_IDENTITY" \
       || "$(node "$DESTINATION/src/runtime-bundle.mjs" verify \
         "$DESTINATION/managed/runtime" \

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -129,6 +129,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(releases[0]).toMatch(/^test_ref-[a-f0-9]{16}$/)
     await expect(access(join(installRoot, 'cli-versions', releases[0], 'bin', 'openalice.ts'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'cli-versions', releases[0], 'managed', 'pi', 'node_modules', '@earendil-works', 'pi-coding-agent', 'dist', 'cli.js'))).resolves.toBeUndefined()
+    await expect(access(join(installRoot, 'cli-versions', releases[0], 'managed', 'pi', 'node_modules', '@earendil-works', 'pi-tui', 'package.json'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'bin', 'openalice.cmd'))).resolves.toBeUndefined()
     await expect(access(join(installRoot, 'bin', 'pi.cmd'))).resolves.toBeUndefined()
 

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -780,3 +780,10 @@ This plan is complete only when:
   had never executed bare `openalice`; the fixture now supplies a minimal
   adapter and the Docker acceptance itself drives Enter, verifies the
   install-provenance plan, cancels, and detaches.
+- 2026-07-30: Hardened the install boundary exposed by that clean-container
+  journey. Staged installs and identical-release reuse now resolve
+  `@earendil-works/pi-tui` from the exact managed Pi closure instead of treating
+  a runnable Pi CLI as proof that the Supervisor renderer exists. Docker
+  acceptance deletes only that dependency from an otherwise healthy release,
+  verifies that the installer preserves the damaged evidence, replaces the
+  release atomically, and confirms the repaired closure before continuing.

--- a/scripts/install-smoke/fake-npm.sh
+++ b/scripts/install-smoke/fake-npm.sh
@@ -16,13 +16,14 @@ done
 
 cli_dir="$PWD/node_modules/@earendil-works/pi-coding-agent/dist"
 tui_dir="$PWD/node_modules/@earendil-works/pi-tui"
+fixture_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p "$cli_dir"
 mkdir -p "$tui_dir"
 printf '%s\n' \
   '#!/usr/bin/env node' \
   "if (process.argv.includes('--version') || process.argv.includes('-v')) console.log('0.83.0')" \
   > "$cli_dir/cli.js"
-cp /fixture/fake-pi-tui.mjs "$tui_dir/index.js"
+cp "$fixture_dir/fake-pi-tui.mjs" "$tui_dir/index.js"
 printf '%s\n' \
   '{"name":"@earendil-works/pi-tui","version":"0.83.0","type":"module","main":"index.js"}' \
   > "$tui_dir/package.json"

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -16,6 +16,10 @@ server_log="$(mktemp)"
 refusal_log="$(mktemp)"
 runtime_deps_log="$(mktemp)"
 tui_log="$(mktemp)"
+tui_input="$(mktemp)"
+rm -f "$tui_input"
+mkfifo "$tui_input"
+tui_pid=""
 runtime_fixture_bin="$(mktemp -d)"
 cp /fixture/fake-package-manager.sh "$runtime_fixture_bin/fake-package-manager"
 chmod +x "$runtime_fixture_bin/fake-package-manager"
@@ -29,10 +33,14 @@ export PATH="$runtime_fixture_bin:$PATH"
 node /fixture/static-server.mjs >"$server_log" 2>&1 &
 server_pid=$!
 cleanup() {
+  if [[ -n "$tui_pid" ]]; then
+    kill "$tui_pid" >/dev/null 2>&1 || true
+    wait "$tui_pid" >/dev/null 2>&1 || true
+  fi
   kill "$server_pid" >/dev/null 2>&1 || true
   wait "$server_pid" >/dev/null 2>&1 || true
   rm -rf "$runtime_fixture_bin"
-  rm -f "$server_log" "$refusal_log" "$runtime_deps_log" "$tui_log"
+  rm -f "$server_log" "$refusal_log" "$runtime_deps_log" "$tui_log" "$tui_input"
 }
 trap cleanup EXIT
 
@@ -107,14 +115,37 @@ if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") proc
 ' "$install_source" "$cli_version" || fail "installed CLI did not preserve its install source"
 [[ "$($bin_dir/pi --version)" == "0.83.0" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"
-{
-  sleep 0.2
-  printf '\r'
-  sleep 0.2
-  printf 'n'
-  sleep 0.2
-  printf 'q'
-} | script -qec "$bin_dir/openalice" "$tui_log" >/dev/null
+wait_for_tui_log() {
+  local pattern="$1"
+  local failure="$2"
+  for _ in $(seq 1 100); do
+    if grep -Fq "$pattern" "$tui_log"; then
+      return
+    fi
+    if ! kill -0 "$tui_pid" >/dev/null 2>&1; then
+      cat "$tui_log" >&2
+      fail "$failure (TUI exited early)"
+    fi
+    sleep 0.1
+  done
+  cat "$tui_log" >&2
+  fail "$failure (timed out)"
+}
+script -qefc "$bin_dir/openalice" "$tui_log" <"$tui_input" >/dev/null &
+tui_pid=$!
+exec 3>"$tui_input"
+wait_for_tui_log "q / Esc / Ctrl+C  Detach without stopping" \
+  "installed bare TUI did not render"
+printf '\r' >&3
+wait_for_tui_log "installer-managed OpenAlice source branch smoke-v1" \
+  "installed bare TUI did not derive managed Runtime setup from install provenance"
+printf 'n' >&3
+wait_for_tui_log "Action cancelled." \
+  "installed bare TUI did not return from the managed Runtime confirmation"
+printf 'q' >&3
+exec 3>&-
+wait "$tui_pid"
+tui_pid=""
 grep -Fq "installer-managed OpenAlice source branch smoke-v1" "$tui_log" \
   || fail "installed bare TUI did not derive managed Runtime setup from install provenance"
 grep -Fq "Action cancelled." "$tui_log" \
@@ -193,6 +224,19 @@ cmp /fixture/packages/cli/src/update.mjs "$v1_release/src/update.mjs" \
   || fail "downloaded update module differs from the fixture"
 cmp /fixture/packages/cli/src/uninstall.mjs "$v1_release/src/uninstall.mjs" \
   || fail "downloaded uninstall module differs from the fixture"
+
+rm -rf "$v1_release/managed/pi/node_modules/@earendil-works/pi-tui"
+install_branch smoke-v1
+damaged_release="$(find "$versions_dir" -mindepth 1 -maxdepth 1 -type d \
+  -name "$(basename "$v1_release").damaged.*" -print -quit)"
+[[ -n "$damaged_release" ]] \
+  || fail "installer reused a release whose managed Pi TUI dependency was missing"
+node -e '
+  const { createRequire } = require("node:module");
+  createRequire(process.argv[1]).resolve("@earendil-works/pi-tui");
+' "$v1_release/managed/pi/node_modules/@earendil-works/pi-coding-agent/dist/cli.js" \
+  || fail "installer did not repair the managed Pi TUI dependency"
+rm -rf "$damaged_release"
 
 expected_path_line="export PATH=$HOME/.openalice/bin:\$PATH"
 path_count="$(grep -Fxc "$expected_path_line" "$HOME/.bashrc" || true)"


### PR DESCRIPTION
## Summary
- require the installed managed Pi closure to resolve `@earendil-works/pi-tui` before activation or identical-release reuse
- preserve and atomically replace an otherwise runnable release when its TUI dependency is missing
- make installer unit/Docker fixtures model the complete Pi/TUI closure and drive the bare TUI with state-based PTY synchronization

## Verification
- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/fake-npm.sh`
- `git diff --check`
- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm vitest run packages/cli/src/install.spec.mjs`
- `pnpm test` (3,765 passed, 9 skipped)
- `pnpm test:install:docker`
- isolated real source install using official Pi 0.83.0 assets, managed `pi-tui` resolution, and installed `openalice uninstall --yes`
