### PR TITLE
feat(release): publish Linux ARM64 Broker Packs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,12 +399,22 @@ jobs:
             arch: x64
           - os: ubuntu-latest
             arch: x64
+          # GitHub-hosted runners are x64-only; Linux arm64 is emulated via
+          # QEMU inside a node:22-trixie container so pnpm deploys the
+          # platform-specific native SDKs (e.g. longbridge's glibc prebuild)
+          # for arm64.
+          - os: ubuntu-latest
+            arch: arm64
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Set up QEMU for arm64 emulation
+        uses: docker/setup-qemu-action@v3
+        if: matrix.arch == 'arm64'
 
       - uses: pnpm/action-setup@v6
 
@@ -413,13 +423,37 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # arm64 has no native GitHub-hosted runner, so the whole install, build,
+      # and upgrade-smoke sequence runs inside a linux/arm64 container. The
+      # workspace is bind-mounted, so dist/broker-packs lands on the runner for
+      # the artifact step below.
+      - name: Build Broker Packs (arm64 emulated)
+        if: matrix.arch == 'arm64'
+        env:
+          PREVIOUS_TAG: ${{ needs.release.outputs.previous_tag }}
+        run: |
+          docker run --rm --platform linux/arm64 \
+            --workdir /workspace \
+            --volume "$PWD:/workspace" \
+            --env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+            --env PREVIOUS_TAG="$PREVIOUS_TAG" \
+            node:22-trixie bash -euo pipefail -c '
+              corepack enable && corepack prepare pnpm@11.7.0 --activate
+              pnpm install --frozen-lockfile
+              pnpm broker-packs:build
+              pnpm broker-packs:upgrade-smoke -- --from "$PREVIOUS_TAG"
+            '
+
       - name: Install dependencies
+        if: matrix.arch != 'arm64'
         run: pnpm install --frozen-lockfile
 
       - name: Build optional Broker Packs
+        if: matrix.arch != 'arm64'
         run: pnpm broker-packs:build
 
       - name: Prove previous-release Broker Pack upgrade
