### PR TITLE
fix(connector): inherit shared proxy and bound startup

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -244,19 +244,16 @@ async function resolveChildProxyEnv(): Promise<Record<string, string>> {
   // Existing env is authoritative on every platform. Electron 39 embeds Node
   // 22.22, whose fetch stack consumes it only when NODE_USE_ENV_PROXY is set.
   const explicit = proxyEnvFromRules('', process.env)
-  if (Object.keys(explicit).length > 0 || process.env['HTTPS_PROXY'] || process.env['HTTP_PROXY'] || process.env['ALL_PROXY']) {
-    return explicit
-  }
-  if (process.platform !== 'win32') return {}
+  if (Object.keys(explicit).length > 0) return explicit
 
   try {
-    // Chromium already understands Windows Internet Options, including PAC.
+    // Chromium already understands the host OS proxy settings, including PAC.
     // Resolve one representative HTTPS API URL and pass a concrete proxy to
     // the pure-Node Alice/UTA children, whose fetch does not consult Chromium.
     const rules = await session.defaultSession.resolveProxy('https://api.openai.com/')
     return proxyEnvFromRules(rules, process.env)
   } catch (err) {
-    console.warn(`[guardian] could not resolve Windows system proxy: ${err instanceof Error ? err.message : String(err)}`)
+    console.warn(`[guardian] could not resolve system proxy: ${err instanceof Error ? err.message : String(err)}`)
     return {}
   }
 }

--- a/apps/desktop/src/proxy-env.spec.ts
+++ b/apps/desktop/src/proxy-env.spec.ts
@@ -20,11 +20,31 @@ describe('proxyEnvFromRules', () => {
 
   it('never overwrites explicit proxy env but enables Node consumption', () => {
     expect(proxyEnvFromRules('PROXY system:8080', { HTTPS_PROXY: 'http://explicit:9000' }))
-      .toEqual({ NODE_USE_ENV_PROXY: '1', NO_PROXY: '127.0.0.1,localhost,::1' })
+      .toEqual({
+        HTTPS_PROXY: 'http://explicit:9000',
+        NODE_USE_ENV_PROXY: '1',
+        NO_PROXY: '127.0.0.1,localhost,::1',
+      })
     expect(proxyEnvFromRules('PROXY system:8080', {
       HTTPS_PROXY: 'http://explicit:9000',
       NODE_USE_ENV_PROXY: '1',
       NO_PROXY: 'internal.example,localhost',
-    })).toEqual({ NO_PROXY: 'internal.example,localhost,127.0.0.1,::1' })
+    })).toEqual({
+      HTTPS_PROXY: 'http://explicit:9000',
+      NO_PROXY: 'internal.example,localhost,127.0.0.1,::1',
+    })
+  })
+
+  it('normalizes lowercase and ALL_PROXY values for child processes', () => {
+    expect(proxyEnvFromRules('DIRECT', {
+      all_proxy: 'http://127.0.0.1:7890',
+      no_proxy: 'private.example',
+    })).toEqual({
+      HTTP_PROXY: 'http://127.0.0.1:7890',
+      HTTPS_PROXY: 'http://127.0.0.1:7890',
+      ALL_PROXY: 'http://127.0.0.1:7890',
+      NODE_USE_ENV_PROXY: '1',
+      NO_PROXY: 'private.example,127.0.0.1,localhost,::1',
+    })
   })
 })

