### PR TITLE
Flatten Win98 session rows into a coherent list

### DIFF
--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -131,6 +131,9 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   Selecting the style must never apply that pair automatically. Settings shows
   an explicit preview and opt-in; the resulting style-scoped override must not
   rewrite the saved Day/Night colors, and leaving that style restores them.
+- Repeated navigation rows remain rows under every style profile. A profile may
+  restyle the row and its compact trailing actions, but must not give the row's
+  primary label its own card or command-button chrome.
 - Delete superseded event plumbing during migration. A component is not
   migrated if its old global Escape/outside-click/focus-loop implementation is
   still running beside the primitive.

--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -206,6 +206,10 @@ describe('SessionRow actions', () => {
       />,
     )
 
-    expect(screen.getByRole('button', { name: 'Review AAPL earnings' }).getAttribute('aria-current')).toBe('page')
+    const main = screen.getByRole('button', { name: 'Review AAPL earnings' })
+    expect(main.getAttribute('aria-current')).toBe('page')
+    expect(main.className).toContain('oa-session-row-main')
+    expect(main.parentElement?.className).toContain('oa-session-row')
+    expect(main.parentElement?.getAttribute('data-active')).toBe('true')
   })
 })

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -656,14 +656,15 @@ export function SessionRow(props: SessionRowProps): ReactElement {
   return (
     <div
       data-reorder-id={props.reorderId}
-      className={`group relative flex items-center gap-1.5 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
+      data-active={props.isActive}
+      className={`oa-session-row group relative flex items-center gap-1.5 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
         props.isActive ? 'bg-muted' : 'hover:bg-muted/50'
       }`}
     >
       {props.isActive && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />}
       <button
         type="button"
-        className="flex-1 min-w-0 flex items-center gap-1.5 text-left"
+        className="oa-session-row-main flex-1 min-w-0 flex items-center gap-1.5 text-left"
         onClick={props.onSelect}
         title={tooltip}
         aria-label={display}

--- a/ui/src/theme/style-profiles.css
+++ b/ui/src/theme/style-profiles.css
@@ -116,6 +116,34 @@
     inset 2px 2px var(--oa-win-shadow);
 }
 
+/* Session entries are list rows, not three adjacent command buttons. Keep the
+   title surface flat and reserve the classic raised chrome for its compact
+   lifecycle/menu actions. The row itself owns hover and selected state. */
+:root[data-ui-style="win98"] .oa-session-row {
+  gap: 2px;
+  min-height: 28px;
+  padding-block: 2px;
+}
+
+:root[data-ui-style="win98"] .oa-session-row-main {
+  align-self: stretch;
+  min-height: 24px;
+  padding-inline: 4px;
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+:root[data-ui-style="win98"] .oa-session-row-main:active {
+  transform: none;
+  box-shadow: none;
+}
+
+:root[data-ui-style="win98"] .oa-session-row > .oa-workspace-row-action {
+  height: 24px;
+  width: 24px;
+}
+
 :root[data-ui-style="win98"] :where(
   [data-slot="dialog-content"],
   [data-slot="alert-dialog-content"],


### PR DESCRIPTION
## What changed

- add stable session-row styling seams to the shared Workspace sidebar row
- keep the session title surface flat under the Win98 profile
- reserve classic raised chrome for the compact lifecycle and overflow actions
- tighten the Win98 session row to a 28 px list rhythm with 24 px trailing controls
- document that repeated navigation labels remain rows rather than becoming independent command buttons

## Root cause

The Win98 profile applied bevel chrome to every native button. A session row is composed of three buttons, so the title, lifecycle action, and overflow action each rendered as a separate raised rectangle.

## User impact

Recent conversations now scan as one continuous list. The title remains the primary target, while Play/Stop and More retain their appropriate classic toolbar affordance.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 3912 passed, 9 skipped
- `pnpm -F open-alice-ui build`
- real `pnpm dev` Chat walk: compact and long session titles, action sizing, no horizontal overflow, menu open/close and focus return