### PR TITLE
Make the Issues board scan-first

### DIFF
--- a/ui/src/components/IssuesBoard.spec.tsx
+++ b/ui/src/components/IssuesBoard.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { IssueListItem, IssueSnapshot } from '../api/issues'
@@ -172,13 +173,97 @@ describe('IssuesBoard', () => {
     render(<IssuesBoard />)
 
     expect(screen.getByText('进行中')).toBeTruthy()
-    expect(screen.getAllByText('运行中')).toHaveLength(2)
-    expect(screen.getAllByText('每工作日 08:30')).toHaveLength(2)
+    expect(screen.getAllByText('运行中')).toHaveLength(1)
+    expect(screen.getAllByText('每工作日 08:30')).toHaveLength(1)
     expect(screen.getByText('首次运行时指派')).toBeTruthy()
     expect(screen.getByText('claude 覆盖')).toBeTruthy()
     expect(screen.getByLabelText('高优先级')).toBeTruthy()
     expect(screen.getByLabelText('折叠“进行中”议题')).toBeTruthy()
     expect(screen.getByTitle('打开 weekday-scan')).toBeTruthy()
     expect(screen.getByTitle('工作区：market-desk（ws-1）')).toBeTruthy()
+  })
+
+  it('uses one flat ledger and renders automation metadata only once per Issue', () => {
+    mocks.useIssues.mockReturnValue({
+      data: snapshot([
+        issue({
+          id: 'scan-once',
+          title: 'Render one operational summary',
+          priority: 'high',
+          when: { kind: 'every', every: '1h' },
+          nextDueAtMs: Date.now() + 60_000,
+          automationHealth: { state: 'healthy', message: 'Latest scheduled run completed.' },
+        }),
+      ]),
+      error: null,
+      loading: false,
+    })
+
+    render(<IssuesBoard />)
+
+    const board = screen.getByTestId('issues-board')
+    const group = screen.getByTestId('issue-status-group-todo')
+    expect(board.className).toContain('max-w-[1240px]')
+    expect(group.className).toContain('border-y')
+    expect(group.className).not.toContain('rounded-lg')
+    expect(screen.getAllByTestId('issue-automation-summary')).toHaveLength(1)
+    expect(screen.getAllByText('Healthy')).toHaveLength(1)
+    expect(screen.getAllByText('Every 1h')).toHaveLength(1)
+
+    const priority = screen.getByLabelText('High priority')
+    expect(priority.querySelectorAll('.bg-muted-foreground\\/80')).toHaveLength(3)
+  })
+
+  it('keeps status disclosure and whole-row keyboard navigation intact', async () => {
+    const user = userEvent.setup()
+    mocks.useIssues.mockReturnValue({
+      data: snapshot([issue({ id: 'keyboard-issue', title: 'Keyboard issue' })]),
+      error: null,
+      loading: false,
+    })
+
+    render(<IssuesBoard />)
+
+    const groupToggle = screen.getByRole('button', { name: 'Collapse Todo issues' })
+    expect(groupToggle.getAttribute('aria-controls')).toBe('issues-status-todo')
+    expect(groupToggle.getAttribute('aria-expanded')).toBe('true')
+
+    await user.click(groupToggle)
+    expect(groupToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByText('Keyboard issue')).toBeNull()
+
+    await user.click(groupToggle)
+    const row = screen.getByTitle('Open keyboard-issue')
+    row.focus()
+    await user.keyboard('{Enter}')
+
+    expect(mocks.setSidebar).toHaveBeenCalledWith('issue')
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'issue-detail',
+      params: { wsId: 'ws-1', id: 'keyboard-issue' },
+    })
+  })
+
+  it('keeps terminal Issues readable and openable without fading the whole row', async () => {
+    const user = userEvent.setup()
+    mocks.useIssues.mockReturnValue({
+      data: snapshot([issue({
+        id: 'completed-issue',
+        title: 'Completed issue',
+        status: 'done',
+      })]),
+      error: null,
+      loading: false,
+    })
+
+    render(<IssuesBoard />)
+
+    const row = screen.getByTitle('Open completed-issue')
+    expect(row.className).not.toContain('opacity-60')
+    await user.click(row)
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'issue-detail',
+      params: { wsId: 'ws-1', id: 'completed-issue' },
+    })
   })
 })

