### PR TITLE
test(release): expand Windows upgrade install path

### DIFF
--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from 'node:child_process'
-import { createWriteStream, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import { createServer as createNetServer } from 'node:net'
 import { tmpdir } from 'node:os'
@@ -328,7 +337,15 @@ async function main() {
     throw new Error(`previous ${fromTag} must differ from candidate ${candidateVersion}`)
   }
 
-  const smokeRoot = mkdtempSync(join(tmpdir(), 'openalice-desktop-upgrade-'))
+  const createdSmokeRoot = mkdtempSync(join(tmpdir(), 'openalice-desktop-upgrade-'))
+  // GitHub's Windows runners expose TEMP through an 8.3 path such as
+  // C:\Users\RUNNER~1\.... NSIS records /D verbatim, while its process check
+  // compares that install root with the long paths returned by CIM. Expanding
+  // the existing directory first keeps the upgrade fixture representative and
+  // lets the candidate installer close every process under the old app root.
+  const smokeRoot = process.platform === 'win32'
+    ? realpathSync.native(createdSmokeRoot)
+    : createdSmokeRoot
   const smokeHome = join(smokeRoot, 'home')
   const smokeWorkspaces = join(smokeRoot, 'workspaces')
   const smokeGlobal = join(smokeRoot, 'global')


### PR DESCRIPTION
## Summary

- expand the Windows temporary upgrade root from its 8.3 alias before installing N-1
- keep NSIS registry install paths aligned with CIM process paths
- allow the final installer to find and close old packaged Guardian processes during the release upgrade smoke

## Evidence

Release run 30705047920 showed the candidate installer repeatedly replacing the app tree, then restoring 0.88.0-beta while the installer remained alive. The fixture installed under `C:\Users\RUNNER~1\...`, while packaged process logs resolved the same root under the long `C:\Users\runneradmin\...` spelling. electron-builder NSIS checks running processes with a case-insensitive `StartsWith($INSTDIR)` comparison, so the path alias prevented it from seeing the old app tree.

## Verification

- `node --check scripts/desktop-upgrade-smoke.mjs`
- `npx vitest run scripts/desktop-upgrade-smoke-lib.spec.ts apps/desktop/src/auto-update.spec.ts`
- `npx tsc --noEmit`
- `pnpm test` (3874 passed, 9 skipped)
- Windows final-artifact N-1 upgrade remains the required hosted release gate