### PR TITLE
feat(chat): teach agents to delegate to AutoQuant

### DIFF
--- a/default/skills/delegate-autoquant/SKILL.md
+++ b/default/skills/delegate-autoquant/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: delegate-autoquant
+description: >
+  Delegate reproducible quantitative research from a general Chat Workspace to
+  the durable AutoQuant desk and consume its evidence-bound handoff. Use when a
+  request needs a quantitative Project, historical data intake, factor or
+  portfolio research, backtesting, governed experiments, robustness evidence,
+  or an AutoQuant follow-up. Do not use for ordinary market commentary, broker
+  state, order execution, or a question Chat can answer directly.
+---
+
+# Delegate quantitative research to AutoQuant
+
+Treat AutoQuant as a specialist coworker, not a function call. OpenAlice owns
+the conversation and routing; the AutoQuant Agent owns Project selection,
+research method, dependencies, experiments, Git history, and evidence.
+
+## Bound the assignment
+
+Before dispatch, preserve the caller-owned parts of the question:
+
+- the decision the research should support;
+- assets or universe, direction, horizon, and cadence when the caller knows them;
+- available data and its provenance;
+- benchmark, costs, constraints, risk limits, and requested deliverable;
+- material unknowns that must be clarified rather than invented.
+
+Do not translate the request into AutoQuant CLI steps, choose a Project or
+Study on its behalf, promise a positive result, or grant trading authority. A
+negative result, unsupported route, or request for clarification can be a
+correct handoff.
+
+## Recruit the default desk
+
+Use the `alice-workspace` collaboration surface:
+
+```bash
+alice-workspace conversation ask --harness autoquant --await --prompt '
+Research question: <question>
+Decision this supports: <decision>
+Caller-owned scope and constraints: <assets, direction, horizon, cadence, benchmark, costs, limits>
+Available evidence or data: <paths and provenance, or say what is missing>
+Expected handoff: answer in plain language; name the Project and every applicable immutable Run, Experiment, Report, or Dossier id and useful path; distinguish validation, visible-test, and external-holdout evidence; state assumptions, unsupported claims, and that trading authority is none.
+Ask before proceeding if a missing caller-owned fact would materially change the study. Do not manufacture a Report or Dossier solely for transport.
+'
+```
+
+Add `--await` when the current turn needs the answer. For longer delegation,
+omit it, retain the returned `taskId`, and use `conversation await`, `read`, or
+`collect` as described by the `alice-workspace` skill. There is no unsolicited
+Agent-to-Agent completion notification bus.
+
+If AutoQuant is not initialized, report that boundary and direct the user to
+initialize the Quant desk. Do not silently perform the research in Chat or
+guess another Workspace.
+
+## Understand the returned state
+
+The universal result is the Agent's ordinary `assistantText` handoff, not one
+mandatory file type:
+
+| Research route | Applicable durable evidence |
+|---|---|
+| Fixed or descriptive Study | Usually an immutable Run and Explorer; no Session Report is required |
+| Editable single lane | Runs/Experiments and often one immutable lane Report |
+| Multi-lane research program | Current lane Reports and, when applicable, one Project Dossier |
+| Blocked, rejected, or unsupported study | Plain-language boundary plus whatever exact evidence ids exist |
+
+A Report is an immutable Markdown/JSON deliverable for one research lane. A
+Dossier synthesizes compatible current lane Reports into a Project-level
+deliverable. Their absence is not failure when the route does not support or
+need them. AutoQuant does not automatically publish either artifact to the
+OpenAlice Inbox.
+
+## Consume and continue
+
+1. Read the direct handoff first. Require the Project identity, applicable
+   evidence ids or paths, assumptions, limitations, and no-trading boundary.
+2. Resolve the returned AutoQuant `workspaceId` with
+   `alice-workspace peer path --id <workspaceId>` when a file needs inspection,
+   then use native Read/Search/Git capabilities on only the named artifacts.
+3. If the answer is incomplete or a clarification round is needed, continue
+   the returned `resumeId`; do not recruit a new AutoQuant Session and discard
+   its context.
+4. Translate the evidence for the user, separating AutoQuant's findings from
+   your judgment. Any live account or execution decision returns to
+   `alice-uta` and its approval flow.
+
+A normal attended Chat reply already reaches the user. Ask AutoQuant to commit
+and push an exact file to Inbox only when the user explicitly wants a durable
+human-facing delivery or asynchronous notification; do not use Inbox as the
+ordinary peer reply channel.

