### PR TITLE
ci: parallelize desktop Broker Pack smoke

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -87,7 +87,39 @@ on:
       - "packages/connector-protocol/**"
       - "packages/uta-broker-*/**"
 
+concurrency:
+  group: desktop-package-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  broker-packs-windows:
+    name: broker-packs windows-latest
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # the N-1 Broker Pack smoke resolves the previous release tag
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build optional Broker Packs on Windows
+        run: pnpm broker-packs:build
+        timeout-minutes: 10
+
+      - name: Prove previous-release Broker Pack upgrade on Windows
+        run: pnpm broker-packs:upgrade-smoke
+        timeout-minutes: 10
+
   package:
     name: package ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -117,16 +149,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Build optional Broker Packs on Windows
-        if: runner.os == 'Windows'
-        run: pnpm broker-packs:build
-        timeout-minutes: 10
-
-      - name: Prove previous-release Broker Pack upgrade on Windows
-        if: runner.os == 'Windows'
-        run: pnpm broker-packs:upgrade-smoke
-        timeout-minutes: 10
 
       # macOS still uses dugite's embedded Git. Windows keeps only dugite's JS
       # wrapper and routes it to managed PortableGit in the packaged smoke.

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -152,10 +152,11 @@ through `ComSpec` on Windows; the shared runner supplies the already-quoted
 command line verbatim so Node does not quote it a second time. Package scripts
 must not rely on POSIX quoting.
 
-The Desktop Package Smoke workflow builds every optional Broker Pack on its
-Windows runner before packaging. It also reruns the cached desktop build
-through the packaged-smoke wrapper, so both release-facing `pnpm.cmd` call
-sites fail during PR validation rather than after a release starts.
+The Desktop Package Smoke workflow runs a dedicated Windows Broker Pack job in
+parallel with desktop packaging. That job exercises the Pack deployment path,
+while the Windows desktop job reruns the cached desktop build through the
+packaged-smoke wrapper, so both release-facing `pnpm.cmd` call sites fail during
+PR validation rather than after a release starts.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/scripts/desktop-package-workflow.spec.ts
+++ b/scripts/desktop-package-workflow.spec.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+}
+
+interface WorkflowJob {
+  name?: string
+  needs?: string | string[]
+  'runs-on'?: string
+  steps?: WorkflowStep[]
+}
+
+interface Workflow {
+  concurrency?: {
+    group?: string
+    'cancel-in-progress'?: boolean
+  }
+  jobs: Record<string, WorkflowJob>
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/desktop-package-smoke.yml'), 'utf8'),
+) as Workflow
+
+describe('Desktop Package Smoke workflow critical path', () => {
+  it('cancels superseded runs for the same pull request or ref', () => {
+    expect(workflow.concurrency).toEqual({
+      group: 'desktop-package-smoke-${{ github.event.pull_request.number || github.ref }}',
+      'cancel-in-progress': true,
+    })
+  })
+
+  it('runs Windows Broker Pack acceptance independently of desktop packaging', () => {
+    const brokerPacks = workflow.jobs['broker-packs-windows']
+    const desktop = workflow.jobs.package
+    const brokerPackSteps = [
+      'Build optional Broker Packs on Windows',
+      'Prove previous-release Broker Pack upgrade on Windows',
+    ]
+
+    expect(brokerPacks).toMatchObject({
+      name: 'broker-packs windows-latest',
+      'runs-on': 'windows-latest',
+    })
+    expect(brokerPacks.needs).toBeUndefined()
+    expect(brokerPacks.steps?.map((step) => step.name)).toEqual(
+      expect.arrayContaining(brokerPackSteps),
+    )
+    expect(desktop.needs).toBeUndefined()
+    for (const stepName of brokerPackSteps) {
+      expect(desktop.steps?.map((step) => step.name)).not.toContain(stepName)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- move the Windows Broker Pack build and N-1 upgrade smoke into an independent Desktop Package Smoke job
- let Broker Pack acceptance and the desktop package matrix start concurrently without dropping either gate
- cancel superseded runs for the same pull request or ref
- lock the parallel DAG in a parsed-workflow regression test and update the owner guide

## Timing baseline

Before: Desktop Package Smoke run https://github.com/TraderAlice/OpenAlice/actions/runs/30771244528 took 25m19s wall time. The Windows job took 25m13s, including 5m03s Broker Pack build plus 5m56s previous-release Pack upgrade acceptance.

Expected after: the approximately 11-minute Broker Pack lane and approximately 14-minute remaining Windows desktop lane run in parallel, reducing the workflow critical path to roughly 14 minutes. The PR run will provide the measured result.

## Verification

- npx tsc --noEmit
- pnpm test (467 files passed, 1 skipped; 3888 tests passed, 9 skipped)
- pnpm exec vitest run scripts/desktop-package-workflow.spec.ts scripts/release-workflow.spec.ts
- git diff --check

No signed package was built locally because this change only restructures the CI DAG; the PR Desktop Package Smoke is the authoritative Windows/package verification.