### PR TITLE
Make News request states honest

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1433,6 +1433,9 @@ export const en = {
     articleCount_other: '{{count}} articles',
     noArticles: 'No articles',
     noArticlesDescription: 'No news articles found for this time range.',
+    loadErrorTitle: 'Couldn’t load News',
+    loadErrorDescription: 'OpenAlice could not refresh the news feed. Check the connection to the OpenAlice backend, then retry.',
+    stale: 'Live refresh failed — showing the last news received for these filters.',
     openOriginal: 'Open original',
   },
   tracked: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1422,6 +1422,9 @@ export const ja: Resources = {
     articleCount_other: '{{count}} 件',
     noArticles: '記事なし',
     noArticlesDescription: 'この期間のニュース記事は見つかりませんでした。',
+    loadErrorTitle: 'ニュースを読み込めませんでした',
+    loadErrorDescription: 'OpenAlice はニュースフィードを更新できませんでした。OpenAlice バックエンドへの接続を確認して、再試行してください。',
+    stale: 'ライブ更新に失敗しました。この条件で最後に取得できたニュースを表示しています。',
     openOriginal: '元記事を開く',
   },
   tracked: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1429,6 +1429,9 @@ export const zhHant: Resources = {
     articleCount_other: '{{count}} 篇文章',
     noArticles: '無文章',
     noArticlesDescription: '此時間範圍內找不到新聞。',
+    loadErrorTitle: '無法載入新聞',
+    loadErrorDescription: 'OpenAlice 暫時無法重新整理新聞動態。請檢查與 OpenAlice 後端的連線，然後重試。',
+    stale: '即時重新整理失敗——目前顯示這些篩選條件下上次成功載入的新聞。',
     openOriginal: '檢視原文',
   },
   tracked: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1421,6 +1421,9 @@ export const zh: Resources = {
     articleCount_other: '{{count}} 篇文章',
     noArticles: '无文章',
     noArticlesDescription: '该时间范围内没有找到新闻。',
+    loadErrorTitle: '无法加载新闻',
+    loadErrorDescription: 'OpenAlice 暂时无法刷新新闻流。请检查与 OpenAlice 后端的连接，然后重试。',
+    stale: '实时刷新失败——当前显示这些筛选条件下上次成功加载的新闻。',
     openOriginal: '查看原文',
   },
   tracked: {

--- a/ui/src/pages/NewsPage.spec.tsx
+++ b/ui/src/pages/NewsPage.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -11,6 +11,31 @@ const mocks = vi.hoisted(() => ({
   list: vi.fn(),
 }))
 
+function newsResponse(title: string, lookback = '24h') {
+  return {
+    items: [{
+      time: '2026-07-29T10:00:00.000Z',
+      title,
+      content: `${title} content`,
+      source: 'Reuters',
+      link: null,
+      categories: null,
+    }],
+    count: 1,
+    lookback,
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 vi.mock('../api', () => ({
   api: {
     news: {
@@ -20,6 +45,7 @@ vi.mock('../api', () => ({
 }))
 
 beforeEach(async () => {
+  mocks.list.mockReset()
   await i18n.changeLanguage('en')
   mocks.list.mockResolvedValue({
     items: [
@@ -56,6 +82,7 @@ beforeEach(async () => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  vi.restoreAllMocks()
 })
 
 describe('NewsPage ordering', () => {
@@ -103,5 +130,100 @@ describe('NewsPage article disclosures', () => {
     const article = await screen.findByRole('button', { name: 'Newest update' })
     expect(article.className).toContain('py-3.5')
     expect(article.closest('[aria-busy]')?.getAttribute('aria-busy')).toBe('false')
+  })
+})
+
+describe('NewsPage request recovery', () => {
+  it('reports an initial failure instead of presenting it as an empty feed, then retries', async () => {
+    mocks.list
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(newsResponse('Recovered update'))
+
+    render(<NewsPage />)
+
+    const error = await screen.findByRole('alert')
+    expect(error.textContent).toContain('Couldn’t load News')
+    expect(error.textContent).toContain('OpenAlice backend')
+    expect(screen.queryByText('No articles')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Recovered update')).toBeTruthy()
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('clears mismatched articles when a new filter fails', async () => {
+    render(<NewsPage />)
+    expect(await screen.findByText('Newest update')).toBeTruthy()
+
+    mocks.list.mockRejectedValueOnce(new Error('filter unavailable'))
+    fireEvent.change(screen.getByRole('combobox', { name: 'News source' }), {
+      target: { value: 'Reuters' },
+    })
+
+    expect(await screen.findByRole('alert')).toBeTruthy()
+    expect(screen.queryByText('Newest update')).toBeNull()
+    expect(screen.queryByText('No articles')).toBeNull()
+  })
+
+  it('keeps the last successful feed visible when a background refresh fails', async () => {
+    let refresh: (() => void) | undefined
+    vi.spyOn(globalThis, 'setInterval').mockImplementation((handler, delay) => {
+      if (delay === 60_000) refresh = handler as () => void
+      return {} as ReturnType<typeof setInterval>
+    })
+
+    render(<NewsPage />)
+    expect(await screen.findByText('Newest update')).toBeTruthy()
+    expect(refresh).toBeTypeOf('function')
+    mocks.list.mockRejectedValueOnce(new Error('refresh unavailable'))
+
+    await act(async () => {
+      refresh?.()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const status = await screen.findByRole('status')
+    expect(status.textContent).toContain('showing the last news received')
+    expect(screen.getByText('Newest update')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    mocks.list.mockResolvedValueOnce(newsResponse('Refreshed update'))
+    fireEvent.click(within(status).getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('Refreshed update')).toBeTruthy()
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('lets the latest filter response win when an older request finishes last', async () => {
+    render(<NewsPage />)
+    expect(await screen.findByText('Newest update')).toBeTruthy()
+
+    const slow = deferred<ReturnType<typeof newsResponse>>()
+    const fast = deferred<ReturnType<typeof newsResponse>>()
+    mocks.list
+      .mockImplementationOnce(() => slow.promise)
+      .mockImplementationOnce(() => fast.promise)
+
+    const lookback = screen.getByRole('combobox', { name: 'News time range' })
+    fireEvent.change(lookback, { target: { value: '1h' } })
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(2))
+    fireEvent.change(lookback, { target: { value: '7d' } })
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(3))
+
+    await act(async () => {
+      fast.resolve(newsResponse('Latest response', '7d'))
+      await fast.promise
+    })
+    expect(await screen.findByText('Latest response')).toBeTruthy()
+
+    await act(async () => {
+      slow.resolve(newsResponse('Stale response', '1h'))
+      await slow.promise
+    })
+    expect(screen.getByText('Latest response')).toBeTruthy()
+    expect(screen.queryByText('Stale response')).toBeNull()
   })
 })

--- a/ui/src/pages/NewsPage.tsx
+++ b/ui/src/pages/NewsPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { CircleAlert } from 'lucide-react'
 import { formatRelativeTime } from '../lib/intl'
 import { api, type NewsArticle } from '../api'
 import { PageHeader } from '../components/PageHeader'
@@ -14,6 +15,8 @@ const LOOKBACK_OPTIONS = [
   { value: '24h', labelKey: 'news.lookback24h' },
   { value: '7d', labelKey: 'news.lookback7d' },
 ] as const
+
+type FetchMode = 'replace' | 'refresh'
 
 // ==================== Article Row ====================
 
@@ -97,7 +100,10 @@ export function NewsPage() {
   const [lookback, setLookback] = useState('24h')
   const [sourceFilter, setSourceFilter] = useState('')
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [loadError, setLoadError] = useState(false)
   const [sources, setSources] = useState<string[]>([])
+  const requestGeneration = useRef(0)
   const orderedArticles = useMemo(
     () => [...articles].sort(
       (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime(),
@@ -105,14 +111,30 @@ export function NewsPage() {
     [articles],
   )
 
-  const fetchArticles = useCallback(async (lb: string, src: string) => {
+  const fetchArticles = useCallback(async (
+    lb: string,
+    src: string,
+    mode: FetchMode = 'refresh',
+  ) => {
+    const request = ++requestGeneration.current
+    if (mode === 'replace') {
+      setArticles([])
+      setLoadError(false)
+      setLoading(true)
+    } else {
+      setRefreshing(true)
+    }
+
     try {
       const res = await api.news.list({
         lookback: lb,
         limit: 200,
         source: src || undefined,
       })
+      if (request !== requestGeneration.current) return
+
       setArticles(res.items)
+      setLoadError(false)
       const seen = new Set<string>()
       for (const item of res.items) {
         if (item.source) seen.add(item.source)
@@ -122,21 +144,40 @@ export function NewsPage() {
         return [...merged].sort()
       })
     } catch (err) {
-      console.warn('Failed to load news:', err)
+      if (request === requestGeneration.current) {
+        setLoadError(true)
+        console.warn('Failed to load news:', err)
+      }
     } finally {
-      setLoading(false)
+      if (request === requestGeneration.current) {
+        setLoading(false)
+        setRefreshing(false)
+      }
     }
   }, [])
 
   useEffect(() => {
-    setLoading(true)
-    fetchArticles(lookback, sourceFilter)
+    void fetchArticles(lookback, sourceFilter, 'replace')
   }, [lookback, sourceFilter, fetchArticles])
 
   useEffect(() => {
-    const id = setInterval(() => fetchArticles(lookback, sourceFilter), 60_000)
+    const id = setInterval(() => {
+      void fetchArticles(lookback, sourceFilter, 'refresh')
+    }, 60_000)
     return () => clearInterval(id)
   }, [lookback, sourceFilter, fetchArticles])
+
+  useEffect(() => () => {
+    requestGeneration.current += 1
+  }, [])
+
+  const retry = useCallback(() => {
+    void fetchArticles(
+      lookback,
+      sourceFilter,
+      articles.length === 0 ? 'replace' : 'refresh',
+    )
+  }, [articles.length, fetchArticles, lookback, sourceFilter])
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -174,9 +215,13 @@ export function NewsPage() {
             </span>
           </div>
 
+          {loadError && articles.length > 0 && (
+            <NewsStaleNotice refreshing={refreshing} onRetry={retry} />
+          )}
+
           {/* Article list */}
           <div
-            aria-busy={loading}
+            aria-busy={loading || refreshing}
             className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border bg-background shadow-[0_1px_2px_rgba(15,23,42,0.03)]"
           >
             {loading && articles.length === 0 ? (
@@ -188,6 +233,8 @@ export function NewsPage() {
                   </div>
                 ))}
               </div>
+            ) : loadError && articles.length === 0 ? (
+              <NewsLoadError refreshing={refreshing} onRetry={retry} />
             ) : articles.length === 0 ? (
               <EmptyState title={t('news.noArticles')} description={t('news.noArticlesDescription')} />
             ) : (
@@ -203,6 +250,65 @@ export function NewsPage() {
           </div>
         </div>
       </div>
+    </div>
+  )
+}
+
+function NewsLoadError({
+  refreshing,
+  onRetry,
+}: {
+  refreshing: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="alert"
+      className="mx-auto flex max-w-[520px] flex-col items-center px-6 py-16 text-center"
+    >
+      <CircleAlert size={24} strokeWidth={1.75} className="text-destructive" aria-hidden />
+      <h2 className="mt-3 text-[15px] font-medium text-foreground">
+        {t('news.loadErrorTitle')}
+      </h2>
+      <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground">
+        {t('news.loadErrorDescription')}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={refreshing}
+        className="oa-pressable mt-4 rounded-md border border-border bg-secondary px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-primary/50 hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+      >
+        {refreshing ? t('common.loading') : t('common.retry')}
+      </button>
+    </div>
+  )
+}
+
+function NewsStaleNotice({
+  refreshing,
+  onRetry,
+}: {
+  refreshing: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 rounded-md border border-warning/25 bg-warning/[0.06] px-3 py-2 text-[12px] text-muted-foreground"
+    >
+      <CircleAlert size={14} className="shrink-0 text-warning" aria-hidden />
+      <span className="min-w-0 flex-1">{t('news.stale')}</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={refreshing}
+        className="oa-pressable shrink-0 rounded px-2 py-1 font-medium text-foreground hover:bg-warning/10 disabled:cursor-wait disabled:opacity-60"
+      >
+        {refreshing ? t('common.loading') : t('common.retry')}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## What changed

- Treat initial News request failures as failures with a clear explanation and Retry action instead of rendering the empty-feed state.
- Clear articles from the previous filter as soon as a replacement request starts, so a failed filter cannot leave mismatched content under the newly selected controls.
- Retain the last successful feed when the 60-second background refresh fails and identify it as stale with an inline retry action.
- Add request generations so only the latest filter or refresh request may commit state; slower superseded responses are ignored.
- Add complete English, Simplified Chinese, Traditional Chinese, and Japanese copy for unavailable and stale states.

## Why

The previous catch path only logged a warning and then ended loading. That made an unreachable API indistinguishable from a legitimate zero-result response. It also let old rows remain under a new filter after failures and allowed slower older requests to overwrite newer selections.

## Validation

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm vitest run ui/src/pages/NewsPage.spec.tsx` (7 tests)
- `pnpm test` (450 files passed, 3775 tests passed)
- Healthy real `pnpm dev --takeover` route remained live through HMR with no Vite/runtime errors; initial failure, filter failure, stale refresh, retry recovery, and out-of-order responses were exercised through controlled API failures in the page tests.

## Topic boundary

This PR deliberately contains only request-state reliability. The scan-first News visual hierarchy lives independently in Draft PR #916; whichever lands second should rebase the shared `NewsPage.tsx` changes rather than mixing the two review themes.