### PR TITLE
feat(ui): add runtime-selectable style profiles

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,9 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/runtime-ui-style-profiles.md]] — Adds independent runtime-selectable
+  component appearance profiles for Default, Windows 98, and Broker Classic
+  while preserving palette choice and shared shadcn/Base UI behavior.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -120,6 +120,13 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
 - Treat `data-slot` as the stable styling seam. Future selectable UI styles
   may vary geometry, elevation, density, typography, and motion through that
   seam; `data-palette` remains the color axis.
+- Runtime-selectable component appearance is published as `data-ui-style` on
+  the document root. Profiles may restyle owned `data-slot` primitives and
+  shared `oa-*` shell/form seams, but must not branch product behavior, fork a
+  primitive, hard-code a second color system, or recolor terminal ANSI output.
+  Keep the current workstation as the compatibility default and gate compact
+  desktop density behind both sufficient width and a fine pointer so a visual
+  profile never reduces touch usability.
 - Delete superseded event plumbing during migration. A component is not
   migrated if its old global Escape/outside-click/focus-loop implementation is
   still running beside the primitive.

--- a/plans/runtime-ui-style-profiles.md
+++ b/plans/runtime-ui-style-profiles.md
@@ -1,0 +1,72 @@
+# Runtime UI Style Profiles
+
+- Status: `active`
+- Updated: `2026-08-04`
+- Delivery: one serial PR targeting `dev`.
+- Owner guides: [[docs/ui-interaction-and-motion.md]],
+  [[docs/development-workflow.md]], and [[docs/project-structure.md]].
+
+## Outcome
+
+OpenAlice can switch its component appearance at runtime without reloading or
+changing the selected color palettes. The first release keeps the current
+workstation as Default and adds Windows 98 and Broker Classic profiles. The
+profiles reuse owned shadcn/Base UI behavior and semantic color tokens rather
+than forking components or introducing profile-specific product logic.
+
+## Decisions
+
+- `data-palette` remains the independent color axis. A new `data-ui-style`
+  attribute owns typography, geometry, elevation, density, and motion.
+- Default is byte-for-byte compatible with the current visual language.
+- Windows 98 uses square geometry, semantic beveled surfaces, classic pressed
+  states, and reduced decorative motion without copying system assets.
+- Broker Classic is an IBKR/TWS-inspired dense workstation profile, not an
+  IBKR brand replica. It uses compact flat controls, strong separators, and
+  tabular data while retaining OpenAlice semantic colors and identity.
+- Touch targets stay usable at narrow widths. Broker density reductions apply
+  only on desktop-sized fine-pointer devices.
+- The persisted choice is normalized defensively and injected by the inline
+  no-flash bootstrap before React renders.
+
+## Work
+
+- [x] Add the style-profile registry, persisted preference, document attribute,
+      no-flash bootstrap, and migration-focused tests.
+- [x] Add a live Settings selector with localized names, descriptions, and
+      miniature profile previews.
+- [x] Style shared shadcn slots and OpenAlice shell/form seams for Windows 98
+      and Broker Classic without changing primitive behavior.
+- [x] Exercise Settings, Chat, sidebars, forms, tables, menus, popovers,
+      dialogs, alert dialogs, and sheets in the real development runtime at
+      desktop, tablet, and phone widths.
+- [x] Run root/UI typechecks, the full Vitest suite, production UI build, and
+      unsigned packaged Electron Workspace smoke.
+- [ ] Merge the serial PR to `dev`, run a post-merge smoke, and archive this
+      plan under Completed.
+
+## Verification Record
+
+- Confirmed live switching, persistence across reload, and independent palette
+  selection in Settings; restored the user's original Default + Auto state
+  after testing.
+- Exercised Default, Windows 98, and Broker Classic on Settings, Chat, a real
+  Portfolio account, and an Issue activity trail. Verified the Chat menu,
+  destructive confirmation, Place Order form without submitting, identity
+  popover, mobile Sheet, and a menu nested inside that Sheet.
+- Checked the 1280px desktop surface, 740px tablet layout, and 390px phone
+  layout. Broker density applies on desktop while phone controls retain their
+  touch-size floor.
+- Passed root and UI TypeScript, 3,907 Vitest tests (plus 9 skipped), the
+  production UI build, and unsigned packaged Electron Workspace acceptance.
+
+## Completion Criteria
+
+- Changing profiles updates the active page and open shared primitives without
+  reload, preserves the palette pair, and survives restart.
+- All three profiles remain legible in day and night palettes and preserve
+  keyboard focus, dismissal, reduced-motion, and responsive behavior.
+- No profile ships hard-coded product colors, copied brand assets, duplicated
+  overlay behavior, or profile-specific domain branches.
+- Required local, browser, and packaged checks pass, and the integration PR is
+  merged with a successful post-merge smoke.

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="auto" data-palette="paper" data-day-palette="paper" data-night-palette="graphite">
+<html lang="en" data-theme="auto" data-palette="paper" data-day-palette="paper" data-night-palette="graphite" data-ui-style="default">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -22,6 +22,8 @@
           var storedNight = palettes.indexOf(state.nightPalette) >= 0 ? state.nightPalette : state.darkPalette;
           var day = palettes.indexOf(storedDay) >= 0 ? storedDay : 'paper';
           var night = palettes.indexOf(storedNight) >= 0 ? storedNight : 'graphite';
