### PR TITLE
ci: parallelize release build work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,10 @@ jobs:
           path: notes.md
           if-no-files-found: error
 
-  # Per-platform desktop installers are built and acceptance-tested before any
-  # tag or GitHub Release exists. Each runner builds only its own platform/arch.
-  # Optional broker SDKs are emitted as separate version/platform-specific
-  # Broker Packs and are rejected if they leak back into the desktop app. macOS
+  # Per-platform desktop installers are built before any tag or GitHub Release
+  # exists. Each runner builds only its own platform/arch, preserves the candidate
+  # immediately after fast package acceptance, and leaves the slower N-1 upgrade
+  # journey to a downstream job that can be retried without rebuilding it. macOS
   # builds are signed and notarized through Developer ID secrets; Windows remains
   # unsigned until a Windows code-signing certificate exists.
   build-desktop:
@@ -118,15 +118,10 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Build optional Broker Packs
-        run: pnpm broker-packs:build
-
-      - name: Prove previous-release Broker Pack upgrade
-        run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
       # macOS still uses dugite's embedded Git. Windows keeps only dugite's JS
       # wrapper and routes it to managed PortableGit in the packaged smoke.
@@ -214,6 +209,61 @@ jobs:
             --arch "$RELEASE_ARCH" \
             --version "$VERSION"
 
