### PR TITLE
Retire per-workspace agent pins

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -28,6 +28,9 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/retire-workspace-adapter-pins.md]] — Retires the legacy per-Workspace
+  adapter allowlist so runtime availability comes from the live installation
+  registry and future default-enabled choices can live in global preferences.
 - [[plans/auto-quant-v2-harness.md]] — Adds AutoQuant V2 as a first-class
   version-pinned Harness, then refines it into an explicitly initialized
   default desk with Session-first daily UI and pinned `v0.8.31` source.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -307,7 +307,7 @@ async function runRendererPtySmoke(win: BrowserWindow): Promise<void> {
       const created = await json(await fetch('/api/workspaces', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ tag, template: 'chat', agents: ['shell'] }),
+        body: JSON.stringify({ tag, template: 'chat' }),
       }))
       workspaceId = created.workspace.id
       const spawned = await json(await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/sessions/spawn', {

--- a/apps/desktop/src/workspace-acceptance-smoke.ts
+++ b/apps/desktop/src/workspace-acceptance-smoke.ts
@@ -241,7 +241,7 @@ export async function runRendererWorkspaceAcceptanceSmoke(
       const created = await json(await fetch('/api/workspaces', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ tag, template: 'chat', agents: ['shell', 'pi'] }),
+        body: JSON.stringify({ tag, template: 'chat' }),
       }))
       workspaceId = created.workspace.id
       checks.workspaceCreated = true

