### PR TITLE
Flatten the Workspace terminal shell

### DIFF
--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -34,7 +34,14 @@ const DemoTerminalReplay = lazy(() =>
   import('../../demo/DemoTerminalReplay').then((m) => ({ default: m.DemoTerminalReplay })),
 );
 
-type Status = 'connecting' | 'reconnecting' | 'connected' | 'closed' | 'error' | 'kicked' | 'locked';
+export type TerminalConnectionStatus =
+  | 'connecting'
+  | 'reconnecting'
+  | 'connected'
+  | 'closed'
+  | 'error'
+  | 'kicked'
+  | 'locked';
 
 interface SocketMessageEventLike {
   readonly data: unknown;
@@ -179,6 +186,10 @@ export interface TerminalViewProps {
   readonly wsUrl?: string;
   /** OpenTUI currently corrupts to an all-black canvas in xterm's WebGL addon. */
   readonly renderer?: 'auto' | 'dom';
+  /** Main Workspace views own the surrounding page chrome themselves. */
+  readonly presentation?: 'framed' | 'embedded';
+  /** Publishes transport state to the page-owned identity bar. */
+  readonly onStatusChange?: (status: TerminalConnectionStatus) => void;
   /**
    * Fires once per WS lifetime when the server's `attached` message lands.
    */
@@ -195,12 +206,17 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
   if (import.meta.env.VITE_DEMO_MODE) {
     return (
       <Suspense fallback={null}>
-        <DemoTerminalReplay label={props.label ?? props.wsId} wsId={props.wsId} sessionId={props.sessionId} />
+        <DemoTerminalReplay
+          label={props.label ?? props.wsId}
+          wsId={props.wsId}
+          sessionId={props.sessionId}
+          embedded={props.presentation === 'embedded'}
+        />
       </Suspense>
     );
   }
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [status, setStatus] = useState<Status>('connecting');
+  const [status, setStatus] = useState<TerminalConnectionStatus>('connecting');
   const [pid, setPid] = useState<number | null>(null);
   const [scrollbackTruncated, setScrollbackTruncated] = useState(false);
   const [exitInfo, setExitInfo] = useState<ExitInfo | null>(null);
@@ -227,6 +243,10 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
   useEffect(() => {
     applyAppearanceRef.current?.(terminalAppearance);
   }, [terminalAppearance]);
+
+  useEffect(() => {
+    props.onStatusChange?.(status);
+  }, [props.onStatusChange, status]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -648,36 +668,48 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     };
   }, [wsId, sessionId, wsUrl, props.renderer]);
 
