### PR TITLE
chore(release): prepare 0.88.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.87.0-beta",
+  "version": "0.88.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.87.0-beta",
+  "version": "0.88.0-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -13,6 +13,9 @@ const execFileAsync = promisify(execFile)
 const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..')
 const fakeNpm = join(repositoryRoot, 'scripts/install-smoke/fake-npm.sh')
 const piAssets = join(repositoryRoot, 'scripts/install-smoke/pi-assets')
+const productVersion = JSON.parse(
+  await readFile(join(repositoryRoot, 'package.json'), 'utf8'),
+).version
 const temporaryPaths = []
 
 afterEach(async () => {
@@ -134,15 +137,15 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     await expect(access(join(installRoot, 'bin', 'pi.cmd'))).resolves.toBeUndefined()
 
     const result = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version'])
-    expect(result.stdout.trim()).toBe('0.87.0-beta')
+    expect(result.stdout.trim()).toBe(productVersion)
     const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
     expect(JSON.parse(versionInfo.stdout)).toEqual({
-      version: '0.87.0-beta',
+      version: productVersion,
       contentIdentity: releases[0].slice(-16),
       installSource: {
         schemaVersion: 1,
         repository: 'TraderAlice/OpenAlice',
-        cliVersion: '0.87.0-beta',
+        cliVersion: productVersion,
         selector: { kind: 'version', value: 'test/ref' },
         installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/test/ref/install',
       },

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -17,6 +17,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 const cliEntry = join(dirname(fileURLToPath(import.meta.url)), '../bin/openalice.ts')
 const cliPackageRoot = dirname(dirname(cliEntry))
+const cliVersion = JSON.parse(
+  await readFile(join(cliPackageRoot, 'package.json'), 'utf8'),
+).version
 const temporaryPaths: string[] = []
 
 afterEach(async () => {
@@ -66,7 +69,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       })
     })
 
-    expect(transcript).toContain('OpenAlice  0.87.0-beta  development')
+    expect(transcript).toContain(`OpenAlice  ${cliVersion}  development`)
     expect(transcript).toContain('Runtime state: absent')
     expect(transcript).toContain('Supervisor controls')
     expect(transcript).toContain('\u001b[?25h')
@@ -196,7 +199,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       writeFile(join(releaseRoot, 'install-source.json'), JSON.stringify({
         schemaVersion: 1,
         repository: 'TraderAlice/OpenAlice',
-        cliVersion: '0.87.0-beta',
+        cliVersion,
         selector: { kind: 'branch', value: 'dev' },
         installerUrl: 'https://openalice.ai/install',
       })),
@@ -249,7 +252,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
       })
     })
 
-    expect(transcript).toContain('OpenAlice  0.87.0-beta  branch dev')
+    expect(transcript).toContain(`OpenAlice  ${cliVersion}  branch dev`)
     expect(transcript).toContain('installer-managed OpenAlice source branch dev')
     expect(transcript).not.toContain('Configure Runtime source')
     expect(transcript).toContain('\u001b[?25h')

--- a/packages/cli/src/update.spec.mjs
+++ b/packages/cli/src/update.spec.mjs
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
+import { readFileSync } from 'node:fs'
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -12,10 +13,16 @@ import {
   runUpdateCommand,
 } from './update.mjs'
 
+const currentCliVersion = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+).version
+const [currentMajor = '0', currentMinor = '0'] = currentCliVersion.split('.')
+const newerCliVersion = `${currentMajor}.${Number(currentMinor) + 1}.0-beta`
+
 const stableSource = {
   schemaVersion: 1,
   repository: 'TraderAlice/OpenAlice',
-  cliVersion: '0.87.0-beta',
+  cliVersion: currentCliVersion,
   selector: { kind: 'branch', value: 'master' },
   installerUrl: 'https://openalice.ai/install',
 }
@@ -43,13 +50,13 @@ describe('OpenAlice CLI updates', () => {
       currentVersion: '0.87.0-beta',
       installSource: stableSource,
     }, {
-      fetchImpl: manifestFetch('0.88.0-beta'),
+      fetchImpl: manifestFetch(newerCliVersion),
       env: {},
     })
     expect(result).toMatchObject({
       status: 'available',
       currentVersion: '0.87.0-beta',
-      latestVersion: '0.88.0-beta',
+      latestVersion: newerCliVersion,
       channel: 'stable',
     })
   })
@@ -80,14 +87,14 @@ describe('OpenAlice CLI updates', () => {
     const stdout = { write: vi.fn() }
     await expect(runUpdateCommand(['--yes'], {
       applyUpdate,
-      fetchImpl: manifestFetch('0.88.0-beta'),
+      fetchImpl: manifestFetch(newerCliVersion),
       layout: { installRoot: '/tmp/.openalice' },
       readInstallSourceImpl: async () => stableSource,
       stdout,
       env: {},
     })).resolves.toBe(0)
     expect(applyUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ latestVersion: '0.88.0-beta' }),
+      expect.objectContaining({ latestVersion: newerCliVersion }),
       expect.objectContaining({
         layout: { installRoot: '/tmp/.openalice' },
         yes: true,
@@ -173,7 +180,7 @@ describe('OpenAlice CLI updates', () => {
       },
       writeFileImpl: async (_path, value) => { cache = value },
       readInstallSourceImpl: async () => stableSource,
-      fetchImpl: manifestFetch('0.88.0-beta'),
+      fetchImpl: manifestFetch(newerCliVersion),
       stderr,
       env: {},
       now: () => Date.parse('2026-07-29T00:00:00.000Z'),


### PR DESCRIPTION
## Summary
- bump OpenAlice and the distributed CLI to 0.88.0-beta
- make installer, Supervisor PTY, and update tests derive the current manifest version so future release bumps do not leave stale expectations

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm -F @traderalice/openalice-cli typecheck
- pnpm build
- pnpm test
- pnpm test:e2e