### PR TITLE
Default the Workspace Files panel to closed

### DIFF
--- a/ui/src/components/workspace/WorkspaceFilesToggle.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.spec.tsx
@@ -51,7 +51,7 @@ describe('WorkspaceFilesToggle', () => {
     })
   })
 
-  it('continues to toggle the persisted preference on desktop', () => {
+  it('toggles the runtime disclosure state on desktop', () => {
     render(<WorkspaceFilesToggle />)
 
     const button = screen.getByRole('button', { name: 'Files' })

--- a/ui/src/components/workspace/WorkspaceFilesToggle.tsx
+++ b/ui/src/components/workspace/WorkspaceFilesToggle.tsx
@@ -11,10 +11,9 @@ import { useWorkspaceSidePanels } from '../../live/workspace-side-panels'
  * leaving a narrow always-on column. Lives next to "Settings" in
  * WorkspacePage's header; replaces the old Layout popover.
  *
- * Desktop state is user-level + persisted (fold it once, it stays folded).
- * Auto-hidden mobile layouts use an explicit, transient overlay state so the
- * control never claims a hidden panel is open and never changes the user's
- * desktop preference.
+ * Desktop state is runtime-only so a new UI load starts collapsed. Auto-hidden
+ * mobile layouts use a separate transient overlay state so the control never
+ * claims a hidden panel is open.
  */
 export function WorkspaceFilesToggle(): ReactElement {
   const { t } = useTranslation()

--- a/ui/src/components/workspace/WorkspaceView.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceView.spec.tsx
@@ -147,7 +147,7 @@ describe('WorkspaceView Files panel', () => {
     expect(container.querySelector('.workspace-view')?.classList.contains('has-no-side')).toBe(false)
   })
 
-  it('continues to follow the persisted Files preference on desktop', () => {
+  it('follows the runtime Files disclosure state on desktop', () => {
     viewMocks.sidePrefs.files = true
 
     const { container } = renderWorkspace()

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -71,10 +71,10 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
     props.activeRecord.state === 'paused';
   const showEmptyCta = props.sessionId === null;
 
-  // Files panel visibility. Desktop follows the persisted user preference;
-  // auto-hidden mobile layouts get an explicit transient overlay state. This
-  // keeps the first phone view clear without turning the Files button into a
-  // dead control or silently changing the user's desktop layout.
+  // Files panel visibility. Desktop uses runtime-only disclosure state so each
+  // UI load starts collapsed; auto-hidden mobile layouts get their own
+  // transient overlay state. This keeps the first view clear without turning
+  // the Files button into a dead control.
   const isDesktop = useIsDesktop();
   const sidePrefs = useWorkspaceSidePanels();
   const usesMobileOverlay = !isDesktop && sidePrefs.autoHideMobile;

--- a/ui/src/live/workspace-side-panels.spec.ts
+++ b/ui/src/live/workspace-side-panels.spec.ts
@@ -7,8 +7,8 @@ beforeEach(() => {
   vi.resetModules()
 })
 
-describe('Workspace Files panel preference', () => {
-  it('starts collapsed for a new user and persists an explicit desktop opt-in', async () => {
+describe('Workspace Files panel state', () => {
+  it('starts collapsed and does not persist an explicit desktop opt-in', async () => {
     const { useWorkspaceSidePanels } = await import('./workspace-side-panels')
 
     expect(useWorkspaceSidePanels.getState().files).toBe(false)
@@ -22,11 +22,42 @@ describe('Workspace Files panel preference', () => {
       localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
     )).toMatchObject({
       state: {
-        files: true,
         autoHideMobile: true,
       },
-      version: 3,
+      version: 4,
     })
+    expect(JSON.parse(
+      localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
+    ).state).not.toHaveProperty('files')
+  })
+
+  it('discards a legacy persisted Files-open value during hydration', async () => {
+    localStorage.setItem('openalice.workspace.side-panels.v1', JSON.stringify({
+      state: {
+        files: true,
+        autoHideMobile: false,
+      },
+      version: 3,
+    }))
+
+    const { useWorkspaceSidePanels } = await import('./workspace-side-panels')
+
+    expect(useWorkspaceSidePanels.getState()).toMatchObject({
+      files: false,
+      autoHideMobile: false,
+      mobileFilesOpen: false,
+    })
+    expect(JSON.parse(
+      localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
+    )).toMatchObject({
+      state: {
+        autoHideMobile: false,
+      },
+      version: 4,
+    })
+    expect(JSON.parse(
+      localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
+    ).state).not.toHaveProperty('files')
   })
 
   it('keeps the explicit mobile overlay state out of persisted preferences', async () => {
@@ -39,10 +70,9 @@ describe('Workspace Files panel preference', () => {
       localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',
     )).toMatchObject({
       state: {
-        files: false,
         autoHideMobile: true,
       },
-      version: 3,
+      version: 4,
     })
     expect(JSON.parse(
       localStorage.getItem('openalice.workspace.side-panels.v1') ?? '{}',

--- a/ui/src/live/workspace-side-panels.ts
+++ b/ui/src/live/workspace-side-panels.ts
@@ -5,17 +5,16 @@ import { reloadOnHotUpdate } from '../lib/hmr'
 reloadOnHotUpdate('live/workspace-side-panels')
 
 /**
- * User preference for the workspace right-pane Files panel.
+ * View state for the workspace right-pane Files panel.
  *
- * Stored at the user level (not per-workspace) — every workspace has the
- * same Files panel, so a per-workspace toggle would be friction for no
- * payoff. Toggled from the Files button in the workspace header; when off,
- * the right column collapses entirely and the terminal gets full width.
+ * Shared at runtime (not per-workspace) — every workspace has the same Files
+ * panel, so a per-workspace toggle would be friction for no payoff. Toggled
+ * from the Files button in the workspace header; when off, the right column
+ * collapses entirely and the terminal gets full width.
  *
- * Defaults to collapsed: in day-to-day chat-workspace use almost nobody
- * reads the raw files tree, so the terminal getting full width is the
- * better resting state. Users who do want it flip the Files button once
- * and the preference sticks.
+ * Files always starts collapsed when the UI loads. Opening a temporary tool
+ * panel must not turn it into the default layout for later visits, so `files`
+ * is deliberately excluded from persisted state.
  *
  * `autoHideMobile` gives sub-md viewports their own transient Files state.
  * Default true: a desktop preference must not make a 360px panel appear when
@@ -52,13 +51,19 @@ export const useWorkspaceSidePanels = create<WorkspaceSidePanelsState & Workspac
       setMobileFilesOpen: (enabled) => set({ mobileFilesOpen: enabled }),
       toggleMobileFiles: () => set((s) => ({ mobileFilesOpen: !s.mobileFilesOpen })),
     }),
-    // version bumped 2 → 3 to reset the old `files: true` default for
-    // existing users (no migrate → persisted state is discarded, falling
-    // back to the new collapsed default).
     {
       name: 'openalice.workspace.side-panels.v1',
-      version: 3,
-      partialize: ({ files, autoHideMobile }) => ({ files, autoHideMobile }),
+      // Version 4 retires the persisted desktop Files toggle. The migration
+      // keeps the responsive preference while discarding any legacy
+      // `files: true` value.
+      version: 4,
+      migrate: (persistedState) => {
+        const previous = persistedState as Partial<WorkspaceSidePanelsState> | undefined
+        return {
+          autoHideMobile: previous?.autoHideMobile ?? true,
+        }
+      },
+      partialize: ({ autoHideMobile }) => ({ autoHideMobile }),
     },
   ),
 )


### PR DESCRIPTION
## Summary
- stop persisting the desktop Files disclosure state across UI loads
- migrate legacy `files: true` storage to the collapsed default while retaining the responsive auto-hide preference
- keep desktop and mobile Files toggles functional for the current runtime

## UI review
- removes an automatically-open tool surface so the Session terminal owns the initial focus
- preserves the existing Files button, layout, motion, and responsive behavior
- introduces no new visual dialect

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3771 passed, 9 skipped)
- targeted Files state, toggle, and WorkspaceView specs (8 passed)
- real AutoQuant Session: closed after reload, opens on click, closes again on the next reload