+          var uiStyles = ['default', 'win98', 'broker-classic'];
+          var uiStyle = uiStyles.indexOf(state.uiStyle) >= 0 ? state.uiStyle : 'default';
           var effective = t === 'auto'
             ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'night' : 'day')
             : t;
@@ -29,12 +31,14 @@
           root.dataset.theme = t;
           root.dataset.dayPalette = day;
           root.dataset.nightPalette = night;
+          root.dataset.uiStyle = uiStyle;
           root.dataset.palette = effective === 'night' ? night : day;
         } catch (e) {
           var root = document.documentElement;
           root.dataset.theme = 'auto';
           root.dataset.dayPalette = 'paper';
           root.dataset.nightPalette = 'graphite';
+          root.dataset.uiStyle = 'default';
           root.dataset.palette = 'paper';
         }
       })();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -285,6 +285,8 @@ export const en = {
     appearance: {
       title: 'Appearance',
       description: 'Color and layout preferences. Stored locally on this device.',
+      interfaceStyle: 'Interface style',
+      interfaceStyleDescription: 'Changes component shape, density, typography, and motion without changing your colors.',
       colorMode: 'Color mode',
       colorModeDescription: 'Auto follows the system between Day and Night slots; Day and Night pin one slot.',
       dayPalette: 'Day palette',
@@ -1210,6 +1212,16 @@ export const en = {
   theme: {
     mode: { auto: 'Auto', day: 'Day', night: 'Night' },
     switchTo: 'Switch to {{mode}}',
+    uiStyle: {
+      default: 'Default',
+      win98: 'Windows 98',
+      'broker-classic': 'Broker Classic',
+    },
+    uiStyleDescription: {
+      default: 'The calm OpenAlice workstation',
+      win98: 'Square, beveled, and unmistakably classic',
+      'broker-classic': 'Dense TWS-inspired trading workstation',
+    },
     palette: {
       paper: 'Paper', porcelain: 'Porcelain', linen: 'Linen',
       graphite: 'Graphite', midnight: 'Midnight', moss: 'Moss', iris: 'Iris',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -274,6 +274,8 @@ export const ja: Resources = {
     appearance: {
       title: '外観',
       description: '色とレイアウトの設定。この端末にのみ保存されます。',
+      interfaceStyle: 'インターフェーススタイル',
+      interfaceStyleDescription: '選択中の色を変えずに、形状、密度、書体、モーションを変更します。',
       colorMode: 'カラーモード',
       colorModeDescription: '自動はシステムに追従して昼と夜のスロットを切り替え、昼と夜は対応するスロットに固定します。',
       dayPalette: '昼用パレット',
@@ -1199,6 +1201,16 @@ export const ja: Resources = {
   theme: {
     mode: { auto: '自動', day: '昼', night: '夜' },
     switchTo: '{{mode}}に切り替え',
+    uiStyle: {
+      default: 'デフォルト',
+      win98: 'Windows 98',
+      'broker-classic': 'Broker Classic',
+    },
+    uiStyleDescription: {
+      default: '落ち着いた OpenAlice ワークステーション',
+      win98: '角張った立体感のあるクラシックスタイル',
+      'broker-classic': 'TWS に着想を得た高密度な取引画面',
+    },
     palette: {
       paper: 'ペーパー', porcelain: 'ポーセリン', linen: 'リネン',
       graphite: 'グラファイト', midnight: 'ミッドナイト', moss: 'モス', iris: 'アイリス',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -281,6 +281,8 @@ export const zhHant: Resources = {
     appearance: {
       title: '外觀',
       description: '色彩與版面偏好，僅儲存在本機。',
+      interfaceStyle: '介面樣式',
+      interfaceStyleDescription: '調整元件外形、密度、字體與動效，不會改變你選擇的色卡。',
       colorMode: '色彩模式',
       colorModeDescription: '自動模式跟隨系統在日間與暗夜槽位間切換；日間與暗夜模式會固定對應槽位。',
       dayPalette: '日間色卡',
@@ -1206,6 +1208,16 @@ export const zhHant: Resources = {
   theme: {
     mode: { auto: '自動', day: '日間', night: '暗夜' },
     switchTo: '切換到{{mode}}',
+    uiStyle: {
+      default: '預設',
+      win98: 'Windows 98',
+      'broker-classic': '經典交易台',
+    },
+    uiStyleDescription: {
+      default: '安靜克制的 OpenAlice 工作台',
+      win98: '直角、浮雕，以及鮮明的經典手感',
+      'broker-classic': '受 TWS 啟發的高密度交易工作台',
+    },
     palette: {
       paper: '紙張', porcelain: '白瓷', linen: '亞麻',
       graphite: '石墨', midnight: '午夜', moss: '苔色', iris: '鳶尾',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -273,6 +273,8 @@ export const zh: Resources = {
     appearance: {
       title: '外观',
       description: '色彩与布局偏好，仅保存在本设备。',
+      interfaceStyle: '界面样式',
+      interfaceStyleDescription: '调整组件外形、密度、字体与动效，不会改变你选择的色卡。',
       colorMode: '色彩模式',
       colorModeDescription: '自动模式跟随系统在日间和暗夜槽位间切换；日间和暗夜模式会固定对应槽位。',
       dayPalette: '日间色卡',
@@ -1198,6 +1200,16 @@ export const zh: Resources = {
   theme: {
     mode: { auto: '自动', day: '日间', night: '暗夜' },
     switchTo: '切换到{{mode}}',
+    uiStyle: {
+      default: '默认',
+      win98: 'Windows 98',
+      'broker-classic': '经典交易台',
+    },
+    uiStyleDescription: {
+      default: '安静克制的 OpenAlice 工作台',
+      win98: '直角、浮雕，以及鲜明的经典手感',
+      'broker-classic': '受 TWS 启发的高密度交易工作台',
+    },
     palette: {
       paper: '纸张', porcelain: '白瓷', linen: '亚麻',
       graphite: '石墨', midnight: '午夜', moss: '苔色', iris: '鸢尾',

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2,6 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "./theme/palette.css";
+@import "./theme/style-profiles.css";
 
 /* Tailwind aliases for the semantic color card. The core names intentionally
    mirror Orca/shadcn; this does not import or require the shadcn component

--- a/ui/src/pages/SettingsPage.appearance.spec.tsx
+++ b/ui/src/pages/SettingsPage.appearance.spec.tsx
@@ -30,6 +30,7 @@ beforeEach(() => {
     theme: 'auto',
     dayPalette: 'paper',
     nightPalette: 'graphite',
+    uiStyle: 'default',
   })
 })
 
@@ -41,6 +42,18 @@ afterEach(() => {
 })
 
 describe('AppearanceSection palette pair editor', () => {
+  it('switches component style immediately without changing the palette pair', () => {
+    render(<AppearanceSection />)
+
+    expect(screen.getByRole('radio', { name: 'Default' }).getAttribute('aria-checked')).toBe('true')
+    fireEvent.click(screen.getByRole('radio', { name: 'Windows 98' }))
+
+    expect(useThemeStore.getState().uiStyle).toBe('win98')
+    expect(useThemeStore.getState().dayPalette).toBe('paper')
+    expect(useThemeStore.getState().nightPalette).toBe('graphite')
+    expect(screen.getByRole('radio', { name: 'Windows 98' }).getAttribute('aria-checked')).toBe('true')
+  })
+
   it('does not expose the retired editor tab strip preference', () => {
     localStorage.setItem('openalice.editor-tabs.v1', JSON.stringify({
       state: { showEditorTabs: true },

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -20,6 +20,7 @@ import {
   type ThemePreferenceSlot,
 } from '../theme/palettes'
 import { useThemeStore, type AppTheme } from '../theme/store'
+import { UI_STYLE_PROFILES, type UiStyleProfileId } from '../theme/styleProfiles'
 import { useEffectivePreferenceSlot } from '../theme/useEffectiveTheme'
 import { AboutOpenAliceSection } from '../components/settings/AboutOpenAliceSection'
 
@@ -36,9 +37,11 @@ export function AppearanceSection() {
   const theme = useThemeStore((s) => s.theme)
   const dayPalette = useThemeStore((s) => s.dayPalette)
   const nightPalette = useThemeStore((s) => s.nightPalette)
+  const uiStyle = useThemeStore((s) => s.uiStyle)
   const setTheme = useThemeStore((s) => s.setTheme)
   const setDayPalette = useThemeStore((s) => s.setDayPalette)
   const setNightPalette = useThemeStore((s) => s.setNightPalette)
+  const setUiStyle = useThemeStore((s) => s.setUiStyle)
   const effectiveSlot = useEffectivePreferenceSlot()
   const [editingSlot, setEditingSlot] = useState<ThemePreferenceSlot>(effectiveSlot)
   const [paletteFilter, setPaletteFilter] = useState<PaletteLibraryFilter>('recommended')
@@ -82,6 +85,33 @@ export function AppearanceSection() {
   return (
     <ConfigSection title={t('settings.appearance.title')} description={t('settings.appearance.description')}>
       <div className="border-b border-border/60 pb-5">
+        <div>
+          <span className="text-sm font-medium text-foreground">
+            {t('settings.appearance.interfaceStyle')}
+          </span>
+          <p className="mt-0.5 text-[12px] leading-relaxed text-muted-foreground">
+            {t('settings.appearance.interfaceStyleDescription')}
+          </p>
+        </div>
+        <div
+          className="mt-3 grid gap-2.5 sm:grid-cols-3"
+          role="radiogroup"
+          aria-label={t('settings.appearance.interfaceStyle')}
+        >
+          {UI_STYLE_PROFILES.map((profile) => (
+            <StyleProfileCard
+              key={profile.id}
+              profile={profile.id}
+              label={t(profile.labelKey)}
+              description={t(profile.descriptionKey)}
+              selected={uiStyle === profile.id}
+              onSelect={setUiStyle}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="border-b border-border/60 py-5">
         <div>
           <span className="text-sm font-medium text-foreground">
             {t('settings.appearance.colorMode')}
@@ -234,6 +264,44 @@ export function AppearanceSection() {
       </div>
 
     </ConfigSection>
+  )
+}
+
+function StyleProfileCard({
+  profile,
+  label,
+  description,
+  selected,
+  onSelect,
+}: {
+  profile: UiStyleProfileId
+  label: string
+  description: string
+  selected: boolean
+  onSelect: (profile: UiStyleProfileId) => void
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      aria-label={label}
+      data-ui-style-preview={profile}
+      data-selected={selected}
+      onClick={() => onSelect(profile)}
+      className="oa-style-profile-card oa-pressable min-h-24 min-w-0 border border-border bg-background p-2.5 text-left"
+    >
+      <span className="oa-style-profile-preview flex h-10 overflow-hidden border border-border bg-card" aria-hidden>
+        <span className="oa-style-profile-rail w-3.5 shrink-0 border-r border-border bg-sidebar" />
+        <span className="flex min-w-0 flex-1 flex-col gap-1 p-1.5">
+          <span className="oa-style-profile-toolbar h-1.5 w-full bg-muted" />
+          <span className="oa-style-profile-row h-2 w-4/5 border border-border bg-background" />
+          <span className="oa-style-profile-row h-2 w-3/5 border border-border bg-background" />
+        </span>
+      </span>
+      <span className="mt-2 block text-[12px] font-semibold text-foreground">{label}</span>
+      <span className="mt-0.5 block text-[10.5px] leading-snug text-muted-foreground">{description}</span>
+    </button>
   )
 }
 

--- a/ui/src/theme/index.ts
+++ b/ui/src/theme/index.ts
@@ -22,6 +22,7 @@ function applyTheme(state: ReturnType<typeof readInitialThemePreferences>): void
   root.dataset.theme = state.theme
   root.dataset.dayPalette = state.dayPalette
   root.dataset.nightPalette = state.nightPalette
+  root.dataset.uiStyle = state.uiStyle
   root.dataset.palette = resolveEffectivePalette(
     state.theme,
     systemTheme.matches,
@@ -37,6 +38,7 @@ useThemeStore.subscribe((state, prev) => {
     state.theme !== prev.theme
     || state.dayPalette !== prev.dayPalette
     || state.nightPalette !== prev.nightPalette
+    || state.uiStyle !== prev.uiStyle
   ) applyTheme(state)
 })
 

--- a/ui/src/theme/noFlashTheme.spec.ts
+++ b/ui/src/theme/noFlashTheme.spec.ts
@@ -29,6 +29,7 @@ describe('no-flash theme bootstrap', () => {
       theme: 'night',
       dayPalette: 'porcelain',
       nightPalette: 'midnight',
+      uiStyle: 'default',
       palette: 'midnight',
     })
   })
@@ -42,6 +43,7 @@ describe('no-flash theme bootstrap', () => {
       theme: 'day',
       dayPalette: 'midnight',
       nightPalette: 'paper',
+      uiStyle: 'default',
       palette: 'midnight',
     })
 
@@ -56,5 +58,10 @@ describe('no-flash theme bootstrap', () => {
     const state = { theme: 'auto', dayPalette: 'linen', nightPalette: 'iris' }
     expect(applyNoFlashTheme(state, false).palette).toBe('linen')
     expect(applyNoFlashTheme(state, true).palette).toBe('iris')
+  })
+
+  it('applies a valid style profile before first paint and repairs invalid values', () => {
+    expect(applyNoFlashTheme({ uiStyle: 'win98' }, false).uiStyle).toBe('win98')
+    expect(applyNoFlashTheme({ uiStyle: 'aqua' }, false).uiStyle).toBe('default')
   })
 })

--- a/ui/src/theme/store.spec.ts
+++ b/ui/src/theme/store.spec.ts
@@ -14,6 +14,7 @@ describe('theme preference persistence', () => {
       theme: 'night',
       dayPalette: 'porcelain',
       nightPalette: 'midnight',
+      uiStyle: 'default',
     })
   })
 
@@ -22,10 +23,12 @@ describe('theme preference persistence', () => {
       theme: 'day',
       dayPalette: 'moss',
       nightPalette: 'linen',
+      uiStyle: 'default',
     })).toEqual({
       theme: 'day',
       dayPalette: 'moss',
       nightPalette: 'linen',
+      uiStyle: 'default',
     })
   })
 
@@ -38,10 +41,23 @@ describe('theme preference persistence', () => {
       theme: 'auto',
       dayPalette: 'porcelain',
       nightPalette: 'midnight',
+      uiStyle: 'win98',
     })).toEqual({
       theme: 'auto',
       dayPalette: 'porcelain',
       nightPalette: 'graphite',
+      uiStyle: 'win98',
     })
+  })
+
+  it('persists known styles and repairs an unknown style independently', () => {
+    expect(normalizeThemePreferences({
+      theme: 'auto',
+      dayPalette: 'paper',
+      nightPalette: 'graphite',
+      uiStyle: 'broker-classic',
+    }).uiStyle).toBe('broker-classic')
+
+    expect(normalizeThemePreferences({ uiStyle: 'aqua' }).uiStyle).toBe('default')
   })
 })

--- a/ui/src/theme/store.ts
+++ b/ui/src/theme/store.ts
@@ -9,6 +9,11 @@ import {
   type ThemePaletteId,
   type ThemePreferenceMode,
 } from './palettes'
+import {
+  DEFAULT_UI_STYLE_PROFILE,
+  isUiStyleProfileId,
+  type UiStyleProfileId,
+} from './styleProfiles'
 
 /**
  * Color-mode and palette-pairing store.
@@ -37,15 +42,18 @@ export interface ThemePreferences {
   theme: AppTheme
   dayPalette: ThemePaletteId
   nightPalette: ThemePaletteId
+  uiStyle: UiStyleProfileId
 }
 
 interface ThemeStore {
   theme: AppTheme
   dayPalette: ThemePaletteId
   nightPalette: ThemePaletteId
+  uiStyle: UiStyleProfileId
   setTheme: (theme: AppTheme) => void
   setDayPalette: (palette: ThemePaletteId) => void
   setNightPalette: (palette: ThemePaletteId) => void
+  setUiStyle: (profile: UiStyleProfileId) => void
   /** Advance to the next mode (drives the ActivityBar toggle). */
   cycleTheme: () => void
 }
@@ -54,6 +62,7 @@ const DEFAULT_PREFERENCES: ThemePreferences = {
   theme: 'auto',
   dayPalette: DEFAULT_DAY_PALETTE,
   nightPalette: DEFAULT_NIGHT_PALETTE,
+  uiStyle: DEFAULT_UI_STYLE_PROFILE,
 }
 
 /** Normalize both the universal-slot shape and the legacy v1 light/dark shape. */
@@ -70,6 +79,7 @@ export function normalizeThemePreferences(
     theme: normalizeThemePreferenceMode(stored.theme) ?? fallback.theme,
     dayPalette: isThemePaletteId(dayPalette) ? dayPalette : fallback.dayPalette,
     nightPalette: isThemePaletteId(nightPalette) ? nightPalette : fallback.nightPalette,
+    uiStyle: isUiStyleProfileId(stored.uiStyle) ? stored.uiStyle : fallback.uiStyle,
   }
 }
 
@@ -79,9 +89,11 @@ export const useThemeStore = create<ThemeStore>()(
       theme: 'auto',
       dayPalette: DEFAULT_DAY_PALETTE,
       nightPalette: DEFAULT_NIGHT_PALETTE,
+      uiStyle: DEFAULT_UI_STYLE_PROFILE,
       setTheme: (theme) => set({ theme }),
       setDayPalette: (dayPalette) => set({ dayPalette }),
       setNightPalette: (nightPalette) => set({ nightPalette }),
+      setUiStyle: (uiStyle) => set({ uiStyle }),
       cycleTheme: () => {
         const i = CYCLE.indexOf(get().theme)
         set({ theme: CYCLE[(i + 1) % CYCLE.length]! })
@@ -107,6 +119,6 @@ export const useThemeStore = create<ThemeStore>()(
 
 /** Persisted preferences at boot (zustand persist rehydrates localStorage sync). */
 export function readInitialThemePreferences(): ThemePreferences {
-  const { theme, dayPalette, nightPalette } = useThemeStore.getState()
-  return { theme, dayPalette, nightPalette }
+  const { theme, dayPalette, nightPalette, uiStyle } = useThemeStore.getState()
+  return { theme, dayPalette, nightPalette, uiStyle }
 }

--- a/ui/src/theme/style-profiles.css
+++ b/ui/src/theme/style-profiles.css
@@ -1,0 +1,273 @@
+/* Runtime component appearance profiles. Colors stay entirely owned by the
+   active semantic palette; these profiles only alter typography, geometry,
+   elevation, density, and motion. */
+
+.oa-style-profile-card {
+  border-radius: 0.75rem;
+  transition:
+    border-color var(--motion-standard) var(--motion-ease-standard),
+    background-color var(--motion-standard) var(--motion-ease-standard),
+    box-shadow var(--motion-standard) var(--motion-ease-standard),
+    transform var(--motion-fast) var(--motion-ease-standard);
+}
+
+.oa-style-profile-card[data-selected="true"] {
+  border-color: var(--primary);
+  background: color-mix(in srgb, var(--primary-muted) 58%, var(--background));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 38%, transparent);
+}
+
+.oa-style-profile-preview {
+  border-radius: 0.4rem;
+}
+
+.oa-style-profile-card[data-ui-style-preview="win98"],
+.oa-style-profile-card[data-ui-style-preview="win98"] .oa-style-profile-preview,
+.oa-style-profile-card[data-ui-style-preview="win98"] .oa-style-profile-row {
+  border-radius: 0;
+}
+
+.oa-style-profile-card[data-ui-style-preview="win98"] .oa-style-profile-preview {
+  box-shadow:
+    inset 1px 1px color-mix(in srgb, var(--background) 92%, var(--foreground)),
+    inset -1px -1px color-mix(in srgb, var(--foreground) 48%, var(--background));
+}
+
+.oa-style-profile-card[data-ui-style-preview="broker-classic"],
+.oa-style-profile-card[data-ui-style-preview="broker-classic"] .oa-style-profile-preview,
+.oa-style-profile-card[data-ui-style-preview="broker-classic"] .oa-style-profile-row {
+  border-radius: 0.125rem;
+}
+
+.oa-style-profile-card[data-ui-style-preview="broker-classic"] .oa-style-profile-toolbar {
+  height: 0.2rem;
+}
+
+.oa-style-profile-card[data-ui-style-preview="broker-classic"] .oa-style-profile-row {
+  height: 0.32rem;
+}
+
+/* Windows 98 ------------------------------------------------------------- */
+
+:root[data-ui-style="win98"] {
+  --font-sans: Tahoma, "MS Sans Serif", "Microsoft Sans Serif", "PingFang SC",
+    "Microsoft YaHei", sans-serif;
+  --motion-fast: 0ms;
+  --motion-standard: 0ms;
+  --motion-slow: 0ms;
+  --oa-win-highlight: color-mix(in srgb, var(--background) 94%, var(--foreground));
+  --oa-win-light: color-mix(in srgb, var(--background) 76%, var(--foreground));
+  --oa-win-shadow: color-mix(in srgb, var(--foreground) 42%, var(--background));
+  --oa-win-dark: color-mix(in srgb, var(--foreground) 72%, var(--background));
+}
+
+:root[data-ui-style="win98"] body {
+  background: var(--background);
+  transition: none;
+}
+
+:root[data-ui-style="win98"] :where(
+  button,
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea,
+  [data-slot="dialog-content"],
+  [data-slot="alert-dialog-content"],
+  [data-slot="sheet-content"],
+  [data-slot="dropdown-menu-content"],
+  [data-slot="dropdown-menu-sub-content"],
+  [data-slot="popover-content"],
+  [data-slot="tooltip-content"],
+  .rounded,
+  .rounded-sm,
+  .rounded-md,
+  .rounded-lg,
+  .rounded-xl,
+  .rounded-2xl,
+  .rounded-3xl
+) {
+  border-radius: 0 !important;
+}
+
+:root[data-ui-style="win98"] :where(
+  button:not([data-slot="dialog-close"]),
+  [role="button"].oa-pressable,
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea
+) {
+  border-color: var(--oa-win-shadow);
+  box-shadow:
+    inset 1px 1px var(--oa-win-highlight),
+    inset -1px -1px var(--oa-win-dark),
+    inset 2px 2px var(--oa-win-light),
+    inset -2px -2px var(--oa-win-shadow);
+}
+
+:root[data-ui-style="win98"] :where(
+  input:not([type="checkbox"]):not([type="radio"]),
+  textarea,
+  select
+) {
+  background: var(--background);
+  box-shadow:
+    inset 1px 1px var(--oa-win-dark),
+    inset -1px -1px var(--oa-win-highlight),
+    inset 2px 2px var(--oa-win-shadow);
+}
+
+:root[data-ui-style="win98"] :where(
+  [data-slot="dialog-content"],
+  [data-slot="alert-dialog-content"],
+  [data-slot="sheet-content"],
+  [data-slot="dropdown-menu-content"],
+  [data-slot="dropdown-menu-sub-content"],
+  [data-slot="popover-content"]
+) {
+  border: 1px solid var(--oa-win-dark);
+  box-shadow:
+    inset 1px 1px var(--oa-win-highlight),
+    inset -1px -1px var(--oa-win-shadow),
+    3px 3px 0 color-mix(in srgb, var(--foreground) 34%, transparent);
+}
+
+:root[data-ui-style="win98"] :where(
+  [data-slot="dropdown-menu-item"],
+  [data-slot="dropdown-menu-checkbox-item"],
+  [data-slot="dropdown-menu-radio-item"],
+  [data-slot="dropdown-menu-sub-trigger"]
+) {
+  border-radius: 0 !important;
+}
+
+:root[data-ui-style="win98"] :where(button, [role="button"]):focus-visible {
+  outline: 1px dotted currentColor;
+  outline-offset: -4px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  :root[data-ui-style="win98"] .oa-pressable:hover:not(:disabled):not([aria-disabled="true"]),
+  :root[data-ui-style="win98"] .oa-icon-action:hover:not(:disabled):not([aria-disabled="true"]),
+  :root[data-ui-style="win98"] .oa-nav-row:hover {
+    transform: none;
+  }
+
+  :root[data-ui-style="win98"] :where(button, [role="button"]):active:not(:disabled):not([aria-disabled="true"]) {
+    transform: translate(1px, 1px);
+    box-shadow:
+      inset 1px 1px var(--oa-win-dark),
+      inset -1px -1px var(--oa-win-highlight),
+      inset 2px 2px var(--oa-win-shadow);
+  }
+}
+
+/* Broker Classic --------------------------------------------------------- */
+
+:root[data-ui-style="broker-classic"] {
+  --font-sans: Arial, Tahoma, "Microsoft YaHei", "PingFang SC", sans-serif;
+  --motion-fast: 60ms;
+  --motion-standard: 90ms;
+  --motion-slow: 120ms;
+}
+
+:root[data-ui-style="broker-classic"] body {
+  background: var(--background);
+}
+
+:root[data-ui-style="broker-classic"] :where(
+  button,
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea,
+  [data-slot="dialog-content"],
+  [data-slot="alert-dialog-content"],
+  [data-slot="sheet-content"],
+  [data-slot="dropdown-menu-content"],
+  [data-slot="dropdown-menu-sub-content"],
+  [data-slot="popover-content"],
+  .rounded,
+  .rounded-sm,
+  .rounded-md,
+  .rounded-lg,
+  .rounded-xl,
+  .rounded-2xl,
+  .rounded-3xl
+) {
+  border-radius: 0.125rem !important;
+}
+
+:root[data-ui-style="broker-classic"] :where(
+  [data-slot="dialog-content"],
+  [data-slot="alert-dialog-content"],
+  [data-slot="sheet-content"],
+  [data-slot="dropdown-menu-content"],
+  [data-slot="dropdown-menu-sub-content"],
+  [data-slot="popover-content"]
+) {
+  border: 1px solid var(--border);
+  box-shadow: 2px 2px 0 color-mix(in srgb, var(--foreground) 20%, transparent);
+}
+
+:root[data-ui-style="broker-classic"] :where(table) {
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+:root[data-ui-style="broker-classic"] :where(th, td) {
+  border-color: var(--border);
+}
+
+:root[data-ui-style="broker-classic"] :where(.text-display, [class*="tabular-nums"]) {
+  font-variant-numeric: tabular-nums;
+}
+
+@media (min-width: 48rem) and (hover: hover) and (pointer: fine) {
+  :root[data-ui-style="broker-classic"] {
+    font-size: 15px;
+  }
+
+  :root[data-ui-style="broker-classic"] :where(
+    [data-slot="button"],
+    [data-slot="dropdown-menu-item"],
+    [data-slot="dropdown-menu-checkbox-item"],
+    [data-slot="dropdown-menu-radio-item"],
+    [data-slot="dropdown-menu-sub-trigger"]
+  ) {
+    min-height: 1.5rem;
+  }
+
+  :root[data-ui-style="broker-classic"] :where(
+    input:not([type="checkbox"]):not([type="radio"]),
+    select,
+    textarea
+  ) {
+    padding-top: 0.3rem;
+    padding-bottom: 0.3rem;
+  }
+
+  :root[data-ui-style="broker-classic"] [data-settings-scroll-area] {
+    scrollbar-width: thin;
+  }
+}
+
+/* Profile choices are specimens, not ordinary controls: keep each card's own
+   geometry visible even while another profile is active on the document. */
+:root[data-ui-style] .oa-style-profile-card {
+  box-shadow: none;
+}
+
+:root[data-ui-style] .oa-style-profile-card[data-ui-style-preview="default"] {
+  border-radius: 0.75rem !important;
+}
+
+:root[data-ui-style] .oa-style-profile-card[data-ui-style-preview="win98"] {
+  border-radius: 0 !important;
+}
+
+:root[data-ui-style] .oa-style-profile-card[data-ui-style-preview="broker-classic"] {
+  border-radius: 0.125rem !important;
+}
+
+:root[data-ui-style] .oa-style-profile-card[data-selected="true"] {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--primary) 38%, transparent);
+}

--- a/ui/src/theme/styleProfiles.ts
+++ b/ui/src/theme/styleProfiles.ts
@@ -1,0 +1,31 @@
+export type UiStyleProfileId = 'default' | 'win98' | 'broker-classic'
+
+export interface UiStyleProfileDefinition {
+  readonly id: UiStyleProfileId
+  readonly labelKey: `theme.uiStyle.${UiStyleProfileId}`
+  readonly descriptionKey: `theme.uiStyleDescription.${UiStyleProfileId}`
+}
+
+export const DEFAULT_UI_STYLE_PROFILE: UiStyleProfileId = 'default'
+
+export const UI_STYLE_PROFILES = [
+  {
+    id: 'default',
+    labelKey: 'theme.uiStyle.default',
+    descriptionKey: 'theme.uiStyleDescription.default',
+  },
+  {
+    id: 'win98',
+    labelKey: 'theme.uiStyle.win98',
+    descriptionKey: 'theme.uiStyleDescription.win98',
+  },
+  {
+    id: 'broker-classic',
+    labelKey: 'theme.uiStyle.broker-classic',
+    descriptionKey: 'theme.uiStyleDescription.broker-classic',
+  },
+] as const satisfies readonly UiStyleProfileDefinition[]
+
+export function isUiStyleProfileId(value: unknown): value is UiStyleProfileId {
+  return UI_STYLE_PROFILES.some(({ id }) => id === value)
+}


### PR DESCRIPTION
## What changed

- add a persisted runtime UI style axis independent from color palettes
- keep the existing OpenAlice workstation as Default
- add Windows 98 geometry, bevels, pressed states, typography, and reduced decorative motion
- add a dense Broker Classic workstation inspired by traditional broker terminals
- add live profile previews and localized controls in Settings
- apply the persisted profile before first paint and normalize malformed/legacy state
- document the component-style contract and execution plan

## Why

The shadcn/Base UI migration established stable behavior and `data-slot` styling seams. This turns that foundation into an actual user-facing capability without forking primitives or coupling component appearance to palette selection.

## UX and safety

- switching is immediate and survives reload
- palettes remain independently selectable
- compact Broker density is limited to desktop-sized fine-pointer devices
- phone touch targets, focus behavior, overlay dismissal, and terminal color reporting remain unchanged
- the Broker Classic profile is inspired by dense TWS-style workstations but does not copy IBKR assets or branding

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 3,907 passed, 9 skipped
- `pnpm -F open-alice-ui build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- real `pnpm dev` browser passes on Settings, Chat, Portfolio, and Issue activity at 1280px, 740px, and 390px
- exercised DropdownMenu, AlertDialog, Dialog, Popover, mobile Sheet, and a menu nested inside Sheet across the new profiles