### PR TITLE
chore(release): prepare 0.89.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.88.0-beta",
+  "version": "0.89.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.88.0-beta",
+  "version": "0.89.0-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump the OpenAlice desktop/product version to 0.89.0-beta
- keep the distributed CLI version aligned at 0.89.0-beta
- include the installer current-shell activation guidance already merged through PR #941

## Verification
- root, UI, and desktop TypeScript checks
- pnpm test: 3869 passed, 9 skipped
- pnpm test:e2e: 30 passed, 3 skipped
- CLI tests: 195 passed
- bash installer syntax checks
- clean Docker installer acceptance
- managed remote SSH install/repair/reconnect acceptance
- interactive installer walkthrough including master/dev/runtime plans
- unsigned packaged Workspace acceptance
- real v0.88.0-beta to 0.89.0-beta Apple Silicon desktop upgrade: 11 receipt checks passed