+  const embedded = props.presentation === 'embedded';
+  const showHeader =
+    !embedded ||
+    status !== 'connected' ||
+    childExited ||
+    scrollbackTruncated ||
+    exitInfo !== null;
+
   return (
-    <div className="terminal-shell">
-      <header className="terminal-header">
-        <StatusDot status={status} />
-        <span className="terminal-title">{props.label ?? wsId}</span>
-        <span className="terminal-meta">
-          {pid !== null ? `pid ${pid}` : ''}
-          {childExited ? ' · child exited' : ''}
-          {scrollbackTruncated ? ' · scrollback truncated' : ''}
-          {exitInfo
-            ? ` · session ended code=${exitInfo.code}${
-                exitInfo.signal !== null ? ` signal=${exitInfo.signal}` : ''
-              }`
-            : ''}
-        </span>
-        {status === 'locked' && (
-          <button
-            type="button"
-            className="terminal-header-action"
-            onClick={() => {
-              takeoverNextAttachRef.current = true;
-              setStatus('connecting');
-              connectRef.current?.();
-            }}
-            title="take over this session"
-          >
-            take over
-          </button>
-        )}
-      </header>
+    <div className={`terminal-shell${embedded ? ' is-embedded' : ''}`}>
+      {showHeader && (
+        <header className={`terminal-header${embedded ? ' is-contextual' : ''}`}>
+          <StatusDot status={status} />
+          <span className="terminal-title">
+            {embedded ? terminalStatusLabel(status) : props.label ?? wsId}
+          </span>
+          <span className="terminal-meta">
+            {!embedded && pid !== null ? `pid ${pid}` : ''}
+            {childExited ? ' · child exited' : ''}
+            {scrollbackTruncated ? ' · scrollback truncated' : ''}
+            {exitInfo
+              ? ` · session ended code=${exitInfo.code}${
+                  exitInfo.signal !== null ? ` signal=${exitInfo.signal}` : ''
+                }`
+              : ''}
+          </span>
+          {status === 'locked' && (
+            <button
+              type="button"
+              className="terminal-header-action"
+              onClick={() => {
+                takeoverNextAttachRef.current = true;
+                setStatus('connecting');
+                connectRef.current?.();
+              }}
+              title="take over this session"
+            >
+              take over
+            </button>
+          )}
+        </header>
+      )}
       {/* FitAddon reads the computed size of xterm's direct parent. Keep that
           parent padding-free: putting the visual inset on `.terminal-host`
           makes FitAddon count the padding as usable columns, so the xterm
@@ -689,8 +721,8 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
   );
 }
 
-function StatusDot({ status }: { status: Status }): ReactElement {
-  const colors: Record<Status, string> = {
+function StatusDot({ status }: { status: TerminalConnectionStatus }): ReactElement {
+  const colors: Record<TerminalConnectionStatus, string> = {
     connecting: 'var(--warning)',
     reconnecting: 'var(--warning)',
     connected: 'var(--success)',
@@ -707,6 +739,18 @@ function StatusDot({ status }: { status: Status }): ReactElement {
       aria-label={status}
     />
   );
+}
+
+function terminalStatusLabel(status: TerminalConnectionStatus): string {
+  switch (status) {
+    case 'connecting': return 'Connecting to session';
+    case 'reconnecting': return 'Reconnecting to session';
+    case 'closed': return 'Session connection closed';
+    case 'error': return 'Session connection failed';
+    case 'kicked': return 'Session opened elsewhere';
+    case 'locked': return 'Session is controlled elsewhere';
+    case 'connected': return 'Session connected';
+  }
 }
 
 function getTerminalControllerId(): string {

--- a/ui/src/components/workspace/WorkspaceView.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceView.spec.tsx
@@ -14,6 +14,7 @@ const viewMocks = vi.hoisted(() => ({
     autoHideMobile: true,
     mobileFilesOpen: false,
   },
+  terminalProps: vi.fn(),
 }))
 
 vi.mock('../../live/use-is-desktop', () => ({ useIsDesktop: () => viewMocks.isDesktop }))
@@ -21,7 +22,12 @@ vi.mock('../../live/workspace-side-panels', () => ({
   useWorkspaceSidePanels: () => viewMocks.sidePrefs,
 }))
 vi.mock('./FilesPanel', () => ({ FilesPanel: () => <div data-testid="files-panel" /> }))
-vi.mock('./Terminal', () => ({ TerminalView: () => null }))
+vi.mock('./Terminal', () => ({
+  TerminalView: (props: unknown) => {
+    viewMocks.terminalProps(props)
+    return <div data-testid="terminal-view" />
+  },
+}))
 vi.mock('./WebPiView', () => ({ WebPiView: () => null }))
 
 function session(index: number, state: SessionRecord['state']): SessionRecord {
@@ -42,6 +48,7 @@ function session(index: number, state: SessionRecord['state']): SessionRecord {
 }
 
 beforeEach(async () => {
+  vi.clearAllMocks()
   viewMocks.isDesktop = true
   viewMocks.sidePrefs.files = false
   viewMocks.sidePrefs.autoHideMobile = true
@@ -154,5 +161,35 @@ describe('WorkspaceView Files panel', () => {
 
     expect(screen.getByTestId('files-panel')).toBeTruthy()
     expect(container.querySelector('.workspace-view')?.classList.contains('has-no-side')).toBe(false)
+  })
+})
+
+describe('WorkspaceView live surface hierarchy', () => {
+  it('embeds a single running Terminal without creating another framed shell', () => {
+    const active = session(1, 'running')
+    const onTerminalStatusChange = vi.fn()
+    const { container } = render(
+      <WorkspaceView
+        wsId="chat-1"
+        sessionId={active.id}
+        activeRecord={active}
+        sessions={[active]}
+        label="AutoQuant"
+        onSpawnFresh={vi.fn()}
+        onResume={vi.fn()}
+        onOpenWebPi={vi.fn()}
+        onSelectSession={vi.fn()}
+        onSessionLost={vi.fn()}
+        onTerminalStatusChange={onTerminalStatusChange}
+      />,
+    )
+
+    expect(container.querySelector('.workspace-view')?.classList.contains('is-running-session')).toBe(true)
+    expect(screen.getByTestId('terminal-view')).toBeTruthy()
+    expect(viewMocks.terminalProps).toHaveBeenCalledWith(expect.objectContaining({
+      presentation: 'embedded',
+      label: 'Conversation 1',
+      onStatusChange: onTerminalStatusChange,
+    }))
   })
 })

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -7,7 +7,7 @@ import type { SessionRecord } from './api';
 import { FilesPanel } from './FilesPanel';
 import { ResumeCta, prefixOf } from './ResumeCta';
 import { formatRelativeTime } from '../../lib/intl';
-import { TerminalView } from './Terminal';
+import { TerminalView, type TerminalConnectionStatus } from './Terminal';
 import { WebPiView } from './WebPiView';
 import { useIsDesktop } from '../../live/use-is-desktop';
 import { useWorkspaceSidePanels } from '../../live/workspace-side-panels';
@@ -36,6 +36,7 @@ export interface WorkspaceViewProps {
    *  rows call this for running entries; paused entries go through `onResume`. */
   readonly onSelectSession: (sessionId: string) => void;
   readonly onSessionLost: () => void;
+  readonly onTerminalStatusChange?: (status: TerminalConnectionStatus) => void;
 }
 
 export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
@@ -80,7 +81,11 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   const usesMobileOverlay = !isDesktop && sidePrefs.autoHideMobile;
   const showFiles = usesMobileOverlay ? sidePrefs.mobileFilesOpen : sidePrefs.files;
   const showAside = showFiles;
-  const viewClass = `workspace-view${showAside ? '' : ' has-no-side'}`;
+  const viewClass = [
+    'workspace-view',
+    showAside ? '' : 'has-no-side',
+    runningSlots.length > 0 ? 'is-running-session' : '',
+  ].filter(Boolean).join(' ');
 
   return (
     <div className={viewClass}>
@@ -120,7 +125,9 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
                     wsId={props.wsId}
                     sessionId={s.id}
                     renderer={s.agent === 'opencode' ? 'dom' : 'auto'}
-                    {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
+                    presentation="embedded"
+                    onStatusChange={props.onTerminalStatusChange}
+                    label={s.title?.trim() || s.name}
                     onSessionLost={props.onSessionLost}
                   />
                 )}

--- a/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
@@ -42,4 +42,15 @@ describe('terminal responsive layout contract', () => {
     expect(declarationsFor('.terminal-title')).toContain('text-overflow: ellipsis')
     expect(declarationsFor('.terminal-meta')).toContain('text-overflow: ellipsis')
   })
+
+  it('removes nested card chrome from an embedded Workspace terminal', () => {
+    const embedded = declarationsFor('.terminal-shell.is-embedded')
+    const body = declarationsFor('.terminal-shell.is-embedded .terminal-body')
+
+    expect(embedded).toContain('display: flex')
+    expect(embedded).toContain('border: 0')
+    expect(embedded).toContain('border-radius: 0')
+    expect(embedded).toContain('box-shadow: none')
+    expect(body).toContain('flex: 1 1 auto')
+  })
 })

