### PR TITLE
Migrate the mobile activity rail to Sheet

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/mobile-activity-sheet.md]] — Moves the phone ActivityBar onto the
+  shared Sheet behavior while preserving the static desktop rail; it is a
+  serial follow-on to Draft PR #970 and remains local until that foundation is
+  explicitly accepted.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,10 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/mobile-activity-sheet.md]] — Moves the phone ActivityBar onto the
-  shared Sheet behavior while preserving the static desktop rail; it is a
-  serial follow-on to Draft PR #970 and remains local until that foundation is
-  explicitly accepted.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY
@@ -32,6 +28,9 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/mobile-activity-sheet.md]] — Moved the phone ActivityBar onto the
+  shared Sheet behavior while preserving the static desktop rail. Delivered as
+  serial PR #971 after the foundation in PR #970 was accepted and merged.
 - [[plans/shadcn-overlay-foundation.md]] — Established an OpenAlice-owned
   shadcn/Radix primitive layer, retired representative hand-written overlay
   behavior, and preserved the current product hierarchy and visual language as

--- a/plans/mobile-activity-sheet.md
+++ b/plans/mobile-activity-sheet.md
@@ -1,10 +1,9 @@
 # Mobile Activity Sheet
 
-- Status: `active`
+- Status: `complete`
 - Updated: `2026-08-04`
-- Delivery: serial PR targeting `dev` after Draft PR #970 is explicitly
-  accepted and merged; the implementation branch is currently stacked on
-  #970 and is not published as a second concurrent PR.
+- Delivery: serial PR #971 targeting `dev`, after the shared overlay foundation
+  was explicitly accepted and merged in PR #970.
 - Related issues: none.
 - Owner guides: [[docs/ui-interaction-and-motion.md]] and
   [[docs/development-workflow.md]].
@@ -43,8 +42,9 @@ information hierarchy, density, collapse behavior, and lifetime.
    normal mounted `aside`.
 2. The App keeps its explicit background `inert` contract while the phone rail
    is open. Sheet owns generic modal behavior; App owns the shell hierarchy.
-3. This is a serial follow-on, not extra scope added to autonomous Draft PR
-   #970 and not a second simultaneously published contribution.
+3. This shipped as serial follow-on PR #971 after autonomous foundation PR
+   #970 was accepted and merged, rather than as extra foundation scope or a
+   simultaneous contribution.
 
 ## Work
 
@@ -58,7 +58,7 @@ information hierarchy, density, collapse behavior, and lifetime.
 - [x] Walk the real `pnpm dev` Inbox and Settings routes at phone and desktop
       widths with keyboard and pointer input in Day and Night palettes.
 - [x] Run the unsigned packaged Electron Workspace smoke.
-- [ ] After #970 is explicitly accepted, update from `dev`, replay this atomic
+- [x] After #970 is explicitly accepted, update from `dev`, replay this atomic
       commit on a fresh serial branch, rerun affected checks, and open/merge a
       dev-targeted PR.
 

--- a/plans/mobile-activity-sheet.md
+++ b/plans/mobile-activity-sheet.md
@@ -55,10 +55,8 @@ information hierarchy, density, collapse behavior, and lifetime.
       containment, Escape, focus return, desktop persistence, and touch sizes
       in focused tests.
 - [x] Run root and UI type checks plus the full Vitest suite.
-- [ ] Walk the real `pnpm dev` Inbox route at phone and desktop widths with
-      keyboard and pointer input. The controlled in-app browser is currently
-      on a Chromium connection-error page and its URL policy rejected agent
-      navigation after the development server recovered.
+- [x] Walk the real `pnpm dev` Inbox and Settings routes at phone and desktop
+      widths with keyboard and pointer input in Day and Night palettes.
 - [x] Run the unsigned packaged Electron Workspace smoke.
 - [ ] After #970 is explicitly accepted, update from `dev`, replay this atomic
       commit on a fresh serial branch, rerun affected checks, and open/merge a
@@ -72,8 +70,14 @@ information hierarchy, density, collapse behavior, and lifetime.
   their existing skips.
 - `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` — unsigned
   packaged Workspace acceptance passed and cleaned its temporary app.
