### PR TITLE
Keep Chat context Escape scoped to its popover

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -163,6 +163,20 @@ describe('ChatWorkspaceSection actions', () => {
     expect(onRequestDisplayMode).toHaveBeenCalledWith('multi')
   })
 
+  it('keeps Escape scoped to the open Workspace context menu', () => {
+    renderSection([chatWorkspace], null, undefined, 'focused')
+
+    const trigger = screen.getByRole('button', { name: 'Chat context: chat-jul11' })
+    fireEvent.click(trigger)
+    expect(screen.getByRole('dialog', { name: 'Chat Workspace options' })).toBeTruthy()
+
+    const allowed = fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(allowed).toBe(false)
+    expect(screen.queryByRole('dialog', { name: 'Chat Workspace options' })).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
   it('offers an explicit recent view and orders sessions across Workspaces with ownership visible', () => {
     const olderWorkspace = {
       ...chatWorkspace,

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -412,14 +412,16 @@ function ChatWorkspaceContextFooter(props: ChatWorkspaceContextFooterProps): Rea
     }
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopPropagation()
       setOpen(false)
       triggerRef.current?.focus({ preventScroll: true })
     }
     document.addEventListener('pointerdown', onPointerDown)
-    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('keydown', onKeyDown, true)
     return () => {
       document.removeEventListener('pointerdown', onPointerDown)
-      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('keydown', onKeyDown, true)
     }
   }, [open])
 


### PR DESCRIPTION
## What changed

- intercepts Escape while the Chat Workspace context popover is open
- closes only that popover and restores focus to its footer trigger
- prevents the same keypress from also dismissing the enclosing mobile Ask Alice drawer
- adds a focused regression test for cancellation, closure, and focus return

## Why

Post-merge mobile browser verification of #968 found that the native outer dialog also consumed the popover's Escape keypress. Nested UI layers should unwind one layer at a time.

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b --pretty false`
- `pnpm test` (469 passed, 1 skipped; 3896 tests passed, 9 skipped)
- real narrow `/chat` browser check: Escape closes the Workspace popover, keeps the Ask Alice drawer open, and returns focus to the footer trigger
