### PR TITLE
hotfix: repair 0.88.0-beta CDN verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -630,7 +630,7 @@ jobs:
           cmp /tmp/openalice-install /tmp/openalice-site-install
           bash -n /tmp/openalice-install
           bash /tmp/openalice-install --plan | tee /tmp/openalice-install-plan
-          grep -Eq '^  Branch[[:space:]]+master$' /tmp/openalice-install-plan
+          grep -Fq "GitHub ref: TraderAlice/OpenAlice@${TAG}" /tmp/openalice-install-plan
           INSTALLER_PATH=/tmp/openalice-install MANIFEST_URL="${BASE_URL}/manifest.json" node -e '
             const { createHash } = require("node:crypto");
             const { readFileSync } = require("node:fs");


### PR DESCRIPTION
Promote the release verification hotfix from dev. The 0.88.0-beta assets were uploaded successfully, but the final CDN gate expected a mutable master branch label while the release installer correctly reports its immutable v0.88.0-beta ref.\n\nAfter merge, the existing release will be re-mirrored with the Release workflow mirror_tag input; no new tag or release will be cut.