### PR TITLE
release: promote 0.89.1-beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             }
             core.setOutput("cross_platform", String(runCrossPlatform));
 
-  build-and-test:
+  build:
     # A dev push is the already-tested result of merging a PR. It gets the
     # focused post-merge smoke below instead of repeating the whole PR suite.
     if: github.event_name != 'push' || github.ref == 'refs/heads/master'
@@ -94,7 +94,46 @@ jobs:
 
       - run: pnpm build
 
+  test:
+    # Build and Vitest do not consume each other's output. Keep them on
+    # separate runners so either failure becomes actionable immediately.
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - run: pnpm test
+
+  # Preserve the established check name for branch protection and external
+  # consumers while the two independent validations report failures earlier.
+  build-and-test:
+    if: always() && (github.event_name != 'push' || github.ref == 'refs/heads/master')
+    needs: [build, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require successful build and test lanes
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$BUILD_RESULT" != "success" || "$TEST_RESULT" != "success" ]]; then
+            echo "Build result: $BUILD_RESULT"
+            echo "Test result: $TEST_RESULT"
+            exit 1
+          fi
 
   # The full Vitest suite includes path, port-binding, process-launch, and
   # packaged-toolchain behavior whose semantics differ materially by host OS.

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -92,8 +92,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    name: fast preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify CI workflow contracts
+        run: >-
+          pnpm exec vitest run
+          scripts/ci-workflow.spec.ts
+          scripts/desktop-package-workflow.spec.ts
+          scripts/release-workflow.spec.ts
+
+      - name: Typecheck root workspace
+        run: npx tsc --noEmit
+        timeout-minutes: 5
+
   broker-packs-windows:
     name: broker-packs windows-latest
+    needs: preflight
     runs-on: windows-latest
     timeout-minutes: 25
 
@@ -122,6 +152,7 @@ jobs:
 
   package:
     name: package ${{ matrix.os }}
+    needs: preflight
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -87,7 +87,39 @@ on:
       - "packages/connector-protocol/**"
       - "packages/uta-broker-*/**"
 
+concurrency:
+  group: desktop-package-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  broker-packs-windows:
+    name: broker-packs windows-latest
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # the N-1 Broker Pack smoke resolves the previous release tag
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build optional Broker Packs on Windows
+        run: pnpm broker-packs:build
+        timeout-minutes: 10
+
+      - name: Prove previous-release Broker Pack upgrade on Windows
+        run: pnpm broker-packs:upgrade-smoke
+        timeout-minutes: 10
+
   package:
     name: package ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -117,16 +149,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Build optional Broker Packs on Windows
-        if: runner.os == 'Windows'
-        run: pnpm broker-packs:build
-        timeout-minutes: 10
-
-      - name: Prove previous-release Broker Pack upgrade on Windows
-        if: runner.os == 'Windows'
-        run: pnpm broker-packs:upgrade-smoke
-        timeout-minutes: 10
 
       # macOS still uses dugite's embedded Git. Windows keeps only dugite's JS
       # wrapper and routes it to managed PortableGit in the packaged smoke.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,10 @@ jobs:
           path: notes.md
           if-no-files-found: error
 
-  # Per-platform desktop installers are built and acceptance-tested before any
-  # tag or GitHub Release exists. Each runner builds only its own platform/arch.
-  # Optional broker SDKs are emitted as separate version/platform-specific
-  # Broker Packs and are rejected if they leak back into the desktop app. macOS
+  # Per-platform desktop installers are built before any tag or GitHub Release
+  # exists. Each runner builds only its own platform/arch, preserves the candidate
+  # immediately after fast package acceptance, and leaves the slower N-1 upgrade
+  # journey to a downstream job that can be retried without rebuilding it. macOS
   # builds are signed and notarized through Developer ID secrets; Windows remains
   # unsigned until a Windows code-signing certificate exists.
   build-desktop:
@@ -118,15 +118,10 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Build optional Broker Packs
-        run: pnpm broker-packs:build
-
-      - name: Prove previous-release Broker Pack upgrade
-        run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
       # macOS still uses dugite's embedded Git. Windows keeps only dugite's JS
       # wrapper and routes it to managed PortableGit in the packaged smoke.
@@ -214,6 +209,61 @@ jobs:
             --arch "$RELEASE_ARCH" \
             --version "$VERSION"
 
+      - name: Preserve desktop release candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
+          path: |
+            dist/electron-app/*.dmg
+            dist/electron-app/*.zip
+            dist/electron-app/*.yml
+            dist/electron-app/*.blockmap
+            dist/electron-app/*.exe
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  # The final-artifact upgrade journey is intentionally downstream from the
+  # build. A failed platform can be retried from its preserved installer without
+  # repeating Electron packaging, macOS signing, or notarization.
+  accept-desktop-upgrade:
+    name: Accept desktop upgrade (${{ matrix.os }}, ${{ matrix.arch }})
+    needs: [release, build-desktop]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && !github.event.inputs.mirror_tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore desktop release candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
+          path: dist/electron-app
+
       - name: Prove final desktop artifact upgrades previous release state
         run: >-
           pnpm electron:smoke:upgrade --
@@ -230,31 +280,6 @@ jobs:
           path: ${{ runner.temp }}/openalice-desktop-upgrade.json
           if-no-files-found: error
           retention-days: 7
-
-      - name: Preserve accepted release assets
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-assets-${{ runner.os }}-${{ matrix.arch }}
-          path: |
-            dist/electron-app/*.dmg
-            dist/electron-app/*.zip
-            dist/electron-app/*.yml
-            dist/electron-app/*.blockmap
-            dist/electron-app/*.exe
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 1
-
-      - name: Preserve optional Broker Packs
-        uses: actions/upload-artifact@v4
-        with:
-          name: broker-packs-${{ runner.os }}-${{ matrix.arch }}
-          path: |
-            dist/broker-packs/*.json
-            dist/broker-packs/*.tgz
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 1
 
   cli-installer-acceptance:
     name: Accept CLI installer candidate
@@ -311,6 +336,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -354,11 +380,26 @@ jobs:
           compression-level: 0
           retention-days: 1
 
-  build-linux-broker-packs:
-    name: Build Linux Broker Packs
+  # Broker Packs are release artifacts, not inputs to the desktop package. Build
+  # and validate them on their native platforms in parallel with desktop and
+  # headless Runtime candidates instead of serializing them in desktop jobs.
+  build-broker-packs:
+    name: Build Broker Packs (${{ matrix.os }}, ${{ matrix.arch }})
     needs: release
     if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            arch: arm64
+          - os: macos-15-intel
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: ubuntu-latest
+            arch: x64
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
 
@@ -370,6 +411,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -380,10 +422,10 @@ jobs:
       - name: Prove previous-release Broker Pack upgrade
         run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
-      - name: Preserve Linux Broker Packs
+      - name: Preserve Broker Packs
         uses: actions/upload-artifact@v4
         with:
-          name: broker-packs-Linux-x64
+          name: broker-packs-${{ runner.os }}-${{ matrix.arch }}
           path: |
             dist/broker-packs/*.json
             dist/broker-packs/*.tgz
@@ -393,8 +435,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, build-headless-runtime, build-linux-broker-packs, cli-installer-acceptance]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.build-headless-runtime.result == 'success' && needs.build-linux-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
+    needs: [release, build-desktop, accept-desktop-upgrade, build-headless-runtime, build-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-headless-runtime.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,15 +483,9 @@ jobs:
           test "$CLI_PACKAGE_VERSION" = "$VERSION"
           bash -n install
           cp install "dist/r2-upload/OpenAlice-${VERSION}-install"
-          node - "$VERSION" "dist/r2-upload/OpenAlice-${VERSION}-install" <<'NODE'
-          const { readFileSync, writeFileSync } = require('node:fs')
-          const [version, path] = process.argv.slice(2)
-          const source = 'OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"'
-          const target = `OPENALICE_INSTALLER_RELEASE_VERSION="\${OPENALICE_INSTALLER_RELEASE_VERSION:-${version}}"`
-          const input = readFileSync(path, 'utf8')
-          if (!input.includes(source)) throw new Error('installer release-version placeholder is missing')
-          writeFileSync(path, input.replace(source, target))
-          NODE
+          node scripts/prepare-cli-release-installer.mjs \
+            "$VERSION" \
+            "dist/r2-upload/OpenAlice-${VERSION}-install"
           bash -n "dist/r2-upload/OpenAlice-${VERSION}-install"
 
       - name: Prepare CDN download aliases
@@ -661,6 +655,7 @@ jobs:
           bash -n /tmp/openalice-install
           bash /tmp/openalice-install --plan | tee /tmp/openalice-install-plan
           grep -Fq "GitHub ref: TraderAlice/OpenAlice@${TAG}" /tmp/openalice-install-plan
+          grep -Fq "Updates        stable" /tmp/openalice-install-plan
           INSTALLER_PATH=/tmp/openalice-install MANIFEST_URL="${BASE_URL}/manifest.json" node -e '
             const { createHash } = require("node:crypto");
             const { readFileSync } = require("node:fs");

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -152,10 +152,11 @@ through `ComSpec` on Windows; the shared runner supplies the already-quoted
 command line verbatim so Node does not quote it a second time. Package scripts
 must not rely on POSIX quoting.
 
-The Desktop Package Smoke workflow builds every optional Broker Pack on its
-Windows runner before packaging. It also reruns the cached desktop build
-through the packaged-smoke wrapper, so both release-facing `pnpm.cmd` call
-sites fail during PR validation rather than after a release starts.
+The Desktop Package Smoke workflow runs a dedicated Windows Broker Pack job in
+parallel with desktop packaging. That job exercises the Pack deployment path,
+while the Windows desktop job reruns the cached desktop build through the
+packaged-smoke wrapper, so both release-facing `pnpm.cmd` call sites fail during
+PR validation rather than after a release starts.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -152,11 +152,12 @@ through `ComSpec` on Windows; the shared runner supplies the already-quoted
 command line verbatim so Node does not quote it a second time. Package scripts
 must not rely on POSIX quoting.
 
-The Desktop Package Smoke workflow runs a dedicated Windows Broker Pack job in
-parallel with desktop packaging. That job exercises the Pack deployment path,
-while the Windows desktop job reruns the cached desktop build through the
-packaged-smoke wrapper, so both release-facing `pnpm.cmd` call sites fail during
-PR validation rather than after a release starts.
+After its fast contract/type preflight, the Desktop Package Smoke workflow runs
+a dedicated Windows Broker Pack job in parallel with desktop packaging. That
+job exercises the Pack deployment path, while the Windows desktop job reruns
+the cached desktop build through the packaged-smoke wrapper, so both
+release-facing `pnpm.cmd` call sites fail during PR validation rather than after
+a release starts.
 
 Desktop package acceptance rejects `ccxt`, `longbridge`, its native binding,
 and `@alpacahq/alpaca-trade-api` if they reappear under packaged

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -290,8 +290,8 @@ Before a release becomes visible, the installer:
    managed Pi closure;
 5. verifies and expands the matching headless Runtime when the selected release
    supplies one, then requires its product version to equal the CLI version;
-6. writes `install-source.json` with the CLI version, selected branch/tag/commit,
-   and installer URL that produced this CLI;
+6. writes `install-source.json` with the CLI version, selected
+   branch/tag/commit, installer URL, and independent update-channel policy;
 7. hashes the ordered OpenAlice CLI payload, install-source metadata, and both
    Pi install files with SHA-256 and uses the first 16 hex characters as the
    cross-platform CLI install content identity.
@@ -356,8 +356,10 @@ An installed stable-channel CLI checks
 `https://download.openalice.ai/manifest.json` before an interactive
 `openalice start`:
 
-- only a recorded public `branch master` installation from
-  `https://openalice.ai/install` participates;
+- public release installers record two independent facts: the immutable
+  release tag used for the installed payload and `updateChannel: stable`;
+- legacy metadata from a public `branch master` installation at
+  `https://openalice.ai/install` remains compatible with the stable channel;
 - exact tag/commit installations remain pinned;
 - `dev` and other branch installations keep their selected development channel;
 - custom installer/mirror installations do not cross into the public trust
@@ -367,6 +369,13 @@ An installed stable-channel CLI checks
 - `--no-update-check` or `OPENALICE_NO_UPDATE_CHECK=1` disables the start check;
 - discovery only prints a notice. It never mutates files or makes startup
   depend on a successful network request.
+
+Release installers published before provenance v2 recorded their embedded tag
+in the same shape as a deliberate `--version` pin. The CLI cannot safely guess
+which intent produced that old metadata. An affected install therefore remains
+pinned until the public stable installer is run once again; that ordinary
+atomic reinstall preserves application state and writes the unambiguous v2
+stable-channel provenance.
 
 Explicit controls are:
 
@@ -520,9 +529,11 @@ Environment inputs:
 | `OPENALICE_PI_SOURCE_DIR` | Read the exact Pi manifest/lock assets from a local fixture |
 | `OPENALICE_NPM_BIN` | Use a single alternate npm executable in installer tests |
 | `OPENALICE_INSTALL_CONTEXT` | Internal managed-remote context; returns control without local checkout/start guidance |
+| `OPENALICE_INSTALL_UPDATE_CHANNEL` | Internal exact-provenance reproduction seam used by managed SSH installs |
 | `OPENALICE_EXPECTED_CLI_VERSION` | Internal verified-update guard; rejects a payload whose CLI/product version differs from the release manifest |
 | `OPENALICE_RUNTIME_RELEASE_BASE_URL` | Release/test override for Runtime metadata and archive downloads |
 | `OPENALICE_INSTALLER_RELEASE_VERSION` | Embedded by the release workflow; binds the installer to one OpenAlice tag and Runtime set |
+| `OPENALICE_INSTALLER_UPDATE_CHANNEL` | Embedded as `stable` by the release workflow; keeps the exact tag independently updateable through the public release channel |
 | `OPENALICE_RUNTIME_ARCHIVE`, `OPENALICE_RUNTIME_ARCHIVE_SHA256` | Local/CI equivalents of the development Runtime archive flags |
 | `NO_COLOR` | Disable installer color output |
 | `HOME`, `SHELL`, `PATH`, `TERM` | Standard environment used for paths, profile detection, conflicts, and color |

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -194,11 +194,16 @@ CI provides both change-level confidence and post-merge integration feedback.
 Its execution stays the same, but its blocking authority depends on the
 delivery lane:
 
-- Every PR to `dev` or `master` runs the Ubuntu build and test gate.
+- Every PR to `dev` or `master` runs independent Ubuntu build and unit-test
+  lanes so either failure is visible without waiting for the other. The stable
+  `build-and-test` aggregate check requires both lanes to pass.
 - PRs whose complete diff is limited to `ui/`, `docs/`, or root documentation
   skip the macOS/Windows runtime matrix. Any other path keeps the full matrix.
 - Superseded runs for the same PR are cancelled. Only the latest-head result is
   actionable evidence.
+- Desktop Package Smoke runs its workflow-contract and root-typecheck preflight
+  before allocating the expensive host package matrix and Windows Broker Pack
+  lane. The native package lanes still start together after that fast gate.
 - In serial mode, a `dev` PR may merge after proportional local verification
   while its remote checks are pending. Before the next serial PR is published,
   inspect both that PR's checks and the resulting `dev` push run. A completed

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -333,11 +333,14 @@ an installer from current `master`.
 Desktop promotion evidence includes a real N-1 state journey on Apple Silicon,
 Intel macOS, and Windows. PR package jobs seed state with the previous published
 app and verify the unpacked candidate can migrate, write, and restart. The
-versioned release repeats that journey against the final signed macOS ZIP or
-Windows NSIS installer and byte-verifies each updater YAML reference, size,
-SHA-512, and blockmap before `publish-release`. These are blocking release
-requirements, not trailing observations; missing receipts or mismatched update
-metadata must prevent the tag and public assets from being created.
+versioned release preserves each final signed macOS ZIP or Windows NSIS
+installer as soon as its fast package acceptance and updater byte verification
+pass, then runs the N-1 journey in a downstream platform job. A failed upgrade
+job can therefore reuse the preserved candidate without repeating packaging,
+signing, or notarization. `publish-release` still requires every platform's
+upgrade receipt and verifies each updater YAML reference, size, SHA-512, and
+blockmap before publishing. Missing receipts or mismatched update metadata must
+prevent the tag and public assets from being created.
 
 Do not delete `dev` after promotion. After a master hotfix, propagate the fix
 back to `dev` immediately so a later promotion cannot revert it.

--- a/install
+++ b/install
@@ -4,6 +4,7 @@ set -euo pipefail
 REPOSITORY="TraderAlice/OpenAlice"
 DEFAULT_BRANCH="master"
 OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"
+OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-}"
 PUBLIC_INSTALLER_URL="https://openalice.ai/install"
 VERSION=""
 REF_KIND=""
@@ -468,6 +469,34 @@ if [[ "$REF_KIND" == "branch" && "$VERSION" == "$DEFAULT_BRANCH" ]]; then
 fi
 INSTALLER_URL="${OPENALICE_INSTALL_URL:-$DEFAULT_INSTALLER_URL}"
 
+if [[ -n "${OPENALICE_INSTALL_UPDATE_CHANNEL:-}" ]]; then
+  UPDATE_CHANNEL="$OPENALICE_INSTALL_UPDATE_CHANNEL"
+elif [[ -n "$REF_OPTION" ]]; then
+  if [[ "$REF_KIND" == "version" ]]; then
+    UPDATE_CHANNEL="pinned"
+  elif [[ "$VERSION" == "$DEFAULT_BRANCH" && "$INSTALLER_URL" == "$PUBLIC_INSTALLER_URL" ]]; then
+    UPDATE_CHANNEL="stable"
+  elif [[ "$VERSION" == "$DEFAULT_BRANCH" ]]; then
+    UPDATE_CHANNEL="custom"
+  else
+    UPDATE_CHANNEL="development"
+  fi
+elif [[ -n "$OPENALICE_INSTALLER_UPDATE_CHANNEL" ]]; then
+  UPDATE_CHANNEL="$OPENALICE_INSTALLER_UPDATE_CHANNEL"
+elif [[ "$REF_KIND" == "version" ]]; then
+  UPDATE_CHANNEL="pinned"
+elif [[ "$VERSION" == "$DEFAULT_BRANCH" && "$INSTALLER_URL" == "$PUBLIC_INSTALLER_URL" ]]; then
+  UPDATE_CHANNEL="stable"
+elif [[ "$VERSION" == "$DEFAULT_BRANCH" ]]; then
+  UPDATE_CHANNEL="custom"
+else
+  UPDATE_CHANNEL="development"
+fi
+case "$UPDATE_CHANNEL" in
+  stable|pinned|development|custom) ;;
+  *) die "Unsupported OpenAlice update channel: $UPDATE_CHANNEL" ;;
+esac
+
 INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
 BIN_DIR="$INSTALL_ROOT/bin"
 VERSIONS_DIR="$INSTALL_ROOT/cli-versions"
@@ -716,6 +745,7 @@ if [[ "$REF_KIND" == "branch" ]]; then
 else
   printf '  %-14s %s\n' "Version" "$VERSION"
 fi
+printf '  %-14s %s\n' "Updates" "$UPDATE_CHANNEL"
 printf '  %-14s %s\n' "Install root" "$INSTALL_ROOT"
 printf '  %-14s %s\n' "Command" "$BIN_DIR/openalice"
 printf '  %-14s %s\n' "Managed agent" "Pi $PI_VERSION -> $BIN_DIR/pi"
@@ -967,29 +997,32 @@ STAGED_VERSION="$(node "$STAGING/bin/openalice.ts" --version)"
 [[ "$STAGED_VERSION" == "$CLI_VERSION" ]] || die "The downloaded CLI did not report its package version"
 node -e '
   const { writeFileSync } = require("node:fs");
-  const [path, repository, cliVersion, kind, value, installerUrl] = process.argv.slice(1);
+  const [path, repository, cliVersion, kind, value, installerUrl, updateChannel] = process.argv.slice(1);
   writeFileSync(path, `${JSON.stringify({
-    schemaVersion: 1,
+    schemaVersion: 2,
     repository,
     cliVersion,
     selector: { kind, value },
     installerUrl,
+    updateChannel,
   }, null, 2)}\n`, { mode: 0o644 });
-' "$STAGING/install-source.json" "$REPOSITORY" "$CLI_VERSION" "$REF_KIND" "$VERSION" "$INSTALLER_URL"
+' "$STAGING/install-source.json" "$REPOSITORY" "$CLI_VERSION" "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$UPDATE_CHANNEL"
 node "$STAGING/bin/openalice.ts" version --json | node -e '
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => { input += chunk; });
   process.stdin.on("end", () => {
-    const [kind, value, installerUrl, cliVersion] = process.argv.slice(1);
+    const [kind, value, installerUrl, cliVersion, updateChannel] = process.argv.slice(1);
     const info = JSON.parse(input);
     if (info.version !== cliVersion
+      || info.installSource?.schemaVersion !== 2
       || info.installSource?.cliVersion !== cliVersion
       || info.installSource?.selector?.kind !== kind
       || info.installSource?.selector?.value !== value
-      || info.installSource?.installerUrl !== installerUrl) process.exit(1);
+      || info.installSource?.installerUrl !== installerUrl
+      || info.installSource?.updateChannel !== updateChannel) process.exit(1);
   });
-' "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$CLI_VERSION" \
+' "$REF_KIND" "$VERSION" "$INSTALLER_URL" "$CLI_VERSION" "$UPDATE_CHANNEL" \
   || die "The downloaded CLI did not preserve its installation source"
 CONTENT_FILES=("${FILES[@]}" "install-source.json" "managed/pi/package.json" "managed/pi/package-lock.json")
 # Keep the CLI identity stable across operating systems. The platform-specific

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.89.0-beta",
+  "version": "0.89.1-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.89.0-beta",
+  "version": "0.89.1-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -7,11 +7,12 @@ import { fileURLToPath } from 'node:url'
 const CLI_VERSION = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
 
 export const DEFAULT_INSTALL_SOURCE = Object.freeze({
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: 'TraderAlice/OpenAlice',
   cliVersion: CLI_VERSION,
   selector: Object.freeze({ kind: 'branch', value: 'master' }),
   installerUrl: 'https://openalice.ai/install',
+  updateChannel: 'stable',
 })
 
 export async function readInstallSource(options = {}) {
@@ -41,8 +42,12 @@ export function parseInstallSource(value) {
   const kind = selector?.kind
   const ref = selector?.value
   const installerUrl = typeof value.installerUrl === 'string' ? value.installerUrl : ''
+  const schemaVersion = value.schemaVersion
+  const updateChannel = schemaVersion === 2
+    ? value.updateChannel
+    : inferLegacyUpdateChannel({ selector, installerUrl })
   if (
-    value.schemaVersion !== 1
+    ![1, 2].includes(schemaVersion)
     || repository !== 'TraderAlice/OpenAlice'
     || cliVersion.length < 1
     || !['branch', 'version'].includes(kind)
@@ -52,15 +57,17 @@ export function parseInstallSource(value) {
     || ref.includes('..')
     || !/^[A-Za-z0-9._/-]+$/.test(ref)
     || !isHttpUrl(installerUrl)
+    || !['stable', 'pinned', 'development', 'custom'].includes(updateChannel)
   ) {
     return null
   }
   return {
-    schemaVersion: 1,
+    schemaVersion,
     repository,
     cliVersion,
     selector: { kind, value: ref },
     installerUrl,
+    ...(schemaVersion === 2 ? { updateChannel } : {}),
   }
 }
 
@@ -79,6 +86,14 @@ export function installSourcesMatch(left, right) {
     && normalizedLeft.selector.kind === normalizedRight.selector.kind
     && normalizedLeft.selector.value === normalizedRight.selector.value
     && normalizedLeft.installerUrl === normalizedRight.installerUrl
+    && installSourceUpdateChannel(normalizedLeft) === installSourceUpdateChannel(normalizedRight)
+}
+
+export function installSourceUpdateChannel(source) {
+  const normalized = requireInstallSource(source)
+  return normalized.schemaVersion === 2
+    ? normalized.updateChannel
+    : inferLegacyUpdateChannel(normalized)
 }
 
 export function formatInstallSelector(source) {
@@ -101,12 +116,26 @@ export function managedSourceKey(source) {
 
 function cloneInstallSource(source) {
   return {
-    schemaVersion: 1,
+    schemaVersion: source.schemaVersion,
     repository: source.repository,
     cliVersion: source.cliVersion,
     selector: { ...source.selector },
     installerUrl: source.installerUrl,
+    ...(source.schemaVersion === 2 ? { updateChannel: source.updateChannel } : {}),
   }
+}
+
+function inferLegacyUpdateChannel(source) {
+  if (source?.selector?.kind === 'version') return 'pinned'
+  if (
+    source?.selector?.kind === 'branch'
+    && source.selector.value === 'master'
+    && source.installerUrl === 'https://openalice.ai/install'
+  ) {
+    return 'stable'
+  }
+  if (source?.selector?.kind === 'branch' && source.selector.value === 'master') return 'custom'
+  return 'development'
 }
 
 function isHttpUrl(value) {

--- a/packages/cli/src/install-source.spec.mjs
+++ b/packages/cli/src/install-source.spec.mjs
@@ -8,7 +8,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   DEFAULT_INSTALL_SOURCE,
   installedContentIdentity,
+  installSourceUpdateChannel,
   installSourcesMatch,
+  parseInstallSource,
   readInstallSource,
 } from './install-source.mjs'
 
@@ -25,8 +27,10 @@ describe('OpenAlice install source', () => {
     await expect(readInstallSource({ metadataUrl: join(root, 'missing.json') }))
       .resolves.toEqual(DEFAULT_INSTALL_SOURCE)
     expect(DEFAULT_INSTALL_SOURCE).toMatchObject({
+      schemaVersion: 2,
       selector: { kind: 'branch', value: 'master' },
       installerUrl: 'https://openalice.ai/install',
+      updateChannel: 'stable',
     })
   })
 
@@ -46,6 +50,40 @@ describe('OpenAlice install source', () => {
     }
     expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, { ...DEFAULT_INSTALL_SOURCE })).toBe(true)
     expect(installSourcesMatch(DEFAULT_INSTALL_SOURCE, dev)).toBe(false)
+  })
+
+  it('reads legacy metadata without changing its inferred channel', () => {
+    const legacyStable = {
+      schemaVersion: 1,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: '0.88.0-beta',
+      selector: { kind: 'branch', value: 'master' },
+      installerUrl: 'https://openalice.ai/install',
+    }
+    const legacyPinned = {
+      ...legacyStable,
+      selector: { kind: 'version', value: 'v0.88.0-beta' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/v0.88.0-beta/install',
+    }
+
+    expect(parseInstallSource(legacyStable)).toEqual(legacyStable)
+    expect(installSourceUpdateChannel(legacyStable)).toBe('stable')
+    expect(installSourceUpdateChannel(legacyPinned)).toBe('pinned')
+  })
+
+  it('keeps an immutable release ref distinct from its stable update policy', () => {
+    const stableRelease = {
+      schemaVersion: 2,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: '0.89.0-beta',
+      selector: { kind: 'version', value: 'v0.89.0-beta' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/v0.89.0-beta/install',
+      updateChannel: 'stable',
+    }
+    const explicitPin = { ...stableRelease, updateChannel: 'pinned' }
+
+    expect(installSourceUpdateChannel(stableRelease)).toBe('stable')
+    expect(installSourcesMatch(stableRelease, explicitPin)).toBe(false)
   })
 
   it('derives installed content identity only from an immutable release directory', () => {

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
+import { createServer } from 'node:http'
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -34,6 +35,7 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
 
     expect(installer).toContain('DEFAULT_BRANCH="master"')
     expect(installer).toContain('PUBLIC_INSTALLER_URL="https://openalice.ai/install"')
+    expect(installer).toContain('OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-}"')
     expect(installer).toContain('MINIMUM_NODE_VERSION="22.19.0"')
     expect(installer).toContain('PI_VERSION="0.83.0"')
     expect(desktopVendor).toContain("const PI_VERSION = '0.83.0'")
@@ -103,8 +105,10 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
 
     const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
     expect(JSON.parse(versionInfo.stdout).installSource).toMatchObject({
+      schemaVersion: 2,
       selector: { kind: 'branch', value: 'master' },
       installerUrl: 'https://openalice.ai/install',
+      updateChannel: 'stable',
     })
   })
 
@@ -150,11 +154,12 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
       version: productVersion,
       contentIdentity: releases[0].slice(-16),
       installSource: {
-        schemaVersion: 1,
+        schemaVersion: 2,
         repository: 'TraderAlice/OpenAlice',
         cliVersion: productVersion,
         selector: { kind: 'version', value: 'test/ref' },
         installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/test/ref/install',
+        updateChannel: 'pinned',
       },
       managedRuntime: null,
     })
@@ -163,6 +168,88 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI installer', { timeo
     expect(pi.stdout.trim()).toBe('0.83.0')
     const launcher = await readFile(join(installRoot, 'bin', 'openalice'), 'utf8')
     expect(launcher).toContain('OPENALICE_MANAGED_PI_PATH=')
+  })
+
+  it('recovers a legacy pinned release install onto stable without losing its exact ref', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'openalice-install-stable-ref-'))
+    temporaryPaths.push(home)
+    const installRoot = join(home, '.openalice')
+    const installerArgs = [
+      '--source', repositoryRoot,
+      '--version', `v${productVersion}`,
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--yes',
+    ]
+
+    await execFileAsync('bash', [join(repositoryRoot, 'install'), ...installerArgs], {
+      env: {
+        ...installerEnv(home),
+        OPENALICE_INSTALL_CONTEXT: 'remote',
+      },
+    })
+    const [legacyRelease] = await readdir(join(installRoot, 'cli-versions'))
+    await writeFile(join(installRoot, 'cli-versions', legacyRelease, 'install-source.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: productVersion,
+      selector: { kind: 'version', value: `v${productVersion}` },
+      installerUrl: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${productVersion}/install`,
+    }, null, 2)}\n`)
+    const pinnedCheck = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['update', '--check', '--json'])
+    expect(JSON.parse(pinnedCheck.stdout)).toMatchObject({ status: 'unsupported', channel: 'pinned' })
+
+    await execFileAsync('bash', [join(repositoryRoot, 'install'), ...installerArgs], {
+      env: {
+        ...installerEnv(home),
+        OPENALICE_INSTALL_CONTEXT: 'remote',
+        OPENALICE_INSTALL_UPDATE_CHANNEL: 'stable',
+      },
+    })
+
+    const versionInfo = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['version', '--json'])
+    expect(JSON.parse(versionInfo.stdout).installSource).toEqual({
+      schemaVersion: 2,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: productVersion,
+      selector: { kind: 'version', value: `v${productVersion}` },
+      installerUrl: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${productVersion}/install`,
+      updateChannel: 'stable',
+    })
+
+    const server = createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({
+        version: productVersion,
+        releaseNotesUrl: `https://github.com/TraderAlice/OpenAlice/releases/tag/v${productVersion}`,
+        installer: {
+          url: 'https://download.openalice.ai/install',
+          versionedUrl: `https://download.openalice.ai/OpenAlice-${productVersion}-install`,
+          sha256: '0'.repeat(64),
+        },
+      }))
+    })
+    await new Promise((resolvePromise, rejectPromise) => {
+      server.once('error', rejectPromise)
+      server.listen(0, '127.0.0.1', resolvePromise)
+    })
+    try {
+      const address = server.address()
+      const stableCheck = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['update', '--check', '--json'], {
+        env: {
+          ...process.env,
+          OPENALICE_UPDATE_MANIFEST_URL: `http://127.0.0.1:${address.port}/manifest.json`,
+        },
+      })
+      expect(JSON.parse(stableCheck.stdout)).toMatchObject({
+        status: 'current',
+        currentVersion: productVersion,
+        latestVersion: productVersion,
+        channel: 'stable',
+      })
+    } finally {
+      await new Promise((resolvePromise) => server.close(resolvePromise))
+    }
   })
 
   it('can show the complete plan without creating the install root', async () => {

--- a/packages/cli/src/managed-source.ts
+++ b/packages/cli/src/managed-source.ts
@@ -20,7 +20,7 @@ const DEFAULT_REPOSITORY_URL = 'https://github.com/TraderAlice/OpenAlice.git'
 const MAX_GIT_ERROR_OUTPUT_BYTES = 64 * 1024
 
 interface InstallSource {
-  schemaVersion: 1
+  schemaVersion: 1 | 2
   repository: string
   cliVersion: string
   selector: {
@@ -28,6 +28,7 @@ interface InstallSource {
     value: string
   }
   installerUrl: string
+  updateChannel?: 'stable' | 'pinned' | 'development' | 'custom'
 }
 
 interface InstalledLayout {

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -9,6 +9,7 @@ import {
   DEFAULT_INSTALL_SOURCE,
   formatInstallSelector,
   installedContentIdentity,
+  installSourceUpdateChannel,
   installSourcesMatch,
   managedSourceKey,
   parseInstallSource,
@@ -903,6 +904,7 @@ export function buildRemoteInstallCommand(installSource, installBaseUrl = '', wi
   const selectorValue = shellQuote(source.selector.value)
   const installEnv = [
     `OPENALICE_INSTALL_URL=${url}`,
+    `OPENALICE_INSTALL_UPDATE_CHANNEL=${shellQuote(installSourceUpdateChannel(source))}`,
     'OPENALICE_INSTALL_CONTEXT=remote',
     `OPENALICE_EXPECTED_CLI_VERSION=${shellQuote(source.cliVersion)}`,
     installBaseUrl ? `OPENALICE_INSTALL_BASE_URL=${shellQuote(installBaseUrl)}` : '',

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -82,9 +82,23 @@ describe('OpenAlice managed remote connector', () => {
   it('builds a remote installer command from local provenance, not remote flags', () => {
     const command = buildRemoteInstallCommand(masterInstallSource)
     expect(command).toContain('OPENALICE_INSTALL_URL=')
+    expect(command).toContain("OPENALICE_INSTALL_UPDATE_CHANNEL='stable'")
     expect(command).toContain('OPENALICE_INSTALL_CONTEXT=remote')
     expect(command).toContain("--branch 'master'")
     expect(command).not.toContain('--version')
+  })
+
+  it('reproduces a stable release from its exact ref without pinning the remote channel', () => {
+    const command = buildRemoteInstallCommand({
+      schemaVersion: 2,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: '0.89.0-beta',
+      selector: { kind: 'version', value: 'v0.89.0-beta' },
+      installerUrl: 'https://raw.githubusercontent.com/TraderAlice/OpenAlice/v0.89.0-beta/install',
+      updateChannel: 'stable',
+    })
+    expect(command).toContain("OPENALICE_INSTALL_UPDATE_CHANNEL='stable'")
+    expect(command).toContain("--version 'v0.89.0-beta'")
   })
 
   it('plans install and start separately, with no implicit takeover', () => {

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { resolveInstalledLayout } from './install-layout.mjs'
-import { readInstallSource } from './install-source.mjs'
+import { installSourceUpdateChannel, readInstallSource } from './install-source.mjs'
 
 const CURRENT_VERSION = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
@@ -36,7 +36,7 @@ export async function checkForUpdate(options = {}, dependencies = {}) {
   const installSource = options.installSource ?? await (
     dependencies.readInstallSourceImpl ?? readInstallSource
   )()
-  const channel = updateChannel(installSource)
+  const channel = installSourceUpdateChannel(installSource)
   if (channel !== 'stable') {
     return {
       status: 'unsupported',
@@ -307,19 +307,6 @@ function runProcess(spawnImpl, command, args, options) {
       else rejectPromise(new Error(`installer exited with code=${String(code)}, signal=${String(signal)}`))
     })
   })
-}
-
-function updateChannel(source) {
-  if (source?.selector?.kind === 'version') return 'pinned'
-  if (
-    source?.selector?.kind === 'branch'
-    && source.selector.value === 'master'
-    && source.installerUrl === 'https://openalice.ai/install'
-  ) {
-    return 'stable'
-  }
-  if (source?.selector?.kind === 'branch' && source.selector.value === 'master') return 'custom'
-  return 'development'
 }
 
 function unsupportedChannelMessage(source, channel) {

--- a/packages/cli/src/update.spec.mjs
+++ b/packages/cli/src/update.spec.mjs
@@ -20,11 +20,12 @@ const [currentMajor = '0', currentMinor = '0'] = currentCliVersion.split('.')
 const newerCliVersion = `${currentMajor}.${Number(currentMinor) + 1}.0-beta`
 
 const stableSource = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: 'TraderAlice/OpenAlice',
   cliVersion: currentCliVersion,
-  selector: { kind: 'branch', value: 'master' },
-  installerUrl: 'https://openalice.ai/install',
+  selector: { kind: 'version', value: `v${currentCliVersion}` },
+  installerUrl: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${currentCliVersion}/install`,
+  updateChannel: 'stable',
 }
 
 describe('OpenAlice CLI updates', () => {
@@ -66,20 +67,40 @@ describe('OpenAlice CLI updates', () => {
       installSource: {
         ...stableSource,
         selector: { kind: 'version', value: 'v0.87.0-beta' },
+        updateChannel: 'pinned',
       },
     })).resolves.toMatchObject({ status: 'unsupported', channel: 'pinned' })
     await expect(checkForUpdate({
       installSource: {
         ...stableSource,
         selector: { kind: 'branch', value: 'dev' },
+        updateChannel: 'development',
       },
     })).resolves.toMatchObject({ status: 'unsupported', channel: 'development' })
     await expect(checkForUpdate({
       installSource: {
         ...stableSource,
+        selector: { kind: 'branch', value: 'master' },
         installerUrl: 'https://mirror.example.test/install',
+        updateChannel: 'custom',
       },
     })).resolves.toMatchObject({ status: 'unsupported', channel: 'custom' })
+  })
+
+  it('continues to recognize legacy public-master metadata as stable', async () => {
+    await expect(checkForUpdate({
+      currentVersion: '0.87.0-beta',
+      installSource: {
+        schemaVersion: 1,
+        repository: 'TraderAlice/OpenAlice',
+        cliVersion: '0.87.0-beta',
+        selector: { kind: 'branch', value: 'master' },
+        installerUrl: 'https://openalice.ai/install',
+      },
+    }, {
+      fetchImpl: manifestFetch(newerCliVersion),
+      env: {},
+    })).resolves.toMatchObject({ status: 'available', channel: 'stable' })
   })
 
   it('uses the ordinary installer only after an explicit update command', async () => {

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -504,6 +504,9 @@ source-tool planning.
 
 ### 9. Atomic Runtime update, activation, and rollback
 
+- [x] Separate immutable install provenance from update-channel policy so a
+  release-owned exact-tag install remains on stable while explicit
+  `--version` installs stay pinned.
 - [ ] Stage matching CLI, Pi, and Runtime as one product release.
 - [ ] Plan compatibility and active-work impact for running instances.
 - [ ] Keep compatible old processes alive with pending activation.
@@ -787,3 +790,10 @@ This plan is complete only when:
   acceptance deletes only that dependency from an otherwise healthy release,
   verifies that the installer preserves the damaged evidence, replaces the
   release atomically, and confirms the repaired closure before continuing.
+- 2026-08-02: Dogfood found that release-owned installers recorded their
+  embedded tag as an explicit pin, disabling both startup notices and the TUI
+  update action. Install provenance v2 now keeps the immutable tag for exact
+  SSH/source reproduction and records update policy separately. Release
+  generation embeds `stable`, human `--version` remains pinned, legacy v1
+  metadata remains readable, and the release-installer transformation plus
+  stable-ref install/check path have dedicated regression coverage.

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  run?: string
+}
+
+interface WorkflowJob {
+  if?: string
+  needs?: string | string[]
+  steps?: WorkflowStep[]
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8'),
+) as { jobs: Record<string, WorkflowJob> }
+
+function commands(job: WorkflowJob): string[] {
+  return job.steps?.flatMap((step) => step.run ? [step.run] : []) ?? []
+}
+
+describe('CI workflow fast failure lanes', () => {
+  it('runs build and unit tests independently', () => {
+    const build = workflow.jobs.build
+    const test = workflow.jobs.test
+
+    expect(build.needs).toBeUndefined()
+    expect(test.needs).toBeUndefined()
+    expect(commands(build)).toContain('pnpm build')
+    expect(commands(build)).not.toContain('pnpm test')
+    expect(commands(test)).toContain('pnpm test')
+    expect(commands(test)).not.toContain('pnpm build')
+  })
+
+  it('preserves build-and-test as the aggregate confidence gate', () => {
+    const aggregate = workflow.jobs['build-and-test']
+
+    expect(aggregate.if).toContain('always()')
+    expect(aggregate.needs).toEqual(['build', 'test'])
+    expect(aggregate.steps?.map((step) => step.name)).toContain(
+      'Require successful build and test lanes',
+    )
+  })
+})

--- a/scripts/desktop-package-workflow.spec.ts
+++ b/scripts/desktop-package-workflow.spec.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+}
+
+interface WorkflowJob {
+  name?: string
+  needs?: string | string[]
+  'runs-on'?: string
+  steps?: WorkflowStep[]
+}
+
+interface Workflow {
+  concurrency?: {
+    group?: string
+    'cancel-in-progress'?: boolean
+  }
+  jobs: Record<string, WorkflowJob>
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/desktop-package-smoke.yml'), 'utf8'),
+) as Workflow
+
+describe('Desktop Package Smoke workflow critical path', () => {
+  it('cancels superseded runs for the same pull request or ref', () => {
+    expect(workflow.concurrency).toEqual({
+      group: 'desktop-package-smoke-${{ github.event.pull_request.number || github.ref }}',
+      'cancel-in-progress': true,
+    })
+  })
+
+  it('runs Windows Broker Pack acceptance independently of desktop packaging', () => {
+    const brokerPacks = workflow.jobs['broker-packs-windows']
+    const desktop = workflow.jobs.package
+    const brokerPackSteps = [
+      'Build optional Broker Packs on Windows',
+      'Prove previous-release Broker Pack upgrade on Windows',
+    ]
+
+    expect(brokerPacks).toMatchObject({
+      name: 'broker-packs windows-latest',
+      'runs-on': 'windows-latest',
+    })
+    expect(brokerPacks.needs).toBeUndefined()
+    expect(brokerPacks.steps?.map((step) => step.name)).toEqual(
+      expect.arrayContaining(brokerPackSteps),
+    )
+    expect(desktop.needs).toBeUndefined()
+    for (const stepName of brokerPackSteps) {
+      expect(desktop.steps?.map((step) => step.name)).not.toContain(stepName)
+    }
+  })
+})

--- a/scripts/desktop-package-workflow.spec.ts
+++ b/scripts/desktop-package-workflow.spec.ts
@@ -5,6 +5,7 @@ import YAML from 'yaml'
 
 interface WorkflowStep {
   name?: string
+  run?: string
 }
 
 interface WorkflowJob {
@@ -36,6 +37,7 @@ describe('Desktop Package Smoke workflow critical path', () => {
   })
 
   it('runs Windows Broker Pack acceptance independently of desktop packaging', () => {
+    const preflight = workflow.jobs.preflight
     const brokerPacks = workflow.jobs['broker-packs-windows']
     const desktop = workflow.jobs.package
     const brokerPackSteps = [
@@ -43,15 +45,28 @@ describe('Desktop Package Smoke workflow critical path', () => {
       'Prove previous-release Broker Pack upgrade on Windows',
     ]
 
+    expect(preflight).toMatchObject({
+      name: 'fast preflight',
+      'runs-on': 'ubuntu-latest',
+    })
+    expect(preflight.needs).toBeUndefined()
+    const preflightSteps = preflight.steps?.map((step) => step.name) ?? []
+    expect(preflightSteps).toEqual(expect.arrayContaining([
+      'Verify CI workflow contracts',
+      'Typecheck root workspace',
+    ]))
+    expect(preflightSteps.indexOf('Verify CI workflow contracts')).toBeLessThan(
+      preflightSteps.indexOf('Typecheck root workspace'),
+    )
     expect(brokerPacks).toMatchObject({
       name: 'broker-packs windows-latest',
       'runs-on': 'windows-latest',
     })
-    expect(brokerPacks.needs).toBeUndefined()
+    expect(brokerPacks.needs).toBe('preflight')
     expect(brokerPacks.steps?.map((step) => step.name)).toEqual(
       expect.arrayContaining(brokerPackSteps),
     )
-    expect(desktop.needs).toBeUndefined()
+    expect(desktop.needs).toBe('preflight')
     for (const stepName of brokerPackSteps) {
       expect(desktop.steps?.map((step) => step.name)).not.toContain(stepName)
     }

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -115,9 +115,11 @@ node -e '
 const value = JSON.parse(process.argv[1]);
 const expectedVersion = process.argv[2];
 if (value.version !== expectedVersion) process.exit(1);
+if (value.installSource?.schemaVersion !== 2) process.exit(1);
 if (value.installSource?.cliVersion !== expectedVersion) process.exit(1);
 if (value.installSource?.selector?.kind !== "branch" || value.installSource?.selector?.value !== "smoke-v1") process.exit(1);
 if (value.installSource?.installerUrl !== "http://127.0.0.1:18080/install") process.exit(1);
+if (value.installSource?.updateChannel !== "development") process.exit(1);
 ' "$install_source" "$cli_version" || fail "installed CLI did not preserve its install source"
 [[ "$($bin_dir/pi --version)" == "0.83.0" ]] || fail "installed managed Pi version check failed"
 "$bin_dir/openalice" --help | grep -Fq "OpenAlice CLI" || fail "installed CLI help check failed"

--- a/scripts/prepare-cli-release-installer.mjs
+++ b/scripts/prepare-cli-release-installer.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+const RELEASE_VERSION_SOURCE = 'OPENALICE_INSTALLER_RELEASE_VERSION="${OPENALICE_INSTALLER_RELEASE_VERSION:-}"'
+const UPDATE_CHANNEL_SOURCE = 'OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-}"'
+
+export function prepareCliReleaseInstaller(version, path) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`invalid OpenAlice release version: ${version}`)
+  }
+  const input = readFileSync(path, 'utf8')
+  if (!input.includes(RELEASE_VERSION_SOURCE)) {
+    throw new Error('installer release-version placeholder is missing')
+  }
+  if (!input.includes(UPDATE_CHANNEL_SOURCE)) {
+    throw new Error('installer update-channel placeholder is missing')
+  }
+  writeFileSync(path, input
+    .replace(
+      RELEASE_VERSION_SOURCE,
+      `OPENALICE_INSTALLER_RELEASE_VERSION="\${OPENALICE_INSTALLER_RELEASE_VERSION:-${version}}"`,
+    )
+    .replace(
+      UPDATE_CHANNEL_SOURCE,
+      'OPENALICE_INSTALLER_UPDATE_CHANNEL="${OPENALICE_INSTALLER_UPDATE_CHANNEL:-stable}"',
+    ))
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [version, path] = process.argv.slice(2)
+  if (!version || !path) {
+    console.error('Usage: prepare-cli-release-installer.mjs <version> <installer-path>')
+    process.exit(2)
+  }
+  prepareCliReleaseInstaller(version, path)
+}

--- a/scripts/prepare-cli-release-installer.spec.mjs
+++ b/scripts/prepare-cli-release-installer.spec.mjs
@@ -1,0 +1,61 @@
+import { execFile } from 'node:child_process'
+import { copyFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { prepareCliReleaseInstaller } from './prepare-cli-release-installer.mjs'
+
+const execFileAsync = promisify(execFile)
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const fakeNpm = join(repositoryRoot, 'scripts/install-smoke/fake-npm.sh')
+const piAssets = join(repositoryRoot, 'scripts/install-smoke/pi-assets')
+const productVersion = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8')).version
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe.skipIf(process.platform === 'win32')('release-owned CLI installer', () => {
+  it('binds an immutable payload ref to the stable update channel', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-release-installer-'))
+    temporaryPaths.push(root)
+    const installer = join(root, 'install')
+    const runtimeArchive = join(root, 'runtime.tar.gz')
+    await copyFile(join(repositoryRoot, 'install'), installer)
+    await writeFile(runtimeArchive, '')
+
+    prepareCliReleaseInstaller(productVersion, installer)
+    await expect(execFileAsync('bash', ['-n', installer])).resolves.toBeDefined()
+
+    const plan = await execFileAsync('bash', [installer,
+      '--source', repositoryRoot,
+      '--runtime-archive', runtimeArchive,
+      '--install-dir', join(root, '.openalice'),
+      '--no-modify-path',
+      '--plan',
+    ], {
+      env: {
+        ...process.env,
+        HOME: root,
+        OPENALICE_NPM_BIN: fakeNpm,
+        OPENALICE_PI_SOURCE_DIR: piAssets,
+      },
+    })
+
+    expect(plan.stdout).toContain(`Version        v${productVersion}`)
+    expect(plan.stdout).toContain('Updates        stable')
+  })
+
+  it('rejects malformed release versions before rewriting the installer', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-release-installer-invalid-'))
+    temporaryPaths.push(root)
+    const installer = join(root, 'install')
+    await copyFile(join(repositoryRoot, 'install'), installer)
+    expect(() => prepareCliReleaseInstaller('master; bad', installer)).toThrow('invalid OpenAlice release version')
+  })
+})

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+interface WorkflowJob {
+  needs?: string | string[]
+  steps?: WorkflowStep[]
+  strategy?: {
+    matrix?: {
+      include?: Array<{ os?: string; arch?: string }>
+    }
+  }
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/release.yml'), 'utf8'),
+) as { jobs: Record<string, WorkflowJob> }
+
+function step(job: WorkflowJob, name: string): WorkflowStep {
+  const found = job.steps?.find((candidate) => candidate.name === name)
+  if (!found) throw new Error(`release workflow step is missing: ${name}`)
+  return found
+}
+
+function needs(job: WorkflowJob): string[] {
+  if (!job.needs) return []
+  return Array.isArray(job.needs) ? job.needs : [job.needs]
+}
+
+describe('Release workflow critical path', () => {
+  it('builds native Broker Packs outside the desktop package jobs', () => {
+    const desktop = workflow.jobs['build-desktop']
+    const brokerPacks = workflow.jobs['build-broker-packs']
+
+    expect(desktop.steps?.map((candidate) => candidate.name)).not.toContain('Build optional Broker Packs')
+    expect(brokerPacks.strategy?.matrix?.include).toEqual([
+      { os: 'macos-14', arch: 'arm64' },
+      { os: 'macos-15-intel', arch: 'x64' },
+      { os: 'windows-latest', arch: 'x64' },
+      { os: 'ubuntu-latest', arch: 'x64' },
+    ])
+    expect(step(brokerPacks, 'Preserve Broker Packs').with?.['name']).toBe(
+      'broker-packs-${{ runner.os }}-${{ matrix.arch }}',
+    )
+  })
+
+  it('preserves desktop candidates before running retriable N-1 acceptance', () => {
+    const desktop = workflow.jobs['build-desktop']
+    const upgrade = workflow.jobs['accept-desktop-upgrade']
+
+    expect(step(desktop, 'Preserve desktop release candidate').uses).toBe('actions/upload-artifact@v4')
+    expect(desktop.steps?.map((candidate) => candidate.name)).not.toContain(
+      'Prove final desktop artifact upgrades previous release state',
+    )
+    expect(needs(upgrade)).toEqual(['release', 'build-desktop'])
+    expect(step(upgrade, 'Restore desktop release candidate').uses).toBe('actions/download-artifact@v4')
+    expect(step(upgrade, 'Prove final desktop artifact upgrades previous release state')).toBeDefined()
+  })
+
+  it('keeps publication gated on both candidate builds and upgrade receipts', () => {
+    expect(needs(workflow.jobs['publish-release'])).toEqual(expect.arrayContaining([
+      'build-desktop',
+      'accept-desktop-upgrade',
+      'build-broker-packs',
+      'build-headless-runtime',
+      'cli-installer-acceptance',
+    ]))
+  })
+})

--- a/src/workspaces/agent-runtime-readiness.spec.ts
+++ b/src/workspaces/agent-runtime-readiness.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   classifyRuntimeReadinessFailure,
+  failedRuntimeReadinessRow,
   runtimeProbeSucceeded,
   snapshotRuntimeReadiness,
   type AgentRuntimeReadinessRow,
@@ -76,6 +77,36 @@ describe('agent runtime readiness helpers', () => {
       exitCode: 0,
       stdoutTail: '{"type":"future_event","message":"started"}',
     }))).toBe('output_unrecognized');
+  });
+
+  it('preserves an in-band provider error instead of calling it unrecognized output', () => {
+    const providerError = result({
+      exitCode: 0,
+      stdoutTail: '{"type":"message_end","message":{"stopReason":"error"}}',
+      structured: {
+        schemaVersion: 1,
+        assistantText: null,
+        blocks: [{
+          type: 'error',
+          message: '429: 余额不足或无可用资源包，请充值。',
+        }],
+        metrics: { textBlocks: 0, toolCalls: 0, toolFailures: 0 },
+        truncated: false,
+      },
+    });
+
+    expect(classifyRuntimeReadinessFailure(providerError)).toBe('failed');
+    expect(failedRuntimeReadinessRow({
+      adapter: piAdapter,
+      availability: { installed: true, path: '/usr/bin/pi' },
+      result: providerError,
+      source: 'launcher-vault',
+    })).toMatchObject({
+      status: 'failed',
+      ready: false,
+      repairTarget: 'retry',
+      message: 'The runtime reported an error: 429: 余额不足或无可用资源包，请充值。',
+    });
   });
 
   it('GET snapshot uses cached rows without inventing readiness', () => {

--- a/src/workspaces/agent-runtime-readiness.ts
+++ b/src/workspaces/agent-runtime-readiness.ts
@@ -165,10 +165,14 @@ export function failedRuntimeReadinessRow(opts: {
 }
 
 export function classifyRuntimeReadinessFailure(
-  result: Pick<HeadlessTaskResult, 'killed' | 'exitCode' | 'stdoutTail' | 'stderrTail' | 'assistantText'>,
+  result: Pick<
+    HeadlessTaskResult,
+    'killed' | 'exitCode' | 'stdoutTail' | 'stderrTail' | 'assistantText' | 'structured'
+  >,
 ): AgentRuntimeReadinessStatus {
   if (result.killed) return 'timeout';
-  const text = `${result.stderrTail}\n${result.stdoutTail}`.toLowerCase();
+  const structuredError = latestStructuredRuntimeError(result);
+  const text = `${structuredError ?? ''}\n${result.stderrTail}\n${result.stdoutTail}`.toLowerCase();
   if (/\b(unauthorized|unauthorised|forbidden|401|403|oauth|log in|login|sign in|signin|auth|authentication|not authenticated)\b/.test(text)) {
     return 'auth_required';
   }
@@ -176,6 +180,10 @@ export function classifyRuntimeReadinessFailure(
     return 'provider_required';
   }
   if (result.exitCode !== 0) return 'failed';
+  // Some CLIs exit 0 after reporting an in-band provider/runtime error. That
+  // is a recognized failure, not an unknown output shape. Preserve it so the
+  // launch surface can show the actual provider response (for example 429).
+  if (structuredError) return 'failed';
   if (!result.assistantText?.trim()) return 'output_unrecognized';
   return 'failed';
 }
@@ -209,7 +217,8 @@ function summarizeRuntimeReadinessFailure(
   if (status === 'output_unrecognized') {
     return 'The runtime exited successfully, but OpenAlice could not read an assistant reply from its structured output.';
   }
-  const tail = `${result.stderrTail || result.stdoutTail}`.trim().replace(/\s+/g, ' ');
+  const structuredError = latestStructuredRuntimeError(result);
+  const tail = `${structuredError || result.stderrTail || result.stdoutTail}`.trim().replace(/\s+/g, ' ');
   const detail = tail ? ` ${tail.slice(0, 280)}` : '';
   if (status === 'auth_required') {
     return `The runtime appears to need CLI login or authentication.${detail}`;
@@ -217,5 +226,18 @@ function summarizeRuntimeReadinessFailure(
   if (status === 'provider_required') {
     return `The runtime appears to need provider or API-key configuration.${detail}`;
   }
+  if (structuredError) {
+    return `The runtime reported an error:${detail}`;
+  }
   return `The runtime readiness probe failed.${detail}`;
+}
+
+function latestStructuredRuntimeError(
+  result: Pick<HeadlessTaskResult, 'structured'>,
+): string | null {
+  for (let index = result.structured.blocks.length - 1; index >= 0; index -= 1) {
+    const block = result.structured.blocks[index];
+    if (block?.type === 'error' && block.message.trim()) return block.message.trim();
+  }
+  return null;
 }

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -325,6 +325,54 @@ describe('ChatLandingPage keyboard submission', () => {
       'chat',
     ))
   })
+
+  it('shows the runtime provider error and does not create a chat session', async () => {
+    mocks.getAgentRuntimeReadiness.mockResolvedValue({
+      agents: {
+        pi: {
+          agent: 'pi',
+          displayName: 'Pi',
+          installed: true,
+          binPath: '/tmp/pi',
+          status: 'unknown',
+          ready: false,
+          source: 'unknown',
+          checkedAt: null,
+          durationMs: null,
+        },
+      },
+      overallReady: false,
+      checkedAt: null,
+    })
+    mocks.probeAgentRuntimeReadiness.mockResolvedValue({
+      agents: {
+        pi: {
+          agent: 'pi',
+          displayName: 'Pi',
+          installed: true,
+          binPath: '/tmp/pi',
+          status: 'failed',
+          ready: false,
+          source: 'launcher-vault',
+          checkedAt: '2026-08-02T00:00:00.000Z',
+          durationMs: 10,
+          repairTarget: 'retry',
+          message: 'The runtime reported an error: 429: balance exhausted',
+        },
+      },
+      overallReady: false,
+      checkedAt: '2026-08-02T00:00:00.000Z',
+    })
+
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    await screen.findByLabelText('Model gemini-3.1-flash-lite')
+    fireEvent.change(screen.getByPlaceholderText('Ask Alice…'), { target: { value: 'hello' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(await screen.findByText('The runtime reported an error: 429: balance exhausted')).toBeTruthy()
+    expect(mocks.quickChat).not.toHaveBeenCalled()
+  })
 })
 
 describe('ChatLandingPage AI source disclosure', () => {


### PR DESCRIPTION
## Release target

- Promote `dev` at `159e04fffdca68aa51c28945e7164d5b127dc24e` to `master`.
- Publish `v0.89.1-beta` (previous release: `v0.89.0-beta`).
- Root and CLI package versions both resolve to `0.89.1-beta`; the target tag is currently absent.

## Included release work

- Installer provenance and stable update-channel repair (#957).
- Provider startup/error surfacing improvements (#960).
- Parallel release/package DAG and fail-fast CI ordering (#961, #962, #963).
- Release version preparation (#964).

## Verified before promotion

- `npx tsc --noEmit`
- `pnpm test` (3890 passed, 9 skipped)
- `pnpm -F @traderalice/openalice-cli test` (200 passed)
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- Version PR CI, Docker smoke, macOS/Windows cross-platform tests, macOS arm64/Intel + Windows package smoke, Windows Broker Pack N-1 upgrade, and Windows desktop N-1 upgrade: all green.
- Post-merge `raw/dev/install` acceptance: https://github.com/TraderAlice/OpenAlice/actions/runs/30775735429
- Post-merge Guardian/full-stack smoke: https://github.com/TraderAlice/OpenAlice/actions/runs/30775735456

This PR is the synchronous release boundary: merge only after every applicable promotion check is green.