--- a/ui/src/components/IssuesBoard.tsx
+++ b/ui/src/components/IssuesBoard.tsx
@@ -165,11 +165,11 @@ const AUTOMATION_HEALTH_CLASS: Record<IssueAutomationHealthState, string> = {
 }
 
 const BOARD_HEALTH_CLASS: Record<IssueAutomationHealthState, string> = {
-  inactive: 'text-muted-foreground/70',
-  not_started: 'text-muted-foreground/70',
+  inactive: 'text-muted-foreground',
+  not_started: 'text-muted-foreground',
   due: 'text-warning',
   running: 'text-info',
-  healthy: 'text-success/85',
+  healthy: 'text-success',
   interrupted: 'rounded-md bg-warning/15 px-2 py-1 text-warning',
   failed: 'rounded-md bg-destructive/15 px-2 py-1 text-destructive',
   blocked: 'rounded-md bg-destructive/15 px-2 py-1 text-destructive',
@@ -220,7 +220,7 @@ export function PriorityIndicator({ priority }: { priority: IssuePriority }) {
         <span
           key={i}
           style={{ height: `${h}px` }}
-          className={`w-[2.5px] rounded-[1px] ${i < filled ? 'bg-muted' : 'bg-muted/25'}`}
+          className={`w-[2.5px] rounded-[1px] ${i < filled ? 'bg-muted-foreground/80' : 'bg-muted-foreground/20'}`}
         />
       ))}
     </span>
@@ -346,7 +346,7 @@ function BoardHealth({ issue }: { issue: IssueListItem }) {
     >
       <span className={`h-1.5 w-1.5 rounded-full bg-current ${active ? 'animate-pulse' : ''}`} aria-hidden />
       {t(`issues.health.${health.state}`)}
-      {lastRun && <span className="font-normal text-muted-foreground/55">· {lastRun}</span>}
+      {lastRun && <span className="font-normal text-muted-foreground/80">· {lastRun}</span>}
     </span>
   )
 }
@@ -358,22 +358,17 @@ function BoardCadence({ issue }: { issue: IssueListItem }) {
   return (
     <span
       title={cadenceTitle(issue.when, t)}
-      className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground/75"
+      className="inline-flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground"
     >
-      <Clock size={11} className="shrink-0 text-muted-foreground/55" aria-hidden />
-      <span className="truncate">{cadenceLabel(issue.when, t)}</span>
-      {nextRun && <span className="shrink-0 text-muted-foreground/50">· {nextRun}</span>}
+      <Clock size={11} className="shrink-0 text-muted-foreground/70" aria-hidden />
+      <span className={`truncate ${nextRun ? 'hidden sm:inline' : ''}`}>{cadenceLabel(issue.when, t)}</span>
+      {nextRun && (
+        <>
+          <span className="hidden shrink-0 text-muted-foreground/50 sm:inline" aria-hidden>·</span>
+          <span className="shrink-0 text-muted-foreground/80">{nextRun}</span>
+        </>
+      )}
     </span>
-  )
-}
-
-function BoardAutomationSummary({ issue, className = '' }: { issue: IssueListItem; className?: string }) {
-  if (!issue.when && !issue.automationHealth) return null
-  return (
-    <div className={`flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 ${className}`}>
-      <BoardHealth issue={issue} />
-      <BoardCadence issue={issue} />
-    </div>
   )
 }
 
@@ -390,17 +385,20 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
         type="button"
         onClick={onOpen}
         title={t('issues.openIssue', { id: issue.id })}
-        className={`oa-pressable flex w-full items-start gap-3 px-3.5 py-3 text-left transition-colors hover:bg-muted/35 sm:px-4 ${
-          terminal ? 'opacity-60' : ''
-        }`}
+        className="oa-pressable grid min-h-11 w-full grid-cols-[1rem_minmax(0,1fr)] items-start gap-x-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/35 sm:px-4 lg:grid-cols-[1rem_minmax(16rem,1.25fr)_minmax(9rem,.65fr)_minmax(19rem,1fr)] lg:items-center lg:gap-x-5"
       >
