### PR TITLE
fix(cli): preserve stable updates for release installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,15 +483,9 @@ jobs:
           test "$CLI_PACKAGE_VERSION" = "$VERSION"
           bash -n install
           cp install "dist/r2-upload/OpenAlice-${VERSION}-install"
-          node - "$VERSION" "dist/r2-upload/OpenAlice-${VERSION}-install" <<'NODE'
-          const { readFileSync, writeFileSync } = require('node:fs')
-          const [version, path] = process.argv.slice(2)
-          const source = 'OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"'
-          const target = `OPENALICE_INSTALLER_RELEASE_VERSION="\${OPENALICE_INSTALLER_RELEASE_VERSION:-${version}}"`
-          const input = readFileSync(path, 'utf8')
-          if (!input.includes(source)) throw new Error('installer release-version placeholder is missing')
-          writeFileSync(path, input.replace(source, target))
-          NODE
+          node scripts/prepare-cli-release-installer.mjs \
+            "$VERSION" \
+            "dist/r2-upload/OpenAlice-${VERSION}-install"
           bash -n "dist/r2-upload/OpenAlice-${VERSION}-install"
 
       - name: Prepare CDN download aliases
@@ -661,6 +655,7 @@ jobs:
           bash -n /tmp/openalice-install
           bash /tmp/openalice-install --plan | tee /tmp/openalice-install-plan
           grep -Fq "GitHub ref: TraderAlice/OpenAlice@${TAG}" /tmp/openalice-install-plan
+          grep -Fq "Updates        stable" /tmp/openalice-install-plan
           INSTALLER_PATH=/tmp/openalice-install MANIFEST_URL="${BASE_URL}/manifest.json" node -e '
             const { createHash } = require("node:crypto");
             const { readFileSync } = require("node:fs");

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -290,8 +290,8 @@ Before a release becomes visible, the installer:
    managed Pi closure;
 5. verifies and expands the matching headless Runtime when the selected release
    supplies one, then requires its product version to equal the CLI version;
-6. writes `install-source.json` with the CLI version, selected branch/tag/commit,
-   and installer URL that produced this CLI;
+6. writes `install-source.json` with the CLI version, selected
+   branch/tag/commit, installer URL, and independent update-channel policy;
 7. hashes the ordered OpenAlice CLI payload, install-source metadata, and both
    Pi install files with SHA-256 and uses the first 16 hex characters as the
    cross-platform CLI install content identity.
@@ -356,8 +356,10 @@ An installed stable-channel CLI checks
 `https://download.openalice.ai/manifest.json` before an interactive
 `openalice start`:
 
-- only a recorded public `branch master` installation from
-  `https://openalice.ai/install` participates;
+- public release installers record two independent facts: the immutable
+  release tag used for the installed payload and `updateChannel: stable`;
+- legacy metadata from a public `branch master` installation at
+  `https://openalice.ai/install` remains compatible with the stable channel;
 - exact tag/commit installations remain pinned;
 - `dev` and other branch installations keep their selected development channel;
 - custom installer/mirror installations do not cross into the public trust
@@ -367,6 +369,13 @@ An installed stable-channel CLI checks
 - `--no-update-check` or `OPENALICE_NO_UPDATE_CHECK=1` disables the start check;
 - discovery only prints a notice. It never mutates files or makes startup
   depend on a successful network request.
+
+Release installers published before provenance v2 recorded their embedded tag
+in the same shape as a deliberate `--version` pin. The CLI cannot safely guess
+which intent produced that old metadata. An affected install therefore remains
+pinned until the public stable installer is run once again; that ordinary
+atomic reinstall preserves application state and writes the unambiguous v2
+stable-channel provenance.
 
 Explicit controls are:
 
@@ -520,9 +529,11 @@ Environment inputs:
 | `OPENALICE_PI_SOURCE_DIR` | Read the exact Pi manifest/lock assets from a local fixture |
 | `OPENALICE_NPM_BIN` | Use a single alternate npm executable in installer tests |
 | `OPENALICE_INSTALL_CONTEXT` | Internal managed-remote context; returns control without local checkout/start guidance |
