### PR TITLE
refactor(cli): clarify workspace command boundaries

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -1,249 +1,195 @@
 ---
 name: alice-workspace
 description: >
-  Use the `alice-workspace` CLI for collaboration and provenance: Inbox
-  delivery, the global Issue board, tracked entities, peer files, and asking an
-  attributable product Session. Use it when work must be surfaced, remembered,
-  assigned, or followed back to the Agent that produced it. Read live help and
-  choose comments for durable Issue discussion versus asks for historical inquiry.
+  Use the `alice-workspace` CLI for collaboration between durable OpenAlice
+  Workspaces: find peers, send ordinary Agent messages, deliver reports to the
+  human Inbox, coordinate Issues, and trace artifacts to attributable product
+  Sessions. Load it when work must cross a Workspace boundary or remain
+  recoverable. Read live help instead of guessing flags.
 ---
 
-# Collaboration — `alice-workspace`
+# Workspace collaboration — `alice-workspace`
 
-Choose the verb from the intent, not from whichever object you happen to have:
+OpenAlice owns addresses, delivery, durable work, and provenance. Coding Agents
+keep using their native file, search, and Git tools inside any resolved path.
 
-| Intent | Command family |
-|---|---|
-| Tell the human about finished/asynchronous work | `inbox push` |
-| Read what desks already surfaced | `inbox read` |
-| Ask why one Inbox entry was produced | `inbox ask` |
-| Inspect the shared work board | `issue list` / `issue show` |
-| Ask an Issue's creator or selected historical run | `issue ask` |
-| Discuss this Workspace's own Issue; notify its fixed owner | `issue comment` |
-| Ask or delegate by product Session/Workspace when no business object exists | `conversation ask` |
-| Bring this desk's managed instructions and skills up to date | `template upgrade` |
-| Inventory every active desk before coordinating the floor | `peer list` |
+## The command model
 
-`issue comment` is the durable conversation entry for this Workspace's own
-Issue. If the Issue has an exact `@resumeId` assignee, a comment from somebody
-else resumes that owner in the background and records the final reply in the
-Activity timeline. A human comment without a fixed owner asks the creator or a
-reconstructed Workspace Agent without changing assignee. Agent-authored
-comments without a fixed owner remain notes. Use `issue ask` when interrogating
-the creator or a specific historical run without adding a comment.
+| Group | Owns | Does not own |
+|---|---|---|
+| `peer` | Active Workspace discovery, absolute paths, Session directory | File reading or research |
+| `conversation` | Ordinary Agent-to-Agent requests and replies | Human notification |
+| `inbox` | Human-facing report delivery and follow-up | General peer chat |
+| `issue` | Durable work, ownership, scheduling, Activity | Ad-hoc questions |
+| `provenance` | Artifact-to-Session attribution | Guessing intent |
+| `signature` | The current Session's safe `@resumeId` | Runtime-native ids |
+| `track` | Shared durable asset/topic index | Work status |
+| `template` | Managed Workspace guidance upgrades | Harness research lifecycle |
 
-**Hand finished work back to the user** — this is the outbound channel. It posts
-to the user's Inbox tab:
+Start with live intent help whenever the route is unclear:
 
 ```bash
-alice-workspace inbox push --doc research/tsla.md --comments "Done — TSLA looks extended; details in the doc."
+alice-workspace
+alice-workspace <group>
+alice-workspace <group> <verb> --help
 ```
 
-(Attach files with repeatable `--doc <path>` — workspace-relative; each renders
-live in the inbox UI. OpenAlice records the exact published content hash even
-though later edits remain visible. `--comments` is your markdown note. At
-least one of `--doc` / `--comments` must be present.)
+## Talk to another Agent
 
-> **Commit before you push.** The inbox renders your files live, not a snapshot —
-> a `git commit` is the only durable record of what you actually sent. Skip it and
-> a later edit changes what the entry shows. The publication hash proves which
-> revision was sent, while the commit preserves content you can recover.
-
-**Look back at the inbox** — recall what's been surfaced, newest first:
+Use `conversation`, not Inbox, for ordinary coworker communication.
 
 ```bash
-alice-workspace inbox read --self            # only your own pushes
-alice-workspace inbox read --limit 5         # latest 5 across all workspaces
-```
-
-(`--self` narrows to entries THIS workspace pushed — their `docs` paths are
-relative to your own workspace root, so you can open them straight from the
-shell. Each entry also carries a `workspaceId`; for entries from OTHER
-workspaces, that's the handle to locate their files — see below. Agent-produced
-entries also carry safe `origin` provenance: `runId` / `sessionId`, `resumeId`,
-`issueId`, and `agent` when available. Native runtime session ids stay hidden.
-`--limit` caps the window, default 20.)
-
-**Read & edit a peer's files** — workspaces collaborate; another workspace's docs
-are reachable. Resolve the peer's absolute dir by its `workspaceId`, then use your
-own file tools:
-
-```bash
-# active office-floor inventory (ids, templates, live workload counts)
+# Discover the active office floor and choose a desk.
 alice-workspace peer list
-# --id is the `workspaceId` from an inbox_read entry (a uuid), e.g.:
-alice-workspace peer path --id 550e8400-e29b-41d4-a716-446655440000
-alice-workspace peer sessions --id 550e8400-e29b-41d4-a716-446655440000
-# -> { path: "/…/workspaces/550e8400-…", tag, id }
-# then read <path>/<the doc path from the inbox entry> with your native tools
+
+# Recruit a fresh Session at that Workspace for new work.
+alice-workspace conversation ask --ws-id <workspaceId> \
+  --prompt 'Investigate this bounded question and report back.'
+
+# Continue one exact attributable product Session.
+alice-workspace conversation ask --resume-id <resumeId> \
+  --prompt 'Explain the missing context.' --await
 ```
 
