### PR TITLE
fix(updater): take over legacy Windows process trees

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -1,0 +1,8 @@
+!macro customInit
+  ${if} ${isUpdated}
+    DetailPrint "Closing the legacy OpenAlice process tree before update."
+    nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /T /F /IM "${APP_EXECUTABLE_FILENAME}"'
+    Pop $0
+    Sleep 1000
+  ${endif}
+!macroend

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
+      "include": "apps/desktop/build/installer.nsh",
       "artifactName": "OpenAlice.Setup.${version}.${ext}"
     },
     "publish": [

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -14,12 +14,19 @@ import {
 } from './desktop-upgrade-smoke-lib.mjs'
 
 describe('desktop upgrade smoke planning', () => {
-  it('keeps the Windows builder filename aligned with the upgrade contract', () => {
+  it('keeps the Windows builder and legacy takeover aligned with the upgrade contract', () => {
     const packageJson = JSON.parse(
       readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
-    ) as { build: { nsis: { artifactName: string } } }
+    ) as { build: { nsis: { artifactName: string; include: string } } }
+    const installerInclude = readFileSync(
+      new URL('../apps/desktop/build/installer.nsh', import.meta.url),
+      'utf8',
+    )
 
     expect(packageJson.build.nsis.artifactName).toBe('OpenAlice.Setup.${version}.${ext}')
+    expect(packageJson.build.nsis.include).toBe('apps/desktop/build/installer.nsh')
+    expect(installerInclude).toContain('${if} ${isUpdated}')
+    expect(installerInclude).toContain('/T /F /IM "${APP_EXECUTABLE_FILENAME}"')
   })
 
   it('selects the newest published version different from the candidate', () => {


### PR DESCRIPTION
## Summary

- add an electron-builder NSIS include for update-only legacy process takeover
- force-close exact `OpenAlice.exe` process trees before the normal uninstall/replace path
- keep fresh and interactive installs on the existing behavior
- pin the installer include and takeover contract in the desktop upgrade smoke spec

## Evidence

Formal Release runs 30705047920 and 30706896953 both launched the 0.89 installer after 0.88 logged Guardian shutdown, then repeatedly alternated the installed tree between 0.88.0-beta and a replacing state. The installer process remained alive until the 20-minute version gate expired. Run 30706896953 used a fully expanded long install path, ruling out the prior 8.3 path alias hypothesis. The unpatchable 0.88 Guardian exits its parent before its child tree has finished, so the candidate installer must take ownership of legacy shutdown.

## Verification

- `npx vitest run scripts/desktop-upgrade-smoke-lib.spec.ts apps/desktop/src/auto-update.spec.ts` (13 passed)
- `npx tsc --noEmit`
- `pnpm test` (3874 passed, 9 skipped)
- unsigned macOS-to-Windows cross-build reached native dependency rebuild and stopped before NSIS because node-gyp does not support cross-compilation; the Windows formal release job remains the required NSIS compile and N-1 acceptance gate