### PR TITLE
chore(release): prepare 0.89.1-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.89.0-beta",
+  "version": "0.89.1-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.89.0-beta",
+  "version": "0.89.1-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the OpenAlice product and distributed CLI versions from 0.89.0-beta to 0.89.1-beta
- prepare the next dev-to-master promotion without changing installer or runtime behavior in this commit

The promotion includes the stable update provenance installer fix from PR #957, explicit provider readiness errors from PR #960, and the release/package CI parallelism and fail-fast changes from PRs #961-#963.

## Verification

- version/tag uniqueness and root/CLI alignment check
- bash -n install scripts/install-smoke/run.sh scripts/install-smoke/interactive.sh scripts/install-channel-smoke/run.sh
- npx tsc --noEmit
- pnpm test (468 files passed, 1 skipped; 3890 tests passed, 9 skipped)
- pnpm -F @traderalice/openalice-cli test (23 files, 200 tests passed)
- pnpm test:install:docker
- pnpm test:remote:docker
- git diff --check

## Boundary touch

Release version only. The promotion and release workflows remain responsible for signed/notarized desktop candidates, N-1 desktop upgrades, Broker Pack upgrades, clean installer/remote acceptance, headless Runtime acceptance, publication, and CDN verification.