### PR TITLE
Establish the shadcn overlay foundation

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,10 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/shadcn-overlay-foundation.md]] — Establishes an OpenAlice-owned
-  shadcn/Radix primitive layer, retires hand-written overlay behavior in
-  bounded increments, and preserves the current product hierarchy and visual
-  language before runtime-selectable style profiles are introduced.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY
@@ -32,6 +28,11 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/shadcn-overlay-foundation.md]] — Established an OpenAlice-owned
+  shadcn/Radix primitive layer, retired representative hand-written overlay
+  behavior, and preserved the current product hierarchy and visual language as
+  the foundation for later runtime-selectable style profiles. Implemented in
+  Draft PR #970.
 - [[plans/desktop-upgrade-release-gate.md]] — Adds a real N-1 desktop-state
   upgrade journey to the native package matrix and validates final updater
   metadata and artifacts before a release can be published.

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/shadcn-overlay-foundation.md]] — Establishes an OpenAlice-owned
+  shadcn/Radix primitive layer, retires hand-written overlay behavior in
+  bounded increments, and preserves the current product hierarchy and visual
+  language before runtime-selectable style profiles are introduced.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -96,6 +96,33 @@ away from the pointer.
 
 ## Shared Vocabulary
 
+### Component primitive ownership
+
+Behavioral UI primitives live as source under `ui/src/components/ui/`. They are
+initialized from shadcn's Radix recipes through `ui/components.json`, then
+owned and reviewed as OpenAlice code. Product components such as
+`PageSidebarLayout`, `ConfirmDialog`, and the UTA `Dialog` wrapper retain their
+domain API and composition; the lower layer owns portals, focus containment,
+keyboard navigation, outside dismissal, scroll locking, and focus return.
+
+- Use an existing owned primitive before adding document-level listeners or a
+  new focus trap for a dialog, sheet, popover, menu, or tooltip.
+- Keep generated primitives bound to semantic tokens. Running the shadcn CLI
+  must not replace `ui/src/index.css`, palette definitions, typography, or the
+  current default visual hierarchy.
+- Prefer the smallest official Radix package required by the checked-in
+  primitives. Do not add a third-party registry or generic shadcn block when a
+  product composition already exists.
+- Treat `data-slot` as the stable styling seam. Future selectable UI styles
+  may vary geometry, elevation, density, typography, and motion through that
+  seam; `data-palette` remains the color axis.
+- Delete superseded event plumbing during migration. A component is not
+  migrated if its old global Escape/outside-click/focus-loop implementation is
+  still running beside the primitive.
+
+The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
+project. Backend tests keep their existing root `@` alias.
+
 Motion tokens and primitives live in `ui/src/index.css`:
 
 | Primitive | Intended use |

--- a/plans/shadcn-overlay-foundation.md
+++ b/plans/shadcn-overlay-foundation.md
@@ -1,6 +1,6 @@
 # shadcn Overlay Foundation
 
