### PR TITLE
Flatten the Workspace shell into one visual hierarchy

### DIFF
--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -175,6 +175,12 @@ export interface TerminalViewProps {
   readonly sessionId: string;
   /** Human-facing label shown in the terminal header. Falls back to wsId. */
   readonly label?: string;
+  /**
+   * Workspace surfaces already own the surrounding identity and layout. This
+   * variant keeps the terminal flush with that shell instead of drawing a
+   * second card inside it.
+   */
+  readonly chrome?: 'panel' | 'workspace';
   /** WebSocket URL base. Defaults to `${ws/wss}://${location.host}/pty`. */
   readonly wsUrl?: string;
   /** OpenTUI currently corrupts to an all-black canvas in xterm's WebGL addon. */
@@ -649,7 +655,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
   }, [wsId, sessionId, wsUrl, props.renderer]);
 
   return (
-    <div className="terminal-shell">
+    <div className={`terminal-shell${props.chrome === 'workspace' ? ' is-workspace' : ''}`}>
       <header className="terminal-header">
         <StatusDot status={status} />
         <span className="terminal-title">{props.label ?? wsId}</span>
@@ -702,7 +708,7 @@ function StatusDot({ status }: { status: Status }): ReactElement {
   return (
     <span
       className="status-dot"
-      style={{ background: colors[status] }}
+      style={{ background: colors[status], color: colors[status] }}
       title={status}
       aria-label={status}
     />

--- a/ui/src/components/workspace/WorkspaceView.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceView.spec.tsx
@@ -21,8 +21,16 @@ vi.mock('../../live/workspace-side-panels', () => ({
   useWorkspaceSidePanels: () => viewMocks.sidePrefs,
 }))
 vi.mock('./FilesPanel', () => ({ FilesPanel: () => <div data-testid="files-panel" /> }))
-vi.mock('./Terminal', () => ({ TerminalView: () => null }))
-vi.mock('./WebPiView', () => ({ WebPiView: () => null }))
+vi.mock('./Terminal', () => ({
+  TerminalView: (props: { label?: string; chrome?: string }) => (
+    <div data-testid="terminal-view" data-label={props.label} data-chrome={props.chrome} />
+  ),
+}))
+vi.mock('./WebPiView', () => ({
+  WebPiView: (props: { label?: string }) => (
+    <div data-testid="webpi-view" data-label={props.label} />
+  ),
+}))
 
 function session(index: number, state: SessionRecord['state']): SessionRecord {
   return {
@@ -154,5 +162,52 @@ describe('WorkspaceView Files panel', () => {
 
     expect(screen.getByTestId('files-panel')).toBeTruthy()
     expect(container.querySelector('.workspace-view')?.classList.contains('has-no-side')).toBe(false)
+  })
+})
+
+describe('WorkspaceView running surface hierarchy', () => {
+  const renderRunning = (record: SessionRecord) => render(
+    <WorkspaceView
+      wsId="auto-quant"
+      sessionId={record.id}
+      activeRecord={record}
+      sessions={[record]}
+      label="AutoQuant"
+      onSpawnFresh={vi.fn()}
+      onResume={vi.fn()}
+      onOpenWebPi={vi.fn()}
+      onSelectSession={vi.fn()}
+      onSessionLost={vi.fn()}
+    />,
+  )
+
+  it('uses the runtime and Session handle without repeating the Workspace name', () => {
+    const record = {
+      ...session(1, 'running'),
+      wsId: 'auto-quant',
+      agent: 'opencode',
+      name: 'x1',
+    }
+
+    const { container } = renderRunning(record)
+
+    const terminal = screen.getByTestId('terminal-view')
+    expect(terminal.getAttribute('data-label')).toBe('opencode · x1')
+    expect(terminal.getAttribute('data-chrome')).toBe('workspace')
+    expect(container.querySelector('.workspace-view')?.classList.contains('has-running-session')).toBe(true)
+  })
+
+  it('keeps WebPi identity at the Session level too', () => {
+    const record = {
+      ...session(2, 'running'),
+      wsId: 'auto-quant',
+      agent: 'pi',
+      name: 'x2',
+      surface: 'webpi' as const,
+    }
+
+    renderRunning(record)
+
+    expect(screen.getByTestId('webpi-view').getAttribute('data-label')).toBe('pi · x2')
   })
 })

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -80,7 +80,12 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   const usesMobileOverlay = !isDesktop && sidePrefs.autoHideMobile;
   const showFiles = usesMobileOverlay ? sidePrefs.mobileFilesOpen : sidePrefs.files;
   const showAside = showFiles;
-  const viewClass = `workspace-view${showAside ? '' : ' has-no-side'}`;
+  const hasRunningSession = runningSlots.length > 0;
+  const viewClass = [
+    'workspace-view',
+    showAside ? '' : 'has-no-side',
+    hasRunningSession ? 'has-running-session' : '',
+  ].filter(Boolean).join(' ');
 
   return (
     <div className={viewClass}>
@@ -112,7 +117,7 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
                   <WebPiView
                     wsId={props.wsId}
                     sessionId={s.id}
-                    {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
+                    label={`${s.agent} · ${s.name}`}
                     onSessionLost={props.onSessionLost}
                   />
                 ) : (
@@ -120,7 +125,8 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
                     wsId={props.wsId}
                     sessionId={s.id}
                     renderer={s.agent === 'opencode' ? 'dom' : 'auto'}
-                    {...(props.label !== undefined ? { label: `${props.label} · ${s.name}` } : {})}
+                    label={`${s.agent} · ${s.name}`}
+                    chrome="workspace"
                     onSessionLost={props.onSessionLost}
                   />
                 )}

--- a/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
+++ b/ui/src/components/workspace/__tests__/terminalLayout.spec.ts
@@ -42,4 +42,19 @@ describe('terminal responsive layout contract', () => {
     expect(declarationsFor('.terminal-title')).toContain('text-overflow: ellipsis')
     expect(declarationsFor('.terminal-meta')).toContain('text-overflow: ellipsis')
   })
+
+  it('flattens the terminal when the Workspace already owns the page shell', () => {
+    const workspaceChrome = declarationsFor('.terminal-shell.is-workspace')
+
+    expect(workspaceChrome).toContain('border: 0')
+    expect(workspaceChrome).toContain('border-radius: 0')
+    expect(workspaceChrome).toContain('box-shadow: none')
+    expect(declarationsFor('.workspace-view.has-running-session')).toContain('gap: 0')
+  })
+
+  it('lets the Files overlay own the full Workspace width on a phone', () => {
+    expect(css).toMatch(
+      /@container \(max-width: 520px\)[\s\S]*?\.workspace-page-shell \.workspace-side\s*\{[\s\S]*?width: 100%/,
+    )
+  })
 })

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -339,10 +339,30 @@
   }
 }
 
