### PR TITLE
feat(models): add DeepSeek V4 Flash

### DIFF
--- a/src/ai-providers/model-semantics.spec.ts
+++ b/src/ai-providers/model-semantics.spec.ts
@@ -33,6 +33,19 @@ describe('model semantics registry', () => {
       .toBe('Reasoning optional · default effort high · interleaved thinking · 1M context')
   })
 
+  it('records the V4 Flash 0731 API contract under its stable model id', () => {
+    expect(resolveModelSemantics('deepseek', 'deepseek-v4-flash')).toEqual({
+      contextWindow: 1_000_000,
+      maxOutputTokens: 384_000,
+      reasoning: {
+        mode: 'optional',
+        efforts: ['low', 'high', 'max'],
+        defaultEffort: 'high',
+        interleaved: true,
+      },
+    })
+  })
+
   it('keeps LongCat\'s documented thinking default separate from effort tiers', () => {
     const semantics = resolveModelSemantics('longcat', 'LongCat-2.0')
     expect(semantics?.reasoning).toEqual({ mode: 'optional', defaultEnabled: true })

--- a/src/ai-providers/model-semantics.ts
+++ b/src/ai-providers/model-semantics.ts
@@ -81,6 +81,7 @@ const GEMINI_3_CONTEXT = 1_048_576
  * - MiniMax Anthropic API: https://platform.minimax.io/docs/api-reference/text-anthropic-api
  * - MiniMax OpenAI `reasoning_split`: https://platform.minimax.io/docs/api-reference/text-openai-api
  * - Kimi thinking models: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
+ * - DeepSeek models/limits: https://api-docs.deepseek.com/quick_start/pricing
  * - DeepSeek thinking: https://api-docs.deepseek.com/guides/thinking_mode
  * - LongCat Chat API: https://longcat.chat/platform/docs/api/chat.html
  *
@@ -233,6 +234,16 @@ export const MODEL_SEMANTICS_BY_VENDOR: Registry = {
     },
   },
   deepseek: {
+    'deepseek-v4-flash': {
+      contextWindow: 1_000_000,
+      maxOutputTokens: 384_000,
+      reasoning: {
+        mode: 'optional',
+        efforts: ['low', 'high', 'max'],
+        defaultEffort: 'high',
+        interleaved: true,
+      },
+    },
     'deepseek-v4-pro': {
       contextWindow: 1_000_000,
       maxOutputTokens: 384_000,

--- a/src/ai-providers/preset-catalog.spec.ts
+++ b/src/ai-providers/preset-catalog.spec.ts
@@ -5,6 +5,7 @@ import {
   CLAUDE_OAUTH,
   CODEX_API,
   CODEX_OAUTH,
+  DEEPSEEK,
   DEFAULT_MODEL_BY_VENDOR,
   GEMINI,
   LONGCAT,
@@ -66,6 +67,19 @@ describe('credential form catalog', () => {
       'gemini-2.5-flash',
       'gemini-2.5-flash-lite',
     ]);
+  });
+
+  it('offers the stable DeepSeek V4 API ids with registered semantics', () => {
+    expect(DEEPSEEK.models?.map((model) => model.id)).toEqual([
+      'deepseek-v4-pro',
+      'deepseek-v4-flash',
+    ]);
+    expect(DEEPSEEK.models?.find((model) => model.id === 'deepseek-v4-flash')?.semantics)
+      .toMatchObject({
+        contextWindow: 1_000_000,
+        maxOutputTokens: 384_000,
+        reasoning: { efforts: ['low', 'high', 'max'], defaultEffort: 'high' },
+      });
   });
 
   it('serializes provider-aware setup guidance for every API-key preset', () => {

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -356,7 +356,7 @@ export const DEEPSEEK: PresetDef = {
   description: 'DeepSeek models via Claude Agent SDK (Anthropic-compatible)',
   category: 'third-party',
   defaultName: 'DeepSeek',
-  hint: 'Get your API key at platform.deepseek.com. Single platform — no regional split. Cached prompt input is heavily discounted ($0.03/M).',
+  hint: 'Get your API key at platform.deepseek.com. Single platform — no regional split. V4 Flash costs $0.0028/M cache-hit input, $0.14/M cache-miss input, and $0.28/M output.',
   zodSchema: z.object({
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
@@ -371,6 +371,7 @@ export const DEEPSEEK: PresetDef = {
   ],
   models: withModelSemantics('deepseek', [
     { id: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro (flagship)' },
+    { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash (fast / economical)' },
   ]),
   setup: {
     apiKeyLabel: 'DeepSeek API key',


### PR DESCRIPTION
## Summary
- add `deepseek-v4-flash` to the DeepSeek credential model suggestions
- register the official V4 Flash 0731 context, output, and reasoning semantics
- refresh the DeepSeek V4 Flash pricing hint while retaining V4 Pro as the default

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (458 files passed, 3846 tests passed)
- verified the live `/api/config/presets` DeepSeek projection