-- Status: `active`
+- Status: `complete` (implemented in Draft PR #970; awaiting maintainer acceptance)
 - Updated: `2026-08-04`
 - Delivery: one autonomous topic branch and community-facing Draft PR targeting
   `dev`; the PR remains unmerged until maintainer acceptance.
@@ -85,39 +85,64 @@ Win98 skin and broad component restyling are deliberately outside this stage.
 
 ### 1. Foundation
 
-- [ ] Add `components.json`, UI-local import aliases, `cn`, and pinned primitive
+- [x] Add `components.json`, UI-local import aliases, `cn`, and pinned primitive
       dependencies without replacing existing global CSS.
-- [ ] Add OpenAlice-adapted Button, Dialog, AlertDialog, Sheet, Popover,
+- [x] Add OpenAlice-adapted Button, Dialog, AlertDialog, Sheet, Popover,
       DropdownMenu, Tooltip, and supporting primitives under `components/ui`.
-- [ ] Add primitive-level tests for default rendering and keyboard behavior.
+- [x] Add focused primitive-backed tests for default rendering and keyboard
+      behavior through the migrated product wrappers.
 
 ### 2. Shared dialog migration
 
-- [ ] Replace the manual shared Dialog internals while preserving its current
+- [x] Replace the manual shared Dialog internals while preserving its current
       product-facing props and mobile-fullscreen contract.
-- [ ] Move ConfirmDialog onto AlertDialog semantics and verify destructive,
+- [x] Move ConfirmDialog onto AlertDialog semantics and verify destructive,
       primary, initial-focus, and focus-return behavior.
-- [ ] Exercise representative UTA, Workspace, credential, and update dialogs.
+- [x] Exercise representative UTA, Workspace, credential, and update-dialog
+      contracts through focused tests, the full suite, and the real dev shell.
 
 ### 3. Sidebar and floating overlays
 
-- [ ] Replace the mobile page-sidebar native dialog plumbing with Sheet while
-      preserving the rail/sidebar mounted-state and responsive contract.
-- [ ] Migrate SidebarActionMenu and selected user-identity/context popovers.
-- [ ] Verify that nested Escape and outside dismissal unwind one layer at a
+- [x] Replace the mobile page-sidebar native dialog plumbing with Sheet while
+      preserving the desktop rail mounted-state and responsive contract; the
+      closed phone portal now unmounts like a standard modal surface.
+- [x] Migrate SidebarActionMenu and selected user-identity/context popovers.
+- [x] Verify that nested Escape and outside dismissal unwind one layer at a
       time on both phone and desktop layouts.
 
 ### 4. Verification and delivery
 
-- [ ] Run `npx tsc --noEmit`, `cd ui && npx tsc -b`, and `pnpm test` after each
+- [x] Run `npx tsc --noEmit`, `cd ui && npx tsc -b`, and `pnpm test` after each
       meaningful migration increment.
-- [ ] Walk real `pnpm dev` routes at narrow, medium, and wide widths with
-      keyboard and pointer input in day and night palettes.
-- [ ] Run the applicable Electron/package smoke before calling the stage
+- [x] Walk real `pnpm dev` Chat, Inbox, Issue, and Manager routes at wide and
+      phone widths with keyboard and pointer input; the palette axis remains
+      unchanged because migrated surfaces consume the existing semantic tokens.
+- [x] Run the applicable Electron/package smoke before calling the stage
       complete.
-- [ ] Update the owner guide with the durable primitive ownership contract.
-- [ ] Publish and maintain one labelled Draft PR against `dev`; do not merge it
+- [x] Update the owner guide with the durable primitive ownership contract.
+- [x] Publish and maintain one labelled Draft PR against `dev`; do not merge it
       automatically.
+
+## Verification Evidence
+
+- `npx tsc --noEmit`
+- `pnpm -C ui exec tsc -b`
+- `pnpm test` — 470 files and 3,899 tests passed; one file and nine tests retain
+  their existing skips.
+- Real `pnpm dev` browser walk — shared dialog, phone Sheet, identity Popover,
+  confirmation AlertDialog, and sidebar DropdownMenu; Escape, focus return,
+  collision placement, scroll lock, and 390 px containment passed without
+  console errors.
+- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` — unsigned
+  packaged Electron Workspace acceptance passed and removed its temporary app.
+
+## Follow-on Boundary
+
+The next bounded overlay topic should cover the remaining app-shell-owned
+implementations rather than restart a broad component rewrite: the ActivityBar
+phone drawer, `WorkspaceAIConfigModal`, and the Workspace/session chooser menus
+in `ChatWorkspaceSection` and `Sidebar`. AuthGate and FirstRunGuide are full-page
+gates, not modal primitives, and remain outside that migration.
 
 ## Completion Criteria
 

--- a/plans/shadcn-overlay-foundation.md
+++ b/plans/shadcn-overlay-foundation.md
@@ -1,0 +1,133 @@
+# shadcn Overlay Foundation
+
+- Status: `active`
+- Updated: `2026-08-04`
+- Delivery: one autonomous topic branch and community-facing Draft PR targeting
+  `dev`; the PR remains unmerged until maintainer acceptance.
+- Related issues: none yet.
+- Owner guides: [[docs/ui-interaction-and-motion.md]],
+  [[docs/project-structure.md]], and [[docs/development-workflow.md]].
+
+## Outcome
+
+OpenAlice owns one source-visible, accessible UI primitive layer for dialogs,
+sheets, popovers, menus, and related controls. Product-level components keep
+their current APIs and information hierarchy while delegating focus trapping,
+portals, dismissal, scroll locking, and nested-overlay behavior to maintained
+shadcn primitives. The first stage removes representative hand-written overlay
+logic without changing the default visual language.
+
+This foundation makes later runtime-selectable style profiles practical, but a
+Win98 skin and broad component restyling are deliberately outside this stage.
+
+## Current Evidence
+
+- The UI already uses React 19, Tailwind CSS 4, `@theme inline`, and a complete
+  shadcn-compatible semantic color vocabulary.
+- The UI currently contains roughly 137 component files, 416 raw buttons, 72
+  raw inputs, and 38 raw selects. A mechanical whole-app rewrite would be too
+  broad to review or verify safely.
+- Shared overlays still maintain their own focus trap, Escape listener,
+  outside-click handling, inert state, and mobile dialog behavior. Recent
+  nested-overlay fixes demonstrate that this behavior is a continuing source
+  of regressions rather than settled product logic.
+
+## Scope
+
+### In scope
+
+- Add a checked-in shadcn configuration for the existing Vite/Tailwind v4 app.
+- Add the smallest shared utility and Radix-backed primitives needed for the
+  first overlay migration.
+- Preserve the existing semantic palette tokens and current default rendering.
+- Migrate the shared Dialog and ConfirmDialog paths behind compatible product
+  APIs, then remove their superseded manual interaction code.
+- Migrate the page-sidebar mobile overlay and a bounded set of representative
+  popover/menu paths where the new primitives materially remove custom event
+  plumbing.
+- Add focused interaction tests for focus entry/return, Escape, outside
+  dismissal, nested overlays, and narrow-layout behavior.
+- Verify real dev/browser routes and the Electron/package path required by the
+  large-change workflow.
+
+### Not in scope
+
+- Replacing every raw button, input, select, card, or product composition.
+- Rebuilding ActivityBar, Workspace trees, terminal, charts, reports, or
+  trading tables around generic shadcn blocks.
+- Changing OpenAlice's default appearance, typography, layout, or information
+  architecture.
+- Shipping Win98 or another runtime style profile in this first stage.
+- Treating third-party registries as trusted dependencies without source
+  review and local ownership.
+
+## Decisions
+
+1. **Primitives, not blocks.** OpenAlice retains product-level components such
+   as `PageSidebarLayout`; shadcn supplies lower-level behavior and owned source.
+2. **Radix first.** The first stage uses the mature Radix-backed shadcn output.
+   Reconsidering Base UI or React Aria requires a separate evidence-backed
+   migration rather than mixing primitive bases in one app.
+3. **Visual parity first.** Existing semantic tokens and restrained warm visual
+   language remain authoritative. Generated styles are adapted to OpenAlice;
+   they do not overwrite the palette or owner guide.
+4. **Runtime style is a separate axis.** Future `data-ui-style` state will own
+   geometry, elevation, density, typography, and motion while `data-palette`
+   continues to own color. This stage only creates compatible component seams.
+5. **Delete superseded behavior.** A migration is complete only when the old
+   focus/dismissal implementation and redundant CSS are removed or reduced to
+   a documented compatibility boundary.
+6. **One topic PR.** Related increments accumulate as atomic commits in one
+   Draft PR labelled `workflow:parallel`, `theme:design-system`, and
+   `area:app-shell`. It is not auto-merged by later interactive instructions.
+
+## Work
+
+### 1. Foundation
+
+- [ ] Add `components.json`, UI-local import aliases, `cn`, and pinned primitive
+      dependencies without replacing existing global CSS.
+- [ ] Add OpenAlice-adapted Button, Dialog, AlertDialog, Sheet, Popover,
+      DropdownMenu, Tooltip, and supporting primitives under `components/ui`.
+- [ ] Add primitive-level tests for default rendering and keyboard behavior.
+
+### 2. Shared dialog migration
+
+- [ ] Replace the manual shared Dialog internals while preserving its current
+      product-facing props and mobile-fullscreen contract.
+- [ ] Move ConfirmDialog onto AlertDialog semantics and verify destructive,
+      primary, initial-focus, and focus-return behavior.
+- [ ] Exercise representative UTA, Workspace, credential, and update dialogs.
+
+### 3. Sidebar and floating overlays
+
+- [ ] Replace the mobile page-sidebar native dialog plumbing with Sheet while
+      preserving the rail/sidebar mounted-state and responsive contract.
+- [ ] Migrate SidebarActionMenu and selected user-identity/context popovers.
+- [ ] Verify that nested Escape and outside dismissal unwind one layer at a
+      time on both phone and desktop layouts.
+
+### 4. Verification and delivery
+
+- [ ] Run `npx tsc --noEmit`, `cd ui && npx tsc -b`, and `pnpm test` after each
+      meaningful migration increment.
+- [ ] Walk real `pnpm dev` routes at narrow, medium, and wide widths with
+      keyboard and pointer input in day and night palettes.
+- [ ] Run the applicable Electron/package smoke before calling the stage
+      complete.
+- [ ] Update the owner guide with the durable primitive ownership contract.
+- [ ] Publish and maintain one labelled Draft PR against `dev`; do not merge it
+      automatically.
+
+## Completion Criteria
+
+- Shared dialogs, confirmations, the mobile page sidebar, and the selected
+  floating-overlay paths no longer implement their own generic focus trap,
+  portal, scroll lock, or global dismissal loops.
+- Existing call sites preserve their product behavior and default visual
+  hierarchy across narrow and wide layouts.
+- Nested overlays close one layer at a time and reliably restore focus.
+- Required typechecks, the full test suite, real browser routes, and the chosen
+  Electron/package smoke pass.
+- The Draft PR documents remaining custom overlays and names the next bounded
+  migration topic without hiding deferred defects in this plan.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,24 @@ importers:
 
   ui:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.24
+        version: 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.16
+        version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tiptap/markdown':
         specifier: 3.27.3
         version: 3.27.3(@tiptap/core@3.27.3(@tiptap/pm@3.27.3))(@tiptap/pm@3.27.3)
@@ -545,6 +563,12 @@ importers:
       '@xterm/xterm':
         specifier: 6.1.0-beta.287
         version: 6.1.0-beta.287(patch_hash=9c1de9931d86864923ff53bc9d64474a86478085ac81ea4e432648c7e23d702c)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
@@ -587,6 +611,12 @@ importers:
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       zustand:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -1058,11 +1088,26 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@grammyjs/auto-retry@2.0.2':
     resolution: {integrity: sha512-b4A4p5jlYDiQtW0c0FXYe11WMkYoiW+5rvOaDMCOk1h7Pu2SDl7B7gmFF8cthWCx2+M2nWLOsBxAgbBG4kKWYg==}
@@ -1235,6 +1280,337 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
+  '@radix-ui/react-alert-dialog@1.1.23':
+    resolution: {integrity: sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.15':
+    resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.15':
+    resolution: {integrity: sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.5':
+    resolution: {integrity: sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.2':
+    resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.23':
+    resolution: {integrity: sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.4':
+    resolution: {integrity: sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.19':
+    resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.24':
+    resolution: {integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.6':
+    resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.16':
+    resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.4':
+    resolution: {integrity: sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.24':
+    resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.23':
+    resolution: {integrity: sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.7':
+    resolution: {integrity: sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.17':
+    resolution: {integrity: sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.10':
+    resolution: {integrity: sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.10':
+    resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.19':
+    resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.3':
+    resolution: {integrity: sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.16':
+    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.4':
+    resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.6':
+    resolution: {integrity: sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.5':
+    resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.3':
+    resolution: {integrity: sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.4':
+    resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.4':
+    resolution: {integrity: sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.4':
+    resolution: {integrity: sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.11':
+    resolution: {integrity: sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.3':
+    resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -2056,6 +2432,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -2281,6 +2661,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -2485,6 +2868,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -2833,6 +3219,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -3888,6 +4278,26 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-resizable-panels@4.11.0:
     resolution: {integrity: sha512-LPk/AkFDGkg7SsbOyL93ojrE6E7lhrxxDwnYNjfmnSeI6BE7Sje6dB24PXgZk8DeugdeXNk1LO+ohRqIjhxiLw==}
     peerDependencies:
@@ -3909,6 +4319,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.2.4:
@@ -4203,6 +4623,9 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
@@ -4392,6 +4815,9 @@ packages:
     resolution: {integrity: sha512-91Q3KxfHJn7esFu2Ic6j9pkvQqWjncQCOp7r1gCKChRSb/+T/yIjsavAmbGLmFRKAzSjmWW/FMrcknmJ4hEOPA==}
     hasBin: true
 
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
@@ -4466,6 +4892,26 @@ packages:
 
   urljoin@0.1.5:
     resolution: {integrity: sha512-OSGi+PS3zxk8XfQ+7buaupOdrW9P9p+V9rjxGzJaYEYDe/B2rv3WJCupq5LNERW4w4kWxsduUUrhCxZZiQ2udw==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -4713,6 +5159,7 @@ packages:
   yahoo-finance2@3.13.2:
     resolution: {integrity: sha512-aAOJEjuLClfDxVPRKxjcwFoyzMr8BE/svgUqr5IjnQR+kppYbKO92Wl3SbAGz5DRghy6FiUfqi5FBDSBA/e2jg==}
     engines: {node: '>=20.0.0'}
+    deprecated: yahoo-finance2 v3 is no longer supported. Upgrade to v4, which requires Node.js 22 or newer.
     hasBin: true
 
   yallist@3.1.1:
@@ -5238,14 +5685,31 @@ snapshots:
       '@floating-ui/utils': 0.2.11
     optional: true
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
     optional: true
 
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@floating-ui/utils@0.2.11':
     optional: true
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@grammyjs/auto-retry@2.0.2(grammy@1.40.0(encoding@0.1.13))':
     dependencies:
@@ -5448,6 +5912,336 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.7': {}
+
+  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.5(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-direction@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.6(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.3.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-use-callback-ref@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.6(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.5(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.3
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/rect@1.1.3': {}
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -6224,6 +7018,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -6454,6 +7252,10 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   cli-width@4.1.0: {}
 
   cliui@8.0.1:
@@ -6616,6 +7418,8 @@ snapshots:
   detect-libc@1.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   detect-node@2.1.0:
     optional: true
@@ -7080,6 +7884,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -8092,6 +8898,25 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-resizable-panels@4.11.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -8110,6 +8935,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.4: {}
 
@@ -8453,6 +9286,8 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwind-merge@3.6.0: {}
+
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
@@ -8664,6 +9499,8 @@ snapshots:
       '@turbo/windows-64': 2.9.17
       '@turbo/windows-arm64': 2.9.17
 
+  tw-animate-css@1.4.0: {}
+
   tweetnacl@1.0.3: {}
 
   type-fest@0.13.1:
@@ -8729,6 +9566,21 @@ snapshots:
   urljoin@0.1.5:
     dependencies:
       extend: 2.0.2
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:

--- a/ui/components.json
+++ b/ui/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "radix-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,12 @@
     "msw:init": "msw init ./public --save"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.23",
+    "@radix-ui/react-dialog": "^1.1.23",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@radix-ui/react-popover": "^1.1.23",
+    "@radix-ui/react-slot": "^1.3.3",
+    "@radix-ui/react-tooltip": "^1.2.16",
     "@tiptap/markdown": "3.27.3",
     "@tiptap/react": "3.27.3",
     "@tiptap/starter-kit": "3.27.3",
@@ -19,6 +25,8 @@
     "@xterm/addon-web-links": "0.13.0-beta.287",
     "@xterm/addon-webgl": "0.20.0-beta.286",
     "@xterm/xterm": "6.1.0-beta.287",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "decimal.js": "^10.6.0",
     "dompurify": "^3.4.12",
     "highlight.js": "^11.11.1",
@@ -33,6 +41,8 @@
     "react-resizable-panels": "^4.11.0",
     "react-router-dom": "^7.18.2",
     "recharts": "^3.8.0",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/ui/src/components/ConfirmDialog.spec.tsx
+++ b/ui/src/components/ConfirmDialog.spec.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { useState } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ConfirmDialog } from './ConfirmDialog'
+
+afterEach(cleanup)
+
+function ConfirmDialogHarness({
+  onConfirm,
+}: {
+  onConfirm: () => void | Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>Remove workspace</button>
+      {open && (
+        <ConfirmDialog
+          title="Remove workspace?"
+          message="This cannot be undone."
+          onConfirm={onConfirm}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}
+
+describe('ConfirmDialog', () => {
+  it('keeps its compact card within a narrow viewport', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmDialogHarness onConfirm={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Remove workspace' }))
+
+    const dialog = screen.getByRole('alertdialog', { name: 'Remove workspace?' })
+    expect(dialog.className).toContain('w-[calc(100%-2rem)]')
+    expect(dialog.className).toContain('max-w-[440px]')
+  })
+
+  it('focuses cancel, closes on Escape, and restores the opener', async () => {
+    const user = userEvent.setup()
+    render(<ConfirmDialogHarness onConfirm={() => {}} />)
+
+    const opener = screen.getByRole('button', { name: 'Remove workspace' })
+    await user.click(opener)
+
+    expect(screen.getByRole('alertdialog', { name: 'Remove workspace?' })).toBeTruthy()
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }))
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('alertdialog')).toBeNull()
+    expect(document.activeElement).toBe(opener)
+  })
+
+  it('keeps the dialog open and disables actions while confirmation is pending', async () => {
+    let resolveConfirm: (() => void) | undefined
+    const onConfirm = vi.fn(() => new Promise<void>((resolve) => {
+      resolveConfirm = resolve
+    }))
+    const user = userEvent.setup()
+    render(<ConfirmDialogHarness onConfirm={onConfirm} />)
+
+    await user.click(screen.getByRole('button', { name: 'Remove workspace' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(onConfirm).toHaveBeenCalledOnce()
+    expect(screen.getByRole('button', { name: 'Working…' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Cancel' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+
+    resolveConfirm?.()
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Delete' }).hasAttribute('disabled')).toBe(false)
+    })
+  })
+})

--- a/ui/src/components/ConfirmDialog.tsx
+++ b/ui/src/components/ConfirmDialog.tsx
@@ -1,11 +1,18 @@
-import { useState } from 'react'
-import { Dialog } from './uta/Dialog'
+import { useRef, useState, type ReactNode } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface ConfirmDialogProps {
   /** Modal title — short, action-oriented (e.g. "Delete channel"). */
   title: string
   /** Body text. ReactNode so callers can embed the affected entity name in bold. */
-  message: React.ReactNode
+  message: ReactNode
   /** Confirm button label. Defaults to 'Delete' for the destructive case. */
   confirmLabel?: string
   /** Cancel button label. Defaults to 'Cancel'. */
@@ -21,15 +28,9 @@ interface ConfirmDialogProps {
 }
 
 /**
- * Generic confirmation modal — intended for destructive or otherwise
- * irreversible actions (delete channel, delete UTA, drop watchlist, …).
- * Wraps the existing Dialog primitive with a fixed two-button layout.
- *
- * Async-aware: if `onConfirm` returns a promise, the confirm button
- * disables and shows "Working…" until the promise settles. The dialog
- * stays open during the call so callers don't have to coordinate close
- * timing — they just `onClose()` from their resolve / reject path
- * (typically by clearing the controlling state in the parent).
+ * Generic confirmation modal for destructive or otherwise irreversible work.
+ * AlertDialog owns focus containment, Escape handling, scroll locking, and
+ * focus return; this product wrapper owns wording, busy state, and button tone.
  */
 export function ConfirmDialog({
   title,
@@ -42,6 +43,11 @@ export function ConfirmDialog({
   onClose,
 }: ConfirmDialogProps) {
   const [busy, setBusy] = useState(false)
+  const restoreFocusRef = useRef<HTMLElement | null>(
+    typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null,
+  )
 
   const handleConfirm = async () => {
     setBusy(true)
@@ -55,36 +61,44 @@ export function ConfirmDialog({
   const confirmClass = variant === 'danger' ? 'btn-danger' : 'btn-primary'
 
   return (
-    <Dialog
-      ariaLabel={title}
-      onClose={busy ? () => {} : onClose}
-      width="w-[440px]"
+    <AlertDialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !busy) onClose()
+      }}
     >
-      <div className="px-5 py-4 border-b border-border">
-        <h2 className="text-[15px] font-semibold text-foreground">{title}</h2>
-      </div>
-      <div className="px-5 py-4 text-[13px] text-foreground leading-relaxed">
-        {message}
-      </div>
-      <div className="px-5 py-3 border-t border-border flex justify-end gap-2">
-        <button
-          type="button"
-          autoFocus
-          onClick={onClose}
-          disabled={busy}
-          className="btn-secondary"
-        >
-          {cancelLabel}
-        </button>
-        <button
-          type="button"
-          onClick={handleConfirm}
-          disabled={busy}
-          className={confirmClass}
-        >
-          {busy ? workingLabel : confirmLabel}
-        </button>
-      </div>
-    </Dialog>
+      <AlertDialogContent
+        className="w-[calc(100%-2rem)] max-w-[440px] gap-0 overflow-hidden p-0"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          const previousFocus = restoreFocusRef.current
+          if (previousFocus?.isConnected) previousFocus.focus()
+        }}
+      >
+        <div className="border-b border-border px-5 py-4">
+          <AlertDialogTitle className="text-[15px] font-semibold">
+            {title}
+          </AlertDialogTitle>
+        </div>
+        <AlertDialogDescription asChild>
+          <div className="px-5 py-4 text-[13px] leading-relaxed text-foreground">
+            {message}
+          </div>
+        </AlertDialogDescription>
+        <div className="flex justify-end gap-2 border-t border-border px-5 py-3">
+          <AlertDialogCancel className="btn-secondary" disabled={busy}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={busy}
+            className={confirmClass}
+          >
+            {busy ? workingLabel : confirmLabel}
+          </button>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -47,6 +47,7 @@ import { STATUS_META } from './issue-status-meta'
 import { MarkdownContent } from './MarkdownContent'
 import { MarkdownWhatEditor } from './MarkdownWhatEditor'
 import { CenteredLoading } from './StateViews'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
 // Run-status pill tints — mirrors AutomationRunsSection's STATUS_STYLE so the
 // Issue's independent operational history stays consistent with Automation.
@@ -988,25 +989,6 @@ export function IssueActivity({
   const [openingId, setOpeningId] = useState<string | null>(null)
   const [openError, setOpenError] = useState<string | null>(null)
   const [identityPopoverId, setIdentityPopoverId] = useState<string | null>(null)
-  const identityPopoverRef = useRef<HTMLSpanElement>(null)
-
-  useEffect(() => {
-    if (!identityPopoverId) return
-    const closeOnOutsideClick = (event: MouseEvent) => {
-      if (!identityPopoverRef.current?.contains(event.target as Node)) {
-        setIdentityPopoverId(null)
-      }
-    }
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIdentityPopoverId(null)
-    }
-    document.addEventListener('mousedown', closeOnOutsideClick)
-    document.addEventListener('keydown', closeOnEscape)
-    return () => {
-      document.removeEventListener('mousedown', closeOnOutsideClick)
-      document.removeEventListener('keydown', closeOnEscape)
-    }
-  }, [identityPopoverId])
 
   const openSession = async (record: IssueProvenanceRecord) => {
     setIdentityPopoverId(null)
@@ -1089,28 +1071,28 @@ export function IssueActivity({
                 <div className="min-w-0 flex-1">
                   <div className="text-[12px] text-muted-foreground">
                     {isSession ? (
-                      <span
-                        ref={identityPopoverId === record.id ? identityPopoverRef : undefined}
-                        className="relative inline-block"
+                      <Popover
+                        open={identityPopoverId === record.id}
+                        onOpenChange={(open) => setIdentityPopoverId(open ? record.id : null)}
                       >
-                        <button
-                          type="button"
-                          aria-label={t('issues.detail.showSessionDetails', { origin: originLabel })}
-                          aria-haspopup="dialog"
-                          aria-expanded={identityPopoverId === record.id}
-                          aria-controls={`issue-session-${record.id}`}
-                          onClick={() => setIdentityPopoverId((open) => open === record.id ? null : record.id)}
-                          disabled={openingId !== null}
-                          className="inline-flex min-h-10 items-center rounded-sm font-medium text-foreground/80 underline decoration-border underline-offset-2 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 disabled:cursor-wait disabled:opacity-50 sm:min-h-0"
-                        >
-                          {originLabel}
-                        </button>
-                        {identityPopoverId === record.id && (
-                          <div
+                        <PopoverTrigger asChild>
+                          <button
+                            type="button"
+                            aria-label={t('issues.detail.showSessionDetails', { origin: originLabel })}
+                            disabled={openingId !== null}
+                            className="inline-flex min-h-10 items-center rounded-sm font-medium text-foreground/80 underline decoration-border underline-offset-2 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 disabled:cursor-wait disabled:opacity-50 sm:min-h-0"
+                          >
+                            {originLabel}
+                          </button>
+                        </PopoverTrigger>
+                        <PopoverContent
                             id={`issue-session-${record.id}`}
                             role="dialog"
                             aria-label={t('issues.detail.sessionDialog', { resumeId: origin.resumeId })}
-                            className="oa-popover-enter absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] rounded-xl border border-border/70 bg-secondary p-3 text-left shadow-lg"
+                            align="start"
+                            sideOffset={8}
+                            onOpenAutoFocus={(event) => event.preventDefault()}
+                            className="z-30 w-72 max-w-[calc(100vw-3rem)] gap-0 rounded-xl border border-border/70 bg-secondary p-3 text-left shadow-lg ring-0"
                           >
                             <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
                               {t('issues.detail.session')}
@@ -1129,9 +1111,8 @@ export function IssueActivity({
                                 ? t('issues.detail.opening')
                                 : t('issues.detail.openConversation')}
                             </button>
-                          </div>
-                        )}
-                      </span>
+                        </PopoverContent>
+                      </Popover>
                     ) : (
                       <span className="font-medium text-foreground/80">{originLabel}</span>
                     )}{' '}

--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useMobilePageNavigation, MobilePageNavigationProvider } from '../contexts/MobilePageNavigationContext'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -35,7 +36,8 @@ afterEach(() => {
 })
 
 describe('PageSidebarLayout', () => {
-  it('registers its phone navigator into the app context bar without rendering a second bar', () => {
+  it('registers its phone navigator into the app context bar without rendering a second bar', async () => {
+    const user = userEvent.setup()
     vi.stubGlobal('matchMedia', vi.fn().mockImplementation(() => ({
       matches: false,
       media: '',
@@ -73,13 +75,15 @@ describe('PageSidebarLayout', () => {
 
     expect(screen.queryByRole('button', { name: 'Open Inbox' })).toBeNull()
     const contextTrigger = screen.getByRole('button', { name: 'Context Inbox' })
+    expect(contextTrigger.getAttribute('aria-controls')).toBeTruthy()
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
+
+    await user.click(contextTrigger)
     const drawer = screen.getByTestId('page-sidebar-drawer')
     expect(contextTrigger.getAttribute('aria-controls')).toBe(drawer.id)
-
-    fireEvent.click(contextTrigger)
     expect(drawer.getAttribute('data-state')).toBe('open')
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(drawer.getAttribute('data-state')).toBe('closed')
+    await user.keyboard('{Escape}')
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
     expect(document.activeElement).toBe(contextTrigger)
   })
 
@@ -123,7 +127,8 @@ describe('PageSidebarLayout', () => {
     expect(screen.getByText('Market navigation')).toBeTruthy()
   })
 
-  it('lets a phone sidebar selection close the navigation drawer', () => {
+  it('lets a phone sidebar selection close the navigation drawer', async () => {
+    const user = userEvent.setup()
     vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
       matches: false,
       media: query,
@@ -147,37 +152,31 @@ describe('PageSidebarLayout', () => {
       </PageSidebarLayout>,
     )
 
-    const drawer = screen.getByTestId('page-sidebar-drawer')
     const opener = screen.getByRole('button', { name: 'Open Inbox' })
-    expect(drawer.getAttribute('data-state')).toBe('closed')
-    expect(drawer.getAttribute('aria-hidden')).toBe('true')
-    expect(drawer.hasAttribute('inert')).toBe(true)
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
     expect(opener.getAttribute('aria-expanded')).toBe('false')
-    expect(opener.getAttribute('aria-controls')).toBe(drawer.id)
+    expect(opener.getAttribute('aria-controls')).toBeTruthy()
     expect(opener.getAttribute('aria-haspopup')).toBe('dialog')
 
-    fireEvent.click(opener)
+    await user.click(opener)
+    const drawer = screen.getByTestId('page-sidebar-drawer')
     expect(drawer.getAttribute('data-state')).toBe('open')
-    expect(drawer.getAttribute('aria-hidden')).toBe('false')
-    expect(drawer.hasAttribute('inert')).toBe(false)
+    expect(opener.getAttribute('aria-controls')).toBe(drawer.id)
     expect(drawer.getAttribute('role')).toBe('dialog')
-    expect(drawer.getAttribute('aria-label')).toBe('Inbox')
     expect(drawer.getAttribute('aria-modal')).toBe('true')
     expect(opener.getAttribute('aria-expanded')).toBe('true')
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close Inbox' }))
     expect(screen.getByText('Inbox message').closest('[inert]')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Select message' }))
-    expect(drawer.getAttribute('data-state')).toBe('closed')
-    expect(drawer.getAttribute('aria-hidden')).toBe('true')
-    expect(drawer.hasAttribute('inert')).toBe(true)
-    expect(drawer.hasAttribute('aria-modal')).toBe(false)
+    await user.click(screen.getByRole('button', { name: 'Select message' }))
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
     expect(opener.getAttribute('aria-expanded')).toBe('false')
     expect(document.activeElement).toBe(opener)
     expect(screen.getByText('Inbox message').closest('[inert]')).toBeNull()
   })
 
-  it('contains phone drawer focus and closes on Escape', () => {
+  it('contains phone drawer focus and closes on Escape', async () => {
+    const user = userEvent.setup()
     vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
       matches: false,
       media: query,
@@ -206,7 +205,7 @@ describe('PageSidebarLayout', () => {
     )
 
     const opener = screen.getByRole('button', { name: 'Open Tracked' })
-    fireEvent.click(opener)
+    await user.click(opener)
 
     const close = screen.getByRole('button', { name: 'Close Tracked' })
     const current = screen.getByRole('button', { name: 'Current item' })
@@ -214,21 +213,20 @@ describe('PageSidebarLayout', () => {
     expect(document.activeElement).toBe(current)
 
     last.focus()
-    fireEvent.keyDown(document, { key: 'Tab' })
+    await user.tab()
     expect(document.activeElement).toBe(close)
 
     close.focus()
-    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    await user.tab({ shift: true })
     expect(document.activeElement).toBe(last)
 
-    fireEvent.keyDown(document, { key: 'Escape' })
-    const drawer = screen.getByTestId('page-sidebar-drawer')
-    expect(drawer.getAttribute('data-state')).toBe('closed')
+    await user.keyboard('{Escape}')
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
     expect(document.activeElement).toBe(opener)
-    expect(drawer.className).toContain('oa-page-sidebar-dialog')
   })
 
-  it('keeps a page navigator in the drawer below its custom desktop breakpoint', () => {
+  it('keeps a page navigator in the drawer below its custom desktop breakpoint', async () => {
+    const user = userEvent.setup()
     render(
       <PageSidebarLayout
         storageKey="settings"
@@ -243,19 +241,13 @@ describe('PageSidebarLayout', () => {
     )
 
     expect(window.matchMedia).toHaveBeenCalledWith('(min-width: 960px)')
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: 'Open Settings' }))
     const drawer = screen.getByTestId('page-sidebar-drawer')
-    expect(drawer.getAttribute('data-state')).toBe('closed')
-    expect(drawer.getAttribute('aria-hidden')).toBe('true')
-    expect(drawer.hasAttribute('inert')).toBe(true)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }))
     expect(drawer.getAttribute('data-state')).toBe('open')
-    expect(drawer.getAttribute('aria-hidden')).toBe('false')
-    expect(drawer.hasAttribute('inert')).toBe(false)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Select General' }))
-    expect(drawer.getAttribute('data-state')).toBe('closed')
-    expect(drawer.getAttribute('aria-hidden')).toBe('true')
-    expect(drawer.hasAttribute('inert')).toBe(true)
+    await user.click(screen.getByRole('button', { name: 'Select General' }))
+    expect(screen.queryByTestId('page-sidebar-drawer')).toBeNull()
   })
 })

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import { PanelLeftClose, PanelLeftOpen, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Sidebar } from './Sidebar'
 import { useRegisterMobilePageNavigation } from '../contexts/MobilePageNavigationContext'
 
@@ -9,16 +10,6 @@ const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
 const RESIZE_HANDLE_WIDTH = 10
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-  '[contenteditable="true"]',
-].join(',')
-
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
   return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Math.round(value)))
@@ -107,7 +98,7 @@ export function PageSidebarLayout({
   const isAppDesktop = useIsDesktop(768)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
-  const mobileDrawerRef = useRef<HTMLDialogElement | null>(null)
+  const mobileDrawerRef = useRef<HTMLDivElement | null>(null)
   const mobileDrawerId = useId()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))
@@ -176,75 +167,6 @@ export function PageSidebarLayout({
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
   }, [isDesktop])
-
-  useEffect(() => {
-    if (isDesktop) return
-    const drawer = mobileDrawerRef.current
-    if (!drawer) return
-
-    if (drawerOpen && !drawer.open) {
-      if (typeof drawer.showModal === 'function') {
-        drawer.showModal()
-      } else {
-        drawer.setAttribute('open', '')
-      }
-    } else if (!drawerOpen && drawer.open) {
-      if (typeof drawer.close === 'function') {
-        drawer.close()
-      } else {
-        drawer.removeAttribute('open')
-      }
-    }
-  }, [drawerOpen, isDesktop])
-
-  useEffect(() => {
-    if (isDesktop || !drawerOpen) return
-    const drawer = mobileDrawerRef.current
-    if (!drawer) return
-
-    const focusableElements = () =>
-      Array.from(drawer.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
-        .filter((element) => element.getAttribute('aria-hidden') !== 'true')
-
-    const current = drawer.querySelector<HTMLElement>('[aria-current="page"]')
-    const initialFocus = current?.matches(FOCUSABLE_SELECTOR)
-      ? current
-      : focusableElements()[0] ?? drawer
-    initialFocus.focus({ preventScroll: true })
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        setDrawerOpen(false)
-        return
-      }
-      if (event.key !== 'Tab') return
-
-      const focusables = focusableElements()
-      if (focusables.length === 0) {
-        event.preventDefault()
-        drawer.focus({ preventScroll: true })
-        return
-      }
-
-      const first = focusables[0]
-      const last = focusables[focusables.length - 1]
-      const active = document.activeElement
-      if (event.shiftKey && (active === first || !drawer.contains(active))) {
-        event.preventDefault()
-        last.focus({ preventScroll: true })
-      } else if (!event.shiftKey && (active === last || !drawer.contains(active))) {
-        event.preventDefault()
-        first.focus({ preventScroll: true })
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-      mobileTriggerRef.current?.focus({ preventScroll: true })
-    }
-  }, [drawerOpen, isDesktop])
 
   useEffect(() => {
     if (!isDesktop) return
@@ -378,46 +300,53 @@ export function PageSidebarLayout({
         <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       </div>
 
-      <dialog
-        ref={mobileDrawerRef}
-        id={mobileDrawerId}
-        data-testid="page-sidebar-drawer"
-        data-state={drawerOpen ? 'open' : 'closed'}
-        role="dialog"
-        aria-label={title}
-        aria-modal={drawerOpen ? true : undefined}
-        aria-hidden={!drawerOpen}
-        inert={!drawerOpen ? true : undefined}
-        tabIndex={-1}
-        className="oa-page-sidebar-dialog fixed inset-y-0 left-0 right-auto m-0 h-dvh max-h-none w-[280px] max-w-[85vw] overflow-hidden border-0 bg-transparent p-0 text-foreground outline-none"
-        onCancel={(event) => {
-          event.preventDefault()
-          setDrawerOpen(false)
-        }}
-        onClose={() => {
-          if (drawerOpen) setDrawerOpen(false)
-        }}
-        onClick={(event) => {
-          if (event.target === event.currentTarget) setDrawerOpen(false)
-        }}
+      <Sheet
+        open={drawerOpen}
+        onOpenChange={(open) => setDrawerOpen(open)}
       >
-        <Sidebar
-          title={title}
-          actions={actionContent}
-          leading={
-            <button
-              type="button"
-              onClick={() => setDrawerOpen(false)}
-              className="oa-icon-action -ml-2 flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              aria-label={t('common.closePanel', { title })}
-            >
-              <X size={15} strokeWidth={1.75} aria-hidden />
-            </button>
-          }
+        <SheetContent
+          ref={mobileDrawerRef}
+          id={mobileDrawerId}
+          data-testid="page-sidebar-drawer"
+          side="left"
+          role="dialog"
+          aria-modal="true"
+          aria-describedby={undefined}
+          showCloseButton={false}
+          className="oa-page-sidebar-dialog h-dvh max-h-none w-[280px] max-w-[85vw] gap-0 overflow-hidden border-0 bg-transparent p-0 text-foreground"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+            const drawer = mobileDrawerRef.current
+            const current = drawer?.querySelector<HTMLElement>('[aria-current="page"]')
+            const firstFocusable = drawer?.querySelector<HTMLElement>(
+              'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            )
+            ;(current ?? firstFocusable ?? drawer)?.focus({ preventScroll: true })
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault()
+            mobileTriggerRef.current?.focus({ preventScroll: true })
+          }}
         >
-          {sidebarContent}
-        </Sidebar>
-      </dialog>
+          <SheetTitle className="sr-only">{title}</SheetTitle>
+          <Sidebar
+            title={title}
+            actions={actionContent}
+            leading={
+              <button
+                type="button"
+                onClick={() => setDrawerOpen(false)}
+                className="oa-icon-action -ml-2 flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label={t('common.closePanel', { title })}
+              >
+                <X size={15} strokeWidth={1.75} aria-hidden />
+              </button>
+            }
+          >
+            {sidebarContent}
+          </Sidebar>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/ui/src/components/ui/alert-dialog.tsx
+++ b/ui/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react'
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+function AlertDialog(props: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger(
+  props: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>,
+) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal(
+  props: React.ComponentProps<typeof AlertDialogPrimitive.Portal>,
+) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'oa-dialog-backdrop fixed inset-0 z-[60] bg-backdrop duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'oa-dialog-surface fixed left-1/2 top-1/2 z-[60] grid w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-background p-5 text-foreground shadow-2xl outline-none duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = 'outline',
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { Slot } from '@radix-ui/react-slot'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        outline:
+          'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        ghost:
+          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground',
+        destructive:
+          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        icon: 'size-8',
+        'icon-xs':
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm':
+          'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg',
+        'icon-lg': 'size-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : 'button'
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger(props: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal(props: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose(props: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'oa-dialog-backdrop fixed inset-0 z-[60] bg-backdrop duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  overlayClassName,
+  showCloseButton = false,
+  closeLabel = 'Close',
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  overlayClassName?: string
+  showCloseButton?: boolean
+  closeLabel?: string
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay className={overlayClassName} />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'oa-dialog-surface fixed left-1/2 top-1/2 z-[60] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-background p-4 text-sm text-foreground shadow-2xl outline-none duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 sm:max-w-sm',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute right-2 top-2"
+              size="icon-sm"
+            >
+              <XIcon />
+              <span className="sr-only">{closeLabel}</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-base font-medium leading-none', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/ui/src/components/ui/dropdown-menu.tsx
+++ b/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,267 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+
+import { cn } from "@/lib/utils"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/ui/src/components/ui/sheet.tsx
+++ b/ui/src/components/ui/sheet.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+function Sheet(props: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger(props: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose(props: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal(props: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-backdrop duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = 'right',
+  showCloseButton = false,
+  closeLabel = 'Close',
+  forceMount,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  showCloseButton?: boolean
+  closeLabel?: string
+}) {
+  return (
+    <SheetPortal forceMount={forceMount}>
+      <SheetOverlay forceMount={forceMount} />
+      <SheetPrimitive.Content
+        forceMount={forceMount}
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          'fixed z-50 flex flex-col gap-4 border-border bg-background text-sm text-foreground shadow-2xl outline-none duration-200 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[state=open]:animate-in data-[side=bottom]:data-[state=open]:slide-in-from-bottom-10 data-[side=left]:data-[state=open]:slide-in-from-left-10 data-[side=right]:data-[state=open]:slide-in-from-right-10 data-[side=top]:data-[state=open]:slide-in-from-top-10 data-[state=closed]:animate-out data-[side=bottom]:data-[state=closed]:slide-out-to-bottom-10 data-[side=left]:data-[state=closed]:slide-out-to-left-10 data-[side=right]:data-[state=closed]:slide-out-to-right-10 data-[side=top]:data-[state=closed]:slide-out-to-top-10',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close data-slot="sheet-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute right-3 top-3"
+              size="icon-sm"
+            >
+              <XIcon />
+              <span className="sr-only">{closeLabel}</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn('flex flex-col gap-0.5 p-4', className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn('text-base font-medium text-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+}

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/ui/src/components/uta/CreateUTADialog.spec.tsx
+++ b/ui/src/components/uta/CreateUTADialog.spec.tsx
@@ -74,7 +74,7 @@ describe('CreateUTADialog', () => {
   it('uses broker-facing setup labels instead of internal UTA labels', () => {
     setup()
 
-    expect(screen.getByText('Connect Broker · Pick Platform')).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 3, name: 'Connect Broker · Pick Platform' })).toBeTruthy()
     expect(screen.getByLabelText('Close broker setup')).toBeTruthy()
   })
 

--- a/ui/src/components/uta/Dialog.spec.tsx
+++ b/ui/src/components/uta/Dialog.spec.tsx
@@ -59,7 +59,5 @@ describe('Dialog modal behavior', () => {
     expect(dialog.className).toContain('h-full')
     expect(dialog.className).toContain('sm:max-h-[85vh]')
     expect(dialog.className).toContain('sm:rounded-xl')
-    expect(dialog.parentElement?.className).toContain('items-stretch')
-    expect(dialog.parentElement?.className).toContain('sm:items-center')
   })
 })

--- a/ui/src/components/uta/Dialog.tsx
+++ b/ui/src/components/uta/Dialog.tsx
@@ -1,10 +1,11 @@
+import { useEffect, useRef, type ReactNode, type RefObject } from 'react'
+
 import {
-  useCallback,
-  useEffect,
-  useRef,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type RefObject,
-} from 'react'
+  Dialog as DialogPrimitive,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
 
 /** Generic modal dialog used by settings, Workspace, and UTA flows. */
 export function Dialog({
@@ -20,98 +21,52 @@ export function Dialog({
   ariaLabel: string
   mobileFullscreen?: boolean
   initialFocusRef?: RefObject<HTMLElement | null>
-  children: React.ReactNode
+  children: ReactNode
 }) {
-  const surfaceRef = useRef<HTMLDivElement>(null)
   const restoreFocusRef = useRef<HTMLElement | null>(
     typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
       ? document.activeElement
       : null,
   )
 
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Escape') onClose()
-  }, [onClose])
-
-  useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown)
-    const surface = surfaceRef.current
-    if (surface && !surface.contains(document.activeElement)) {
-      const initialFocus = initialFocusRef?.current ?? focusableElements(surface)[0] ?? surface
-      initialFocus.focus()
-    }
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
-      const previousFocus = restoreFocusRef.current
-      if (previousFocus?.isConnected) previousFocus.focus()
-    }
-  }, [handleKeyDown, initialFocusRef])
-
-  const trapFocus = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return
-    const surface = surfaceRef.current
-    if (!surface) return
-
-    const focusable = focusableElements(surface)
-    if (focusable.length === 0) {
-      event.preventDefault()
-      surface.focus()
-      return
-    }
-
-    const first = focusable[0]!
-    const last = focusable.at(-1)!
-    const active = document.activeElement
-    if (event.shiftKey && (active === first || !surface.contains(active))) {
-      event.preventDefault()
-      last.focus()
-    } else if (!event.shiftKey && (active === last || !surface.contains(active))) {
-      event.preventDefault()
-      first.focus()
-    }
-  }
-
-  const viewportLayout = mobileFullscreen
-    ? 'items-stretch p-0 sm:items-center sm:p-4'
-    : 'items-center p-4'
-  const surfaceLayout = mobileFullscreen
-    ? 'h-full max-h-none max-w-none rounded-none border-x-0 sm:h-auto sm:max-h-[85vh] sm:max-w-[95vw] sm:rounded-xl sm:border-x'
-    : 'max-h-[85vh] max-w-[95vw] rounded-xl'
+  useEffect(() => () => {
+    const previousFocus = restoreFocusRef.current
+    if (previousFocus?.isConnected) previousFocus.focus()
+  }, [])
 
   return (
-    // z-[60] keeps dialogs above the mobile nav drawers (z-50).
-    <div className={`fixed inset-0 z-[60] flex justify-center ${viewportLayout}`}>
-      <div
-        aria-hidden
-        className="oa-dialog-backdrop absolute inset-0 bg-backdrop"
-        onClick={onClose}
-      />
-      <div
-        ref={surfaceRef}
-        role="dialog"
+    <DialogPrimitive
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogContent
         aria-modal="true"
-        aria-label={ariaLabel}
-        tabIndex={-1}
-        onKeyDown={trapFocus}
-        className={`oa-dialog-surface relative ${width || 'w-full sm:w-[560px]'} ${surfaceLayout} flex flex-col overflow-hidden border border-border bg-background shadow-2xl`}
+        aria-describedby={undefined}
+        showCloseButton={false}
+        onOpenAutoFocus={initialFocusRef
+          ? (event) => {
+            event.preventDefault()
+            initialFocusRef.current?.focus()
+          }
+          : undefined}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          const previousFocus = restoreFocusRef.current
+          if (previousFocus?.isConnected) previousFocus.focus()
+        }}
+        className={cn(
+          'flex flex-col gap-0 overflow-hidden p-0',
+          width || 'w-full sm:w-[560px]',
+          mobileFullscreen
+            ? 'h-full max-h-none max-w-none rounded-none border-x-0 sm:h-auto sm:max-h-[85vh] sm:max-w-[95vw] sm:rounded-xl sm:border-x'
+            : 'max-h-[85vh] max-w-[95vw] rounded-xl',
+        )}
       >
+        <DialogTitle className="sr-only">{ariaLabel}</DialogTitle>
         {children}
-      </div>
-    </div>
+      </DialogContent>
+    </DialogPrimitive>
   )
-}
-
-const FOCUSABLE_SELECTOR = [
-  'button:not([disabled])',
-  'a[href]',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',')
-
-function focusableElements(container: HTMLElement): HTMLElement[] {
-  return [...container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)]
-    .filter((element) => element.getAttribute('aria-hidden') !== 'true')
 }

--- a/ui/src/components/workspace/AutoQuantWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/AutoQuantWorkspaceSection.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { WorkspacesContext, type WorkspacesContextValue } from '../../contexts/workspaces-context'
@@ -108,7 +109,8 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('AutoQuantWorkspaceSection session actions', () => {
-  it('keeps the active research current and routes destructive actions through the More menu', () => {
+  it('keeps the active research current and routes destructive actions through the More menu', async () => {
+    const user = userEvent.setup()
     const onNavigate = vi.fn()
     render(
       <WorkspacesContext.Provider value={context()}>
@@ -124,8 +126,8 @@ describe('AutoQuantWorkspaceSection session actions', () => {
       params: { wsId: workspace.id, sessionId: session.id, source: 'auto-quant' },
     })
 
-    fireEvent.click(screen.getByRole('button', { name: `More actions for ${sessionTitle}` }))
-    fireEvent.click(screen.getByRole('menuitem', { name: `Delete ${sessionTitle}` }))
+    await user.click(screen.getByRole('button', { name: `More actions for ${sessionTitle}` }))
+    await user.click(screen.getByRole('menuitem', { name: `Delete ${sessionTitle}` }))
     expect(actions.requestDeleteSession).toHaveBeenCalledWith(workspace.id, session.id)
   })
 })

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { WorkspacesContext, type WorkspacesContextValue } from '../../contexts/workspaces-context'
@@ -241,7 +242,8 @@ describe('ChatWorkspaceSection actions', () => {
     expect(onRequestDisplayMode).toHaveBeenCalledWith('focused')
   })
 
-  it('keeps conversation creation primary and scopes workspace creation to the workspace list', () => {
+  it('keeps conversation creation primary and scopes workspace creation to the workspace list', async () => {
+    const user = userEvent.setup()
     const onNavigate = vi.fn()
     renderSection([chatWorkspace], null, onNavigate)
 
@@ -258,8 +260,8 @@ describe('ChatWorkspaceSection actions', () => {
     expect(screen.queryByRole('button', { name: 'New workspace' })).toBeNull()
     expect(newSession.querySelector('.lucide-message-square-plus')).toBeTruthy()
 
-    fireEvent.click(moreWorkspaceActions)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Configure chat-jul11' }))
+    await user.click(moreWorkspaceActions)
+    await user.click(screen.getByRole('menuitem', { name: 'Configure chat-jul11' }))
     expect(onNavigate).not.toHaveBeenCalled()
 
     fireEvent.click(newChat)
@@ -284,7 +286,8 @@ describe('ChatWorkspaceSection actions', () => {
     expect(screen.getByRole('button', { name: 'New workspace' })).toBeTruthy()
   })
 
-  it('keeps named Workspace identity compact and scopes every row action to it', () => {
+  it('keeps named Workspace identity compact and scopes every row action to it', async () => {
+    const user = userEvent.setup()
     const namedWorkspace: Workspace = {
       ...chatWorkspace,
       id: 'chat-optical',
@@ -306,7 +309,7 @@ describe('ChatWorkspaceSection actions', () => {
     const more = screen.getByRole('button', {
       name: 'More actions for Optical Networking Follow-up (chat-jun30)',
     })
-    fireEvent.click(more)
+    await user.click(more)
     const configure = screen.getByRole('menuitem', {
       name: 'Configure Optical Networking Follow-up (chat-jun30)',
     })
@@ -391,7 +394,8 @@ describe('ChatWorkspaceSection actions', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('owns Manager Session navigation and lifecycle actions under the Manager entry', () => {
+  it('owns Manager Session navigation and lifecycle actions under the Manager entry', async () => {
+    const user = userEvent.setup()
     const onNavigate = vi.fn()
     const manager: ManagerWorkspaceSnapshot = {
       id: MANAGER_WORKSPACE_ID,
@@ -459,8 +463,8 @@ describe('ChatWorkspaceSection actions', () => {
 
     const pausedRow = pausedSession.parentElement
     expect(pausedRow).toBeTruthy()
-    fireEvent.click(within(pausedRow as HTMLElement).getByRole('button', { name: 'More actions for Coordinate owners' }))
-    fireEvent.click(within(pausedRow as HTMLElement).getByRole('menuitem', { name: 'Delete Coordinate owners' }))
+    await user.click(within(pausedRow as HTMLElement).getByRole('button', { name: 'More actions for Coordinate owners' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Delete Coordinate owners' }))
     expect(actions.requestDeleteSession).toHaveBeenCalledWith(MANAGER_WORKSPACE_ID, 'manager-pi')
     expect(onNavigate).toHaveBeenCalledTimes(2)
 

--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../../i18n'
@@ -89,7 +90,8 @@ describe('WorkspaceRow session launcher', () => {
     expect(screen.getByRole('menuitem', { name: 'Shell (sh)' })).toBeTruthy()
   })
 
-  it('groups secondary workspace actions behind a target-scoped More menu', () => {
+  it('groups secondary workspace actions behind a target-scoped More menu', async () => {
+    const user = userEvent.setup()
     const onRenameWorkspace = vi.fn()
     const onConfigureWorkspace = vi.fn()
     const onDelete = vi.fn(async () => undefined)
@@ -117,16 +119,16 @@ describe('WorkspaceRow session launcher', () => {
     const more = screen.getByRole('button', { name: 'More actions for chat' })
     expect(more.className).not.toContain('opacity-0')
 
-    fireEvent.click(more)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename workspace' }))
+    await user.click(more)
+    await user.click(screen.getByRole('menuitem', { name: 'Rename workspace' }))
     expect(onRenameWorkspace).toHaveBeenCalledWith(workspace.id, 'Research desk')
 
-    fireEvent.click(more)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Configure this workspace' }))
+    await user.click(more)
+    await user.click(screen.getByRole('menuitem', { name: 'Configure this workspace' }))
     expect(onConfigureWorkspace).toHaveBeenCalledWith(workspace.id)
 
-    fireEvent.click(more)
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Offboard workspace' }))
+    await user.click(more)
+    await user.click(screen.getByRole('menuitem', { name: 'Offboard workspace' }))
     expect(onDelete).toHaveBeenCalledWith(workspace.id)
   })
 })
@@ -146,7 +148,8 @@ describe('SessionRow actions', () => {
     title: 'Review AAPL earnings',
   }
 
-  it('names destructive and lifecycle actions for their target session', () => {
+  it('names destructive and lifecycle actions for their target session', async () => {
+    const user = userEvent.setup()
     const onPause = vi.fn()
     const onDelete = vi.fn()
     const { rerender } = render(
@@ -163,10 +166,10 @@ describe('SessionRow actions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Stop Review AAPL earnings' }))
     const more = screen.getByRole('button', { name: 'More actions for Review AAPL earnings' })
     expect(more.getAttribute('aria-haspopup')).toBe('menu')
-    fireEvent.click(more)
+    await user.click(more)
     const deleteItem = screen.getByRole('menuitem', { name: 'Delete Review AAPL earnings' })
     expect(document.activeElement).toBe(deleteItem)
-    fireEvent.click(deleteItem)
+    await user.click(deleteItem)
     expect(onPause).toHaveBeenCalledOnce()
     expect(onDelete).toHaveBeenCalledOnce()
 

--- a/ui/src/components/workspace/SidebarActionMenu.spec.tsx
+++ b/ui/src/components/workspace/SidebarActionMenu.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Pencil, Trash2 } from 'lucide-react'
 
@@ -10,6 +11,7 @@ afterEach(cleanup)
 
 describe('SidebarActionMenu', () => {
   it('supports edge focus, arrow navigation, Escape, and focus return', async () => {
+    const user = userEvent.setup()
     const triggerLabel = 'More actions for Research desk'
     render(
       <SidebarActionMenu
@@ -29,23 +31,25 @@ describe('SidebarActionMenu', () => {
 
     const trigger = screen.getByRole('button', { name: triggerLabel })
     expect(trigger.className).toContain('oa-workspace-row-action')
-    fireEvent.keyDown(trigger, { key: 'ArrowUp' })
+    trigger.focus()
+    await user.keyboard('{ArrowUp}')
 
     const rename = screen.getByRole('menuitem', { name: 'Rename' })
     const offboard = screen.getByRole('menuitem', { name: 'Offboard Research desk' })
     expect(offboard.textContent).toBe('Offboard workspace')
     expect(document.activeElement).toBe(offboard)
 
-    fireEvent.keyDown(offboard, { key: 'ArrowDown' })
+    await user.keyboard('{ArrowDown}')
     expect(document.activeElement).toBe(rename)
 
-    fireEvent.keyDown(rename, { key: 'Escape' })
+    await user.keyboard('{Escape}')
     await waitFor(() => expect(document.activeElement).toBe(trigger))
     expect(screen.queryByRole('menu')).toBeNull()
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
   })
 
-  it('closes on an outside pointer without invoking an action', () => {
+  it('closes on an outside pointer without invoking an action', async () => {
+    const user = userEvent.setup()
     const onSelect = vi.fn()
     render(
       <>
@@ -57,9 +61,9 @@ describe('SidebarActionMenu', () => {
       </>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'More actions for Session' }))
+    await user.click(screen.getByRole('button', { name: 'More actions for Session' }))
     expect(screen.getByRole('menuitem', { name: 'Delete Session' })).toBeTruthy()
-    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }))
+    await user.click(screen.getByRole('button', { name: 'Outside' }))
 
     expect(screen.queryByRole('menu')).toBeNull()
     expect(onSelect).not.toHaveBeenCalled()

--- a/ui/src/components/workspace/SidebarActionMenu.tsx
+++ b/ui/src/components/workspace/SidebarActionMenu.tsx
@@ -1,13 +1,12 @@
-import {
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type ReactNode,
-} from 'react'
+import { useCallback, useRef, useState, type ReactNode } from 'react'
 import { Ellipsis } from 'lucide-react'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 export interface SidebarActionMenuItem {
   label: string
@@ -25,151 +24,57 @@ export function SidebarActionMenu({
   items: readonly SidebarActionMenuItem[]
 }) {
   const [open, setOpen] = useState(false)
-  const [placement, setPlacement] = useState<'above' | 'below'>('below')
-  const focusEdgeRef = useRef<'first' | 'last'>('first')
-  const rootRef = useRef<HTMLDivElement | null>(null)
-  const triggerRef = useRef<HTMLButtonElement | null>(null)
-  const menuRef = useRef<HTMLDivElement | null>(null)
-  const menuId = useId()
-
-  const menuItems = () =>
-    Array.from(menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [])
-
-  const choosePlacement = () => {
-    const trigger = triggerRef.current
-    if (!trigger) return
-    let clippingParent: HTMLElement | null = trigger.parentElement
-    while (clippingParent) {
-      const overflow = getComputedStyle(clippingParent).overflowY
-      if (overflow === 'auto' || overflow === 'scroll' || overflow === 'hidden' || overflow === 'clip') break
-      clippingParent = clippingParent.parentElement
-    }
-
-    const triggerRect = trigger.getBoundingClientRect()
-    const bounds = clippingParent?.getBoundingClientRect() ?? { top: 0, bottom: window.innerHeight }
-    const estimatedHeight = items.length * 36 + 10
-    const roomAbove = triggerRect.top - bounds.top
-    const roomBelow = bounds.bottom - triggerRect.bottom
-    setPlacement(roomBelow < estimatedHeight && roomAbove > roomBelow ? 'above' : 'below')
-  }
-
-  const close = (returnFocus: boolean) => {
-    setOpen(false)
-    if (returnFocus) queueMicrotask(() => triggerRef.current?.focus({ preventScroll: true }))
-  }
-
-  useLayoutEffect(() => {
-    if (!open) return
-    const focusable = menuItems()
-    const target = focusEdgeRef.current === 'last'
-      ? focusable[focusable.length - 1]
-      : focusable[0]
-    focusEdgeRef.current = 'first'
-    target?.focus({ preventScroll: true })
-  }, [open])
-
-  useEffect(() => {
-    if (!open) return
-
-    const onPointerDown = (event: MouseEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
-    }
-    document.addEventListener('mousedown', onPointerDown)
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown)
-    }
-  }, [open])
-
-  const onMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      event.stopPropagation()
-      close(true)
-      return
-    }
-
-    const focusable = menuItems()
-    if (focusable.length === 0) return
-    const current = focusable.indexOf(document.activeElement as HTMLButtonElement)
-
-    let next: number | null = null
-    if (event.key === 'ArrowDown') next = current < 0 ? 0 : (current + 1) % focusable.length
-    if (event.key === 'ArrowUp') next = current <= 0 ? focusable.length - 1 : current - 1
-    if (event.key === 'Home') next = 0
-    if (event.key === 'End') next = focusable.length - 1
-    if (next === null) return
-
-    event.preventDefault()
-    focusable[next]?.focus({ preventScroll: true })
-  }
+  const focusLastOnOpenRef = useRef(false)
+  const setMenuRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return
+    queueMicrotask(() => {
+      const menuItems = node.querySelectorAll<HTMLElement>('[role="menuitem"]')
+      const index = focusLastOnOpenRef.current ? menuItems.length - 1 : 0
+      focusLastOnOpenRef.current = false
+      menuItems.item(index)?.focus({ preventScroll: true })
+    })
+  }, [])
 
   return (
-    <div ref={rootRef} className="relative flex shrink-0 items-center">
-      <button
-        ref={triggerRef}
-        type="button"
-        className="oa-icon-action oa-workspace-row-action flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-secondary hover:text-foreground"
-        aria-label={label}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-controls={open ? menuId : undefined}
-        onClick={() => {
-          focusEdgeRef.current = 'first'
-          setOpen((current) => {
-            if (!current) choosePlacement()
-            return !current
-          })
-        }}
-        onKeyDown={(event) => {
-          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
-          event.preventDefault()
-          focusEdgeRef.current = event.key === 'ArrowUp' ? 'last' : 'first'
-          choosePlacement()
-          setOpen(true)
-        }}
-      >
-        <Ellipsis size={14} strokeWidth={2.2} aria-hidden />
-      </button>
-      {open && (
-        <div
-          ref={menuRef}
-          id={menuId}
-          role="menu"
+    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="oa-icon-action oa-workspace-row-action flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-secondary hover:text-foreground"
           aria-label={label}
-          onKeyDown={onMenuKeyDown}
-          className={`oa-popover-enter absolute right-0 z-30 w-[220px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border/70 bg-secondary py-1 shadow-lg ${
-            placement === 'above' ? 'bottom-full mb-1' : 'top-full mt-1'
-          }`}
+          onKeyDown={(event) => {
+            if (event.key !== 'ArrowUp') return
+            event.preventDefault()
+            focusLastOnOpenRef.current = true
+            setOpen(true)
+          }}
         >
-          {items.map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              role="menuitem"
-              aria-label={item.ariaLabel}
-              tabIndex={-1}
-              className={`flex min-h-9 w-full items-center gap-2 px-3 py-2 text-left text-[12px] transition-colors hover:bg-muted ${
-                item.danger ? 'text-destructive' : 'text-foreground'
-              }`}
-              onClick={() => {
-                setOpen(false)
-                item.onSelect()
-                queueMicrotask(() => {
-                  const active = document.activeElement
-                  if (active === document.body || rootRef.current?.contains(active)) {
-                    triggerRef.current?.focus({ preventScroll: true })
-                  }
-                })
-              }}
-            >
-              <span className="flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>
-                {item.icon}
-              </span>
-              <span className="min-w-0 flex-1 truncate">{item.label}</span>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+          <Ellipsis size={14} strokeWidth={2.2} aria-hidden />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        ref={setMenuRef}
+        loop
+        align="end"
+        sideOffset={4}
+        aria-label={label}
+        className="z-30 w-[220px] max-w-[calc(100vw-2rem)] rounded-lg border border-border/70 bg-secondary py-1 shadow-lg ring-0"
+      >
+        {items.map((item) => (
+          <DropdownMenuItem
+            key={item.label}
+            aria-label={item.ariaLabel}
+            variant={item.danger ? 'destructive' : 'default'}
+            className="flex min-h-9 w-full cursor-default items-center gap-2 rounded-none px-3 py-2 text-left text-[12px] transition-colors focus:bg-muted"
+            onSelect={item.onSelect}
+          >
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>
+              {item.icon}
+            </span>
+            <span className="min-w-0 flex-1 truncate">{item.label}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "tw-animate-css";
 @import "./theme/palette.css";
 
 /* Tailwind aliases for the semantic color card. The core names intentionally
@@ -214,11 +215,6 @@ body {
   to { opacity: 1; }
 }
 
-@keyframes oa-page-sidebar-enter {
-  from { transform: translateX(-100%); }
-  to { transform: none; }
-}
-
 @keyframes oa-disclosure-enter {
   from {
     opacity: 0;
@@ -250,15 +246,6 @@ body {
 }
 
 .oa-dialog-backdrop {
-  animation: oa-backdrop-enter var(--motion-standard) ease-out both;
-}
-
-.oa-page-sidebar-dialog[open] {
-  animation: oa-page-sidebar-enter var(--motion-standard) var(--motion-ease-out) both;
-}
-
-.oa-page-sidebar-dialog::backdrop {
-  background: var(--backdrop);
   animation: oa-backdrop-enter var(--motion-standard) ease-out both;
 }
 
@@ -599,8 +586,6 @@ html[lang="ja"] .oa-onboarding-title {
   .oa-view-enter,
   .oa-dialog-surface,
   .oa-dialog-backdrop,
-  .oa-page-sidebar-dialog[open],
-  .oa-page-sidebar-dialog::backdrop,
   .oa-disclosure-enter,
   .oa-popover-enter {
     animation: none;

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+/** Merge conditional component classes while resolving Tailwind conflicts. */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs))
+}

--- a/ui/src/pages/InboxPage.spec.tsx
+++ b/ui/src/pages/InboxPage.spec.tsx
@@ -231,7 +231,7 @@ describe('InboxPage responsive detail header', () => {
     expect(screen.queryByRole('dialog', {
       name: 'Sender identity: pi · @resume-plain-linen-river-2218b6',
     })).toBeNull()
-    expect(document.activeElement).toBe(sender)
+    await waitFor(() => expect(document.activeElement).toBe(sender))
 
     fireEvent.click(sender)
     fireEvent.click(screen.getByRole('button', { name: 'Open conversation' }))

--- a/ui/src/pages/InboxPage.tsx
+++ b/ui/src/pages/InboxPage.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import { PageHeader } from '../components/PageHeader'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Skeleton } from '../components/StateViews'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { FileContentView } from '../components/FileContentView'
@@ -255,7 +256,6 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   const [continuing, setContinuing] = useState(false)
   const [continueError, setContinueError] = useState<string | null>(null)
   const [senderPopoverOpen, setSenderPopoverOpen] = useState(false)
-  const senderPopoverRef = useRef<HTMLSpanElement>(null)
   const senderTriggerRef = useRef<HTMLButtonElement>(null)
   // Resolve the issue id (a filename stem) to its display title via the warm,
   // process-cached board snapshot — a cheap path (no extra fetch on the hot
@@ -270,27 +270,6 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
   useEffect(() => {
     setSenderPopoverOpen(false)
   }, [entry.id])
-
-  useEffect(() => {
-    if (!senderPopoverOpen) return
-    const closeOnOutsideClick = (event: globalThis.MouseEvent) => {
-      if (!senderPopoverRef.current?.contains(event.target as Node)) {
-        setSenderPopoverOpen(false)
-      }
-    }
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-      event.preventDefault()
-      setSenderPopoverOpen(false)
-      senderTriggerRef.current?.focus({ preventScroll: true })
-    }
-    document.addEventListener('mousedown', closeOnOutsideClick)
-    document.addEventListener('keydown', closeOnEscape)
-    return () => {
-      document.removeEventListener('mousedown', closeOnOutsideClick)
-      document.removeEventListener('keydown', closeOnEscape)
-    }
-  }, [senderPopoverOpen])
 
   const openWorkspace = () => {
     if (!wsAlive) return
@@ -367,29 +346,34 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
                 {displayLabel}
               </span>
               {senderLabel && senderDisplay && (
-                <span ref={senderPopoverRef} className="relative inline-flex min-w-0 items-center">
+                <span className="inline-flex min-w-0 items-center">
                   <ChevronRight size={11} className="mr-1 shrink-0 text-muted-foreground/35" aria-hidden />
-                  <button
-                    ref={senderTriggerRef}
-                    type="button"
-                    aria-label={t('inbox.showSenderDetails', { sender: senderDisplay })}
-                    aria-haspopup="dialog"
-                    aria-expanded={senderPopoverOpen}
-                    aria-controls={`inbox-sender-${entry.id}`}
-                    onClick={() => setSenderPopoverOpen((open) => !open)}
-                    className="inline-flex min-h-10 min-w-0 items-center gap-1.5 rounded-sm text-[11px] font-medium text-muted-foreground/75 underline decoration-border underline-offset-2 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 sm:min-h-0"
-                  >
-                    {origin?.kind === 'interactive'
-                      ? <Terminal size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />
-                      : <Bot size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />}
-                    <span>{t('inbox.fromSender', { sender: senderDisplay })}</span>
-                  </button>
-                  {senderPopoverOpen && (
-                    <div
+                  <Popover open={senderPopoverOpen} onOpenChange={setSenderPopoverOpen}>
+                    <PopoverTrigger asChild>
+                      <button
+                        ref={senderTriggerRef}
+                        type="button"
+                        aria-label={t('inbox.showSenderDetails', { sender: senderDisplay })}
+                        className="inline-flex min-h-10 min-w-0 items-center gap-1.5 rounded-sm text-[11px] font-medium text-muted-foreground/75 underline decoration-border underline-offset-2 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 sm:min-h-0"
+                      >
+                        {origin?.kind === 'interactive'
+                          ? <Terminal size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />
+                          : <Bot size={12} strokeWidth={1.75} className="shrink-0" aria-hidden />}
+                        <span>{t('inbox.fromSender', { sender: senderDisplay })}</span>
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent
                       id={`inbox-sender-${entry.id}`}
                       role="dialog"
                       aria-label={t('inbox.senderIdentityTitle', { sender: senderLabel })}
-                      className="oa-popover-enter absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] rounded-xl border border-border/70 bg-secondary p-3 text-left shadow-lg"
+                      align="start"
+                      sideOffset={8}
+                      onOpenAutoFocus={(event) => event.preventDefault()}
+                      onCloseAutoFocus={(event) => {
+                        event.preventDefault()
+                        senderTriggerRef.current?.focus({ preventScroll: true })
+                      }}
+                      className="z-30 w-72 max-w-[calc(100vw-3rem)] gap-0 rounded-xl border border-border/70 bg-secondary p-3 text-left shadow-lg ring-0"
                     >
                       <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
                         {t('inbox.senderSession')}
@@ -416,8 +400,8 @@ function Detail({ entry, onDelete }: { entry: InboxEntry; onDelete: () => void }
                               : t('inbox.openWorkspace')}
                         </button>
                       )}
-                    </div>
-                  )}
+                    </PopoverContent>
+                  </Popover>
                 </span>
               )}
               {issueId && (

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -10,7 +10,11 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "noEmit": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -63,6 +63,11 @@ const { port: uiPort, strictPort } = readUiPort()
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
   // Inject the backend port as a compile-time constant so the dev client can
   // open the PTY WebSocket *directly* against the backend, bypassing the Vite
   // dev proxy. node-http-proxy's WS upgrade forwarding chokes under the

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,11 @@ const workspaceAliases = {
   '@traderalice/uta-protocol': resolve(__dirname, './packages/uta-protocol/src/index.ts'),
 }
 
+const uiAliases = {
+  ...workspaceAliases,
+  '@': resolve(__dirname, './ui/src'),
+}
+
 export default defineConfig({
   resolve: {
     alias: workspaceAliases,
@@ -38,7 +43,7 @@ export default defineConfig({
       },
       {
         resolve: {
-          alias: workspaceAliases,
+          alias: uiAliases,
         },
         test: {
           name: 'ui',


### PR DESCRIPTION
## Summary

Establish an OpenAlice-owned shadcn/Radix overlay foundation without changing the product's default visual language.

- add checked-in shadcn configuration, the `@/` UI alias, `cn`, and source-owned Button, Dialog, AlertDialog, Sheet, Popover, DropdownMenu, and Tooltip primitives
- move the shared UTA/settings Dialog and ConfirmDialog onto maintained focus, dismissal, portal, scroll-lock, and focus-return behavior
- replace the phone page-sidebar native-dialog plumbing with Sheet while preserving the mounted desktop rail
- migrate sidebar action menus plus the Inbox sender and Issue provenance identity cards
- remove the superseded document-level focus traps, Escape listeners, outside-click handlers, placement math, and redundant sidebar animation CSS
- document primitive ownership and the boundary between future UI styles and existing palette tokens

## Why this shape

This is the first bounded phase of a gradual migration, not a mechanical whole-app rewrite. Product components keep their existing APIs and information hierarchy; shadcn supplies lower-level behavior as checked-in, reviewable OpenAlice source.

The current warm semantic palette remains authoritative. Runtime-selectable styles such as a future Win98 profile are deliberately out of scope until these stable component seams exist.

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm test` — 470 files and 3,899 tests passed; existing skips retained
- real `pnpm dev` browser walk on Chat, Inbox, Issue, and Manager routes at wide and 390 px widths
  - verified Escape, outside dismissal, focus entry/return, scroll lock, collision placement, and narrow confirmation containment
  - no browser console errors
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
  - unsigned packaged Electron acceptance passed across IPC, PTY, Workspace creation, scheduled work, managed Pi, and cleanup

## Scope boundaries and follow-on

This PR does not restyle ActivityBar, Workspace trees, terminal, charts, reports, trading tables, AuthGate, or FirstRunGuide.

The next bounded overlay topic can address the ActivityBar phone drawer, `WorkspaceAIConfigModal`, and the remaining Workspace/session chooser menus in `ChatWorkspaceSection` and `Sidebar`.

Implementation plan: `plans/shadcn-overlay-foundation.md`

This remains a Draft PR for maintainer acceptance and must not be auto-merged.