### PR TITLE
fix(release): unblock 0.89 desktop artifacts

### DIFF
--- a/apps/desktop/src/child-shutdown.spec.ts
+++ b/apps/desktop/src/child-shutdown.spec.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+
+import { childIsRunning, stopChild } from './child-shutdown.js'
+
+class FakeChild extends EventEmitter {
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+  killed = false
+
+  finish(signal: NodeJS.Signals): void {
+    this.signalCode = signal
+    this.emit('exit', null, signal)
+  }
+}
+
+describe('desktop child shutdown', () => {
+  it('treats a signalled-but-still-alive child as running', () => {
+    const child = new FakeChild()
+    child.killed = true
+
+    expect(childIsRunning(child as unknown as ChildProcess)).toBe(true)
+  })
+
+  it('does not force a child that exits during the SIGTERM grace period', async () => {
+    const child = new FakeChild()
+    const signals: NodeJS.Signals[] = []
+
+    await stopChild(child as unknown as ChildProcess, {
+      graceMs: 20,
+      sendSignal: (signal) => {
+        signals.push(signal)
+        queueMicrotask(() => child.finish(signal))
+      },
+    })
+
+    expect(signals).toEqual(['SIGTERM'])
+  })
+
+  it('forces a child that accepted SIGTERM but did not exit', async () => {
+    const child = new FakeChild()
+    const signals: NodeJS.Signals[] = []
+    let forced = false
+
+    await stopChild(child as unknown as ChildProcess, {
+      graceMs: 1,
+      sendSignal: (signal) => {
+        signals.push(signal)
+        child.killed = true
+        if (signal === 'SIGKILL') queueMicrotask(() => child.finish(signal))
+      },
+      onForce: () => { forced = true },
+    })
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL'])
+    expect(forced).toBe(true)
+  })
+})

--- a/apps/desktop/src/child-shutdown.ts
+++ b/apps/desktop/src/child-shutdown.ts
@@ -1,0 +1,55 @@
+import type { ChildProcess } from 'node:child_process'
+
+export type StoppableChild = Pick<ChildProcess, 'exitCode' | 'signalCode' | 'once' | 'off'>
+
+export interface StopChildOptions {
+  graceMs: number
+  sendSignal: (signal: NodeJS.Signals) => void
+  onForce?: () => void
+}
+
+export function childIsRunning(child: Pick<ChildProcess, 'exitCode' | 'signalCode'>): boolean {
+  return child.exitCode === null && child.signalCode === null
+}
+
+function waitForExitWithin(exited: Promise<void>, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs)
+    void exited.then(() => {
+      clearTimeout(timer)
+      resolve(true)
+    })
+  })
+}
+
+/**
+ * Stop one managed child gracefully, then force it if it is still running.
+ *
+ * `ChildProcess.killed` is deliberately not consulted: Node sets it as soon as
+ * a signal is sent, even when the process ignores that signal and stays alive.
+ */
+export async function stopChild(child: StoppableChild, options: StopChildOptions): Promise<void> {
+  if (!childIsRunning(child)) return
+
+  const onExit = (): void => resolveExit()
+  let resolveExit!: () => void
+  const exited = new Promise<void>((resolve) => {
+    resolveExit = resolve
+    child.once('exit', onExit)
+  })
+
+  // Close the small race where the process exits between the first state
+  // check and listener registration.
+  if (!childIsRunning(child)) {
+    child.off('exit', onExit)
+    return
+  }
+
+  options.sendSignal('SIGTERM')
+  const exitedGracefully = await waitForExitWithin(exited, options.graceMs)
+  if (exitedGracefully || !childIsRunning(child)) return
+
+  options.onForce?.()
+  options.sendSignal('SIGKILL')
+  await exited
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -57,6 +57,7 @@ import {
   type ResolvedDesktopDataHome,
 } from './data-home-desktop.js'
 import { inspectPreviousUpdateAttempt, recordUpdateAttempt } from './update-attempt.js'
+import { childIsRunning, stopChild } from './child-shutdown.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -1281,20 +1282,17 @@ async function startFlagWatcher(
 /** Cascade tree-kill every managed child. */
 async function stopChildren(): Promise<void> {
   appQuitting = true
-  const children = [uta, connector, alice].filter((c): c is ChildProcess => c != null && c.exitCode === null && !c.killed)
+  const children = [uta, connector, alice].filter((c): c is ChildProcess => c != null && childIsRunning(c))
   if (children.length === 0) return
   console.log(`[guardian] shutting down — SIGTERM → ${children.length} child(ren)`)
   await Promise.all(
-    children.map(async (c) => {
-      const exited = new Promise<void>((r) => c.once('exit', () => r()))
-      killTree(c, 'SIGTERM')
-      await Promise.race([exited, new Promise((r) => setTimeout(r, SIGTERM_GRACE_MS))])
-      if (c.exitCode === null && !c.killed) {
+    children.map((c) => stopChild(c, {
+      graceMs: SIGTERM_GRACE_MS,
+      sendSignal: (signal) => killTree(c, signal),
+      onForce: () => {
         console.warn(`[guardian] child pid=${c.pid} did not exit after ${SIGTERM_GRACE_MS}ms → SIGKILL`)
-        killTree(c, 'SIGKILL')
-        await exited
-      }
-    }),
+      },
+    })),
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "artifactName": "OpenAlice.Setup.${version}.${ext}"
     },
     "publish": [
       {

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
 
 import { describe, expect, it } from 'vitest'
 
@@ -12,6 +13,14 @@ import {
 } from './desktop-upgrade-smoke-lib.mjs'
 
 describe('desktop upgrade smoke planning', () => {
+  it('keeps the Windows builder filename aligned with the upgrade contract', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as { build: { nsis: { artifactName: string } } }
+
+    expect(packageJson.build.nsis.artifactName).toBe('OpenAlice.Setup.${version}.${ext}')
+  })
+
   it('selects the newest published version different from the candidate', () => {
     expect(selectPreviousDesktopTag(
       ['v0.88.0-beta', 'v0.87.0-beta', 'v0.86.0-beta'],


### PR DESCRIPTION
## Summary
- pin the NSIS artifact name to the dotted filename used by the updater and release mirror
- distinguish a sent signal from an exited Electron child process
- force SIGKILL after the graceful shutdown window when a child ignores SIGTERM
- add regressions for the Windows artifact contract and Guardian shutdown semantics

## Release context
The first v0.89.0-beta Release run stopped before publishing any tag, GitHub Release, or CDN asset. Windows produced a space-separated installer name while the update contract expects the historical dotted name. The Intel macOS N-1 smoke also reproduced a child that accepted SIGTERM without exiting; the Node `ChildProcess.killed` flag caused the existing SIGKILL fallback to be skipped.

## Verification
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test` (3873 passed, 9 skipped)
- targeted desktop shutdown and upgrade-contract specs (8 passed)
- Guardian recovery package matrix: runtime-lock unit/type checks, stubborn-owner real-process recovery, full suite, dev three-child smoke, Electron Guardian/PTY smoke, packaged app boot/renderer/clean shutdown

This is an emergency release hotfix targeting `master`; no v0.89.0-beta assets were published by the failed run.