+| `OPENALICE_INSTALL_UPDATE_CHANNEL` | Internal exact-provenance reproduction seam used by managed SSH installs |
 | `OPENALICE_EXPECTED_CLI_VERSION` | Internal verified-update guard; rejects a payload whose CLI/product version differs from the release manifest |
 | `OPENALICE_RUNTIME_RELEASE_BASE_URL` | Release/test override for Runtime metadata and archive downloads |
 | `OPENALICE_INSTALLER_RELEASE_VERSION` | Embedded by the release workflow; binds the installer to one OpenAlice tag and Runtime set |
+| `OPENALICE_INSTALLER_UPDATE_CHANNEL` | Embedded as `stable` by the release workflow; keeps the exact tag independently updateable through the public release channel |
 | `OPENALICE_RUNTIME_ARCHIVE`, `OPENALICE_RUNTIME_ARCHIVE_SHA256` | Local/CI equivalents of the development Runtime archive flags |
 | `NO_COLOR` | Disable installer color output |
 | `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |

--- a/install
+++ b/install
@@ -4,6 +4,7 @@ set -euo pipefail
 REPOSITORY="TraderAlice/OpenAlice"
 DEFAULT_BRANCH="master"
 OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"
+OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-}"
 PUBLIC_INSTALLER_URL="https://openalice.ai/install"
 VERSION=""
 REF_KIND=""
@@ -468,6 +469,34 @@ if [[ "$REF_KIND" == "branch" && "$VERSION" == "$DEFAULT_BRANCH" ]]; then
 fi
 INSTALLER_URL="${OPENALICE_INSTALL_URL:-$DEFAULT_INSTALLER_URL}"
 
+if [[ -n "${OPENALICE_INSTALL_UPDATE_CHANNEL:-}" ]]; then
+  UPDATE_CHANNEL="$OPENALICE_INSTALL_UPDATE_CHANNEL"
+elif [[ -n "$REF_OPTION" ]]; then
+  if [[ "$REF_KIND" == "version" ]]; then
+    UPDATE_CHANNEL="pinned"
+  elif [[ "$VERSION" == "$DEFAULT_BRANCH" && "$INSTALLER_URL" == "$PUBLIC_INSTALLER_URL" ]]; then
+    UPDATE_CHANNEL="stable"
+  elif [[ "$VERSION" == "$DEFAULT_BRANCH" ]]; then
+    UPDATE_CHANNEL="custom"
+  else
+    UPDATE_CHANNEL="development"
+  fi
+elif [[ -n "$OPENALICE_INSTALLER_UPDATE_CHANNEL" ]]; then
+  UPDATE_CHANNEL="$OPENALICE_INSTALLER_UPDATE_CHANNEL"
+elif [[ "$REF_KIND" == "version" ]]; then
+  UPDATE_CHANNEL="pinned"
+elif [[ "$VERSION" == "$DEFAULT_BRANCH" && "$INSTALLER_URL" == "$PUBLIC_INSTALLER_URL" ]]; then
+  UPDATE_CHANNEL="stable"
+elif [[ "$VERSION" == "$DEFAULT_BRANCH" ]]; then
+  UPDATE_CHANNEL="custom"
+else
+  UPDATE_CHANNEL="development"
+fi
+case "$UPDATE_CHANNEL" in
+  stable|pinned|development|custom) ;;
+  *) die "Unsupported OpenAlice update channel: $UPDATE_CHANNEL" ;;
+esac
+
 INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
 BIN_DIR="$INSTALL_ROOT/bin"
 VERSIONS_DIR="$INSTALL_ROOT/cli-versions"
@@ -716,6 +745,7 @@ if [[ "$REF_KIND" == "branch" ]]; then
 else
   printf '  %-14s %s\n' "Version" "$VERSION"
 fi
+printf '  %-14s %s\n' "Updates" "$UPDATE_CHANNEL"
 printf '  %-14s %s\n' "Install root" "$INSTALL_ROOT"
 printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-14s %s\n' "Managed agent" "Pi $PI_VERSION -> $BIN_DIR/pi"
@@ -967,29 +997,32 @@ STAGED_VERSION="$(node "$STAGING/bin/openalice.ts" --version)"
 [[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
 node -e '
   const { writeFileSync } = require("node:fs");
-  const [path, repository, cliVersion, kind, value, installerUrl] = process.argv.slice(1);
+  const [path, repository, cliVersion, kind, value, installerUrl, updateChannel] = process.argv.slice(1);
   writeFileSync(path, `${JSON.stringify({
-    schemaVersion: 1,
+    schemaVersion: 2,
     repository,
     cliVersion,
     selector: { kind, value },
     installerUrl,
+    updateChannel,
   }, null, 2)}\n`, { mode: 0o644 });
-' "$STAGING/install-source.json" "$REPOSITORY" "$CLI_VERSION" "$REF_KIND" "$VERSION" "$INSTALLER_URL"
+' "$STAGING/install-source.json" "$REPOSITORY" "$CLI_VERSION" "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$UPDATE_CHANNEL"
 node "$STAGING/bin/openalice.ts" version --json | node -e '
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { input += chunk; });
   process.stdin.on("end", () => {
-    const [kind, value, installerUrl, cliVersion] = process.argv.slice(1);
+    const [kind, value, installerUrl, cliVersion, updateChannel] = process.argv.slice(1);
     const info = JSON.parse(input);
     if (info.version !== cliVersion
+      || info.installSource?.schemaVersion !== 2
       || info.installSource?.cliVersion !== cliVersion
       || info.installSource?.selector?.kind !== kind
       || info.installSource?.selector?.value !== value
-      || info.installSource?.installerUrl !== installerUrl) process.exit(1);
+      || info.installSource?.installerUrl !== installerUrl
+      || info.installSource?.updateChannel !== updateChannel) process.exit(1);
   });
-' "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$CLI_VERSION" \
+' "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$CLI_VERSION" "$UPDATE_CHANNEL" \
   || die "The downloaded CLI did not preserve its installation source"
 CONTENT_FILES=("${FILES[@]}" "install-source.json" "managed/pi/package.json" "managed/pi/package-lock.json")
 # Keep the CLI identity stable across operating systems. The platform-specific

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -7,11 +7,12 @@ import { fileURLToPath } from 'node:url'
 const CLI_VERSION = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
 export const DEFAULT_INSTALL_SOURCE = Object.freeze({
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: 'TraderAlice/OpenAlice',
   cliVersion: CLI_VERSION,
   selector: Object.freeze({ kind: 'branch', value: 'master' }),
   installerUrl: 'https://openalice.ai/install',
+  updateChannel: 'stable',
 })
 
 export async function readInstallSource(options = {}) {
@@ -41,8 +42,12 @@ export function parseInstallSource(value) {
   const kind = selector?.kind
   const ref = selector?.value
   const installerUrl = typeof value.installerUrl === 'string' ? value.installerUrl : ''
+  const schemaVersion = value.schemaVersion
+  const updateChannel = schemaVersion === 2
+    ? value.updateChannel
+    : inferLegacyUpdateChannel({ selector, installerUrl })
   if (
-    value.schemaVersion !== 1
+    ![1, 2].includes(schemaVersion)
     || repository !== 'TraderAlice/OpenAlice'
     || cliVersion.length < 1
     || !['branch', 'version'].includes(kind)
@@ -52,15 +57,17 @@ export function parseInstallSource(value) {
     || ref.includes('..')
     || !/^[A-Za-z0-9._/-]+$/.test(ref)
     || !isHttpUrl(installerUrl)
+    || !['stable', 'pinned', 'development', 'custom'].includes(updateChannel)
   ) {
     return null
   }
   return {
-    schemaVersion: 1,
+    schemaVersion,
     repository,
     cliVersion,
     selector: { kind, value: ref },
     installerUrl,
+    ...(schemaVersion === 2 ? { updateChannel } : {}),
   }
 }
 
@@ -79,6 +86,14 @@ export function installSourcesMatch(left, right) {
     && normalizedLeft.selector.kind === normalizedRight.selector.kind
     && normalizedLeft.selector.value === normalizedRight.selector.value
     && normalizedLeft.installerUrl === normalizedRight.installerUrl
+    && installSourceUpdateChannel(normalizedLeft) === installSourceUpdateChannel(normalizedRight)
+}
+
+export function installSourceUpdateChannel(source) {
+  const normalized = requireInstallSource(source)
+  return normalized.schemaVersion === 2
+    ? normalized.updateChannel
+    : inferLegacyUpdateChannel(normalized)
 }
 
 export function formatInstallSelector(source) {
@@ -101,12 +116,26 @@ export function managedSourceKey(source) {
 
 function cloneInstallSource(source) {
   return {
-    schemaVersion: 1,
+    schemaVersion: source.schemaVersion,
     repository: source.repository,
     cliVersion: source.cliVersion,
     selector: { ...source.selector },
     installerUrl: source.installerUrl,
+    ...(source.schemaVersion === 2 ? { updateChannel: source.updateChannel } : {}),
   }
+}
+
+function inferLegacyUpdateChannel(source) {
+  if (source?.selector?.kind === 'version') return 'pinned'
+  if (
+    source?.selector?.kind === 'branch'
+    && source.selector.value === 'master'
+    && source.installerUrl === 'https://openalice.ai/install'
+  ) {
+    return 'stable'
+  }
+  if (source?.selector?.kind === 'branch' && source.selector.value === 'master') return 'custom'
+  return 'development'
 }
 
 function isHttpUrl(value) {

--- a/packages/cli/src/install-source.spec.mjs
+++ b/packages/cli/src/install-source.spec.mjs
@@ -8,7 +8,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   DEFAULT_INSTALL_SOURCE,
   installedContentIdentity,
+  installSourceUpdateChannel,
   installSourcesMatch,
+  parseInstallSource,
   readInstallSource,
 } from './install-source.mjs'
 
@@ -25,8 +27,10 @@ describe('OpenAlice install source', () => {
     await expect(readInstallSource({ metadataUrl: join(root, 'missing.json') }))
       .resolves.toEqual(DEFAULT_INSTALL_SOURCE)
     expect(DEFAULT_INSTALL_SOURCE).toMatchObject({
+      schemaVersion: 2,
       selector: { kind: 'branch', value: 'master' },
       installerUrl: 'https://openalice.ai/install',
+      updateChannel: 'stable',
     })
   })
 
@@ -46,6 +50,40 @@ describe('OpenAlice install source', () => {
     }
     expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, { ...DEFAULT_INSTALL_SOURCE })).toBe(true)
     expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, dev)).toBe(false)
+  })
+
+  it('reads legacy metadata without changing its inferred channel', () => {
+    const legacyStable = {
+      schemaVersion: 1,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: '0.88.0-beta',
+      selector: { kind: 'branch', value: 'master' },
+      installerUrl: 'https://openalice.ai/install',
+    }
+    const legacyPinned = {
+      ...legacyStable,
+      selector: { kind: 'version', value: 'v0.88.0-beta' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/v0.88.0-beta/install',
+    }
+
+    expect(parseInstallSource(legacyStable)).toEqual(legacyStable)
+    expect(installSourceUpdateChannel(legacyStable)).toBe('stable')
+    expect(installSourceUpdateChannel(legacyPinned)).toBe('pinned')
+  })
+
+  it('keeps an immutable release ref distinct from its stable update policy', () => {
+    const stableRelease = {
+      schemaVersion: 2,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: '0.89.0-beta',
+      selector: { kind: 'version', value: 'v0.89.0-beta' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/v0.89.0-beta/install',
+      updateChannel: 'stable',
+    }
+    const explicitPin = { ...stableRelease, updateChannel: 'pinned' }
+
+    expect(installSourceUpdateChannel(stableRelease)).toBe('stable')
+    expect(installSourcesMatch(stableRelease, explicitPin)).toBe(false)
   })
 
   it('derives installed content identity only from an immutable release directory', () => {

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
+import { createServer } from 'node:http'
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -34,6 +35,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
 
     expect(installer).toContain('DEFAULT_BRANCH="master"')
     expect(installer).toContain('PUBLIC_INSTALLER_URL="https://openalice.ai/install"')
+    expect(installer).toContain('OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-}"')
     expect(installer).toContain('MINIMUM_NODE_VERSION="22.19.0"')
     expect(installer).toContain('PI_VERSION="0.83.0"')
     expect(desktopVendor).toContain("const PI_VERSION = '0.83.0'")
@@ -103,8 +105,10 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
 
     const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
     expect(JSON.parse(versionInfo.stdout).installSource).toMatchObject({
+      schemaVersion: 2,
       selector: { kind: 'branch', value: 'master' },
       installerUrl: 'https://openalice.ai/install',
+      updateChannel: 'stable',
     })
   })
 
@@ -150,11 +154,12 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
       version: productVersion,
       contentIdentity: releases[0].slice(-16),
       installSource: {
-        schemaVersion: 1,
+        schemaVersion: 2,
         repository: 'TraderAlice/OpenAlice',
         cliVersion: productVersion,
         selector: { kind: 'version', value: 'test/ref' },
         installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/test/ref/install',
+        updateChannel: 'pinned',
       },
       managedRuntime: null,
     })
@@ -163,6 +168,88 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(pi.stdout.trim()).toBe('0.83.0')
     const launcher = await readFile(join(installRoot, 'bin', 'openalice'), 'utf8')
     expect(launcher).toContain('OPENALICE_MANAGED_PI_PATH=')
+  })
+
+  it('recovers a legacy pinned release install onto stable without losing its exact ref', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-stable-ref-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const installerArgs = [
+      '--source', repositoryRoot,
+      '--version', `v${productVersion}`,
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--yes',
+    ]
+
+    await execFileAsync('bash', [join(repositoryRoot, 'install'), ...installerArgs], {
+      env: {
+        ...installerEnv(home),
+        OPENALICE_INSTALL_CONTEXT: 'remote',
+      },
+    })
+    const [legacyRelease] = await readdir(join(installRoot, 'cli-versions'))
+    await writeFile(join(installRoot, 'cli-versions', legacyRelease, 'install-source.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: productVersion,
+      selector: { kind: 'version', value: `v${productVersion}` },
+      installerUrl: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${productVersion}/install`,
+    }, null, 2)}\n`)
+    const pinnedCheck = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['update', '--check', '--json'])
+    expect(JSON.parse(pinnedCheck.stdout)).toMatchObject({ status: 'unsupported', channel: 'pinned' })
+
+    await execFileAsync('bash', [join(repositoryRoot, 'install'), ...installerArgs], {
+      env: {
+        ...installerEnv(home),
+        OPENALICE_INSTALL_CONTEXT: 'remote',
+        OPENALICE_INSTALL_UPDATE_CHANNEL: 'stable',
+      },
+    })
+
+    const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
+    expect(JSON.parse(versionInfo.stdout).installSource).toEqual({
+      schemaVersion: 2,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: productVersion,
+      selector: { kind: 'version', value: `v${productVersion}` },
+      installerUrl: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${productVersion}/install`,
+      updateChannel: 'stable',
+    })
+
+    const server = createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({
+        version: productVersion,
+        releaseNotesUrl: `https://github.com/TraderAlice/OpenAlice/releases/tag/v${productVersion}`,
+        installer: {
+          url: 'https://download.openalice.ai/install',
+          versionedUrl: `https://download.openalice.ai/OpenAlice-${productVersion}-install`,
+          sha256: '0'.repeat(64),
+        },
+      }))
+    })
+    await new Promise((resolvePromise, rejectPromise) => {
+      server.once('error', rejectPromise)
+      server.listen(0, '127.0.0.1', resolvePromise)
+    })
+    try {
+      const address = server.address()
+      const stableCheck = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['update', '--check', '--json'], {
+        env: {
+          ...process.env,
+          OPENALICE_UPDATE_MANIFEST_URL: `http://127.0.0.1:${address.port}/manifest.json`,
+        },
+      })
+      expect(JSON.parse(stableCheck.stdout)).toMatchObject({
+        status: 'current',
+        currentVersion: productVersion,
+        latestVersion: productVersion,
+        channel: 'stable',
+      })
+    } finally {
+      await new Promise((resolvePromise) => server.close(resolvePromise))
+    }
   })
 
   it('can show the complete plan without creating the install root', async () => {

--- a/packages/cli/src/managed-source.ts
+++ b/packages/cli/src/managed-source.ts
@@ -20,7 +20,7 @@ const DEFAULT_REPOSITORY_URL = 'https://github.com/TraderAlice/OpenAlice.git'
 const MAX_GIT_ERROR_OUTPUT_BYTES = 64 * 1024
 
 interface InstallSource {
-  schemaVersion: 1
+  schemaVersion: 1 | 2
   repository: string
   cliVersion: string
   selector: {
@@ -28,6 +28,7 @@ interface InstallSource {
     value: string
   }
   installerUrl: string
+  updateChannel?: 'stable' | 'pinned' | 'development' | 'custom'
 }
 
 interface InstalledLayout {

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -9,6 +9,7 @@ import {
   DEFAULT_INSTALL_SOURCE,
   formatInstallSelector,
   installedContentIdentity,
+  installSourceUpdateChannel,
   installSourcesMatch,
   managedSourceKey,
   parseInstallSource,
@@ -903,6 +904,7 @@ export function buildRemoteInstallCommand(installSource, installBaseUrl = '', wi
   const selectorValue = shellQuote(source.selector.value)
   const installEnv = [
     `OPENALICE_INSTALL_URL=${url}`,
+    `OPENALICE_INSTALL_UPDATE_CHANNEL=${shellQuote(installSourceUpdateChannel(source))}`,
     'OPENALICE_INSTALL_CONTEXT=remote',
     `OPENALICE_EXPECTED_CLI_VERSION=${shellQuote(source.cliVersion)}`,
     installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)}` : '',

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -82,9 +82,23 @@ describe('OpenAlice managed remote connector', () => {
   it('builds a remote installer command from local provenance, not remote flags', () => {
     const command = buildRemoteInstallCommand(masterInstallSource)
     expect(command).toContain('OPENALICE_INSTALL_URL=')
+    expect(command).toContain("OPENALICE_INSTALL_UPDATE_CHANNEL='stable'")
     expect(command).toContain('OPENALICE_INSTALL_CONTEXT=remote')
     expect(command).toContain("--branch 'master'")
     expect(command).not.toContain('--version')
+  })
+
+  it('reproduces a stable release from its exact ref without pinning the remote channel', () => {
+    const command = buildRemoteInstallCommand({
+      schemaVersion: 2,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: '0.89.0-beta',
+      selector: { kind: 'version', value: 'v0.89.0-beta' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/v0.89.0-beta/install',
+      updateChannel: 'stable',
+    })
+    expect(command).toContain("OPENALICE_INSTALL_UPDATE_CHANNEL='stable'")
+    expect(command).toContain("--version 'v0.89.0-beta'")
   })
 
   it('plans install and start separately, with no implicit takeover', () => {

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { resolveInstalledLayout } from './install-layout.mjs'
-import { readInstallSource } from './install-source.mjs'
+import { installSourceUpdateChannel, readInstallSource } from './install-source.mjs'
 
 const CURRENT_VERSION = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
@@ -36,7 +36,7 @@ export async function checkForUpdate(options = {}, dependencies = {}) {
   const installSource = options.installSource ?? await (
     dependencies.readInstallSourceImpl ?? readInstallSource
   )()
-  const channel = updateChannel(installSource)
+  const channel = installSourceUpdateChannel(installSource)
   if (channel !== 'stable') {
     return {
       status: 'unsupported',
@@ -307,19 +307,6 @@ function runProcess(spawnImpl, command, args, options) {
       else rejectPromise(new Error(`installer exited with code=${String(code)}, signal=${String(signal)}`))
     })
   })
-}
-
-function updateChannel(source) {
-  if (source?.selector?.kind === 'version') return 'pinned'
-  if (
-    source?.selector?.kind === 'branch'
-    && source.selector.value === 'master'
-    && source.installerUrl === 'https://openalice.ai/install'
-  ) {
-    return 'stable'
-  }
-  if (source?.selector?.kind === 'branch' && source.selector.value === 'master') return 'custom'
-  return 'development'
 }
 
 function unsupportedChannelMessage(source, channel) {

--- a/packages/cli/src/update.spec.mjs
+++ b/packages/cli/src/update.spec.mjs
@@ -20,11 +20,12 @@ const [currentMajor = '0', currentMinor = '0'] = currentCliVersion.split('.')
 const newerCliVersion = `${currentMajor}.${Number(currentMinor) + 1}.0-beta`
 
 const stableSource = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: 'TraderAlice/OpenAlice',
   cliVersion: currentCliVersion,
-  selector: { kind: 'branch', value: 'master' },
-  installerUrl: 'https://openalice.ai/install',
+  selector: { kind: 'version', value: `v${currentCliVersion}` },
+  installerUrl: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${currentCliVersion}/install`,
+  updateChannel: 'stable',
 }
 
 describe('OpenAlice CLI updates', () => {
@@ -66,20 +67,40 @@ describe('OpenAlice CLI updates', () => {
       installSource: {
         ...stableSource,
         selector: { kind: 'version', value: 'v0.87.0-beta' },
+        updateChannel: 'pinned',
       },
     })).resolves.toMatchObject({ status: 'unsupported', channel: 'pinned' })
     await expect(checkForUpdate({
       installSource: {
         ...stableSource,
         selector: { kind: 'branch', value: 'dev' },
+        updateChannel: 'development',
       },
     })).resolves.toMatchObject({ status: 'unsupported', channel: 'development' })
     await expect(checkForUpdate({
       installSource: {
         ...stableSource,
+        selector: { kind: 'branch', value: 'master' },
         installerUrl: 'https://mirror.example.test/install',
+        updateChannel: 'custom',
       },
     })).resolves.toMatchObject({ status: 'unsupported', channel: 'custom' })
+  })
+
+  it('continues to recognize legacy public-master metadata as stable', async () => {
+    await expect(checkForUpdate({
+      currentVersion: '0.87.0-beta',
+      installSource: {
+        schemaVersion: 1,
+        repository: 'TraderAlice/OpenAlice',
+        cliVersion: '0.87.0-beta',
+        selector: { kind: 'branch', value: 'master' },
+        installerUrl: 'https://openalice.ai/install',
+      },
+    }, {
+      fetchImpl: manifestFetch(newerCliVersion),
+      env: {},
+    })).resolves.toMatchObject({ status: 'available', channel: 'stable' })
   })
 
   it('uses the ordinary installer only after an explicit update command', async () => {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -504,6 +504,9 @@ source-tool planning.
 
 ### 9. Atomic Runtime update, activation, and rollback
 
+- [x] Separate immutable install provenance from update-channel policy so a
+  release-owned exact-tag install remains on stable while explicit
+  `--version` installs stay pinned.
 - [ ] Stage matching CLI, Pi, and Runtime as one product release.
 - [ ] Plan compatibility and active-work impact for running instances.
 - [ ] Keep compatible old processes alive with pending activation.
@@ -787,3 +790,10 @@ This plan is complete only when:
   acceptance deletes only that dependency from an otherwise healthy release,
   verifies that the installer preserves the damaged evidence, replaces the
   release atomically, and confirms the repaired closure before continuing.
+- 2026-08-02: Dogfood found that release-owned installers recorded their
+  embedded tag as an explicit pin, disabling both startup notices and the TUI
+  update action. Install provenance v2 now keeps the immutable tag for exact
+  SSH/source reproduction and records update policy separately. Release
+  generation embeds `stable`, human `--version` remains pinned, legacy v1
+  metadata remains readable, and the release-installer transformation plus
+  stable-ref install/check path have dedicated regression coverage.

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -115,9 +115,11 @@ node -e '
 const value = JSON.parse(process.argv[1]);
 const expectedVersion = process.argv[2];
 if (value.version !== expectedVersion) process.exit(1);
+if (value.installSource?.schemaVersion !== 2) process.exit(1);
 if (value.installSource?.cliVersion !== expectedVersion) process.exit(1);
 if (value.installSource?.selector?.kind !== "branch" || value.installSource?.selector?.value !== "smoke-v1") process.exit(1);
 if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") process.exit(1);
+if (value.installSource?.updateChannel !== "development") process.exit(1);
 ' "$install_source" "$cli_version" || fail "installed CLI did not preserve its install source"
 [[ "$($bin_dir/pi --version)" == "0.83.0" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"

--- a/scripts/prepare-cli-release-installer.mjs
+++ b/scripts/prepare-cli-release-installer.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+const RELEASE_VERSION_SOURCE = 'OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"'
+const UPDATE_CHANNEL_SOURCE = 'OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-}"'
+
+export function prepareCliReleaseInstaller(version, path) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`invalid OpenAlice release version: ${version}`)
+  }
+  const input = readFileSync(path, 'utf8')
+  if (!input.includes(RELEASE_VERSION_SOURCE)) {
+    throw new Error('installer release-version placeholder is missing')
+  }
+  if (!input.includes(UPDATE_CHANNEL_SOURCE)) {
+    throw new Error('installer update-channel placeholder is missing')
+  }
+  writeFileSync(path, input
+    .replace(
+      RELEASE_VERSION_SOURCE,
+      `OPENALICE_INSTALLER_RELEASE_VERSION="\${OPENALICE_INSTALLER_RELEASE_VERSION:-${version}}"`,
+    )
+    .replace(
+      UPDATE_CHANNEL_SOURCE,
+      'OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-stable}"',
+    ))
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [version, path] = process.argv.slice(2)
+  if (!version || !path) {
+    console.error('Usage: prepare-cli-release-installer.mjs <version> <installer-path>')
+    process.exit(2)
+  }
+  prepareCliReleaseInstaller(version, path)
+}

--- a/scripts/prepare-cli-release-installer.spec.mjs
+++ b/scripts/prepare-cli-release-installer.spec.mjs
@@ -1,0 +1,61 @@
+import { execFile } from 'node:child_process'
+import { copyFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { prepareCliReleaseInstaller } from './prepare-cli-release-installer.mjs'
+
+const execFileAsync = promisify(execFile)
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const fakeNpm = join(repositoryRoot, 'scripts/install-smoke/fake-npm.sh')
+const piAssets = join(repositoryRoot, 'scripts/install-smoke/pi-assets')
+const productVersion = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8')).version
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe.skipIf(process.platform === 'win32')('release-owned CLI installer', () => {
+  it('binds an immutable payload ref to the stable update channel', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-release-installer-'))
+    temporaryPaths.push(root)
+    const installer = join(root, 'install')
+    const runtimeArchive = join(root, 'runtime.tar.gz')
+    await copyFile(join(repositoryRoot, 'install'), installer)
+    await writeFile(runtimeArchive, '')
+
+    prepareCliReleaseInstaller(productVersion, installer)
+    await expect(execFileAsync('bash', ['-n', installer])).resolves.toBeDefined()
+
+    const plan = await execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--runtime-archive', runtimeArchive,
+      '--install-dir', join(root, '.openalice'),
+      '--no-modify-path',
+      '--plan',
+    ], {
+      env: {
+        ...process.env,
+        HOME: root,
+        OPENALICE_NPM_BIN: fakeNpm,
+        OPENALICE_PI_SOURCE_DIR: piAssets,
+      },
+    })
+
+    expect(plan.stdout).toContain(`Version        v${productVersion}`)
+    expect(plan.stdout).toContain('Updates        stable')
+  })
+
+  it('rejects malformed release versions before rewriting the installer', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-release-installer-invalid-'))
+    temporaryPaths.push(root)
+    const installer = join(root, 'install')
+    await copyFile(join(repositoryRoot, 'install'), installer)
+    expect(() => prepareCliReleaseInstaller('master; bad', installer)).toThrow('invalid OpenAlice release version')
+  })
+})


### PR DESCRIPTION
## Summary
- separate immutable CLI install refs from update-channel policy in provenance v2
- embed `stable` in release-owned installers while keeping explicit `--version` installs pinned
- preserve the policy through managed SSH reproduction and verify old-install recovery end to end

## Verification
- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli typecheck`
- `pnpm test` (3,881 passed, 9 skipped)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- targeted release-installer and CLI provenance/update tests