### PR TITLE
fix(conversation): make timeouts opt in

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -82,6 +82,13 @@ alice-workspace conversation read --task-id <taskId>
 alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
 ```
 
+Conversation work has no implicit execution deadline. `--await`, `conversation
+await`, and `conversation collect` also wait for terminal task state when no
+limit is supplied. Add `--timeout-ms <milliseconds>` only when the caller
+deliberately wants a hard execution watchdog (for `conversation ask`) or a
+bounded server-side wait (for `await`/`collect`). A bounded wait returning does
+not stop a task unless that same explicit timeout was attached at dispatch.
+
 There is no unsolicited Agent-to-Agent completion notification bus. Inbox
 notifies the human; `await`, `read`, and `collect` retrieve direct Agent replies.
 Do not build shell sleep loops.

--- a/default/skills/delegate-autoquant/SKILL.md
+++ b/default/skills/delegate-autoquant/SKILL.md
@@ -48,7 +48,9 @@ Ask before proceeding if a missing caller-owned fact would materially change the
 Add `--await` when the current turn needs the answer. For longer delegation,
 omit it, retain the returned `taskId`, and use `conversation await`, `read`, or
 `collect` as described by the `alice-workspace` skill. There is no unsolicited
-Agent-to-Agent completion notification bus.
+Agent-to-Agent completion notification bus. AutoQuant assignments deliberately
+have no default runtime deadline; add `--timeout-ms` only when the caller has
+chosen a real hard stop for that particular study.
 
 If AutoQuant is not initialized, report that boundary and direct the user to
 initialize the Quant desk. Do not silently perform the research in Chat or

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -556,18 +556,23 @@ does not change whom OpenAlice addresses.
 Choose waiting behavior from the work rather than treating every ask as a
 blocking follow-up:
 
-- use `--await` for a bounded consultation whose answer is required in the
-  current turn;
+- use `--await` when the answer is required in the current turn; without an
+  explicit timeout it waits until the task reaches a terminal state;
 - omit it for delegation, retain the returned `taskId`/`resumeId`, and retrieve
   the reply later with `read` or `await`;
 - dispatch multiple independent asks before one ordered `collect`;
 - ask a long-running peer to manage its own local Issue/schedule and `inbox
   push` the finished report when the human should be notified.
 
+Conversation dispatch has no implicit execution deadline. `--timeout-ms` is an
+explicit opt-in watchdog on `conversation ask`; omitting it lets the native
+one-shot Agent run to its natural exit. The same option is only a server-side
+wait budget on standalone `await` and `collect`. A bounded wait preserves every
+task, so callers can use a later collect/read snapshot instead of scripting
+arbitrary sleeps.
+
 Inbox is human-facing delivery. OpenAlice does not yet inject an unsolicited
-completion message into another Agent's active transcript. A timed-out collect
-preserves every task; callers fall back to a later collect/read snapshot instead
-of scripting arbitrary sleeps.
+completion message into another Agent's active transcript.
 
 The first fresh reconstruction appends a `reconstructed` occurrence to the
 artifact. Later questions about that same otherwise-unattributed artifact

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -138,7 +138,8 @@ export type WorkspaceConversationAskResult =
 export interface WorkspaceConversationControl {
   ask(input: {
     readonly prompt: string
-    readonly timeoutMs: number
+    /** Optional execution watchdog. Omit to let the Session run to completion. */
+    readonly timeoutMs?: number
     readonly target: WorkspaceConversationTarget
     readonly agent?: string
     /** Add the artifact-reconstruction preamble when a fresh fallback worker is

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -65,7 +65,6 @@ describe('inbox_ask', () => {
       prompt: 'why?',
       target: { kind: 'resume', resumeId: 'resume-peer' },
       subject: { kind: 'inbox', entryId: entry.id },
-      timeoutMs: 300_000,
       source: { kind: 'workspace', workspaceId: 'ws-caller' },
     })
   })

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -62,9 +62,22 @@ describe('conversation_ask', () => {
     expect(ask).toHaveBeenCalledWith({
       prompt: 'why?',
       target,
-      timeoutMs: 300_000,
       source: { kind: 'workspace', workspaceId: 'ws-caller' },
     })
+  })
+
+  it('installs an execution watchdog only when timeoutMs is explicit', async () => {
+    const ask = vi.fn(async () => ({
+      status: 'dispatched' as const,
+      taskId: 'task-1', resumeId: 'resume-1', workspaceId: 'ws-peer',
+      workspace: 'peer', agent: 'pi',
+      resolution: { mode: 'reconstructed' as const, workspaceId: 'ws-peer', reason: 'explicit-workspace' as const },
+    }))
+    const tool = conversationAskFactory.build(context({ conversation: { ask, read: vi.fn() } }))
+
+    await run(tool, { prompt: 'why?', wsId: 'ws-peer', timeoutMs: 42_000 })
+
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 42_000 }))
   })
 
   it('surfaces unavailable attribution without starting another worker', async () => {

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -12,8 +12,7 @@ import { sessionOriginFromInboxOrigin } from '../core/provenance-store.js'
 import type { HeadlessMessageBlock } from '../workspaces/headless-output.js'
 import type { HeadlessInquirySubject } from '../workspaces/headless-task-registry.js'
 
-const DEFAULT_TIMEOUT_MS = 300_000
-const MAX_TIMEOUT_MS = 1_800_000
+const MAX_TIMEOUT_MS = 2_147_478_647
 const MAX_PROMPT_CHARS = 16_000
 const AWAIT_POLL_MS = 250
 
@@ -23,7 +22,7 @@ export const conversationAskCommonShape = {
   agent: z.string().min(1).optional()
     .describe('Optional runtime for reconstructed/fresh work only; exact Session runtime cannot be overridden.'),
   timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
-    .describe(`Headless watchdog in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+    .describe('Optional headless watchdog in milliseconds. Omit to allow the Session to run without a time limit.'),
   await: z.boolean().optional().default(false)
     .describe('Wait server-side for a reply needed now; omit for asynchronous delegation and use the returned taskId later.'),
   reconstruct: z.boolean().optional().default(false)
