### PR TITLE
Make Global Macro readable on mobile

### DIFF
--- a/ui/src/pages/MarketBoardPage.spec.tsx
+++ b/ui/src/pages/MarketBoardPage.spec.tsx
@@ -108,6 +108,52 @@ describe('MarketBoardPage', () => {
     expect(screen.getByRole('button', { name: '成长科技' }).getAttribute('aria-pressed')).toBe('true')
   })
 
+  it('gives Global Macro a scan-first mobile hierarchy without removing the desktop comparison table', async () => {
+    await i18n.changeLanguage('en')
+    mocks.boardData = {
+      meta: {},
+      rows: [{
+        country: 'US',
+        label: 'United States',
+        cpiYoy: { value: 4.25, date: '2026-06-01' },
+        shortRate: { value: 3.625, date: '2026-07-29' },
+        cli: { value: 100.8, date: '2026-06-01' },
+        housePrice: { value: 156.4, date: '2026-05-01' },
+        sharePrice: { value: null, date: null, error: 'market closed' },
+      }],
+    }
+
+    render(
+      <MarketBoardPage
+        spec={{ kind: 'market-board', params: { board: 'global-macro' } }}
+        visible
+      />,
+    )
+
+    const mobile = screen.getByTestId('global-macro-mobile')
+    const desktop = screen.getByTestId('global-macro-desktop')
+    expect(mobile.className).toContain('md:hidden')
+    expect(mobile.className).not.toContain('overflow-x-auto')
+    expect(desktop.className).toContain('hidden')
+    expect(desktop.className).toContain('md:block')
+    expect(desktop.className).toContain('overflow-x-auto')
+
+    expect(within(mobile).getByRole('heading', { name: 'United States' })).toBeTruthy()
+    const metricGroups = mobile.querySelectorAll('dl')
+    expect(metricGroups).toHaveLength(2)
+    expect(metricGroups[0]?.className).toContain('grid-cols-3')
+    expect(metricGroups[1]?.className).toContain('grid-cols-2')
+
+    expect(within(mobile).getByLabelText('CPI YoY: 4.25% · 2026-06-01').className).toContain('text-destructive')
+    expect(within(mobile).getByLabelText('Short rate (3M): 3.63% · 2026-07-29')).toBeTruthy()
+    expect(within(mobile).getByLabelText('CLI: 100.8 · 2026-06-01').className).toContain('text-success')
+    expect(within(mobile).getByLabelText('House (2015=100): 156.4 · 2026-05-01')).toBeTruthy()
+    expect(within(mobile).getByLabelText('Equity (2015=100): — · market closed').className).toContain('text-muted-foreground/50')
+
+    const comparisonTable = within(desktop).getByRole('table')
+    expect(within(comparisonTable).getAllByRole('columnheader')).toHaveLength(6)
+  })
+
   it('keeps Shipping card metadata intact when the card narrows', () => {
     mocks.boardData = {
       meta: {},

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -748,48 +748,132 @@ function GlobalMacroBoardView() {
           <div className="text-[13px] text-destructive border border-destructive/30 rounded-md px-3 py-2 bg-destructive/5">{error}</div>
         )}
         {data && (
-          <div className="overflow-x-auto">
-            <table className="w-full text-[12px] border-collapse">
-              <thead>
-                <tr className="text-muted-foreground/70 text-left border-b border-border">
-                  <th className="py-1.5 pr-3 font-medium">{t('market.colCountry')}</th>
-                  <th className="py-1.5 px-3 font-medium text-right">{t('market.colCpiYoy')}</th>
-                  <th className="py-1.5 px-3 font-medium text-right">{t('market.colShortRate')}</th>
-                  <th className="py-1.5 px-3 font-medium text-right">{t('market.colCli')}</th>
-                  <th className="py-1.5 px-3 font-medium text-right">{t('market.colHousePrice')}</th>
-                  <th className="py-1.5 pl-3 font-medium text-right">{t('market.colSharePrice')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.rows.map((r) => (
-                  <tr key={r.country} className="border-b border-border/50 hover:bg-secondary/40">
-                    <td className="py-1.5 pr-3 text-foreground font-medium">{r.label}</td>
-                    <GlobalCell cell={r.cpiYoy} fmt={(v) => `${v.toFixed(2)}%`} colorBy="cpi" />
-                    <GlobalCell cell={r.shortRate} fmt={(v) => `${v.toFixed(2)}%`} />
-                    <GlobalCell cell={r.cli} fmt={(v) => v.toFixed(1)} colorBy="cli" />
-                    <GlobalCell cell={r.housePrice} fmt={(v) => v.toFixed(1)} />
-                    <GlobalCell cell={r.sharePrice} fmt={(v) => v.toFixed(1)} />
+          <>
+            <div
+              data-testid="global-macro-mobile"
+              className="divide-y divide-border/60 border-y border-border/70 md:hidden"
+            >
+              {data.rows.map((r) => (
+                <article key={r.country} className="py-3">
+                  <h3 className="truncate text-[13px] font-semibold text-foreground">{r.label}</h3>
+                  <dl className="mt-2 grid grid-cols-3 gap-x-3">
+                    <GlobalMetric
+                      label={t('market.colCpiYoy')}
+                      cell={r.cpiYoy}
+                      fmt={(v) => `${v.toFixed(2)}%`}
+                      colorBy="cpi"
+                    />
+                    <GlobalMetric
+                      label={t('market.colShortRate')}
+                      cell={r.shortRate}
+                      fmt={(v) => `${v.toFixed(2)}%`}
+                    />
+                    <GlobalMetric
+                      label={t('market.colCli')}
+                      cell={r.cli}
+                      fmt={(v) => v.toFixed(1)}
+                      colorBy="cli"
+                    />
+                  </dl>
+                  <dl className="mt-2 grid grid-cols-2 gap-x-3 border-t border-border/40 pt-2">
+                    <GlobalMetric
+                      label={t('market.colHousePrice')}
+                      cell={r.housePrice}
+                      fmt={(v) => v.toFixed(1)}
+                    />
+                    <GlobalMetric
+                      label={t('market.colSharePrice')}
+                      cell={r.sharePrice}
+                      fmt={(v) => v.toFixed(1)}
+                    />
+                  </dl>
+                </article>
+              ))}
+            </div>
+
+            <div data-testid="global-macro-desktop" className="hidden overflow-x-auto md:block">
+              <table className="w-full text-[12px] border-collapse">
+                <thead>
+                  <tr className="text-muted-foreground/70 text-left border-b border-border">
+                    <th className="py-1.5 pr-3 font-medium">{t('market.colCountry')}</th>
+                    <th className="py-1.5 px-3 font-medium text-right">{t('market.colCpiYoy')}</th>
+                    <th className="py-1.5 px-3 font-medium text-right">{t('market.colShortRate')}</th>
+                    <th className="py-1.5 px-3 font-medium text-right">{t('market.colCli')}</th>
+                    <th className="py-1.5 px-3 font-medium text-right">{t('market.colHousePrice')}</th>
+                    <th className="py-1.5 pl-3 font-medium text-right">{t('market.colSharePrice')}</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {data.rows.map((r) => (
+                    <tr key={r.country} className="border-b border-border/50 hover:bg-secondary/40">
+                      <td className="py-1.5 pr-3 text-foreground font-medium">{r.label}</td>
+                      <GlobalCell cell={r.cpiYoy} fmt={(v) => `${v.toFixed(2)}%`} colorBy="cpi" />
+                      <GlobalCell cell={r.shortRate} fmt={(v) => `${v.toFixed(2)}%`} />
+                      <GlobalCell cell={r.cli} fmt={(v) => v.toFixed(1)} colorBy="cli" />
+                      <GlobalCell cell={r.housePrice} fmt={(v) => v.toFixed(1)} />
+                      <GlobalCell cell={r.sharePrice} fmt={(v) => v.toFixed(1)} />
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
             <p className="mt-2 text-[10px] text-muted-foreground/60">{t('market.globalMacroNote')}</p>
-          </div>
+          </>
         )}
       </div>
     </div>
   )
 }
 
-function GlobalCell({ cell, fmt, colorBy }: { cell: GlobalMacroCell; fmt: (v: number) => string; colorBy?: 'cpi' | 'cli' }) {
-  if (cell.value == null) {
-    return <td className="py-1.5 px-3 text-right text-muted-foreground/50" title={cell.error ?? 'no data'}>—</td>
+type GlobalCellColor = 'cpi' | 'cli'
+
+function globalCellColor(cell: GlobalMacroCell, colorBy?: GlobalCellColor): string {
+  if (cell.value == null) return 'text-muted-foreground/50'
+  if (colorBy === 'cpi') {
+    return cell.value >= 4 ? 'text-destructive' : cell.value <= 1 ? 'text-muted-foreground' : 'text-foreground'
   }
-  let color = 'text-foreground'
-  if (colorBy === 'cpi') color = cell.value >= 4 ? 'text-destructive' : cell.value <= 1 ? 'text-muted-foreground' : 'text-foreground'
-  if (colorBy === 'cli') color = cell.value >= 100 ? 'text-success' : 'text-destructive'
+  if (colorBy === 'cli') return cell.value >= 100 ? 'text-success' : 'text-destructive'
+  return 'text-foreground'
+}
+
+function globalCellTitle(cell: GlobalMacroCell): string {
+  return cell.value == null ? cell.error ?? 'no data' : cell.date ?? ''
+}
+
+function GlobalMetric({
+  label,
+  cell,
+  fmt,
+  colorBy,
+}: {
+  label: string
+  cell: GlobalMacroCell
+  fmt: (v: number) => string
+  colorBy?: GlobalCellColor
+}) {
+  const value = cell.value == null ? '—' : fmt(cell.value)
+  const title = globalCellTitle(cell)
   return (
-    <td className={`py-1.5 px-3 text-right font-mono ${color}`} title={cell.date ?? ''}>{fmt(cell.value)}</td>
+    <div className="min-w-0" title={title}>
+      <dt className="min-h-8 text-[10px] leading-4 text-muted-foreground">{label}</dt>
+      <dd
+        className={`truncate font-mono text-[13px] font-medium tabular-nums ${globalCellColor(cell, colorBy)}`}
+        aria-label={`${label}: ${value}${title ? ` · ${title}` : ''}`}
+      >
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function GlobalCell({ cell, fmt, colorBy }: { cell: GlobalMacroCell; fmt: (v: number) => string; colorBy?: GlobalCellColor }) {
+  if (cell.value == null) {
+    return <td className="py-1.5 px-3 text-right text-muted-foreground/50" title={globalCellTitle(cell)}>—</td>
+  }
+  return (
+    <td className={`py-1.5 px-3 text-right font-mono ${globalCellColor(cell, colorBy)}`} title={globalCellTitle(cell)}>
+      {fmt(cell.value)}
+    </td>
   )
 }
 


### PR DESCRIPTION
## What changed

- add a scan-first mobile layout for Global Macro, grouping CPI, short rate, CLI, house price, and equity into readable metric rows
- retain the six-column comparison table from the `md` breakpoint upward
- share value formatting, observation metadata, missing-data treatment, and CPI/CLI semantic colors between mobile and desktop
- add regression coverage for both responsive representations

## Why

The desktop comparison table was being squeezed into the phone layout. At 390px, its 422px content sat inside a 358px container, leaving the Equity column outside the viewport and forcing routine horizontal scrolling just to scan one country.

The mobile view now exposes all five metrics in the normal reading flow while desktop keeps its higher-density comparison table.

## Verification

- `cd ui && npx tsc -b`
- `cd ui && pnpm exec vitest run src/pages/MarketBoardPage.spec.tsx --reporter=dot` — 7 tests passed
- `npx tsc --noEmit`
- `pnpm test -- --reporter=dot` — 450 files passed, 1 skipped; 3,772 tests passed, 9 skipped
- real `pnpm dev` walkthrough at 320, 390, 767, 768, and 1440px in English, Chinese, and Japanese, including light and dark themes; no document overflow and browser warning/error logs stayed clean
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:packaged --temp-data` — packaged app reached renderer bridge ready and Guardian shut down its child cleanly; this manual smoke was ended with Ctrl-C, so the wrapper exits non-zero by design