### PR TITLE
Flatten Workspace terminal chrome

### DIFF
--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -173,8 +173,13 @@ export interface TerminalViewProps {
   readonly wsId: string;
   /** Stable session record id. Required; emits `?session=<id>` on the WS. */
   readonly sessionId: string;
-  /** Human-facing label shown in the terminal header. Falls back to wsId. */
+  /** Human-facing label shown by framed terminal chrome. Falls back to wsId. */
   readonly label?: string;
+  /**
+   * `integrated` lets the owning page carry normal Workspace / Session
+   * identity. Terminal chrome then appears only for transport exceptions.
+   */
+  readonly chrome?: 'framed' | 'integrated';
   /** WebSocket URL base. Defaults to `${ws/wss}://${location.host}/pty`. */
   readonly wsUrl?: string;
   /** OpenTUI currently corrupts to an all-black canvas in xterm's WebGL addon. */
@@ -648,36 +653,45 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     };
   }, [wsId, sessionId, wsUrl, props.renderer]);
 
+  const integrated = props.chrome === 'integrated';
+  const hasTransportException =
+    status !== 'connected' || childExited || scrollbackTruncated || exitInfo !== null;
+  const showHeader = !integrated || hasTransportException;
+
   return (
-    <div className="terminal-shell">
-      <header className="terminal-header">
-        <StatusDot status={status} />
-        <span className="terminal-title">{props.label ?? wsId}</span>
-        <span className="terminal-meta">
-          {pid !== null ? `pid ${pid}` : ''}
-          {childExited ? ' · child exited' : ''}
-          {scrollbackTruncated ? ' · scrollback truncated' : ''}
-          {exitInfo
-            ? ` · session ended code=${exitInfo.code}${
-                exitInfo.signal !== null ? ` signal=${exitInfo.signal}` : ''
-              }`
-            : ''}
-        </span>
-        {status === 'locked' && (
-          <button
-            type="button"
-            className="terminal-header-action"
-            onClick={() => {
-              takeoverNextAttachRef.current = true;
-              setStatus('connecting');
-              connectRef.current?.();
-            }}
-            title="take over this session"
-          >
-            take over
-          </button>
-        )}
-      </header>
+    <div
+      className={`terminal-shell${integrated ? ' is-integrated' : ''}${showHeader ? ' has-header' : ''}`}
+    >
+      {showHeader && (
+        <header className="terminal-header">
+          <StatusDot status={status} />
+          <span className="terminal-title">{integrated ? status : (props.label ?? wsId)}</span>
+          <span className="terminal-meta">
+            {pid !== null ? `pid ${pid}` : ''}
+            {childExited ? ' · child exited' : ''}
+            {scrollbackTruncated ? ' · scrollback truncated' : ''}
+            {exitInfo
+              ? ` · session ended code=${exitInfo.code}${
+                  exitInfo.signal !== null ? ` signal=${exitInfo.signal}` : ''
+                }`
+              : ''}
+          </span>
+          {status === 'locked' && (
+            <button
+              type="button"
+              className="terminal-header-action"
+              onClick={() => {
+                takeoverNextAttachRef.current = true;
+                setStatus('connecting');
+                connectRef.current?.();
+              }}
+              title="take over this session"
+            >
+              take over
+            </button>
+          )}
+        </header>
+      )}
       {/* FitAddon reads the computed size of xterm's direct parent. Keep that
           parent padding-free: putting the visual inset on `.terminal-host`
           makes FitAddon count the padding as usable columns, so the xterm

--- a/ui/src/components/workspace/WorkspaceView.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceView.spec.tsx
@@ -9,6 +9,7 @@ import { WorkspaceView } from './WorkspaceView'
 
 const viewMocks = vi.hoisted(() => ({
   isDesktop: true,
+  terminalProps: vi.fn(),
   sidePrefs: {
     files: false,
     autoHideMobile: true,
@@ -21,7 +22,12 @@ vi.mock('../../live/workspace-side-panels', () => ({
   useWorkspaceSidePanels: () => viewMocks.sidePrefs,
 }))
 vi.mock('./FilesPanel', () => ({ FilesPanel: () => <div data-testid="files-panel" /> }))
-vi.mock('./Terminal', () => ({ TerminalView: () => null }))
+vi.mock('./Terminal', () => ({
+  TerminalView: (props: unknown) => {
+    viewMocks.terminalProps(props)
+    return <div data-testid="terminal-view" />
+  },
+}))
 vi.mock('./WebPiView', () => ({ WebPiView: () => null }))
 
 function session(index: number, state: SessionRecord['state']): SessionRecord {
@@ -42,6 +48,7 @@ function session(index: number, state: SessionRecord['state']): SessionRecord {
 }
 
 beforeEach(async () => {
+  viewMocks.terminalProps.mockClear()
   viewMocks.isDesktop = true
   viewMocks.sidePrefs.files = false
   viewMocks.sidePrefs.autoHideMobile = true
@@ -50,6 +57,32 @@ beforeEach(async () => {
 })
 
 afterEach(cleanup)
+
+describe('WorkspaceView terminal chrome', () => {
+  it('lets the owning page carry normal Workspace and Session identity', () => {
+    const active = session(2, 'running')
+    render(
+      <WorkspaceView
+        wsId="chat-1"
+        sessionId={active.id}
+        activeRecord={active}
+        sessions={[active]}
+        label="Research desk"
+        onSpawnFresh={vi.fn()}
+        onResume={vi.fn()}
+        onOpenWebPi={vi.fn()}
+        onSelectSession={vi.fn()}
+        onSessionLost={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('terminal-view')).toBeTruthy()
+    expect(viewMocks.terminalProps).toHaveBeenCalledWith(expect.objectContaining({
+      chrome: 'integrated',
+      label: 'Research desk · p2',
+    }))
+  })
+})
 
 describe('WorkspaceView Session library', () => {
   it('keeps a large Workspace searchable and routes running and paused rows correctly', () => {

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -120,6 +120,7 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
                     wsId={props.wsId}
                     sessionId={s.id}
                     renderer={s.agent === 'opencode' ? 'dom' : 'auto'}
+                    chrome="integrated"
                     {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
                     onSessionLost={props.onSessionLost}
                   />

--- a/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
@@ -42,4 +42,12 @@ describe('terminal responsive layout contract', () => {
     expect(declarationsFor('.terminal-title')).toContain('text-overflow: ellipsis')
     expect(declarationsFor('.terminal-meta')).toContain('text-overflow: ellipsis')
   })
+
+  it('lets Workspace pages integrate the terminal without nested card chrome', () => {
+    const integrated = declarationsFor('.terminal-shell.is-integrated')
+    expect(integrated).toContain('border: 0')
+    expect(integrated).toContain('border-radius: 0')
+    expect(integrated).toContain('box-shadow: none')
+    expect(declarationsFor('.terminal-shell.has-header')).toContain('grid-template-rows: auto 1fr')
+  })
 })

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1048,7 +1048,7 @@ button.files-row:focus-visible {
 
 .terminal-shell {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: 1fr;
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -1059,6 +1059,17 @@ button.files-row:focus-visible {
   overflow: hidden;
   background: var(--secondary);
   box-shadow: 0 10px 30px color-mix(in srgb, var(--shadow-color) 35%, transparent);
+}
+
+.terminal-shell.has-header {
+  grid-template-rows: auto 1fr;
+}
+
+.terminal-shell.is-integrated {
+  border: 0;
+  border-radius: 0;
+  background: var(--background);
+  box-shadow: none;
 }
 
 .terminal-header {
@@ -1073,6 +1084,19 @@ button.files-row:focus-visible {
   font-size: 12px;
   color: var(--muted-foreground);
   user-select: none;
+}
+
+.terminal-shell.is-integrated .terminal-header {
+  min-height: 30px;
+  padding: 5px 8px;
+  background: color-mix(in srgb, var(--secondary) 72%, transparent);
+  font-size: 11px;
+}
+
+.terminal-shell.is-integrated .status-dot {
+  width: 6px;
+  height: 6px;
+  box-shadow: none;
 }
 
 .terminal-title {

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -67,7 +67,9 @@ vi.mock('../api/config', () => ({
 }))
 
 vi.mock('../components/workspace/Terminal', () => ({
-  TerminalView: () => <div data-testid="terminal-view" />,
+  TerminalView: ({ chrome }: { chrome?: string }) => (
+    <div data-testid="terminal-view" data-chrome={chrome} />
+  ),
 }))
 
 vi.mock('../components/workspace/WebPiView', () => ({
@@ -486,6 +488,31 @@ describe('WorkspaceManagerPage runtime selection', () => {
       session.id,
     )
     expect(mocks.openWebPiSession).not.toHaveBeenCalled()
+  })
+
+  it('integrates a running Manager terminal into the owning page header', () => {
+    const session: SessionRecord = {
+      id: 'manager-codex-running',
+      resumeId: 'manager-codex-running-resume',
+      wsId: 'workspace-manager',
+      agent: 'codex',
+      name: 'x1',
+      createdAt: '2026-07-16T00:00:00.000Z',
+      lastActiveAt: '2026-07-16T00:00:00.000Z',
+      state: 'running',
+      surface: 'terminal',
+      pid: 42,
+      startedAt: 1,
+      title: 'Inspect the floor',
+    }
+    mocks.useWorkspaces.mockImplementation(() => context('codex', managerSnapshot([session])))
+
+    render(<WorkspaceManagerPage spec={{
+      kind: 'workspace-manager',
+      params: { sessionId: session.id },
+    }} />)
+
+    expect(screen.getByTestId('terminal-view').getAttribute('data-chrome')).toBe('integrated')
   })
 
   it('reopens a paused Pi Manager Session in its saved WebPi surface', () => {

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -181,6 +181,7 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
               sessionId={sessionId}
               renderer={session.agent === 'opencode' ? 'dom' : 'auto'}
               label={`${t('workspaceManager.title')} · ${session.name}`}
+              chrome="integrated"
               onSessionLost={() => void refreshWorkspaceManager()}
             />
           )}

--- a/ui/src/pages/WorkspacePage.spec.tsx
+++ b/ui/src/pages/WorkspacePage.spec.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '../i18n'
-import type { Workspace } from '../components/workspace/api'
+import type { SessionRecord, Workspace } from '../components/workspace/api'
 import { WorkspacePage } from './WorkspacePage'
 
 const mocks = vi.hoisted(() => ({
@@ -59,6 +59,21 @@ function workspace(overrides: Partial<Workspace> = {}): Workspace {
   }
 }
 
+const runningSession: SessionRecord = {
+  id: 'codex-calm-glass-harbor',
+  resumeId: 'resume-1',
+  wsId: 'chat-1',
+  agent: 'codex',
+  name: 'x1',
+  createdAt: '2026-06-30T00:00:00.000Z',
+  lastActiveAt: '2026-06-30T00:05:00.000Z',
+  state: 'running',
+  surface: 'terminal',
+  pid: 49949,
+  startedAt: 1,
+  title: 'Cross-market rotation',
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.workspaces = [workspace({ displayName: 'Optical Networking Follow-up' })]
@@ -96,5 +111,28 @@ describe('WorkspacePage identity', () => {
 
     expect(screen.getByTitle('chat-jun30').textContent).toBe('chat-jun30')
     expect(screen.getByTestId('workspace-view').getAttribute('data-label')).toBe('chat-jun30')
+  })
+
+  it('combines Workspace and Session identity in the owning page header', () => {
+    mocks.workspaces = [workspace({
+      displayName: 'AutoQuant',
+      sessions: [runningSession],
+    })]
+
+    render(
+      <WorkspacePage
+        spec={{
+          kind: 'workspace',
+          params: { wsId: 'chat-1', sessionId: runningSession.id, source: 'auto-quant' },
+        }}
+        visible
+      />,
+    )
+
+    expect(screen.getByText('AutoQuant').parentElement?.getAttribute('title'))
+      .toBe('AutoQuant\nchat-jun30')
+    expect(screen.getByTitle('Cross-market rotation').textContent).toBe('Cross-market rotation')
+    expect(screen.getByText('x1')).toBeTruthy()
+    expect(screen.getByTitle('running · pid 49949').textContent).toContain('pid 49949')
   })
 })

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -94,6 +94,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   const workspaceName = workspaceDisplayName(workspace)
   const workspaceTitle = workspaceDisplayTitle(workspace)
   const hasCustomName = workspaceName !== workspace.tag
+  const sessionTitle = activeRecord?.title?.trim() || activeRecord?.name || null
 
   // Sessions list: pass the full workspace.sessions. WorkspaceView's
   // `runningSlots` is gated on sessionId so the multi-terminal mount
@@ -102,24 +103,58 @@ export function WorkspacePage({ spec, visible }: Props) {
   // state needs the full list to render resume/continue cards.
   return (
     <div className="workspaces-root workspace-page-shell flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
-       *  launcher component itself is byte-faithful; we add the AI-provider
-       *  affordance here. */}
+      {/* One owning header for Workspace identity, active Session identity,
+       *  runtime state, and page actions. A normally connected terminal
+       *  deliberately contributes no second title card below it. */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-secondary/30 shrink-0">
-        <div
-          className="flex min-w-0 items-baseline gap-2 pr-2"
-          title={workspaceTitle}
-        >
-          <span className="truncate text-[12px] font-medium text-foreground">
-            {workspaceName}
-          </span>
-          {hasCustomName && (
-            <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/70 sm:inline">
-              {workspace.tag}
+        <div className="flex min-w-0 items-center gap-2 pr-2">
+          <div
+            className="flex min-w-0 items-baseline gap-2"
+            title={workspaceTitle}
+          >
+            <span className={`truncate text-[12px] font-medium ${
+              sessionTitle ? 'text-muted-foreground' : 'text-foreground'
+            }`}>
+              {workspaceName}
             </span>
+            {hasCustomName && (
+              <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/60 lg:inline">
+                {workspace.tag}
+              </span>
+            )}
+          </div>
+          {sessionTitle && activeRecord && (
+            <>
+              <span aria-hidden="true" className="shrink-0 text-[11px] text-muted-foreground/35">/</span>
+              <span
+                className="min-w-0 truncate text-[12px] font-semibold text-foreground"
+                title={sessionTitle}
+              >
+                {sessionTitle}
+              </span>
+              {sessionTitle !== activeRecord.name && (
+                <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/60 sm:inline">
+                  {activeRecord.name}
+                </span>
+              )}
+            </>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {activeRecord && (
+            <span
+              className="mr-1 hidden items-center gap-1.5 text-[10px] text-muted-foreground md:inline-flex"
+              title={`${activeRecord.state}${activeRecord.pid !== null ? ` · pid ${activeRecord.pid}` : ''}`}
+            >
+              <span
+                aria-hidden="true"
+                className={`h-1.5 w-1.5 rounded-full ${
+                  activeRecord.state === 'running' ? 'bg-success' : 'bg-muted-foreground/50'
+                }`}
+              />
+              {activeRecord.pid !== null ? `pid ${activeRecord.pid}` : t('workspace.paused')}
+            </span>
+          )}
           {activeRecord?.agent === 'pi' && activeRecord.state === 'running' && (
             <button
               type="button"


### PR DESCRIPTION
## What changed

- move the active Session identity into the owning Workspace page header, producing one `Workspace / Session` hierarchy instead of separate Harness and terminal-card titles
- surface the sticky Session name plus running/PID state beside the page actions
- add an integrated Terminal chrome mode used by Chat, AutoQuant, generic Workspaces, and Workspace Manager
- remove the normal terminal card border, radius, shadow, and duplicate title bar in integrated views
- keep a compact terminal status strip for connecting, reconnecting, locked, kicked, closed, child-exit, truncated-scrollback, and ended-session exceptions

## Why

The previous surface stacked three competing containers: the page Harness header, an inset Workspace panel, and a framed terminal with another `workspace · x1` title. Workspace and Session identity were repeated while the actual terminal content was visually pushed into a card inside a card.

Identity now belongs to the page shell once. A healthy connected terminal behaves as the working canvas; transport chrome appears only when it has diagnostic or recovery value.

## User impact

- the active hierarchy reads in one line: `Workspace / Session · sticky name · PID`
- the terminal gains space and no longer looks embedded in an unrelated dashboard card
- long native Session titles truncate inside the page header without horizontal overflow
- Files, Settings, WebPi switching, takeover, and terminal lifecycle behavior are unchanged

## Verification

- `pnpm -C ui exec vitest run src/pages/WorkspacePage.spec.tsx src/components/workspace/WorkspaceView.spec.tsx src/components/workspace/__tests__/terminalLayout.spec.ts src/pages/WorkspaceManagerPage.spec.tsx` (21 tests passed)
- `pnpm -C ui exec tsc -b --pretty false`
- `npx tsc --noEmit`
- `pnpm test` (450 files passed, 3775 tests passed)
- real `pnpm dev` running Session walkthrough in light and dark themes at 1440×900, 820×700, and 390×844
- verified integrated terminal computed chrome: 0px border/radius, no shadow, no normal terminal header, and no horizontal overflow
- verified a clean browser console after reconnect/reload
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` (packaged Workspace/PTY acceptance passed)

AutoQuant uses the same `WorkspacePage` path exercised by the running Chat Session. The isolated home had no initialized AutoQuant Workspace, so the source-specific route is covered by the shared Workspace contract rather than a live AutoQuant fixture.