### PR TITLE
feat(inbox): expose absolute attachment paths

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -95,13 +95,17 @@ alice-workspace inbox read --limit 5
 alice-workspace inbox read --self
 ```
 
-For your own entries, document paths are relative to the current cwd. For a
-peer entry, use its `workspaceId` only to resolve the peer root:
+Each attachment is returned in `files[]` with a directly usable `absolutePath`,
+its original `relativePath`, and the published `revision` when available. The
+legacy `docs` relative-path list remains for compatibility.
+
+If `absolutePath` is null because the Workspace is unavailable or the stored
+path is unsafe, do not guess it. For broader inspection of an available peer
+desk, resolve its root explicitly:
 
 ```bash
 alice-workspace peer path --id <workspaceId>
-# Combine the returned absolute path with the Inbox document's relative path,
-# then use the Coding Agent's native Read/Search/Glob/Git capabilities.
+# Then use the Coding Agent's native Read/Search/Glob/Git capabilities.
 ```
 
 There is deliberately no Workspace-level file-read command. `peer path` owns

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -72,10 +72,12 @@ groups. Top-level and group help must explain which namespace owns an action
 before listing verbs. Skills may teach workflows, but an old copied skill must
 be able to recover from current live help.
 
-`alice-workspace peer path` is an addressing primitive only. Once a Workspace
-root is resolved, native Coding Agent file, search, and Git capabilities own
-the read flow. Do not grow a second Workspace file API merely to reproduce
-those capabilities; adapter permission problems belong at the runtime boundary.
+`alice-workspace inbox read` projects each attached document with a directly
+usable absolute path when its source Workspace is available. `peer path` is the
+lower-level addressing primitive for inspecting that desk. In both cases,
+native Coding Agent file, search, and Git capabilities own the read flow. Do
+not grow a second Workspace file API merely to reproduce those capabilities;
+adapter permission problems belong at the runtime boundary.
 
 ## Snapshot and upgrade semantics
 

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { Hono } from 'hono'
 import { tool } from 'ai'
 import { z } from 'zod'
+import { resolve } from 'node:path'
 import { ToolCenter } from '../core/tool-center.js'
 import { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
 import { createThinkingTools } from '../tool/thinking.js'
@@ -199,13 +200,28 @@ describe('CLI gateway — inbox read (scoped, string-arg coercion)', () => {
   // stringbool + number coercion through extractMcpShape + strictObject.
   async function makeWsApp(): Promise<Hono> {
     const inboxStore = createMemoryInboxStore()
-    await inboxStore.append({ workspaceId: 'ws1', workspaceLabel: 'demo', comments: 'mine' })
+    await inboxStore.append({
+      workspaceId: 'ws1',
+      workspaceLabel: 'demo',
+      comments: 'mine',
+      docs: [{ path: 'reports/mine.md' }],
+    })
     await inboxStore.append({ workspaceId: 'other', workspaceLabel: 'them', comments: 'theirs' })
 
     const wtc = new WorkspaceToolCenter()
     wtc.register(inboxReadFactory)
 
-    const fakeSvc = { registry: { get: (id: string) => (id === 'ws1' ? { id: 'ws1', tag: 'demo' } : undefined) } }
+    const fakeSvc = {
+      registry: {
+        get: (id: string) => (
+          id === 'ws1'
+            ? { id: 'ws1', tag: 'demo', dir: resolve('/workspaces/ws1') }
+            : id === 'other'
+              ? { id: 'other', tag: 'them', dir: resolve('/workspaces/other') }
+              : undefined
+        ),
+      },
+    }
     const app = new Hono()
     registerCliRoutes(app, {
       toolCenter: new ToolCenter(),
@@ -234,6 +250,10 @@ describe('CLI gateway — inbox read (scoped, string-arg coercion)', () => {
     expect(status).toBe(200)
     expect(payload.count).toBe(1)
     expect(payload.entries[0].mine).toBe(true)
+    expect(payload.entries[0].files).toEqual([{
+      relativePath: 'reports/mine.md',
+      absolutePath: resolve('/workspaces/ws1/reports/mine.md'),
+    }])
   })
 
   it('no flags returns the full cross-workspace stream', async () => {

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -148,7 +148,7 @@ export const conversationAskFactory: WorkspaceToolFactory = {
   build(ctx) {
     return tool({
       description: [
-        'Ask a known product Session, an Issue owner, or a fresh worker in one Workspace.',
+        "Ask a known product Session, an Issue's attributable creator, or a fresh worker in one Workspace.",
         '',
         'Use exactly one addressing form: resumeId for an exact Session; issueId (optionally',
         'scoped by wsId) for Issue provenance; or wsId alone to recruit a fresh worker.',
@@ -169,7 +169,7 @@ export const conversationAskFactory: WorkspaceToolFactory = {
         wsId: z.string().min(1).optional()
           .describe('Workspace for a fresh worker, or optional scope for issueId.'),
         issueId: z.string().min(1).optional()
-          .describe('Issue whose attributable Session should answer. Defaults to the current Workspace.'),
+          .describe("Issue whose attributable creator should answer. Defaults to the current Workspace; use `issue ask --owner` for the declared owner."),
       }),
       execute: async ({
         prompt,
@@ -331,7 +331,8 @@ export const conversationReadFactory: WorkspaceToolFactory = {
       ].join('\n'),
       inputSchema: z.object({
         taskId: z.string().min(1).describe('taskId returned by conversation_ask.'),
-        mode: z.enum(['summary', 'detailed']).optional().default('summary'),
+        mode: z.enum(['summary', 'detailed']).optional().default('summary')
+          .describe('`summary` returns status and assistant text; `detailed` also returns normalized tool, error, and message blocks.'),
       }),
       execute: async ({ taskId, mode }) => {
         if (!ctx.conversation) {

--- a/src/tool/inbox-read.spec.ts
+++ b/src/tool/inbox-read.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { Tool } from 'ai'
+import { resolve } from 'node:path'
 import { inboxReadFactory } from './inbox-read.js'
 import { createMemoryInboxStore, type InboxOrigin } from '../core/inbox-store.js'
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
@@ -20,6 +21,11 @@ async function run(tool: Tool, args: Record<string, unknown>) {
       workspace: string
       comments?: string
       docs: string[]
+      files: Array<{
+        relativePath: string
+        absolutePath: string | null
+        revision?: string
+      }>
       docRevisions?: Record<string, string>
       origin?: InboxOrigin
     }>
@@ -50,6 +56,11 @@ async function seeded(): Promise<WorkspaceToolContext> {
     workspaceLabel: 'Mine',
     inboxStore,
     entityStore: {} as never,
+    resolveWorkspace: (id) => ({
+      id,
+      tag: id === WS ? 'Mine' : 'Theirs',
+      dir: resolve('/workspaces', id),
+    }),
     resolveInboxOrigin: (entry) => entry.origin?.runId === 'run-peer'
       ? { ...entry.origin, resumeId: 'resume-peer' }
       : entry.origin,
@@ -105,6 +116,29 @@ describe('inbox_read', () => {
     const res = await run(inboxReadFactory.build(await seeded()), { self: true })
     expect(res.entries[0].docs).toEqual(['b.md', 'c.md'])
     expect(res.entries[0].docRevisions).toEqual({ 'b.md': 'sha256:bbbb' })
+    expect(res.entries[0].files).toEqual([
+      {
+        relativePath: 'b.md',
+        absolutePath: resolve('/workspaces', WS, 'b.md'),
+        revision: 'sha256:bbbb',
+      },
+      {
+        relativePath: 'c.md',
+        absolutePath: resolve('/workspaces', WS, 'c.md'),
+      },
+    ])
+  })
+
+  it('returns a null absolute path instead of escaping the Workspace root', async () => {
+    const inboxStore = createMemoryInboxStore()
+    await inboxStore.append({ workspaceId: OTHER, docs: [{ path: '../outside.md' }] })
+    const base = await seeded()
+    const res = await run(inboxReadFactory.build({ ...base, inboxStore }), {})
+
+    expect(res.entries[0].files).toEqual([{
+      relativePath: '../outside.md',
+      absolutePath: null,
+    }])
   })
 
   it('`limit` caps the newest-first window and reports hasMore', async () => {

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -21,6 +21,7 @@
 
 import { tool } from 'ai'
 import { z } from 'zod'
+import { resolve, sep } from 'node:path'
 import {
   toSafeInboxOrigin,
   type WorkspaceToolFactory,
@@ -28,6 +29,14 @@ import {
 } from '../core/workspace-tool-center.js'
 
 const DEFAULT_LIMIT = 20
+
+function resolveInboxDocPath(workspaceDir: string | undefined, docPath: string): string | null {
+  if (!workspaceDir) return null
+  const root = resolve(workspaceDir)
+  const absolutePath = resolve(root, docPath)
+  if (absolutePath !== root && !absolutePath.startsWith(`${root}${sep}`)) return null
+  return absolutePath
+}
 
 export const inboxReadFactory: WorkspaceToolFactory = {
   name: 'inbox_read',
@@ -38,9 +47,11 @@ export const inboxReadFactory: WorkspaceToolFactory = {
         '',
         'Use this to recall what you already reported, or to see the broader stream of what every workspace has surfaced to the user.',
         '',
-        "Pass `self` to limit the list to entries THIS workspace pushed; their `docs` paths are relative to your own workspace root, so you can open them directly with your shell (cat / read the path).",
+        "Pass `self` to limit the list to entries THIS workspace pushed.",
         '',
-        'Entries from other workspaces each carry a `workspaceId` — resolve it with `workspace_path` (CLI: `alice-workspace peer path`) to locate and read that peer\'s files.',
+        'Each attachment appears in `files` with its stored `relativePath`, a directly usable `absolutePath`, and the published `revision` when known. `absolutePath` is null only when the source Workspace is unavailable or the stored path is unsafe.',
+        '',
+        'The legacy `docs` relative-path list and `docRevisions` map remain for compatibility. `workspaceId` can still be resolved with `workspace_path` (CLI: `alice-workspace peer path`) when inspecting the source desk itself.',
         '',
         'When an entry came from an agent run/session, `origin` carries its safe OpenAlice provenance (`runId` / `sessionId`, `resumeId`, `issueId`, `agent`). Native runtime session ids are never exposed.',
         '',
@@ -72,6 +83,12 @@ export const inboxReadFactory: WorkspaceToolFactory = {
             hasMore,
             entries: entries.map((e) => {
               const origin = toSafeInboxOrigin(ctx.resolveInboxOrigin?.(e) ?? e.origin)
+              const workspace = ctx.resolveWorkspace?.(e.workspaceId)
+              const files = (e.docs ?? []).map((doc) => ({
+                relativePath: doc.path,
+                absolutePath: resolveInboxDocPath(workspace?.dir, doc.path),
+                ...(doc.revision ? { revision: doc.revision } : {}),
+              }))
               return {
                 id: e.id,
                 ts: new Date(e.ts).toISOString(),
@@ -84,6 +101,7 @@ export const inboxReadFactory: WorkspaceToolFactory = {
                 workspace: e.workspaceLabel ?? e.workspaceId,
                 comments: e.comments,
                 docs: (e.docs ?? []).map((d) => d.path),
+                files,
                 ...((e.docs ?? []).some((doc) => doc.revision)
                   ? {
                       docRevisions: Object.fromEntries(

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.0
+version: 1.1.1
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.7.0
+version: 1.7.1
 ---
 
 # Chat


### PR DESCRIPTION
## Summary
- expose Inbox attachments as structured `files[]` with relative path, absolute path, and published revision
- preserve the existing `docs` and `docRevisions` fields for compatibility
- return `absolutePath: null` for unavailable Workspaces or unsafe stored paths
- correct Conversation help: generic `--issue-id` follows creator provenance, while owner follow-up remains under `issue ask --owner`
- document the absolute-path/native-file-tool boundary and bump Chat/AutoQuant guidance patch versions

## Verification
- `npx tsc --noEmit`
- `pnpm test` (458 files, 3835 tests passed)
- real `alice-workspace inbox read` against main local data
- real Conversation ask/read live help through the CLI shim

## Compatibility
- no command or flag changes
- relative Inbox document fields remain available