### PR TITLE
test(cli): normalize path assertions on Windows

### DIFF
--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -110,7 +110,7 @@ describe('ResolvedLaunchContext', () => {
       },
     })
 
-    expect(installed.appDir).toBe('/installed/runtime')
+    expect(installed.appDir).toBe(resolve('/installed/runtime'))
     expect(installed.runtimeProvider).toEqual({
       kind: 'bundle',
       contentIdentity: '0123456789abcdef',
@@ -130,7 +130,7 @@ describe('ResolvedLaunchContext', () => {
         OPENALICE_MANAGED_RUNTIME_CONTENT_IDENTITY: '0123456789abcdef',
       },
     })
-    expect(configured.appDir).toBe('/configured/source')
+    expect(configured.appDir).toBe(resolve('/configured/source'))
     expect(configured.runtimeProvider).toEqual({
       kind: 'source',
       contentIdentity: null,

--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -179,7 +179,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
     expect(inspectRuntime).toHaveBeenCalledWith(
       expect.objectContaining({
         instance: 'research',
-        homeRoot: '/srv/openalice-research',
+        homeRoot: resolve('/srv/openalice-research'),
       }),
       expect.any(Object),
     )
@@ -202,7 +202,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
     expect(automaticStart).toHaveBeenCalledWith(
       expect.objectContaining({
         appDir: null,
-        homeRoot: '/home/alice/.openalice',
+        homeRoot: resolve('/home/alice/.openalice'),
         port: undefined,
         checkUpdates: true,
       }),
@@ -236,8 +236,8 @@ describe('OpenAlice top-level lifecycle commands', () => {
     )).resolves.toBe(0)
     expect(configuredStart).toHaveBeenCalledWith(
       expect.objectContaining({
-        appDir: '/srv/OpenAlice',
-        homeRoot: '/srv/openalice-research',
+        appDir: resolve('/srv/OpenAlice'),
+        homeRoot: resolve('/srv/openalice-research'),
         port: 49_001,
         checkUpdates: false,
       }),

--- a/packages/cli/src/observability-command.spec.mjs
+++ b/packages/cli/src/observability-command.spec.mjs
@@ -132,7 +132,7 @@ describe('observability command presenter', () => {
     expect(readLogs).toHaveBeenCalledWith(
       expect.objectContaining({
         instance: 'research',
-        homeRoot: '/srv/openalice-research',
+        homeRoot: resolve('/srv/openalice-research'),
       }),
       expect.any(Object),
     )

--- a/packages/cli/src/supervisor-config.spec.ts
+++ b/packages/cli/src/supervisor-config.spec.ts
@@ -67,9 +67,9 @@ describe('Supervisor configuration', () => {
 
     expect(context).toMatchObject({
       instance: 'research',
-      home: '/env-home',
+      home: resolve('/env-home'),
       port: 44_000,
-      appDir: '/instance-app',
+      appDir: resolve('/instance-app'),
       provenance: {
         instance: { source: 'machine-config' },
         home: { source: 'environment' },


### PR DESCRIPTION
## Summary
- make Supervisor launch-context, lifecycle, logs, and configuration assertions use the host platform's `node:path.resolve` result
- preserve production path normalization while removing POSIX-only expectations from the Windows cross-platform lane
- address the five assertions reported by the post-merge #894 Windows job

## Verification
- targeted CLI specs: 4 files, 36 tests passed
- `pnpm -F @traderalice/openalice-cli build`
- `npx tsc --noEmit`
- `pnpm test` (458 files passed, 3,830 tests passed)

## CI evidence
The failed Windows runner produced normalized `D:\\...` paths while the tests expected `/...`; these assertions now derive the expected native path through `resolve(...)`.
