### PR TITLE
fix(release): mirror NSIS updater install mode

### DIFF
--- a/scripts/desktop-upgrade-smoke-lib.mjs
+++ b/scripts/desktop-upgrade-smoke-lib.mjs
@@ -26,6 +26,15 @@ export function candidateDesktopAssetName(version, platform, arch) {
   return previousDesktopAssetName(version, platform, arch)
 }
 
+export function windowsInstallerArgs(installRoot, isUpdate = false) {
+  // Keep the replacement path identical to electron-updater's NsisUpdater.
+  return [
+    ...(isUpdate ? ['--updated'] : []),
+    '/S',
+    `/D=${installRoot}`,
+  ]
+}
+
 export function buildDesktopUpgradeSmokePlan(argv, options = {}) {
   const cwd = options.cwd ?? process.cwd()
   const args = argv[0] === '--' ? argv.slice(1) : [...argv]

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -10,6 +10,7 @@ import {
   candidateDesktopAssetName,
   previousDesktopAssetName,
   selectPreviousDesktopTag,
+  windowsInstallerArgs,
 } from './desktop-upgrade-smoke-lib.mjs'
 
 describe('desktop upgrade smoke planning', () => {
@@ -39,6 +40,17 @@ describe('desktop upgrade smoke planning', () => {
     expect(() => previousDesktopAssetName('1.0.0', 'linux', 'x64')).toThrow(
       'unsupported desktop upgrade host',
     )
+  })
+
+  it('matches electron-updater arguments for an in-place Windows update', () => {
+    const installRoot = 'C:\\OpenAlice'
+
+    expect(windowsInstallerArgs(installRoot)).toEqual(['/S', '/D=C:\\OpenAlice'])
+    expect(windowsInstallerArgs(installRoot, true)).toEqual([
+      '--updated',
+      '/S',
+      '/D=C:\\OpenAlice',
+    ])
   })
 
   it('keeps package and final-artifact candidate modes exclusive', () => {

--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -18,6 +18,7 @@ import {
   previousDesktopAssetName,
   selectPreviousDesktopTag,
   versionFromTag,
+  windowsInstallerArgs,
 } from './desktop-upgrade-smoke-lib.mjs'
 import { packagedElectronExecutable } from './smoke-packaged-toolchain.mjs'
 
@@ -82,9 +83,9 @@ async function waitForPath(path, timeoutMs = 30_000) {
   throw new Error(`timed out waiting for ${path}`)
 }
 
-async function installWindows(archive, installRoot) {
+async function installWindows(archive, installRoot, isUpdate = false) {
   mkdirSync(dirname(installRoot), { recursive: true })
-  run(archive, ['/S', `/D=${installRoot}`])
+  run(archive, windowsInstallerArgs(installRoot, isUpdate))
   const executable = join(installRoot, 'OpenAlice.exe')
   await waitForPath(executable)
   return executable
@@ -351,7 +352,7 @@ async function main() {
       candidateSource = 'final-artifact'
       candidateExecutable = process.platform === 'darwin'
         ? extractMacZip(asset, join(smokeRoot, 'candidate'))
-        : await installWindows(asset, join(smokeRoot, 'installed', 'OpenAlice'))
+        : await installWindows(asset, join(smokeRoot, 'installed', 'OpenAlice'), true)
     } else {
       candidateSource = 'unpacked-package'
       candidateExecutable = await candidateExecutableFromPackage(plan.candidatePackageRoot)


### PR DESCRIPTION
## Summary

- make the Windows final-artifact upgrade smoke invoke NSIS with the same update-mode arguments as electron-updater
- keep the previous-version fresh install in normal silent-install mode
- lock both argument sets with a focused unit test

## Why

The second v0.89.0-beta release run successfully built and verified the dotted Windows installer name, but its N-1 replacement step invoked the candidate with only /S and /D. Production electron-updater also passes --updated; without it, the assisted NSIS installer remained open until the workflow timeout.

## Verification

- npx vitest run scripts/desktop-upgrade-smoke-lib.spec.ts
- node --check scripts/desktop-upgrade-smoke.mjs
- node --check scripts/desktop-upgrade-smoke-lib.mjs
- npx tsc --noEmit
- pnpm test (3874 passed, 9 skipped)