-(Reading a peer's files is fine. For your OWN entries you don't need this at all;
-their doc paths are already relative to your cwd.)
+Prompts are ordinary coworker messages. Add `--reconstruct` only when the task
+explicitly requires a fresh worker to reconstruct missing historical intent.
+Provenance may still report `resolution.mode: reconstructed` without changing
+the prompt when no original author is available.
 
-**Trace an artifact back to a Session** — query the immutable attribution trail
-without exposing a runtime-native session id:
+Choose the waiting rhythm from the work:
+
+- A short answer needed now: add `--await`.
+- A longer delegation: omit `--await`, retain `taskId`, then retrieve it later.
+- Several independent peers: dispatch first, then collect the task ids together.
 
 ```bash
-alice-workspace provenance show --kind issue --issue-id <id>
-alice-workspace provenance show --kind report --path research/report.md --revision <sha256:...>
-alice-workspace provenance show --kind trade-decision --account-id <account> --decision-id <uta-commit-hash>
-alice-workspace provenance show --resume-id <resumeId>  # reverse lookup: artifacts attributed to one Session
+alice-workspace conversation await --task-id <taskId>
+alice-workspace conversation read --task-id <taskId>
+alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
 ```
 
-For Issue/report keys, `--workspace-id` defaults to your current Workspace.
-`resumeId` is the follow-up handle; `taskId` is only execution evidence. A
-missing origin is not permission to pick an arbitrary old Session.
+There is no unsolicited Agent-to-Agent completion notification bus. Inbox
+notifies the human; `await`, `read`, and `collect` retrieve direct Agent replies.
+Do not build shell sleep loops.
 
-**Ask who was responsible** — resolve the business target, then dispatch a
-headless follow-up without leaving the embedded Workspace CLI:
+## Deliver and read reports
+
+Inbox is the outbound human delivery surface. A normal attended Chat reply
+already reaches the user; scheduled/headless work must push explicitly when its
+result deserves human attention.
+
+```bash
+alice-workspace inbox push \
+  --doc research/report.md \
+  --comments 'Finished — the report contains the evidence and conclusion.'
+```
+
+`--doc` is repeatable and Workspace-relative. The Inbox renders the live file
+and records the exact published content hash. Commit before pushing so Git can
+recover what was sent even if the path later changes.
+
+Read recent deliveries with:
+
+```bash
+alice-workspace inbox read --limit 5
+alice-workspace inbox read --self
+```
+
+For your own entries, document paths are relative to the current cwd. For a
+peer entry, use its `workspaceId` only to resolve the peer root:
+
+```bash
+alice-workspace peer path --id <workspaceId>
+# Combine the returned absolute path with the Inbox document's relative path,
+# then use the Coding Agent's native Read/Search/Glob/Git capabilities.
+```
+
+There is deliberately no Workspace-level file-read command. `peer path` owns
+addressing; the Coding Agent owns file operations. Reading another Workspace is
+normal. Autonomous/headless work writes only its own Workspace. An attended
+cross-Workspace edit requires explicit human approval and must be committed in
+the peer repository so its owner can review or revert it.
+
+For AutoQuant, a lane Report is the focused handoff and a Dossier is the
+cross-lane deliverable. AutoQuant owns their contents and evidence; OpenAlice
+only delivers the exact committed files and stamps their origin.
+
+## Follow up on an existing object
+
+Prefer the business object when one already identifies the responsible work:
 
 ```bash
 alice-workspace inbox ask --id <entryId> \
   --prompt 'Why did you send this result?' --await
+
 alice-workspace issue ask --id <issueName> --creator \
-  --prompt 'Why did you create this Issue?' --await
+  --prompt 'Why was this Issue created?' --await
 alice-workspace issue ask --id <issueName> --owner \
   --prompt 'What is the current state and next decision?' --await
 alice-workspace issue ask --id <issueName> --run-id <taskId> \
-  --prompt 'What happened in this run?' --await
-
-# Lower-level escape hatches when there is no Inbox/Issue business object:
-alice-workspace conversation ask --resume-id <resumeId> \
-  --prompt 'Explain the missing context.' --await
-alice-workspace conversation ask --ws-id <ws> \
-  --prompt 'Please investigate this bounded question and report back.'
-alice-workspace conversation ask --ws-id <ws> \
-  --prompt 'Reconstruct why this unattributed artifact was produced.' --reconstruct --await
-alice-workspace conversation await --task-id <taskId>
-alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
-alice-workspace conversation read --task-id <taskId>
+  --prompt 'What happened in this execution?' --await
 ```
 
-Prefer the Inbox/Issue commands: they resolve provenance without making you
-extract `resumeId` or `wsId`. `issue ask` defaults to `--creator`; `--owner`
-requires a stable resume owner, while `--run-id` selects one exact run Session.
-Use the lower-level conversation command only when no business object already
-identifies whom to ask. Never construct or pass an internal target JSON object.
+These wrappers resolve provenance without making you extract a `resumeId`.
+Never choose an arbitrary old Session when an artifact lacks an exact author.
 
-Choose the waiting rhythm from the work:
+Resolution means:
 
-- **Short consultation needed for the current answer:** use `ask --await`.
-  OpenAlice waits server-side and returns the final reply without a guessed
-  sleep duration.
-- **Delegation that may take a while:** omit `--await`. Keep the returned
-  `taskId`/`resumeId`, continue useful work, and later use `conversation read`
-  or `conversation await`. The peer can create its own local Issue/schedule and
-  push a finished report to Inbox.
-- **Several independent peers:** dispatch every ask first without `--await`,
-  then pass the task ids to one `conversation collect` call.
-- **Human-facing completion:** ask the worker to use `inbox push` when the
-  result should surface in the user's Inbox.
+- `exact`: the attributable product Session continued;
+- `reconstructed`: a fresh worker was recruited only in the known Workspace;
+- `unavailable`: the attributed Session or safe Workspace target cannot resume.
 
