### PR TITLE
Keep nested overlays inside modal boundaries

### DIFF
--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -107,6 +107,10 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
 
 - Use an existing owned primitive before adding document-level listeners or a
   new focus trap for a dialog, sheet, popover, menu, or tooltip.
+- Modal Dialog, AlertDialog, and Sheet content establishes the portal boundary
+  for descendant non-modal overlays. Dropdown menus, popovers, and tooltips
+  must use the nearest boundary instead of escaping to `body`, where the owning
+  modal would make them inert or place them below its backdrop.
 - Keep generated primitives bound to semantic tokens. Running the shadcn CLI
   must not replace `ui/src/index.css`, palette definitions, typography, or the
   current default visual hierarchy.

--- a/ui/src/components/ui/alert-dialog.tsx
+++ b/ui/src/components/ui/alert-dialog.tsx
@@ -2,6 +2,10 @@ import * as React from 'react'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
 import { Button } from '@/components/ui/button'
+import {
+  OverlayPortalBoundary,
+  useOverlayPortalBoundary,
+} from '@/components/ui/overlay-portal-boundary'
 import { cn } from '@/lib/utils'
 
 function AlertDialog(props: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
@@ -38,19 +42,28 @@ function AlertDialogOverlay({
 
 function AlertDialogContent({
   className,
+  children,
+  ref: forwardedRef,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  const { boundaryRef, container } = useOverlayPortalBoundary<HTMLDivElement>(forwardedRef)
+
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
+        ref={boundaryRef}
         data-slot="alert-dialog-content"
         className={cn(
           'oa-dialog-surface fixed left-1/2 top-1/2 z-[60] grid w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-background p-5 text-foreground shadow-2xl outline-none duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           className,
         )}
         {...props}
-      />
+      >
+        <OverlayPortalBoundary container={container}>
+          {children}
+        </OverlayPortalBoundary>
+      </AlertDialogPrimitive.Content>
     </AlertDialogPortal>
   )
 }

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -3,6 +3,10 @@ import { XIcon } from 'lucide-react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 
 import { Button } from '@/components/ui/button'
+import {
+  OverlayPortalBoundary,
+  useOverlayPortalBoundary,
+} from '@/components/ui/overlay-portal-boundary'
 import { cn } from '@/lib/utils'
 
 function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
@@ -43,16 +47,20 @@ function DialogContent({
   overlayClassName,
   showCloseButton = false,
   closeLabel = 'Close',
+  ref: forwardedRef,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   overlayClassName?: string
   showCloseButton?: boolean
   closeLabel?: string
 }) {
+  const { boundaryRef, container } = useOverlayPortalBoundary<HTMLDivElement>(forwardedRef)
+
   return (
     <DialogPortal>
       <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
+        ref={boundaryRef}
         data-slot="dialog-content"
         className={cn(
           'oa-dialog-surface fixed left-1/2 top-1/2 z-[60] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-background p-4 text-sm text-foreground shadow-2xl outline-none duration-150 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 sm:max-w-sm',
@@ -60,19 +68,21 @@ function DialogContent({
         )}
         {...props}
       >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close data-slot="dialog-close" asChild>
-            <Button
-              variant="ghost"
-              className="absolute right-2 top-2"
-              size="icon-sm"
-            >
-              <XIcon />
-              <span className="sr-only">{closeLabel}</span>
-            </Button>
-          </DialogPrimitive.Close>
-        )}
+        <OverlayPortalBoundary container={container}>
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close data-slot="dialog-close" asChild>
+              <Button
+                variant="ghost"
+                className="absolute right-2 top-2"
+                size="icon-sm"
+              >
+                <XIcon />
+                <span className="sr-only">{closeLabel}</span>
+              </Button>
+            </DialogPrimitive.Close>
+          )}
+        </OverlayPortalBoundary>
       </DialogPrimitive.Content>
     </DialogPortal>
   )

--- a/ui/src/components/ui/dropdown-menu.tsx
+++ b/ui/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 
+import { useOverlayPortalContainer } from '@/components/ui/overlay-portal-boundary'
 import { cn } from "@/lib/utils"
 import { CheckIcon, ChevronRightIcon } from "lucide-react"
 
@@ -13,8 +14,14 @@ function DropdownMenu({
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  const container = useOverlayPortalContainer()
+
   return (
-    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+    <DropdownMenuPrimitive.Portal
+      data-slot="dropdown-menu-portal"
+      container={container ?? undefined}
+      {...props}
+    />
   )
 }
 
@@ -36,7 +43,7 @@ function DropdownMenuContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPortal>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
@@ -44,7 +51,7 @@ function DropdownMenuContent({
         className={cn("z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
         {...props}
       />
-    </DropdownMenuPrimitive.Portal>
+    </DropdownMenuPortal>
   )
 }
 

--- a/ui/src/components/ui/overlay-portal-boundary.tsx
+++ b/ui/src/components/ui/overlay-portal-boundary.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+
+const OverlayPortalBoundaryContext = React.createContext<HTMLElement | null>(null)
+
+function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null) {
+  if (typeof ref === 'function') {
+    ref(value)
+    return
+  }
+  if (ref) ref.current = value
+}
+
+function OverlayPortalBoundary({
+  container,
+  children,
+}: {
+  container: HTMLElement | null
+  children: React.ReactNode
+}) {
+  return (
+    <OverlayPortalBoundaryContext.Provider value={container}>
+      {children}
+    </OverlayPortalBoundaryContext.Provider>
+  )
+}
+
+function useOverlayPortalBoundary<T extends HTMLElement>(forwardedRef?: React.Ref<T>) {
+  const [container, setContainer] = React.useState<T | null>(null)
+  const boundaryRef = React.useCallback((node: T | null) => {
+    setContainer(node)
+    assignRef(forwardedRef, node)
+  }, [forwardedRef])
+
+  return { boundaryRef, container }
+}
+
+function useOverlayPortalContainer() {
+  return React.useContext(OverlayPortalBoundaryContext)
+}
+
+export {
+  OverlayPortalBoundary,
+  useOverlayPortalBoundary,
+  useOverlayPortalContainer,
+}

--- a/ui/src/components/ui/popover.tsx
+++ b/ui/src/components/ui/popover.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as PopoverPrimitive from '@radix-ui/react-popover'
 
+import { useOverlayPortalContainer } from '@/components/ui/overlay-portal-boundary'
 import { cn } from "@/lib/utils"
 
 function Popover({
@@ -21,8 +22,10 @@ function PopoverContent({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  const container = useOverlayPortalContainer()
+
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container ?? undefined}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}

--- a/ui/src/components/ui/sheet.tsx
+++ b/ui/src/components/ui/sheet.tsx
@@ -3,6 +3,10 @@ import { XIcon } from 'lucide-react'
 import * as SheetPrimitive from '@radix-ui/react-dialog'
 
 import { Button } from '@/components/ui/button'
+import {
+  OverlayPortalBoundary,
+  useOverlayPortalBoundary,
+} from '@/components/ui/overlay-portal-boundary'
 import { cn } from '@/lib/utils'
 
 function Sheet(props: React.ComponentProps<typeof SheetPrimitive.Root>) {
@@ -44,16 +48,20 @@ function SheetContent({
   showCloseButton = false,
   closeLabel = 'Close',
   forceMount,
+  ref: forwardedRef,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left'
   showCloseButton?: boolean
   closeLabel?: string
 }) {
+  const { boundaryRef, container } = useOverlayPortalBoundary<HTMLDivElement>(forwardedRef)
+
   return (
     <SheetPortal forceMount={forceMount}>
       <SheetOverlay forceMount={forceMount} />
       <SheetPrimitive.Content
+        ref={boundaryRef}
         forceMount={forceMount}
         data-slot="sheet-content"
         data-side={side}
@@ -63,19 +71,21 @@ function SheetContent({
         )}
         {...props}
       >
-        {children}
-        {showCloseButton && (
-          <SheetPrimitive.Close data-slot="sheet-close" asChild>
-            <Button
-              variant="ghost"
-              className="absolute right-3 top-3"
-              size="icon-sm"
-            >
-              <XIcon />
-              <span className="sr-only">{closeLabel}</span>
-            </Button>
-          </SheetPrimitive.Close>
-        )}
+        <OverlayPortalBoundary container={container}>
+          {children}
+          {showCloseButton && (
+            <SheetPrimitive.Close data-slot="sheet-close" asChild>
+              <Button
+                variant="ghost"
+                className="absolute right-3 top-3"
+                size="icon-sm"
+              >
+                <XIcon />
+                <span className="sr-only">{closeLabel}</span>
+              </Button>
+            </SheetPrimitive.Close>
+          )}
+        </OverlayPortalBoundary>
       </SheetPrimitive.Content>
     </SheetPortal>
   )

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 
+import { useOverlayPortalContainer } from '@/components/ui/overlay-portal-boundary'
 import { cn } from "@/lib/utils"
 
 function TooltipProvider({
@@ -34,8 +35,10 @@ function TooltipContent({
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  const container = useOverlayPortalContainer()
+
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={container ?? undefined}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}

--- a/ui/src/components/workspace/SidebarActionMenu.spec.tsx
+++ b/ui/src/components/workspace/SidebarActionMenu.spec.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Pencil, Trash2 } from 'lucide-react'
 
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { SidebarActionMenu } from './SidebarActionMenu'
 
 afterEach(cleanup)
@@ -67,5 +68,27 @@ describe('SidebarActionMenu', () => {
 
     expect(screen.queryByRole('menu')).toBeNull()
     expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('keeps its portal inside a modal Sheet boundary', async () => {
+    const user = userEvent.setup()
+    render(
+      <Sheet open>
+        <SheetContent aria-describedby={undefined}>
+          <SheetTitle>Ask Alice</SheetTitle>
+          <SidebarActionMenu
+            label="More actions for Session"
+            items={[{ label: 'Delete Session', icon: <Trash2 />, onSelect: vi.fn(), danger: true }]}
+          />
+        </SheetContent>
+      </Sheet>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'More actions for Session' }))
+
+    const sheet = screen.getByRole('dialog', { name: 'Ask Alice' })
+    const menu = screen.getByRole('menu', { name: 'More actions for Session' })
+    expect(sheet.contains(menu)).toBe(true)
+    expect(menu.closest('[data-radix-popper-content-wrapper]')?.parentElement).toBe(sheet)
   })
 })


### PR DESCRIPTION
## What

- add a shared portal boundary owned by Dialog, AlertDialog, and Sheet content
- route nested DropdownMenu, Popover, and Tooltip portals into their nearest modal boundary
- add regression coverage for a SidebarActionMenu rendered inside a Sheet
- document the nested-overlay ownership contract

## Root cause

At tablet widths, Ask Alice's page sidebar is rendered inside a modal Sheet. The session action DropdownMenu still portaled to `document.body`, so Radix correctly treated it as content outside the owning modal: the wrapper received `pointer-events: none` and rendered below the Sheet. The menu existed in the DOM but could not be seen or used.

## Impact

Nested floating controls now stay in the modal that owns their trigger. Desktop behavior is unchanged, while tablet and phone menus remain visible, interactive, keyboard-dismissible, and correctly focused.

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- focused Vitest: 4 files, 13 tests
- `pnpm test`: 470 files passed, 1 skipped; 3901 tests passed, 9 skipped
- real `pnpm dev` at 732×802 on Ask Alice: menu inside Sheet, pointer events enabled, 220px menu in viewport, Escape closes only the menu and returns focus to its trigger, clean console
