### PR TITLE
Make Appearance settings progressive

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -295,6 +295,8 @@ export const en = {
       followsSystem: 'follows system',
       themePair: 'Theme pair',
       themePairDescription: 'Auto switches between these slots. Select one to edit its palette.',
+      customizePalettes: 'Customize palettes',
+      hidePaletteEditor: 'Hide palette editor',
       resetPair: 'Reset pair',
       activeSlot: 'Active',
       editingSlot: 'Editing',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -284,6 +284,8 @@ export const ja: Resources = {
       followsSystem: 'システムに追従',
       themePair: 'テーマの組み合わせ',
       themePairDescription: '自動モードはこの 2 つを切り替えます。編集するスロットを選んでください。',
+      customizePalettes: 'パレットをカスタマイズ',
+      hidePaletteEditor: 'パレット編集を閉じる',
       resetPair: '組み合わせをリセット',
       activeSlot: '使用中',
       editingSlot: '編集中',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -291,6 +291,8 @@ export const zhHant: Resources = {
       followsSystem: '跟隨系統',
       themePair: '主題組合',
       themePairDescription: '自動模式會在這兩個槽位間切換。選擇一個槽位來編輯它的色卡。',
+      customizePalettes: '自訂配色',
+      hidePaletteEditor: '收合配色編輯器',
       resetPair: '重設組合',
       activeSlot: '目前生效',
       editingSlot: '正在編輯',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -283,6 +283,8 @@ export const zh: Resources = {
       followsSystem: '跟随系统',
       themePair: '主题组合',
       themePairDescription: '自动模式会在这两个槽位间切换。选择一个槽位来编辑它的色卡。',
+      customizePalettes: '自定义配色',
+      hidePaletteEditor: '收起配色编辑器',
       resetPair: '重置组合',
       activeSlot: '当前生效',
       editingSlot: '正在编辑',

--- a/ui/src/pages/SettingsPage.appearance.spec.tsx
+++ b/ui/src/pages/SettingsPage.appearance.spec.tsx
@@ -52,16 +52,29 @@ describe('AppearanceSection palette pair editor', () => {
     expect(screen.queryByText('Show editor tabs')).toBeNull()
   })
 
-  it('shows the active slot and one recommended palette library at a time', () => {
+  it('keeps the palette library collapsed until the user asks to customize it', () => {
     render(<AppearanceSection />)
 
     expect(screen.getByText('Currently using Day · Paper')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Edit Day palette: Paper' }).getAttribute('aria-pressed'))
       .toBe('true')
+    const disclosure = screen.getByRole('button', { name: 'Customize palettes' })
+    const editor = document.getElementById(disclosure.getAttribute('aria-controls') ?? '')
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false')
+    expect(editor?.hidden).toBe(true)
+    expect(screen.queryByRole('button', { name: 'Recommended' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reset pair' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Choose Paper' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Auto' }).className).toContain('min-h-10')
+
+    fireEvent.click(disclosure)
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true')
+    expect(editor?.hidden).toBe(false)
     expect(screen.getByRole('button', { name: 'Recommended' }).getAttribute('aria-pressed'))
       .toBe('true')
     expect(screen.getByRole('button', { name: 'Recommended' }).className).toContain('min-h-10')
-    expect(screen.getByRole('button', { name: 'Auto' }).className).toContain('min-h-10')
     expect(screen.getByRole('button', { name: 'Reset pair' }).className).toContain('min-h-10')
     expect(screen.getByRole('button', { name: 'Choose Paper' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Choose Linen' })).toBeTruthy()
@@ -99,6 +112,7 @@ describe('AppearanceSection palette pair editor', () => {
     useThemeStore.setState({ theme: 'night', dayPalette: 'linen', nightPalette: 'midnight' })
     render(<AppearanceSection />)
 
+    fireEvent.click(screen.getByRole('button', { name: 'Customize palettes' }))
     fireEvent.click(screen.getByRole('button', { name: 'Reset pair' }))
 
     expect(useThemeStore.getState().theme).toBe('night')
@@ -113,5 +127,19 @@ describe('AppearanceSection palette pair editor', () => {
     expect(screen.getByText('Currently using Night · Graphite')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Edit Night palette: Graphite' }).getAttribute('aria-pressed'))
       .toBe('true')
+  })
+
+  it('preserves a selected pair when the palette editor is collapsed again', () => {
+    render(<AppearanceSection />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Customize palettes' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Choose Linen' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hide palette editor' }))
+
+    expect(useThemeStore.getState().dayPalette).toBe('linen')
+    expect(screen.getByRole('button', { name: 'Edit Day palette: Linen' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Customize palettes' }).getAttribute('aria-expanded'))
+      .toBe('false')
+    expect(screen.queryByRole('button', { name: 'Choose Linen' })).toBeNull()
   })
 })

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useId, useMemo } from 'react'
-import { Moon, RotateCcw, Sun } from 'lucide-react'
+import { ChevronDown, Moon, RotateCcw, Sun } from 'lucide-react'
 import { api } from '../api'
 import type { ToolInfo } from '../api/tools'
 import { Toggle } from '../components/Toggle'
@@ -42,6 +42,8 @@ export function AppearanceSection() {
   const effectiveSlot = useEffectivePreferenceSlot()
   const [editingSlot, setEditingSlot] = useState<ThemePreferenceSlot>(effectiveSlot)
   const [paletteFilter, setPaletteFilter] = useState<PaletteLibraryFilter>('recommended')
+  const [customizingPalettes, setCustomizingPalettes] = useState(false)
+  const paletteEditorId = useId()
   const modes: readonly AppTheme[] = ['auto', 'day', 'night']
   const activePalette = effectiveSlot === 'day' ? dayPalette : nightPalette
   const activePaletteDefinition = paletteDefinition(activePalette)
@@ -59,6 +61,11 @@ export function AppearanceSection() {
   const chooseSlot = (slot: ThemePreferenceSlot) => {
     setEditingSlot(slot)
     setPaletteFilter('recommended')
+  }
+
+  const editSlot = (slot: ThemePreferenceSlot) => {
+    chooseSlot(slot)
+    setCustomizingPalettes(true)
   }
 
   const choosePalette = (palette: ThemePaletteId) => {
@@ -135,33 +142,44 @@ export function AppearanceSection() {
           </div>
           <button
             type="button"
-            onClick={resetPair}
-            disabled={isDefaultPair}
-            className="oa-pressable inline-flex min-h-10 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[11px] text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-45 sm:min-h-8"
+            onClick={() => setCustomizingPalettes((current) => !current)}
+            aria-expanded={customizingPalettes}
+            aria-controls={paletteEditorId}
+            className="oa-pressable inline-flex min-h-10 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:border-primary/35 hover:text-primary sm:min-h-8"
           >
-            <RotateCcw className="h-3.5 w-3.5" />
-            {t('settings.appearance.resetPair')}
+            {t(customizingPalettes
+              ? 'settings.appearance.hidePaletteEditor'
+              : 'settings.appearance.customizePalettes')}
+            <ChevronDown
+              className={`h-3.5 w-3.5 transition-transform ${customizingPalettes ? 'rotate-180' : ''}`}
+              aria-hidden
+            />
           </button>
         </div>
 
-        <div className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,17rem),1fr))] gap-3">
+        <div className="mt-3 grid grid-cols-2 gap-2.5 sm:gap-3">
           <PaletteSlotCard
             slot="day"
             palette={paletteDefinition(dayPalette)}
             active={effectiveSlot === 'day'}
             editing={editingSlot === 'day'}
-            onSelect={() => chooseSlot('day')}
+            onSelect={() => editSlot('day')}
           />
           <PaletteSlotCard
             slot="night"
             palette={paletteDefinition(nightPalette)}
             active={effectiveSlot === 'night'}
             editing={editingSlot === 'night'}
-            onSelect={() => chooseSlot('night')}
+            onSelect={() => editSlot('night')}
           />
         </div>
 
-        <div className="mt-4 rounded-xl border border-border/70 bg-secondary/35 p-3 sm:p-4">
+        <div
+          id={paletteEditorId}
+          hidden={!customizingPalettes}
+          inert={!customizingPalettes ? true : undefined}
+          className="oa-disclosure-enter mt-4 border-t border-border/60 pt-4"
+        >
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
               <span className="text-sm font-medium text-foreground">
@@ -171,26 +189,37 @@ export function AppearanceSection() {
                 {t('settings.appearance.paletteLibraryDescription')}
               </p>
             </div>
-            <div
-              className="inline-flex rounded-md border border-border bg-background p-0.5"
-              role="group"
-              aria-label={t('settings.appearance.paletteFilter')}
-            >
-              {(['recommended', 'all'] as const).map((filter) => (
-                <button
-                  key={filter}
-                  type="button"
-                  onClick={() => setPaletteFilter(filter)}
-                  aria-pressed={paletteFilter === filter}
-                  className={`min-h-10 rounded px-2.5 py-1 text-[11px] font-medium transition-colors sm:min-h-0 ${
-                    paletteFilter === filter
-                      ? 'bg-primary-muted text-primary'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
-                >
-                  {t(`settings.appearance.paletteFilterOption.${filter}`)}
-                </button>
-              ))}
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={resetPair}
+                disabled={isDefaultPair}
+                className="oa-pressable inline-flex min-h-10 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[11px] text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-45 sm:min-h-8"
+              >
+                <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+                {t('settings.appearance.resetPair')}
+              </button>
+              <div
+                className="inline-flex rounded-md border border-border bg-background p-0.5"
+                role="group"
+                aria-label={t('settings.appearance.paletteFilter')}
+              >
+                {(['recommended', 'all'] as const).map((filter) => (
+                  <button
+                    key={filter}
+                    type="button"
+                    onClick={() => setPaletteFilter(filter)}
+                    aria-pressed={paletteFilter === filter}
+                    className={`min-h-10 rounded px-2.5 py-1 text-[11px] font-medium transition-colors sm:min-h-0 ${
+                      paletteFilter === filter
+                        ? 'bg-primary-muted text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {t(`settings.appearance.paletteFilterOption.${filter}`)}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 
@@ -234,16 +263,16 @@ function PaletteSlotCard({
         palette: t(palette.labelKey),
       })}
       onClick={onSelect}
-      className="oa-palette-preview oa-pressable min-w-0 rounded-xl border p-3 text-left shadow-sm transition-[border-color,box-shadow,transform]"
+      className="oa-palette-preview oa-pressable min-w-0 rounded-xl border p-2.5 text-left shadow-sm transition-[border-color,box-shadow,transform] sm:p-3"
     >
-      <span className="flex min-w-0 items-start justify-between gap-3">
+      <span className="flex min-w-0 items-start justify-between gap-2 sm:gap-3">
         <span className="min-w-0">
           <span className="flex items-center gap-1.5 text-[11px] font-medium">
             <Icon className="h-3.5 w-3.5" />
             {t(`theme.mode.${slot}`)}
           </span>
           <span className="mt-1 block truncate text-[14px] font-semibold">{t(palette.labelKey)}</span>
-          <span className="oa-palette-preview-muted mt-0.5 block text-[10.5px] leading-snug">
+          <span className="oa-palette-preview-muted mt-0.5 hidden text-[10.5px] leading-snug sm:block">
             {t(palette.descriptionKey)}
           </span>
         </span>
@@ -260,12 +289,12 @@ function PaletteSlotCard({
           )}
         </span>
       </span>
-      <span className="mt-3 flex items-center gap-1.5" aria-hidden>
-        <span className="h-2.5 flex-1 rounded-sm bg-primary" />
-        <span className="h-2.5 flex-1 rounded-sm bg-success" />
-        <span className="h-2.5 flex-1 rounded-sm bg-warning" />
-        <span className="h-2.5 flex-1 rounded-sm bg-destructive" />
-        <span className="h-2.5 flex-1 rounded-sm bg-ai-action" />
+      <span className="mt-2.5 flex items-center gap-1 sm:mt-3 sm:gap-1.5" aria-hidden>
+        <span className="h-2 flex-1 rounded-sm bg-primary sm:h-2.5" />
+        <span className="h-2 flex-1 rounded-sm bg-success sm:h-2.5" />
+        <span className="h-2 flex-1 rounded-sm bg-warning sm:h-2.5" />
+        <span className="h-2 flex-1 rounded-sm bg-destructive sm:h-2.5" />
+        <span className="h-2 flex-1 rounded-sm bg-ai-action sm:h-2.5" />
       </span>
     </button>
   )


### PR DESCRIPTION
## What changed

- keep color mode, the active palette, and the Day/Night pair visible at a glance
- move the full palette library, filters, and pair reset into an accessible disclosure
- open the editor directly when a Day or Night slot is selected
- compact the pair summary on narrow screens so Language returns to the first content viewport
- add localized disclosure labels and focused interaction coverage

## Why

Appearance had become a full palette editor before users asked to edit anything. On narrow screens it pushed the next setting several screens down and repeated container chrome. This keeps the common state readable while making advanced palette work deliberate.

## Validation

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm vitest run ui/src/pages/SettingsPage.appearance.spec.tsx`
- `pnpm test` (450 files passed, 3772 tests passed)
- real `pnpm dev` walkthrough at desktop and 390×844 in Day/Auto and Night modes; verified disclosure, pair editing, no horizontal overflow, and Language entering the first mobile viewport