-There is not yet an unsolicited Agent-to-Agent completion notification bus.
-Inbox reaches the human; `read`/`await`/`collect` retrieves a dispatched Agent
-reply. If collect reports a task still `running`, do other useful work and
-collect again later or use one-shot `conversation read`; never build a shell
-`sleep` polling loop.
-
-Prompts are delivered as ordinary coworker messages by default. Add
-`--reconstruct` only when the request explicitly asks a fresh fallback worker
-to reconstruct an artifact or decision whose author cannot be resumed. The
-`resolution.mode` may still say `reconstructed` for honest provenance even when
-that optional prompt guidance was not requested.
-
-Inspect `resolution.mode` on the ask result:
-
-- `exact` continues the attributable product Session;
-- `reconstructed` starts a fresh worker only in the target's known Workspace,
-  records it against the artifact, and reuses it on later questions without
-  letting it impersonate the original author;
-- `unavailable` means an attributed Session cannot resume, or no safe
-  Workspace target exists. Do not work around it by picking another old
-Session. Poll `conversation read` until `status` leaves `running`; its default
-output keeps the final `assistantText` and a compact error when needed. Prefer
-the server-side await flow above; use `read` as the fallback snapshot. Use
-`--mode detailed` only for diagnostics that genuinely need tool/message blocks.
-
-> **Editing a peer is interactive-only.** Reading another workspace is always OK.
-> *Editing* one means reaching outside your own workspace — only do that in an
-> interactive session where a person is present to approve it. An autonomous /
-> headless run reads peers but writes ONLY its own workspace. If you do edit a
-> peer (with approval), leave your change as a clear `git commit` in that repo so
-> the owner can review or revert it — never edit-and-walk-away. (Your workspace's
-> git identity is set automatically, so the author is honest.)
-
-**Track entities** — the durable cross-workspace tracked index (`[[name]]`):
+## Trace provenance
 
 ```bash
-alice-workspace track search --query "uranium"
-alice-workspace track add --name uranium-ccj --description "Cameco — uranium miner"
+alice-workspace provenance show --kind inbox --inbox-entry-id <entryId>
+alice-workspace provenance show --kind issue --issue-id <id>
+alice-workspace provenance show --kind report --workspace-id <workspaceId> \
+  --path research/report.md --revision <sha256:...>
+alice-workspace provenance show --resume-id <resumeId>
+alice-workspace signature show
 ```
 
-**The issue board** — the cross-workspace work list, shared by you and the user.
-It's *what's on the plate* when you've lost the thread — scan it when you start.
-**Reads are global, writes are local:**
+`resumeId` is the product follow-up handle; `taskId` is one execution. Native
+runtime Session ids remain backend-only. `inbox ask` identifies the sender of a
+delivery, which may differ from whoever last edited its live document.
+
+## Coordinate durable work
+
+Issue reads span the shared board; writes belong to this Workspace:
 
 ```bash
-alice-workspace issue list                  # startup-safe summary: local + active urgent/high/medium rows
-alice-workspace issue list --mode detailed  # full global board, including low-priority scheduled noise
-alice-workspace issue show --id <name>      # compact issue + provenance/resumeId run/report references
-alice-workspace issue show --id <name> --mode detailed  # every execution prompt + full reports
-alice-workspace issue create --title "…"    # a new issue on THIS workspace's board
-alice-workspace issue create --title "…" --when '{"kind":"every","every":"1h"}' --assignee @me
+alice-workspace issue list
+alice-workspace issue list --mode detailed
+alice-workspace issue show --id <name>
+alice-workspace issue create --title 'Investigate the anomaly'
 alice-workspace issue update --id <id> --status in_progress
-alice-workspace issue comment --id <id> --text "question / progress note / finding"
-alice-workspace signature show               # your @resumeId for standalone Markdown
+alice-workspace issue comment --id <id> --text 'Evidence collected; review next.'
 ```
 
-Work it like a human board: start with plain `list`, decide which focus rows
-matter, then `show --id <name>` to read those in full. Plain `list` is deliberately
-curated for startup so old low-priority scheduled items do not distract you; use
-`--mode detailed` only when you are auditing the full board. `list` / `show` span
-the whole board (all workspaces); `create` / `update` / `comment` write **this**
-workspace's own `.alice/issues/` files (changing a peer's board is the
-human-approved peer-edit path). The full on-disk file model + self-scheduling
-(an issue with a `when` fires a headless run) lives in the **`self-scheduling`**
-skill. `assignee` is the single ownership and dispatch contract: `@new`
-recruits once and then keeps that first Session, `@workspace` recruits a new
-Session each fire, `@me` resolves to the caller, and an exact `@resumeId` keeps
-one accountable product Session. Omitted scheduled ownership defaults to
-`@new` unless an attributable resumable caller owns it as `@me`; use
-`@workspace` explicitly for fresh-every-fire work. Commit intentional
-Issue-file changes as a focused Git change; Activity remains an audit fallback,
-while Git is the exact rollback history. Issue/Inbox CLI actions are signed
-automatically. End standalone reports with `Signed-by: @resumeId`
-(copy it from `signature show`) so another Agent can return to the author.
+Use `issue comment` for durable discussion on this Workspace's Issue. Use
+`issue ask` to interrogate a creator, fixed owner, or selected historical run.
+Scheduling and the complete Issue file/assignee contract belong to the
+`self-scheduling` skill.
 
