### PR TITLE
fix(desktop): run assisted updates silently

### DIFF
--- a/apps/desktop/src/auto-update.spec.ts
+++ b/apps/desktop/src/auto-update.spec.ts
@@ -148,7 +148,7 @@ describe('configureAutoUpdate', () => {
 
     expect(beforeInstall).toHaveBeenCalledWith('0.88.0-beta', expect.any(Function))
     expect(onInstallHandoff).toHaveBeenCalledWith('0.88.0-beta')
-    expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true)
     expect(setProgressBar).toHaveBeenCalledWith(0.424)
     expect(setProgressBar).toHaveBeenCalledWith(2)
     expect(send.mock.calls.map(([, status]) => status)).toContainEqual({

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -112,7 +112,9 @@ export function configureAutoUpdate(win: BrowserWindow, hooks: AutoUpdateHooks):
       })
       sendStatus({ phase: 'installing', version, stage: 'handing-off' })
       await hooks.onInstallHandoff?.(version)
-      autoUpdater.quitAndInstall(false, true)
+      // Assisted NSIS updates must be silent or they stop on the installer UI
+      // after Electron exits. Force-run restarts the updated app on success.
+      autoUpdater.quitAndInstall(true, true)
       return { ok: true }
     } catch (error) {
       const normalized = error instanceof Error ? error : new Error(String(error))

--- a/scripts/desktop-upgrade-smoke-lib.mjs
+++ b/scripts/desktop-upgrade-smoke-lib.mjs
@@ -27,9 +27,13 @@ export function candidateDesktopAssetName(version, platform, arch) {
 }
 
 export function windowsInstallerArgs(installRoot, isUpdate = false) {
-  // Keep the replacement path identical to electron-updater's NsisUpdater.
+  if (isUpdate) {
+    // Mirror the silent NsisUpdater path. The production handoff additionally
+    // uses --force-run; the smoke owns the candidate launch so it can inject
+    // isolated state and verify both the first launch and a restart.
+    return ['--updated', '/S']
+  }
   return [
-    ...(isUpdate ? ['--updated'] : []),
     '/S',
     `/D=${installRoot}`,
   ]

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -49,7 +49,6 @@ describe('desktop upgrade smoke planning', () => {
     expect(windowsInstallerArgs(installRoot, true)).toEqual([
       '--updated',
       '/S',
-      '/D=C:\\OpenAlice',
     ])
   })
 


### PR DESCRIPTION
## Summary

- invoke electron-updater with silent install plus forced restart
- prevent the assisted NSIS flow from stopping on installer UI after Electron exits
- make the Windows final-artifact smoke use NSIS update discovery instead of forcing a /D directory
- keep the smoke-owned candidate launch so state and restart checks remain isolated

## Evidence

Release run 30701137082 launched the updater-style installer detached but the installed version remained 0.88.0-beta for eight minutes. The product currently calls quitAndInstall(false, true), which omits /S. Because OpenAlice uses assisted NSIS, that non-silent update waits on installer UI. Production now calls quitAndInstall(true, true), while the smoke uses the corresponding silent update mode and lets NSIS resolve the existing registered install location.

## Verification

- npx vitest run apps/desktop/src/auto-update.spec.ts scripts/desktop-upgrade-smoke-lib.spec.ts
- npx tsc --noEmit
- npx tsc -p apps/desktop/tsconfig.json --noEmit
- node --check scripts/desktop-upgrade-smoke.mjs
- pnpm test (3874 passed, 9 skipped)