--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -69,7 +69,7 @@ are reachable. Resolve the peer's absolute dir by its `workspaceId`, then use yo
 own file tools:
 
 ```bash
-# active office-floor inventory (ids, templates, agents, live workload counts)
+# active office-floor inventory (ids, templates, live workload counts)
 alice-workspace peer list
 # --id is the `workspaceId` from an inbox_read entry (a uuid), e.g.:
 alice-workspace peer path --id 550e8400-e29b-41d4-a716-446655440000

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -334,11 +334,11 @@ PTY pool, then shows:
 - only launcher-controlled environment contributions, grouped by terminal,
   Workspace, toolchain, and adapter ownership.
 
-The Shell utility is always present in this surface even when it is not listed
-as a Workspace agent runtime. Its plan uses the same launcher-built base
-environment and cwd as coding agents, so the injected `alice*` and `traderhub`
-CLI path and local tool transport remain visible. Shell does not receive an AI
-provider credential or another runtime's adapter-specific environment.
+The Shell utility is always present in this surface alongside the registered
+agent runtimes. Its plan uses the same launcher-built base environment and cwd
+as coding agents, so the injected `alice*` and `traderhub` CLI path and local
+tool transport remain visible. Shell does not receive an AI provider credential
+or another runtime's adapter-specific environment.
 
 Reading a launch plan never runs `prepareWorkspace`, writes native runtime
 configuration, or starts a process. The response omits inherited host

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -113,6 +113,13 @@ and git repository plus PTY sessions, scrollback, issues, schedules, and agent
 configuration. The launcher supplies reusable infrastructure; the work itself
 lives in templates, skills, files, and satellite repositories.
 
+Coding-agent adapters are installation capabilities, not Workspace identity.
+Every registered adapter is eligible in every active Workspace; install and
+credential readiness are checked when a runtime is selected. Workspace registry
+and lifecycle rows do not persist adapter allowlists. A future user choice for
+the default enabled adapter set belongs in installation preferences, never in
+historical Workspace metadata.
+
 Chat uses that boundary deliberately:
 
 - **New conversation** creates a Session inside the recent Chat Workspace.

--- a/docs/workspace-lifecycle.md
+++ b/docs/workspace-lifecycle.md
@@ -100,7 +100,7 @@ Restore is “rehire with the old desk”:
 
 1. refuse a missing archive, occupied active path, or active tag collision;
 2. move the checkout back to its immutable original `activeDir`;
-3. re-add the exact `WorkspaceMeta` to the active registry;
+3. re-add the exact durable `WorkspaceMeta` to the active registry;
 4. recall its resume identities without changing their ids or native mappings;
 5. mark the Catalog row active.
 
@@ -126,6 +126,11 @@ that is absent from `workspaces.json` moves to `departed-workspaces/` and gets a
 best-effort departed Catalog row. Nothing is deleted. Session files are used to
 recover known runtime names; unknown metadata stays visibly marked as a legacy
 import.
+
+Migration `0030_retire_workspace_agent_pins` removes the obsolete `agents`
+array from active and lifecycle rows. Restored desks use the live installation
+adapter registry like every other Workspace; the adapter set present when a
+desk was created or departed is not part of its durable identity.
 
 Before moving anything, the migration preflights the complete directory set. If
 both an active orphan path and its departed destination exist, or a registered

--- a/plans/retire-workspace-adapter-pins.md
+++ b/plans/retire-workspace-adapter-pins.md
@@ -1,0 +1,71 @@
+# Retire Workspace Adapter Pins
+
+Status: Completed
+
+Related owner guides: [[docs/project-structure.md]], [[docs/workspace-lifecycle.md]]
+
+## Scope
+
+Retire the legacy `agents` array from active Workspace registry rows and
+Workspace lifecycle catalog rows. Adapter availability is installation-wide:
+every registered adapter is eligible in every active Workspace, while installed
+runtime and credential readiness remain explicit launch-time checks.
+
+This change does not add the future user preference for a default enabled
+adapter set. That preference belongs in installation-level preferences rather
+than Workspace identity.
+
+## Decisions
+
+- `WorkspaceMeta` and public Workspace payloads no longer contain an adapter
+  allowlist.
+- Explicit runtime requests validate against the live adapter registry, not
+  historical Workspace metadata.
+- Default runtime resolution uses installation preferences first and the live
+  registered runtime order as fallback.
+- Template `defaultAgents` remains a transient ordering hint during Workspace
+  creation; it is not persisted into the Workspace.
+- Legacy create payloads may still include `agents`, but the field has no
+  pinning effect and is not persisted.
+- Migration `0030` removes `agents` from both `workspaces.json` and
+  `state/workspace-catalog.json` idempotently.
+- Historical migration `0021` now derives its launcher root from the migration
+  context, so isolated startup tests and alternate homes cannot rewrite the
+  default `~/.openalice` catalog.
+
+## Work
+
+- [x] Remove `agents` from Workspace registry and catalog models.
+- [x] Remove Workspace allowlist checks from spawn, Issue, conversation, and
+      credential-readiness paths.
+- [x] Make Chat, Quant, Workspace, and Issue selectors use the global adapter
+      inventory.
+- [x] Remove adapter arrays from Workspace API, CLI/MCP peer inventory, and demo
+      contracts.
+- [x] Add migration `0030_retire_workspace_agent_pins`, its tests, registry
+      entry, and generated index row.
+- [x] Update owner guides and agent-facing Workspace inventory guidance.
+- [x] Verify the real Chat and Quant routes against durable legacy Workspaces.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `cd ui && npx tsc -b`
+- `pnpm test`
+- targeted migration, Workspace creator/registry/catalog, Quick Chat, Issue,
+  conversation, and UI selector specs
+- `pnpm build:migration-index`
+- real `/chat` and `/auto-quant` browser checks using the main development
+  instance
+
+## Completion
+
+The plan is complete when no production path reads a Workspace-level adapter
+allowlist, persisted legacy fields are removed by migration, all registered
+agent runtimes appear in Chat and Quant regardless of Workspace age, and the
+change is merged into `dev`.
+
+All implementation and verification criteria passed on 2026-07-31. The main
+development data set was migrated with backups, and the real Chat and Quant
+selectors both exposed Claude Code, Codex, opencode, and Pi from the
+installation inventory.

--- a/scripts/docker-runtime-smoke.mjs
+++ b/scripts/docker-runtime-smoke.mjs
@@ -437,7 +437,6 @@ try {
     body: JSON.stringify({
       tag: `docker-smoke-${suffix}`,
       template: 'chat',
-      agents: ['shell', ...(aiCredential ? [aiAgent] : [])],
     }),
   }, 201)
   const workspaceId = created?.workspace?.id

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -214,9 +214,9 @@ export const aiProviderSchema = z.object({
   workspaceCredentialDefaults: z.record(z.string(), workspaceCredentialDefaultSchema).default({}),
   /**
    * User-level default runtime for new interactive workspace sessions. This is
-   * intentionally separate from workspace identity (`agents[]`) and from
-   * credential defaults: it answers "which agent TUI should a plain New Session
-   * start?" Shell is a utility adapter, not a valid stored default.
+   * intentionally separate from Workspace identity and credential defaults: it
+   * answers "which agent TUI should a plain New Session start?" Shell is a
+   * utility adapter, not a valid stored default.
    */
   workspaceDefaultAgent: z.string().nullable().default(null),
   /**

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -187,7 +187,6 @@ export interface WorkspaceToolContext {
     id: string
     tag: string
     template?: string
-    agents: readonly string[]
     createdAt: string
     sessions: {
       total: number

--- a/src/migrations/0021_workspace_departure_catalog.spec.ts
+++ b/src/migrations/0021_workspace_departure_catalog.spec.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { migrateWorkspaceDepartureCatalog } from './0021_workspace_departure_catalog/index.js'
+import { migrateWorkspaceDepartureCatalog, migration } from './0021_workspace_departure_catalog/index.js'
 
 let root: string
 
@@ -77,5 +77,20 @@ describe('0021 Workspace departure catalog', () => {
     expect(existsSync(join(root, 'workspaces', 'chat-second-orphan'))).toBe(true)
     expect(existsSync(join(root, 'departed-workspaces', 'chat-orphan'))).toBe(true)
     expect(existsSync(join(root, 'departed-workspaces', 'chat-second-orphan'))).toBe(false)
+  })
+
+  it('derives the launcher root from the migration context', async () => {
+    const instance = join(root, 'isolated-instance')
+    const configDir = join(instance, 'data', 'config')
+    await mkdir(configDir, { recursive: true })
+
+    await migration.up({
+      configDir: () => configDir,
+      readJson: async () => undefined,
+      writeJson: async () => undefined,
+      removeJson: async () => undefined,
+    })
+
+    expect(existsSync(join(instance, 'workspaces', 'state', 'workspace-catalog.json'))).toBe(true)
   })
 })

--- a/src/migrations/0021_workspace_departure_catalog/index.ts
+++ b/src/migrations/0021_workspace_departure_catalog/index.ts
@@ -5,6 +5,10 @@ import { dirname, join, resolve } from 'node:path'
 import type { WorkspaceCatalogRecord } from '../../workspaces/workspace-catalog.js'
 import type { Migration } from '../types.js'
 
+type LegacyWorkspaceCatalogRecord = WorkspaceCatalogRecord & {
+  agents?: string[]
+}
+
 interface RegistryMeta {
   id: string
   tag: string
@@ -55,7 +59,7 @@ async function readRequiredRegistry(path: string): Promise<RegistryMeta[] | null
   return metas
 }
 
-async function readExistingCatalog(path: string): Promise<WorkspaceCatalogRecord[]> {
+async function readExistingCatalog(path: string): Promise<LegacyWorkspaceCatalogRecord[]> {
   let text: string
   try { text = await readFile(path, 'utf8') }
   catch (err) {
@@ -70,12 +74,13 @@ async function readExistingCatalog(path: string): Promise<WorkspaceCatalogRecord
     (parsed as { version?: unknown }).version !== 1 ||
     !Array.isArray((parsed as { workspaces?: unknown }).workspaces)
   ) throw new Error('cannot migrate Workspace lifecycle: workspace-catalog.json has an unsupported shape')
-  const records = (parsed as { workspaces: WorkspaceCatalogRecord[] }).workspaces
+  const records = (parsed as { workspaces: LegacyWorkspaceCatalogRecord[] }).workspaces
   for (const record of records) {
     if (
       !record || typeof record.id !== 'string' || typeof record.tag !== 'string' ||
       typeof record.activeDir !== 'string' || typeof record.createdAt !== 'string' ||
-      typeof record.updatedAt !== 'string' || !Array.isArray(record.agents) ||
+      typeof record.updatedAt !== 'string' ||
+      (record.agents !== undefined && !Array.isArray(record.agents)) ||
       !['active', 'offboarding', 'departed', 'restoring', 'purging', 'purged'].includes(record.lifecycle)
     ) throw new Error('cannot migrate Workspace lifecycle: invalid catalog row')
   }
@@ -110,7 +115,7 @@ function inferredTemplate(id: string): string | undefined {
   return undefined
 }
 
-function activeRecord(meta: RegistryMeta, now: string): WorkspaceCatalogRecord {
+function activeRecord(meta: RegistryMeta, now: string): LegacyWorkspaceCatalogRecord {
   return {
     id: meta.id,
     tag: meta.tag,
@@ -130,7 +135,7 @@ async function legacyRecord(
   activeDir: string,
   departedDir: string,
   now: string,
-): Promise<WorkspaceCatalogRecord> {
+): Promise<LegacyWorkspaceCatalogRecord> {
   const info = await stat(departedDir).catch(() => null)
   const createdAt = info && Number.isFinite(info.birthtimeMs) && info.birthtimeMs > 0
     ? info.birthtime.toISOString()
@@ -170,7 +175,7 @@ export async function migrateWorkspaceDepartureCatalog(
   const activeMetas = registryMetas ?? []
   const activeById = new Map(activeMetas.map((meta) => [meta.id, meta]))
   const catalogPath = join(root, 'state', 'workspace-catalog.json')
-  const records = new Map<string, WorkspaceCatalogRecord>()
+  const records = new Map<string, LegacyWorkspaceCatalogRecord>()
   for (const value of await readExistingCatalog(catalogPath)) {
     if (!value || typeof value.id !== 'string') {
       throw new Error('cannot migrate Workspace lifecycle: invalid catalog row')
@@ -238,5 +243,11 @@ export const migration: Migration = {
   affects: ['workspaces/workspaces.json', 'workspaces/workspaces/*', 'workspaces/departed-workspaces/*', 'workspaces/state/workspace-catalog.json'],
   summary: 'Move unregistered Workspace directories into a durable departed catalog without deleting them.',
   rationale: 'The active Workspace root is a manager-visible office floor; departed desks must leave that namespace while retaining handoff and restore history.',
-  up: async () => { await migrateWorkspaceDepartureCatalog() },
+  up: async (ctx) => {
+    const userDataHome = resolve(ctx.configDir(), '..', '..')
+    const launcherRoot = resolve(
+      process.env['AQ_LAUNCHER_ROOT'] ?? join(userDataHome, 'workspaces'),
+    )
+    await migrateWorkspaceDepartureCatalog(launcherRoot)
+  },
 }

--- a/src/migrations/0030_retire_workspace_agent_pins.spec.ts
+++ b/src/migrations/0030_retire_workspace_agent_pins.spec.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  migrateWorkspaceAgentPins,
+  stripWorkspaceAgentPins,
+} from './0030_retire_workspace_agent_pins/index.js'
+
+describe('0030 retire Workspace adapter pins', () => {
+  it('removes only legacy agents keys and is idempotent', () => {
+    const raw = {
+      version: 1,
+      workspaces: [
+        { id: 'old', tag: 'old', agents: ['claude', 'codex'], lifecycle: 'active' },
+        { id: 'new', tag: 'new' },
+      ],
+    }
+    expect(stripWorkspaceAgentPins(raw)).toEqual({
+      updated: 1,
+      value: {
+        version: 1,
+        workspaces: [
+          { id: 'old', tag: 'old', lifecycle: 'active' },
+          { id: 'new', tag: 'new' },
+        ],
+      },
+    })
+    const once = stripWorkspaceAgentPins(raw).value
+    expect(stripWorkspaceAgentPins(once)).toEqual({ value: once, updated: 0 })
+  })
+
+  it('migrates and backs up both registry files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-agent-pins-'))
+    const state = join(root, 'state')
+    const backup = join(root, 'backup')
+    await mkdir(state, { recursive: true })
+    await writeFile(join(root, 'workspaces.json'), JSON.stringify({
+      version: 1,
+      workspaces: [{ id: 'active', agents: ['claude'] }],
+    }))
+    await writeFile(join(state, 'workspace-catalog.json'), JSON.stringify({
+      version: 1,
+      workspaces: [{ id: 'departed', agents: ['pi'], lifecycle: 'departed' }],
+    }))
+
+    await expect(migrateWorkspaceAgentPins(root, { backupRoot: backup })).resolves.toEqual({
+      registryUpdated: 1,
+      catalogUpdated: 1,
+    })
+    expect(JSON.parse(await readFile(join(root, 'workspaces.json'), 'utf8'))).toEqual({
+      version: 1,
+      workspaces: [{ id: 'active' }],
+    })
+    expect(JSON.parse(await readFile(join(state, 'workspace-catalog.json'), 'utf8'))).toEqual({
+      version: 1,
+      workspaces: [{ id: 'departed', lifecycle: 'departed' }],
+    })
+    expect(JSON.parse(await readFile(join(backup, 'workspaces.json'), 'utf8')))
+      .toEqual({ version: 1, workspaces: [{ id: 'active', agents: ['claude'] }] })
+    expect(JSON.parse(await readFile(join(backup, 'state', 'workspace-catalog.json'), 'utf8')))
+      .toEqual({
+        version: 1,
+        workspaces: [{ id: 'departed', agents: ['pi'], lifecycle: 'departed' }],
+      })
+    await expect(migrateWorkspaceAgentPins(root, { backupRoot: backup })).resolves.toEqual({
+      registryUpdated: 0,
+      catalogUpdated: 0,
+    })
+  })
+})

--- a/src/migrations/0030_retire_workspace_agent_pins/index.ts
+++ b/src/migrations/0030_retire_workspace_agent_pins/index.ts
@@ -1,0 +1,118 @@
+/**
+ * 0030_retire_workspace_agent_pins — remove the retired per-Workspace adapter
+ * allowlist from active and lifecycle registry records.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { cp, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import type { Migration } from '../types.js'
+
+interface MigrationOptions {
+  readonly backupRoot?: string
+}
+
+function defaultLauncherRoot(): string {
+  return resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(homedir(), '.openalice', 'workspaces'))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function stripWorkspaceAgentPins(raw: unknown): {
+  value: unknown
+  updated: number
+} {
+  if (!isRecord(raw) || !Array.isArray(raw['workspaces'])) {
+    return { value: raw, updated: 0 }
+  }
+  let updated = 0
+  const workspaces = raw['workspaces'].map((value) => {
+    if (!isRecord(value) || !Object.prototype.hasOwnProperty.call(value, 'agents')) return value
+    const next = { ...value }
+    delete next['agents']
+    updated += 1
+    return next
+  })
+  return {
+    value: updated > 0 ? { ...raw, workspaces } : raw,
+    updated,
+  }
+}
+
+async function writeAtomicJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const temp = join(dirname(path), `.${randomUUID()}.tmp`)
+  await writeFile(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 })
+  await rename(temp, path)
+}
+
+async function migrateFile(
+  path: string,
+  backupPath?: string,
+): Promise<number> {
+  let raw: unknown
+  try {
+    raw = JSON.parse(await readFile(path, 'utf8')) as unknown
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0
+    throw error
+  }
+  const migrated = stripWorkspaceAgentPins(raw)
+  if (migrated.updated === 0) return 0
+  if (backupPath) {
+    await mkdir(dirname(backupPath), { recursive: true })
+    await cp(path, backupPath, { errorOnExist: false })
+  }
+  await writeAtomicJson(path, migrated.value)
+  return migrated.updated
+}
+
+export async function migrateWorkspaceAgentPins(
+  launcherRoot: string = defaultLauncherRoot(),
+  options: MigrationOptions = {},
+): Promise<{ registryUpdated: number; catalogUpdated: number }> {
+  const registryPath = join(launcherRoot, 'workspaces.json')
+  const catalogPath = join(launcherRoot, 'state', 'workspace-catalog.json')
+  const registryUpdated = await migrateFile(
+    registryPath,
+    options.backupRoot ? join(options.backupRoot, 'workspaces.json') : undefined,
+  )
+  const catalogUpdated = await migrateFile(
+    catalogPath,
+    options.backupRoot ? join(options.backupRoot, 'state', 'workspace-catalog.json') : undefined,
+  )
+  return { registryUpdated, catalogUpdated }
+}
+
+export const migration: Migration = {
+  id: '0030_retire_workspace_agent_pins',
+  appVersion: '0.87.0-beta',
+  introducedAt: '2026-07-31',
+  affects: [
+    'workspaces/workspaces.json',
+    'workspaces/state/workspace-catalog.json',
+  ],
+  summary:
+    'Remove per-Workspace adapter allowlists so runtime availability follows the live installation registry.',
+  rationale:
+    'Workspace creation time is not a durable capability boundary. New adapters and future installation-level defaults must not be hidden by historical Workspace metadata.',
+  up: async (ctx) => {
+    const userDataHome = resolve(ctx.configDir(), '..', '..')
+    const launcherRoot = resolve(
+      process.env['AQ_LAUNCHER_ROOT'] ?? join(userDataHome, 'workspaces'),
+    )
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    await migrateWorkspaceAgentPins(launcherRoot, {
+      backupRoot: join(
+        dirname(ctx.configDir()),
+        '_backup',
+        `${timestamp}-pre-0030_retire_workspace_agent_pins`,
+        'workspace-registry',
+      ),
+    })
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -29,3 +29,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0027_repair_snapshot_interval` | 0.87.0-beta | 2026-07-29 | snapshot.json | Repair invalid historical portfolio snapshot intervals before strict duration validation loads them. |
 | `0028_auto_quant_default_workspace` | 0.87.0-beta | 2026-07-30 | data/preferences.json | Add the explicit default Workspace pointer that defines whether AutoQuant is initialized. |
 | `0029_session_native_titles` | 0.87.0-beta | 2026-07-30 | workspaces/state/sessions/*.json | Treat the first Session message as a fallback and reserve the preferred title for native runtime metadata. |
+| `0030_retire_workspace_agent_pins` | 0.87.0-beta | 2026-07-31 | workspaces/workspaces.json, workspaces/state/workspace-catalog.json | Remove per-Workspace adapter allowlists so runtime availability follows the live installation registry. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -41,6 +41,7 @@ import { migration as migration_0026_agent_conversation_log } from './0026_agent
 import { migration as migration_0027_repair_snapshot_interval } from './0027_repair_snapshot_interval/index.js'
 import { migration as migration_0028_auto_quant_default_workspace } from './0028_auto_quant_default_workspace/index.js'
 import { migration as migration_0029_session_native_titles } from './0029_session_native_titles/index.js'
+import { migration as migration_0030_retire_workspace_agent_pins } from './0030_retire_workspace_agent_pins/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -65,4 +66,5 @@ export const REGISTRY: Migration[] = [
   migration_0027_repair_snapshot_interval,
   migration_0028_auto_quant_default_workspace,
   migration_0029_session_native_titles,
+  migration_0030_retire_workspace_agent_pins,
 ]

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -110,7 +110,6 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
               id: meta.id,
               tag: meta.tag,
               ...(meta.template ? { template: meta.template } : {}),
-              agents: meta.agents,
               createdAt: meta.createdAt,
               sessions: {
                 total: sessions.length,

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -120,7 +120,6 @@ export class McpPlugin implements Plugin {
               id: meta.id,
               tag: meta.tag,
               ...(meta.template ? { template: meta.template } : {}),
-              agents: meta.agents,
               createdAt: meta.createdAt,
               sessions: {
                 total: sessions.length,

--- a/src/tool/workspace-list.spec.ts
+++ b/src/tool/workspace-list.spec.ts
@@ -14,7 +14,6 @@ function ctx(overrides: Partial<WorkspaceToolContext> = {}): WorkspaceToolContex
       id: 'ws-market',
       tag: 'Market Desk',
       template: 'chat',
-      agents: ['pi'],
       createdAt: '2026-07-15T00:00:00.000Z',
       sessions: {
         total: 3,
@@ -46,7 +45,6 @@ describe('workspace_list', () => {
         id: 'ws-market',
         tag: 'Market Desk',
         template: 'chat',
-        agents: ['pi'],
         createdAt: '2026-07-15T00:00:00.000Z',
         sessions: {
           total: 3,

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -22,7 +22,7 @@ function build(opts: { assignee?: string } = {}) {
   ) => ({ taskId: 'run-new', resumeId: _resumeId ?? 'resume-new' }))
   const list = vi.fn((_filters: unknown) => [] as HeadlessTaskRecord[])
   const svc = {
-    registry: { get: (id: string) => id === 'ws-1' ? { id, tag: 'Research', dir: '/tmp/ws-1', agents: ['pi'] } : undefined },
+    registry: { get: (id: string) => id === 'ws-1' ? { id, tag: 'Research', dir: '/tmp/ws-1' } : undefined },
     resumeRegistry: {
       get: (id: string) => id === 'resume-author' || id === 'resume-owner' || id === 'resume-run'
         ? { resumeId: id, wsId: 'ws-1', agent: 'pi', agentSessionId: `native-${id}` }

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -71,7 +71,7 @@ function build(inboxReports: InboxEntry[] = []) {
     registry: {
       get: (id: string) => (
         id === 'ws-1'
-          ? { id: 'ws-1', dir: wsDir, tag: 'ws-1', agents: ['claude', 'codex', 'pi', 'shell'] }
+          ? { id: 'ws-1', dir: wsDir, tag: 'ws-1' }
           : undefined
       ),
     },

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -201,8 +201,8 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
       } else {
         const agent = raw.trim()
         const adapter = svc.adapters.get(agent)
-        if (!adapter || !isAgentRuntime(adapter) || !meta.agents.includes(agent)) {
-          return c.json({ error: 'invalid_agent', message: `unknown or disabled agent runtime: ${agent}` }, 400)
+        if (!adapter || !isAgentRuntime(adapter)) {
+          return c.json({ error: 'invalid_agent', message: `unknown agent runtime: ${agent}` }, 400)
         }
         patch.agent = agent
       }

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -55,7 +55,6 @@ function build(opts: {
   const META = {
     id: 'ws-1',
     dir: '/w',
-    agents: ['claude', 'opencode'],
     template: 'chat',
     tag: 'chat-x',
     createdAt: '2026-07-01T00:00:00.000Z',
@@ -141,7 +140,10 @@ function build(opts: {
     resolveOrCreateAutoQuantWorkspace: (preferredWorkspaceId?: string | null, sourceVersion?: string) =>
       autoQuantWorkspaceResolver.resolveOrCreate(preferredWorkspaceId, sourceVersion),
     resolveAdapter: (_m: any, agentId?: string) => adapters[agentId ?? 'claude'] ?? claude,
-    adapters: { get: (id: string) => adapters[id] },
+    adapters: {
+      get: (id: string) => adapters[id],
+      list: () => [claude, opencode, shell],
+    },
     sessionRegistry,
     resumeRegistry,
     pool: { spawn, get: vi.fn(() => undefined), setTerminalViewAttributes },
@@ -426,7 +428,6 @@ describe('GET /credentials — Quick Chat launch metadata', () => {
       runtimeWorkspace: {
         id: 'workspace-manager',
         dir: '/manager',
-        agents: ['opencode'],
         template: 'workspace-manager',
         tag: 'Workspace Manager',
         createdAt: '2026-07-16T00:00:00.000Z',
@@ -468,7 +469,6 @@ describe('GET /credentials — Quick Chat launch metadata', () => {
       runtimeWorkspace: {
         id: 'workspace-manager',
         dir: '/manager',
-        agents: ['opencode'],
         template: 'workspace-manager',
         tag: 'Workspace Manager',
         createdAt: '2026-07-16T00:00:00.000Z',
@@ -586,7 +586,6 @@ describe('POST /quick-chat — loginless credential injection', () => {
     const recent = {
       id: 'ws-recent',
       dir: '/recent',
-      agents: ['claude'],
       template: 'chat',
       tag: 'long-running-chat',
       createdAt: '2026-06-01T00:00:00.000Z',
@@ -604,11 +603,11 @@ describe('POST /quick-chat — loginless credential injection', () => {
 
   it('falls back to the most recently active Chat workspace and remembers it', async () => {
     const older = {
-      id: 'ws-older', dir: '/older', agents: ['claude'], template: 'chat', tag: 'older',
+      id: 'ws-older', dir: '/older', template: 'chat', tag: 'older',
       createdAt: '2026-07-09T00:00:00.000Z',
     };
     const active = {
-      id: 'ws-active', dir: '/active', agents: ['claude'], template: 'chat', tag: 'active',
+      id: 'ws-active', dir: '/active', template: 'chat', tag: 'active',
       createdAt: '2026-07-01T00:00:00.000Z',
     };
     const { app, creator, spawn, rememberRecentChatWorkspace } = build({
@@ -665,7 +664,6 @@ describe('POST /quick-chat — loginless credential injection', () => {
     const existing = {
       id: 'aq-existing',
       dir: '/aq',
-      agents: ['claude'],
       template: 'auto-quant-v2',
       tag: 'auto-quant',
       createdAt: '2026-07-01T00:00:00.000Z',
@@ -684,7 +682,6 @@ describe('POST /quick-chat — loginless credential injection', () => {
     const existing = {
       id: 'aq-existing',
       dir: '/aq',
-      agents: ['claude'],
       template: 'auto-quant-v2',
       tag: 'auto-quant',
       createdAt: '2026-07-01T00:00:00.000Z',
@@ -708,7 +705,6 @@ describe('POST /quick-chat — loginless credential injection', () => {
     const defaultWorkspace = {
       id: 'aq-default',
       dir: '/aq-default',
-      agents: ['claude'],
       template: 'auto-quant-v2',
       tag: 'auto-quant',
       createdAt: '2026-07-01T00:00:00.000Z',
@@ -739,7 +735,7 @@ describe('POST /quick-chat — loginless credential injection', () => {
   // workspace, not today's (so no creator.create).
   it('targetWsId spawns into the given workspace, skipping find-or-create', async () => {
     const { app, spawn, creator } = build({
-      workspaces: [{ id: 'ws-1', dir: '/w', agents: ['claude'], template: 'chat', tag: 'chat-x' }],
+      workspaces: [{ id: 'ws-1', dir: '/w', template: 'chat', tag: 'chat-x' }],
     });
     const r = await quickChat(app, { prompt: 'hi', agent: 'claude', targetWsId: 'ws-1' });
     expect(r.status).toBe(201);
@@ -748,9 +744,9 @@ describe('POST /quick-chat — loginless credential injection', () => {
     expect((spawn.mock.calls[0] as any[])[0]).toBe('ws-1'); // spawned into the target
   });
 
-  it('omitted agent ignores shell at agents[0] and uses the first agent runtime', async () => {
+  it('omitted agent ignores utility adapters and uses the first registered agent runtime', async () => {
     const { app, spawn } = build({
-      workspaces: [{ id: 'ws-1', dir: '/w', agents: ['shell', 'claude'], template: 'chat', tag: 'chat-x' }],
+      workspaces: [{ id: 'ws-1', dir: '/w', template: 'chat', tag: 'chat-x' }],
     });
     const r = await quickChat(app, { prompt: 'hi', targetWsId: 'ws-1' });
     expect(r.status).toBe(201);
@@ -758,11 +754,11 @@ describe('POST /quick-chat — loginless credential injection', () => {
     expect((spawn.mock.calls[0] as any[])[1].agentId).toBe('claude');
   });
 
-  it('omitted agent honors a configured default runtime when enabled', async () => {
+  it('omitted agent honors a configured default runtime when registered', async () => {
     vi.mocked(readWorkspaceDefaultAgent).mockResolvedValue('opencode');
     vi.mocked(readCredentials).mockResolvedValue({ 'openai-1': openaiKey });
     const { app, spawn } = build({
-      workspaces: [{ id: 'ws-1', dir: '/w', agents: ['shell', 'claude', 'opencode'], template: 'chat', tag: 'chat-x' }],
+      workspaces: [{ id: 'ws-1', dir: '/w', template: 'chat', tag: 'chat-x' }],
     });
     const r = await quickChat(app, { prompt: 'hi', targetWsId: 'ws-1' });
     expect(r.status).toBe(201);

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -49,7 +49,7 @@ function build(
     composeHeadlessCommand: () => [],
     lifecycle: { prepareWorkspace: vi.fn(async () => {}) },
   };
-  const meta = opts.meta ?? { id: 'ws-1', dir: '/w', agents: ['claude'] };
+  const meta = opts.meta ?? { id: 'ws-1', dir: '/w' };
   const adapters = opts.adapters ?? { claude };
   const runHeadlessTask = vi.fn(async () => HEADLESS_RESULT);
   const dispatchHeadlessTask = opts.dispatch ?? vi.fn(async () => ({ taskId: 'task-1', resumeId: 'resume-1' }));
@@ -114,7 +114,10 @@ function build(
   const svc = {
     registry: { get: (id: string) => (id === 'ws-1' ? meta : undefined) },
     resolveRuntimeWorkspace: (id: string) => (id === meta.id ? meta : undefined),
-    adapters: { get: (a: string) => adapters[a] },
+    adapters: {
+      get: (a: string) => adapters[a],
+      list: () => Object.values(adapters),
+    },
     resolveAdapter: (_m: any, a?: string) => opts.resolveTo ?? adapters[a ?? 'claude'] ?? claude,
     detectAgents: () => opts.availability ?? {
       claude: { installed: true, path: '/usr/bin/claude' },
@@ -187,7 +190,7 @@ describe('GET /:id/resumes', () => {
 })
 
 describe('GET /:id/launch-plan', () => {
-  it('returns the safe fresh launch plan for an enabled Workspace runtime', async () => {
+  it('returns the safe fresh launch plan for a registered runtime', async () => {
     const { app } = build()
     const result = await get(app, '/ws-1/launch-plan?agent=claude')
 
@@ -218,7 +221,7 @@ describe('GET /:id/launch-plan', () => {
     })
   })
 
-  it('rejects missing, unknown, and disabled agent runtimes but permits the Shell utility', async () => {
+  it('rejects missing and unknown adapters while permitting any registered adapter', async () => {
     const codex = {
       id: 'codex',
       displayName: 'Codex',
@@ -243,7 +246,10 @@ describe('GET /:id/launch-plan', () => {
 
     expect((await get(app, '/ws-1/launch-plan')).body.error).toBe('agent_required')
     expect((await get(app, '/ws-1/launch-plan?agent=ghost')).body.error).toBe('unknown_agent')
-    expect((await get(app, '/ws-1/launch-plan?agent=codex')).body.error).toBe('agent_not_enabled')
+    expect(await get(app, '/ws-1/launch-plan?agent=codex')).toMatchObject({
+      status: 200,
+      body: { agent: { id: 'codex' } },
+    })
     expect(await get(app, '/ws-1/launch-plan?agent=shell')).toMatchObject({
       status: 200,
       body: {
@@ -489,7 +495,7 @@ describe('PATCH /:id/metadata', () => {
   it('writes workspace-owned display metadata without changing launcher identity', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'workspace-route-meta-'));
     try {
-      const meta = { id: 'ws-1', tag: 'aapl-q1', dir, agents: ['claude'] };
+      const meta = { id: 'ws-1', tag: 'aapl-q1', dir };
       const { app } = build({ meta });
 
       const r = await patch(app, '/ws-1/metadata', { displayName: 'AAPL earnings review' });
@@ -510,7 +516,7 @@ describe('PATCH /:id/metadata', () => {
   it('ignores attempts to smuggle registry fields into workspace metadata', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'workspace-route-meta-'));
     try {
-      const { app } = build({ meta: { id: 'ws-1', tag: 'stable-tag', dir, agents: ['claude'] } });
+      const { app } = build({ meta: { id: 'ws-1', tag: 'stable-tag', dir } });
       const r = await patch(app, '/ws-1/metadata', { displayName: 'Nice label', id: 'different' });
 
       expect(r.status).toBe(200);
@@ -590,18 +596,18 @@ describe('POST /:id/headless', () => {
     expect((await post(app, '/ws-1/headless', { prompt: 'x', agent: 'ghost' })).body.error).toBe('unknown_agent');
   });
 
-  it('400 agent_not_enabled when the agent exists but is not on the workspace', async () => {
+  it('accepts a registered headless agent without a Workspace allowlist', async () => {
     const codex = { id: 'codex', capabilities: { headless: true }, composeHeadlessCommand: () => [] };
     const { app } = build({
-      meta: { id: 'ws-1', dir: '/w', agents: ['claude'] },
+      meta: { id: 'ws-1', dir: '/w' },
       adapters: { claude: { id: 'claude', capabilities: { headless: true } }, codex },
     });
-    expect((await post(app, '/ws-1/headless', { prompt: 'x', agent: 'codex' })).body.error).toBe('agent_not_enabled');
+    expect((await post(app, '/ws-1/headless', { prompt: 'x', agent: 'codex' })).status).toBe(202);
   });
 
   it('400 no_headless when the resolved adapter has no headless mode', async () => {
     const shell = { id: 'shell', capabilities: {} };
-    const { app } = build({ meta: { id: 'ws-1', dir: '/w', agents: ['shell'] }, adapters: { shell }, resolveTo: shell });
+    const { app } = build({ meta: { id: 'ws-1', dir: '/w' }, adapters: { shell }, resolveTo: shell });
     expect((await post(app, '/ws-1/headless', { prompt: 'x', agent: 'shell' })).body.error).toBe('no_headless');
   });
 
@@ -723,7 +729,7 @@ describe('POST /:id/headless/:taskId/session', () => {
       });
     }
     const svc = {
-      registry: { get: (id: string) => id === 'ws-1' ? { id, dir: '/w', agents: ['codex'] } : undefined },
+      registry: { get: (id: string) => id === 'ws-1' ? { id, dir: '/w' } : undefined },
       headlessTasks: { get: (id: string) => id === task.taskId ? task : null },
       sessionRegistry,
       resumeRegistry: {
@@ -840,9 +846,9 @@ describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', (
       sessionRegistry: { get: () => record, update: vi.fn(async () => {}) },
       resumeRegistry: { get: () => ({ agentSessionId: 'aid' }) },
       pool: { get: () => live, spawn, disposeToken: vi.fn() },
-      registry: { get: () => resolverOnly ? undefined : ({ id: workspaceId, dir: '/w', agents: ['claude'] }) },
+      registry: { get: () => resolverOnly ? undefined : ({ id: workspaceId, dir: '/w' }) },
       resolveRuntimeWorkspace: resolverOnly
-        ? () => ({ id: workspaceId, dir: '/w', agents: ['claude'] })
+        ? () => ({ id: workspaceId, dir: '/w' })
         : undefined,
       adapters: { get: () => adapter },
       computeSpawnPlan: () => ({
@@ -925,7 +931,7 @@ describe('WebPi surface routes', () => {
       abort: vi.fn(async () => snapshot),
     };
     const svc = {
-      registry: { get: () => ({ id: 'ws-1', dir: '/w', agents: ['pi'] }) },
+      registry: { get: () => ({ id: 'ws-1', dir: '/w' }) },
       sessionRegistry: {
         get: () => record,
         update: vi.fn(async (_wsId: string, _id: string, patch: any) => Object.assign(record, patch)),
@@ -975,7 +981,6 @@ describe('Workspace manager surface routes', () => {
       id: 'workspace-manager',
       tag: 'Workspace Manager',
       dir: '/floor/workspaces',
-      agents: ['opencode'],
       createdAt: new Date(0).toISOString(),
     };
     const session = {
@@ -1051,7 +1056,6 @@ describe('Workspace manager surface routes', () => {
       id: 'workspace-manager',
       tag: 'Workspace Manager',
       dir: '/floor/workspaces',
-      agents: ['pi'],
       createdAt: new Date(0).toISOString(),
     };
     let createdRecord: any = null;
@@ -1084,7 +1088,10 @@ describe('Workspace manager surface routes', () => {
         list: () => [{ id: 'ws-1' }, { id: 'ws-2' }],
         get: () => undefined,
       },
-      adapters: { get: (id: string) => id === 'pi' ? adapter : undefined },
+      adapters: {
+        get: (id: string) => id === 'pi' ? adapter : undefined,
+        list: () => [adapter],
+      },
       resolveAdapter: () => adapter,
       getAgentRuntimeReadiness: () => ({
         agents: { pi: { ready: true, source: 'managed-runtime' } },
@@ -1148,12 +1155,11 @@ describe('Workspace manager surface routes', () => {
     expect(prompt).toHaveBeenCalledWith(createdRecord.id, 'Audit the floor.');
   });
 
-  it('starts any enabled agent runtime in its native TUI with the manager contract', async () => {
+  it('starts any registered agent runtime in its native TUI with the manager contract', async () => {
     const meta = {
       id: 'workspace-manager',
       tag: 'Workspace Manager',
       dir: '/floor/workspaces',
-      agents: ['claude', 'codex', 'opencode', 'pi'],
       createdAt: new Date(0).toISOString(),
     };
     const records = new Map<string, any>();
@@ -1169,7 +1175,14 @@ describe('Workspace manager surface routes', () => {
     const svc = {
       managerWorkspace: meta,
       registry: { list: () => [{ id: 'ws-1' }], get: () => undefined },
-      adapters: { get: (id: string) => id === 'codex' ? adapter : undefined },
+      adapters: {
+        get: (id: string) => id === 'codex'
+          ? adapter
+          : id === 'shell'
+            ? { id: 'shell', kind: 'utility', capabilities: {} }
+            : undefined,
+        list: () => [adapter],
+      },
       resolveAdapter: () => adapter,
       getAgentRuntimeReadiness: () => ({
         agents: { codex: { ready: true, source: 'global-login' } },

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -218,16 +218,13 @@ export function createWorkspaceRoutes(
     return c.json({ ok: true, changed: svc.pool.setTerminalViewAttributes(attributes) });
   });
 
-  const resolveDefaultAgentId = async (meta: WorkspaceMeta): Promise<string | undefined> => {
+  const resolveDefaultAgentId = async (_meta: WorkspaceMeta): Promise<string | undefined> => {
     const configured = await readWorkspaceDefaultAgent().catch(() => null);
-    if (configured && meta.agents.includes(configured)) {
+    if (configured) {
       const adapter = svc.adapters.get(configured);
       if (adapter && isAgentRuntime(adapter)) return configured;
     }
-    return meta.agents.find((id) => {
-      const adapter = svc.adapters.get(id);
-      return adapter ? isAgentRuntime(adapter) : false;
-    });
+    return svc.adapters.list().find(isAgentRuntime)?.id;
   };
 
   /**
@@ -285,7 +282,7 @@ export function createWorkspaceRoutes(
     if (requestedIdentity?.agentSessionId) resume = { sessionId: requestedIdentity.agentSessionId };
     const agentId = opts.agentId ?? requestedIdentity?.agent ?? await resolveDefaultAgentId(meta);
     if (!agentId) {
-      return { ok: false, status: 400, body: { error: 'no_agent_runtime', message: 'workspace has no agent runtime enabled' } };
+      return { ok: false, status: 400, body: { error: 'no_agent_runtime', message: 'no agent runtime is registered' } };
     }
     if (!svc.adapters.get(agentId)) {
       return { ok: false, status: 400, body: { error: 'unknown_agent', message: `no adapter: ${agentId}` } };
@@ -580,12 +577,16 @@ export function createWorkspaceRoutes(
     const meta = svc.managerWorkspace;
     const resolvedAgentId = agentId ?? await resolveDefaultAgentId(meta);
     if (!resolvedAgentId) {
-      return c.json({ error: 'no_agent_runtime', message: 'Workspace Manager has no agent runtime enabled' }, 400);
+      return c.json({ error: 'no_agent_runtime', message: 'no agent runtime is registered' }, 400);
     }
-    if (!meta.agents.includes(resolvedAgentId)) {
+    const resolvedAdapter = svc.adapters.get(resolvedAgentId);
+    if (!resolvedAdapter) {
+      return c.json({ error: 'unknown_agent', message: `no adapter: ${resolvedAgentId}` }, 400);
+    }
+    if (!isAgentRuntime(resolvedAdapter)) {
       return c.json({
         error: 'unsupported_agent_runtime',
-        message: `${resolvedAgentId} is not an enabled Workspace Manager agent runtime`,
+        message: `${resolvedAgentId} is not an agent runtime`,
       }, 400);
     }
     const spawned = await spawnInteractiveSession(meta, {
@@ -739,12 +740,6 @@ export function createWorkspaceRoutes(
     }
     const adapter = svc.adapters.get(agentId);
     if (!adapter) return c.json({ error: 'unknown_agent' }, 400);
-    if (isAgentRuntime(adapter) && !meta.agents.includes(agentId)) {
-      return c.json({
-        error: 'agent_not_enabled',
-        message: `agent "${agentId}" not enabled on this workspace`,
-      }, 400);
-    }
 
     const availability = svc.detectAgents()[agentId];
     const plan = svc.computeSpawnPlan(meta, adapter, undefined);
@@ -907,7 +902,6 @@ export function createWorkspaceRoutes(
           : result.code === 'unknown_template' ? 400
           : result.code === 'unknown_source_version' ? 400
           : result.code === 'invalid_tag' ? 400
-          : result.code === 'unknown_agent' ? 400
           : 500;
         return c.json({ error: result.code, message: result.message }, status as 400 | 409 | 500);
       }
@@ -940,10 +934,6 @@ export function createWorkspaceRoutes(
       }
       templateName = def;
     }
-    const rawAgents = fields['agents'];
-    const agentsRequested = Array.isArray(rawAgents)
-      ? rawAgents.filter((a): a is string => typeof a === 'string' && a.length > 0)
-      : undefined;
     const rawSourceVersion = fields['sourceVersion'];
     const sourceVersion = typeof rawSourceVersion === 'string' && rawSourceVersion.length > 0
       ? rawSourceVersion
@@ -951,7 +941,6 @@ export function createWorkspaceRoutes(
     const result = await svc.creator.create(
       tag,
       templateName,
-      agentsRequested && agentsRequested.length > 0 ? agentsRequested : undefined,
       sourceVersion,
     );
     if (!result.ok) {
@@ -959,7 +948,6 @@ export function createWorkspaceRoutes(
         result.code === 'invalid_tag' ? 400
         : result.code === 'unknown_template' ? 400
         : result.code === 'unknown_source_version' ? 400
-        : result.code === 'unknown_agent' ? 400
         : result.code === 'tag_in_use' ? 409
         : result.code === 'insufficient_storage' ? 507
         : 500;
@@ -1466,7 +1454,6 @@ export function createWorkspaceRoutes(
           : target.code === 'unknown_template' ? 400
           : target.code === 'unknown_source_version' ? 400
           : target.code === 'invalid_tag' ? 400
-          : target.code === 'unknown_agent' ? 400
           : target.code === 'auto_quant_not_initialized' ? 409
           : 500;
         launcherLogger.error('quick_chat.create_failed', {
@@ -1871,7 +1858,6 @@ export function createWorkspaceRoutes(
       workspace: {
         id: meta.id,
         dir: meta.dir,
-        agents: meta.agents,
       },
       record: {
         id: record.id,
@@ -2053,17 +2039,9 @@ export function createWorkspaceRoutes(
     if (agentId && !svc.adapters.get(agentId)) {
       return c.json({ error: 'unknown_agent', message: `no adapter: ${agentId}` }, 400);
     }
-    // An explicit agent must be one ENABLED on this workspace — else
-    // resolveAdapter would honor it and spawn a CLI with no provider config
-    // injected (silent fallback to the user's global config). Omitting `agent`
-    // resolves through the user default / first enabled agent runtime, never
-    // through utility adapters such as shell.
-    if (agentId && !meta.agents.includes(agentId)) {
-      return c.json({ error: 'agent_not_enabled', message: `agent "${agentId}" not enabled on this workspace` }, 400);
-    }
     const effectiveAgentId = agentId ?? resumeIdentity?.agent ?? await resolveDefaultAgentId(meta);
     if (!effectiveAgentId) {
-      return c.json({ error: 'no_agent_runtime', message: 'workspace has no agent runtime enabled' }, 400);
+      return c.json({ error: 'no_agent_runtime', message: 'no agent runtime is registered' }, 400);
     }
     const adapter = svc.resolveAdapter(meta, effectiveAgentId);
     if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
@@ -2296,9 +2274,9 @@ export function createWorkspaceRoutes(
     try {
       const credentials = await readCredentials();
       const rows = await Promise.all(
-        meta.agents
-          .map((agentId) => ({ agentId, adapter: svc.adapters.get(agentId) }))
-          .filter(({ adapter }) => adapter !== undefined && isAgentRuntime(adapter))
+        svc.adapters.list()
+          .filter(isAgentRuntime)
+          .map((adapter) => ({ agentId: adapter.id, adapter }))
           .map(({ agentId, adapter }) =>
             getAgentCredentialReadiness({ meta, agentId, adapter, credentials }),
           ),

--- a/src/workspaces/agent-credential-readiness.spec.ts
+++ b/src/workspaces/agent-credential-readiness.spec.ts
@@ -28,7 +28,6 @@ const meta: WorkspaceMeta = {
   dir: '/tmp/ws-1',
   createdAt: '2026-07-04T00:00:00.000Z',
   template: 'chat',
-  agents: ['claude', 'opencode', 'pi'],
 };
 
 const openaiKey: Credential = {

--- a/src/workspaces/agent-credential-readiness.ts
+++ b/src/workspaces/agent-credential-readiness.ts
@@ -19,7 +19,6 @@ export type AgentCredentialSource =
   | 'launcher-vault'
   | 'missing'
   | 'unknown-agent'
-  | 'disabled-agent'
 
 export interface AgentCredentialReadiness {
   readonly agent: string
@@ -115,20 +114,6 @@ export async function getAgentCredentialReadiness(opts: {
       compatibleCredentialSlugs: [],
       injectableCredentialSlugs: [],
       message: `unknown agent runtime: ${agentId}`,
-    }
-  }
-  if (!meta.agents.includes(agentId)) {
-    return {
-      agent: agentId,
-      ready: false,
-      requiresCredential: requiresWorkspaceCredential(adapter),
-      source: 'disabled-agent',
-      hasWorkspaceConfig: false,
-      hasUsableWorkspaceConfig: false,
-      detectedCredentialSlug: null,
-      compatibleCredentialSlugs: [],
-      injectableCredentialSlugs: [],
-      message: `agent "${agentId}" is not enabled on this workspace`,
     }
   }
   if (!requiresWorkspaceCredential(adapter)) {

--- a/src/workspaces/chat-workspace-resolver.ts
+++ b/src/workspaces/chat-workspace-resolver.ts
@@ -100,7 +100,6 @@ export class TemplateWorkspaceResolver {
         : await this.deps.creator.create(
             this.starterTag(),
             this.templateName,
-            undefined,
             sourceVersion,
           );
     } catch (error) {

--- a/src/workspaces/conversation-control.spec.ts
+++ b/src/workspaces/conversation-control.spec.ts
@@ -40,7 +40,6 @@ function fakeService(opts: {
     tag: 'peer-desk',
     dir: '/tmp/peer-desk',
     createdAt: '2026-07-11T00:00:00.000Z',
-    agents: ['pi'],
   }
   const dispatchHeadlessTask = vi.fn(async () => ({
     taskId: 'task-follow-up',

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -233,9 +233,6 @@ export function createWorkspaceConversationControl(
         ? continuingOrigin.agent
         : input.agent ?? await svc.resolveDefaultAgentId(meta)
       if (!agentId) throw new Error(`workspace has no agent runtime: ${meta.tag}`)
-      if (resolution.mode === 'reconstructed' && !continuingOrigin && !meta.agents.includes(agentId)) {
-        throw new Error(`agent "${agentId}" is not enabled on workspace ${meta.tag}`)
-      }
       const adapter = svc.adapters.get(agentId)
       if (!adapter || !isAgentRuntime(adapter)) throw new Error(`unknown agent runtime: ${agentId}`)
       if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -305,7 +305,7 @@ describe('injectWorkspaceCredentials', () => {
     'anthropic-1': anthropicKey,
   }
 
-  it('writes AI config for each declared+enabled agent, mapping the credential', async () => {
+  it('writes AI config for each declared and registered agent, mapping the credential', async () => {
     const calls: WriteCall[] = []
     const reg = new AdapterRegistry()
     reg.register(stubAdapter('claude', calls))
@@ -314,7 +314,6 @@ describe('injectWorkspaceCredentials', () => {
 
     await injectWorkspaceCredentials({
       dir: '/ws',
-      agents: ['claude', 'codex'],
       agentCredentials: {
         claude: { credentialSlug: 'anthropic-1', model: 'claude-opus-4-8' },
         codex: { credentialSlug: 'openai-1', model: 'gpt-5.5' },
@@ -339,7 +338,6 @@ describe('injectWorkspaceCredentials', () => {
 
     await injectWorkspaceCredentials({
       dir: '/ws',
-      agents: ['opencode'],
       agentCredentials: { opencode: { credentialSlug: 'openai-1' } },
       adapterRegistry: reg,
       credentials: {
@@ -360,7 +358,6 @@ describe('injectWorkspaceCredentials', () => {
 
     await injectWorkspaceCredentials({
       dir: '/ws',
-      agents: ['pi'],
       agentCredentials: {
         pi: {
           credentialSlug: 'custom-1',
@@ -377,7 +374,7 @@ describe('injectWorkspaceCredentials', () => {
     expect(calls[0]?.cred.reasoning).toBeUndefined()
   })
 
-  it('skips (loud warn) an agent declared but not enabled on the workspace', async () => {
+  it('skips (loud warn) an agent with no registered adapter', async () => {
     const calls: WriteCall[] = []
     const reg = new AdapterRegistry()
     reg.register(stubAdapter('claude', calls))
@@ -385,7 +382,6 @@ describe('injectWorkspaceCredentials', () => {
 
     await injectWorkspaceCredentials({
       dir: '/ws',
-      agents: ['claude'], // codex NOT enabled
       agentCredentials: { codex: { credentialSlug: 'openai-1', model: 'gpt-5.5' } },
       adapterRegistry: reg,
       credentials,
@@ -393,7 +389,7 @@ describe('injectWorkspaceCredentials', () => {
     })
 
     expect(calls).toHaveLength(0)
-    expect(warns).toContain('workspace.cred_inject_skip_disabled')
+    expect(warns).toContain('workspace.cred_inject_skip_no_adapter')
   })
 
   it('skips (loud warn) when the credential has no wire the agent speaks', async () => {
@@ -404,7 +400,6 @@ describe('injectWorkspaceCredentials', () => {
 
     await injectWorkspaceCredentials({
       dir: '/ws',
-      agents: ['codex'],
       // chatOnlyGateway has only openai-chat; codex is Responses-only.
       agentCredentials: { codex: { credentialSlug: 'chat-only', model: 'gpt-5.5' } },
       adapterRegistry: reg,
@@ -424,7 +419,6 @@ describe('injectWorkspaceCredentials', () => {
 
     await injectWorkspaceCredentials({
       dir: '/ws',
-      agents: ['claude'],
       agentCredentials: { claude: { credentialSlug: 'does-not-exist' } },
       adapterRegistry: reg,
       credentials,

--- a/src/workspaces/credential-injection.ts
+++ b/src/workspaces/credential-injection.ts
@@ -271,24 +271,19 @@ function positiveNumber(value: number | null | undefined): number | null {
  * `setup_git_excludes` keeps out of git —
  * but only post-commit are we certain the key never lands in the initial commit.
  *
- * Every miss (agent not enabled, no adapter, credential slug absent) is a loud
+ * Every miss (no adapter, credential slug absent) is a loud
  * `warn` + skip, never a hard failure — a workspace that boots without a seeded
  * provider is still usable (the user configures it manually). Best-effort.
  */
 export async function injectWorkspaceCredentials(opts: {
   readonly dir: string
-  readonly agents: readonly string[]
   readonly agentCredentials: Readonly<Record<string, AgentCredentialDecl>>
   readonly adapterRegistry: AdapterRegistry
   readonly credentials: Record<string, Credential>
   readonly logger: Logger
 }): Promise<void> {
-  const { dir, agents, agentCredentials, adapterRegistry, credentials, logger } = opts
+  const { dir, agentCredentials, adapterRegistry, credentials, logger } = opts
   for (const [agentId, decl] of Object.entries(agentCredentials)) {
-    if (!agents.includes(agentId)) {
-      logger.warn('workspace.cred_inject_skip_disabled', { agentId })
-      continue
-    }
     const adapter = adapterRegistry.get(agentId)
     if (!adapter?.writeAiConfig) {
       logger.warn('workspace.cred_inject_skip_no_adapter', { agentId })

--- a/src/workspaces/manager-workspace.ts
+++ b/src/workspaces/manager-workspace.ts
@@ -12,14 +12,12 @@ export const MANAGER_WORKSPACE_TAG = 'Workspace Manager'
 
 export function createManagerWorkspaceMeta(
   launcherRoot: string,
-  agentIds: readonly string[],
 ): WorkspaceMeta {
   return {
     id: MANAGER_WORKSPACE_ID,
     tag: MANAGER_WORKSPACE_TAG,
     dir: join(launcherRoot, 'workspaces'),
     createdAt: new Date(0).toISOString(),
-    agents: [...agentIds],
   }
 }
 

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -109,7 +109,7 @@ async function makeWs(id: string, issues: IssueSpec[]): Promise<WorkspaceMeta> {
   for (const issue of issues) {
     await writeFile(join(issuesDir, `${issue.id}.md`), issueMd(issue), 'utf8')
   }
-  return { id, tag: id, dir, createdAt: new Date(NOW).toISOString(), agents: ['claude'] }
+  return { id, tag: id, dir, createdAt: new Date(NOW).toISOString() }
 }
 
 function scannerFor(
@@ -434,7 +434,7 @@ describe('ScheduleScanner', () => {
   it('ignores a workspace with no issues dir', async () => {
     const dir = join(root, 'empty')
     await mkdir(dir, { recursive: true })
-    const ws: WorkspaceMeta = { id: 'empty', tag: 'empty', dir, createdAt: new Date(NOW).toISOString(), agents: ['claude'] }
+    const ws: WorkspaceMeta = { id: 'empty', tag: 'empty', dir, createdAt: new Date(NOW).toISOString() }
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
     expect(dispatch).not.toHaveBeenCalled()
@@ -445,7 +445,7 @@ describe('ScheduleScanner', () => {
     const dir = join(root, 'legacy')
     await mkdir(join(dir, '.alice'), { recursive: true })
     await writeFile(join(dir, '.alice', 'issue.json'), JSON.stringify({ issues: [] }), 'utf8')
-    const ws: WorkspaceMeta = { id: 'legacy', tag: 'legacy', dir, createdAt: new Date(NOW).toISOString(), agents: ['claude'] }
+    const ws: WorkspaceMeta = { id: 'legacy', tag: 'legacy', dir, createdAt: new Date(NOW).toISOString() }
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
     expect(dispatch).not.toHaveBeenCalled()

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -384,7 +384,7 @@ export interface WorkspaceService {
     preferredWorkspaceId?: string | null,
     sourceVersion?: string,
   ): Promise<TemplateWorkspaceResolution>;
-  /** Resolve the configured Workspace runtime, then fall back to its first enabled runtime. */
+  /** Resolve the installation default, then fall back to the first registered agent runtime. */
   resolveDefaultAgentId(meta: WorkspaceMeta): Promise<string | undefined>;
   resolveAdapter(meta: WorkspaceMeta, agentId?: string): CliAdapter;
   /** Open the same persisted Pi Session through Pi RPC instead of its PTY. */
@@ -767,10 +767,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   });
   const refreshSessionTitles = (meta: WorkspaceMeta): Promise<void> =>
     sessionTitleResolver.refreshWorkspace(meta);
-  const managerWorkspace = createManagerWorkspaceMeta(
-    config.launcherRoot,
-    adapters.list().filter(isAgentRuntime).map((adapter) => adapter.id),
-  );
+  const managerWorkspace = createManagerWorkspaceMeta(config.launcherRoot);
   await mkdir(managerWorkspace.dir, { recursive: true });
   const resolveRuntimeWorkspace = (workspaceId: string): WorkspaceMeta | undefined =>
     workspaceId === managerWorkspace.id ? managerWorkspace : registry.get(workspaceId);
@@ -815,30 +812,19 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     },
   );
 
-  const resolveAdapter = (wsMeta: WorkspaceMeta, agentId?: string): CliAdapter => {
+  const resolveAdapter = (_wsMeta: WorkspaceMeta, agentId?: string): CliAdapter => {
     if (agentId) {
       const a = adapters.get(agentId);
-      if (a) return a;
-    }
-    const fromWorkspace = wsMeta.agents.find((id) => {
-      const a = adapters.get(id);
-      return a ? isAgentRuntime(a) : false;
-    });
-    if (fromWorkspace) {
-      const a = adapters.get(fromWorkspace);
       if (a) return a;
     }
     return adapters.resolve(null);
   };
 
-  const firstWorkspaceRuntime = (wsMeta: WorkspaceMeta): string | undefined =>
-    wsMeta.agents.find((id) => {
-      const adapter = adapters.get(id);
-      return adapter ? isAgentRuntime(adapter) : false;
-    });
+  const firstRegisteredRuntime = (): string | undefined =>
+    adapters.list().find(isAgentRuntime)?.id;
 
-  const validRuntimeForWorkspace = (wsMeta: WorkspaceMeta, agentId: string | null): string | undefined => {
-    if (!agentId || !wsMeta.agents.includes(agentId)) return undefined;
+  const validRegisteredRuntime = (agentId: string | null): string | undefined => {
+    if (!agentId) return undefined;
     const adapter = adapters.get(agentId);
     return adapter && isAgentRuntime(adapter) ? agentId : undefined;
   };
@@ -846,14 +832,14 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   /**
    * Default for scheduled issues with no frontmatter `agent`: issue-specific
    * setting first, then the interactive workspace default for backwards
-   * continuity, then the workspace's first enabled runtime.
+   * continuity, then the first registered runtime.
    */
-  const resolveDefaultAgentId = async (wsMeta: WorkspaceMeta): Promise<string | undefined> =>
-    validRuntimeForWorkspace(wsMeta, await readWorkspaceDefaultAgent().catch(() => null)) ??
-    firstWorkspaceRuntime(wsMeta);
+  const resolveDefaultAgentId = async (_wsMeta: WorkspaceMeta): Promise<string | undefined> =>
+    validRegisteredRuntime(await readWorkspaceDefaultAgent().catch(() => null)) ??
+    firstRegisteredRuntime();
 
   const resolveIssueDefaultAgentId = async (wsMeta: WorkspaceMeta): Promise<string | undefined> =>
-    validRuntimeForWorkspace(wsMeta, await readIssueDefaultAgent().catch(() => null)) ??
+    validRegisteredRuntime(await readIssueDefaultAgent().catch(() => null)) ??
     await resolveDefaultAgentId(wsMeta);
 
   /**

--- a/src/workspaces/template-registry.ts
+++ b/src/workspaces/template-registry.ts
@@ -6,7 +6,7 @@ import type { Logger } from './logger.js';
 import type { CredentialWireShape } from '@/core/config.js';
 
 /**
- * A template's declaration that an enabled agent should be seeded, at
+ * A template's declaration that a registered agent should be seeded, at
  * workspace-create time, from a named credential in Alice's central store.
  * `credentialSlug` points into `aiProviderSchema.credentials`; `model` and the
  * adapter-specific knobs feed `credentialToWorkspaceAiCred`. Sourced from

--- a/src/workspaces/template-upgrade.spec.ts
+++ b/src/workspaces/template-upgrade.spec.ts
@@ -45,7 +45,6 @@ beforeEach(async () => {
     createdAt: '2026-01-01T00:00:00.000Z',
     template: 'chat',
     spawnedFromVersion: '1.0.0',
-    agents: ['pi'],
   };
   registry = await WorkspaceRegistry.load(join(root, 'workspaces.json'), logger);
   await registry.add(workspace);

--- a/src/workspaces/workspace-absorb.spec.ts
+++ b/src/workspaces/workspace-absorb.spec.ts
@@ -271,7 +271,6 @@ function workspace(id: string, tag: string): WorkspaceMeta {
     dir: join(root, 'workspaces', id),
     createdAt: '2026-01-01T00:00:00.000Z',
     template: 'chat',
-    agents: ['pi'],
   }
 }
 

--- a/src/workspaces/workspace-catalog.spec.ts
+++ b/src/workspaces/workspace-catalog.spec.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Logger } from './logger.js'
+import { WorkspaceCatalog } from './workspace-catalog.js'
+
+const temporaryPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('WorkspaceCatalog legacy adapter metadata', () => {
+  it('drops unknown agents fields while loading and never flushes them again', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-catalog-agents-'))
+    temporaryPaths.push(root)
+    const path = join(root, 'workspace-catalog.json')
+    await writeFile(path, JSON.stringify({
+      version: 1,
+      workspaces: [{
+        id: 'chat-old',
+        tag: 'chat-old',
+        activeDir: join(root, 'chat-old'),
+        createdAt: '2026-07-01T00:00:00.000Z',
+        lifecycle: 'active',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+        agents: ['claude'],
+      }],
+    }))
+
+    const catalog = await WorkspaceCatalog.load(path, [], logger())
+    expect(catalog.get('chat-old')).not.toHaveProperty('agents')
+
+    await catalog.recordCreated({
+      id: 'chat-new',
+      tag: 'chat-new',
+      dir: join(root, 'chat-new'),
+      createdAt: '2026-07-31T00:00:00.000Z',
+    })
+    expect(await readFile(path, 'utf8')).not.toContain('"agents"')
+  })
+})
+
+function logger(): Logger {
+  const value = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => value,
+  }
+  return value as unknown as Logger
+}

--- a/src/workspaces/workspace-catalog.ts
+++ b/src/workspaces/workspace-catalog.ts
@@ -35,7 +35,6 @@ export interface WorkspaceCatalogRecord {
   readonly tag: string
   readonly activeDir: string
   readonly createdAt: string
-  readonly agents: readonly string[]
   readonly template?: string
   readonly spawnedFromVersion?: string
   lifecycle: WorkspaceLifecycleState
@@ -65,7 +64,6 @@ export function catalogRecordToMeta(record: WorkspaceCatalogRecord): WorkspaceMe
     tag: record.tag,
     dir: record.activeDir,
     createdAt: record.createdAt,
-    agents: record.agents,
     ...(record.template ? { template: record.template } : {}),
     ...(record.spawnedFromVersion ? { spawnedFromVersion: record.spawnedFromVersion } : {}),
   }
@@ -77,7 +75,6 @@ function recordFromMeta(meta: WorkspaceMeta, now: string): WorkspaceCatalogRecor
     tag: meta.tag,
     activeDir: meta.dir,
     createdAt: meta.createdAt,
-    agents: [...meta.agents],
     ...(meta.template ? { template: meta.template } : {}),
     ...(meta.spawnedFromVersion ? { spawnedFromVersion: meta.spawnedFromVersion } : {}),
     lifecycle: 'active',
@@ -159,7 +156,7 @@ export class WorkspaceCatalog {
     return [...this.records.values()]
       .filter((record) => !wanted || wanted.has(record.lifecycle))
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-      .map((record) => ({ ...record, agents: [...record.agents] }))
+      .map((record) => ({ ...record }))
   }
 
   async recordCreated(meta: WorkspaceMeta): Promise<void> {
@@ -276,13 +273,42 @@ function validateRecord(value: unknown): WorkspaceCatalogRecord | null {
     typeof record['tag'] !== 'string' ||
     typeof record['activeDir'] !== 'string' ||
     typeof record['createdAt'] !== 'string' ||
-    !Array.isArray(record['agents']) ||
-    !record['agents'].every((agent) => typeof agent === 'string') ||
     typeof record['updatedAt'] !== 'string' ||
     (record['absorbedIntoWorkspaceId'] !== undefined && typeof record['absorbedIntoWorkspaceId'] !== 'string') ||
     (record['absorbedAt'] !== undefined && typeof record['absorbedAt'] !== 'string') ||
     (record['absorbCommit'] !== undefined && typeof record['absorbCommit'] !== 'string') ||
     !['active', 'offboarding', 'departed', 'restoring', 'purging', 'purged'].includes(String(lifecycle))
   ) return null
-  return value as WorkspaceCatalogRecord
+  const sanitized: WorkspaceCatalogRecord = {
+    id: record['id'],
+    tag: record['tag'],
+    activeDir: record['activeDir'],
+    createdAt: record['createdAt'],
+    ...(typeof record['template'] === 'string' ? { template: record['template'] } : {}),
+    ...(typeof record['spawnedFromVersion'] === 'string'
+      ? { spawnedFromVersion: record['spawnedFromVersion'] }
+      : {}),
+    lifecycle: lifecycle as WorkspaceLifecycleState,
+    updatedAt: record['updatedAt'],
+  }
+  const optionalStrings = [
+    'departedDir',
+    'departedAt',
+    'restoredAt',
+    'purgedAt',
+    'reason',
+    'absorbedIntoWorkspaceId',
+    'absorbedAt',
+    'absorbCommit',
+  ] as const
+  for (const key of optionalStrings) {
+    if (typeof record[key] === 'string') sanitized[key] = record[key]
+  }
+  if (record['handoff'] && typeof record['handoff'] === 'object') {
+    sanitized.handoff = record['handoff'] as WorkspaceHandoffSnapshot
+  }
+  if (typeof record['legacyImported'] === 'boolean') {
+    sanitized.legacyImported = record['legacyImported']
+  }
+  return sanitized
 }

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -14,7 +14,7 @@ import { EventEmitter } from 'node:events';
 import * as childProcess from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveCreateAgents, resolveTemplateSource, runScript } from './workspace-creator.js';
+import { orderCreateAdapters, resolveTemplateSource, runScript } from './workspace-creator.js';
 import type { TemplateMeta } from './template-registry.js';
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -50,40 +50,35 @@ function setPlatform(value: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value, configurable: true });
 }
 
-describe('resolveCreateAgents — single home of the agent policy', () => {
+describe('orderCreateAdapters', () => {
   const ALL = ['claude', 'codex', 'opencode', 'pi', 'shell'];
 
-  it('enables EVERY registered adapter when the caller pins nothing', () => {
-    // The quick-chat bug: it called create() with no explicit set, so it used
-    // to get only the template head (claude+codex). Policy now expands here.
-    expect(resolveCreateAgents(undefined, ['claude', 'codex'], ALL)).toEqual(ALL);
-  });
-
-  it('honors template defaultAgents as the agent-runtime order head', () => {
-    // A template that wants codex first still gets all four, codex leading.
-    expect(resolveCreateAgents(undefined, ['codex'], ALL)).toEqual([
+  it('uses template defaults only as a transient preparation order', () => {
+    expect(orderCreateAdapters(['codex'], ALL)).toEqual([
       'codex', 'claude', 'opencode', 'pi', 'shell',
     ]);
   });
 
   it('first-wins dedupes when the head repeats a registered id', () => {
-    expect(resolveCreateAgents(undefined, ['pi', 'claude'], ALL)).toEqual([
+    expect(orderCreateAdapters(['pi', 'claude'], ALL)).toEqual([
       'pi', 'claude', 'codex', 'opencode', 'shell',
     ]);
   });
 
-  it('keeps shell enabled but never ahead of agent runtimes', () => {
-    expect(resolveCreateAgents(undefined, ['shell', 'codex'], ALL)).toEqual([
+  it('keeps utility adapters behind agent runtimes', () => {
+    expect(orderCreateAdapters(['shell', 'codex'], ALL)).toEqual([
       'codex', 'claude', 'opencode', 'pi', 'shell',
     ]);
   });
 
-  it('an explicit non-empty request wins verbatim (subset pinning)', () => {
-    expect(resolveCreateAgents(['claude'], ['claude', 'codex'], ALL)).toEqual(['claude']);
+  it('falls back to registry order when a template has no defaults', () => {
+    expect(orderCreateAdapters([], ALL)).toEqual(ALL);
   });
 
-  it('treats an empty explicit request as "not pinned" → full expansion', () => {
-    expect(resolveCreateAgents([], ['claude', 'codex'], ALL)).toEqual(ALL);
+  it('ignores stale template defaults that are not registered', () => {
+    expect(orderCreateAdapters(['future-agent', 'codex'], ALL)).toEqual([
+      'codex', 'claude', 'opencode', 'pi', 'shell',
+    ]);
   });
 });
 

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -61,8 +61,7 @@ export type CreateResult =
         | 'bootstrap_failed'
         | 'injection_failed'
         | 'unknown_template'
-        | 'unknown_source_version'
-        | 'unknown_agent';
+        | 'unknown_source_version';
       readonly message: string;
       readonly stderr?: string;
       readonly exitCode?: number;
@@ -72,28 +71,22 @@ const TAG_RE = /^[a-z0-9][a-z0-9_-]{0,32}$/;
 export const MIN_WORKSPACE_FREE_BYTES = 64 * 1024 * 1024;
 
 /**
- * Resolve the adapter set a new workspace is created with. This is the single
- * home of the agent policy, so every create path — the form, quick-chat,
- * headless — converges on it:
- *
- * - An explicit `agentsRequested` (a caller pinning a subset) wins verbatim.
- * - Otherwise a workspace gets EVERY registered adapter enabled; restricting
- *   it was a create-time decision with no first-action basis. The template's
- *   `defaultAgents` is honored as an ordering hint for agent runtimes, while
- *   utility adapters such as `shell` are kept at the tail so they never become
- *   an implicit workload.
- *
- * This used to live in the frontend create hook alone, which silently left
- * backend-only callers (quick-chat) on the bare-`defaultAgents` set.
+ * Order the live adapter registry for transient Workspace preparation.
+ * Templates may put preferred runtimes first, but this order is never
+ * persisted as a Workspace capability boundary.
  */
-export function resolveCreateAgents(
-  agentsRequested: readonly string[] | undefined,
+export function orderCreateAdapters(
   templateDefaultAgents: readonly string[],
   allAdapterIds: readonly string[],
 ): readonly string[] {
-  if (agentsRequested && agentsRequested.length > 0) return agentsRequested;
   const utility = new Set(['shell']);
-  const ordered = [...new Set([...templateDefaultAgents, ...allAdapterIds])];
+  const registered = new Set(allAdapterIds);
+  const ordered = [
+    ...new Set([
+      ...templateDefaultAgents.filter((id) => registered.has(id)),
+      ...allAdapterIds,
+    ]),
+  ];
   return [
     ...ordered.filter((id) => !utility.has(id)),
     ...ordered.filter((id) => utility.has(id)),
@@ -124,7 +117,6 @@ export class WorkspaceCreator {
   async create(
     tag: string,
     templateName: string,
-    agentsRequested?: readonly string[],
     sourceVersion?: string,
   ): Promise<CreateResult> {
     if (!TAG_RE.test(tag)) {
@@ -159,24 +151,10 @@ export class WorkspaceCreator {
       };
     }
 
-    // Agent policy lives in `resolveCreateAgents` (this file) so every create
-    // path — form, quick-chat, headless — converges on it.
-    const agents = resolveCreateAgents(
-      agentsRequested,
+    const adapters = orderCreateAdapters(
       template.defaultAgents,
       this.opts.adapterRegistry.list().map((a) => a.id),
     );
-
-    // Validate every requested adapter exists in the registry.
-    for (const a of agents) {
-      if (!this.opts.adapterRegistry.get(a)) {
-        return {
-          ok: false,
-          code: 'unknown_agent',
-          message: `unknown agent: ${a}`,
-        };
-      }
-    }
 
     const storage = await inspectWorkspaceStorage(this.opts.workspacesRoot);
     if (!storage.ok) return insufficientStorageResult(storage.availableBytes);
@@ -194,7 +172,7 @@ export class WorkspaceCreator {
       id,
       dir,
       template: templateName,
-      agents,
+      adapters,
       ...(templateSource ? { sourceVersion: templateSource.version } : {}),
     });
 
@@ -278,8 +256,8 @@ export class WorkspaceCreator {
 
     // Run the same per-runtime preparation hook used before later process
     // launches. Hooks are idempotent. A single adapter failure does not fail
-    // Workspace creation; another enabled runtime can still be used.
-    for (const a of agents) {
+    // Workspace creation; another registered runtime can still be used.
+    for (const a of adapters) {
       const adapter = this.opts.adapterRegistry.get(a);
       if (!adapter) continue;
       try {
@@ -300,7 +278,7 @@ export class WorkspaceCreator {
     // with any template-declared `agentCredentials` — the template wins per agent
     // (explicit per-template intent), though in practice no in-repo template
     // declares them, so the user defaults are the effective source. Best-effort:
-    // a miss (disabled agent, dangling slug, incompatible wire) warns + skips,
+    // a miss (dangling slug or incompatible wire) warns + skips,
     // the workspace stays usable.
     try {
       const userDefaults = await readWorkspaceCredentialDefaults();
@@ -312,7 +290,6 @@ export class WorkspaceCreator {
         const credentials = await readCredentials();
         await injectWorkspaceCredentials({
           dir,
-          agents,
           agentCredentials: effective,
           adapterRegistry: this.opts.adapterRegistry,
           credentials,
@@ -330,7 +307,6 @@ export class WorkspaceCreator {
       createdAt: new Date().toISOString(),
       template: templateName,
       spawnedFromVersion: template.version,
-      agents,
     };
     try {
       // The first commit is the exact Base for every future Template Upgrade.

--- a/src/workspaces/workspace-lifecycle.spec.ts
+++ b/src/workspaces/workspace-lifecycle.spec.ts
@@ -51,7 +51,6 @@ beforeEach(async () => {
     dir: activeDir,
     createdAt: '2026-01-01T00:00:00.000Z',
     template: 'chat',
-    agents: ['pi', 'shell'],
   }
   registry = await WorkspaceRegistry.load(join(root, 'workspaces.json'), noopLogger)
   await registry.add(workspace)

--- a/src/workspaces/workspace-registry.spec.ts
+++ b/src/workspaces/workspace-registry.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -26,12 +26,45 @@ describe('WorkspaceRegistry persistence failures', () => {
       tag: 'diskfull',
       dir: join(root, 'chat-failed-row'),
       createdAt: '2026-07-15T00:00:00.000Z',
-      agents: ['pi'],
     })).rejects.toMatchObject({ code: 'ENOSPC' })
 
     expect(registry.hasId('chat-failed-row')).toBe(false)
     expect(registry.hasTag('diskfull')).toBe(false)
     expect(registry.list()).toEqual([])
+  })
+})
+
+describe('WorkspaceRegistry legacy adapter metadata', () => {
+  it('ignores legacy agents and never persists them again', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-registry-agents-'))
+    temporaryPaths.push(root)
+    const path = join(root, 'workspaces.json')
+    await writeFile(path, JSON.stringify({
+      version: 1,
+      workspaces: [{
+        id: 'chat-old',
+        tag: 'chat-old',
+        dir: join(root, 'chat-old'),
+        createdAt: '2026-07-01T00:00:00.000Z',
+        agents: ['claude'],
+      }],
+    }))
+
+    const registry = await WorkspaceRegistry.load(path, logger())
+    expect(registry.get('chat-old')).toEqual({
+      id: 'chat-old',
+      tag: 'chat-old',
+      dir: join(root, 'chat-old'),
+      createdAt: '2026-07-01T00:00:00.000Z',
+    })
+
+    await registry.add({
+      id: 'chat-new',
+      tag: 'chat-new',
+      dir: join(root, 'chat-new'),
+      createdAt: '2026-07-31T00:00:00.000Z',
+    })
+    expect(await readFile(path, 'utf8')).not.toContain('"agents"')
   })
 })
 

--- a/src/workspaces/workspace-registry.ts
+++ b/src/workspaces/workspace-registry.ts
@@ -24,12 +24,6 @@ export interface WorkspaceMeta {
    * missing this field — treat as unknown rather than back-filling.
    */
   readonly spawnedFromVersion?: string;
-  /**
-   * Adapter ids enabled in this workspace. Order is significant: the first
-   * entry is the default for one-click spawns. Legacy rows (missing this
-   * field) are normalized to `['claude']` at load time.
-   */
-  readonly agents: readonly string[];
 }
 
 interface FileShape {
@@ -153,15 +147,11 @@ function validateFile(value: unknown): WorkspaceMeta[] {
     ) {
       throw new Error(`workspaces.json: entry ${i} has wrong shape`);
     }
-    const agents = Array.isArray(e['agents'])
-      ? (e['agents'].filter((a): a is string => typeof a === 'string') as string[])
-      : ['claude']; // legacy migration
     const base: WorkspaceMeta = {
       id: e['id'],
       tag: e['tag'],
       dir: e['dir'],
       createdAt: e['createdAt'],
-      agents: agents.length > 0 ? agents : ['claude'],
     };
     let withTemplate: WorkspaceMeta = typeof e['template'] === 'string'
       ? { ...base, template: e['template'] }

--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -64,7 +64,7 @@ vi.mock('../contexts/workspaces-context', () => ({
     ],
     defaultAgent: 'pi',
     issueDefaultAgent: null,
-    workspaces: [{ id: 'demo-ws-auto-quant', agents: ['codex', 'pi'] }],
+    workspaces: [{ id: 'demo-ws-auto-quant' }],
     openAgentConfig: mocks.openAgentConfig,
     openHeadlessRun: mocks.openHeadlessRun,
   }),

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1333,7 +1333,7 @@ export function IssueDetail({
 }: IssueDetailProps) {
   const { t } = useTranslation()
   const { data, error, loading, mutate } = useIssueDetail(wsId, id)
-  const { agents, defaultAgent, issueDefaultAgent, openAgentConfig, openHeadlessRun, workspaces } = useWorkspaces()
+  const { agents, defaultAgent, issueDefaultAgent, openAgentConfig, openHeadlessRun } = useWorkspaces()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const selectInboxEntry = useInboxSelection((s) => s.select)
@@ -1437,11 +1437,8 @@ export function IssueDetail({
     [gotoEntity, gotoIssue],
   )
 
-  const workspace = workspaces.find((w) => w.id === wsId) ?? null
   const agentOptions = agents.filter(
-    (agent) =>
-      agent.kind !== 'utility' &&
-      (workspace ? workspace.agents.includes(agent.id) : true),
+    (agent) => agent.kind !== 'utility',
   )
 
   const onPatch = useCallback(

--- a/ui/src/components/IssuesBoard.spec.tsx
+++ b/ui/src/components/IssuesBoard.spec.tsx
@@ -25,7 +25,7 @@ vi.mock('../contexts/workspaces-context', () => ({
     ],
     defaultAgent: 'pi',
     issueDefaultAgent: null,
-    workspaces: [{ id: 'ws-1', agents: ['pi', 'claude'] }],
+    workspaces: [{ id: 'ws-1' }],
   }),
 }))
 

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -263,7 +263,7 @@ function agentName(id: string, agents: readonly { id: string; displayName: strin
 
 function resolveAgentRuntime(
   issue: IssueListItem,
-  workspace: { agents: readonly string[] } | null,
+  workspace: object | null,
   agents: readonly { id: string; displayName: string; kind?: 'agent' | 'utility' }[],
   issueDefaultAgent: string | null,
   defaultAgent: string | null,
@@ -273,10 +273,9 @@ function resolveAgentRuntime(
       ? { id: issue.agent, displayName: agentName(issue.agent, agents), source: 'override', distinctOverride: true }
       : undefined
   }
-  const runtimeIds = workspace.agents.filter((id) => {
-    const agent = agents.find((a) => a.id === id)
-    return agent ? agent.kind !== 'utility' : id !== 'shell'
-  })
+  const runtimeIds = agents
+    .filter((agent) => agent.kind !== 'utility')
+    .map((agent) => agent.id)
   const issueDefaultId = issueDefaultAgent && runtimeIds.includes(issueDefaultAgent) ? issueDefaultAgent : null
   const workspaceDefaultId = defaultAgent && runtimeIds.includes(defaultAgent) ? defaultAgent : null
   const effectiveDefaultId = issueDefaultId ?? workspaceDefaultId ?? runtimeIds[0] ?? null

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -45,7 +45,6 @@ const chatWorkspace: Workspace = {
   dir: '/tmp/chat-jul11',
   createdAt: '2026-07-11T00:00:00.000Z',
   template: 'chat',
-  agents: ['pi'],
   sessions: [],
 }
 

--- a/ui/src/components/workspace/OverviewCard.spec.tsx
+++ b/ui/src/components/workspace/OverviewCard.spec.tsx
@@ -22,7 +22,6 @@ const workspace: Workspace = {
   template: 'chat',
   spawnedFromVersion: '0.1.0',
   upgradeAvailable: { from: '0.1.0', to: '0.2.0' },
-  agents: ['codex'],
   agentOverride: {
     claude: false,
     codex: true,

--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -24,7 +24,6 @@ const workspace: Workspace = {
   tag: 'chat',
   dir: '/tmp/chat',
   createdAt: '2026-07-15T00:00:00.000Z',
-  agents: ['pi', 'shell'],
   sessions: [],
 }
 

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -335,11 +335,8 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
   const [spawnMenuOpen, setSpawnMenuOpen] = useState(false);
   const spawnControlsRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLUListElement | null>(null);
-  const enabledAgents = w.agents
-    .map((id) => props.agents.find((a) => a.id === id))
-    .filter((a): a is AgentInfo => !!a);
-  const runtimeAgents = enabledAgents.filter((a) => a.kind !== 'utility');
-  const utilityAgents = enabledAgents.filter((a) => a.kind === 'utility');
+  const runtimeAgents = props.agents.filter((a) => a.kind !== 'utility');
+  const utilityAgents = props.agents.filter((a) => a.kind === 'utility');
   const defaultAgentEnabled =
     props.defaultAgent !== null &&
     runtimeAgents.some((a) => a.id === props.defaultAgent);
@@ -428,7 +425,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
             <Pencil size={12} strokeWidth={2} />
           </button>
         )}
-        {enabledAgents.length > 0 && (
+        {props.agents.length > 0 && (
           <div ref={spawnControlsRef} className="relative flex shrink-0 items-center">
             <button
               type="button"

--- a/ui/src/components/workspace/TemplateCard.tsx
+++ b/ui/src/components/workspace/TemplateCard.tsx
@@ -36,8 +36,7 @@ function humanize(name: string): string {
 
 interface Props {
   template: TemplateInfo
-  /** All registered agents — every workspace enables all of them, so the card
-   *  shows the full set (not a per-template subset). */
+  /** All registered agents; eligibility is installation-wide. */
   agents: readonly AgentInfo[]
   onOpen: () => void
 }

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
@@ -56,7 +56,6 @@ beforeEach(async () => {
       dir: '/tmp/chat-1',
       createdAt: '2026-07-18T00:00:00.000Z',
       template: 'chat',
-      agents: ['pi'],
       sessions: [],
     }],
     agents: [

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.tsx
@@ -1353,7 +1353,7 @@ export function WorkspaceAIConfigModal({
             {section === 'launch' && (
               <WorkspaceLaunchConfigurationPanel
                 wsId={wsId}
-                agents={workspace?.agents ?? []}
+                agents={agents.map((agent) => agent.id)}
                 initialAgent={initialAgent}
               />
             )}

--- a/ui/src/components/workspace/WorkspaceAbsorbPanel.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAbsorbPanel.spec.tsx
@@ -134,7 +134,6 @@ function workspace(id: string, tag: string): Workspace {
     dir: `/workspaces/${id}`,
     createdAt: '2026-01-01T00:00:00.000Z',
     template: 'chat',
-    agents: ['pi'],
     sessions: [],
   }
 }

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -39,8 +39,6 @@ export interface Workspace {
     readonly version: string;
     readonly commit: string;
   };
-  /** Adapter ids enabled for this workspace. Default runtime lives in user config. */
-  readonly agents: readonly string[];
   /**
    * Single ordered list of all session records (running + paused) the
    * launcher tracks for this workspace. Source of truth for sidebar + main
@@ -70,7 +68,6 @@ export interface CreateError {
     | 'bootstrap_failed'
     | 'unknown_template'
     | 'unknown_source_version'
-    | 'unknown_agent'
     | 'no_templates_configured';
   readonly message?: string;
   readonly stderr?: string;
@@ -323,19 +320,13 @@ export async function listWorkspaces(): Promise<Workspace[]> {
   return body.workspaces;
 }
 
-/**
- * Create a workspace. `agents` is optional and normally omitted — the backend
- * owns the "every registered adapter, template-headed" policy (see
- * `WorkspaceCreator.create`). Pass an explicit set only to pin a subset.
- */
+/** Create a Workspace from a template, optionally pinned to a source version. */
 export async function createWorkspace(
   tag: string,
   template: string,
-  agents?: readonly string[],
   sourceVersion?: string,
 ): Promise<CreateResult> {
   const body: Record<string, unknown> = { tag, template };
-  if (agents && agents.length > 0) body['agents'] = agents;
   if (sourceVersion !== undefined) body['sourceVersion'] = sourceVersion;
   const res = await fetch('/api/workspaces', {
     method: 'POST',
@@ -1300,8 +1291,7 @@ export type AgentCredentialSource =
   | 'workspace-config'
   | 'launcher-vault'
   | 'missing'
-  | 'unknown-agent'
-  | 'disabled-agent';
+  | 'unknown-agent';
 
 export interface AgentCredentialReadiness {
   readonly agent: string;

--- a/ui/src/components/workspace/sidebar-order.spec.ts
+++ b/ui/src/components/workspace/sidebar-order.spec.ts
@@ -34,7 +34,6 @@ function workspace(
     dir: `/tmp/${id}`,
     createdAt,
     template: 'chat',
-    agents: ['pi'],
     sessions: sessions.map((record) => ({ ...record, wsId: id })),
   }
 }

--- a/ui/src/contexts/WorkspacesContext.spec.tsx
+++ b/ui/src/contexts/WorkspacesContext.spec.tsx
@@ -84,7 +84,6 @@ function workspace(): Workspace {
     dir: '/tmp/research-desk',
     createdAt: '2026-07-16T00:00:00.000Z',
     template: 'auto-quant',
-    agents: ['pi'],
     sessions: [],
   }
 }

--- a/ui/src/contexts/workspace-list-reconcile.spec.ts
+++ b/ui/src/contexts/workspace-list-reconcile.spec.ts
@@ -10,7 +10,6 @@ function workspace(id: string, title: string): Workspace {
     dir: `/tmp/${id}`,
     createdAt: '2026-07-16T00:00:00.000Z',
     template: 'chat',
-    agents: ['pi'],
     sessions: [{
       id: `${id}-session`,
       resumeId: `${id}-resume`,

--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -33,7 +33,6 @@ export const demoWorkspace: Workspace = {
   spawnedFromVersion: '0.1.0',
   currentVersion: '0.1.0',
   upgradeAvailable: { from: '0.1.0', to: '0.2.0' },
-  agents: ['pi'],
   sessions: [demoSession],
   agentOverride: { claude: false, codex: false, opencode: false, pi: false },
 }
@@ -116,7 +115,6 @@ export const demoChatWorkspace: Workspace = {
   spawnedFromVersion: '0.1.0',
   currentVersion: '0.1.0',
   upgradeAvailable: null,
-  agents: ['claude', 'codex', 'opencode', 'pi'],
   sessions: demoChatSessions,
   agentOverride: { claude: false, codex: false, opencode: false, pi: false },
 }
@@ -136,7 +134,6 @@ const demoIssueWorkspaces: Workspace[] = [
       version: 'v0.8.31',
       commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
     },
-    agents: ['codex'],
     sessions: [],
     agentOverride: { claude: false, codex: false, opencode: false, pi: false },
   },
@@ -146,7 +143,6 @@ const demoIssueWorkspaces: Workspace[] = [
     displayName: 'Macro Research',
     dir: '/demo/workspaces/macro-research',
     createdAt: new Date().toISOString(),
-    agents: ['codex'],
     sessions: [],
     agentOverride: { claude: false, codex: false, opencode: false, pi: false },
   },

--- a/ui/src/demo/handlers/workspaces-create.spec.ts
+++ b/ui/src/demo/handlers/workspaces-create.spec.ts
@@ -37,7 +37,6 @@ describe('demo Workspace creation handler', () => {
       spawnedFromVersion: '0.2.0',
       currentVersion: '0.2.0',
       upgradeAvailable: null,
-      agents: ['claude', 'codex', 'opencode', 'pi'],
       sessions: [],
     })
 

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -463,7 +463,6 @@ export const workspacesHandlers = [
         ? { spawnedFromVersion: template.version, currentVersion: template.version }
         : {}),
       upgradeAvailable: null,
-      agents: ['claude', 'codex', 'opencode', 'pi'],
       sessions: [],
       agentOverride: { claude: false, codex: false, opencode: false, pi: false },
     }
@@ -941,7 +940,7 @@ export const workspacesHandlers = [
     const prompt = typeof body?.prompt === 'string' && body.prompt.trim()
       ? body.prompt.trim()
       : 'Show me how this Workspace is doing.'
-    const agent = typeof body?.agent === 'string' && ws.agents.includes(body.agent)
+    const agent = typeof body?.agent === 'string'
       ? body.agent
       : 'pi'
     const startedAt = Date.now()
@@ -968,7 +967,6 @@ export const workspacesHandlers = [
     }
     const updatedWorkspace = {
       ...ws,
-      agents: ws.agents.includes(agent) ? ws.agents : [...ws.agents, agent],
       sessions: [...ws.sessions, record],
     }
     const workspaceIndex = demoWorkspaces.findIndex((workspace) => workspace.id === ws.id)

--- a/ui/src/hooks/useCreateWorkspace.ts
+++ b/ui/src/hooks/useCreateWorkspace.ts
@@ -47,12 +47,9 @@ interface UseCreateWorkspaceState {
  * agent-checkbox state + submit handler. They've drifted in small ways
  * over time; bundling here keeps them in lockstep.
  *
- * Adapter enablement policy lives in the backend (`WorkspaceCreator.create`):
- * every workspace gets every registered adapter enabled, with template
- * defaults kept only as ordering hints. The user's default runtime is stored
- * separately; `shell` is a utility adapter, not a default workload candidate.
- * This hook sends NO agent set, so the form, quick-chat, and headless all
- * converge on that one source of truth.
+ * Adapter availability is installation-wide. The user's default runtime is
+ * stored separately; `shell` is a utility adapter, not a default workload
+ * candidate.
  */
 export function useCreateWorkspace(opts: UseCreateWorkspaceOpts): UseCreateWorkspaceState {
   const [tag, setTag] = useState('')
@@ -71,7 +68,7 @@ export function useCreateWorkspace(opts: UseCreateWorkspaceOpts): UseCreateWorks
     }
     setCreating(true)
     setError(null)
-    const result = await createWorkspace(t, opts.template, undefined, opts.sourceVersion)
+    const result = await createWorkspace(t, opts.template, opts.sourceVersion)
     setCreating(false)
     if (result.ok) {
       setTag('')

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -602,7 +602,7 @@ export const en = {
       description: 'Shows the plan OpenAlice will hand to the PTY for the next fresh Session. Reading it does not run hooks, write configuration, or start a process.',
       loading: 'Resolving the launch plan…',
       loadError: 'Could not load the launch plan',
-      noRuntimes: 'This Workspace has no enabled runtime to preview.',
+      noRuntimes: 'No agent runtime is registered to preview.',
       runtimeReady: 'Runtime found',
       runtimeMissing: 'Runtime missing',
       runtimeMissingHelp: 'This runtime was not found on the current search path. Launch will still be attempted, but the process will likely fail with executable not found.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -591,7 +591,7 @@ export const ja: Resources = {
       description: '次の新規 Session で OpenAlice が PTY に渡す起動プランを表示します。読み取り時にフックの実行、設定の書き込み、プロセスの起動は行いません。',
       loading: '起動プランを解決しています…',
       loadError: '起動プランを読み込めませんでした',
-      noRuntimes: 'このワークスペースにはプレビュー可能な Runtime がありません。',
+      noRuntimes: 'プレビューできる Agent Runtime が登録されていません。',
       runtimeReady: 'Runtime を検出',
       runtimeMissing: 'Runtime が見つかりません',
       runtimeMissingHelp: '現在の検索パスに Runtime がありません。起動は試行されますが、実行ファイルが見つからず失敗する可能性があります。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -598,7 +598,7 @@ export const zhHant: Resources = {
       description: '顯示下一個新 Session 中 OpenAlice 實際交給 PTY 的啟動計畫。讀取時不會執行 Hook、寫入設定或啟動程序。',
       loading: '正在解析啟動計畫…',
       loadError: '無法讀取啟動計畫',
-      noRuntimes: '此工作區沒有可預覽的 Runtime。',
+      noRuntimes: '目前沒有已註冊、可供預覽的 Agent Runtime。',
       runtimeReady: '已找到 Runtime',
       runtimeMissing: '找不到 Runtime',
       runtimeMissingHelp: '目前搜尋路徑中找不到此 Runtime。系統仍會嘗試啟動，但可能因找不到執行檔而失敗。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -590,7 +590,7 @@ export const zh: Resources = {
       description: '展示下一次新建 Session 时，OpenAlice 实际会交给 PTY 的启动计划。这里不会运行 Hook、写入配置或拉起进程。',
       loading: '正在解析启动计划…',
       loadError: '无法读取启动计划',
-      noRuntimes: '此工作区没有启用可预览的 Runtime。',
+      noRuntimes: '当前没有已注册、可供预览的 Agent Runtime。',
       runtimeReady: '已找到 Runtime',
       runtimeMissing: '未找到 Runtime',
       runtimeMissingHelp: '当前路径中没有找到这个 Runtime。启动仍会尝试，但进程很可能以 executable not found 失败。',

--- a/ui/src/pages/AutoQuantSetupPage.spec.tsx
+++ b/ui/src/pages/AutoQuantSetupPage.spec.tsx
@@ -53,7 +53,6 @@ const existingWorkspace: Workspace = {
   dir: '/tmp/aq-existing',
   createdAt: '2026-07-30T00:00:00.000Z',
   template: 'auto-quant-v2',
-  agents: ['codex'],
   sessions: [],
   harnessSource: {
     schemaVersion: 1,

--- a/ui/src/pages/AutomationRunsSection.spec.tsx
+++ b/ui/src/pages/AutomationRunsSection.spec.tsx
@@ -50,7 +50,6 @@ const liveWorkspace: Workspace = {
   dir: '/tmp/quant-desk',
   createdAt: '2026-07-29T00:00:00.000Z',
   template: 'chat',
-  agents: ['codex'],
   sessions: [],
 }
 

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -76,6 +76,12 @@ const piAgent: AgentInfo = {
   },
 }
 
+const opencodeAgent: AgentInfo = {
+  ...piAgent,
+  id: 'opencode',
+  displayName: 'opencode',
+}
+
 function chatWorkspace(): Workspace {
   return {
     id: 'chat-1',
@@ -83,7 +89,6 @@ function chatWorkspace(): Workspace {
     dir: '/tmp/chat-jul16',
     createdAt: '2026-07-16T00:00:00.000Z',
     template: 'chat',
-    agents: ['pi'],
     sessions: [],
   }
 }
@@ -92,7 +97,7 @@ function context(workspaces: readonly Workspace[]): WorkspacesContextValue {
   return {
     workspaces,
     templates: [],
-    agents: [piAgent],
+    agents: [piAgent, opencodeAgent],
     defaultAgent: 'pi',
     issueDefaultAgent: null,
     listError: null,
@@ -212,6 +217,17 @@ describe('ChatLandingPage polling stability', () => {
 
     expect(mocks.detectWorkspaceCredential).toHaveBeenCalledTimes(1)
     expect(mocks.getAgentReadiness).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ChatLandingPage adapter inventory', () => {
+  it('offers installation-level runtimes regardless of Workspace age', async () => {
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Select agent' }))
+
+    expect(screen.getByRole('menuitem', { name: /Pi/ })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /opencode/ })).toBeTruthy()
   })
 })
 

--- a/ui/src/pages/ChatLandingPage.spec.ts
+++ b/ui/src/pages/ChatLandingPage.spec.ts
@@ -50,7 +50,6 @@ function workspace(
     dir: `/tmp/${id}`,
     createdAt,
     template,
-    agents: ['pi'],
     sessions: lastActiveAt
       ? [{
           id: `${id}-session`,

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -133,9 +133,6 @@ function HarnessLandingPage({
   // The selectable agent runtimes = the agent CLIs (the bare shell has no agent
   // loop, so it can't be seeded with a first message).
   const cliAgents = agents.filter((a) => a.kind !== 'utility')
-  const targetCliAgents = workspaceTarget
-    ? cliAgents.filter((a) => workspaceTarget.agents.includes(a.id))
-    : cliAgents
 
   const [value, setValue] = useState('')
   const [launching, setLaunching] = useState(false)
@@ -144,7 +141,7 @@ function HarnessLandingPage({
   const launchSelectorsRef = useRef<AgentLaunchSelectorsHandle>(null)
   const credentialWorkspace = workspaceTarget
   const launchConfig = useAgentLaunchConfig({
-    agents: targetCliAgents,
+    agents: cliAgents,
     defaultAgent,
     setDefaultAgent,
     preferences: launchPreferences,

--- a/ui/src/pages/IssueSettingsPage.spec.tsx
+++ b/ui/src/pages/IssueSettingsPage.spec.tsx
@@ -37,7 +37,7 @@ describe('IssueSettingsPage', () => {
 
     expect(select.id).not.toBe('')
     expect(document.querySelector(`label[for="${select.id}"]`)?.textContent).toBe('Agent runtime')
-    expect(description?.textContent).toContain('workspace session default (opencode)')
+    expect(description?.textContent).toContain('installation session default (opencode)')
     expect(screen.queryByRole('option', { name: 'Shell' })).toBeNull()
   })
 })

--- a/ui/src/pages/IssueSettingsPage.tsx
+++ b/ui/src/pages/IssueSettingsPage.tsx
@@ -49,8 +49,8 @@ export function IssueSettingsPage() {
               descriptionId={runtimeDescriptionId}
               description={
                 workspaceDefault
-                  ? `Unset uses the workspace session default (${workspaceDefault.displayName}), then the workspace's first enabled runtime.`
-                  : "Unset uses the workspace's first enabled runtime."
+                  ? `Unset uses the installation session default (${workspaceDefault.displayName}), then the first registered runtime.`
+                  : 'Unset uses the first registered runtime.'
               }
             >
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center">

--- a/ui/src/pages/WorkspacePage.spec.tsx
+++ b/ui/src/pages/WorkspacePage.spec.tsx
@@ -54,7 +54,6 @@ function workspace(overrides: Partial<Workspace> = {}): Workspace {
     tag: 'chat-jun30',
     dir: '/tmp/chat-jun30',
     createdAt: '2026-06-30T00:00:00.000Z',
-    agents: ['codex'],
     sessions: [],
     ...overrides,
   }

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -48,7 +48,6 @@ export function WorkspacePage({ spec, visible }: Props) {
     : null
   const defaultAgentEnabled =
     ctx.defaultAgent !== null &&
-    workspace?.agents.includes(ctx.defaultAgent) === true &&
     ctx.agents.some((a) => a.id === ctx.defaultAgent && a.kind !== 'utility')
 
   const spawnDefault = (): void => {


### PR DESCRIPTION
## Summary
- remove the legacy `agents` field from Workspace metadata, API contracts, CLI/MCP inventory, and UI runtime selection
- resolve Chat, Quant, Issues, schedules, and manager launches from the live global adapter registry
- add migration 0030 to strip persisted pins and harden catalog loading against legacy fields
- fix migration 0021 to respect isolated migration roots instead of touching the main Workspace catalog

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3770 passed, 9 skipped)
- `cd ui && npx tsc -b`
- `pnpm build:migration-index`
- focused packaged-runtime specs (143 passed)
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- `pnpm docker:smoke`
- real `/chat` and `/auto-quant` browser checks with Claude Code, Codex, opencode, and Pi visible for an existing Workspace