### PR TITLE
fix(release): verify tag-pinned installer plan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -630,7 +630,7 @@ jobs:
           cmp /tmp/openalice-install /tmp/openalice-site-install
           bash -n /tmp/openalice-install
           bash /tmp/openalice-install --plan | tee /tmp/openalice-install-plan
-          grep -Eq '^  Branch[[:space:]]+master$' /tmp/openalice-install-plan
+          grep -Fq "GitHub ref: TraderAlice/OpenAlice@${TAG}" /tmp/openalice-install-plan
           INSTALLER_PATH=/tmp/openalice-install MANIFEST_URL="${BASE_URL}/manifest.json" node -e '
             const { createHash } = require("node:crypto");
             const { readFileSync } = require("node:fs");


### PR DESCRIPTION
Fix the final CDN verification gate for release-owned installers. The published installer correctly reports a pinned GitHub release ref, so the workflow now asserts the exact requested tag instead of expecting a mutable master branch label.\n\nVerified with the live 0.88.0-beta installer plan, workflow YAML parsing, npx tsc --noEmit, and pnpm test.