@@ -60,12 +59,12 @@ function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'deta
 async function awaitConversationTask(
   conversation: WorkspaceConversationControl,
   taskId: string,
-  timeoutMs: number,
+  timeoutMs?: number,
 ): Promise<WorkspaceConversationTask | null> {
-  const deadline = Date.now() + timeoutMs
+  const deadline = timeoutMs === undefined ? null : Date.now() + timeoutMs
   let task = await conversation.read(taskId)
   while (task?.status === 'running') {
-    const remaining = deadline - Date.now()
+    const remaining = deadline === null ? AWAIT_POLL_MS : deadline - Date.now()
     if (remaining <= 0) return task
     await new Promise((resolve) => setTimeout(resolve, Math.min(AWAIT_POLL_MS, remaining)))
     task = await conversation.read(taskId)
@@ -89,11 +88,10 @@ export async function askWorkspaceConversation(
     return { ok: false as const, error: 'workspace conversation control is unavailable' }
   }
   try {
-    const effectiveTimeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS
     const result = await ctx.conversation.ask({
       prompt: input.prompt,
       target: input.target,
-      timeoutMs: effectiveTimeoutMs,
+      ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
       source: sessionOriginFromInboxOrigin(ctx.workspaceId, ctx.origin) ?? {
         kind: 'workspace',
         workspaceId: ctx.workspaceId,
@@ -122,7 +120,7 @@ export async function askWorkspaceConversation(
         : { mode: result.resolution.mode },
     }
     if (!input.await) return dispatched
-    const task = await awaitConversationTask(ctx.conversation, result.taskId, effectiveTimeoutMs)
+    const task = await awaitConversationTask(ctx.conversation, result.taskId, input.timeoutMs)
     if (!task) {
       return {
         ok: false as const,
@@ -244,7 +242,7 @@ export const conversationAskFactory: WorkspaceToolFactory = {
           target,
           ...(inboxAddress ? { subject: inboxAddress.subject } : {}),
           ...(agent ? { agent } : {}),
-          ...(timeoutMs ? { timeoutMs } : {}),
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           await: shouldAwait,
           reconstruct,
         })
@@ -264,24 +262,21 @@ export const conversationAwaitFactory: WorkspaceToolFactory = {
         'Wait server-side for one conversation task to finish.',
         '',
         'Use after dispatching several conversation_ask calls so their headless runs execute',
-        'concurrently. This replaces hand-written sleep loops. If the wait budget expires,',
-        'the task remains running and can be awaited again or inspected with conversation_read.',
+        'concurrently. This replaces hand-written sleep loops. With an explicit wait budget,',
+        'an expired wait returns while the task keeps running; without one, this waits until',
+        'the task reaches a terminal state.',
       ].join('\n'),
       inputSchema: z.object({
         taskId: z.string().min(1).describe('Short taskId returned by conversation_ask.'),
         timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
-          .describe(`Server-side wait budget in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+          .describe('Optional server-side wait budget in milliseconds. Omit to wait until the task finishes.'),
       }),
       execute: async ({ taskId, timeoutMs }) => {
         if (!ctx.conversation) {
           return { ok: false as const, error: 'workspace conversation control is unavailable' }
         }
         try {
-          const task = await awaitConversationTask(
-            ctx.conversation,
-            taskId,
-            timeoutMs ?? DEFAULT_TIMEOUT_MS,
-          )
+          const task = await awaitConversationTask(ctx.conversation, taskId, timeoutMs)
           if (!task) return { ok: false as const, error: `conversation task not found: ${taskId}` }
           return {
             ok: true as const,
@@ -314,7 +309,7 @@ export const conversationCollectFactory: WorkspaceToolFactory = {
         taskId: z.array(z.string().min(1)).min(1).max(32)
           .describe('Task id to collect. Repeat --task-id for multiple concurrent peers.'),
         timeoutMs: z.coerce.number().int().positive().max(MAX_TIMEOUT_MS).optional()
-          .describe(`Server-side wait budget per task in milliseconds (default ${DEFAULT_TIMEOUT_MS}).`),
+          .describe('Optional server-side wait budget per task in milliseconds. Omit to wait until every task finishes.'),
       }),
       execute: async ({ taskId, timeoutMs }) => {
         if (!ctx.conversation) {
@@ -325,7 +320,7 @@ export const conversationCollectFactory: WorkspaceToolFactory = {
           const tasks = await Promise.all(ids.map((id) => awaitConversationTask(
             ctx.conversation!,
             id,
-            timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            timeoutMs,
           )))
           const results = tasks.map((task, index) => task
             ? {

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -69,7 +69,7 @@ describe('business inquiry routes', () => {
     expect(response.status).toBe(202)
     expect((await json(response)).resolution.mode).toBe('exact')
     expect(dispatchHeadlessTask).toHaveBeenCalledWith(
-      expect.anything(), expect.anything(), 'Why?', 300_000, undefined, 'resume-author',
+      expect.anything(), expect.anything(), 'Why?', undefined, undefined, 'resume-author',
       expect.objectContaining({
         subject: { kind: 'inbox', entryId: entry.id },
         question: 'Why?',

--- a/src/webui/routes/inquiries.ts
+++ b/src/webui/routes/inquiries.ts
@@ -16,7 +16,6 @@ import type { HeadlessInquiryScope, HeadlessInquirySubject, HeadlessTaskRecord }
 import { issueAssigneeResumeId } from '../../workspaces/issues/declaration.js'
 import { HeadlessCapacityError, HeadlessResumeError, type WorkspaceService } from '../../workspaces/service.js'
 
-const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_PROMPT_CHARS = 16_000
 const LIST_LIMIT = 50
 
@@ -105,7 +104,6 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
       const result = await conversation.ask({
         prompt: request.prompt,
         target,
-        timeoutMs: DEFAULT_TIMEOUT_MS,
         source: { kind: 'human' },
         ...(request.reconstruct ? { reconstruct: true } : {}),
         subject: { kind: 'inbox', entryId: entry.id },
@@ -176,7 +174,6 @@ export function createInquiryRoutes(deps: InquiryRoutesDeps): Hono {
       const result = await conversation.ask({
         prompt,
         target,
-        timeoutMs: DEFAULT_TIMEOUT_MS,
         source: { kind: 'human' },
         ...(body.reconstruct === true ? { reconstruct: true } : {}),
         subject,

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -611,12 +611,12 @@ describe('POST /:id/headless', () => {
     expect((await post(app, '/ws-1/headless', { prompt: 'x', agent: 'shell' })).body.error).toBe('no_headless');
   });
 
-  it('clamps timeoutMs to <= 1_800_000 and defaults to 300_000', async () => {
+  it('enables the watchdog only for an explicit timeoutMs', async () => {
     const { app, dispatchHeadlessTask } = build();
-    await post(app, '/ws-1/headless', { prompt: 'x', timeoutMs: 9e9 });
-    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 'x', 1_800_000);
+    await post(app, '/ws-1/headless', { prompt: 'x', timeoutMs: 42_000 });
+    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 'x', 42_000);
     await post(app, '/ws-1/headless', { prompt: 'x' });
-    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 'x', 300_000);
+    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 'x', undefined);
   });
 
   it('continues a headless conversation by product resumeId only', async () => {
@@ -629,7 +629,7 @@ describe('POST /:id/headless', () => {
     expect(response.status).toBe(202);
     expect(response.body).toMatchObject({ taskId: 'task-1', resumeId: 'resume-1' });
     expect(dispatchHeadlessTask).toHaveBeenCalledWith(
-      expect.anything(), expect.anything(), 'follow up', 300_000, undefined, 'resume-1',
+      expect.anything(), expect.anything(), 'follow up', undefined, undefined, 'resume-1',
     );
   });
 

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1998,7 +1998,7 @@ export function createWorkspaceRoutes(
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
     let prompt: string;
-    let timeoutMs: number;
+    let timeoutMs: number | undefined;
     let agentId: string | undefined;
     let resumeId: string | undefined;
     let wait = false;
@@ -2016,8 +2016,9 @@ export function createWorkspaceRoutes(
       }
       prompt = rawPrompt;
       const rawTimeout = fields['timeoutMs'];
-      timeoutMs =
-        typeof rawTimeout === 'number' && rawTimeout > 0 ? Math.min(rawTimeout, 1_800_000) : 300_000;
+      timeoutMs = typeof rawTimeout === 'number' && rawTimeout > 0
+        ? Math.min(rawTimeout, 2_147_478_647)
+        : undefined;
       const rawAgent = fields['agent'];
       if (typeof rawAgent === 'string' && rawAgent.length > 0) agentId = rawAgent;
       const rawResumeId = fields['resumeId'];
@@ -2051,7 +2052,7 @@ export function createWorkspaceRoutes(
       id,
       agent: adapter.id,
       promptLen: prompt.length,
-      timeoutMs,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       wait,
     });
     // `wait:true` → run synchronously and return the full result (curl/tests).

--- a/src/workspaces/conversation-control.spec.ts
+++ b/src/workspaces/conversation-control.spec.ts
@@ -160,7 +160,6 @@ describe('Workspace conversation control', () => {
     }).ask({
       target: { kind: 'harness', harness: 'chat' },
       prompt: 'Start fresh.',
-      timeoutMs: 300_000,
     })
 
     expect(result).toMatchObject({
@@ -174,7 +173,7 @@ describe('Workspace conversation control', () => {
       workspace,
       expect.anything(),
       'Start fresh.',
-      300_000,
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/src/workspaces/headless-task.spec.ts
+++ b/src/workspaces/headless-task.spec.ts
@@ -22,6 +22,18 @@ const noopLogger = {
 const baseEnv = { PATH: process.env['PATH'] ?? '' };
 
 describe('runHeadlessTask', () => {
+  it('runs to natural exit when no watchdog is requested', async () => {
+    const r = await runHeadlessTask({
+      command: ['node', '-e', 'setTimeout(() => process.stdout.write("finished"), 50)'],
+      cwd: process.cwd(),
+      env: baseEnv,
+      logger: noopLogger,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.killed).toBe(false);
+    expect(r.stdoutTail).toBe('finished');
+  });
+
   it('captures clean exit + stdout tail on a one-shot command', async () => {
     const r = await runHeadlessTask({
       command: ['node', '-e', 'process.stdout.write("hello-headless")'],

--- a/src/workspaces/headless-task.ts
+++ b/src/workspaces/headless-task.ts
@@ -12,8 +12,8 @@
  *    control bytes (verified across all four adapters).
  *  - **Exit is the done signal.** One-shot modes (`-p` / `exec` / `run`) exit
  *    at the turn boundary, so we wait on exit rather than timeout-killing the
- *    way probe must (interactive TUIs never exit). The watchdog is a backstop
- *    (codex can hang under heavy logging).
+ *    way probe must (interactive TUIs never exit). Callers may opt into a
+ *    watchdog when they need a hard execution deadline.
  *  - **NOT routed through SessionPool/PersistentSession**, whose respawn-on-exit
  *    circuit is anti-semantic for a one-shot task (exit == completion).
  *
@@ -48,8 +48,8 @@ export interface HeadlessTaskArgs {
   readonly command: readonly string[];
   readonly cwd: string;
   readonly env: Readonly<Record<string, string>>;
-  /** Watchdog: SIGTERM at `timeoutMs`, SIGKILL after a grace window. */
-  readonly timeoutMs: number;
+  /** Optional watchdog: SIGTERM at `timeoutMs`, SIGKILL after a grace window. */
+  readonly timeoutMs?: number;
   readonly logger: Logger;
   /**
    * Stream stdout/stderr to bounded operator logs (16MB per stream; the
@@ -499,9 +499,9 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
     });
   });
 
-  // Watchdog armed BEFORE the await so it covers the wait: SIGTERM at
-  // timeoutMs, SIGKILL after the grace window.
-  const softKill = setTimeout(() => {
+  // An explicit watchdog is armed BEFORE the await so it covers the whole
+  // process lifetime. Without one, a one-shot Agent runs to its natural exit.
+  const softKill = timeoutMs === undefined ? undefined : setTimeout(() => {
     killed = true;
     try {
       child.kill('SIGTERM');
@@ -509,19 +509,19 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
       /* already gone */
     }
   }, timeoutMs);
-  softKill.unref();
-  const hardKill = setTimeout(() => {
+  softKill?.unref();
+  const hardKill = timeoutMs === undefined ? undefined : setTimeout(() => {
     try {
       child.kill('SIGKILL');
     } catch {
       /* ignore */
     }
   }, timeoutMs + KILL_GRACE_MS);
-  hardKill.unref();
+  hardKill?.unref();
 
   await closePromise;
-  clearTimeout(softKill);
-  clearTimeout(hardKill);
+  if (softKill) clearTimeout(softKill);
+  if (hardKill) clearTimeout(hardKill);
   scanner?.finish();
   const structured = structuredOutput.snapshot(false);
   assistantText = structured.assistantText;

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -443,7 +443,7 @@ export interface WorkspaceService {
     meta: WorkspaceMeta,
     adapter: CliAdapter,
     prompt: string,
-    timeoutMs: number,
+    timeoutMs?: number,
   ): Promise<HeadlessTaskResult>;
   /** Cached install/ready snapshot for global first-run runtime gating. */
   getAgentRuntimeReadiness(): AgentRuntimeReadinessSnapshot;
@@ -470,7 +470,7 @@ export interface WorkspaceService {
     meta: WorkspaceMeta,
     adapter: CliAdapter,
     prompt: string,
-    timeoutMs: number,
+    timeoutMs?: number,
     /** Business source of the dispatch. Its Workspace may differ from `meta`
      * when an Issue explicitly resumes a signed Session across Workspaces. */
     trigger?: HeadlessTaskTrigger,
@@ -1329,7 +1329,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     ws: WorkspaceMeta,
     adapter: CliAdapter,
     prompt: string,
-    timeoutMs: number,
+    timeoutMs?: number,
     // Dispatch-path extras: a taskId keys the on-disk task log; onSessionId
     // fires when the adapter's stdout scanner captures the agent's own session
     // id (recorded WHILE running, so the panel can offer "open as session").
@@ -1406,7 +1406,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           command,
           cwd,
           env,
-          timeoutMs,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           logger: launcherLogger.child({
             scope: 'headless',
             wsId: ws.id,
@@ -1455,7 +1455,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     ws: WorkspaceMeta,
     adapter: CliAdapter,
     prompt: string,
-    timeoutMs: number,
+    timeoutMs?: number,
     // Composite Issue source when dispatched by ScheduleScanner. Manual and
     // external runs leave it undefined.
     trigger?: HeadlessTaskTrigger,

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.2
+version: 1.1.3
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.8.1
+version: 1.8.2
 ---
 
 # Chat


### PR DESCRIPTION
## Summary
- remove the implicit five-minute watchdog from Conversation, Inbox/Issue follow-ups, and the raw headless dispatch route
- let `--await` and `collect` wait to terminal state unless callers explicitly provide `--timeout-ms`
- document the opt-in deadline contract in bundled Chat/AutoQuant skills and bump template guidance versions

## Verification
- `npx tsc --noEmit`
- targeted Conversation/headless/CLI/router suite: 141 tests passed
- `pnpm test`: 3843 tests passed; 10 unrelated timeout-sensitive tests failed under full parallel load
- isolated rerun of all 10 failures: 55 tests passed
- live `alice-workspace conversation ask --help` / `conversation await --help` against the running tools gateway