### PR TITLE
ci: fail fast before desktop package smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             }
             core.setOutput("cross_platform", String(runCrossPlatform));
 
-  build-and-test:
+  build:
     # A dev push is the already-tested result of merging a PR. It gets the
     # focused post-merge smoke below instead of repeating the whole PR suite.
     if: github.event_name != 'push' || github.ref == 'refs/heads/master'
@@ -94,7 +94,46 @@ jobs:
 
       - run: pnpm build
 
+  test:
+    # Build and Vitest do not consume each other's output. Keep them on
+    # separate runners so either failure becomes actionable immediately.
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - run: pnpm test
+
+  # Preserve the established check name for branch protection and external
+  # consumers while the two independent validations report failures earlier.
+  build-and-test:
+    if: always() && (github.event_name != 'push' || github.ref == 'refs/heads/master')
+    needs: [build, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require successful build and test lanes
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$BUILD_RESULT" != "success" || "$TEST_RESULT" != "success" ]]; then
+            echo "Build result: $BUILD_RESULT"
+            echo "Test result: $TEST_RESULT"
+            exit 1
+          fi
 
   # The full Vitest suite includes path, port-binding, process-launch, and
   # packaged-toolchain behavior whose semantics differ materially by host OS.

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -92,8 +92,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    name: fast preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify CI workflow contracts
+        run: >-
+          pnpm exec vitest run
+          scripts/ci-workflow.spec.ts
+          scripts/desktop-package-workflow.spec.ts
+          scripts/release-workflow.spec.ts
+
+      - name: Typecheck root workspace
+        run: npx tsc --noEmit
+        timeout-minutes: 5
+
   broker-packs-windows:
     name: broker-packs windows-latest
+    needs: preflight
     runs-on: windows-latest
     timeout-minutes: 25
 
@@ -122,6 +152,7 @@ jobs:
 
   package:
     name: package ${{ matrix.os }}
+    needs: preflight
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -152,11 +152,12 @@ through `ComSpec` on Windows; the shared runner supplies the already-quoted
 command line verbatim so Node does not quote it a second time. Package scripts
 must not rely on POSIX quoting.
 
-The Desktop Package Smoke workflow runs a dedicated Windows Broker Pack job in
-parallel with desktop packaging. That job exercises the Pack deployment path,
-while the Windows desktop job reruns the cached desktop build through the
-packaged-smoke wrapper, so both release-facing `pnpm.cmd` call sites fail during
-PR validation rather than after a release starts.
+After its fast contract/type preflight, the Desktop Package Smoke workflow runs
+a dedicated Windows Broker Pack job in parallel with desktop packaging. That
+job exercises the Pack deployment path, while the Windows desktop job reruns
+the cached desktop build through the packaged-smoke wrapper, so both
+release-facing `pnpm.cmd` call sites fail during PR validation rather than after
+a release starts.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -194,11 +194,16 @@ CI provides both change-level confidence and post-merge integration feedback.
 Its execution stays the same, but its blocking authority depends on the
 delivery lane:
 
-- Every PR to `dev` or `master` runs the Ubuntu build and test gate.
+- Every PR to `dev` or `master` runs independent Ubuntu build and unit-test
+  lanes so either failure is visible without waiting for the other. The stable
+  `build-and-test` aggregate check requires both lanes to pass.
 - PRs whose complete diff is limited to `ui/`, `docs/`, or root documentation
   skip the macOS/Windows runtime matrix. Any other path keeps the full matrix.
 - Superseded runs for the same PR are cancelled. Only the latest-head result is
   actionable evidence.
+- Desktop Package Smoke runs its workflow-contract and root-typecheck preflight
+  before allocating the expensive host package matrix and Windows Broker Pack
+  lane. The native package lanes still start together after that fast gate.
 - In serial mode, a `dev` PR may merge after proportional local verification
   while its remote checks are pending. Before the next serial PR is published,
   inspect both that PR's checks and the resulting `dev` push run. A completed

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  run?: string
+}
+
+interface WorkflowJob {
+  if?: string
+  needs?: string | string[]
+  steps?: WorkflowStep[]
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8'),
+) as { jobs: Record<string, WorkflowJob> }
+
+function commands(job: WorkflowJob): string[] {
+  return job.steps?.flatMap((step) => step.run ? [step.run] : []) ?? []
+}
+
+describe('CI workflow fast failure lanes', () => {
+  it('runs build and unit tests independently', () => {
+    const build = workflow.jobs.build
+    const test = workflow.jobs.test
+
+    expect(build.needs).toBeUndefined()
+    expect(test.needs).toBeUndefined()
+    expect(commands(build)).toContain('pnpm build')
+    expect(commands(build)).not.toContain('pnpm test')
+    expect(commands(test)).toContain('pnpm test')
+    expect(commands(test)).not.toContain('pnpm build')
+  })
+
+  it('preserves build-and-test as the aggregate confidence gate', () => {
+    const aggregate = workflow.jobs['build-and-test']
+
+    expect(aggregate.if).toContain('always()')
+    expect(aggregate.needs).toEqual(['build', 'test'])
+    expect(aggregate.steps?.map((step) => step.name)).toContain(
+      'Require successful build and test lanes',
+    )
+  })
+})