+      - name: Preserve desktop release candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
+          path: |
+            dist/electron-app/*.dmg
+            dist/electron-app/*.zip
+            dist/electron-app/*.yml
+            dist/electron-app/*.blockmap
+            dist/electron-app/*.exe
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  # The final-artifact upgrade journey is intentionally downstream from the
+  # build. A failed platform can be retried from its preserved installer without
+  # repeating Electron packaging, macOS signing, or notarization.
+  accept-desktop-upgrade:
+    name: Accept desktop upgrade (${{ matrix.os }}, ${{ matrix.arch }})
+    needs: [release, build-desktop]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && !github.event.inputs.mirror_tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore desktop release candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
+          path: dist/electron-app
+
       - name: Prove final desktop artifact upgrades previous release state
         run: >-
           pnpm electron:smoke:upgrade --
@@ -230,31 +280,6 @@ jobs:
           path: ${{ runner.temp }}/openalice-desktop-upgrade.json
           if-no-files-found: error
           retention-days: 7
-
-      - name: Preserve accepted release assets
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
-          path: |
-            dist/electron-app/*.dmg
-            dist/electron-app/*.zip
-            dist/electron-app/*.yml
-            dist/electron-app/*.blockmap
-            dist/electron-app/*.exe
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 1
-
-      - name: Preserve optional Broker Packs
-        uses: actions/upload-artifact@v4
-        with:
-          name: broker-packs-${{ runner.os }}-${{ matrix.arch }}
-          path: |
-            dist/broker-packs/*.json
-            dist/broker-packs/*.tgz
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 1
 
   cli-installer-acceptance:
     name: Accept CLI installer candidate
@@ -311,6 +336,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -354,11 +380,26 @@ jobs:
           compression-level: 0
           retention-days: 1
 
-  build-linux-broker-packs:
-    name: Build Linux Broker Packs
+  # Broker Packs are release artifacts, not inputs to the desktop package. Build
+  # and validate them on their native platforms in parallel with desktop and
+  # headless Runtime candidates instead of serializing them in desktop jobs.
+  build-broker-packs:
+    name: Build Broker Packs (${{ matrix.os }}, ${{ matrix.arch }})
     needs: release
     if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: ubuntu-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
 
@@ -370,6 +411,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -380,10 +422,10 @@ jobs:
       - name: Prove previous-release Broker Pack upgrade
         run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
-      - name: Preserve Linux Broker Packs
+      - name: Preserve Broker Packs
         uses: actions/upload-artifact@v4
         with:
-          name: broker-packs-Linux-x64
+          name: broker-packs-${{ runner.os }}-${{ matrix.arch }}
           path: |
             dist/broker-packs/*.json
             dist/broker-packs/*.tgz
@@ -393,8 +435,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, build-headless-runtime, build-linux-broker-packs, cli-installer-acceptance]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.build-headless-runtime.result == 'success' && needs.build-linux-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
+    needs: [release, build-desktop, accept-desktop-upgrade, build-headless-runtime, build-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-headless-runtime.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -333,11 +333,14 @@ an installer from current `master`.
 Desktop promotion evidence includes a real N-1 state journey on Apple Silicon,
 Intel macOS, and Windows. PR package jobs seed state with the previous published
 app and verify the unpacked candidate can migrate, write, and restart. The
-versioned release repeats that journey against the final signed macOS ZIP or
-Windows NSIS installer and byte-verifies each updater YAML reference, size,
-SHA-512, and blockmap before `publish-release`. These are blocking release
-requirements, not trailing observations; missing receipts or mismatched update
-metadata must prevent the tag and public assets from being created.
+versioned release preserves each final signed macOS ZIP or Windows NSIS
+installer as soon as its fast package acceptance and updater byte verification
+pass, then runs the N-1 journey in a downstream platform job. A failed upgrade
+job can therefore reuse the preserved candidate without repeating packaging,
+signing, or notarization. `publish-release` still requires every platform's
+upgrade receipt and verifies each updater YAML reference, size, SHA-512, and
+blockmap before publishing. Missing receipts or mismatched update metadata must
+prevent the tag and public assets from being created.
 
 Do not delete `dev` after promotion. After a master hotfix, propagate the fix
 back to `dev` immediately so a later promotion cannot revert it.

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+interface WorkflowJob {
+  needs?: string | string[]
+  steps?: WorkflowStep[]
+  strategy?: {
+    matrix?: {
+      include?: Array<{ os?: string; arch?: string }>
+    }
+  }
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/release.yml'), 'utf8'),
+) as { jobs: Record<string, WorkflowJob> }
+
+function step(job: WorkflowJob, name: string): WorkflowStep {
+  const found = job.steps?.find((candidate) => candidate.name === name)
+  if (!found) throw new Error(`release workflow step is missing: ${name}`)
+  return found
+}
+
+function needs(job: WorkflowJob): string[] {
+  if (!job.needs) return []
+  return Array.isArray(job.needs) ? job.needs : [job.needs]
+}
+
+describe('Release workflow critical path', () => {
+  it('builds native Broker Packs outside the desktop package jobs', () => {
+    const desktop = workflow.jobs['build-desktop']
+    const brokerPacks = workflow.jobs['build-broker-packs']
+
+    expect(desktop.steps?.map((candidate) => candidate.name)).not.toContain('Build optional Broker Packs')
+    expect(brokerPacks.strategy?.matrix?.include).toEqual([
+      { os: 'macos-14', arch: 'arm64' },
+      { os: 'macos-15-intel', arch: 'x64' },
+      { os: 'windows-latest', arch: 'x64' },
+      { os: 'ubuntu-latest', arch: 'x64' },
+    ])
+    expect(step(brokerPacks, 'Preserve Broker Packs').with?.['name']).toBe(
+      'broker-packs-${{ runner.os }}-${{ matrix.arch }}',
+    )
+  })
+
+  it('preserves desktop candidates before running retriable N-1 acceptance', () => {
+    const desktop = workflow.jobs['build-desktop']
+    const upgrade = workflow.jobs['accept-desktop-upgrade']
+
+    expect(step(desktop, 'Preserve desktop release candidate').uses).toBe('actions/upload-artifact@v4')
+    expect(desktop.steps?.map((candidate) => candidate.name)).not.toContain(
+      'Prove final desktop artifact upgrades previous release state',
+    )
+    expect(needs(upgrade)).toEqual(['release', 'build-desktop'])
+    expect(step(upgrade, 'Restore desktop release candidate').uses).toBe('actions/download-artifact@v4')
+    expect(step(upgrade, 'Prove final desktop artifact upgrades previous release state')).toBeDefined()
+  })
+
+  it('keeps publication gated on both candidate builds and upgrade receipts', () => {
+    expect(needs(workflow.jobs['publish-release'])).toEqual(expect.arrayContaining([
+      'build-desktop',
+      'accept-desktop-upgrade',
+      'build-broker-packs',
+      'build-headless-runtime',
+      'cli-installer-acceptance',
+    ]))
+  })
+})


### PR DESCRIPTION
## Summary

- build and validate native Broker Packs in their own four-platform matrix, in parallel with desktop installers, headless Runtimes, and CLI acceptance
- preserve verified desktop candidates before the slow N-1 journey, then run final-artifact upgrade acceptance in downstream retriable platform jobs
- add pnpm caching to dependency-heavy release jobs and a workflow contract spec that locks the new DAG in place

## Timing evidence

Baseline: [v0.89.0-beta Release run](https://github.com/TraderAlice/OpenAlice/actions/runs/30715168553)

- full Release wall time: 34:29
- Windows desktop critical-path job: 29:28
- Windows Broker Pack build + N-1 Pack upgrade: 7:47, previously serialized before Electron build/package
- Windows final-artifact N-1 acceptance: 12:13, previously ran before candidate artifact preservation

Expected effect:

- removes the 7:47 Broker Pack segment from the Windows desktop build path by running it in the independent native matrix
- preserves the Windows EXE and signed/notarized macOS artifacts before deep upgrade acceptance
- a same-candidate acceptance retry can rerun the downstream upgrade job without repeating Electron packaging, macOS signing, or notarization

The next versioned Release will provide authoritative post-change wall-clock timing; this PR does not invoke release signing secrets merely to benchmark the DAG.

## Confidence boundary

`publish-release` still depends on successful desktop builds, all three final-artifact upgrade jobs, all four Broker Pack jobs, all four headless Runtime jobs, and CLI installer acceptance. No release gate is removed.

## Verification

- `pnpm exec vitest run scripts/release-workflow.spec.ts`
- `npx tsc --noEmit`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `pnpm test` — 466 files passed, 1 skipped; 3,886 tests passed, 9 skipped
- YAML parse + release DAG assertions