-        <span className="mt-0.5 flex h-5 w-4 shrink-0 items-center justify-center">
+        <span className="col-start-1 row-start-1 mt-0.5 flex h-5 w-4 shrink-0 items-center justify-center">
           <PriorityIndicator priority={issue.priority} />
         </span>
 
-        <div className="min-w-0 flex-1">
+        <div className="col-start-2 row-start-1 min-w-0">
           <div className="flex min-w-0 items-center gap-2">
-            <span title={issue.title} className="min-w-0 truncate text-[13px] font-medium text-foreground sm:text-[13.5px]">
+            <span
+              title={issue.title}
+              className={`min-w-0 text-[13px] font-medium leading-5 sm:text-[13.5px] lg:truncate ${
+                terminal ? 'text-muted-foreground' : 'text-foreground'
+              } line-clamp-2 lg:line-clamp-1`}
+            >
               {issue.title}
             </span>
             {issue.nameCollision && (
@@ -415,35 +413,38 @@ function IssueRow({ wsId, wsTag, issue, agentRuntime, dupOthers, onOpen }: Board
               </span>
             )}
           </div>
-
-          <BoardAutomationSummary issue={issue} className="mt-2 lg:hidden" />
-
-          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 text-[10.5px] text-muted-foreground/60">
-            <span className="truncate" title={t('issues.workspaceTitle', { workspace: wsTag, id: wsId.slice(0, 8) })}>
-              {wsTag}
-            </span>
-            {!titleMatchesId && (
-              <span className="hidden max-w-[14rem] truncate font-mono text-muted-foreground/45 sm:inline" title={t('issues.issueIdTitle', { id: issue.id })}>
-                #{issue.id}
-              </span>
-            )}
-            {explicitAssignee && (
-              <span className="max-w-[14rem] truncate text-muted-foreground/70" title={t('issues.assigneeTitle', { assignee: issue.assignee })}>
-                {assigneeLabel}
-              </span>
-            )}
-            {explicitAgent && agentRuntime && (
-              <span className="inline-flex items-center gap-1 text-muted-foreground/70" title={t('issues.agentOverrideTitle', { agent: agentRuntime.displayName })}>
-                <Bot size={10} aria-hidden /> {t('issues.agentOverrideShort', { agent: agentRuntime.id })}
-              </span>
-            )}
-          </div>
         </div>
 
-        <BoardAutomationSummary
-          issue={issue}
-          className="hidden max-w-[48%] shrink-0 justify-end lg:flex"
-        />
+        {(issue.when || issue.automationHealth) && (
+          <div
+            data-testid="issue-automation-summary"
+            className="col-start-2 row-start-2 mt-1.5 grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-1 lg:col-start-4 lg:row-start-1 lg:mt-0 lg:grid-cols-[minmax(7rem,.65fr)_minmax(0,1fr)] lg:items-start lg:gap-x-4"
+          >
+            <BoardHealth issue={issue} />
+            <BoardCadence issue={issue} />
+          </div>
+        )}
+
+        <div className="col-start-2 mt-1 flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1 text-[10.5px] text-muted-foreground/80 lg:col-start-3 lg:row-start-1 lg:mt-0">
+          <span className="truncate" title={t('issues.workspaceTitle', { workspace: wsTag, id: wsId.slice(0, 8) })}>
+            {wsTag}
+          </span>
+          {!titleMatchesId && (
+            <span className="hidden max-w-[14rem] truncate font-mono text-muted-foreground/60 sm:inline" title={t('issues.issueIdTitle', { id: issue.id })}>
+              #{issue.id}
+            </span>
+          )}
+          {explicitAssignee && (
+            <span className="max-w-[14rem] truncate text-muted-foreground" title={t('issues.assigneeTitle', { assignee: issue.assignee })}>
+              {assigneeLabel}
+            </span>
+          )}
+          {explicitAgent && agentRuntime && (
+            <span className="inline-flex items-center gap-1 text-muted-foreground" title={t('issues.agentOverrideTitle', { agent: agentRuntime.displayName })}>
+              <Bot size={10} aria-hidden /> {t('issues.agentOverrideShort', { agent: agentRuntime.id })}
+            </span>
+          )}
+        </div>
       </button>
     </li>
   )
