### PR TITLE
fix(updater): stop residual Windows install processes

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -3,6 +3,9 @@
     DetailPrint "Closing the legacy OpenAlice process tree before update."
     nsExec::ExecToLog '"$SYSDIR\taskkill.exe" /T /F /IM "${APP_EXECUTABLE_FILENAME}"'
     Pop $0
+    DetailPrint "Closing remaining processes launched from the OpenAlice install directory."
+    nsExec::ExecToLog `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -Command "Get-CimInstance -ClassName Win32_Process | Where-Object {$$_.ExecutablePath -and $$_.ExecutablePath.StartsWith('$INSTDIR', [System.StringComparison]::OrdinalIgnoreCase)} | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }"`
+    Pop $0
     Sleep 1000
   ${endif}
 !macroend

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -27,6 +27,8 @@ describe('desktop upgrade smoke planning', () => {
     expect(packageJson.build.nsis.include).toBe('apps/desktop/build/installer.nsh')
     expect(installerInclude).toContain('${if} ${isUpdated}')
     expect(installerInclude).toContain('/T /F /IM "${APP_EXECUTABLE_FILENAME}"')
+    expect(installerInclude).toContain("ExecutablePath.StartsWith('$INSTDIR'")
+    expect(installerInclude).toContain('Stop-Process -Id')
   })
 
   it('selects the newest published version different from the candidate', () => {

--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -115,10 +115,48 @@ async function waitForInstalledVersion(installRoot, expectedVersion, timeoutMs =
       )
       lastObservedVersion = observedVersion
       lastProgressAt = now
+      if (process.platform === 'win32') logWindowsUpgradeProcesses(installRoot)
     }
     await sleep(500)
   }
   throw new Error(`timed out waiting for installed OpenAlice ${expectedVersion} under ${installRoot}`)
+}
+
+function logWindowsUpgradeProcesses(installRoot) {
+  const powershell = join(
+    process.env['SystemRoot'] || 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe',
+  )
+  const script = [
+    "$root = [IO.Path]::GetFullPath($env:OPENALICE_UPGRADE_INSTALL_ROOT);",
+    'Get-CimInstance -ClassName Win32_Process',
+    '| Where-Object {',
+    "  ($_.ExecutablePath -and $_.ExecutablePath.StartsWith($root, [StringComparison]::OrdinalIgnoreCase))",
+    "  -or $_.Name -like 'OpenAlice*'",
+    "  -or $_.Name -eq 'old-uninstaller.exe'",
+    '}',
+    '| Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine',
+    '| ConvertTo-Json -Compress',
+  ].join(' ')
+  const result = spawnSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', script], {
+    encoding: 'utf8',
+    timeout: 15_000,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      OPENALICE_UPGRADE_INSTALL_ROOT: installRoot,
+    },
+  })
+  const output = result.stdout?.trim()
+  if (result.status === 0) {
+    console.log(`[desktop-upgrade] Windows process snapshot: ${output || '[]'}`)
+  } else {
+    const detail = result.error?.message || result.stderr?.trim() || `exit ${result.status ?? 'unknown'}`
+    console.log(`[desktop-upgrade] Windows process snapshot unavailable: ${detail}`)
+  }
 }
 
 async function spawnDetached(command, args) {


### PR DESCRIPTION
## Summary
- terminate every process whose executable lives under the installed OpenAlice directory before an NSIS update
- retain the existing process-tree takeover for legacy OpenAlice executables
- record Windows process snapshots during N-1 upgrade smoke waits

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3874 passed, 9 skipped)
- `pnpm vitest run scripts/desktop-upgrade-smoke-lib.spec.ts`
- Windows NSIS compilation and N-1 upgrade remain gated by package-smoke / Release runners