-**Upgrade this Workspace's managed template assets** — preview first, then
-apply explicitly:
+Tracked entities are the durable cross-Workspace subject index, not tasks:
+
+```bash
+alice-workspace track search --query uranium
+alice-workspace track add --name uranium-ccj --description 'Cameco — uranium miner'
+```
+
+## Upgrade managed Workspace guidance
+
+Preview first; apply only after reviewing the plan:
 
 ```bash
 alice-workspace template upgrade
-alice-workspace template upgrade --apply
-alice-workspace template upgrade --id <workspaceId>       # manage a paused peer
-alice-workspace template upgrade --id <workspaceId> --apply
-```
-
-The default call is read-only. It compares this Workspace with the current
-template and lists ready changes, protected local customizations, blockers, and
-conflicts. `--apply` re-plans and runs the launcher's transactional upgrade;
-there is no HTTP endpoint or plan digest to copy by hand. Omit `--id` for this
-Workspace, or pass a peer Workspace id when interactively managing another
-desk. Applying to the current Workspace from one of its own live Sessions will
-correctly remain blocked; pause it or use a separate manager Workspace. A
-headless run may preview a peer but cannot apply a cross-Workspace upgrade.
-
-If a managed file changed both locally and in the template, resolve every
-conflict explicitly before applying:
-
-```bash
 alice-workspace template upgrade --mode detailed
-alice-workspace template upgrade --id <workspaceId> --apply \
-  --keep-workspace AGENTS.md \
-  --use-template .agents/skills/alice-workspace/SKILL.md
+alice-workspace template upgrade --apply
+alice-workspace template upgrade --id <workspaceId>
 ```
 
-Both resolution flags are repeatable. Upgrade never adopts research, reports,
-Issues, credentials, runtime state, or other user files. It also refuses to run
-while Sessions/headless work are active or unrelated changes are staged.
+Applying to a live current Workspace is blocked. A headless run may preview a
+peer but cannot apply a cross-Workspace upgrade. Conflict resolution, lifecycle
+guards, and managed-file boundaries are reported by the live command.

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -57,6 +57,26 @@ product bug.
 Use the real shim in the verification loop; direct tool calls do not exercise
 argv parsing or manifest help.
 
