### PR TITLE
docs: archive runtime style profile plan

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,9 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/runtime-ui-style-profiles.md]] — Adds independent runtime-selectable
-  component appearance profiles for Default, Windows 98, and Broker Classic
-  while preserving palette choice and shared shadcn/Base UI behavior.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY
@@ -31,6 +28,10 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/runtime-ui-style-profiles.md]] — Added independent runtime-selectable
+  component appearance profiles for Default, Windows 98, and Broker Classic
+  while preserving palette choice and shared shadcn/Base UI behavior. Delivered
+  in serial PR #976.
 - [[plans/shadcn-systematic-ui-audit.md]] — Exercised every installed
   shadcn/Base UI primitive through real product entries, repaired the
   menu-to-dialog focus handoff, and passed browser, full-suite, build, and

--- a/plans/runtime-ui-style-profiles.md
+++ b/plans/runtime-ui-style-profiles.md
@@ -1,8 +1,8 @@
 # Runtime UI Style Profiles
 
-- Status: `active`
+- Status: `completed`
 - Updated: `2026-08-04`
-- Delivery: one serial PR targeting `dev`.
+- Delivery: serial PR #976 merged to `dev`.
 - Owner guides: [[docs/ui-interaction-and-motion.md]],
   [[docs/development-workflow.md]], and [[docs/project-structure.md]].
 
@@ -42,7 +42,7 @@ than forking components or introducing profile-specific product logic.
       desktop, tablet, and phone widths.
 - [x] Run root/UI typechecks, the full Vitest suite, production UI build, and
       unsigned packaged Electron Workspace smoke.
-- [ ] Merge the serial PR to `dev`, run a post-merge smoke, and archive this
+- [x] Merge the serial PR to `dev`, run a post-merge smoke, and archive this
       plan under Completed.
 
 ## Verification Record
@@ -59,6 +59,9 @@ than forking components or introducing profile-specific product logic.
   touch-size floor.
 - Passed root and UI TypeScript, 3,907 Vitest tests (plus 9 skipped), the
   production UI build, and unsigned packaged Electron Workspace acceptance.
+- Serial PR #976 merged to `dev`; the merge commit passed the focused 23-test
+  theme suite and a real Default → Windows 98 → Default runtime switch while
+  preserving the user's Auto + Iris preference.
 
 ## Completion Criteria
 


### PR DESCRIPTION
## What changed

- mark the runtime UI style profile plan completed after PR #976 merged
- record the post-merge focused test and real runtime-switch smoke
- move the plan from Active to Completed in `PLANS.md`

## Verification

- PR #976 merge commit passed the focused 23-test theme suite
- real Default → Windows 98 → Default switch passed on merged `dev`
- user preference was restored to Default + Auto + Iris