--- a/apps/desktop/src/proxy-env.ts
+++ b/apps/desktop/src/proxy-env.ts
@@ -15,9 +15,14 @@ export function proxyEnvFromRules(
   rules: string,
   env: EnvLike = process.env,
 ): Record<string, string> {
-  const explicit = PROXY_KEYS.some((key) => !!env[key]?.trim())
-  if (explicit) {
+  const allProxy = envValue(env, 'ALL_PROXY')
+  const httpProxy = envValue(env, 'HTTP_PROXY') ?? allProxy
+  const httpsProxy = envValue(env, 'HTTPS_PROXY') ?? httpProxy
+  if (httpProxy || httpsProxy) {
     return {
+      ...(httpProxy ? { HTTP_PROXY: httpProxy } : {}),
+      ...(httpsProxy ? { HTTPS_PROXY: httpsProxy } : {}),
+      ...(allProxy ? { ALL_PROXY: allProxy } : {}),
       ...(!env['NODE_USE_ENV_PROXY'] ? { NODE_USE_ENV_PROXY: '1' } : {}),
       ...localBypassEnv(env),
     }
@@ -39,6 +44,11 @@ export function proxyEnvFromRules(
     NODE_USE_ENV_PROXY: '1',
     ...localBypassEnv(env),
   }
+}
+
+function envValue(env: EnvLike, key: typeof PROXY_KEYS[number]): string | undefined {
+  const value = env[key]?.trim() || env[key.toLowerCase()]?.trim()
+  return value || undefined
 }
 
 function localBypassEnv(env: EnvLike): { NO_PROXY?: string } {

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -125,6 +125,30 @@ not ordinary operator-entered configuration.
 Both adapters reject commands from any account other than the linked owner.
 Use `/status` for adapter health and `/test` for an explicit delivery check.
 
+### Proxy inheritance and bounded startup
+
+Connector Service inherits the launcher's conventional `HTTPS_PROXY`,
+`HTTP_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment (upper- or lower-case).
+Connector SDK proxy endpoints must use HTTP or HTTPS; SOCKS-only proxy rules
+remain unsupported.
+When no explicit environment proxy exists, Electron resolves the host system
+proxy through Chromium and forwards the concrete HTTP(S) rule to every Node
+child. Loopback addresses remain in `NO_PROXY` so local Alice, UTA, and
+Connector health traffic never leaves the machine.
+
+The service installs one shared transport for Node HTTP(S), WebSocket SDKs,
+Undici, and adapters that replace the global agent. Telegram therefore passes
+the shared Node agent into grammY/node-fetch and bridges grammY's bundled abort
+signal into Node's native signal; Discord passes the shared Undici
+dispatcher into both command publication and the client's REST manager, while
+its gateway WebSocket inherits the process Node agent. New adapters must reuse
+this transport instead of reading a connector-specific proxy setting.
+
+The loopback health server binds while adapters are still starting. Each
+adapter gets a 30-second total startup deadline and reports the concrete
+failure through adapter health; a platform outage must never leave the whole
+Connector Service indefinitely unavailable or stuck at `starting`.
+
 ### Setup lifecycle and UI ownership
 
 Connector setup is a lifecycle, not a single `enabled` checkbox. Keep these

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,6 +444,9 @@ importers:
       '@traderalice/connector-protocol':
         specifier: workspace:*
         version: link:../../packages/connector-protocol
+      agent-base:
+        specifier: ^7.1.2
+        version: 7.1.4
       discord.js:
         specifier: 14.26.5
         version: 14.26.5
@@ -453,6 +456,18 @@ importers:
       hono:
         specifier: ^4.12.32
         version: 4.12.32
+      http-proxy-agent:
+        specifier: ^7.0.2
+        version: 7.0.2
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0(encoding@0.1.13)
+      undici:
+        specifier: ^6.27.0
+        version: 6.27.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -460,6 +475,9 @@ importers:
       '@types/node':
         specifier: ^22.13.4
         version: 22.19.15
+      '@types/node-fetch':
+        specifier: ^2.6.13
+        version: 2.6.13
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.25)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -1802,6 +1820,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -5941,6 +5962,11 @@ snapshots:
       '@types/node': 25.2.3
 
   '@types/ms@2.1.0': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.2.3
+      form-data: 4.0.6
 
   '@types/node@22.19.15':
     dependencies:

--- a/services/connector/package.json
+++ b/services/connector/package.json
@@ -15,12 +15,18 @@
     "@grammyjs/auto-retry": "^2.0.2",
     "@hono/node-server": "^2.0.12",
     "@traderalice/connector-protocol": "workspace:*",
+    "agent-base": "^7.1.2",
     "discord.js": "14.26.5",
     "grammy": "^1.40.0",
     "hono": "^4.12.32",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
+    "node-fetch": "2.7.0",
+    "undici": "^6.27.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/node-fetch": "^2.6.13",
     "@types/node": "^22.13.4",
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",

--- a/services/connector/src/adapters/discord.spec.ts
+++ b/services/connector/src/adapters/discord.spec.ts
@@ -1,0 +1,112 @@
+import type { Dispatcher } from 'undici'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CommandRegistry, type ConnectorAdapterContext } from '../core/adapter.js'
+import type { ConnectorProxyTransport } from '../core/proxy.js'
+
+const discordMocks = vi.hoisted(() => ({
+  restConstruct: vi.fn(),
+  restSetToken: vi.fn(),
+  restPut: vi.fn(),
+  clientConstruct: vi.fn(),
+  clientOn: vi.fn(),
+  clientOnce: vi.fn(),
+  clientLogin: vi.fn(),
+  clientDestroy: vi.fn(),
+}))
+
+vi.mock('discord.js', () => {
+  class REST {
+    constructor(options: unknown) {
+      discordMocks.restConstruct(options)
+    }
+    setToken(token: string): this {
+      discordMocks.restSetToken(token)
+      return this
+    }
+    put(route: string, data: unknown): Promise<unknown> {
+      return discordMocks.restPut(route, data)
+    }
+  }
+
+  class Client {
+    constructor(options: unknown) {
+      discordMocks.clientConstruct(options)
+    }
+    on(event: string, listener: (...args: unknown[]) => unknown): this {
+      discordMocks.clientOn(event, listener)
+      return this
+    }
+    once(event: string, listener: () => void): this {
+      discordMocks.clientOnce(event, listener)
+      if (event === 'ready') queueMicrotask(listener)
+      return this
+    }
+    login(token: string): Promise<string> {
+      return discordMocks.clientLogin(token)
+    }
+    destroy(): void {
+      discordMocks.clientDestroy()
+    }
+  }
+
+  class SlashCommandBuilder {
+    setName(): this { return this }
+    setDescription(): this { return this }
+    toJSON(): Record<string, never> { return {} }
+  }
+
+  return {
+    ApplicationIntegrationType: { UserInstall: 1 },
+    Client,
+    Events: { InteractionCreate: 'interaction', Error: 'error', ClientReady: 'ready' },
+    GatewayIntentBits: { Guilds: 1, DirectMessages: 2 },
+    InteractionContextType: { BotDM: 1 },
+    Partials: { Channel: 1 },
+    REST,
+    Routes: { applicationCommands: (id: string) => `/applications/${id}/commands` },
+    SlashCommandBuilder,
+  }
+})
+
+import { DiscordConnectorAdapter } from './discord.js'
+
+describe('DiscordConnectorAdapter proxy startup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    discordMocks.restPut.mockResolvedValue([])
+    discordMocks.clientLogin.mockResolvedValue('test-token')
+  })
+
+  it('passes the shared Undici dispatcher into command and client REST paths', async () => {
+    const dispatcher = {} as Dispatcher
+    const proxy: ConnectorProxyTransport = {
+      active: true,
+      dispatcher,
+      close: async () => undefined,
+    }
+    const adapter = new DiscordConnectorAdapter(proxy)
+
+    await adapter.start({
+      enabled: true,
+      settings: { applicationId: 'app-1', botToken: 'test-token' },
+    }, context())
+
+    expect(discordMocks.restConstruct).toHaveBeenCalledWith({ version: '10', agent: dispatcher })
+    expect(discordMocks.clientConstruct).toHaveBeenCalledWith(expect.objectContaining({
+      rest: { agent: dispatcher },
+    }))
+    expect(discordMocks.restPut).toHaveBeenCalledWith(
+      '/applications/app-1/commands',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+})
+
+function context(): ConnectorAdapterContext {
+  return {
+    commands: new CommandRegistry('discord'),
+    updateSettings: vi.fn(),
+    getServiceStatus: () => 'healthy',
+    sendTest: vi.fn(),
+  }
+}

--- a/services/connector/src/adapters/discord.ts
+++ b/services/connector/src/adapters/discord.ts
@@ -11,6 +11,14 @@ import type {
   ConnectorAdapterRegistration,
 } from '../core/adapter.js'
 import {
+  DIRECT_CONNECTOR_PROXY_TRANSPORT,
+  type ConnectorProxyTransport,
+} from '../core/proxy.js'
+import {
+  CONNECTOR_ADAPTER_STARTUP_TIMEOUT_MS,
+  withStartupDeadline,
+} from '../core/startup.js'
+import {
   AdapterHealthTracker,
   decodeInboxAttachments,
   formatInboxNotification,
@@ -21,6 +29,11 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
   private readonly tracker = new AdapterHealthTracker(this.id)
   private client?: Client
   private ownerUserId?: string
+
+  constructor(
+    private readonly proxy: ConnectorProxyTransport = DIRECT_CONNECTOR_PROXY_TRANSPORT,
+    private readonly startupTimeoutMs = CONNECTOR_ADAPTER_STARTUP_TIMEOUT_MS,
+  ) {}
 
   async start(config: ConnectorAdapterConfig, context: ConnectorAdapterContext): Promise<void> {
     const discord = await import('discord.js')
@@ -35,43 +48,49 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
     this.ownerUserId = optionalString(config, 'ownerUserId')
 
     this.registerCommands(context)
-    await this.publishSlashCommands(applicationId, botToken, discord)
+    let client: Client | undefined
+    try {
+      await withStartupDeadline('Discord', this.startupTimeoutMs, async (signal) => {
+        await this.publishSlashCommands(applicationId, botToken, discord, signal)
 
-    const client = new Client({
-      intents: [GatewayIntentBits.Guilds, GatewayIntentBits.DirectMessages],
-      partials: [Partials.Channel],
-    })
-    this.client = client
-    client.on(Events.InteractionCreate, async (interaction) => {
-      if (!interaction.isChatInputCommand()) return
-      const handled = await context.commands.execute({
-        connectorId: this.id,
-        command: interaction.commandName,
-        userId: interaction.user.id,
-        chatId: interaction.channelId,
-        reply: async (message) => {
-          await interaction.reply({ content: message, ephemeral: false })
-        },
-      }).catch(async (error) => {
-        this.tracker.degraded(error)
-        if (!interaction.replied) await interaction.reply('Connector command failed. Check OpenAlice logs.').catch(() => undefined)
-        return true
+        const createdClient = new Client({
+          intents: [GatewayIntentBits.Guilds, GatewayIntentBits.DirectMessages],
+          partials: [Partials.Channel],
+          ...(this.proxy.dispatcher ? { rest: { agent: this.proxy.dispatcher } } : {}),
+        })
+        client = createdClient
+        this.client = createdClient
+        createdClient.on(Events.InteractionCreate, async (interaction) => {
+          if (!interaction.isChatInputCommand()) return
+          const handled = await context.commands.execute({
+            connectorId: this.id,
+            command: interaction.commandName,
+            userId: interaction.user.id,
+            chatId: interaction.channelId,
+            reply: async (message) => {
+              await interaction.reply({ content: message, ephemeral: false })
+            },
+          }).catch(async (error) => {
+            this.tracker.degraded(error)
+            if (!interaction.replied) await interaction.reply('Connector command failed. Check OpenAlice logs.').catch(() => undefined)
+            return true
+          })
+          if (!handled && !interaction.replied) await interaction.reply('Unknown connector command.').catch(() => undefined)
+        })
+        createdClient.on(Events.Error, (error) => this.tracker.degraded(error))
+
+        const ready = new Promise<void>((resolveReady) => {
+          createdClient.once(Events.ClientReady, () => resolveReady())
+        })
+        await createdClient.login(botToken)
+        await ready
       })
-      if (!handled && !interaction.replied) await interaction.reply('Unknown connector command.').catch(() => undefined)
-    })
-    client.on(Events.Error, (error) => this.tracker.degraded(error))
-
-    const ready = new Promise<void>((resolveReady) => {
-      client.once(Events.ClientReady, () => resolveReady())
-    })
-    await client.login(botToken)
-    await Promise.race([
-      ready,
-      new Promise<never>((_resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error('Discord gateway did not become ready within 15 seconds')), 15_000)
-        timer.unref?.()
-      }),
-    ])
+    } catch (error) {
+      client?.destroy()
+      this.client = undefined
+      this.tracker.degraded(error)
+      throw error
+    }
     if (this.ownerUserId) this.tracker.healthy(this.ownerUserId)
     else this.tracker.awaitingLink()
   }
@@ -139,6 +158,7 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
     applicationId: string,
     token: string,
     discord: typeof import('discord.js'),
+    signal: AbortSignal,
   ): Promise<void> {
     const {
       ApplicationIntegrationType,
@@ -152,12 +172,17 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
       integration_types: [ApplicationIntegrationType.UserInstall],
       contexts: [InteractionContextType.BotDM],
     }))
-    await new REST({ version: '10' }).setToken(token).put(Routes.applicationCommands(applicationId), { body })
+    await new REST({
+      version: '10',
+      ...(this.proxy.dispatcher ? { agent: this.proxy.dispatcher } : {}),
+    }).setToken(token).put(Routes.applicationCommands(applicationId), { body, signal })
   }
 }
 
-export function discordConnectorRegistration(): ConnectorAdapterRegistration {
-  return { definition: DISCORD_CONNECTOR_DEFINITION, create: () => new DiscordConnectorAdapter() }
+export function discordConnectorRegistration(
+  proxy: ConnectorProxyTransport = DIRECT_CONNECTOR_PROXY_TRANSPORT,
+): ConnectorAdapterRegistration {
+  return { definition: DISCORD_CONNECTOR_DEFINITION, create: () => new DiscordConnectorAdapter(proxy) }
 }
 
 function requiredString(config: ConnectorAdapterConfig, key: string): string {

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -1,0 +1,103 @@
+import type { Agent as NodeHttpAgent } from 'node:http'
+import type nodeFetch from 'node-fetch'
+import type { Response } from 'node-fetch'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CommandRegistry, type ConnectorAdapterContext } from '../core/adapter.js'
+import type { ConnectorProxyTransport } from '../core/proxy.js'
+
+const telegramMocks = vi.hoisted(() => ({
+  construct: vi.fn(),
+  autoRetry: vi.fn(() => Symbol('retry-transformer')),
+  use: vi.fn(),
+  command: vi.fn(),
+  setMyCommands: vi.fn(),
+  init: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}))
+
+vi.mock('@grammyjs/auto-retry', () => ({ autoRetry: telegramMocks.autoRetry }))
+vi.mock('grammy', () => ({
+  Bot: class {
+    readonly api = {
+      config: { use: telegramMocks.use },
+      setMyCommands: telegramMocks.setMyCommands,
+    }
+    readonly command = telegramMocks.command
+    readonly init = telegramMocks.init
+    readonly start = telegramMocks.start
+    readonly stop = telegramMocks.stop
+
+    constructor(token: string, config: unknown) {
+      telegramMocks.construct(token, config)
+    }
+  },
+  InputFile: class {},
+}))
+
+import { createTelegramFetch, TelegramConnectorAdapter } from './telegram.js'
+
+describe('TelegramConnectorAdapter proxy startup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    telegramMocks.setMyCommands.mockResolvedValue(true)
+    telegramMocks.init.mockResolvedValue(undefined)
+    telegramMocks.start.mockResolvedValue(undefined)
+    telegramMocks.stop.mockResolvedValue(undefined)
+  })
+
+  it('passes the shared Node agent into grammY and bounds retries', async () => {
+    const nodeAgent = {} as NodeHttpAgent
+    const proxy: ConnectorProxyTransport = {
+      active: true,
+      nodeAgent,
+      close: async () => undefined,
+    }
+    const adapter = new TelegramConnectorAdapter(proxy)
+
+    await adapter.start({ enabled: true, settings: { botToken: 'test-token' } }, context())
+
+    expect(telegramMocks.construct).toHaveBeenCalledWith('test-token', {
+      client: {
+        timeoutSeconds: 45,
+        baseFetchConfig: { agent: nodeAgent },
+        fetch: expect.any(Function),
+      },
+    })
+    expect(telegramMocks.autoRetry).toHaveBeenCalledWith({
+      maxRetryAttempts: 2,
+      maxDelaySeconds: 10,
+    })
+    const commandSignal = telegramMocks.setMyCommands.mock.calls[0]?.[2]
+    expect(commandSignal).toBeInstanceOf(AbortSignal)
+    expect(telegramMocks.init).toHaveBeenCalledWith(commandSignal)
+  })
+
+  it('mirrors grammY shim cancellation into a native AbortSignal', async () => {
+    const sourceController = new AbortController()
+    let receivedSignal: AbortSignal | undefined
+    let finish: ((response: Response) => void) | undefined
+    const fetchImplementation = vi.fn((_url, init) => {
+      receivedSignal = init?.signal
+      return new Promise<Response>((resolve) => { finish = resolve })
+    }) as unknown as typeof nodeFetch
+    const fetch = createTelegramFetch(fetchImplementation)
+
+    const request = fetch('https://api.telegram.org', { signal: sourceController.signal })
+    sourceController.abort()
+
+    expect(receivedSignal).not.toBe(sourceController.signal)
+    expect(receivedSignal?.aborted).toBe(true)
+    finish?.({} as Response)
+    await request
+  })
+})
+
+function context(): ConnectorAdapterContext {
+  return {
+    commands: new CommandRegistry('telegram'),
+    updateSettings: vi.fn(),
+    getServiceStatus: () => 'healthy',
+    sendTest: vi.fn(),
+  }
+}

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -1,5 +1,6 @@
 import { Bot, InputFile } from 'grammy'
 import { autoRetry } from '@grammyjs/auto-retry'
+import nodeFetch from 'node-fetch'
 import type {
   ConnectorAdapterConfig,
   ConnectorAdapterHealth,
@@ -11,6 +12,14 @@ import type {
   ConnectorAdapterContext,
   ConnectorAdapterRegistration,
 } from '../core/adapter.js'
+import {
+  DIRECT_CONNECTOR_PROXY_TRANSPORT,
+  type ConnectorProxyTransport,
+} from '../core/proxy.js'
+import {
+  CONNECTOR_ADAPTER_STARTUP_TIMEOUT_MS,
+  withStartupDeadline,
+} from '../core/startup.js'
 import {
   AdapterHealthTracker,
   decodeInboxAttachments,
@@ -24,12 +33,24 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   private ownerUserId?: string
   private chatId?: string
 
+  constructor(
+    private readonly proxy: ConnectorProxyTransport = DIRECT_CONNECTOR_PROXY_TRANSPORT,
+    private readonly startupTimeoutMs = CONNECTOR_ADAPTER_STARTUP_TIMEOUT_MS,
+  ) {}
+
   async start(config: ConnectorAdapterConfig, context: ConnectorAdapterContext): Promise<void> {
     const token = requiredString(config, 'botToken')
     this.ownerUserId = optionalString(config, 'ownerUserId')
     this.chatId = optionalString(config, 'chatId')
-    const bot = new Bot(token)
-    bot.api.config.use(autoRetry())
+    const bot = new Bot(token, {
+      client: {
+        // Telegram long polling holds a request for up to 30 seconds. Keep
+        // ordinary calls finite while leaving enough headroom for that poll.
+        timeoutSeconds: 45,
+        ...(this.proxy.nodeAgent ? { baseFetchConfig: { agent: this.proxy.nodeAgent } } : {}),
+        fetch: createTelegramFetch(),
+      },
+    })
     this.bot = bot
 
     for (const command of TELEGRAM_CONNECTOR_DEFINITION.commands) {
@@ -50,11 +71,30 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       })
     }
     this.registerCommands(context)
-    await bot.api.setMyCommands(TELEGRAM_CONNECTOR_DEFINITION.commands.map(({ name, description }) => ({
-      command: name,
-      description,
-    })))
-    await bot.init()
+    try {
+      await withStartupDeadline('Telegram', this.startupTimeoutMs, async (signal) => {
+        // grammY exposes abort-controller's structural type while Node 22
+        // supplies the runtime-compatible native AbortSignal.
+        const telegramSignal = signal as unknown as Parameters<typeof bot.init>[0]
+        await bot.init(telegramSignal)
+        console.log('[connector] Telegram identity verified')
+        await bot.api.setMyCommands(TELEGRAM_CONNECTOR_DEFINITION.commands.map(({ name, description }) => ({
+          command: name,
+          description,
+        })), undefined, telegramSignal)
+        console.log('[connector] Telegram commands published')
+      })
+    } catch (error) {
+      this.bot = undefined
+      this.tracker.degraded(error)
+      throw error
+    }
+    // Startup should fail fast. Runtime polling and delivery get a small,
+    // finite retry budget only after credentials and reachability are proven.
+    bot.api.config.use(autoRetry({
+      maxRetryAttempts: 2,
+      maxDelaySeconds: 10,
+    }))
     if (this.ownerUserId && this.chatId) this.tracker.healthy(this.ownerUserId)
     else this.tracker.awaitingLink()
     void bot.start({ drop_pending_updates: true }).catch((error) => {
@@ -121,8 +161,37 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   }
 }
 
-export function telegramConnectorRegistration(): ConnectorAdapterRegistration {
-  return { definition: TELEGRAM_CONNECTOR_DEFINITION, create: () => new TelegramConnectorAdapter() }
+/**
+ * grammY creates signals with `abort-controller`. Once both grammY and
+ * node-fetch are bundled into one CJS deployable, node-fetch rejects that
+ * shimmed signal before opening a socket. Mirror it into Node's native signal
+ * so packaged requests retain cancellation, timeouts, and proxy agents.
+ */
+export function createTelegramFetch(
+  fetchImplementation: typeof nodeFetch = nodeFetch,
+): typeof nodeFetch {
+  return ((url, init = {}) => {
+    const sourceSignal = init.signal
+    if (!sourceSignal) return fetchImplementation(url, init)
+
+    const controller = new AbortController()
+    const abort = (): void => controller.abort()
+    if (sourceSignal.aborted) abort()
+    else sourceSignal.addEventListener('abort', abort, { once: true })
+    try {
+      return fetchImplementation(url, { ...init, signal: controller.signal })
+        .finally(() => sourceSignal.removeEventListener('abort', abort))
+    } catch (error) {
+      sourceSignal.removeEventListener('abort', abort)
+      throw error
+    }
+  }) as typeof nodeFetch
+}
+
+export function telegramConnectorRegistration(
+  proxy: ConnectorProxyTransport = DIRECT_CONNECTOR_PROXY_TRANSPORT,
+): ConnectorAdapterRegistration {
+  return { definition: TELEGRAM_CONNECTOR_DEFINITION, create: () => new TelegramConnectorAdapter(proxy) }
 }
 
 function requiredString(config: ConnectorAdapterConfig, key: string): string {

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -40,6 +40,64 @@ class FakeThirdPartyAdapter implements ConnectorAdapter {
 }
 
 describe('DeliveryManager connector registry', () => {
+  it('exposes adapter startup immediately instead of blocking service health', async () => {
+    let finishStart: (() => void) | undefined
+    const registry = new ConnectorRegistry()
+    registry.register({
+      definition: { id: 'slow', label: 'Slow', description: 'Slow adapter.', fields: [], commands: [] },
+      create: () => ({
+        id: 'slow',
+        start: async () => new Promise<void>((resolve) => { finishStart = resolve }),
+        stop: async () => undefined,
+        deliver: async () => undefined,
+        health: () => ({ id: 'slow', enabled: true, status: 'starting' as const }),
+      }),
+    })
+    const manager = new DeliveryManager({
+      registry,
+      config: { version: 1, adapters: { slow: { enabled: true, settings: {} } } },
+      updateAdapterSettings: vi.fn(),
+    })
+
+    const startup = manager.start()
+    expect(manager.health()).toMatchObject({
+      status: 'healthy',
+      adapters: [{ id: 'slow', status: 'starting' }],
+    })
+    finishStart?.()
+    await startup
+  })
+
+  it('retains the concrete startup error after isolating a failed adapter', async () => {
+    const registry = new ConnectorRegistry()
+    registry.register({
+      definition: { id: 'offline', label: 'Offline', description: 'Offline adapter.', fields: [], commands: [] },
+      create: () => ({
+        id: 'offline',
+        start: async () => { throw new Error('proxy connection refused') },
+        stop: async () => undefined,
+        deliver: async () => undefined,
+        health: () => ({ id: 'offline', enabled: true, status: 'starting' as const }),
+      }),
+    })
+    const manager = new DeliveryManager({
+      registry,
+      config: { version: 1, adapters: { offline: { enabled: true, settings: {} } } },
+      updateAdapterSettings: vi.fn(),
+    })
+
+    await manager.start()
+
+    expect(manager.health()).toMatchObject({
+      status: 'degraded',
+      adapters: [{
+        id: 'offline',
+        status: 'degraded',
+        lastError: 'proxy connection refused',
+      }],
+    })
+  })
+
   it('runs an unrecognized third adapter without changing delivery core', async () => {
     const adapter = new FakeThirdPartyAdapter()
     const registry = new ConnectorRegistry()

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -35,7 +35,9 @@ export interface DeliveryManagerOptions {
 export class DeliveryManager {
   private readonly adapters = new Map<string, ConnectorAdapter>()
   private readonly commands = new Map<string, CommandRegistry>()
+  private readonly startFailures = new Map<string, string>()
   private readonly startedAt: string
+  private starting = false
   private stopped = false
 
   constructor(private readonly options: DeliveryManagerOptions) {
@@ -43,11 +45,17 @@ export class DeliveryManager {
   }
 
   async start(): Promise<void> {
-    for (const [id, config] of Object.entries(this.options.config.adapters)) {
-      if (!config.enabled || !this.options.registry.has(id)) continue
-      await this.startAdapter(id, config).catch((error) => {
-        console.warn(`[connector] ${id} failed to start:`, error instanceof Error ? error.message : error)
-      })
+    this.starting = true
+    try {
+      for (const [id, config] of Object.entries(this.options.config.adapters)) {
+        if (this.stopped) break
+        if (!config.enabled || !this.options.registry.has(id)) continue
+        await this.startAdapter(id, config).catch((error) => {
+          console.warn(`[connector] ${id} failed to start:`, error instanceof Error ? error.message : error)
+        })
+      }
+    } finally {
+      this.starting = false
     }
   }
 
@@ -119,12 +127,19 @@ export class DeliveryManager {
     const adapters: ConnectorAdapterHealth[] = []
     for (const [id, config] of Object.entries(this.options.config.adapters)) {
       const adapter = this.adapters.get(id)
-      adapters.push(adapter?.health() ?? {
+      const startFailure = this.startFailures.get(id)
+      adapters.push(adapter?.health() ?? (startFailure ? {
         id,
         enabled: config.enabled,
-        status: config.enabled ? 'degraded' : 'disabled',
-        detail: config.enabled ? 'Adapter is configured but not running.' : undefined,
-      })
+        status: 'degraded',
+        detail: 'External connector failed to start.',
+        lastError: startFailure,
+      } : {
+        id,
+        enabled: config.enabled,
+        status: config.enabled ? (this.starting ? 'starting' : 'degraded') : 'disabled',
+        detail: config.enabled && !this.starting ? 'Adapter is configured but not running.' : undefined,
+      }))
     }
     return {
       status: adapters.some((adapter) => adapter.status === 'degraded') ? 'degraded' : 'healthy',
@@ -149,9 +164,24 @@ export class DeliveryManager {
       getServiceStatus: () => this.health().status,
       sendTest: (connectorId) => this.sendTest(connectorId),
     }
-    await adapter.start(config, context)
     this.adapters.set(id, adapter)
     this.commands.set(id, commands)
+    this.startFailures.delete(id)
+    try {
+      await adapter.start(config, context)
+      if (this.stopped) {
+        await adapter.stop().catch(() => undefined)
+        this.adapters.delete(id)
+        this.commands.delete(id)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.startFailures.set(id, message)
+      await adapter.stop().catch(() => undefined)
+      if (this.adapters.get(id) === adapter) this.adapters.delete(id)
+      this.commands.delete(id)
+      throw error
+    }
   }
 
   private get recorder(): ConnectorIORecorder {

--- a/services/connector/src/core/proxy.spec.ts
+++ b/services/connector/src/core/proxy.spec.ts
@@ -1,0 +1,53 @@
+import http from 'node:http'
+import https from 'node:https'
+import { getGlobalDispatcher } from 'undici'
+import { describe, expect, it } from 'vitest'
+import {
+  installConnectorProxyTransport,
+  proxyUrlFor,
+  resolveConnectorProxySettings,
+} from './proxy.js'
+
+describe('Connector proxy transport', () => {
+  it('normalizes lowercase and ALL_PROXY variables for every SDK', () => {
+    expect(resolveConnectorProxySettings({
+      all_proxy: 'http://127.0.0.1:7890',
+      no_proxy: 'localhost,.internal.example',
+    })).toEqual({
+      httpProxy: 'http://127.0.0.1:7890',
+      httpsProxy: 'http://127.0.0.1:7890',
+      noProxy: 'localhost,.internal.example',
+    })
+  })
+
+  it('selects secure proxies and respects NO_PROXY hosts and ports', () => {
+    const settings = {
+      httpProxy: 'http://http-proxy:8080',
+      httpsProxy: 'http://https-proxy:8443',
+      noProxy: 'localhost,.internal.example,api.example:444',
+    }
+    expect(proxyUrlFor('https://api.telegram.org/', settings)).toBe('http://https-proxy:8443')
+    expect(proxyUrlFor('http://discord.com/', settings)).toBe('http://http-proxy:8080')
+    expect(proxyUrlFor('https://service.internal.example/', settings)).toBe('')
+    expect(proxyUrlFor('https://api.example:444/', settings)).toBe('')
+    expect(proxyUrlFor('https://api.example/', settings)).toBe('http://https-proxy:8443')
+  })
+
+  it('installs and restores Node and Undici process defaults', async () => {
+    const previousHttpAgent = http.globalAgent
+    const previousHttpsAgent = https.globalAgent
+    const previousDispatcher = getGlobalDispatcher()
+    const transport = installConnectorProxyTransport({ HTTPS_PROXY: 'http://127.0.0.1:7890' })
+    try {
+      expect(transport.active).toBe(true)
+      expect(http.globalAgent).toBe(transport.nodeAgent)
+      expect(https.globalAgent).toBe(transport.nodeAgent)
+      expect(getGlobalDispatcher()).toBe(transport.dispatcher)
+    } finally {
+      await transport.close()
+    }
+    expect(http.globalAgent).toBe(previousHttpAgent)
+    expect(https.globalAgent).toBe(previousHttpsAgent)
+    expect(getGlobalDispatcher()).toBe(previousDispatcher)
+  })
+})

--- a/services/connector/src/core/proxy.ts
+++ b/services/connector/src/core/proxy.ts
@@ -1,0 +1,219 @@
+import http, {
+  type Agent as NodeHttpAgent,
+  type ClientRequest,
+} from 'node:http'
+import https from 'node:https'
+import { Agent as AgentBase, type AgentConnectOpts } from 'agent-base'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
+import {
+  Agent as UndiciAgent,
+  Pool,
+  ProxyAgent as UndiciProxyAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+  type Dispatcher,
+} from 'undici'
+
+type EnvLike = Readonly<Record<string, string | undefined>>
+
+export interface ConnectorProxySettings {
+  httpProxy?: string
+  httpsProxy?: string
+  noProxy?: string
+}
+
+export interface ConnectorProxyTransport {
+  readonly active: boolean
+  readonly nodeAgent?: NodeHttpAgent
+  readonly dispatcher?: Dispatcher
+  close(): Promise<void>
+}
+
+export const DIRECT_CONNECTOR_PROXY_TRANSPORT: ConnectorProxyTransport = {
+  active: false,
+  close: async () => undefined,
+}
+
+/**
+ * Normalize the conventional upper/lower-case proxy variables once for every
+ * connector SDK. ALL_PROXY is a fallback because Node/Undici consumers do not
+ * consistently implement it themselves.
+ */
+export function resolveConnectorProxySettings(
+  env: EnvLike = process.env,
+): ConnectorProxySettings {
+  const allProxy = envValue(env, 'ALL_PROXY')
+  const httpProxy = envValue(env, 'HTTP_PROXY') ?? allProxy
+  const httpsProxy = envValue(env, 'HTTPS_PROXY') ?? httpProxy
+  const noProxy = envValue(env, 'NO_PROXY')
+  return {
+    ...(httpProxy ? { httpProxy } : {}),
+    ...(httpsProxy ? { httpsProxy } : {}),
+    ...(noProxy ? { noProxy } : {}),
+  }
+}
+
+/**
+ * Install process-wide proxy defaults for Node HTTP(S), WebSocket SDKs, and
+ * Undici, while also returning explicit agents for SDKs that replace globals
+ * (grammY/node-fetch and discord.js REST both do this).
+ */
+export function installConnectorProxyTransport(
+  env: EnvLike = process.env,
+): ConnectorProxyTransport {
+  const settings = resolveConnectorProxySettings(env)
+  if (!settings.httpProxy && !settings.httpsProxy) return DIRECT_CONNECTOR_PROXY_TRANSPORT
+
+  const nodeAgent = new ConnectorNodeProxyAgent(settings)
+  const previousHttpAgent = http.globalAgent
+  const previousHttpsAgent = https.globalAgent
+  const previousDispatcher = getGlobalDispatcher()
+  const dispatcher = createUndiciDispatcher(settings)
+
+  http.globalAgent = nodeAgent
+  https.globalAgent = nodeAgent
+  if (dispatcher) setGlobalDispatcher(dispatcher)
+
+  let closed = false
+  return {
+    active: true,
+    nodeAgent,
+    dispatcher,
+    close: async () => {
+      if (closed) return
+      closed = true
+      if (http.globalAgent === nodeAgent) http.globalAgent = previousHttpAgent
+      if (https.globalAgent === nodeAgent) https.globalAgent = previousHttpsAgent
+      if (dispatcher && getGlobalDispatcher() === dispatcher) setGlobalDispatcher(previousDispatcher)
+      nodeAgent.destroy()
+      await dispatcher?.close()
+    },
+  }
+}
+
+/**
+ * A statically bundled HTTP(S)-proxy router. `proxy-agent` loads protocol
+ * implementations dynamically, which does not survive Connector Service's
+ * single-file tsup bundle; keeping the two supported constructors explicit
+ * makes packaged behavior match source behavior.
+ */
+class ConnectorNodeProxyAgent extends AgentBase {
+  private readonly agents = new Map<string, NodeHttpAgent>()
+  private readonly directHttp = new http.Agent()
+  private readonly directHttps = new https.Agent()
+
+  constructor(private readonly settings: ConnectorProxySettings) {
+    super()
+  }
+
+  async connect(request: ClientRequest, options: AgentConnectOpts): Promise<NodeHttpAgent> {
+    const isWebSocket = request.getHeader('upgrade') === 'websocket'
+    const protocol = options.secureEndpoint
+      ? (isWebSocket ? 'wss:' : 'https:')
+      : (isWebSocket ? 'ws:' : 'http:')
+    const host = request.getHeader('host')
+    if (typeof host !== 'string') throw new Error('Connector proxy request host is missing')
+    const requestUrl = new URL(request.path, `${protocol}//${host}`).href
+    const proxy = proxyUrlFor(requestUrl, this.settings)
+    if (!proxy) return options.secureEndpoint ? this.directHttps : this.directHttp
+
+    const proxyProtocol = new URL(proxy).protocol
+    if (proxyProtocol !== 'http:' && proxyProtocol !== 'https:') {
+      throw new Error(`Connector proxy protocol is not supported: ${proxyProtocol}`)
+    }
+    const cacheKey = `${options.secureEndpoint || isWebSocket ? 'tunnel' : 'forward'}:${proxy}`
+    const cached = this.agents.get(cacheKey)
+    if (cached) return cached
+    const agent = options.secureEndpoint || isWebSocket
+      ? new HttpsProxyAgent(proxy)
+      : new HttpProxyAgent(proxy)
+    this.agents.set(cacheKey, agent)
+    return agent
+  }
+
+  override destroy(): void {
+    for (const agent of this.agents.values()) agent.destroy()
+    this.directHttp.destroy()
+    this.directHttps.destroy()
+    super.destroy()
+  }
+}
+
+export function proxyUrlFor(
+  rawUrl: string,
+  settings: ConnectorProxySettings,
+): string {
+  const url = new URL(rawUrl)
+  if (bypassesProxy(url, settings.noProxy)) return ''
+  const secure = url.protocol === 'https:' || url.protocol === 'wss:'
+  return (secure ? settings.httpsProxy ?? settings.httpProxy : settings.httpProxy ?? settings.httpsProxy) ?? ''
+}
+
+function createUndiciDispatcher(settings: ConnectorProxySettings): UndiciAgent | undefined {
+  // Undici's ProxyAgent accepts HTTP(S) proxy endpoints. Route per origin so
+  // the same NO_PROXY contract also applies to Discord REST.
+  if (!supportedUndiciProxy(settings.httpsProxy) && !supportedUndiciProxy(settings.httpProxy)) {
+    return undefined
+  }
+  return new UndiciAgent({
+    factory: (origin, options) => {
+      const proxy = supportedUndiciProxy(proxyUrlFor(String(origin), settings))
+      return proxy
+        ? new UndiciProxyAgent({ uri: proxy })
+        : new Pool(origin, options)
+    },
+  })
+}
+
+function supportedUndiciProxy(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === 'http:' || protocol === 'https:' ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function bypassesProxy(url: URL, rawNoProxy: string | undefined): boolean {
+  if (!rawNoProxy) return false
+  const entries = rawNoProxy.split(/[\s,]+/).map((entry) => entry.trim()).filter(Boolean)
+  if (entries.includes('*')) return true
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  const port = Number(url.port) || defaultPort(url.protocol)
+  return entries.some((entry) => {
+    const parsed = parseNoProxyEntry(entry)
+    if (!parsed || (parsed.port !== undefined && parsed.port !== port)) return false
+    return hostname === parsed.hostname || hostname.endsWith(`.${parsed.hostname}`)
+  })
+}
+
+function parseNoProxyEntry(entry: string): { hostname: string; port?: number } | undefined {
+  let value = entry.toLowerCase()
+  let port: number | undefined
+  if (value.startsWith('[')) {
+    const match = /^\[([^\]]+)\](?::(\d+))?$/.exec(value)
+    if (!match?.[1]) return undefined
+    value = match[1]
+    if (match[2]) port = Number(match[2])
+  } else {
+    const match = /^(.*):(\d+)$/.exec(value)
+    if (match?.[1] && !match[1].includes(':')) {
+      value = match[1]
+      port = Number(match[2])
+    }
+  }
+  const hostname = value.replace(/^\*?\./, '')
+  return hostname ? { hostname, ...(port !== undefined ? { port } : {}) } : undefined
+}
+
+function defaultPort(protocol: string): number {
+  return protocol === 'https:' || protocol === 'wss:' ? 443 : 80
+}
+
+function envValue(env: EnvLike, key: string): string | undefined {
+  const value = env[key]?.trim() || env[key.toLowerCase()]?.trim()
+  return value || undefined
+}

--- a/services/connector/src/core/startup.spec.ts
+++ b/services/connector/src/core/startup.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { withStartupDeadline } from './startup.js'
+
+describe('withStartupDeadline', () => {
+  it('preserves an immediate SDK failure', async () => {
+    const failure = new Error('invalid credential')
+    await expect(withStartupDeadline('Telegram', 50, async () => { throw failure }))
+      .rejects.toBe(failure)
+  })
+
+  it('bounds an SDK promise even when it ignores AbortSignal', async () => {
+    await expect(withStartupDeadline('Telegram', 5, async () => new Promise(() => undefined)))
+      .rejects.toThrow('Telegram startup timed out after 1 seconds')
+  })
+})

--- a/services/connector/src/core/startup.ts
+++ b/services/connector/src/core/startup.ts
@@ -1,0 +1,37 @@
+export const CONNECTOR_ADAPTER_STARTUP_TIMEOUT_MS = 30_000
+
+/** Bound third-party SDK bootstrap even when the SDK ignores AbortSignal. */
+export async function withStartupDeadline<T>(
+  label: string,
+  timeoutMs: number,
+  task: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const signal = AbortSignal.timeout(timeoutMs)
+  try {
+    return await raceWithAbort(Promise.resolve().then(() => task(signal)), signal)
+  } catch (error) {
+    if (!signal.aborted) throw error
+    throw new Error(
+      `${label} startup timed out after ${Math.ceil(timeoutMs / 1_000)} seconds`,
+      { cause: error },
+    )
+  }
+}
+
+function raceWithAbort<T>(task: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+  return new Promise<T>((resolve, reject) => {
+    const aborted = (): void => reject(signal.reason)
+    signal.addEventListener('abort', aborted, { once: true })
+    void task.then(
+      (value) => {
+        signal.removeEventListener('abort', aborted)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener('abort', aborted)
+        reject(error)
+      },
+    )
+  })
+}

--- a/services/connector/src/main.ts
+++ b/services/connector/src/main.ts
@@ -17,6 +17,7 @@ import { ConnectorConfigStore } from './config-store.js'
 import { discordConnectorRegistration } from './adapters/discord.js'
 import { telegramConnectorRegistration } from './adapters/telegram.js'
 import { ConnectorIOJournal } from './core/io-journal.js'
+import { installConnectorProxyTransport } from './core/proxy.js'
 import { dataPath } from '@/core/paths.js'
 
 const CONNECTOR_PORT = Number(process.env['OPENALICE_CONNECTOR_PORT'] ?? 47334)
@@ -27,9 +28,11 @@ async function main(): Promise<void> {
 
   const configStore = new ConnectorConfigStore()
   const config = await configStore.read()
+  const proxy = installConnectorProxyTransport()
+  if (proxy.active) console.log('[connector] shared environment proxy enabled')
   const registry = new ConnectorRegistry()
-  registry.register(discordConnectorRegistration())
-  registry.register(telegramConnectorRegistration())
+  registry.register(discordConnectorRegistration(proxy))
+  registry.register(telegramConnectorRegistration(proxy))
   const journal = new ConnectorIOJournal({
     path: dataPath('logs', 'connector-io.jsonl'),
     warn: (message) => console.warn(`[connector] ${message}`),
@@ -42,7 +45,10 @@ async function main(): Promise<void> {
     recorder: journal,
     updateAdapterSettings: (id, patch) => configStore.patchAdapter(id, patch),
   })
-  await manager.start()
+  // Begin SDK startup before binding so health can immediately report each
+  // adapter as `starting`; do not make the loopback control plane wait on an
+  // external platform request.
+  const adapterStartup = manager.start()
 
   const app = new Hono()
   app.get('/__connector/health', (c) => c.json(manager.health()))
@@ -71,10 +77,13 @@ async function main(): Promise<void> {
     server.close()
     await manager.stop()
     await journal.flush()
+    await proxy.close()
     process.exit(0)
   }
   process.on('SIGINT', () => { void shutdown('SIGINT') })
   process.on('SIGTERM', () => { void shutdown('SIGTERM') })
+
+  await adapterStartup
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

- normalize conventional proxy environment variables (including lowercase and `ALL_PROXY`) and resolve the host system proxy through Electron on every desktop platform
- add one shared HTTP(S) proxy transport for Node HTTP(S), WebSocket SDKs, Undici, Telegram, and Discord
- bind Connector health immediately while adapters start, cap each adapter bootstrap at 30 seconds, and preserve concrete startup failures as degraded health
- make bundled grammY/node-fetch cancellation compatible and keep runtime retries finite

## Root cause

The Connector child already inherited proxy environment variables, but grammY/node-fetch and Discord's REST stack supplied their own transports and bypassed Node's environment/global proxy behavior. Telegram could then wait on grammY's long API timeout and retries before the service ever bound its health port.

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 469 files passed, 1 skipped; 3892 tests passed, 9 skipped
- `pnpm build`
- Connector service typecheck and targeted suite — 9 files / 27 tests
- `pnpm test:connector-replay`
- `pnpm test:connector-service`
- Settings → Connectors browser walk in demo mode; no console errors and no secret values read
- unsigned `pnpm electron:smoke:workspace`; all packaged Workspace receipt checks passed and the temporary app was cleaned
- bundled Connector smoke with an existing sealed Telegram configuration reached `awaiting_link` after identity validation and command publication; no test notification was sent
- Discord public gateway REST probe through the shared dispatcher returned HTTP 200

## Scope and safety

- supports HTTP and HTTPS proxy endpoints; SOCKS-only rules remain unsupported
- no broker/trading path changed
- no outbound notification test, credential change, or real-account mutation was performed