--- a/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
@@ -53,4 +53,10 @@ describe('terminal responsive layout contract', () => {
     expect(embedded).toContain('box-shadow: none')
     expect(body).toContain('flex: 1 1 auto')
   })
+
+  it('lets the Files overlay own the full Workspace width on a phone', () => {
+    expect(css).toMatch(
+      /@container \(max-width: 520px\)[\s\S]*?\.workspace-page-shell \.workspace-side\s*\{[\s\S]*?width: 100%/,
+    )
+  })
 })

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -312,6 +312,47 @@
   position: relative;
 }
 
+.workspace-view.is-running-session {
+  gap: 0;
+}
+
+.workspace-view.is-running-session .workspace-side {
+  gap: 0;
+  border-left: 1px solid var(--border);
+}
+
+.workspace-view.is-running-session .workspace-side > .panel {
+  border: 0;
+  border-radius: 0;
+}
+
+.workspace-runtime-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+}
+
+.workspace-runtime-dot[data-status="connected"] {
+  background: var(--success);
+}
+
+.workspace-runtime-dot[data-status="connecting"],
+.workspace-runtime-dot[data-status="reconnecting"] {
+  background: var(--warning);
+}
+
+.workspace-runtime-dot[data-status="error"],
+.workspace-runtime-dot[data-status="closed"] {
+  background: var(--destructive);
+}
+
+.workspace-runtime-dot[data-status="kicked"],
+.workspace-runtime-dot[data-status="locked"] {
+  background: var(--ai-action);
+}
+
 /* Measure the space actually left for WorkspacePage after the global rail and
  * its contextual sidebar, rather than the browser viewport. At this width a
  * fixed 360px Files column would leave the terminal too narrow to be useful.
@@ -1061,6 +1102,15 @@ button.files-row:focus-visible {
   box-shadow: 0 10px 30px color-mix(in srgb, var(--shadow-color) 35%, transparent);
 }
 
+.terminal-shell.is-embedded {
+  display: flex;
+  flex-direction: column;
+  border: 0;
+  border-radius: 0;
+  background: var(--background);
+  box-shadow: none;
+}
+
 .terminal-header {
   display: flex;
   align-items: center;
@@ -1073,6 +1123,11 @@ button.files-row:focus-visible {
   font-size: 12px;
   color: var(--muted-foreground);
   user-select: none;
+}
+
+.terminal-shell.is-embedded .terminal-header.is-contextual {
+  padding: 6px 12px;
+  background: var(--secondary);
 }
 
 .terminal-title {
@@ -1125,6 +1180,11 @@ button.files-row:focus-visible {
   padding: 8px 8px 4px;
   overflow: hidden;
   background: var(--background);
+}
+
+.terminal-shell.is-embedded .terminal-body {
+  flex: 1 1 auto;
+  padding: 8px 12px 6px;
 }
 
 .terminal-host {

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -380,6 +380,12 @@
   }
 }
 
+@container (max-width: 520px) {
+  .workspace-page-shell .workspace-side {
+    width: 100%;
+  }
+}
+
 /* Both side panels hidden (or auto-hidden on mobile) — collapse the
  * 360px aside column so the terminal pane fills the whole width. */
 .workspace-view.has-no-side {

--- a/ui/src/demo/DemoTerminalReplay.tsx
+++ b/ui/src/demo/DemoTerminalReplay.tsx
@@ -17,15 +17,24 @@ interface DemoTerminalReplayProps {
   readonly label: string
   readonly wsId: string
   readonly sessionId: string
+  readonly embedded?: boolean
 }
 
 export function DemoTerminalReplay(props: DemoTerminalReplayProps): ReactElement {
   const transcript = transcriptsByWorkspace[props.wsId]
   if (!transcript) return <DemoTerminalStub label={props.label} />
-  return <ReplayPane key={props.sessionId} label={props.label} transcript={transcript} />
+  return <ReplayPane key={props.sessionId} label={props.label} transcript={transcript} embedded={props.embedded === true} />
 }
 
-function ReplayPane({ label, transcript }: { label: string; transcript: Transcript }): ReactElement {
+function ReplayPane({
+  label,
+  transcript,
+  embedded,
+}: {
+  label: string
+  transcript: Transcript
+  embedded: boolean
+}): ReactElement {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [done, setDone] = useState(false)
   const [replayKey, setReplayKey] = useState(0)
@@ -117,7 +126,7 @@ function ReplayPane({ label, transcript }: { label: string; transcript: Transcri
   }, [transcript, replayKey, terminalAppearance])
 
   return (
-    <div className="terminal-shell">
+    <div className={`terminal-shell${embedded ? ' is-embedded' : ''}`}>
       <header className="terminal-header">
         <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-warning">
           <span className="w-1.5 h-1.5 rounded-full bg-warning animate-pulse" />

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -67,7 +67,9 @@ vi.mock('../api/config', () => ({
 }))
 
 vi.mock('../components/workspace/Terminal', () => ({
-  TerminalView: () => <div data-testid="terminal-view" />,
+  TerminalView: ({ presentation }: { presentation?: string }) => (
+    <div data-testid="terminal-view" data-presentation={presentation} />
+  ),
 }))
 
 vi.mock('../components/workspace/WebPiView', () => ({
@@ -486,6 +488,31 @@ describe('WorkspaceManagerPage runtime selection', () => {
       session.id,
     )
     expect(mocks.openWebPiSession).not.toHaveBeenCalled()
+  })
+
+  it('integrates a running Manager terminal into the owning page header', () => {
+    const session: SessionRecord = {
+      id: 'manager-codex-running',
+      resumeId: 'manager-codex-running-resume',
+      wsId: 'workspace-manager',
+      agent: 'codex',
+      name: 'x1',
+      createdAt: '2026-07-16T00:00:00.000Z',
+      lastActiveAt: '2026-07-16T00:00:00.000Z',
+      state: 'running',
+      surface: 'terminal',
+      pid: 42,
+      startedAt: 1,
+      title: 'Inspect the floor',
+    }
+    mocks.useWorkspaces.mockImplementation(() => context('codex', managerSnapshot([session])))
+
+    render(<WorkspaceManagerPage spec={{
+      kind: 'workspace-manager',
+      params: { sessionId: session.id },
+    }} />)
+
+    expect(screen.getByTestId('terminal-view').getAttribute('data-presentation')).toBe('embedded')
   })
 
   it('reopens a paused Pi Manager Session in its saved WebPi surface', () => {

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -181,6 +181,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
               sessionId={sessionId}
               renderer={session.agent === 'opencode' ? 'dom' : 'auto'}
               label={`${t('workspaceManager.title')} · ${session.name}`}
+              presentation="embedded"
               onSessionLost={() => void refreshWorkspaceManager()}
             />
           )}

--- a/ui/src/pages/WorkspacePage.spec.tsx
+++ b/ui/src/pages/WorkspacePage.spec.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '../i18n'
-import type { Workspace } from '../components/workspace/api'
+import type { SessionRecord, Workspace } from '../components/workspace/api'
 import { WorkspacePage } from './WorkspacePage'
 
 const mocks = vi.hoisted(() => ({
@@ -38,7 +38,7 @@ vi.mock('../tabs/store', () => ({
 }))
 
 vi.mock('../components/workspace/WorkspaceView', () => ({
-  WorkspaceView: (props: { label?: string }) => {
+  WorkspaceView: (props: { label?: string; onTerminalStatusChange?: (status: string) => void }) => {
     mocks.workspaceViewProps(props)
     return <div data-testid="workspace-view" data-label={props.label} />
   },
@@ -55,6 +55,24 @@ function workspace(overrides: Partial<Workspace> = {}): Workspace {
     dir: '/tmp/chat-jun30',
     createdAt: '2026-06-30T00:00:00.000Z',
     sessions: [],
+    ...overrides,
+  }
+}
+
+function runningSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'codex-1',
+    resumeId: 'resume-1',
+    wsId: 'chat-1',
+    agent: 'codex',
+    name: 'x1',
+    title: 'Optical networking supplier map',
+    createdAt: '2026-07-30T00:00:00.000Z',
+    lastActiveAt: '2026-07-30T00:00:00.000Z',
+    state: 'running',
+    surface: 'terminal',
+    pid: 42,
+    startedAt: 42,
     ...overrides,
   }
 }
@@ -96,5 +114,28 @@ describe('WorkspacePage identity', () => {
 
     expect(screen.getByTitle('chat-jun30').textContent).toBe('chat-jun30')
     expect(screen.getByTestId('workspace-view').getAttribute('data-label')).toBe('chat-jun30')
+  })
+
+  it('merges Workspace, research, and runtime status into one identity bar', () => {
+    mocks.workspaces = [workspace({
+      displayName: 'AutoQuant',
+      sessions: [runningSession()],
+    })]
+
+    render(
+      <WorkspacePage
+        spec={{
+          kind: 'workspace',
+          params: { wsId: 'chat-1', sessionId: 'codex-1', source: 'auto-quant' },
+        }}
+        visible
+      />,
+    )
+
+    expect(screen.getByText('AutoQuant')).toBeTruthy()
+    expect(screen.getByText('Optical networking supplier map')).toBeTruthy()
+    expect(screen.queryByText('x1')).toBeNull()
+    expect(screen.getByLabelText('connecting')).toBeTruthy()
+    expect(screen.getByTestId('workspace-view').parentElement?.classList.contains('p-3')).toBe(false)
   })
 })

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -16,7 +16,7 @@
  * keeps running on the server. Use the sidebar's × to actually delete.
  */
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Bot, Monitor } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import '@xterm/xterm/css/xterm.css'
@@ -26,6 +26,7 @@ import { useWorkspace } from '../tabs/store'
 import { workspaceDisplayName, workspaceDisplayTitle } from '../components/workspace/display'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
 import { WorkspaceFilesToggle } from '../components/workspace/WorkspaceFilesToggle'
+import type { TerminalConnectionStatus } from '../components/workspace/Terminal'
 import type { ViewSpec } from '../tabs/types'
 
 interface Props {
@@ -46,6 +47,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   const activeRecord = sessionId
     ? sessions.find((s) => s.id === sessionId) ?? null
     : null
+  const [terminalStatus, setTerminalStatus] = useState<TerminalConnectionStatus>('connecting')
   const defaultAgentEnabled =
     ctx.defaultAgent !== null &&
     ctx.agents.some((a) => a.id === ctx.defaultAgent && a.kind !== 'utility')
@@ -83,6 +85,10 @@ export function WorkspacePage({ spec, visible }: Props) {
     return () => document.removeEventListener('keydown', handler, { capture: true })
   }, [visible, ctx, wsId, defaultAgentEnabled])
 
+  useEffect(() => {
+    setTerminalStatus('connecting')
+  }, [sessionId])
+
   if (!workspace) {
     return (
       <div className="workspaces-root flex flex-col items-center justify-center h-full text-muted-foreground text-sm">
@@ -94,6 +100,14 @@ export function WorkspacePage({ spec, visible }: Props) {
   const workspaceName = workspaceDisplayName(workspace)
   const workspaceTitle = workspaceDisplayTitle(workspace)
   const hasCustomName = workspaceName !== workspace.tag
+  const activeTitle = activeRecord?.title?.trim() || activeRecord?.name || null
+  const hasRunningSurface = activeRecord?.state === 'running'
+  const activeStatus: TerminalConnectionStatus | null = hasRunningSurface
+    ? (activeRecord.surface === 'webpi' ? 'connected' : terminalStatus)
+    : null
+  const identityTitle = activeTitle
+    ? `${workspaceTitle}\n${activeTitle} · ${activeStatus ?? activeRecord?.state ?? ''}`
+    : workspaceTitle
 
   // Sessions list: pass the full workspace.sessions. WorkspaceView's
   // `runningSlots` is gated on sessionId so the multi-terminal mount
@@ -102,18 +116,33 @@ export function WorkspacePage({ spec, visible }: Props) {
   // state needs the full list to render resume/continue cards.
   return (
     <div className="workspaces-root workspace-page-shell flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
-       *  launcher component itself is byte-faithful; we add the AI-provider
-       *  affordance here. */}
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-secondary/30 shrink-0">
+      {/* One page-owned identity bar. The live terminal is an embedded working
+       * surface below it, not a second application shell. */}
+      <div className="flex min-h-11 shrink-0 items-center justify-between border-b border-border bg-background px-4 py-2">
         <div
-          className="flex min-w-0 items-baseline gap-2 pr-2"
-          title={workspaceTitle}
+          className="flex min-w-0 items-center gap-2 pr-3"
+          title={identityTitle}
         >
-          <span className="truncate text-[12px] font-medium text-foreground">
+          {activeStatus && (
+            <span
+              className="workspace-runtime-dot"
+              data-status={activeStatus}
+              aria-label={activeStatus}
+            />
+          )}
+          <span
+            className={`${activeTitle ? 'max-w-[45%]' : 'max-w-full'} shrink-0 truncate text-[13px] font-semibold text-foreground`}
+          >
             {workspaceName}
           </span>
-          {hasCustomName && (
+          {activeTitle ? (
+            <>
+              <span className="shrink-0 text-muted-foreground/45" aria-hidden="true">/</span>
+              <span className="truncate text-[12px] text-muted-foreground">
+                {activeTitle}
+              </span>
+            </>
+          ) : hasCustomName && (
             <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/70 sm:inline">
               {workspace.tag}
             </span>
@@ -155,7 +184,7 @@ export function WorkspacePage({ spec, visible }: Props) {
         </div>
       </div>
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col p-3">
+      <div className={`flex min-h-0 min-w-0 flex-1 flex-col${hasRunningSurface ? '' : ' p-3'}`}>
         <WorkspaceView
           wsId={wsId}
           sessionId={sessionId}
@@ -163,6 +192,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           activeRecord={activeRecord}
           sessions={workspace.sessions}
           label={workspaceName}
+          onTerminalStatusChange={setTerminalStatus}
           onSpawnFresh={spawnDefault}
           onResume={(id) => void ctx.resumeSession(wsId, id, source)}
           onOpenWebPi={(id) => void ctx.openWebPiSession(wsId, id, source)}


### PR DESCRIPTION
## What changed

- promotes the Workspace name, native Session title, and live connection state into one page-owned identity bar
- embeds running terminals directly in the working surface across Chat, AutoQuant, generic Workspaces, and Workspace Manager
- removes the duplicate terminal title card, border, radius, and shadow
- preserves a compact contextual terminal row only for connecting, reconnecting, locked, kicked, closed, child-exit, and truncated-scrollback states
- flattens the live Files split into a divider instead of another card, and truncates long identity text at narrow widths
- updates the real demo terminal presentation and adds focused component/CSS contract coverage

## Why

The previous Workspace shell repeats identity and chrome across the page header, terminal header, and terminal card. In AutoQuant this produces a visible `auto-quant` / `auto-quant · x1` stack and makes the terminal feel like an application nested inside another application. The page should own navigation and identity; the terminal should be the focused work surface.

## User impact

Running AutoQuant, Chat, and Workspace Manager sessions now use a single, quieter hierarchy. Research titles remain visible, internal Session names such as `x1` no longer dominate the normal connected view, Files remains available, and transport/takeover feedback still appears when action is needed.

## Verification

- `pnpm -C ui exec tsc -b --pretty false`
- focused Vitest: WorkspacePage, WorkspaceView, Workspace Manager, terminal layout (21 tests passed)
- `npx tsc --noEmit`
- `pnpm test` (450 passed files, 3775 passed tests; existing conditional skips remain)
- real isolated `pnpm dev` AutoQuant flow in day/night themes at 1280px and 800px; verified no horizontal overflow, no connected terminal subheader, zero terminal border/radius, flattened Files split, and reconnect state
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` (all packaged Workspace acceptance checks passed)