--- a/default/skills/delegate-autoquant/agents/openai.yaml
+++ b/default/skills/delegate-autoquant/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AutoQuant Coworker"
+  short_description: "Delegate quantitative research to AutoQuant"
+  default_prompt: "Use $delegate-autoquant to hand this quantitative research assignment to the AutoQuant desk."

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -37,6 +37,7 @@ One concept has one primary owner:
 | Concept | Owner |
 |---|---|
 | Inbox, Issue collaboration, provenance, peer questions | `alice-workspace` |
+| Delegating quantitative research from Chat to AutoQuant | `delegate-autoquant` |
 | Issue file shape, ownership, schedules, headless delivery | `self-scheduling` |
 | Low-frequency market/fundamental/macro data | `traderhub` |
 | Quantitative K-line panels and source choice | `alice-analysis` |

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -113,6 +113,20 @@ describe('injectWorkspaceContext — skills', () => {
     expect(existsSync(join(dir, '.pi/skills'))).toBe(false);                        // no Pi collision copy
   });
 
+  it('copies the Chat AutoQuant delegation contract into both discovery paths', async () => {
+    await injectWorkspaceContext({
+      template: makeTemplate({ bundledSkills: ['delegate-autoquant'] }),
+      wsId: 'ws-chat',
+      dir,
+    });
+    for (const root of ['.claude/skills', '.agents/skills']) {
+      const skill = await read(`${root}/delegate-autoquant/SKILL.md`);
+      expect(skill).toContain('alice-workspace conversation ask --harness autoquant');
+      expect(skill).toContain('The universal result is the Agent\'s ordinary `assistantText` handoff');
+      expect(skill).toContain('does not automatically publish either artifact to the');
+    }
+  });
+
   it('injects the per-CLI playbooks (alice* + traderhub) for a tool-bearing template', async () => {
     await injectWorkspaceContext({
       template: makeTemplate({ injectTools: true, bundledSkills: ['scan-value-chain'] }),

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.7.2
+version: 1.8.0
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/template.json
+++ b/src/workspaces/templates/chat/template.json
@@ -6,5 +6,5 @@
   "injectTools": true,
   "injectPersona": true,
   "upgradeStrategy": "managed-context",
-  "bundledSkills": ["scan-value-chain", "build-thesis", "sector-rotation", "retrospective", "opencli-reader"]
+  "bundledSkills": ["scan-value-chain", "build-thesis", "sector-rotation", "retrospective", "opencli-reader", "delegate-autoquant"]
 }

--- a/src/workspaces/workspace-creation.e2e.spec.ts
+++ b/src/workspaces/workspace-creation.e2e.spec.ts
@@ -79,7 +79,7 @@ function chatMeta(): TemplateMeta {
     defaultAgents: ['claude', 'codex'],
     injectTools: true,
     injectPersona: true,
-    bundledSkills: ['scan-value-chain'],
+    bundledSkills: ['scan-value-chain', 'delegate-autoquant'],
   };
 }
 
@@ -109,6 +109,8 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
       'CLAUDE.md', 'AGENTS.md', 'README.md',
       '.claude/skills/scan-value-chain/SKILL.md',
       '.agents/skills/scan-value-chain/SKILL.md',
+      '.claude/skills/delegate-autoquant/SKILL.md',
+      '.agents/skills/delegate-autoquant/SKILL.md',
       // per-CLI playbooks injected for every tool-bearing template
       '.claude/skills/alice/SKILL.md',
       '.claude/skills/alice-analysis/SKILL.md',


### PR DESCRIPTION
## Summary
- add a Chat-only delegate-autoquant skill for assigning bounded quantitative research
- document the real AutoQuant handoff contract: plain-language reply plus applicable immutable evidence, not a mandatory Report or Dossier
- teach Chat how to await, inspect named peer artifacts, continue the same Session, and reserve Inbox for deliberate human delivery
- bump the Chat template guidance version to 1.8.0

## Verification
- skill-creator quick_validate
- npx tsc --noEmit
- pnpm vitest run src/workspaces/context-injector.spec.ts
- pnpm vitest run --config vitest.e2e.config.ts src/workspaces/workspace-creation.e2e.spec.ts
- pnpm test (458 files passed, 1 skipped; 3842 tests passed, 9 skipped)