### PR TITLE
Make Inbox updates message-first

### DIFF
--- a/ui/src/components/InboxSidebar.spec.tsx
+++ b/ui/src/components/InboxSidebar.spec.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   loading: false,
   selectedEntryId: 'inbox-1' as string | null,
   mode: 'workspace' as 'workspace' | 'time',
-  workspaces: [] as Array<{ id: string; tag: string }>,
+  workspaces: [] as Array<{ id: string; tag: string; displayName?: string }>,
   markRead: vi.fn(),
   select: vi.fn(),
   setMode: vi.fn(),
@@ -68,7 +68,7 @@ beforeEach(async () => {
   mocks.loading = false
   mocks.selectedEntryId = 'inbox-1'
   mocks.mode = 'workspace'
-  mocks.workspaces = [{ id: 'workspace-1', tag: 'renamed-desk' }]
+  mocks.workspaces = [{ id: 'workspace-1', tag: 'renamed-desk', displayName: 'Research desk' }]
 })
 
 afterEach(() => {
@@ -78,13 +78,14 @@ afterEach(() => {
 
 describe('InboxSidebar Workspace labels', () => {
   it.each(['workspace', 'time'] as const)(
-    'uses the current Workspace tag in %s view',
+    'uses the current Workspace display name in %s view',
     (mode) => {
       mocks.mode = mode
 
       render(<InboxSidebar />)
 
-      expect(screen.getByText('renamed-desk')).toBeTruthy()
+      expect(screen.getByText('Research desk')).toBeTruthy()
+      expect(screen.queryByText('renamed-desk')).toBeNull()
       expect(screen.queryByText('old-desk')).toBeNull()
     },
   )
@@ -95,6 +96,27 @@ describe('InboxSidebar Workspace labels', () => {
     render(<InboxSidebar />)
 
     expect(screen.getByText('old-desk')).toBeTruthy()
+  })
+
+  it('makes the update primary and keeps Workspace provenance secondary in time view', () => {
+    mocks.mode = 'time'
+
+    render(<InboxSidebar />)
+
+    const update = screen.getByText('Research is ready.')
+    const workspace = screen.getByText('Research desk')
+    expect(update.compareDocumentPosition(workspace) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(update.className).toMatch(/font-(medium|semibold)/)
+    expect(workspace.className).toContain('text-muted-foreground')
+  })
+
+  it('keeps entries without comments or attachments scannable', () => {
+    mocks.mode = 'time'
+    mocks.entries = [{ ...mocks.entries[0]!, comments: '', docs: [] }]
+
+    render(<InboxSidebar />)
+
+    expect(screen.getByText('Update without a summary')).toBeTruthy()
   })
 })
 

--- a/ui/src/components/InboxSidebar.tsx
+++ b/ui/src/components/InboxSidebar.tsx
@@ -8,6 +8,7 @@ import { useInboxRead } from '../live/inbox-read'
 import { useInboxSelection } from '../live/inbox-selection'
 import { useInboxViewMode } from '../live/inbox-view-mode'
 import { groupThreads, previewForEntry } from '../live/inbox-threads'
+import { workspaceDisplayName } from './workspace/display'
 import { Skeleton } from './StateViews'
 import type { InboxEntry } from '../api/inbox'
 
@@ -36,15 +37,19 @@ export function InboxSidebar({ onNavigate }: { onNavigate?: () => void } = {}) {
   const [query, setQuery] = useState('')
 
   const workspaceLabels = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspaceDisplayName(workspace)])),
+    [workspaces],
+  )
+  const workspaceTags = useMemo(
     () => new Map(workspaces.map((workspace) => [workspace.id, workspace.tag])),
     [workspaces],
   )
   const normalizedQuery = normalizeSearch(query)
   const filteredEntries = useMemo(
     () => normalizedQuery
-      ? entries.filter((entry) => inboxSearchText(entry, workspaceLabels).includes(normalizedQuery))
+      ? entries.filter((entry) => inboxSearchText(entry, workspaceLabels, workspaceTags).includes(normalizedQuery))
       : entries,
-    [entries, normalizedQuery, workspaceLabels],
+    [entries, normalizedQuery, workspaceLabels, workspaceTags],
   )
   const threads = useMemo(() => groupThreads(filteredEntries), [filteredEntries])
   const readIds = useMemo(() => {
@@ -193,9 +198,11 @@ function normalizeSearch(value: string): string {
 function inboxSearchText(
   entry: InboxEntry,
   workspaceLabels: ReadonlyMap<string, string>,
+  workspaceTags: ReadonlyMap<string, string>,
 ): string {
   return normalizeSearch([
     workspaceLabels.get(entry.workspaceId),
+    workspaceTags.get(entry.workspaceId),
     entry.workspaceLabel,
     entry.workspaceId,
     entry.comments,
@@ -322,6 +329,8 @@ function ClusterRow({
   unread: boolean
   onClick: () => void
 }) {
+  const { t } = useTranslation()
+  const preview = previewForEntry(entry) || t('inbox.untitledUpdate')
   return (
     <div
       role="button"
@@ -345,7 +354,7 @@ function ClusterRow({
         className={`mt-[7px] shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`}
       />
       <span className={`min-w-0 truncate text-[11px] leading-5 ${unread ? 'text-muted-foreground' : 'text-muted-foreground/70'}`}>
-        {previewForEntry(entry)}
+        {preview}
       </span>
       <span className="col-start-2 text-[10px] text-muted-foreground/50 tabular-nums">
         {formatRelativeTime(entry.ts)}
@@ -404,6 +413,9 @@ function TimeRow({
   workspaceLabel?: string
   onClick: () => void
 }) {
+  const { t } = useTranslation()
+  const preview = previewForEntry(entry) || t('inbox.untitledUpdate')
+  const source = workspaceLabel ?? entry.workspaceLabel ?? entry.workspaceId
   return (
     <div
       role="button"
@@ -415,7 +427,7 @@ function TimeRow({
           onClick()
         }
       }}
-      className={`group relative flex min-h-14 flex-col gap-0.5 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-muted/70 ${
+      className={`group relative flex min-h-14 flex-col justify-center gap-1 px-3 py-2 cursor-pointer transition-colors outline-none focus-visible:bg-muted/70 ${
         active ? 'bg-muted' : 'hover:bg-muted/50'
       }`}
     >
@@ -423,23 +435,30 @@ function TimeRow({
         <span aria-hidden className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />
       )}
 
-      {/* Line 1: unread dot · workspace · time */}
-      <div className="flex items-center gap-1.5">
+      {/* Line 1: the update itself is the object users are scanning. */}
+      <div className="flex min-w-0 items-center gap-1.5">
         <span
           aria-hidden
           className={`shrink-0 w-1.5 h-1.5 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`}
         />
-        <span className={`flex-1 truncate text-[12px] ${unread ? 'font-medium text-foreground' : 'text-foreground'}`}>
-          {workspaceLabel ?? entry.workspaceLabel ?? entry.workspaceId}
+        <span
+          className={`min-w-0 flex-1 truncate text-[12px] ${
+            unread ? 'font-semibold text-foreground' : 'font-medium text-foreground/90'
+          }`}
+          title={preview}
+        >
+          {preview}
+        </span>
+      </div>
+
+      {/* Line 2: source and time are supporting provenance. */}
+      <div className="flex min-w-0 items-center gap-2 pl-3">
+        <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground/60">
+          {source}
         </span>
         <span className="shrink-0 text-[10px] text-muted-foreground/60 tabular-nums">
           {formatRelativeTime(entry.ts)}
         </span>
-      </div>
-
-      {/* Line 2: preview */}
-      <div className={`pl-3 text-[11px] truncate ${unread ? 'text-muted-foreground' : 'text-muted-foreground/70'}`}>
-        {previewForEntry(entry)}
       </div>
     </div>
   )

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1498,6 +1498,7 @@ export const en = {
   inbox: {
     noMessages: 'No inbox messages.',
     emptyHint: 'Workspaces will push status updates here.',
+    untitledUpdate: 'Update without a summary',
     dateToday: 'Today',
     dateYesterday: 'Yesterday',
     dateThisWeek: 'This week',
@@ -1527,6 +1528,8 @@ export const en = {
     workspaceNotExists: 'Workspace no longer exists',
     fromSender: 'from {{sender}}',
     senderIdentityTitle: 'Sender identity: {{sender}}',
+    showSenderDetails: 'Show sender details for {{sender}}',
+    senderSession: 'Session',
     fromIssue: 'from {{issue}}',
     fromIssueTitle: 'From Issue {{issue}}',
     followUpSender: 'Continue with the sender',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1487,6 +1487,7 @@ export const ja: Resources = {
   inbox: {
     noMessages: '受信トレイにメッセージがありません。',
     emptyHint: 'ワークスペースがステータス更新をここに送ります。',
+    untitledUpdate: '要約のない更新',
     dateToday: '今日',
     dateYesterday: '昨日',
     dateThisWeek: '今週',
@@ -1516,6 +1517,8 @@ export const ja: Resources = {
     workspaceNotExists: 'ワークスペースは存在しません',
     fromSender: '{{sender}} から',
     senderIdentityTitle: '送信者 ID: {{sender}}',
+    showSenderDetails: '{{sender}} の送信者情報を表示',
+    senderSession: 'セッション',
     fromIssue: '{{issue}} から',
     fromIssueTitle: 'Issue {{issue}} から',
     followUpSender: '送信者と続ける',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1494,6 +1494,7 @@ export const zhHant: Resources = {
   inbox: {
     noMessages: '收件匣是空的。',
     emptyHint: '工作區會將狀態更新推送到這裡。',
+    untitledUpdate: '沒有摘要的更新',
     dateToday: '今天',
     dateYesterday: '昨天',
     dateThisWeek: '本週',
@@ -1523,6 +1524,8 @@ export const zhHant: Resources = {
     workspaceNotExists: '工作區已不存在',
     fromSender: '來自 {{sender}}',
     senderIdentityTitle: '發送者身份：{{sender}}',
+    showSenderDetails: '查看 {{sender}} 的發送者資訊',
+    senderSession: 'Session',
     fromIssue: '來自 {{issue}}',
     fromIssueTitle: '來自 Issue {{issue}}',
     followUpSender: '繼續和發送者溝通',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1486,6 +1486,7 @@ export const zh: Resources = {
   inbox: {
     noMessages: '收件箱为空。',
     emptyHint: '工作区会把状态更新推送到这里。',
+    untitledUpdate: '没有摘要的更新',
     dateToday: '今天',
     dateYesterday: '昨天',
     dateThisWeek: '本周',
@@ -1515,6 +1516,8 @@ export const zh: Resources = {
     workspaceNotExists: '工作区已不存在',
     fromSender: '来自 {{sender}}',
     senderIdentityTitle: '发送者身份：{{sender}}',
+    showSenderDetails: '查看 {{sender}} 的发送者信息',
+    senderSession: 'Session',
     fromIssue: '来自 {{issue}}',
     fromIssueTitle: '来自 Issue {{issue}}',
     followUpSender: '继续和发送者沟通',

--- a/ui/src/live/inbox-threads.ts
+++ b/ui/src/live/inbox-threads.ts
@@ -50,9 +50,9 @@ export function groupThreads(entries: readonly InboxEntry[]): InboxThread[] {
 }
 
 /**
- * Second-line preview text for a sidebar row — the latest push's comment
- * first line, else its first doc path. Mirrors the per-entry preview the
- * flat list used.
+ * Human scan label for one push — its first non-empty comment line, otherwise
+ * the first attached document. The Inbox time view treats this as the primary
+ * row identity; Workspace and timestamp remain supporting provenance.
  */
 export function previewForEntry(entry: InboxEntry): string {
   const c = (entry.comments ?? '').trim()

--- a/ui/src/pages/InboxPage.spec.tsx
+++ b/ui/src/pages/InboxPage.spec.tsx
@@ -9,6 +9,11 @@ import { useInboxSelection } from '../live/inbox-selection'
 import { readWorkspaceFile } from '../components/workspace/api'
 import { InboxAttachment, InboxPage } from './InboxPage'
 
+const workspaceMocks = vi.hoisted(() => ({
+  openHeadlessRun: vi.fn(),
+  resumeSession: vi.fn(),
+}))
+
 vi.mock('../contexts/workspaces-context', () => ({
   useWorkspaces: () => ({
     workspaces: [{
@@ -16,8 +21,8 @@ vi.mock('../contexts/workspaces-context', () => ({
       tag: 'research',
       sessions: [],
     }],
-    openHeadlessRun: vi.fn(),
-    resumeSession: vi.fn(),
+    openHeadlessRun: workspaceMocks.openHeadlessRun,
+    resumeSession: workspaceMocks.resumeSession,
   }),
 }))
 
@@ -177,7 +182,7 @@ describe('InboxPage deletion', () => {
 })
 
 describe('InboxPage responsive detail header', () => {
-  it('keeps long provenance readable and mobile actions touch-sized', async () => {
+  it('keeps machine provenance on demand and mobile actions touch-sized', async () => {
     const entry = {
       id: 'inbox-mobile-header',
       ts: Date.now(),
@@ -200,9 +205,13 @@ describe('InboxPage responsive detail header', () => {
 
     render(<InboxPage visible />)
 
-    const sender = await screen.findByText('from pi · @resume-plain-linen-river-2218b6')
-    expect(sender.className).toContain('break-all')
-    expect(sender.className).toContain('sm:truncate')
+    const sender = await screen.findByRole('button', { name: 'Show sender details for pi' })
+    expect(sender.textContent).toContain('from pi')
+    expect(sender.textContent).not.toContain('resume-plain-linen-river-2218b6')
+    expect(sender.className).toContain('min-h-10')
+    expect(sender.className).toContain('sm:min-h-0')
+    expect(screen.queryByText('@resume-plain-linen-river-2218b6')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Open conversation' })).toBeNull()
 
     const issue = screen.getByRole('button', {
       name: 'from daily-us-market-close-with-a-long-name',
@@ -210,9 +219,30 @@ describe('InboxPage responsive detail header', () => {
     expect(issue.className).toContain('min-h-10')
     expect(issue.className).toContain('sm:min-h-0')
 
+    fireEvent.click(sender)
+    expect(screen.getByRole('dialog', {
+      name: 'Sender identity: pi · @resume-plain-linen-river-2218b6',
+    })).toBeTruthy()
+    expect(screen.getByText('@resume-plain-linen-river-2218b6').className).toContain('break-all')
     const openConversation = screen.getByRole('button', { name: 'Open conversation' })
-    expect(openConversation.className).toContain('h-10')
-    expect(openConversation.className).toContain('sm:h-8')
+    expect(openConversation.className).toContain('min-h-10')
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('dialog', {
+      name: 'Sender identity: pi · @resume-plain-linen-river-2218b6',
+    })).toBeNull()
+    expect(document.activeElement).toBe(sender)
+
+    fireEvent.click(sender)
+    fireEvent.click(screen.getByRole('button', { name: 'Open conversation' }))
+    await waitFor(() => expect(workspaceMocks.openHeadlessRun).toHaveBeenCalledWith(
+      'ws-1',
+      'resume-plain-linen-river-2218b6',
+      { title: 'A durable research update.' },
+    ))
+    expect(screen.queryByRole('dialog', {
+      name: 'Sender identity: pi · @resume-plain-linen-river-2218b6',
+    })).toBeNull()
 
     const deleteEntry = screen.getByRole('button', { name: 'Delete this inbox entry' })
     expect(deleteEntry.className).toContain('h-10')

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime, getIntlLocale } from '../lib/intl'
 import {
@@ -30,6 +30,7 @@ import { useIssues } from '../hooks/useIssues'
 import { useWorkspace } from '../tabs/store'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { readWorkspaceFile, type ReadFileResult } from '../components/workspace/api'
+import { workspaceDisplayName, workspaceDisplayTitle } from '../components/workspace/display'
 import type { InboxEntry, InboxDoc } from '../api/inbox'
 
 interface InboxPageProps {
@@ -225,7 +226,10 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   const { workspaces } = workspacesCtx
   const aliveWorkspace = workspaces.find((w) => w.id === entry.workspaceId) ?? null
   const wsAlive = aliveWorkspace !== null
-  const displayLabel = aliveWorkspace?.tag ?? entry.workspaceLabel ?? entry.workspaceId
+  const displayLabel = aliveWorkspace
+    ? workspaceDisplayName(aliveWorkspace)
+    : entry.workspaceLabel ?? entry.workspaceId
+  const displayTitle = aliveWorkspace ? workspaceDisplayTitle(aliveWorkspace) : displayLabel
 
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
@@ -238,6 +242,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   const issueId = origin?.issueId
   const senderSignature = origin?.resumeId ? `@${origin.resumeId}` : null
   const senderLabel = [origin?.agent, senderSignature].filter(Boolean).join(' · ') || null
+  const senderDisplay = origin?.agent ?? (senderSignature ? t('inbox.senderSession') : null)
   // Interactive provenance — the human-attended session this push came from
   // (server-stamped from AQ_SESSION_ID, validated against the session registry).
   // Navigable: opens/focuses that exact session tab.
@@ -249,6 +254,9 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   const hasSenderIdentity = !!(origin?.resumeId || origin?.runId || origin?.sessionId)
   const [continuing, setContinuing] = useState(false)
   const [continueError, setContinueError] = useState<string | null>(null)
+  const [senderPopoverOpen, setSenderPopoverOpen] = useState(false)
+  const senderPopoverRef = useRef<HTMLSpanElement>(null)
+  const senderTriggerRef = useRef<HTMLButtonElement>(null)
   // Resolve the issue id (a filename stem) to its display title via the warm,
   // process-cached board snapshot — a cheap path (no extra fetch on the hot
   // line). Falls back to the stem when the board hasn't resolved it.
@@ -258,6 +266,31 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
     const ws = issueBoard?.workspaces.find((w) => w.wsId === entry.workspaceId)
     return ws?.issues.find((i) => i.id === issueId)?.title ?? null
   }, [issueBoard, entry.workspaceId, issueId])
+
+  useEffect(() => {
+    setSenderPopoverOpen(false)
+  }, [entry.id])
+
+  useEffect(() => {
+    if (!senderPopoverOpen) return
+    const closeOnOutsideClick = (event: globalThis.MouseEvent) => {
+      if (!senderPopoverRef.current?.contains(event.target as Node)) {
+        setSenderPopoverOpen(false)
+      }
+    }
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      setSenderPopoverOpen(false)
+      senderTriggerRef.current?.focus({ preventScroll: true })
+    }
+    document.addEventListener('mousedown', closeOnOutsideClick)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutsideClick)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [senderPopoverOpen])
 
   const openWorkspace = () => {
     if (!wsAlive) return
@@ -300,6 +333,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
       } else {
         openWorkspace()
       }
+      setSenderPopoverOpen(false)
     } catch (err) {
       setContinueError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -320,30 +354,70 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   return (
     <div className="mx-auto max-w-[920px] px-4 py-6 md:px-8 md:py-8">
       {/* Provenance is identity, not a third way to open the same Session. */}
-      <header className="mb-6 border-b border-border/70 pb-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+      <header className="mb-5 border-b border-border/70 pb-3">
+        <div className="flex items-start gap-3">
           <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 flex-col items-start gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               <span
                 className={`text-[14px] font-semibold ${
                   wsAlive ? 'text-foreground' : 'text-muted-foreground/70 line-through'
                 }`}
-                title={wsAlive ? undefined : t('inbox.workspaceNotExists')}
+                title={wsAlive ? displayTitle : t('inbox.workspaceNotExists')}
               >
                 {displayLabel}
               </span>
-              {senderLabel && (
-                <span
-                  className="inline-flex min-w-0 items-start gap-1.5 text-[11px] text-muted-foreground/75 sm:items-center"
-                  title={t('inbox.senderIdentityTitle', { sender: senderLabel })}
-                >
-                  <ChevronRight size={11} className="shrink-0 text-muted-foreground/35" aria-hidden />
-                  {origin?.kind === 'interactive'
-                    ? <Terminal size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />
-                    : <Bot size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />}
-                  <span className="min-w-0 break-all sm:max-w-[380px] sm:truncate">
-                    {t('inbox.fromSender', { sender: senderLabel })}
-                  </span>
+              {senderLabel && senderDisplay && (
+                <span ref={senderPopoverRef} className="relative inline-flex min-w-0 items-center">
+                  <ChevronRight size={11} className="mr-1 shrink-0 text-muted-foreground/35" aria-hidden />
+                  <button
+                    ref={senderTriggerRef}
+                    type="button"
+                    aria-label={t('inbox.showSenderDetails', { sender: senderDisplay })}
+                    aria-haspopup="dialog"
+                    aria-expanded={senderPopoverOpen}
+                    aria-controls={`inbox-sender-${entry.id}`}
+                    onClick={() => setSenderPopoverOpen((open) => !open)}
+                    className="inline-flex min-h-10 min-w-0 items-center gap-1.5 rounded-sm text-[11px] font-medium text-muted-foreground/75 underline decoration-border underline-offset-2 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 sm:min-h-0"
+                  >
+                    {origin?.kind === 'interactive'
+                      ? <Terminal size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />
+                      : <Bot size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />}
+                    <span>{t('inbox.fromSender', { sender: senderDisplay })}</span>
+                  </button>
+                  {senderPopoverOpen && (
+                    <div
+                      id={`inbox-sender-${entry.id}`}
+                      role="dialog"
+                      aria-label={t('inbox.senderIdentityTitle', { sender: senderLabel })}
+                      className="oa-popover-enter absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] rounded-xl border border-border/70 bg-secondary p-3 text-left shadow-lg"
+                    >
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
+                        {t('inbox.senderSession')}
+                      </p>
+                      {origin?.agent && (
+                        <p className="mt-1 text-[12px] font-medium text-foreground">{origin.agent}</p>
+                      )}
+                      {senderSignature && (
+                        <p className="mt-0.5 break-all font-mono text-[10px] leading-relaxed text-muted-foreground">
+                          {senderSignature}
+                        </p>
+                      )}
+                      {wsAlive && (
+                        <button
+                          type="button"
+                          onClick={() => void continueOrigin()}
+                          disabled={continuing}
+                          className="oa-pressable mt-3 min-h-10 w-full rounded-lg bg-primary px-3 py-2 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-50"
+                        >
+                          {continuing
+                            ? t('inbox.continuingSession')
+                            : canContinueOrigin
+                              ? t('inbox.openConversation')
+                              : t('inbox.openWorkspace')}
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </span>
               )}
               {issueId && (
@@ -351,7 +425,7 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
                   type="button"
                   onClick={openIssue}
                   title={t('inbox.fromIssueTitle', { issue: issueId })}
-                  className="oa-pressable inline-flex min-h-10 w-full min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-left text-[11px] text-muted-foreground/75 hover:bg-primary/10 hover:text-primary sm:min-h-0 sm:w-auto sm:py-0.5"
+                  className="oa-pressable inline-flex min-h-10 min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-left text-[11px] text-muted-foreground/75 hover:bg-primary/10 hover:text-primary sm:min-h-0 sm:py-0.5"
                 >
                   <ListChecks size={12} strokeWidth={1.75} className="shrink-0" />
                   <span className="min-w-0 break-words sm:max-w-[220px] sm:truncate">
@@ -366,13 +440,13 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
               {formatRelativeTime(entry.ts)}
             </div>
           </div>
-          <div className="flex w-full items-center gap-2 sm:-mr-1 sm:w-auto sm:shrink-0 sm:gap-1">
-            {wsAlive && (
+          <div className="-mr-1 flex shrink-0 items-center gap-1">
+            {wsAlive && !senderLabel && (
               <button
                 type="button"
                 onClick={() => void continueOrigin()}
                 disabled={continuing}
-                className="oa-pressable inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-lg border border-border bg-background px-2 text-[11px] font-medium text-muted-foreground hover:border-primary/35 hover:text-primary disabled:cursor-not-allowed disabled:opacity-45 sm:h-8 sm:flex-none sm:px-2.5"
+                className="oa-pressable inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-border bg-background px-2 text-[11px] font-medium text-muted-foreground hover:border-primary/35 hover:text-primary disabled:cursor-not-allowed disabled:opacity-45 sm:h-8 sm:px-2.5"
                 title={canContinueOrigin ? t('inbox.openConversation') : t('inbox.openWorkspace')}
                 aria-label={canContinueOrigin ? t('inbox.openConversation') : t('inbox.openWorkspace')}
               >


### PR DESCRIPTION
## What changed

- Flipped the default time-feed hierarchy so the update headline is primary and Workspace/time are supporting provenance.
- Used current Workspace display names while retaining tags, recorded labels, ids, content, and Session provenance in search.
- Added an explicit localized fallback for pushes without comments or attachments.
- Replaced the always-visible runtime + full `resumeId` and separate Open conversation button with a compact sender trigger.
- Added an accessible sender popover that exposes the durable Session signature on demand and keeps Open conversation as an explicit second action.
- Tightened the responsive provenance header while preserving touch targets, linked Issue navigation, reply-in-Inbox, and delete.

## Why

With realistic history, most rows repeated a tag such as `chat-jul12` on the prominent line while the actual update was truncated beneath it. The detail header then exposed a long machine Session id and a large navigation action before the message. The result made Inbox read like infrastructure provenance rather than a human notification feed.

This topic removes that noise: users scan what happened first, can still search and inspect every source identity, and only leave Inbox when they explicitly choose Open conversation from the sender popover.

## UI review

- **Hierarchy:** update → Workspace/time in the list; Workspace/sender/Issue → exact Session details on demand.
- **Next action:** reply remains in Inbox; original-conversation navigation is one explicit action inside sender details.
- **Widths:** verified real 72-entry data on desktop and 390×844; no horizontal overflow at 390px.
- **Themes/locales:** verified Day/Auto, Night, English, and simplified Chinese.
- **Existing vocabulary:** reuses page navigator rows, `oa-pressable`, and `oa-popover-enter`; no new visual dialect.

## Validation

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm exec vitest run ui/src/components/InboxSidebar.spec.tsx ui/src/pages/InboxPage.spec.tsx ui/src/components/InboxReplyThread.spec.tsx` (15 passed)
- `pnpm test` (3,773 passed, 9 skipped)
- Real `pnpm dev --takeover` walkthrough of the time feed, grouped feed, sender popover, narrow drawer/detail, linked Issue, Activity, Runs, Inbox reports, and independent Automation Runs

No messages, comments, Session resumes, deletions, or trading actions were triggered during acceptance.