### PR TITLE
fix shadcn overlay focus handoff

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/shadcn-systematic-ui-audit.md]] — Systematically walks every
+  installed shadcn/Base UI primitive through its real OpenAlice feature entry,
+  responsive modes, palettes, and keyboard/pointer behavior, repairing any
+  migration regressions before serial integration.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY

--- a/plans/shadcn-systematic-ui-audit.md
+++ b/plans/shadcn-systematic-ui-audit.md
@@ -1,0 +1,77 @@
+# shadcn Systematic UI Audit
+
+- Status: `active`
+- Updated: `2026-08-04`
+- Delivery: one serial PR targeting `dev` if the audit finds changes.
+- Related PR: #973.
+- Owner guides: [[docs/ui-interaction-and-motion.md]],
+  [[docs/development-workflow.md]], and [[docs/project-structure.md]].
+
+## Outcome
+
+Every installed shadcn/Base UI primitive is exercised through a real OpenAlice
+feature rather than inferred from typechecks or isolated primitive tests. Any
+migration regression is repaired at the product call site or with the official
+primitive API, without rebuilding a parallel overlay/focus system.
+
+## Acceptance Matrix
+
+| Primitive | Real product entry | Required evidence |
+|---|---|---|
+| Button | generated Dialog/Sheet close controls and ordinary form actions | pointer and keyboard activation, focus ring, disabled state, no layout drift |
+| Dialog | AI credential, Create Workspace, Workspace offboarding, UTA forms | centered/fullscreen geometry, initial focus, focus containment/return, Escape/backdrop dismissal, scroll |
+| AlertDialog | Inbox/Workspace/provider destructive confirmations | safe initial focus, cancel/Escape, pending lock, focus return, narrow viewport |
+| Sheet | phone ActivityBar and page-owned secondary navigators | overlay dismissal, current-item focus, focus loop/return, content selection, nested overlay |
+| DropdownMenu | Workspace and Session action menus | pointer and keyboard open/select, outside/Escape dismissal, edge positioning, nested Sheet use |
+| Popover | Inbox sender identity and Issue Session provenance | pointer/keyboard open, non-modal focus, outside/Escape dismissal, focus return, mobile fit |
+| Tooltip | shared primitive baseline (currently no product consumer) | source/registry parity and focused primitive smoke until a product consumer exists |
+
+All interactive rows are checked at representative phone (390px), narrow
+tablet (740px), wide tablet (900px), and desktop (1200px) widths. At least one
+desktop and one constrained-width pass run in both Paper and Iris palettes.
+
+## Work
+
+- [x] Inventory every primitive consumer and map it to a reachable real-data
+      route without using demo mode.
+- [x] Exercise pointer, keyboard, focus, dismissal, and viewport behavior for
+      every matrix row in `pnpm dev`.
+- [x] Repair each confirmed regression and add the narrowest durable test that
+      would have caught it.
+- [x] Run root/UI typechecks, the full Vitest suite, production UI build, and
+      unsigned packaged Electron Workspace smoke.
+- [ ] Prepare and merge one serial PR to `dev`, then inspect the post-merge
+      smoke and archive this plan under Completed.
+
+## Audit Record
+
+- Exercised Chat and Workspace action menus at 390, 740, 900, and 1200 pixels,
+  including a menu nested in the mobile Sheet and the menu-to-AlertDialog and
+  menu-to-Dialog handoffs.
+- Exercised AI credential, Create Workspace, Workspace offboarding, and UTA
+  dialogs; provider and Session deletion confirmations; mobile ActivityBar and
+  page navigator Sheets; and Inbox/Issue identity Popovers in real `pnpm dev`.
+- Confirmed Paper and Iris rendering at desktop and constrained widths, body
+  scroll locking, narrow-screen overlay bounds, safe initial focus, Escape and
+  outside dismissal, and return focus.
+- Repaired a confirmed focus regression: selecting a menu item that opens a
+  follow-up dialog captured the disappearing menu item as its return target.
+  Actions now run after the menu closes and focus returns to the durable trigger.
+- Confirmed Tooltip has no product consumer yet and matches Base UI's visual-only
+  tooltip semantics; added focused pointer and keyboard smoke coverage.
+- Verification passed: root and UI TypeScript, 3,904 Vitest tests (plus 9
+  skipped), the production UI build, and unsigned packaged Electron Workspace
+  acceptance. One UTA registry test exceeded its 5-second timeout only while
+  running concurrently with the first production build; its isolated rerun and
+  the subsequent independent full suite passed.
+
+## Completion Criteria
+
+- Each installed primitive has authoritative real-surface or explicit
+  no-consumer evidence.
+- Every reachable overlay works with pointer and keyboard input across its
+  responsive ownership boundary and returns focus predictably.
+- No browser console errors, inert interactive overlays, clipped menus, or
+  off-viewport dialogs remain in the audited routes.
+- All required local and packaged checks pass, and any integration PR is merged
+  with a successful post-merge `dev` smoke.