+The four public CLI names are deliberate authority boundaries rather than one
+flat command bag:
+
+| CLI | Boundary |
+|---|---|
+| `alice` | Workspace research data, subscribed-feed archive, symbols, and bounded K-line analysis |
+| `traderhub` | Low-frequency boards, fundamentals, macro, and calendars |
+| `alice-workspace` | Peer addressing, Agent conversation, human Inbox delivery, durable work, and provenance |
+| `alice-uta` | Broker reads plus explicit trading mutations and approval flow |
+
+Every export manifest supplies intent-first descriptions for its command
+groups. Top-level and group help must explain which namespace owns an action
+before listing verbs. Skills may teach workflows, but an old copied skill must
+be able to recover from current live help.
+
+`alice-workspace peer path` is an addressing primitive only. Once a Workspace
+root is resolved, native Coding Agent file, search, and Git capabilities own
+the read flow. Do not grow a second Workspace file API merely to reproduce
+those capabilities; adapter permission problems belong at the runtime boundary.
+
 ## Snapshot and upgrade semantics
 
 Guidance is copied into a Workspace at creation and committed as part of its

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -176,11 +176,11 @@ export interface WorkspaceToolContext {
   /** Durable Session -> artifact occurrence trail. Optional for older/tests. */
   provenanceStore?: IProvenanceStore
   /** Resolve ANY workspace's location by id (not just this one) — the backing
-   *  for cross-workspace collaboration: an inbox entry from a peer carries its
+   *  for cross-workspace collaboration: an Inbox entry from a peer carries its
    *  workspaceId, and `workspace_path` turns that into the peer's absolute dir
-   *  so the agent can read/edit its files with native tools. Optional because
-   *  it needs the live WorkspaceService (created after this center); the two
-   *  build sites (cli.ts, mcp.ts) inject a lazy closure, tests may omit it. */
+   *  for native file/search/Git tools. Optional because it needs the live
+   *  WorkspaceService (created after this center); the two build sites (cli.ts,
+   *  mcp.ts) inject a lazy closure, tests may omit it. */
   resolveWorkspace?: (id: string) => { id: string; dir: string; tag: string } | null
   /** Active-desk inventory for manager and peer-discovery flows. */
   workspaceInventory?: () => Promise<readonly {

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -6,6 +6,7 @@ import {
   exportKeyForBinary,
   getExport,
   mappedToolNames,
+  mappedToolNamesForScope,
 } from './cli-commands.js'
 import { createNewsArchiveTools } from '../tool/news.js'
 import { createMarketSearchTools } from '../tool/market.js'
@@ -120,6 +121,17 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
 })
 
 describe('CLI_EXPORTS — structure', () => {
+  it('describes every group exactly once for live intent-first help', () => {
+    for (const [key, exp] of Object.entries(CLI_EXPORTS)) {
+      expect(Object.keys(exp.groupDescriptions), `${key}: group help drift`).toEqual(
+        Object.keys(exp.commands),
+      )
+      for (const [group, description] of Object.entries(exp.groupDescriptions)) {
+        expect(description.trim().length, `${key} ${group}: empty group description`).toBeGreaterThan(0)
+      }
+    }
+  })
+
   it('no export maps the same tool from two verbs', () => {
     for (const [key, exp] of Object.entries(CLI_EXPORTS)) {
       const seen = new Set<string>()
@@ -130,6 +142,18 @@ describe('CLI_EXPORTS — structure', () => {
         }
       }
     }
+  })
+
+  it('unions sibling exports without crossing registry scopes', () => {
+    const global = mappedToolNamesForScope('global')
+    const scoped = mappedToolNamesForScope('scoped')
+    expect(global).toEqual(new Set([
+      ...mappedToolNames('data'),
+      ...mappedToolNames('traderhub'),
+      ...mappedToolNames('uta'),
+    ]))
+    expect(scoped).toEqual(mappedToolNames('workspace'))
+    for (const name of scoped) expect(global.has(name)).toBe(false)
   })
 
   it('maps a binary name to its export key (alice -> data, alice-<x> -> <x>)', () => {

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -38,6 +38,10 @@ export interface CliExport {
   /** Which registry backs this export — global catalog vs per-workspace scoped. */
   readonly scope: 'global' | 'scoped'
   readonly description: string
+  /** Short intent-first help for each command group. The live manifest exposes
+   * this separately from verb descriptions so old Workspace skills can recover
+   * from the CLI itself without guessing which namespace owns an action. */
+  readonly groupDescriptions: Record<string, string>
   /** group -> verb -> internal tool name. */
   readonly commands: Record<string, Record<string, string>>
 }
@@ -47,6 +51,12 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
     binary: 'alice',
     scope: 'global',
     description: 'Market & research data sources',
+    groupDescriptions: {
+      rss: 'Search and read the user\'s collected subscribed-feed archive',
+      market: 'Discover symbols, bar sources, and optional market-data vendors',
+      analysis: 'Read dated K-lines, calculate indicators, and run bounded simulations',
+      think: 'Evaluate side-effect-free calculations',
+    },
     commands: {
       // `rss`, not `news`: the backing store is the RSS collector's archive —
       // only what the user's subscribed feeds pulled. Naming it "news" baited
@@ -84,6 +94,17 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
     binary: 'traderhub',
     scope: 'global',
     description: 'Low-frequency market data — boards, fundamentals, macro, calendars (TraderHub-first)',
+    groupDescriptions: {
+      board: 'Read finished market boards and sector rotation',
+      equity: 'Read company profiles, fundamentals, estimates, and calendars',
+      etf: 'Search ETFs and inspect holdings or sector exposure',
+      economy: 'Read US and euro-area macro series',
+      global: 'Compare cross-country economic indicators',
+      shipping: 'Inspect ports and maritime chokepoints',
+      fed: 'Read FOMC documents, the Fed balance sheet, and dealer positioning',
+      crypto: 'Inspect crypto derivatives markets',
+      index: 'Discover index identifiers',
+    },
     commands: {
       board: {
         get: 'marketGetBoard',
@@ -145,8 +166,31 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
   workspace: {
     binary: 'alice-workspace',
     scope: 'scoped',
-    description: 'Workspace collaboration and management — Inbox, Issues, peers, provenance, and managed template upgrades',
+    description: 'Workspace collaboration — address peers, talk to Agents, deliver reports, coordinate Issues, and inspect provenance',
+    groupDescriptions: {
+      peer: 'Discover active desks, their Sessions, and absolute filesystem locations',
+      conversation: 'Send ordinary Agent-to-Agent requests and retrieve their replies',
+      inbox: 'Deliver reports to the human Inbox or inspect and follow up on deliveries',
+      issue: 'Read the shared work board and manage this Workspace\'s durable work',
+      provenance: 'Trace business artifacts to attributable product Sessions',
+      signature: 'Show this Session\'s safe product identity',
+      track: 'Maintain the shared index of durable assets and topics',
+      template: 'Preview or apply managed Workspace-template updates',
+    },
     commands: {
+      // Peer commands only provide collaboration addresses. Coding Agents use
+      // their own native file/search/Git tools once `path` resolves a desk.
+      peer: {
+        list: 'workspace_list',
+        path: 'workspace_path',
+        sessions: 'workspace_sessions',
+      },
+      conversation: {
+        ask: 'conversation_ask',
+        await: 'conversation_await',
+        collect: 'conversation_collect',
+        read: 'conversation_read',
+      },
       // inbox push: surface doc(s) + comment to the user's Inbox tab. Attach
       // files with repeatable `--doc <path>` (the shim folds them into the
       // `docs: [{ path }]` array; bare paths wrap, JSON objects pass through);
@@ -158,19 +202,6 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
         push: 'inbox_push',
         read: 'inbox_read',
         ask: 'inbox_ask',
-      },
-      // peer path: resolve another workspace's absolute dir by id (the
-      // `workspaceId` an inbox_read entry carries), so the agent can read/edit
-      // that peer's files with native tools — cross-workspace collaboration.
-      peer: {
-        list: 'workspace_list',
-        path: 'workspace_path',
-        sessions: 'workspace_sessions',
-      },
-      // track: the durable cross-workspace tracked-entity index ([[name]]).
-      track: {
-        add: 'entity_upsert',
-        search: 'entity_search',
       },
       // issue: the issue board. READS are GLOBAL — `list` scans every
       // workspace's titles, `show <name>` resolves a name across the board and
@@ -191,11 +222,10 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       signature: {
         show: 'session_signature',
       },
-      conversation: {
-        ask: 'conversation_ask',
-        await: 'conversation_await',
-        collect: 'conversation_collect',
-        read: 'conversation_read',
+      // track: the durable cross-workspace tracked-entity index ([[name]]).
+      track: {
+        add: 'entity_upsert',
+        search: 'entity_search',
       },
       // Current-Workspace managed template reconciliation. Preview is the
       // default; `--apply` explicitly performs the reviewed safe operation.
@@ -208,6 +238,15 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
     binary: 'alice-uta',
     scope: 'global',
     description: 'Trading — accounts, portfolio, orders, and the trading-as-git approval flow',
+    groupDescriptions: {
+      account: 'Read trading accounts and portfolios',
+      contract: 'Resolve broker instruments and quotes before trading',
+      order: 'Inspect or mutate broker orders',
+      position: 'Close an existing position',
+      git: 'Review, commit, push, reject, or synchronize staged trading decisions',
+      market: 'Read broker market-clock state',
+      sim: 'Drive the MockBroker simulator only',
+    },
     commands: {
       account: {
         list: 'listUTAs',
@@ -275,6 +314,18 @@ export function mappedToolNames(exportKey: string): Set<string> {
   if (!exp) return names
   for (const verbs of Object.values(exp.commands)) {
     for (const toolName of Object.values(verbs)) names.add(toolName)
+  }
+  return names
+}
+
+/** Every tool exposed by any CLI export sharing one registry scope. Used by
+ * manifest diagnostics so a tool owned by `alice-uta` is not falsely reported
+ * as an unmapped capability merely because the caller opened `alice` help. */
+export function mappedToolNamesForScope(scope: CliExport['scope']): Set<string> {
+  const names = new Set<string>()
+  for (const [key, exp] of Object.entries(CLI_EXPORTS)) {
+    if (exp.scope !== scope) continue
+    for (const name of mappedToolNames(key)) names.add(name)
   }
   return names
 }

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -121,9 +121,16 @@ describe('CLI gateway — export scope isolation', () => {
   it('the workspace export manifest resolves (its own scope)', async () => {
     const res = await app.request('/cli/ws1/workspace/manifest')
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { export: string; groups: Record<string, unknown> }
+    const body = (await res.json()) as {
+      export: string
+      groupDescriptions: Record<string, string>
+      groups: Record<string, unknown>
+    }
     expect(body.export).toBe('workspace')
     expect(typeof body.groups).toBe('object')
+    expect(body.groupDescriptions['peer']).toContain('absolute filesystem locations')
+    expect(body.groupDescriptions['conversation']).toContain('Agent-to-Agent')
+    expect(body.groupDescriptions['inbox']).toContain('human Inbox')
   })
 })
 

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -20,7 +20,8 @@
  * Each export resolves tools from ONE scope (global ToolCenter for `data`,
  * the per-workspace WorkspaceToolCenter for `workspace`) and invoke is gated to
  * that export's own map — so `alice` can't reach a collaboration tool and
- * vice-versa, and trading/cron stay off entirely (no `uta` export yet).
+ * vice-versa. Trading has its own explicit `uta` export; cron remains off the
+ * CLI surface and is available only through its owned scheduling paths.
  */
 
 import type { Hono } from 'hono'
@@ -39,7 +40,12 @@ import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
 import type { WorkspaceService } from '../workspaces/service.js'
 import { logger as launcherLogger } from '../workspaces/logger.js'
 import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
-import { type CliExport, getExport, mappedToolNames } from './cli-commands.js'
+import {
+  type CliExport,
+  getExport,
+  mappedToolNames,
+  mappedToolNamesForScope,
+} from './cli-commands.js'
 import { resolveInboxOrigin } from './inbox-origin.js'
 import { extractTradeDecisionRefs } from './trade-provenance.js'
 import { createWorkspaceConversationControl } from '../workspaces/conversation-control.js'
@@ -220,12 +226,19 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps): void {
       }
     }
 
-    // No-silent-caps: surface tools registered IN THIS SCOPE but not reachable
-    // via this export, so coverage gaps are visible rather than implied-complete.
-    const mapped = mappedToolNames(c.req.param('export'))
+    // No-silent-caps diagnostics: surface tools registered in this registry
+    // scope but not owned by ANY public CLI. Sibling global exports deliberately
+    // share ToolCenter, so a UTA tool must not look like a missing `alice` verb.
+    const mapped = mappedToolNamesForScope(r.exp.scope)
     const unmapped = cat.inventoryNames().filter((n) => !mapped.has(n))
 
-    return c.json({ export: c.req.param('export'), description: r.exp.description, groups, unmapped })
+    return c.json({
+      export: c.req.param('export'),
+      description: r.exp.description,
+      groupDescriptions: r.exp.groupDescriptions,
+      groups,
+      unmapped,
+    })
   })
 
   app.post('/cli/:wsId/:export/invoke', async (c) => {

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -14,9 +14,9 @@
  * The `self` case is the load-bearing one: an entry's `docs` are paths
  * relative to the workspace that pushed it. For self-entries that root IS
  * the agent's own cwd, so once it has the paths back it reads the files
- * with ordinary shell tools — no cross-workspace file API needed. Foreign
- * entries' doc paths are relative to *another* workspace's root and are
- * surfaced for awareness only, not directly readable from here.
+ * with ordinary native file tools — no Workspace-level file-read API needed.
+ * Foreign entries carry the other Workspace id so `peer path` can resolve an
+ * absolute root for those same native tools.
  */
 
 import { tool } from 'ai'
@@ -51,7 +51,7 @@ export const inboxReadFactory: WorkspaceToolFactory = {
           .stringbool()
           .optional()
           .describe(
-            'Only entries pushed by THIS workspace. Their doc paths are relative to your own cwd, so you can read the files directly.',
+            'Only entries pushed by THIS workspace. Their doc paths are relative to your own cwd, so you can use native file tools directly.',
           ),
         limit: z
           .number()

--- a/src/tool/workspace-path.ts
+++ b/src/tool/workspace-path.ts
@@ -4,9 +4,8 @@
  * The addressing primitive for cross-workspace collaboration. Workspaces are
  * a group of collaborating agents; an inbox entry from a peer carries that
  * peer's `workspaceId` (see inbox_read). This tool turns that id into the
- * peer's absolute directory, so the agent can point its NATIVE file tools at
- * `<path>/<the doc path from the inbox entry>` to read — and, with the user's
- * approval prompt, edit — the peer's files.
+ * peer's absolute directory, so the agent can point its NATIVE file, search,
+ * and Git tools at `<path>/<the doc path from the inbox entry>`.
  *
  * It deliberately returns only the directory and lets the agent concatenate
  * the doc path itself: coding agents locate and operate by absolute path, and
@@ -14,11 +13,9 @@
  * launcher root) out of the agent's prose contract — the layout can change
  * without retraining the agent.
  *
- * Cross-workspace edits are expected and fine; what's NOT fine is editing a
- * peer's file and walking away. Its repo is the owner's record — commit your
- * change there (the per-workspace git identity makes the author honest) so the
- * owner can review or revert it. That obligation lives in the skill/instruction
- * prose, not enforced here.
+ * This is intentionally an address resolver, not a second file-read API.
+ * Cross-workspace mutation policy lives in the Workspace guidance rather than
+ * being implied by a read-oriented addressing primitive.
  */
 
 import { tool } from 'ai'
@@ -32,9 +29,9 @@ export const workspacePathFactory: WorkspaceToolFactory = {
       description: [
         "Resolve a workspace's absolute directory by its id — the addressing step for reading a peer workspace's files.",
         '',
-        "An inbox entry from another workspace (see inbox_read) carries its `workspaceId`; pass that here to get the peer's absolute path, then READ `<path>/<the entry's doc path>` with your normal file tools. Reading a peer is fine.",
+        "An Inbox entry from another Workspace carries its `workspaceId`; pass it here, combine the returned path with the entry's relative document path, and use your native file, search, and Git tools.",
         '',
-        "EDITING a peer is different: only do it in an interactive session where a person is present to approve reaching outside your own workspace. An autonomous / headless run must read peers but write ONLY its own workspace. If you do edit a peer (with approval), commit the change in that repo with a clear message — it's the owner's record, and the commit is how they review or revert it. Never edit-and-walk-away.",
+        'This command resolves identity and location only. It deliberately does not reimplement Coding Agent file operations.',
         '',
         "For your OWN entries (inbox_read `mine: true`) you don't need this — those doc paths are already relative to your current working directory.",
       ].join('\n'),

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -74,7 +74,9 @@ async function main() {
   }
 
   // `<bin> <group>` / `<bin> <group> --help` -> verb listing
-  if (!verb || (wantsHelp && !m.groups[group][verb])) return printVerbs(group, groupCmds)
+  if (!verb || (wantsHelp && !m.groups[group][verb])) {
+    return printVerbs(group, groupCmds, m.groupDescriptions && m.groupDescriptions[group])
+  }
 
   const cmd = groupCmds[verb]
   if (!cmd) {
@@ -292,18 +294,22 @@ function printGroups(m) {
   if (m.description) out(m.description)
   out('')
   for (const g of groups) {
-    out(`  ${g.padEnd(width)}  ${Object.keys(m.groups[g]).join(', ')}`)
+    const verbs = Object.keys(m.groups[g]).join(', ')
+    const description = m.groupDescriptions && m.groupDescriptions[g]
+    out(`  ${g.padEnd(width)}  ${description ? `${description} (${verbs})` : verbs}`)
   }
   out(`\nRun \`${BIN} <group>\` or \`${BIN} <group> <verb> --help\` for details.`)
-  if (m.unmapped && m.unmapped.length) {
-    out(`\n(${m.unmapped.length} tool(s) reachable via MCP but not this CLI)`)
+  if (process.env.OPENALICE_CLI_DEBUG === '1' && m.unmapped && m.unmapped.length) {
+    out(`\n(${m.unmapped.length} MCP-only tool(s) in this registry scope)`)
   }
 }
 
-function printVerbs(group, cmds) {
+function printVerbs(group, cmds, description) {
   const verbs = Object.keys(cmds)
   const width = Math.max(...verbs.map((v) => v.length), 1)
-  out(`${BIN} ${group} <verb> [--flags]\n`)
+  out(`${BIN} ${group} <verb> [--flags]`)
+  if (description) out(`${description}\n`)
+  else out('')
   for (const v of verbs) {
     out(`  ${v.padEnd(width)}  ${firstLine(cmds[v].description)}`)
   }

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -74,6 +74,9 @@ describe('CLI launchers and payload', () => {
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify({
         description: 'test manifest',
+        groupDescriptions: {
+          market: 'Discover symbols and bar sources',
+        },
         groups: {
           market: {
             search: {
@@ -101,7 +104,52 @@ describe('CLI launchers and payload', () => {
       expect(stdout).toContain('[openalice-cli-debug] socket.response')
       expect(stdout).toContain('OpenAlice CLI')
       expect(stdout).toContain('market')
+      expect(stdout).toContain('Discover symbols and bar sources')
+      expect(stdout).not.toContain('MCP-only tool')
       expect(seen).toEqual(['/cli/ws1/data/manifest'])
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('shows a group purpose before its verb help', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openalice-cli-shim-group-help-'))
+    const socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\openalice-cli-shim-group-help-${process.pid}-${Date.now()}`
+      : join(dir, 'tools.sock')
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        description: 'Workspace collaboration',
+        groupDescriptions: {
+          inbox: 'Deliver reports to the human Inbox',
+        },
+        groups: {
+          inbox: {
+            push: {
+              tool: 'inbox_push',
+              description: 'Push one delivery',
+              schema: { type: 'object', properties: {} },
+            },
+          },
+        },
+      }))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, resolve)
+    })
+    try {
+      const { stdout } = await runCli('alice-workspace', ['inbox'], {
+        ...process.env,
+        AQ_WS_ID: 'ws1',
+        OPENALICE_TOOL_SOCKET: socketPath,
+        OPENALICE_TOOL_URL: '/cli',
+      })
+      expect(stdout).toContain('alice-workspace inbox <verb>')
+      expect(stdout).toContain('Deliver reports to the human Inbox')
+      expect(stdout).toContain('push')
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))
       await rm(dir, { recursive: true, force: true })

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -92,6 +92,7 @@ describe('injectWorkspaceContext — persona', () => {
     expect(instruction.split('\n').length).toBeLessThan(120);
     expect(instruction).toContain('Every price, return, date, ratio');
     expect(instruction).toContain('A comment is a board');
+    expect(instruction).toContain('OpenAlice does not wrap');
     expect(instruction).toContain('The `alice-workspace` skill contains the exact commands');
     expect(instruction).not.toContain('alice-workspace issue comment --text');
     expect(instruction).not.toContain('alice-workspace inbox push --doc');
@@ -123,6 +124,19 @@ describe('injectWorkspaceContext — skills', () => {
       expect(existsSync(join(dir, '.agents/skills', name, 'SKILL.md')), name).toBe(true);
     }
     expect(existsSync(join(dir, '.pi/skills'))).toBe(false);
+  });
+
+  it('keeps peer file access on native Coding Agent capabilities', async () => {
+    await injectWorkspaceContext({
+      template: makeTemplate({ injectTools: true }),
+      wsId: 'ws-abc',
+      dir,
+    });
+    const skill = await read('.agents/skills/alice-workspace/SKILL.md');
+    expect(skill).toContain('There is deliberately no Workspace-level file-read command');
+    expect(skill).toContain('alice-workspace peer path --id <workspaceId>');
+    expect(skill).toContain("Coding Agent's native Read/Search/Glob/Git capabilities");
+    expect(skill).not.toContain('peer file-read');
   });
 
   it('gives every runtime copyable UTA read recipes', async () => {

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.1.0
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.6.4
+version: 1.7.0
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -34,16 +34,15 @@ files, Issues, Inbox reports, tracked entities, and attributable Sessions.
 
 ## Choose the right surface
 
-OpenAlice places these CLIs on PATH. Their skills own the current manuals; read
-the relevant skill before the first domain command and use `<cli> --help` /
-`<cli> <group> <verb> --help` instead of guessing flags or positional
-arguments.
+OpenAlice places four boundary-specific CLIs on PATH. Their live top-level help
+explains each group; their skills own procedures and exact examples. Read the
+relevant skill before the first domain command and never guess flags.
 
 | Need | Surface | Skill |
 |---|---|---|
 | Current market boards, fundamentals, macro, calendars | `traderhub` | `traderhub` |
-| Symbol discovery, collected research, quantitative panels | `alice` / `alice analysis` | `alice`, `alice-analysis` |
-| Inbox, Issues, tracked entities, provenance, peer questions | `alice-workspace` | `alice-workspace` |
+| Symbol discovery, collected RSS, K-lines and bounded analysis | `alice` | `alice`, `alice-analysis` |
+| Peer addressing, Agent conversation, Inbox, Issues and provenance | `alice-workspace` | `alice-workspace` |
 | Issue files, schedules, headless delivery contracts | `.alice/issues/` + `alice-workspace issue` | `self-scheduling` |
 | Accounts, positions, orders, trading-as-git | `alice-uta` | `alice-uta` |
 | Optional sources Alice does not ship | `opencli` | `opencli-reader` |
@@ -52,28 +51,24 @@ Use the bundled research skills (`build-thesis`, `sector-rotation`,
 `scan-value-chain`, `retrospective`) when their workflow matches the request.
 They are methods, not mandatory ceremony.
 
-## Collaboration decisions
+## Collaboration model
 
-- **Need to understand an Inbox result:** use `inbox ask --id … --await`.
-- **Need the creator, owner, or one run of an Issue:** use `issue ask` with the
-  corresponding target and start with `--await`.
-- **Need to delegate new work to another desk:** use `conversation ask --ws-id
-  …` with a normal coworker prompt. Omit `--await` when the peer should accept
-  the work, manage it locally, and report back later.
-- **Need a missing author's intent reconstructed:** add `--reconstruct`
-  explicitly. Ordinary peer messages must not carry reconstruction framing.
-- **Need several independent answers:** dispatch the asks concurrently, then
-  collect them; do not write shell sleep loops.
-- **Need a long-running result surfaced to the user:** ask the peer to commit
-  its report and push it to Inbox. Inbox is human-facing delivery; later
-  `read`/`await`/`collect` retrieves the direct Agent reply.
-- **Need to record progress on this Workspace's own Issue:** use `issue comment`.
-- **Need to read a peer artifact:** resolve its Workspace from the Inbox entry,
-  then read the referenced file. Autonomous runs never edit a peer Workspace.
+- `peer` discovers desks and resolves absolute paths. Use native Coding Agent
+  file, search, and Git capabilities after resolution; OpenAlice does not wrap
+  them in another Workspace read API.
+- `conversation` carries ordinary Agent-to-Agent requests and replies.
+- `inbox` delivers committed reports to the human and supports attributable
+  follow-up; it is not general peer chat.
+- `issue` records durable work and discussion. A comment is not an Agent call.
+- `provenance` identifies the responsible product Session. Ask that Session
+  instead of guessing intent or selecting an arbitrary historical coworker.
 
-The `alice-workspace` skill contains the exact commands and provenance rules.
-If attribution is unavailable, say so and recruit a fresh Session only in the
-known Workspace; never choose an arbitrary old Session.
+For long delegation, let the peer manage its work locally and return an
+ordinary reply; when the result also deserves human attention, have it commit
+the report and push the exact file to Inbox.
+
+The `alice-workspace` skill contains the exact commands. It also owns waiting
+rhythms, reconstruction rules, and the report-reading flow.
 
 ## Durable objects
 
@@ -81,8 +76,8 @@ known Workspace; never choose an arbitrary old Session.
   publishing so the sent revision is recoverable.
 - **Issue:** an owned work item. Add a schedule only when time should trigger
   execution; scheduling is an Issue capability, not a separate task system.
-- **Inbox entry:** a human-facing notification or handoff, not general chat
-  between agents.
+- **Inbox entry:** a human-facing notification or report handoff, not general
+  chat between Agents.
 - **Tracked entity:** the cross-workspace index for a lasting asset or topic.
 - **Session signature (`resumeId`):** the product handle for attributable
   follow-up. Never expose or depend on an Agent Runtime's native session id.


### PR DESCRIPTION
## Summary
- add intent-first group descriptions to all four public CLI manifests and render them in live help
- remove false per-export unmapped-tool noise by diagnosing coverage across each registry scope
- align Chat and AutoQuant Workspace guidance around peer addressing, Agent conversation, human Inbox delivery, Issues, and provenance
- keep cross-Workspace file access on native Coding Agent file/search/Git tools after `alice-workspace peer path`

## Verification
- `npx tsc --noEmit`
- `pnpm test` (458 files, 3834 tests passed)
- real `alice-workspace` shim against `http://127.0.0.1:3003/cli`
- real peer path resolution across the main local Workspace data
- wrong-endpoint diagnostic against the Vite UI URL

## Compatibility
- no CLI command or flag renames
- older manifests without group descriptions retain the prior help fallback