### PR TITLE
fix: surface runtime provider errors

### DIFF
--- a/src/workspaces/agent-runtime-readiness.spec.ts
+++ b/src/workspaces/agent-runtime-readiness.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   classifyRuntimeReadinessFailure,
+  failedRuntimeReadinessRow,
   runtimeProbeSucceeded,
   snapshotRuntimeReadiness,
   type AgentRuntimeReadinessRow,
@@ -76,6 +77,36 @@ describe('agent runtime readiness helpers', () => {
       exitCode: 0,
       stdoutTail: '{"type":"future_event","message":"started"}',
     }))).toBe('output_unrecognized');
+  });
+
+  it('preserves an in-band provider error instead of calling it unrecognized output', () => {
+    const providerError = result({
+      exitCode: 0,
+      stdoutTail: '{"type":"message_end","message":{"stopReason":"error"}}',
+      structured: {
+        schemaVersion: 1,
+        assistantText: null,
+        blocks: [{
+          type: 'error',
+          message: '429: 余额不足或无可用资源包，请充值。',
+        }],
+        metrics: { textBlocks: 0, toolCalls: 0, toolFailures: 0 },
+        truncated: false,
+      },
+    });
+
+    expect(classifyRuntimeReadinessFailure(providerError)).toBe('failed');
+    expect(failedRuntimeReadinessRow({
+      adapter: piAdapter,
+      availability: { installed: true, path: '/usr/bin/pi' },
+      result: providerError,
+      source: 'launcher-vault',
+    })).toMatchObject({
+      status: 'failed',
+      ready: false,
+      repairTarget: 'retry',
+      message: 'The runtime reported an error: 429: 余额不足或无可用资源包，请充值。',
+    });
   });
 
   it('GET snapshot uses cached rows without inventing readiness', () => {

--- a/src/workspaces/agent-runtime-readiness.ts
+++ b/src/workspaces/agent-runtime-readiness.ts
@@ -165,10 +165,14 @@ export function failedRuntimeReadinessRow(opts: {
 }
 
 export function classifyRuntimeReadinessFailure(
-  result: Pick<HeadlessTaskResult, 'killed' | 'exitCode' | 'stdoutTail' | 'stderrTail' | 'assistantText'>,
+  result: Pick<
+    HeadlessTaskResult,
+    'killed' | 'exitCode' | 'stdoutTail' | 'stderrTail' | 'assistantText' | 'structured'
+  >,
 ): AgentRuntimeReadinessStatus {
   if (result.killed) return 'timeout';
-  const text = `${result.stderrTail}\n${result.stdoutTail}`.toLowerCase();
+  const structuredError = latestStructuredRuntimeError(result);
+  const text = `${structuredError ?? ''}\n${result.stderrTail}\n${result.stdoutTail}`.toLowerCase();
   if (/\b(unauthorized|unauthorised|forbidden|401|403|oauth|log in|login|sign in|signin|auth|authentication|not authenticated)\b/.test(text)) {
     return 'auth_required';
   }
@@ -176,6 +180,10 @@ export function classifyRuntimeReadinessFailure(
     return 'provider_required';
   }
   if (result.exitCode !== 0) return 'failed';
+  // Some CLIs exit 0 after reporting an in-band provider/runtime error. That
+  // is a recognized failure, not an unknown output shape. Preserve it so the
+  // launch surface can show the actual provider response (for example 429).
+  if (structuredError) return 'failed';
   if (!result.assistantText?.trim()) return 'output_unrecognized';
   return 'failed';
 }
@@ -209,7 +217,8 @@ function summarizeRuntimeReadinessFailure(
   if (status === 'output_unrecognized') {
     return 'The runtime exited successfully, but OpenAlice could not read an assistant reply from its structured output.';
   }
-  const tail = `${result.stderrTail || result.stdoutTail}`.trim().replace(/\s+/g, ' ');
+  const structuredError = latestStructuredRuntimeError(result);
+  const tail = `${structuredError || result.stderrTail || result.stdoutTail}`.trim().replace(/\s+/g, ' ');
   const detail = tail ? ` ${tail.slice(0, 280)}` : '';
   if (status === 'auth_required') {
     return `The runtime appears to need CLI login or authentication.${detail}`;
@@ -217,5 +226,18 @@ function summarizeRuntimeReadinessFailure(
   if (status === 'provider_required') {
     return `The runtime appears to need provider or API-key configuration.${detail}`;
   }
+  if (structuredError) {
+    return `The runtime reported an error:${detail}`;
+  }
   return `The runtime readiness probe failed.${detail}`;
+}
+
+function latestStructuredRuntimeError(
+  result: Pick<HeadlessTaskResult, 'structured'>,
+): string | null {
+  for (let index = result.structured.blocks.length - 1; index >= 0; index -= 1) {
+    const block = result.structured.blocks[index];
+    if (block?.type === 'error' && block.message.trim()) return block.message.trim();
+  }
+  return null;
 }

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -325,6 +325,54 @@ describe('ChatLandingPage keyboard submission', () => {
       'chat',
     ))
   })
+
+  it('shows the runtime provider error and does not create a chat session', async () => {
+    mocks.getAgentRuntimeReadiness.mockResolvedValue({
+      agents: {
+        pi: {
+          agent: 'pi',
+          displayName: 'Pi',
+          installed: true,
+          binPath: '/tmp/pi',
+          status: 'unknown',
+          ready: false,
+          source: 'unknown',
+          checkedAt: null,
+          durationMs: null,
+        },
+      },
+      overallReady: false,
+      checkedAt: null,
+    })
+    mocks.probeAgentRuntimeReadiness.mockResolvedValue({
+      agents: {
+        pi: {
+          agent: 'pi',
+          displayName: 'Pi',
+          installed: true,
+          binPath: '/tmp/pi',
+          status: 'failed',
+          ready: false,
+          source: 'launcher-vault',
+          checkedAt: '2026-08-02T00:00:00.000Z',
+          durationMs: 10,
+          repairTarget: 'retry',
+          message: 'The runtime reported an error: 429: balance exhausted',
+        },
+      },
+      overallReady: false,
+      checkedAt: '2026-08-02T00:00:00.000Z',
+    })
+
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    await screen.findByLabelText('Model gemini-3.1-flash-lite')
+    fireEvent.change(screen.getByPlaceholderText('Ask Alice…'), { target: { value: 'hello' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(await screen.findByText('The runtime reported an error: 429: balance exhausted')).toBeTruthy()
+    expect(mocks.quickChat).not.toHaveBeenCalled()
+  })
 })
 
 describe('ChatLandingPage AI source disclosure', () => {


### PR DESCRIPTION
## Summary
- preserve structured runtime/provider failures reported in-band by native CLIs, even when the process exits 0
- surface the actual error in Chat readiness feedback instead of misclassifying it as unrecognized output
- cover the backend classification and Chat submission gate with regressions

## Verification
- `pnpm vitest run src/workspaces/agent-runtime-readiness.spec.ts ui/src/pages/ChatLandingPage.render.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test`
- real installed OpenAlice 0.88 browser smoke against the configured Workspace: DeepSeek readiness passed and Ask Alice returned `OK`

## Boundary touch
- runtime readiness and UI error presentation; no trading, migrations, installer payload, or credential storage changes

## Non-goals
- upgrading the currently installed global 0.88 CLI
- changing provider selection or retry policy in product code