### PR TITLE
Refine Quant navigation placement

### DIFF
--- a/ui/src/components/ActivityBar.spec.ts
+++ b/ui/src/components/ActivityBar.spec.ts
@@ -3,11 +3,19 @@ import { describe, expect, it } from 'vitest'
 import { NAV_SECTIONS } from './activity-navigation'
 
 describe('ActivityBar navigation hierarchy', () => {
-  it('keeps Workspaces out of primary navigation and under System', () => {
+  it('keeps the primary workflow ordered with Quant below Issues', () => {
     const primary = NAV_SECTIONS.find((section) => section.sectionLabel === '')
     const system = NAV_SECTIONS.find((section) => section.sectionLabel === 'System')
 
-    expect(primary?.items.map((item) => item.page)).not.toContain('workspaces')
+    expect(primary?.items.map((item) => item.page)).toEqual([
+      'chat',
+      'inbox',
+      'issue',
+      'auto-quant',
+      'tracked',
+      'market',
+      'news',
+    ])
     expect(system?.items.map((item) => item.page)).toContain('workspaces')
   })
 })

--- a/ui/src/components/activity-navigation.ts
+++ b/ui/src/components/activity-navigation.ts
@@ -48,9 +48,9 @@ export const NAV_SECTIONS: NavSection[] = [
     sectionLabel: '',
     items: [
       { page: 'chat',       labelKey: 'nav.item.chat',       icon: MessageSquare, defaultTab: { kind: 'chat-landing', params: {} } },
-      { page: 'auto-quant', labelKey: 'nav.item.autoQuant',  icon: Microscope, defaultTab: { kind: 'auto-quant-landing', params: {} } },
       { page: 'inbox',      labelKey: 'nav.item.inbox',      icon: Inbox, defaultTab: { kind: 'inbox', params: {} } },
       { page: 'issue',      labelKey: 'nav.item.issue',      icon: ListChecks, defaultTab: { kind: 'issue', params: {} } },
+      { page: 'auto-quant', labelKey: 'nav.item.autoQuant',  icon: Microscope, defaultTab: { kind: 'auto-quant-landing', params: {} } },
       { page: 'tracked',    labelKey: 'nav.item.tracked',    icon: Telescope, defaultTab: { kind: 'tracked', params: {} } },
       { page: 'market',     labelKey: 'nav.item.market',     icon: BarChart3, defaultTab: { kind: 'market-list', params: {} } },
       { page: 'news',       labelKey: 'nav.item.news',       icon: Newspaper, defaultTab: { kind: 'news', params: {} } },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -18,7 +18,7 @@ export const en = {
       inbox: 'Inbox',
       tracked: 'Tracked',
       chat: 'Ask Alice',
-      autoQuant: 'AutoQuant',
+      autoQuant: 'Quant',
       workspaces: 'Workspaces',
       market: 'Market',
       news: 'News',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -7,7 +7,7 @@ export const ja: Resources = {
       inbox: '受信トレイ',
       tracked: 'トラッキング',
       chat: 'Alice に質問',
-      autoQuant: 'AutoQuant',
+      autoQuant: 'Quant',
       workspaces: 'ワークスペース',
       market: 'マーケット',
       news: 'ニュース',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -7,7 +7,7 @@ export const zh: Resources = {
       inbox: '收件箱',
       tracked: '追踪',
       chat: '问 Alice',
-      autoQuant: 'AutoQuant',
+      autoQuant: 'Quant',
       workspaces: '工作区',
       market: '市场',
       news: '新闻',


### PR DESCRIPTION
## Summary

- rename the activity-rail label from AutoQuant to Quant
- move the Quant entry below Issues
- keep `/auto-quant`, initialization copy, template identity, and Harness behavior unchanged
- lock the primary navigation order with a focused regression test

## Verification

- `npx tsc --noEmit`
- `pnpm test` (448 files passed, 1 skipped; 3765 tests passed, 9 skipped)
- `cd ui && npx tsc -b`
- `cd ui && pnpm exec vitest run src/components/ActivityBar.spec.ts`
- verified `/auto-quant` against the running main-data development instance