+@container (max-width: 520px) {
+  .workspace-page-shell .workspace-side {
+    width: 100%;
+  }
+}
+
 /* Both side panels hidden (or auto-hidden on mobile) — collapse the
  * 360px aside column so the terminal pane fills the whole width. */
 .workspace-view.has-no-side {
   grid-template-columns: minmax(0, 1fr);
+}
+
+.workspace-view.has-running-session {
+  gap: 0;
+}
+
+.workspace-view.has-running-session .workspace-side {
+  gap: 0;
+  border-left: 1px solid var(--border);
+}
+
+.workspace-view.has-running-session .workspace-side > .panel {
+  border: 0;
+  border-radius: 0;
 }
 
 .workspace-terminal {
@@ -1061,14 +1081,21 @@ button.files-row:focus-visible {
   box-shadow: 0 10px 30px color-mix(in srgb, var(--shadow-color) 35%, transparent);
 }
 
+.terminal-shell.is-workspace {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 .terminal-header {
   display: flex;
   align-items: center;
   min-width: 0;
   overflow: hidden;
   gap: 10px;
-  padding: 8px 12px;
-  background: linear-gradient(180deg, var(--muted), var(--secondary));
+  min-height: 34px;
+  padding: 6px 12px;
+  background: var(--secondary);
   border-bottom: 1px solid var(--border);
   font-size: 12px;
   color: var(--muted-foreground);
@@ -1081,8 +1108,8 @@ button.files-row:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--foreground);
-  font-weight: 600;
-  letter-spacing: 0.2px;
+  font-weight: 550;
+  letter-spacing: 0.1px;
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
@@ -1115,8 +1142,9 @@ button.files-row:focus-visible {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  box-shadow: 0 0 6px currentColor;
+  border: 2px solid color-mix(in srgb, currentColor 24%, transparent);
   display: inline-block;
+  flex: 0 0 auto;
 }
 
 .terminal-body {

--- a/ui/src/pages/WorkspacePage.spec.tsx
+++ b/ui/src/pages/WorkspacePage.spec.tsx
@@ -97,4 +97,39 @@ describe('WorkspacePage identity', () => {
     expect(screen.getByTitle('chat-jun30').textContent).toBe('chat-jun30')
     expect(screen.getByTestId('workspace-view').getAttribute('data-label')).toBe('chat-jun30')
   })
+
+  it('presents the active Session as part of the page identity without replacing the Workspace', () => {
+    mocks.workspaces = [workspace({
+      displayName: 'AutoQuant',
+      sessions: [{
+        id: 'opencode-fresh-cloud',
+        resumeId: 'resume-1',
+        wsId: 'chat-1',
+        agent: 'opencode',
+        name: 'x1',
+        title: 'Research semiconductor momentum',
+        state: 'running',
+        surface: 'terminal',
+        createdAt: '2026-07-31T00:00:00.000Z',
+        lastActiveAt: '2026-07-31T00:00:00.000Z',
+        pid: 49949,
+        startedAt: 1,
+      }],
+    })]
+
+    render(
+      <WorkspacePage
+        spec={{
+          kind: 'workspace',
+          params: { wsId: 'chat-1', sessionId: 'opencode-fresh-cloud' },
+        }}
+        visible
+      />,
+    )
+
+    expect(screen.getByText('AutoQuant')).toBeTruthy()
+    expect(screen.getByText('Research semiconductor momentum')).toBeTruthy()
+    expect(screen.getByText('AutoQuant').parentElement?.getAttribute('title'))
+      .toBe('AutoQuant\nchat-jun30\nResearch semiconductor momentum')
+  })
 })

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -94,6 +94,8 @@ export function WorkspacePage({ spec, visible }: Props) {
   const workspaceName = workspaceDisplayName(workspace)
   const workspaceTitle = workspaceDisplayTitle(workspace)
   const hasCustomName = workspaceName !== workspace.tag
+  const activeSessionTitle = activeRecord?.title?.trim() || activeRecord?.name || null
+  const embedsRunningSurface = activeRecord?.state === 'running'
 
   // Sessions list: pass the full workspace.sessions. WorkspaceView's
   // `runningSlots` is gated on sessionId so the multi-terminal mount
@@ -102,21 +104,29 @@ export function WorkspacePage({ spec, visible }: Props) {
   // state needs the full list to render resume/continue cards.
   return (
     <div className="workspaces-root workspace-page-shell flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      {/* OpenAlice-side header bar above the launcher's WorkspaceView. The
-       *  launcher component itself is byte-faithful; we add the AI-provider
-       *  affordance here. */}
-      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-secondary/30 shrink-0">
+      {/* One page-owned identity bar. Session surfaces below it only report
+       * runtime state; they must not repeat the Workspace name as another
+       * nested title. */}
+      <div className="flex min-h-10 shrink-0 items-center justify-between border-b border-border bg-secondary/30 px-3 py-1.5">
         <div
-          className="flex min-w-0 items-baseline gap-2 pr-2"
-          title={workspaceTitle}
+          className="flex min-w-0 items-center gap-2 pr-2"
+          title={activeSessionTitle ? `${workspaceTitle}\n${activeSessionTitle}` : workspaceTitle}
         >
-          <span className="truncate text-[12px] font-medium text-foreground">
+          <span className="shrink-0 truncate text-[12px] font-semibold text-foreground">
             {workspaceName}
           </span>
           {hasCustomName && (
-            <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/70 sm:inline">
+            <span className="hidden shrink-0 font-mono text-[10px] text-muted-foreground/60 md:inline">
               {workspace.tag}
             </span>
+          )}
+          {activeSessionTitle && (
+            <>
+              <span className="shrink-0 text-[11px] text-muted-foreground/45" aria-hidden="true">/</span>
+              <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+                {activeSessionTitle}
+              </span>
+            </>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
@@ -155,7 +165,11 @@ export function WorkspacePage({ spec, visible }: Props) {
         </div>
       </div>
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col p-3">
+      <div
+        className={`flex min-h-0 min-w-0 flex-1 flex-col ${
+          embedsRunningSurface ? '' : 'p-3'
+        }`}
+      >
         <WorkspaceView
           wsId={wsId}
           sessionId={sessionId}


### PR DESCRIPTION
## What changed

- makes the Workspace header the single owner of `Workspace / Session` identity
- changes terminal and WebPi labels to runtime-local identity (`agent · handle`) instead of repeating the Workspace name
- adds a flat Workspace terminal chrome variant without the inner card border, radius, gradient, or shadow
- removes the padded gap between a running surface and its Files pane, keeping a single separator between the two working regions
- makes the Files overlay full-width below 520px so a mobile view does not leave a strip of terminal visible behind it
- adds focused identity, layout, and responsive contract coverage

## Why

The running Workspace rendered its own page header, then inset another bordered terminal card whose header repeated the same Harness name. The result was a card-inside-card hierarchy (`auto-quant` above `auto-quant · x1`) that made the terminal feel secondary to its chrome.

The new hierarchy is intentionally linear:

1. page identity: Workspace / Session
2. runtime state: connection, agent handle, PID
3. one dominant terminal or WebPi working surface

This follows the warm editorial workstation rule of using typography, spacing, and thin separators before adding containers.

## Responsive behavior

- wide: terminal and Files are flush sibling regions separated by one rule
- medium: Files remains an overlay so the terminal is not crushed
- phone: Files owns the full Workspace width and remains dismissible from the persistent top-bar toggle

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- focused Vitest: 3 files, 13 tests passed
- `pnpm test`: 450 files passed, 3785 tests passed, 1 file / 9 tests skipped
- real isolated `pnpm dev` on the AutoQuant route in day and night palettes
- browser checks at desktop and 390×844; no horizontal overflow, Files overlay measured 390px at a 390px viewport
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:pty`: renderer bridge, Electron IPC PTY attach, and CLI socket smoke passed

No PTY transport, session lifecycle, or persisted state contract changed.