--- a/ui/src/components/ui/tooltip.spec.tsx
+++ b/ui/src/components/ui/tooltip.spec.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './tooltip'
+
+afterEach(cleanup)
+
+function TooltipHarness() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger aria-label="Explains this control">?</TooltipTrigger>
+        <TooltipContent>Explains this control</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+describe('Tooltip', () => {
+  it('opens from pointer hover and closes when the pointer leaves', async () => {
+    const user = userEvent.setup()
+    render(<TooltipHarness />)
+
+    const trigger = screen.getByRole('button', { name: 'Explains this control' })
+    await user.hover(trigger)
+    await waitFor(() => expect(
+      document.querySelector('[data-slot="tooltip-content"]')?.textContent,
+    ).toContain('Explains this control'))
+
+    await user.unhover(trigger)
+    await waitFor(() => expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull())
+  })
+
+  it('opens for keyboard focus and closes on Escape without losing focus', async () => {
+    const user = userEvent.setup()
+    render(<TooltipHarness />)
+
+    const trigger = screen.getByRole('button', { name: 'Explains this control' })
+    await user.tab()
+    expect(document.activeElement).toBe(trigger)
+    await waitFor(() => expect(
+      document.querySelector('[data-slot="tooltip-content"]')?.textContent,
+    ).toContain('Explains this control'))
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull())
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/ui/src/components/workspace/SidebarActionMenu.spec.tsx
+++ b/ui/src/components/workspace/SidebarActionMenu.spec.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
+import { useState } from 'react'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Pencil, Trash2 } from 'lucide-react'
 
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
+import { ConfirmDialog } from '../ConfirmDialog'
 import { SidebarActionMenu } from './SidebarActionMenu'
 
 afterEach(cleanup)
@@ -94,5 +96,46 @@ describe('SidebarActionMenu', () => {
     expect(menu.hasAttribute('data-open')).toBe(true)
     expect(menu.closest('[inert]')).toBeNull()
     expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Delete Session' }))
+  })
+
+  it('hands focus to a follow-up dialog and restores the durable menu trigger', async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [confirming, setConfirming] = useState(false)
+      return (
+        <>
+          <SidebarActionMenu
+            label="More actions for Session"
+            items={[{
+              label: 'Delete Session',
+              icon: <Trash2 />,
+              onSelect: () => setConfirming(true),
+              danger: true,
+            }]}
+          />
+          {confirming && (
+            <ConfirmDialog
+              title="Delete Session?"
+              message="This cannot be undone."
+              onConfirm={() => {}}
+              onClose={() => setConfirming(false)}
+            />
+          )}
+        </>
+      )
+    }
+
+    render(<Harness />)
+    const trigger = screen.getByRole('button', { name: 'More actions for Session' })
+    trigger.focus()
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(screen.getByRole('alertdialog', { name: 'Delete Session?' })).toBeTruthy())
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' })))
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
   })
 })

--- a/ui/src/components/workspace/SidebarActionMenu.tsx
+++ b/ui/src/components/workspace/SidebarActionMenu.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 import { Ellipsis } from 'lucide-react'
 
 import {
@@ -23,10 +23,23 @@ export function SidebarActionMenu({
   label: string
   items: readonly SidebarActionMenuItem[]
 }) {
+  const pendingActionRef = useRef<(() => void) | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChangeComplete={(open) => {
+        if (open) return
+        const action = pendingActionRef.current
+        pendingActionRef.current = null
+        if (!action) return
+        triggerRef.current?.focus()
+        action()
+      }}
+    >
       <DropdownMenuTrigger
         render={<button
+          ref={triggerRef}
           type="button"
           className="oa-icon-action oa-workspace-row-action flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-secondary hover:text-foreground"
           aria-label={label}
@@ -46,7 +59,12 @@ export function SidebarActionMenu({
             aria-label={item.ariaLabel}
             variant={item.danger ? 'destructive' : 'default'}
             className="flex min-h-9 w-full cursor-default items-center gap-2 rounded-none px-3 py-2 text-left text-[12px] transition-colors focus:bg-muted"
-            onClick={item.onSelect}
+            onClick={() => {
+              // Base UI restores focus to the trigger as the menu finishes
+              // closing. Run follow-up dialogs only after that handoff so they
+              // capture a durable return target instead of an unmounted item.
+              pendingActionRef.current = item.onSelect
+            }}
           >
             <span className="flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>
               {item.icon}


### PR DESCRIPTION
## What changed

- run a systematic real-surface audit of every installed shadcn/Base UI primitive across phone, tablet, desktop, Paper, and Iris
- defer Workspace/Session menu actions until Base UI finishes closing the menu and restores focus to the durable trigger
- add integration coverage for menu-to-confirmation focus handoff and focused Tooltip pointer/keyboard smoke
- record the audit matrix and verification evidence in the implementation plan

## Root cause

A menu item that opened a follow-up Dialog or AlertDialog ran before the DropdownMenu had completed its close/focus lifecycle. The confirmation captured the soon-to-unmount menu item as its return target, so closing the dialog dropped focus onto the document body.

## User impact

Destructive and lifecycle flows opened from Workspace or Session action menus now return keyboard focus to the originating ellipsis button, including inside the mobile Sheet. No overlay was replaced with a custom focus or positioning system.

## Verification

- real `pnpm dev` browser walks at 390, 740, 900, and 1200 px in Paper and Iris
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 3,904 passed, 9 skipped
- `pnpm -F open-alice-ui build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