--- a/scripts/desktop-package-workflow.spec.ts
+++ b/scripts/desktop-package-workflow.spec.ts
@@ -5,6 +5,7 @@ import YAML from 'yaml'
 
 interface WorkflowStep {
   name?: string
+  run?: string
 }
 
 interface WorkflowJob {
@@ -36,6 +37,7 @@ describe('Desktop Package Smoke workflow critical path', () => {
   })
 
   it('runs Windows Broker Pack acceptance independently of desktop packaging', () => {
+    const preflight = workflow.jobs.preflight
     const brokerPacks = workflow.jobs['broker-packs-windows']
     const desktop = workflow.jobs.package
     const brokerPackSteps = [
@@ -43,15 +45,28 @@ describe('Desktop Package Smoke workflow critical path', () => {
       'Prove previous-release Broker Pack upgrade on Windows',
     ]
 
+    expect(preflight).toMatchObject({
+      name: 'fast preflight',
+      'runs-on': 'ubuntu-latest',
+    })
+    expect(preflight.needs).toBeUndefined()
+    const preflightSteps = preflight.steps?.map((step) => step.name) ?? []
+    expect(preflightSteps).toEqual(expect.arrayContaining([
+      'Verify CI workflow contracts',
+      'Typecheck root workspace',
+    ]))
+    expect(preflightSteps.indexOf('Verify CI workflow contracts')).toBeLessThan(
+      preflightSteps.indexOf('Typecheck root workspace'),
+    )
     expect(brokerPacks).toMatchObject({
       name: 'broker-packs windows-latest',
       'runs-on': 'windows-latest',
     })
-    expect(brokerPacks.needs).toBeUndefined()
+    expect(brokerPacks.needs).toBe('preflight')
     expect(brokerPacks.steps?.map((step) => step.name)).toEqual(
       expect.arrayContaining(brokerPackSteps),
     )
-    expect(desktop.needs).toBeUndefined()
+    expect(desktop.needs).toBe('preflight')
     for (const stepName of brokerPackSteps) {
       expect(desktop.steps?.map((step) => step.name)).not.toContain(stepName)
     }


### PR DESCRIPTION
## Summary

- split the Ubuntu build and Vitest suite into independent CI jobs so either lane reports its failure without waiting for the other
- preserve build-and-test as an aggregate check that fails when either parallel lane fails
- gate the native Desktop Package Smoke matrix and Windows Broker Pack lane behind a short workflow-contract and root-typecheck preflight
- lock the DAG with parsed-workflow tests and document the new CI contract

## Timing baseline and expectation

Before: PR #962 CI build-and-test took 4m22s, with pnpm build (1m07s) followed by pnpm test (2m44s). Desktop Package Smoke took 12m55s wall time.

Expected: build failures become visible in roughly 1-2 minutes and test failures in roughly 3 minutes. Obvious workflow/type failures should stop before native runners are allocated. A green package run pays only the short preflight delay (expected about 1 minute) before the three desktop jobs and Broker Pack job still start together.

## Verification

- npx tsc --noEmit
- pnpm build
- pnpm test (468 files passed, 1 skipped; 3890 tests passed, 9 skipped)
- pnpm exec vitest run scripts/ci-workflow.spec.ts scripts/desktop-package-workflow.spec.ts scripts/release-workflow.spec.ts
- git diff --check

## Boundary touch

CI ordering and unsigned desktop package validation only. No signing, release publication, trading, credentials, or persisted state changes.