@@ -465,14 +466,19 @@ function StatusGroup({
   const { t } = useTranslation()
   const meta = STATUS_META[status]
   const statusLabel = t(`issues.status.${status}`)
+  const listId = `issues-status-${status}`
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-secondary">
+    <section
+      data-testid={`issue-status-group-${status}`}
+      className="border-y border-border/70"
+    >
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={!collapsed}
+        aria-controls={listId}
         aria-label={t(collapsed ? 'issues.expandStatus' : 'issues.collapseStatus', { status: statusLabel })}
-        className="flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors hover:bg-muted/40"
+        className="flex min-h-11 w-full items-center gap-2 bg-secondary/25 px-2 py-2.5 text-left transition-colors hover:bg-muted/40 sm:px-3"
       >
         {collapsed ? (
           <ChevronRight size={14} className="shrink-0 text-muted-foreground/70" />
@@ -484,7 +490,7 @@ function StatusGroup({
         <span className="text-xs text-muted-foreground">{rows.length}</span>
       </button>
       {!collapsed && (
-        <ul className="divide-y divide-border/60 border-t border-border">
+        <ul id={listId} className="divide-y divide-border/60 border-t border-border/70">
           {rows.map((row) => (
             <IssueRow
               key={`${row.wsId}:${row.issue.id}`}
@@ -494,7 +500,7 @@ function StatusGroup({
           ))}
         </ul>
       )}
-    </div>
+    </section>
   )
 }
 
@@ -612,7 +618,7 @@ export function IssuesBoard() {
 
   if (groups.length === 0 && invalid.length === 0) {
     return (
-      <div className="space-y-3">
+      <div className="mx-auto max-w-[1240px] space-y-3">
         {staleBanner}
         <div className="rounded-lg border border-dashed border-border px-6 py-12 text-center">
           <ListChecks size={24} className="mx-auto text-muted-foreground/50" />
@@ -630,7 +636,7 @@ export function IssuesBoard() {
   }
 
   return (
-    <div className="space-y-3">
+    <div data-testid="issues-board" className="mx-auto max-w-[1240px] space-y-5">
       {staleBanner}
       <InvalidWorkspaces workspaces={invalid} />
       {groups.map((g) => (


### PR DESCRIPTION
## What changed

- replace separate mobile/desktop automation summaries with one responsive information hierarchy
- give desktop rows stable identity, Workspace, health, and cadence lanes inside a bounded board width
- make compact rows lead with health and next-run timing, while allowing long Issue titles to use two lines
- flatten status groups into a continuous ledger with restrained headers and row separators
- raise contrast for priority, health, last/next run, Workspace, and execution-exception metadata
- keep completed and canceled Issues readable instead of fading the entire interactive row
- connect each status disclosure to its controlled list with `aria-controls`

## Why

The previous flexible row pushed health and cadence to the far edge of wide screens, so operators had to scan across a large empty gap to connect an Issue with its runtime state. Essential metadata also used very low opacity in both day and night themes. On compact screens, duplicated responsive markup preserved the information but produced a taller, fragmented three-layer row.

This is a presentation-only change. It preserves the existing status groups, attention → priority → due → title ordering, full-row navigation, cross-Workspace identity, default metadata suppression, collision warnings, and Issue data contracts.

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm vitest run ui/src/components/IssuesBoard.spec.tsx` (7 tests)
- `pnpm test` (450 files passed, 3774 tests passed)
- real `pnpm dev` with the current 10-item Todo group
- desktop, 1024px, and 390×844 in day/night/auto themes
- confirmed no body or main horizontal overflow at 390px and 1024px
- confirmed collapse removes the controlled list from the DOM and restores it on expand
