### PR TITLE
feat(conversation): add Inbox and Harness targets

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -49,7 +49,21 @@ alice-workspace conversation ask --ws-id <workspaceId> \
 # Continue one exact attributable product Session.
 alice-workspace conversation ask --resume-id <resumeId> \
   --prompt 'Explain the missing context.' --await
+
+# Ask the attributable sender of one Inbox delivery.
+alice-workspace conversation ask --inbox-id <entryId> \
+  --prompt 'What did you send, and what should I inspect first?' --await
+
+# Recruit a fresh Session in a Harness default Workspace.
+alice-workspace conversation ask --harness autoquant \
+  --prompt 'Start a new quantitative research assignment.'
 ```
+
+`--harness chat` follows the recent/default Chat desk policy and creates the
+stable starter Chat Workspace only when none exists. `--harness autoquant`
+requires the explicitly initialized AutoQuant default Workspace and never
+creates or guesses one. Both launch a fresh product Session in the resolved
+desk; use the returned `resumeId` for later continuation.
 
 Prompts are ordinary coworker messages. Add `--reconstruct` only when the task
 explicitly requires a fresh worker to reconstruct missing historical intent.

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -509,8 +509,11 @@ The embedded generic entry point is:
 
 ```bash
 alice-workspace conversation ask --resume-id <resumeId> --prompt '<question>'
+alice-workspace conversation ask --inbox-id <entryId> --prompt '<question>'
 alice-workspace conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
 alice-workspace conversation ask --ws-id <workspaceId> --prompt '<question>'
+alice-workspace conversation ask --harness chat --prompt '<new assignment>'
+alice-workspace conversation ask --harness autoquant --prompt '<new assignment>'
 alice-workspace conversation ask --ws-id <workspaceId> --prompt '<reconstruction request>' --reconstruct
 alice-workspace conversation await --task-id <taskId>
 alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
