### PR TITLE
fix(installer): highlight current shell activation

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -472,6 +472,14 @@ The migration also removes the exact unmarked PATH line written by the earlier
 preview installer. A symlinked profile is updated through the symlink instead
 of replacing the symlink itself.
 
+The installer cannot mutate the environment of the parent shell that invoked
+`curl | bash`. When the installed bin directory is not already active, the
+success output therefore labels and prints the exact shell-specific command as
+`Activate OpenAlice in this terminal now (no restart required)`. Running that
+one line makes `openalice` and `pi` immediately available; the managed profile
+block covers future terminals. The printed path reflects `--install-dir`, and
+fish receives `fish_add_path` rather than POSIX `export` syntax.
+
 PATH integration is non-critical. If profile editing fails, the validated CLI
 remains installed and the user receives the command needed for the current
 shell. The installer never uninstalls a conflicting npm, Homebrew, or other

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -43,6 +43,10 @@ The public installer distributes the TypeScript CLI application from the stable
 curl -fsSL https://openalice.ai/install | bash
 ```
 
+The installer prints one shell-specific activation command after success. Run
+it to use `openalice` immediately in the current terminal without restarting;
+the managed shell-profile block makes future terminals work automatically.
+
 Development dogfooding can opt into `dev` explicitly with `--branch dev`. The
 installer requires Node.js 22.19.0 or newer and installs the CLI, pinned Pi,
 and matching macOS/Linux headless Runtime inside one immutable release. The two

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -55,7 +55,9 @@ not install Node.js or configure SSH keys for you.
 curl -fsSL https://openalice.ai/install | bash
 ```
 
-Open a new terminal and verify the installed commands:
+Run the shell-specific activation command printed after installation; it makes
+the commands available in this terminal immediately, with no restart. Then
+verify the installed commands:
 
 ```bash
 openalice --version

--- a/install
+++ b/install
@@ -1131,7 +1131,7 @@ if [[ "$path_updated" -eq 1 ]]; then
   printf '  %-12s %s\n' "Shell" "Future terminals will load the managed block in $profile"
 fi
 if [[ "$path_present" -eq 0 ]]; then
-  printf '\nFor this terminal, run:\n  %s\n' "$current_path_command"
+  printf '\nActivate OpenAlice in this terminal now (no restart required):\n  %s\n' "$current_path_command"
 fi
 if [[ -n "$existing_command" && "$existing_command" != "$BIN_DIR/openalice" ]]; then
   printf '\n%bPATH note:%b this terminal still resolves %s first.\n' "$YELLOW" "$RESET" "$existing_command"

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -22,7 +22,7 @@ afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
 })
 
-describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeout: 15_000 }, () => {
+describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeout: 30_000 }, () => {
   it('keeps the CLI and desktop managed-Pi pins aligned', async () => {
     const installer = await readFile(join(repositoryRoot, 'install'), 'utf8')
     const desktopVendor = await readFile(join(repositoryRoot, 'scripts/vendor-managed-runtime.mjs'), 'utf8')
@@ -127,6 +127,13 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(installed.stdout).toContain('Install plan')
     expect(installed.stdout).toContain('Managed agent  Pi 0.83.0')
     expect(installed.stdout).toContain('OpenAlice and Pi are ready')
+    expect(installed.stdout).toContain('Activate OpenAlice in this terminal now (no restart required):')
+    const activation = installed.stdout.match(/Activate OpenAlice in this terminal now \(no restart required\):\n  (.+)\n/)?.[1]
+    expect(activation).toBeDefined()
+    const activated = await execFileAsync('bash', ['-c', `${activation}; command -v openalice`], {
+      env: installerEnv(home),
+    })
+    expect(activated.stdout.trim()).toBe(join(installRoot, 'bin', 'openalice'))
     const releases = await readdir(join(installRoot, 'cli-versions'))
     expect(releases).toHaveLength(1)
     expect(releases[0]).toMatch(/^test_ref-[a-f0-9]{16}$/)
@@ -293,7 +300,7 @@ function runInstallerInPty(args, { home, reply }) {
     const timeout = setTimeout(() => {
       terminal.kill()
       rejectPromise(new Error(`installer PTY timed out:\n${output}`))
-    }, 10_000)
+    }, 20_000)
 
     terminal.onData((data) => {
       output += data

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -100,6 +100,12 @@ grep -Fq "Press Enter inside the Supervisor to prepare, start, and open OpenAlic
 grep -Fq "Use c only if you want to select an existing checkout instead." \
   <<<"$first_install_output" \
   || fail "source-only install did not keep manual checkout selection secondary"
+grep -Fq "Activate OpenAlice in this terminal now (no restart required):" \
+  <<<"$first_install_output" \
+  || fail "installer did not offer immediate current-shell activation"
+grep -Fq "export PATH=$HOME/.openalice/bin:\$PATH" \
+  <<<"$first_install_output" \
+  || fail "installer did not print the current-shell PATH command"
 
 bin_dir="$HOME/.openalice/bin"
 versions_dir="$HOME/.openalice/cli-versions"


### PR DESCRIPTION
## Summary
- label the installer-provided PATH command as immediate current-shell activation with no restart required
- verify the emitted command actually resolves the installed `openalice` launcher
- lock the copy into clean-container acceptance and update local/remote quickstarts
- give the installer PTY test enough headroom under concurrent CI load without weakening its prompt handshake

## Verification
- `bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh scripts/install-channel-smoke/run.sh`
- `git diff --check`
- `pnpm -F @traderalice/openalice-cli typecheck`
- `pnpm vitest run packages/cli/src/install.spec.mjs` (10 passed)
- `npx tsc --noEmit`
- `pnpm test` (3,869 passed, 9 skipped)
- `pnpm test:install:docker`
- `pnpm test:install:docker --interactive`; reviewed consent/plan/completion copy and proved the printed `export PATH=...` resolves both installed launchers in a no-profile shell

Electron smoke not run: this changes only Bash installer completion copy, installer tests, and documentation; no payload, Runtime, dependency topology, PTY implementation, or Electron file changed.
