### PR TITLE
fix(release): mirror detached NSIS updater launch

### DIFF
--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -83,9 +83,42 @@ async function waitForPath(path, timeoutMs = 30_000) {
   throw new Error(`timed out waiting for ${path}`)
 }
 
+async function waitForInstalledVersion(installRoot, expectedVersion, timeoutMs = 8 * 60_000) {
+  const packageJson = join(installRoot, 'resources', 'app', 'package.json')
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const installedVersion = JSON.parse(readFileSync(packageJson, 'utf8')).version
+      if (installedVersion === expectedVersion) return
+    } catch {
+      // NSIS replaces the package tree in place; partial reads are expected while it runs.
+    }
+    await sleep(500)
+  }
+  throw new Error(`timed out waiting for installed OpenAlice ${expectedVersion} under ${installRoot}`)
+}
+
+async function spawnDetached(command, args) {
+  console.log(`[desktop-upgrade] ${command} ${args.join(' ')}`)
+  const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+  await new Promise((resolveSpawn, rejectSpawn) => {
+    child.once('spawn', resolveSpawn)
+    child.once('error', rejectSpawn)
+  })
+  child.unref()
+}
+
 async function installWindows(archive, installRoot, isUpdate = false) {
   mkdirSync(dirname(installRoot), { recursive: true })
-  run(archive, windowsInstallerArgs(installRoot, isUpdate))
+  const args = windowsInstallerArgs(installRoot, isUpdate)
+  if (isUpdate) {
+    // NsisUpdater starts the installer detached, then quits Electron. Waiting for
+    // the detached NSIS process itself can hang after its files are installed.
+    await spawnDetached(archive, args)
+    await waitForInstalledVersion(installRoot, candidateVersion)
+  } else {
+    run(archive, args)
+  }
   const executable = join(installRoot, 'OpenAlice.exe')
   await waitForPath(executable)
   return executable


### PR DESCRIPTION
## Summary

- launch the Windows replacement installer detached, matching electron-updater production behavior
- poll the installed package version until the candidate is fully present before launching verification
- keep fresh previous-release installation synchronous

## Evidence

Release run 30695726963 passed the expected --updated /S /D arguments but the smoke used spawnSync and waited until the outer 15-minute timeout. electron-updater uses a detached, unreferenced spawn and then quits Electron. The smoke now follows that lifecycle while still requiring the installed version to become 0.89.0-beta.

## Verification

- node --check scripts/desktop-upgrade-smoke.mjs
- npx vitest run scripts/desktop-upgrade-smoke-lib.spec.ts
- npx tsc --noEmit
- pnpm test (3874 passed, 9 skipped)