-- Browser/dev — not yet accepted; a running Vite server alone is not visual or
-  interaction evidence.
+- Browser/dev — at 390 × 844, verified a 280 px Sheet, current-destination
+  initial focus, body scroll lock, inert/hidden background, Escape, visible
+  overlay dismissal, trigger focus return, and navigation-driven close. At
+  1280 × 900, verified the normal 188 px `aside` with no Sheet/overlay portal.
+  Day and Night palettes rendered cleanly and the console had no warnings or
+  errors. This walk found and repaired a side-variant width conflict that had
+  expanded the first render to 292.5 px; the theme preference was restored to
+  Auto afterward.
 
 ## Completion Criteria
 

--- a/plans/mobile-activity-sheet.md
+++ b/plans/mobile-activity-sheet.md
@@ -1,0 +1,86 @@
+# Mobile Activity Sheet
+
+- Status: `active`
+- Updated: `2026-08-04`
+- Delivery: serial PR targeting `dev` after Draft PR #970 is explicitly
+  accepted and merged; the implementation branch is currently stacked on
+  #970 and is not published as a second concurrent PR.
+- Related issues: none.
+- Owner guides: [[docs/ui-interaction-and-motion.md]] and
+  [[docs/development-workflow.md]].
+
+## Outcome
+
+The phone ActivityBar uses the OpenAlice-owned Sheet primitive for its portal,
+backdrop, scroll lock, focus containment, Escape handling, outside dismissal,
+animation, and focus return. The static desktop rail keeps its existing
+information hierarchy, density, collapse behavior, and lifetime.
+
+## Scope
+
+### In scope
+
+- Replace the phone ActivityBar's document-level keyboard and focus loop with
+  the shared Sheet behavior introduced by #970.
+- Remove the duplicate App-level body scroll lock.
+- Preserve the current destination as initial focus and return focus to the
+  mobile rail trigger after dismissal.
+- Keep the 280 px phone rail, current navigation grouping, touch targets,
+  badges, footer controls, and desktop widths visually stable.
+- Add reduced-motion coverage to the shared Sheet surface and overlay.
+
+### Not in scope
+
+- Restyling or regrouping top-level navigation.
+- Migrating the ActivityBar section information disclosure to a Popover.
+- Changing page-owned navigators, `WorkspaceAIConfigModal`, or the remaining
+  Workspace/session chooser menus.
+- Publishing a stacked PR before its foundation is present on `dev`.
+
+## Decisions
+
+1. The phone Sheet portal unmounts while closed; the desktop rail remains a
+   normal mounted `aside`.
+2. The App keeps its explicit background `inert` contract while the phone rail
+   is open. Sheet owns generic modal behavior; App owns the shell hierarchy.
+3. This is a serial follow-on, not extra scope added to autonomous Draft PR
+   #970 and not a second simultaneously published contribution.
+
+## Work
+
+- [x] Audit the current ActivityBar and its responsive shell ownership.
+- [x] Migrate the phone rail to Sheet and delete superseded backdrop, body
+      scroll lock, document Escape listener, and manual focus loop.
+- [x] Verify closed unmounting, overlay dismissal, current-item focus, Tab
+      containment, Escape, focus return, desktop persistence, and touch sizes
+      in focused tests.
+- [x] Run root and UI type checks plus the full Vitest suite.
+- [ ] Walk the real `pnpm dev` Inbox route at phone and desktop widths with
+      keyboard and pointer input. The controlled in-app browser is currently
+      on a Chromium connection-error page and its URL policy rejected agent
+      navigation after the development server recovered.
+- [x] Run the unsigned packaged Electron Workspace smoke.
+- [ ] After #970 is explicitly accepted, update from `dev`, replay this atomic
+      commit on a fresh serial branch, rerun affected checks, and open/merge a
+      dev-targeted PR.
+
+## Verification Evidence
+
+- `npx tsc --noEmit`
+- `pnpm -C ui exec tsc -b`
+- `pnpm test` — 470 files and 3,900 tests passed; one file and nine tests keep
+  their existing skips.
+- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` — unsigned
+  packaged Workspace acceptance passed and cleaned its temporary app.
+- Browser/dev — not yet accepted; a running Vite server alone is not visual or
+  interaction evidence.
+
+## Completion Criteria
+
+- No ActivityBar-owned generic modal focus loop, backdrop, body scroll lock, or
+  document Escape handler remains.
+- Phone and desktop routes preserve the existing hierarchy and usable width.
+- Required type checks, full tests, real browser verification, and Electron
+  smoke pass.
+- The serial PR is merged to `dev`, its post-merge run is inspected, and the
+  working checkout returns to updated `dev`.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -94,17 +94,6 @@ function AppShellContent() {
     if (isDesktop) setSidebarOpen(false)
   }, [isDesktop])
 
-  // Lock body scroll while a drawer is open so the page behind doesn't drift
-  // under the backdrop. Restores the previous value on close/unmount.
-  useEffect(() => {
-    if (!sidebarOpen) return
-    const prev = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = prev
-    }
-  }, [sidebarOpen])
-
   const mainContent = (
     <main className="flex flex-col min-w-0 min-h-0 bg-background h-full">
       {/* Mobile header — visible only below md */}

--- a/ui/src/components/ActivityBar.drawer-state.spec.tsx
+++ b/ui/src/components/ActivityBar.drawer-state.spec.tsx
@@ -82,6 +82,7 @@ describe('ActivityBar mobile drawer state', () => {
     expect(mobileActivityBar.getAttribute('data-slot')).toBe('sheet-content')
     expect(mobileActivityBar.getAttribute('role')).toBe('dialog')
     expect(mobileActivityBar.getAttribute('aria-modal')).toBe('true')
+    expect(mobileActivityBar.className).toContain('data-[side=left]:w-[280px]')
 
     rerender(<ActivityBar open={false} onClose={onClose} desktopStatic={false} />)
     expect(screen.queryByTestId('activity-bar')).toBeNull()

--- a/ui/src/components/ActivityBar.drawer-state.spec.tsx
+++ b/ui/src/components/ActivityBar.drawer-state.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ActivityBar } from './ActivityBar'
@@ -69,22 +70,25 @@ afterEach(() => {
 })
 
 describe('ActivityBar mobile drawer state', () => {
-  it('keeps the closed mobile drawer out of navigation without hiding the desktop rail', () => {
+  it('unmounts the closed mobile drawer without hiding the desktop rail', () => {
     const onClose = vi.fn()
     const { rerender } = render(
       <ActivityBar open={false} onClose={onClose} desktopStatic={false} />,
     )
-    const activityBar = screen.getByTestId('activity-bar')
-
-    expect(activityBar.getAttribute('aria-hidden')).toBe('true')
-    expect(activityBar.hasAttribute('inert')).toBe(true)
+    expect(screen.queryByTestId('activity-bar')).toBeNull()
 
     rerender(<ActivityBar open onClose={onClose} desktopStatic={false} />)
-    expect(activityBar.getAttribute('aria-hidden')).toBe('false')
-    expect(activityBar.hasAttribute('inert')).toBe(false)
+    const mobileActivityBar = screen.getByTestId('activity-bar')
+    expect(mobileActivityBar.getAttribute('data-slot')).toBe('sheet-content')
+    expect(mobileActivityBar.getAttribute('role')).toBe('dialog')
+    expect(mobileActivityBar.getAttribute('aria-modal')).toBe('true')
+
+    rerender(<ActivityBar open={false} onClose={onClose} desktopStatic={false} />)
+    expect(screen.queryByTestId('activity-bar')).toBeNull()
 
     rerender(<ActivityBar open={false} onClose={onClose} desktopStatic />)
-    expect(activityBar.getAttribute('aria-hidden')).toBe('false')
+    const activityBar = screen.getByTestId('activity-bar')
+    expect(activityBar.getAttribute('aria-hidden')).toBeNull()
     expect(activityBar.hasAttribute('inert')).toBe(false)
     expect(activityBar.getAttribute('role')).toBeNull()
     expect(activityBar.getAttribute('aria-modal')).toBeNull()
@@ -109,7 +113,19 @@ describe('ActivityBar mobile drawer state', () => {
     expect(sectionInfo.className).toContain('md:min-w-7')
   })
 
-  it('contains mobile focus, closes on Escape, and restores the trigger', () => {
+  it('dismisses through the shared Sheet overlay', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ActivityBar open onClose={onClose} desktopStatic={false} />)
+
+    const overlay = document.querySelector<HTMLElement>('[data-slot="sheet-overlay"]')
+    expect(overlay).toBeTruthy()
+    await user.click(overlay!)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('contains mobile focus, closes on Escape, and restores the trigger', async () => {
+    const user = userEvent.setup()
     const trigger = document.createElement('button')
     document.body.append(trigger)
     trigger.focus()
@@ -128,24 +144,23 @@ describe('ActivityBar mobile drawer state', () => {
     const currentDestination = screen.getByRole('button', { name: 'Settings' })
     const firstAction = screen.getByRole('button', { name: 'Ask Alice' })
     const lastAction = screen.getByRole('button', { name: 'Dev Panel' })
-    const backdrop = document.querySelector<HTMLElement>('.bg-backdrop')
+    const backdrop = document.querySelector<HTMLElement>('[data-slot="sheet-overlay"]')
 
     expect(drawer.getAttribute('aria-modal')).toBe('true')
-    expect(drawer.getAttribute('tabindex')).toBe('-1')
     expect(document.activeElement).toBe(currentDestination)
     expect(drawer.className).toContain('motion-reduce:transition-none')
     expect(backdrop?.getAttribute('aria-hidden')).toBe('true')
-    expect(backdrop?.className).toContain('motion-reduce:transition-none')
+    expect(backdrop?.className).toContain('motion-reduce:animate-none')
 
     lastAction.focus()
-    fireEvent.keyDown(document, { key: 'Tab' })
+    await user.tab()
     expect(document.activeElement).toBe(firstAction)
 
     firstAction.focus()
-    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    await user.tab({ shift: true })
     expect(document.activeElement).toBe(lastAction)
 
-    fireEvent.keyDown(document, { key: 'Escape' })
+    await user.keyboard('{Escape}')
     expect(onClose).toHaveBeenCalledOnce()
 
     rerender(
@@ -156,7 +171,7 @@ describe('ActivityBar mobile drawer state', () => {
         returnFocusRef={returnFocusRef}
       />,
     )
-    expect(document.activeElement).toBe(trigger)
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
     trigger.remove()
   })
 })

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -286,7 +286,7 @@ export function ActivityBar({
         aria-modal="true"
         aria-describedby={undefined}
         showCloseButton={false}
-        className={`${railClassName} max-w-[85vw] gap-0 p-0 shadow-none motion-reduce:animate-none motion-reduce:transition-none sm:max-w-[85vw]`}
+        className={`${railClassName} max-w-[85vw] gap-0 p-0 shadow-none motion-reduce:animate-none motion-reduce:transition-none data-[side=left]:w-[280px] data-[side=left]:max-w-[85vw] sm:max-w-[85vw]`}
         onOpenAutoFocus={(event) => {
           event.preventDefault()
           const drawer = mobileDrawerRef.current

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -9,6 +9,7 @@ import { useActivityBarCollapse } from '../live/activity-bar-collapse'
 import { useTranslation } from 'react-i18next'
 import { ThemeToggle } from './ThemeToggle'
 import { NAV_SECTIONS } from './activity-navigation'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 
 /**
  * Map ActivityBar page enum (visual layout grouping) to the ActivitySection
@@ -102,93 +103,10 @@ export function ActivityBar({
   const compactRail = desktopStatic && (forcedCompactRail || railCollapsed)
   const narrowRail = desktopStatic && railMode === 'narrow' && !compactRail
   const denseRail = desktopStatic && shortRailHeight
-  const mobileDrawerClosed = !desktopStatic && !open
-  const drawerRef = useRef<HTMLElement>(null)
-  const onCloseRef = useRef(onClose)
-  onCloseRef.current = onClose
+  const mobileDrawerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    if (!open || desktopStatic) return
-    const drawer = drawerRef.current
-    if (!drawer) return
-
-    const previousFocus = returnFocusRef?.current
-      ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null)
-    const initialFocus = drawer.querySelector<HTMLElement>('[aria-current="page"]')
-      ?? drawerFocusableElements(drawer)[0]
-      ?? drawer
-    initialFocus.focus()
-
-    const handleDrawerKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        onCloseRef.current()
-        return
-      }
-      if (event.key !== 'Tab') return
-
-      const focusable = drawerFocusableElements(drawer)
-      if (focusable.length === 0) {
-        event.preventDefault()
-        drawer.focus()
-        return
-      }
-
-      const first = focusable[0]!
-      const last = focusable[focusable.length - 1]!
-      const active = document.activeElement
-      if (!drawer.contains(active)) {
-        event.preventDefault()
-        first.focus()
-      } else if (event.shiftKey && active === first) {
-        event.preventDefault()
-        last.focus()
-      } else if (!event.shiftKey && active === last) {
-        event.preventDefault()
-        first.focus()
-      }
-    }
-
-    document.addEventListener('keydown', handleDrawerKeyDown)
-    return () => {
-      document.removeEventListener('keydown', handleDrawerKeyDown)
-      if (previousFocus?.isConnected) previousFocus.focus()
-    }
-  }, [desktopStatic, open, returnFocusRef])
-
-  return (
+  const railContent = (
     <>
-      {/* Backdrop — mobile only */}
-      <div
-        aria-hidden
-        className={`fixed inset-0 bg-backdrop z-40 md:hidden transition-opacity duration-200 motion-reduce:transition-none ${
-          open ? 'opacity-100' : 'opacity-0 pointer-events-none'
-        }`}
-        onClick={onClose}
-      />
-
-      {/* ActivityBar — Linear-style workspace rail. Mobile: slide-in over
-       *  page with backdrop. Desktop: static column flush left. */}
-      <aside
-        ref={drawerRef}
-        id="activity-bar"
-        data-testid="activity-bar"
-        role={!desktopStatic ? 'dialog' : undefined}
-        aria-modal={!desktopStatic && open ? 'true' : undefined}
-        aria-label={!desktopStatic ? t('nav.primaryNavigation') : undefined}
-        aria-hidden={mobileDrawerClosed}
-        inert={mobileDrawerClosed ? true : undefined}
-        tabIndex={!desktopStatic ? -1 : undefined}
-        className={`
-          w-[280px] ${compactRail ? 'md:w-[60px]' : narrowRail ? 'md:w-[152px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
-          bg-muted
-          border-r border-border/80
-          fixed z-50 top-0 left-0 transition-[transform,width] duration-200 motion-reduce:transition-none
-          ${open ? 'translate-x-0' : '-translate-x-full'}
-          md:static md:translate-x-0 md:z-auto
-        `}
-      >
         {/* Branding — h-10 to line up with the Sidebar header and preserve
             the shell's 40px header rhythm. */}
         <div className={`${denseRail ? 'h-10 mb-2 md:h-7 md:mb-0.5' : 'h-10 mb-2'} flex items-center shrink-0 ${compactRail ? 'justify-center px-0' : narrowRail ? 'pl-[18px] pr-3 gap-2' : 'pl-[22px] pr-4 gap-2.5'}`}>
@@ -333,26 +251,61 @@ export function ActivityBar({
             </button>
           )}
         </div>
-      </aside>
     </>
   )
-}
 
-const DRAWER_FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-].join(',')
+  const railClassName = `
+    w-[280px] ${compactRail ? 'md:w-[60px]' : narrowRail ? 'md:w-[152px]' : 'md:w-[188px]'} h-full flex flex-col shrink-0
+    bg-muted border-r border-border/80
+  `
 
-function drawerFocusableElements(drawer: HTMLElement): HTMLElement[] {
-  return [...drawer.querySelectorAll<HTMLElement>(DRAWER_FOCUSABLE_SELECTOR)]
-    .filter((element) => (
-      element.tabIndex >= 0 &&
-      element.closest('[hidden], [aria-hidden="true"], [inert]') === null
-    ))
+  if (desktopStatic) {
+    return (
+      <aside
+        id="activity-bar"
+        data-testid="activity-bar"
+        className={`${railClassName} static z-auto transition-[width] duration-200 motion-reduce:transition-none`}
+      >
+        {railContent}
+      </aside>
+    )
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose()
+      }}
+    >
+      <SheetContent
+        ref={mobileDrawerRef}
+        id="activity-bar"
+        data-testid="activity-bar"
+        side="left"
+        aria-modal="true"
+        aria-describedby={undefined}
+        showCloseButton={false}
+        className={`${railClassName} max-w-[85vw] gap-0 p-0 shadow-none motion-reduce:animate-none motion-reduce:transition-none sm:max-w-[85vw]`}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          const drawer = mobileDrawerRef.current
+          const current = drawer?.querySelector<HTMLElement>('[aria-current="page"]')
+          const firstAction = drawer?.querySelector<HTMLElement>('button:not([disabled])')
+          ;(current ?? firstAction ?? drawer)?.focus({ preventScroll: true })
+        }}
+        onCloseAutoFocus={returnFocusRef
+          ? (event) => {
+            event.preventDefault()
+            returnFocusRef.current?.focus({ preventScroll: true })
+          }
+          : undefined}
+      >
+        <SheetTitle className="sr-only">{t('nav.primaryNavigation')}</SheetTitle>
+        {railContent}
+      </SheetContent>
+    </Sheet>
+  )
 }
 
 // ==================== SectionHeader ====================

--- a/ui/src/components/ui/sheet.tsx
+++ b/ui/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-backdrop duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+        'fixed inset-0 z-50 bg-backdrop duration-150 motion-reduce:animate-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
         className,
       )}
       {...props}
@@ -58,7 +58,7 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          'fixed z-50 flex flex-col gap-4 border-border bg-background text-sm text-foreground shadow-2xl outline-none duration-200 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[state=open]:animate-in data-[side=bottom]:data-[state=open]:slide-in-from-bottom-10 data-[side=left]:data-[state=open]:slide-in-from-left-10 data-[side=right]:data-[state=open]:slide-in-from-right-10 data-[side=top]:data-[state=open]:slide-in-from-top-10 data-[state=closed]:animate-out data-[side=bottom]:data-[state=closed]:slide-out-to-bottom-10 data-[side=left]:data-[state=closed]:slide-out-to-left-10 data-[side=right]:data-[state=closed]:slide-out-to-right-10 data-[side=top]:data-[state=closed]:slide-out-to-top-10',
+          'fixed z-50 flex flex-col gap-4 border-border bg-background text-sm text-foreground shadow-2xl outline-none duration-200 motion-reduce:animate-none motion-reduce:transition-none data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[state=open]:animate-in data-[side=bottom]:data-[state=open]:slide-in-from-bottom-10 data-[side=left]:data-[state=open]:slide-in-from-left-10 data-[side=right]:data-[state=open]:slide-in-from-right-10 data-[side=top]:data-[state=open]:slide-in-from-top-10 data-[state=closed]:animate-out data-[side=bottom]:data-[state=closed]:slide-out-to-bottom-10 data-[side=left]:data-[state=closed]:slide-out-to-left-10 data-[side=right]:data-[state=closed]:slide-out-to-right-10 data-[side=top]:data-[state=closed]:slide-out-to-top-10',
           className,
         )}
         {...props}


### PR DESCRIPTION
## What

- replace the phone-only ActivityBar overlay with the shared shadcn/Radix Sheet primitive
- remove the duplicate backdrop, Escape listener, focus loop, and body-scroll lock from ActivityBar and App
- preserve the desktop aside path and the intended 280px mobile rail width
- respect reduced-motion settings in the shared Sheet primitive

## Why

The mobile rail had accumulated a second hand-written dialog stack beside the new overlay foundation. Moving it onto the shared primitive consolidates focus containment, dismissal, portal, accessibility, and scroll-lock behavior while keeping the visible navigation model unchanged.

## Impact

- phone rail now uses Radix dialog semantics and unmounts when closed
- desktop ActivityBar remains a normal aside
- background shell stays inert while the rail is open
- no persisted data or backend contract changes

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- focused Vitest: 4 files, 11 tests
- `pnpm test`: 470 files passed, 1 skipped; 3900 tests passed, 9 skipped
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- real `pnpm dev --takeover` browser walk at 390x844 and 1280x900: open/close, Escape, backdrop, focus return, navigation, inert background, Day/Night themes, exact 280px width, desktop aside preservation, clean console

The rebased branch has the exact same Git tree hash as the fully verified pre-rebase tree.