### PR TITLE
docs complete shadcn UI audit plan

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,10 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/shadcn-systematic-ui-audit.md]] — Systematically walks every
-  installed shadcn/Base UI primitive through its real OpenAlice feature entry,
-  responsive modes, palettes, and keyboard/pointer behavior, repairing any
-  migration regressions before serial integration.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY
@@ -32,6 +28,10 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/shadcn-systematic-ui-audit.md]] — Exercised every installed
+  shadcn/Base UI primitive through real product entries, repaired the
+  menu-to-dialog focus handoff, and passed browser, full-suite, build, and
+  packaged Electron acceptance. Delivered in serial PR #974.
 - [[plans/shadcn-base-ui-migration.md]] — Replaced the initial Radix-backed
   shadcn primitives and custom overlay patches with the official Base UI + Nova
   source while preserving OpenAlice's product hierarchy and palette. Delivered

--- a/plans/shadcn-systematic-ui-audit.md
+++ b/plans/shadcn-systematic-ui-audit.md
@@ -1,6 +1,6 @@
 # shadcn Systematic UI Audit
 
-- Status: `active`
+- Status: `completed`
 - Updated: `2026-08-04`
 - Delivery: one serial PR targeting `dev` if the audit finds changes.
 - Related PR: #973.
@@ -40,7 +40,7 @@ desktop and one constrained-width pass run in both Paper and Iris palettes.
       would have caught it.
 - [x] Run root/UI typechecks, the full Vitest suite, production UI build, and
       unsigned packaged Electron Workspace smoke.
-- [ ] Prepare and merge one serial PR to `dev`, then inspect the post-merge
+- [x] Prepare and merge one serial PR to `dev`, then inspect the post-merge
       smoke and archive this plan under Completed.
 
 ## Audit Record
@@ -64,6 +64,9 @@ desktop and one constrained-width pass run in both Paper and Iris palettes.
   acceptance. One UTA registry test exceeded its 5-second timeout only while
   running concurrently with the first production build; its isolated rerun and
   the subsequent independent full suite passed.
+- Serial PR #974 merged to `dev`; the updated integration checkout passed the
+  focused six-test overlay suite and the real mobile
+  Sheet-to-menu-to-AlertDialog Escape/focus-return flow.
 
 ## Completion Criteria
 


### PR DESCRIPTION
## Summary

- mark the shadcn systematic UI audit complete after PR #974 merged
- move the execution plan from Active to Completed
- record the focused post-merge `dev` test and browser smoke evidence

## Verification

Documentation-only follow-up to locally and packaged-verified PR #974. `git diff --check` passes.