### PR TITLE
test(release): allow slow Windows update replacement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
           --from "${{ needs.release.outputs.previous_tag }}"
           --candidate-artifact-dir dist/electron-app
           --receipt "${{ runner.temp }}/openalice-desktop-upgrade.json"
-        timeout-minutes: 15
+        timeout-minutes: 30
 
       - name: Preserve desktop upgrade acceptance receipt
         if: always()

--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -83,15 +83,29 @@ async function waitForPath(path, timeoutMs = 30_000) {
   throw new Error(`timed out waiting for ${path}`)
 }
 
-async function waitForInstalledVersion(installRoot, expectedVersion, timeoutMs = 8 * 60_000) {
+async function waitForInstalledVersion(installRoot, expectedVersion, timeoutMs = 20 * 60_000) {
   const packageJson = join(installRoot, 'resources', 'app', 'package.json')
+  const startedAt = Date.now()
   const deadline = Date.now() + timeoutMs
+  let lastObservedVersion = null
+  let lastProgressAt = 0
   while (Date.now() < deadline) {
+    let observedVersion = '<replacing>'
     try {
-      const installedVersion = JSON.parse(readFileSync(packageJson, 'utf8')).version
-      if (installedVersion === expectedVersion) return
+      observedVersion = JSON.parse(readFileSync(packageJson, 'utf8')).version ?? '<missing>'
+      if (observedVersion === expectedVersion) return
     } catch {
       // NSIS replaces the package tree in place; partial reads are expected while it runs.
+    }
+    const now = Date.now()
+    if (observedVersion !== lastObservedVersion || now - lastProgressAt >= 30_000) {
+      const elapsedSeconds = Math.round((now - startedAt) / 1000)
+      console.log(
+        `[desktop-upgrade] waiting for installed ${expectedVersion}: ` +
+        `observed=${observedVersion} elapsed=${elapsedSeconds}s`,
+      )
+      lastObservedVersion = observedVersion
+      lastProgressAt = now
     }
     await sleep(500)
   }


### PR DESCRIPTION
## Summary

- allow up to twenty minutes for the signed Windows installer to replace a large existing package on hosted runners
- raise the release step budget to thirty minutes so old install, state seeding, replacement, launch, restart, and receipt checks can all complete
- log the observed installed version every thirty seconds while NSIS is replacing files

## Evidence

Release run 30703267921 used the corrected updater arguments --updated /S. The old v0.88 installation alone took about five and a half minutes; the candidate was still running when the eight-minute inner version wait expired. GitHub cleanup found the installer process alive. The expanded budget remains bounded and now reports whether the tree is still v0.88, temporarily unreadable during replacement, or v0.89.

## Verification

- node --check scripts/desktop-upgrade-smoke.mjs
- npx vitest run scripts/desktop-upgrade-smoke-lib.spec.ts apps/desktop/src/auto-update.spec.ts
- npx tsc --noEmit
- pnpm test (3874 passed, 9 skipped)