### PR TITLE
test(desktop): normalize upgrade smoke path assertion

### DIFF
--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -33,7 +35,7 @@ describe('desktop upgrade smoke planning', () => {
   it('keeps package and final-artifact candidate modes exclusive', () => {
     const defaultPlan = buildDesktopUpgradeSmokePlan([], { cwd: '/repo' })
     expect(defaultPlan.errors).toEqual([])
-    expect(defaultPlan.candidatePackageRoot).toBe('/repo/dist/electron-app')
+    expect(defaultPlan.candidatePackageRoot).toBe(resolve('/repo', 'dist/electron-app'))
 
     const invalid = buildDesktopUpgradeSmokePlan([
       '--candidate-package-root', 'dist/package',


### PR DESCRIPTION
## Summary
- build the desktop upgrade smoke plan expectation with the host path resolver
- keep the assertion equivalent on POSIX while accepting the correct drive-qualified Windows path

## Evidence
- PR #942 Windows CI failed only because /repo/dist/electron-app resolves to D:\repo\dist\electron-app on the runner
- pnpm exec vitest run scripts/desktop-upgrade-smoke-lib.spec.ts