### PR TITLE
fix(guardian): retry transient Windows owner writes

### DIFF
--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -13,6 +13,7 @@ import {
 
 const OWNER_FILE = 'owner.json'
 const RECLAIM_DIR = 'reclaiming'
+const WINDOWS_RENAME_RETRY_DELAYS_MS = [10, 25, 50, 100] as const
 
 export const DEFAULT_HEARTBEAT_MS = 30_000
 export const DEFAULT_STALE_HEARTBEAT_MS = 90_000
@@ -203,7 +204,7 @@ export async function acquireRuntimeLock(
   for (let attempt = 0; attempt < 40; attempt++) {
     try {
       await mkdir(lockDir)
-      await writeOwnerAtomic(lockDir, owner)
+      await writeOwnerAtomic(lockDir, owner, controller)
       return makeLock(lockDir, owner, opts)
     } catch (err) {
       if (!isErrno(err, 'EEXIST')) throw err
@@ -339,7 +340,7 @@ function makeLock(lockDir: string, initialOwner: RuntimeLockOwner, opts: Runtime
       const current = await readOwner(lockDir)
       if (current.token !== owner.token) throw new Error(`runtime lock ownership changed at ${lockDir}`)
       owner = { ...owner, heartbeatAt: new Date().toISOString() }
-      await writeOwnerAtomic(lockDir, owner)
+      await writeOwnerAtomic(lockDir, owner, opts.processController ?? defaultProcessController)
     } catch (err) {
       loseOwnership(err)
     } finally {
@@ -395,15 +396,36 @@ async function claimAndRemove(current: RuntimeLockInspection): Promise<boolean> 
   }
 }
 
-async function writeOwnerAtomic(lockDir: string, owner: RuntimeLockOwner): Promise<void> {
+async function writeOwnerAtomic(
+  lockDir: string,
+  owner: RuntimeLockOwner,
+  controller: ProcessController,
+): Promise<void> {
   const ownerPath = join(lockDir, OWNER_FILE)
   const tempPath = join(lockDir, `.${OWNER_FILE}.${owner.token}.${randomUUID()}.tmp`)
   try {
     await writeFile(tempPath, JSON.stringify(owner, null, 2) + '\n', 'utf8')
-    await rename(tempPath, ownerPath)
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await rename(tempPath, ownerPath)
+        break
+      } catch (error) {
+        const retryDelay = WINDOWS_RENAME_RETRY_DELAYS_MS[attempt]
+        if (
+          process.platform !== 'win32' ||
+          retryDelay === undefined ||
+          !isTransientWindowsRenameError(error)
+        ) throw error
+        await controller.sleep(retryDelay)
+      }
+    }
   } finally {
     await rm(tempPath, { force: true }).catch(() => undefined)
   }
+}
+
+function isTransientWindowsRenameError(error: unknown): boolean {
+  return isErrno(error, 'EPERM') || isErrno(error, 'EACCES') || isErrno(error, 'EBUSY')
 }
 
 async function readOwner(lockDir: string): Promise<RuntimeLockOwner> {

--- a/packages/guardian-runtime/src/runtime-lock.windows-retry.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.windows-retry.spec.ts
@@ -1,0 +1,124 @@
+import { mkdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProcessController } from './process-control.js'
+
+const renameFault = vi.hoisted(() => ({
+  calls: 0,
+  code: 'EPERM',
+  remaining: 0,
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rename: async (...args: Parameters<typeof actual.rename>) => {
+      renameFault.calls += 1
+      if (renameFault.remaining > 0) {
+        renameFault.remaining -= 1
+        throw Object.assign(new Error(`simulated ${renameFault.code}`), { code: renameFault.code })
+      }
+      return actual.rename(...args)
+    },
+  }
+})
+
+const { acquireRuntimeLock } = await import('./runtime-lock.js')
+
+let home: string
+let originalPlatform: PropertyDescriptor | undefined
+let retryDelays: number[]
+let controller: ProcessController
+
+beforeEach(async () => {
+  home = join(tmpdir(), `guardian-runtime-windows-retry-${process.pid}-${Math.random().toString(16).slice(2)}`)
+  await mkdir(home, { recursive: true })
+  originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  renameFault.calls = 0
+  renameFault.code = 'EPERM'
+  renameFault.remaining = 0
+  retryDelays = []
+  controller = {
+    isAlive: () => true,
+    startedAt: async () => 10_000,
+    machineId: async () => 'machine-a',
+    signalTree: async () => {},
+    sleep: async (ms) => {
+      retryDelays.push(ms)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    },
+  }
+})
+
+afterEach(async () => {
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+  await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
+})
+
+describe('Windows owner replacement retry', () => {
+  it('keeps ownership through transient heartbeat rename failures', async () => {
+    const lockDir = join(home, 'runtime.lock')
+    let ownershipError: Error | null = null
+    const lock = await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 5,
+      processController: controller,
+      onOwnershipLost: (error) => { ownershipError = error },
+    })
+    const callsAfterAcquire = renameFault.calls
+    renameFault.remaining = 2
+
+    await waitFor(() => renameFault.calls >= callsAfterAcquire + 3)
+
+    expect(ownershipError).toBeNull()
+    expect(retryDelays).toEqual([10, 25])
+    await expect(readFile(join(lockDir, 'owner.json'), 'utf8')).resolves.toContain(lock.owner.token)
+    await lock.release()
+  })
+
+  it('stops retrying after the bounded transient-error schedule', async () => {
+    const lockDir = join(home, 'runtime.lock')
+    renameFault.remaining = 10
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toMatchObject({ code: 'EPERM' })
+
+    expect(renameFault.calls).toBe(5)
+    expect(retryDelays).toEqual([10, 25, 50, 100])
+  })
+
+  it('does not retry unrelated rename failures', async () => {
+    const lockDir = join(home, 'runtime.lock')
+    renameFault.code = 'EIO'
+    renameFault.remaining = 1
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toMatchObject({ code: 'EIO' })
+
+    expect(renameFault.calls).toBe(1)
+    expect(retryDelays).toEqual([])
+  })
+})
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  throw new Error('timed out waiting for the heartbeat rename retry')
+}

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -352,7 +352,7 @@ and verification before the next dependent branch starts from updated `dev`.
   parsing, transcripts, and timeouts.
 - [ ] Test normal exit, Ctrl+C, SIGTERM, renderer failure, disconnect, resize,
   Unicode, no-color, and Git Bash.
-- [ ] Salvage the independent Windows Guardian atomic-owner replacement fix
+- [x] Salvage the independent Windows Guardian atomic-owner replacement fix
   from #857 and close that superseded PR.
 
 ### 4. Supervisor TUI application


### PR DESCRIPTION
## Summary
- retry only transient Windows `EPERM`, `EACCES`, and `EBUSY` failures while atomically replacing Guardian owner metadata
- keep retries bounded to 10/25/50/100 ms and preserve immediate failure on other platforms or unrelated I/O errors
- add deterministic acquisition, heartbeat, exhaustion, and non-retry regressions
- salvage the independent Guardian fix from superseded TUI prototype #857 without bringing its rejected handwritten renderer into `dev`

## Verification
- `pnpm exec vitest run packages/guardian-runtime/src/runtime-lock.windows-retry.spec.ts` (3 passed)
- `pnpm -F @traderalice/guardian-runtime typecheck`
- Guardian recovery skill `full`: 24 package tests, real duplicate/takeover/crash/stubborn-tree recovery, full repository Vitest (3,830 passed, 9 skipped), and real dev Guardian boot/teardown

## Residual platform gate
The retry behavior is deterministically simulated locally. The Windows CI lane remains the authoritative platform confirmation.