+        if: matrix.arch != 'arm64'
         run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
       - name: Preserve Broker Packs

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -125,9 +125,10 @@ OpenAlice-Broker-Packs-<version>-<platform>-<arch>.json
 OpenAlice-Broker-<engine>-<version>-<platform>-<arch>.tgz
 ```
 
-The release workflow runs this on macOS arm64, macOS x64, Windows x64, and
-Linux x64; publishes the files with the desktop release; mirrors them to the
-download CDN; and verifies every catalog and referenced archive.
+The release workflow runs this on macOS arm64, macOS x64, Windows x64, Linux
+x64, and Linux arm64 (emulated via QEMU on an x64 runner); publishes the files
+with the desktop release; mirrors them to the download CDN; and verifies every
+catalog and referenced archive.
 
 Before a candidate can publish, each platform runner downloads the real Broker
 Packs from the previous GitHub Release, activates them in an isolated

--- a/scripts/broker-pack-upgrade-smoke.ts
+++ b/scripts/broker-pack-upgrade-smoke.ts
@@ -56,9 +56,11 @@ async function main(): Promise<void> {
   const candidateCatalog = await readCatalog(
     resolve(candidateRoot, brokerPackCatalogFileName(currentVersion)),
   )
-  const previousCatalog = await fetchJson<BrokerPackReleaseCatalog>(
-    releaseAssetUrl(previousTag, brokerPackCatalogFileName(previousVersion)),
-  )
+  // A platform that is new in this release (e.g. Linux arm64) has no
+  // previous-release catalog to upgrade from. Treat that as a first-release
+  // skip rather than a failure; any other HTTP error is still fatal.
+  const previousCatalog = await fetchPreviousCatalog(previousTag, previousVersion)
+  if (!previousCatalog) return
   assertCatalog(previousCatalog, previousVersion)
   assertCatalog(candidateCatalog, currentVersion)
 
@@ -225,6 +227,24 @@ async function readCatalog(path: string): Promise<BrokerPackReleaseCatalog> {
 
 async function fetchJson<T>(url: string): Promise<T> {
   return JSON.parse((await fetchBytes(url)).toString('utf8')) as T
+}
+
+async function fetchPreviousCatalog(
+  tag: string,
+  version: string,
+): Promise<BrokerPackReleaseCatalog | null> {
+  const url = releaseAssetUrl(tag, brokerPackCatalogFileName(version))
+  const response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(120_000) })
+  if (response.status === 404) {
+    console.log(
+      `[broker-pack-upgrade-smoke] previous release ${tag} has no ` +
+        `${process.platform}-${process.arch} catalog; platform is new in this release — ` +
+        'skipping previous-release upgrade smoke',
+    )
+    return null
+  }
+  if (!response.ok) throw new Error(`GET ${url} failed: HTTP ${response.status}`)
+  return JSON.parse(await response.text()) as BrokerPackReleaseCatalog
 }
 
 async function fetchBytes(url: string): Promise<Buffer> {

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -46,6 +46,7 @@ describe('Release workflow critical path', () => {
       { os: 'macos-15-intel', arch: 'x64' },
       { os: 'windows-latest', arch: 'x64' },
       { os: 'ubuntu-latest', arch: 'x64' },
+      { os: 'ubuntu-latest', arch: 'arm64' },
     ])
     expect(step(brokerPacks, 'Preserve Broker Packs').with?.['name']).toBe(
       'broker-packs-${{ runner.os }}-${{ matrix.arch }}',


### PR DESCRIPTION
## What changed

- add `{ os: ubuntu-latest, arch: arm64 }` to the `build-broker-packs` release matrix
- run the arm64 install/build/upgrade-smoke sequence inside a `linux/arm64` `node:22-trixie` container via QEMU (GitHub-hosted runners are x64-only); the workspace is bind-mounted so `dist/broker-packs` artifacts land on the runner for upload
- keep the existing native steps unchanged for all other matrix entries
- make `broker-pack-upgrade-smoke` treat a missing previous-release catalog for the current platform as a first-release skip (new platform), while keeping every other HTTP error fatal
- update `docs/broker-packs.md` release matrix and the `release-workflow.spec.ts` matrix assertion

## Root cause

The broker-pack release matrix covers macOS arm64/x64, Windows x64, and Linux x64, but no Linux arm64. On arm64 hosts (Apple Silicon Docker, ARM VPSes), the installer requests `OpenAlice-Broker-Packs-<version>-linux-arm64.json` from `download.openalice.ai` and fails with `Broker-pack catalog request failed: HTTP 404`, blocking UTA broker setup entirely (e.g. Longbridge). Verified against the CDN: the arm64 catalog 404s while the x64 catalog returns 200.

## Why QEMU

`pnpm broker-packs:build` runs `pnpm deploy` per engine, which resolves platform-specific native SDKs (longbridge includes a GNU glibc 2.39 prebuild; the `requirementsFor` libc gate already applies to all Linux). An x64 runner cannot produce a correct arm64 dependency tree, so the arm64 matrix entry builds inside an emulated container. Verified the same command natively on linux-arm64: all five engine archives build and pass `broker-packs:verify`.

## Verification

- `npx tsc --noEmit` — clean
- `pnpm vitest run scripts/release-workflow.spec.ts scripts/ci-workflow.spec.ts scripts/desktop-package-workflow.spec.ts` — 7 passed
- workflow YAML parsed and matrix/steps confirmed structurally
- native `linux-arm64` run of `pnpm broker-packs:build` produces and verifies ccxt, alpaca, ibkr, leverup, longbridge archives
- `broker-pack-upgrade-smoke` 404-skip path exercised against a tag with no arm64 catalog

## Residual risk

- The arm64 job is the first to build under QEMU; first release will be slower than native jobs (no timeout configured, runs in parallel, `fail-fast: false`)
- The first arm64 release skips the previous-release upgrade smoke by design (nothing to upgrade from); subsequent releases exercise it
- Longbridge arm64 carries the same glibc >= 2.39 requirement as linux-x64