@@ -527,12 +530,22 @@ alice-workspace issue ask --id <issueName> --run-id <taskId> --prompt '<question
 ```
 
 The public CLI accepts only flat identity flags. `resumeId` addresses one exact
-Session, `issueId` consults the Phase 1 index, and `wsId` recruits a fresh worker
-when there is no known owner. Rich Inbox/report/trade target structures stay
-inside the resolver and future business-specific convenience commands; agents
-never serialize them into `conversation ask`. The ask result reports a compact
-`resolution.mode`; read returns runtime status and the latest assistant text by
-default. Full tool/message blocks are diagnostic data behind `--mode detailed`.
+Session, `inboxId` resolves the sender of one immutable delivery, `issueId`
+consults the Phase 1 creation index, and `wsId` recruits a fresh worker in one
+exact desk. `harness=chat|autoquant` resolves the corresponding default desk
+before recruiting a fresh Session, so callers do not need to discover its
+Workspace id. Rich report/trade target structures stay inside business-specific
+commands; agents never serialize them into `conversation ask`. The ask result
+reports a compact `resolution.mode`; read returns runtime status and the latest
+assistant text by default. Full tool/message blocks are diagnostic data behind
+`--mode detailed`.
+
+Harness resolution preserves each product's initialization contract. Chat uses
+the recent/default durable Chat Workspace policy and creates one stable starter
+only when no Chat desk exists. AutoQuant requires the explicit
+`autoQuant.defaultWorkspaceId`; Conversation never guesses, switches, or creates
+an AutoQuant Workspace as a side effect. In either case the resolved desk starts
+a new product Session and returns its new `resumeId`.
 
 Provenance resolution and prompt semantics are separate. A fallback worker is
 still labeled `reconstructed` so it cannot impersonate a missing author, but

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -45,6 +45,7 @@ import type {
 export type WorkspaceConversationTarget =
   | { kind: 'resume'; resumeId: string }
   | { kind: 'workspace'; workspaceId: string }
+  | { kind: 'harness'; harness: 'chat' | 'autoquant' }
   | { kind: 'inbox'; inboxEntryId: string; workspaceId?: string }
   | {
       kind: 'issue'
@@ -83,7 +84,7 @@ export type WorkspaceConversationResolution =
   | {
       mode: 'reconstructed'
       workspaceId: string
-      reason: 'explicit-workspace' | 'missing-origin' | 'non-session-origin' | 'prior-reconstruction' | 'unavailable-reconstruction'
+      reason: 'explicit-workspace' | 'harness-default' | 'missing-origin' | 'non-session-origin' | 'prior-reconstruction' | 'unavailable-reconstruction'
       /** Present when continuing a previously recruited reconstruction worker. */
       origin?: SessionOrigin
       artifact?: ArtifactRef
@@ -98,6 +99,8 @@ export type WorkspaceConversationResolution =
         | 'purged-workspace'
         | 'deleted-workspace'
         | 'missing-workspace'
+        | 'chat-workspace-unavailable'
+        | 'autoquant-not-initialized'
       attributedOrigin?: SessionOrigin
       artifact?: ArtifactRef
     }

--- a/src/tool/conversation-artifacts.ts
+++ b/src/tool/conversation-artifacts.ts
@@ -2,7 +2,6 @@ import { tool } from 'ai'
 import { z } from 'zod'
 
 import {
-  toSafeInboxOrigin,
   type WorkspaceToolContext,
   type WorkspaceToolFactory,
 } from '../core/workspace-tool-center.js'
@@ -10,6 +9,7 @@ import { issueAssigneeResumeId } from '../workspaces/issues/declaration.js'
 import {
   askWorkspaceConversation,
   conversationAskCommonShape,
+  resolveInboxConversationAddress,
 } from './conversation.js'
 
 function withSubject<T extends object>(subject: Record<string, unknown>, result: T) {
@@ -43,26 +43,18 @@ export const inboxAskFactory: WorkspaceToolFactory = {
         reconstruct = false,
       }) => {
         try {
-          const entry = await ctx.inboxStore.get(id)
-          if (!entry) return { ok: false as const, error: `inbox entry not found: ${id}` }
-          const origin = toSafeInboxOrigin(ctx.resolveInboxOrigin?.(entry) ?? entry.origin)
-          const target = origin?.resumeId
-            ? { kind: 'resume' as const, resumeId: origin.resumeId }
-            : {
-                kind: 'inbox' as const,
-                inboxEntryId: entry.id,
-                workspaceId: entry.workspaceId,
-              }
+          const address = await resolveInboxConversationAddress(ctx, id)
+          if ('error' in address) return { ok: false as const, error: address.error }
           const result = await askWorkspaceConversation(ctx, {
             prompt,
-            target,
-            subject: { kind: 'inbox', entryId: entry.id },
+            target: address.target,
+            subject: address.subject,
             ...(agent ? { agent } : {}),
             ...(timeoutMs ? { timeoutMs } : {}),
             await: shouldAwait,
             reconstruct,
           })
-          return withSubject({ kind: 'inbox', id: entry.id }, result)
+          return withSubject({ kind: 'inbox', id: address.subject.entryId }, result)
         } catch (err) {
           return { ok: false as const, error: err instanceof Error ? err.message : String(err) }
         }

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -1,6 +1,7 @@
 import type { Tool } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
 
+import { createMemoryInboxStore } from '../core/inbox-store.js'
 import type { WorkspaceToolContext } from '../core/workspace-tool-center.js'
 import {
   conversationAskFactory,
@@ -90,13 +91,70 @@ describe('conversation_ask', () => {
       conversation: { ask: vi.fn(), read: vi.fn() },
     }))
     await expect(run(tool, { prompt: 'why?' })).resolves.toMatchObject({
-      ok: false, error: expect.stringContaining('provide --resume-id'),
+      ok: false, error: expect.stringContaining('choose exactly one target'),
     })
     await expect(run(tool, {
       prompt: 'why?', resumeId: 'resume-1', wsId: 'ws-peer',
     })).resolves.toMatchObject({
-      ok: false, error: expect.stringContaining('choose one target'),
+      ok: false, error: expect.stringContaining('choose exactly one target'),
     })
+  })
+
+  it('resolves an Inbox id to the attributable sender and preserves the subject', async () => {
+    const inboxStore = createMemoryInboxStore()
+    const entry = await inboxStore.append({
+      workspaceId: 'ws-peer',
+      comments: 'report ready',
+      origin: { kind: 'headless', runId: 'run-peer', agent: 'pi' },
+    })
+    const ask = vi.fn(async () => ({
+      status: 'dispatched' as const,
+      taskId: 'task-1', resumeId: 'resume-peer', workspaceId: 'ws-peer',
+      workspace: 'peer', agent: 'pi',
+      resolution: {
+        mode: 'exact' as const,
+        origin: { kind: 'session' as const, workspaceId: 'ws-peer', resumeId: 'resume-peer', agent: 'pi' },
+      },
+    }))
+    const tool = conversationAskFactory.build(context({
+      inboxStore,
+      resolveInboxOrigin: () => ({
+        kind: 'headless', runId: 'run-peer', resumeId: 'resume-peer', agent: 'pi',
+      }),
+      conversation: { ask, read: vi.fn() },
+    }))
+
+    await expect(run(tool, {
+      prompt: 'What did you send?', inboxId: entry.id,
+    })).resolves.toMatchObject({
+      ok: true,
+      subject: { kind: 'inbox', id: entry.id },
+    })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      target: { kind: 'resume', resumeId: 'resume-peer' },
+      subject: { kind: 'inbox', entryId: entry.id },
+    }))
+  })
+
+  it('addresses a fresh Session through a Harness default', async () => {
+    const ask = vi.fn(async () => ({
+      status: 'dispatched' as const,
+      taskId: 'task-1', resumeId: 'resume-fresh', workspaceId: 'ws-aq',
+      workspace: 'quant', agent: 'codex',
+      resolution: {
+        mode: 'reconstructed' as const,
+        workspaceId: 'ws-aq',
+        reason: 'harness-default' as const,
+      },
+    }))
+    const tool = conversationAskFactory.build(context({
+      conversation: { ask, read: vi.fn() },
+    }))
+
+    await run(tool, { prompt: 'Start a new study.', harness: 'autoquant' })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      target: { kind: 'harness', harness: 'autoquant' },
+    }))
   })
 
   it('passes reconstruction guidance only when explicitly requested', async () => {

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -143,17 +143,40 @@ export async function askWorkspaceConversation(
   }
 }
 
+export async function resolveInboxConversationAddress(
+  ctx: WorkspaceToolContext,
+  inboxEntryId: string,
+): Promise<{
+  target: WorkspaceConversationTarget
+  subject: Extract<HeadlessInquirySubject, { kind: 'inbox' }>
+} | { error: string }> {
+  const entry = await ctx.inboxStore.get(inboxEntryId)
+  if (!entry) return { error: `inbox entry not found: ${inboxEntryId}` }
+  const origin = ctx.resolveInboxOrigin?.(entry) ?? entry.origin
+  const sessionOrigin = sessionOriginFromInboxOrigin(entry.workspaceId, origin)
+  return {
+    target: sessionOrigin
+      ? { kind: 'resume', resumeId: sessionOrigin.resumeId }
+      : {
+          kind: 'inbox',
+          inboxEntryId: entry.id,
+          workspaceId: entry.workspaceId,
+        },
+    subject: { kind: 'inbox', entryId: entry.id },
+  }
+}
+
 export const conversationAskFactory: WorkspaceToolFactory = {
   name: 'conversation_ask',
   build(ctx) {
     return tool({
       description: [
-        "Ask a known product Session, an Issue's attributable creator, or a fresh worker in one Workspace.",
+        "Ask a known product Session, an Inbox sender, an Issue's attributable creator, or a fresh worker.",
         '',
-        'Use exactly one addressing form: resumeId for an exact Session; issueId (optionally',
-        'scoped by wsId) for Issue provenance; or wsId alone to recruit a fresh worker.',
-        'The CLI exposes these as --resume-id, --issue-id, and --ws-id. It never requires',
-        'callers to construct an internal target object.',
+        'Use exactly one addressing form: resumeId for an exact Session; inboxId for the',
+        'sender of one delivery; issueId (optionally scoped by wsId) for Issue creation',
+        'provenance; wsId for a fresh worker in an exact desk; or harness for a fresh',
+        'worker in the current default Chat/AutoQuant desk.',
         '',
         'Use --await when this turn needs the reply. Without it, the call returns a',
         'short taskId immediately for delegated work or several concurrent questions;',
@@ -165,17 +188,23 @@ export const conversationAskFactory: WorkspaceToolFactory = {
       inputSchema: z.object({
         ...conversationAskCommonShape,
         resumeId: z.string().min(1).optional()
-          .describe('Exact product Session to continue. Cannot be combined with wsId or issueId.'),
+          .describe('Exact product Session to continue. Cannot be combined with another target flag.'),
+        inboxId: z.string().min(1).optional()
+          .describe('Inbox entry whose attributable sender should answer; unattributed entries fall back only to their source Workspace.'),
         wsId: z.string().min(1).optional()
           .describe('Workspace for a fresh worker, or optional scope for issueId.'),
         issueId: z.string().min(1).optional()
           .describe("Issue whose attributable creator should answer. Defaults to the current Workspace; use `issue ask --owner` for the declared owner."),
+        harness: z.enum(['chat', 'autoquant']).optional()
+          .describe('Create a fresh Session in the default `chat` or `autoquant` Workspace.'),
       }),
       execute: async ({
         prompt,
         resumeId,
+        inboxId,
         wsId,
         issueId,
+        harness,
         agent,
         timeoutMs,
         await: shouldAwait = false,
@@ -184,31 +213,44 @@ export const conversationAskFactory: WorkspaceToolFactory = {
         if (!ctx.conversation) {
           return { ok: false as const, error: 'workspace conversation control is unavailable' }
         }
-        if (resumeId && (wsId || issueId)) {
+        const targetCount = Number(Boolean(resumeId))
+          + Number(Boolean(inboxId))
+          + Number(Boolean(issueId))
+          + Number(Boolean(harness))
+          + Number(Boolean(wsId && !issueId))
+        if (targetCount !== 1) {
           return {
             ok: false as const,
-            error: 'choose one target: --resume-id, --issue-id [--ws-id], or --ws-id',
+            error: 'choose exactly one target: --resume-id, --inbox-id, --issue-id [--ws-id], --ws-id, or --harness',
           }
         }
-        if (!resumeId && !issueId && !wsId) {
-          return {
-            ok: false as const,
-            error: 'provide --resume-id, --issue-id [--ws-id], or --ws-id',
-          }
+        const inboxAddress = inboxId
+          ? await resolveInboxConversationAddress(ctx, inboxId)
+          : null
+        if (inboxAddress && 'error' in inboxAddress) {
+          return { ok: false as const, error: inboxAddress.error }
         }
-        const target = resumeId
+        const target = inboxAddress
+          ? inboxAddress.target
+          : resumeId
           ? { kind: 'resume' as const, resumeId }
           : issueId
             ? { kind: 'issue' as const, workspaceId: wsId ?? ctx.workspaceId, issueId }
-            : { kind: 'workspace' as const, workspaceId: wsId! }
-        return askWorkspaceConversation(ctx, {
+            : harness
+              ? { kind: 'harness' as const, harness }
+              : { kind: 'workspace' as const, workspaceId: wsId! }
+        const result = await askWorkspaceConversation(ctx, {
           prompt,
           target,
+          ...(inboxAddress ? { subject: inboxAddress.subject } : {}),
           ...(agent ? { agent } : {}),
           ...(timeoutMs ? { timeoutMs } : {}),
           await: shouldAwait,
           reconstruct,
         })
+        return inboxAddress
+          ? { subject: { kind: 'inbox' as const, id: inboxAddress.subject.entryId }, ...result }
+          : result
       },
     })
   },

--- a/src/workspaces/agent-conversation-log.spec.ts
+++ b/src/workspaces/agent-conversation-log.spec.ts
@@ -109,7 +109,9 @@ describe('AgentConversationLog', () => {
         startedAt,
         conversation: {
           source: { kind: 'workspace', workspaceId: 'ws-chat' },
-          requestedTarget: { kind: 'workspace', workspaceId: 'ws-quant' },
+          requestedTarget: taskId === 'run-2'
+            ? { kind: 'harness', harness: 'autoquant' }
+            : { kind: 'workspace', workspaceId: 'ws-quant' },
           originalPrompt: `Prompt ${taskId}`,
           deliveredPrompt: `Prompt ${taskId}`,
           promptMode: 'plain',
@@ -135,6 +137,7 @@ describe('AgentConversationLog', () => {
         taskId: 'run-2',
         status: 'running',
         assistantText: null,
+        requestedTarget: { kind: 'harness', harness: 'autoquant' },
       }],
     })
     await expect(log.query({ page: 2, pageSize: 1 })).resolves.toMatchObject({

--- a/src/workspaces/agent-conversation-log.ts
+++ b/src/workspaces/agent-conversation-log.ts
@@ -363,6 +363,8 @@ function isConversationTarget(value: unknown): value is WorkspaceConversationTar
       return typeof value.resumeId === 'string'
     case 'workspace':
       return typeof value.workspaceId === 'string'
+    case 'harness':
+      return value.harness === 'chat' || value.harness === 'autoquant'
     case 'inbox':
       return typeof value.inboxEntryId === 'string'
         && (value.workspaceId === undefined || typeof value.workspaceId === 'string')

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -136,6 +136,8 @@ describe('injectWorkspaceContext — skills', () => {
     expect(skill).toContain('There is deliberately no Workspace-level file-read command');
     expect(skill).toContain('alice-workspace peer path --id <workspaceId>');
     expect(skill).toContain("Coding Agent's native Read/Search/Glob/Git capabilities");
+    expect(skill).toContain('alice-workspace conversation ask --inbox-id <entryId>');
+    expect(skill).toContain('alice-workspace conversation ask --harness autoquant');
     expect(skill).not.toContain('peer file-read');
   });
 

--- a/src/workspaces/conversation-control.spec.ts
+++ b/src/workspaces/conversation-control.spec.ts
@@ -33,6 +33,7 @@ function fakeService(opts: {
   reconstruction?: ProvenanceRecord | null
   task?: HeadlessTaskRecord | null
   logsDir?: string
+  workspaceTemplate?: string
 } = {}) {
   const adapter = fakeAdapter()
   const workspace = {
@@ -40,6 +41,7 @@ function fakeService(opts: {
     tag: 'peer-desk',
     dir: '/tmp/peer-desk',
     createdAt: '2026-07-11T00:00:00.000Z',
+    ...(opts.workspaceTemplate ? { template: opts.workspaceTemplate } : {}),
   }
   const dispatchHeadlessTask = vi.fn(async () => ({
     taskId: 'task-follow-up',
@@ -58,6 +60,7 @@ function fakeService(opts: {
       append: appendProvenance,
     },
     resolveDefaultAgentId: vi.fn(async () => 'pi'),
+    resolveOrCreateChatWorkspace: vi.fn(async () => ({ ok: true as const, workspace })),
     dispatchHeadlessTask,
     headlessTasks: { get: () => opts.task ?? null },
     headlessLogsDir: opts.logsDir ?? '/tmp/logs',
@@ -147,6 +150,74 @@ describe('Workspace conversation target resolution', () => {
 })
 
 describe('Workspace conversation control', () => {
+  it('creates a fresh Session in the resolved default Chat Workspace', async () => {
+    const { svc, workspace, dispatchHeadlessTask } = fakeService()
+    const rememberRecentChatWorkspace = vi.fn(async () => undefined)
+    const result = await createWorkspaceConversationControl(svc, {
+      readQuickChatPreferences: vi.fn(async () => ({ recentChatWorkspaceId: workspace.id })),
+      rememberRecentChatWorkspace,
+      readAutoQuantPreferences: vi.fn(async () => ({ defaultWorkspaceId: null })),
+    }).ask({
+      target: { kind: 'harness', harness: 'chat' },
+      prompt: 'Start fresh.',
+      timeoutMs: 300_000,
+    })
+
+    expect(result).toMatchObject({
+      status: 'dispatched',
+      resumeId: 'resume-fresh',
+      resolution: { mode: 'reconstructed', reason: 'harness-default' },
+    })
+    expect(svc.resolveOrCreateChatWorkspace).toHaveBeenCalledWith(workspace.id)
+    expect(rememberRecentChatWorkspace).toHaveBeenCalledWith(workspace.id)
+    expect(dispatchHeadlessTask).toHaveBeenCalledWith(
+      workspace,
+      expect.anything(),
+      'Start fresh.',
+      300_000,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      expect.anything(),
+    )
+  })
+
+  it('creates a fresh Session only in the initialized default AutoQuant Workspace', async () => {
+    const { svc, workspace } = fakeService({ workspaceTemplate: 'auto-quant-v2' })
+    const dependencies = {
+      readQuickChatPreferences: vi.fn(async () => ({ recentChatWorkspaceId: null })),
+      rememberRecentChatWorkspace: vi.fn(async () => undefined),
+      readAutoQuantPreferences: vi.fn(async () => ({ defaultWorkspaceId: workspace.id })),
+    }
+    await expect(createWorkspaceConversationControl(svc, dependencies).ask({
+      target: { kind: 'harness', harness: 'autoquant' },
+      prompt: 'Start a study.',
+      timeoutMs: 300_000,
+    })).resolves.toMatchObject({
+      status: 'dispatched',
+      workspaceId: workspace.id,
+      resolution: { mode: 'reconstructed', reason: 'harness-default' },
+    })
+  })
+
+  it('does not create an AutoQuant Workspace when the Harness is not initialized', async () => {
+    const { svc, dispatchHeadlessTask } = fakeService()
+    await expect(createWorkspaceConversationControl(svc, {
+      readQuickChatPreferences: vi.fn(async () => ({ recentChatWorkspaceId: null })),
+      rememberRecentChatWorkspace: vi.fn(async () => undefined),
+      readAutoQuantPreferences: vi.fn(async () => ({ defaultWorkspaceId: null })),
+    }).ask({
+      target: { kind: 'harness', harness: 'autoquant' },
+      prompt: 'Start a study.',
+      timeoutMs: 300_000,
+    })).resolves.toMatchObject({
+      status: 'unavailable',
+      resolution: { reason: 'autoquant-not-initialized' },
+    })
+    expect(dispatchHeadlessTask).not.toHaveBeenCalled()
+  })
+
   it('continues the exact Session behind Issue provenance', async () => {
     const identity = { ...origin, wsId: origin.workspaceId, agentSessionId: 'native-private' }
     const { svc, adapter, workspace, dispatchHeadlessTask } = fakeService({

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -1,5 +1,10 @@
 import { readFile } from 'node:fs/promises'
 
+import {
+  readAutoQuantPreferences,
+  readQuickChatPreferences,
+  rememberRecentChatWorkspace,
+} from '../core/preferences.js'
 import type {
   WorkspaceConversationAskResult,
   WorkspaceConversationControl,
@@ -14,6 +19,19 @@ import type { HeadlessStructuredOutput } from './headless-output.js'
 import { headlessLogPaths } from './headless-task-registry.js'
 import { logger as launcherLogger } from './logger.js'
 import type { WorkspaceService } from './service.js'
+import { AUTO_QUANT_WORKSPACE_TEMPLATE } from './chat-workspace-resolver.js'
+
+interface ConversationHarnessDependencies {
+  readQuickChatPreferences(): Promise<{ recentChatWorkspaceId: string | null }>
+  rememberRecentChatWorkspace(workspaceId: string): Promise<unknown>
+  readAutoQuantPreferences(): Promise<{ defaultWorkspaceId: string | null }>
+}
+
+const defaultHarnessDependencies: ConversationHarnessDependencies = {
+  readQuickChatPreferences,
+  rememberRecentChatWorkspace,
+  readAutoQuantPreferences,
+}
 
 interface ArtifactTarget {
   artifact: ArtifactRef
@@ -203,10 +221,13 @@ function reconstructionPrompt(
 
 export function createWorkspaceConversationControl(
   svc: WorkspaceService,
+  harnessDependencies: ConversationHarnessDependencies = defaultHarnessDependencies,
 ): WorkspaceConversationControl {
   return {
     async ask(input): Promise<WorkspaceConversationAskResult> {
-      const resolution = resolveWorkspaceConversationTarget(svc, input.target)
+      const resolution = input.target.kind === 'harness'
+        ? await resolveHarnessConversationTarget(svc, input.target.harness, harnessDependencies)
+        : resolveWorkspaceConversationTarget(svc, input.target)
       if (resolution.mode === 'unavailable') return { status: 'unavailable', resolution }
 
       const continuingOrigin = resolution.origin
@@ -341,6 +362,51 @@ export function createWorkspaceConversationControl(
       }
       return result
     },
+  }
+}
+
+async function resolveHarnessConversationTarget(
+  svc: WorkspaceService,
+  harness: 'chat' | 'autoquant',
+  dependencies: ConversationHarnessDependencies,
+): Promise<WorkspaceConversationResolution> {
+  if (harness === 'chat') {
+    const preferences = await dependencies.readQuickChatPreferences().catch((err) => {
+      launcherLogger.warn('conversation.harness_chat_preference_read_failed', { err })
+      return { recentChatWorkspaceId: null }
+    })
+    const target = await svc.resolveOrCreateChatWorkspace(preferences.recentChatWorkspaceId)
+    if (!target.ok) {
+      launcherLogger.warn('conversation.harness_chat_workspace_unavailable', {
+        code: target.code,
+        message: target.message,
+      })
+      return { mode: 'unavailable', reason: 'chat-workspace-unavailable' }
+    }
+    await dependencies.rememberRecentChatWorkspace(target.workspace.id).catch((err) => {
+      launcherLogger.warn('conversation.harness_chat_preference_write_failed', { err })
+    })
+    return {
+      mode: 'reconstructed',
+      workspaceId: target.workspace.id,
+      reason: 'harness-default',
+    }
+  }
+
+  const preferences = await dependencies.readAutoQuantPreferences().catch((err) => {
+    launcherLogger.warn('conversation.harness_autoquant_preference_read_failed', { err })
+    return { defaultWorkspaceId: null }
+  })
+  const workspace = preferences.defaultWorkspaceId
+    ? svc.registry.get(preferences.defaultWorkspaceId)
+    : undefined
+  if (!workspace || workspace.template !== AUTO_QUANT_WORKSPACE_TEMPLATE) {
+    return { mode: 'unavailable', reason: 'autoquant-not-initialized' }
+  }
+  return {
+    mode: 'reconstructed',
+    workspaceId: workspace.id,
+    reason: 'harness-default',
   }
 }
 

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.1
+version: 1.1.2
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.7.1
+version: 1.7.2
 ---
 
 # Chat

--- a/ui/src/api/agentConversations.ts
+++ b/ui/src/api/agentConversations.ts
@@ -11,6 +11,7 @@ export type AgentConversationSource =
 export type AgentConversationTarget =
   | { kind: 'resume'; resumeId: string }
   | { kind: 'workspace'; workspaceId: string }
+  | { kind: 'harness'; harness: 'chat' | 'autoquant' }
   | { kind: 'inbox'; inboxEntryId: string; workspaceId?: string }
   | { kind: 'issue'; workspaceId: string; issueId: string; action?: string }
   | { kind: 'report'; workspaceId: string; path: string; revision?: string; action?: string }

--- a/ui/src/pages/LogsPage.spec.tsx
+++ b/ui/src/pages/LogsPage.spec.tsx
@@ -104,6 +104,20 @@ describe('LogsPage Agent conversations', () => {
     expect(screen.getByText('run-reconstructed')).toBeTruthy()
   })
 
+  it('shows Harness-default addressing in the routing detail', async () => {
+    mocks.conversationQuery.mockResolvedValue({
+      entries: [{ ...ordinary, requestedTarget: { kind: 'harness', harness: 'autoquant' } }],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    })
+    render(<LogsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run an ordinary research task/ }))
+    expect(screen.getByText('Harness autoquant')).toBeTruthy()
+  })
+
   it('can switch back to the existing tool-call log', async () => {
     render(<LogsPage />)
     await screen.findByText(/2 conversations/)

--- a/ui/src/pages/LogsPage.tsx
+++ b/ui/src/pages/LogsPage.tsx
@@ -309,6 +309,8 @@ function requestedTargetLabel(target: AgentConversationRecord['requestedTarget']
       return `Session ${target.resumeId}`
     case 'workspace':
       return `Workspace ${target.workspaceId}`
+    case 'harness':
+      return `Harness ${target.harness}`
     case 'inbox':
       return `Inbox ${target.inboxEntryId}`
     case 'issue':


### PR DESCRIPTION
## Summary
- let conversation ask address an Inbox sender with --inbox-id
- let conversation ask start a fresh Session in the default Chat or AutoQuant Workspace with --harness
- record Harness routing in conversation logs and sync the injected alice-workspace skill

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (458 files passed, 1 skipped; 3841 tests passed, 9 skipped)
- live CLI smoke: fresh Chat Session, fresh AutoQuant Session, exact Inbox-sender continuation
- browser smoke: /dev/logs renders Harness chat routing detail