### PR TITLE
test(cli): preserve Windows default-home semantics

### DIFF
--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -202,7 +202,7 @@ describe('OpenAlice top-level lifecycle commands', () => {
     expect(automaticStart).toHaveBeenCalledWith(
       expect.objectContaining({
         appDir: null,
-        homeRoot: resolve('/home/alice/.openalice'),
+        homeRoot: join('/home/alice', '.openalice'),
         port: undefined,
         checkUpdates: true,
       }),


### PR DESCRIPTION
## Summary
- derive the default OpenAlice home expectation with `join(homeDir, '.openalice')`, matching the production contract on Windows and POSIX
- fix the final Windows assertion left after #923 normalized explicit absolute-path fixtures

## Verification
- targeted lifecycle command spec: 12 tests passed
- `npx tsc --noEmit`
- `pnpm test` (458 files passed, 3,830 tests passed)

## CI evidence
#923's Windows rerun confirmed the four explicit-path fixes and isolated this last mismatch: production correctly returned the root-relative `\\home\\alice\\.openalice`, while `resolve(...)` incorrectly injected the runner's `D:` working drive into the expectation.
