### PR TITLE
fix(updater): bypass legacy long-path uninstaller

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -7,5 +7,26 @@
     nsExec::ExecToLog `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -Command "Get-CimInstance -ClassName Win32_Process | Where-Object {$$_.ExecutablePath -and $$_.ExecutablePath.StartsWith('$INSTDIR', [System.StringComparison]::OrdinalIgnoreCase)} | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }"`
     Pop $0
     Sleep 1000
+
+    ; Releases before 0.89 were unpacked (asar=false) and can contain paths
+    ; beyond the legacy MAX_PATH limit. Their NSIS uninstaller repeatedly
+    ; fails while atomically renaming that tree. cmd's extended-length path
+    ; removes the app directory without touching Electron/OpenAlice user data,
+    ; which lives outside $INSTDIR. Clear only the old uninstall commands so
+    ; electron-builder skips launching the incompatible legacy uninstaller;
+    ; the candidate writes fresh uninstall metadata after extraction.
+    DetailPrint "Removing the legacy OpenAlice app directory with long-path support."
+    ; The app/installer may inherit $INSTDIR as its working directory. Move out
+    ; first because cmd refuses to remove the current directory.
+    SetOutPath "$TEMP"
+    nsExec::ExecToLog '"$SYSDIR\cmd.exe" /D /C RD /S /Q "\\?\$INSTDIR"'
+    Pop $0
+    ${if} $0 != 0
+      DetailPrint "Unable to remove the legacy OpenAlice app directory (exit $0)."
+      SetErrorLevel 2
+      Quit
+    ${endif}
+    DeleteRegValue SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "UninstallString"
+    DeleteRegValue SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "QuietUninstallString"
   ${endif}
 !macroend

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -29,6 +29,9 @@ describe('desktop upgrade smoke planning', () => {
     expect(installerInclude).toContain('/T /F /IM "${APP_EXECUTABLE_FILENAME}"')
     expect(installerInclude).toContain("ExecutablePath.StartsWith('$INSTDIR'")
     expect(installerInclude).toContain('Stop-Process -Id')
+    expect(installerInclude).toContain('SetOutPath "$TEMP"')
+    expect(installerInclude).toContain('/D /C RD /S /Q "\\\\?\\$INSTDIR"')
+    expect(installerInclude).toContain('DeleteRegValue SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "UninstallString"')
   })
 
   it('selects the newest published version different from the candidate', () => {


### PR DESCRIPTION
## Summary
- remove the pre-0.89 unpacked Windows app tree through an extended-length path during updates
- skip the incompatible legacy uninstaller after preserving its shortcut metadata
- fail explicitly if the old app directory cannot be removed

## Evidence
Release 30712188035 showed only the candidate installer and `old-uninstaller.exe`; the old uninstaller retried its atomic tree rename five times and restored 0.88 each time. The unpacked package has relative paths over 220 characters before the install-root prefix.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (3874 passed, 9 skipped)
- `pnpm vitest run scripts/desktop-upgrade-smoke-lib.spec.ts`
- formal Windows NSIS compile and N-1 upgrade remain release-gated