### PR TITLE
fix(runtime): keep readiness diagnostic

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -256,6 +256,10 @@ OpenAlice-vault credential merely because a Workspace has no managed provider
 binding. Runtime readiness probes exercise the effective native or existing
 Workspace configuration; they never inject the first compatible vault entry as
 a fallback and never mutate provider ownership while diagnosing readiness.
+Readiness is diagnostic rather than a synchronous preflight: ordinary Chat,
+Manager, Session spawn, and Session resume proceed through the selected native
+runtime without waiting for a probe. Onboarding, explicit Retry, and background
+health surfaces may probe and cache the result without becoming a launch gate.
 
 Choosing an OpenAlice credential is an explicit override. Only that choice, a
 saved new-Workspace default, or an existing OpenAlice-owned Workspace binding
@@ -341,6 +345,7 @@ Tests for this subsystem must cover:
 - credential secrets never appear in logs, docs, committed fixtures, or test snapshots;
 - sensitive rollback sidecars remain excluded from git alongside native provider config.
 - readiness probes never create or replace a Workspace provider binding;
+- diagnostic readiness failures never block an ordinary native launch or resume;
 - missing OpenAlice credentials never block a native-login-capable runtime;
 - failed interactive resumes return a visible error and remain retryable.
 

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -1,8 +1,7 @@
 /**
- * POST /quick-chat — the loginless-runtime credential injection (opencode/pi).
- * claude/codex carry their own CLI login and must NOT be injected; opencode/pi
- * are seeded from the vault before spawn, and dead-end (no compatible cred) with
- * a 400 the composer turns into a "configure a provider" bounce.
+ * POST /quick-chat — native runtime authentication plus explicit Workspace
+ * overrides. Every agent CLI owns its normal login/provider state; a selected
+ * OpenAlice credential is the only path that writes a Workspace configuration.
  *
  * core/config is partial-mocked so we can drive the vault per-test without
  * touching the real ai-provider-manager.json.

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -860,7 +860,7 @@ describe('POST /:id/headless/:taskId/session', () => {
 describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', () => {
   const TOKEN = 'claude-calm-amber-river';
 
-  function buildResume(workspaceId = 'ws-1', resolverOnly = false) {
+  function buildResume(workspaceId = 'ws-1', resolverOnly = false, adapterOverride?: any) {
     const session = {
       recordId: TOKEN,
       wsId: workspaceId,
@@ -874,16 +874,19 @@ describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', (
       live = session;
       return session;
     });
+    const adapter = adapterOverride ?? {
+      id: 'claude',
+      capabilities: { resumeById: true, resumeLast: false },
+    };
     const record = {
       id: TOKEN,
       resumeId: 'resume-aid',
       wsId: workspaceId,
-      agent: 'claude',
+      agent: adapter.id,
       name: 'c1',
       state: 'paused',
       resumeHint: { kind: 'agent-session-id', value: 'aid' },
     };
-    const adapter = { id: 'claude', capabilities: { resumeById: true, resumeLast: false } };
     const svc = {
       sessionRegistry: { get: () => record, update: vi.fn(async () => {}) },
       resumeRegistry: { get: () => ({ agentSessionId: 'aid' }) },
@@ -924,6 +927,31 @@ describe('POST /:id/sessions/:sid/resume — concurrent coalescing (ANG-120)', (
     const result = await post(app, `/workspace-manager/sessions/${TOKEN}/resume`);
 
     expect(result.body.ok).toBe(true);
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  it('resumes a native-login runtime with an empty Workspace config without injecting a vault credential', async () => {
+    const opencode = {
+      id: 'opencode',
+      capabilities: {
+        resumeById: true,
+        resumeLast: false,
+        aiProvider: {
+          credentialSource: 'runtime-or-workspace',
+          wirePreference: ['openai-chat'],
+        },
+      },
+      readAiConfig: vi.fn(async () => null),
+      writeAiConfig: vi.fn(async () => {}),
+    };
+    const { app, spawn } = buildResume('ws-1', false, opencode);
+
+    const result = await post(app, `/ws-1/sessions/${TOKEN}/resume`);
+
+    expect(result.status).toBe(200);
+    expect(result.body.ok).toBe(true);
+    expect(opencode.readAiConfig).toHaveBeenCalledOnce();
+    expect(opencode.writeAiConfig).not.toHaveBeenCalled();
     expect(spawn).toHaveBeenCalledOnce();
   });
 });

--- a/src/workspaces/agent-credential-readiness.spec.ts
+++ b/src/workspaces/agent-credential-readiness.spec.ts
@@ -99,6 +99,26 @@ describe('agent credential readiness', () => {
     expect(a.writeAiConfig).not.toHaveBeenCalled();
   });
 
+  it('does not let an unreadable Alice vault block a native Workspace config', async () => {
+    const a = adapter('pi', {
+      baseUrl: null,
+      apiKey: 'native-project-key',
+      model: 'project-model',
+      wireShape: 'openai-chat',
+    });
+    vi.mocked(readCredentials).mockRejectedValue(new Error('vault unavailable'));
+
+    const row = await getAgentCredentialReadiness({ meta, agentId: 'pi', adapter: a });
+
+    expect(row).toMatchObject({
+      ready: true,
+      requiresCredential: false,
+      source: 'workspace-config',
+      hasWorkspaceConfig: true,
+    });
+    expect(a.writeAiConfig).not.toHaveBeenCalled();
+  });
+
   it('does not overwrite an explicit Workspace wire when Quick Chat repeats the same credential', async () => {
     const a = adapter('pi', {
       baseUrl: 'https://api.minimax.io/anthropic',

--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -81,7 +81,6 @@ function launchConfig(overrides: Partial<AgentLaunchConfigState> = {}): AgentLau
     selectCredential: vi.fn(),
     selectRuntimeDefault: vi.fn(),
     resetCredentialSelection: vi.fn(),
-    checkSelectedRuntime: vi.fn(async () => null),
     ...overrides,
   }
 }

--- a/ui/src/components/workspace/api.spec.ts
+++ b/ui/src/components/workspace/api.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resumeSession } from './api'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('resumeSession', () => {
+  it('rejects with the server diagnostic instead of resolving an empty Session', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      error: 'agent_credential_failed',
+      message: 'Pi CLI login is required',
+    }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(resumeSession('chat-1', 'pi-paused'))
+      .rejects.toThrow('Pi CLI login is required')
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/workspaces/chat-1/sessions/pi-paused/resume',
+      { method: 'POST' },
+    )
+  })
+})

--- a/ui/src/hooks/useAgentLaunchConfig.ts
+++ b/ui/src/hooks/useAgentLaunchConfig.ts
@@ -8,7 +8,6 @@ import {
   getAgentReadiness,
   getAgentRuntimeReadiness,
   listAgentCredentials,
-  probeAgentRuntimeReadiness,
   type AgentCredentialReadiness,
   type AgentInfo,
   type AgentRuntimeReadinessRow,
@@ -311,7 +310,6 @@ export interface AgentLaunchConfigState {
   selectCredential(credentialSlug: string): void
   selectRuntimeDefault(): void
   resetCredentialSelection(): void
-  checkSelectedRuntime(): Promise<AgentRuntimeReadinessRow | null>
 }
 
 /** Canonical launch-state hook for Quick Chat, Workspace Manager, and future
@@ -527,15 +525,6 @@ export function useAgentLaunchConfig({
 
   const resetCredentialSelection = useCallback(() => setPickedCredential(null), [])
 
-  const checkSelectedRuntime = useCallback(async (): Promise<AgentRuntimeReadinessRow | null> => {
-    if (!effectiveAgent) return null
-    const current = runtimeReadiness?.agents[effectiveAgent] ?? null
-    if (current?.ready === true) return current
-    const snapshot = await probeAgentRuntimeReadiness(effectiveAgent)
-    setRuntimeReadiness(snapshot)
-    return snapshot.agents[effectiveAgent] ?? null
-  }, [effectiveAgent, runtimeReadiness])
-
   return useMemo(() => ({
     agents,
     effectiveAgent,
@@ -567,11 +556,9 @@ export function useAgentLaunchConfig({
     selectCredential,
     selectRuntimeDefault,
     resetCredentialSelection,
-    checkSelectedRuntime,
   }), [
     agents,
     aiDetails,
-    checkSelectedRuntime,
     canSelectCredential,
     credentials,
     credential,

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -326,7 +326,29 @@ describe('ChatLandingPage keyboard submission', () => {
     ))
   })
 
-  it('shows the runtime provider error and does not create a chat session', async () => {
+  it('does not let a diagnostic readiness failure block a native chat launch', async () => {
+    const nativePiAgent: AgentInfo = {
+      ...piAgent,
+      capabilities: {
+        ...piAgent.capabilities,
+        aiProvider: {
+          ...piAgent.capabilities.aiProvider!,
+          credentialSource: 'runtime-or-workspace',
+        },
+      },
+    }
+    mocks.useWorkspaces.mockImplementation(() => ({
+      ...context(workspaces),
+      agents: [nativePiAgent],
+    }))
+    mocks.listAgentCredentials.mockResolvedValue([])
+    mocks.detectWorkspaceCredential.mockResolvedValue({
+      configured: false,
+      slug: null,
+      model: null,
+      contextWindow: null,
+      wireShape: null,
+    })
     mocks.getAgentRuntimeReadiness.mockResolvedValue({
       agents: {
         pi: {
@@ -366,12 +388,19 @@ describe('ChatLandingPage keyboard submission', () => {
 
     render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
 
-    await screen.findByLabelText('Model gemini-3.1-flash-lite')
+    await screen.findByText('Model, reasoning, and context are managed by Pi')
     fireEvent.change(screen.getByPlaceholderText('Ask Alice…'), { target: { value: 'hello' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
-    expect(await screen.findByText('The runtime reported an error: 429: balance exhausted')).toBeTruthy()
-    expect(mocks.quickChat).not.toHaveBeenCalled()
+    await waitFor(() => expect(mocks.quickChat).toHaveBeenCalledWith(
+      'hello',
+      'pi',
+      undefined,
+      'chat-1',
+      'chat',
+    ))
+    expect(mocks.probeAgentRuntimeReadiness).not.toHaveBeenCalled()
+    expect(screen.queryByText('The runtime reported an error: 429: balance exhausted')).toBeNull()
   })
 })
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -201,18 +201,13 @@ function HarnessLandingPage({
       launchSelectorsRef.current?.openAgentMenu()
       return
     }
+    if (launchConfig.needsProviderSetup) {
+      goConfigureProvider()
+      return
+    }
     setError(null)
     setLaunching(true)
     try {
-      const runtimeRow = await launchConfig.checkSelectedRuntime()
-      if (runtimeRow?.ready !== true) {
-        if (runtimeRow?.repairTarget === 'ai-provider' || launchConfig.needsProviderSetup) {
-          goConfigureProvider()
-          return
-        }
-        setError(runtimeRow?.message ?? t('chatLanding.runtimeNotReady'))
-        return
-      }
       // A global OpenCode/Pi config is only a fallback when the user has not
       // selected a vault credential for this launch. The provider pill is an
       // explicit per-Workspace choice: always send it so the backend can write

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -264,6 +264,40 @@ describe('WorkspaceManagerPage runtime selection', () => {
     ))
   })
 
+  it('starts the Manager without synchronously probing diagnostic readiness', async () => {
+    mocks.getAgentRuntimeReadiness.mockResolvedValue({
+      agents: {
+        codex: {
+          agent: 'codex',
+          displayName: 'Codex',
+          installed: true,
+          binPath: '/tmp/codex',
+          status: 'unknown',
+          ready: false,
+          source: 'unknown',
+          checkedAt: null,
+          durationMs: null,
+        },
+      },
+      overallReady: false,
+      checkedAt: null,
+    })
+    mocks.probeAgentRuntimeReadiness.mockRejectedValue(new Error('readiness timed out'))
+
+    render(<WorkspaceManagerPage spec={{ kind: 'workspace-manager', params: {} }} />)
+
+    await screen.findByRole('button', { name: 'Select agent' })
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Inspect without a preflight.' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start manager' }))
+
+    await waitFor(() => expect(mocks.quickStartWorkspaceManager).toHaveBeenCalledWith(
+      'Inspect without a preflight.',
+      'codex',
+      undefined,
+    ))
+    expect(mocks.probeAgentRuntimeReadiness).not.toHaveBeenCalled()
+  })
+
   it('offers a retry when the manager snapshot cannot load', async () => {
     mocks.useWorkspaces.mockImplementation(() => ({
       ...context('codex'),

--- a/ui/src/pages/WorkspaceManagerPage.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.tsx
@@ -88,18 +88,13 @@ export function WorkspaceManagerPage({ spec }: { spec: ManagerSpec }) {
       launchSelectorsRef.current?.openAgentMenu()
       return
     }
+    if (launchConfig.needsProviderSetup) {
+      openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
+      return
+    }
     setLaunching(true)
     setError(null)
     try {
-      const runtimeRow = await launchConfig.checkSelectedRuntime()
-      if (runtimeRow?.ready !== true) {
-        if (runtimeRow?.repairTarget === 'ai-provider' || launchConfig.needsProviderSetup) {
-          openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
-          return
-        }
-        setError(runtimeRow?.message ?? t('chatLanding.runtimeNotReady'))
-        return
-      }
       const result = await quickStartWorkspaceManager(
         prompt,
         effectiveAgent,


### PR DESCRIPTION
## What changed

- Stop Chat and Workspace Manager from synchronously probing runtime readiness before an ordinary launch.
- Preserve the hard structural gate only for runtimes that truly require a Workspace credential.
- Add route, API, hook, and UI regressions for native login, empty or unreadable OpenAlice vault state, failed readiness snapshots, and retryable Session resume errors.
- Document readiness as a diagnostic/background health signal rather than a launch gate.

## Root cause

The credential requirement was corrected in PR #983, but the shared launch surfaces still called the active runtime probe before every first send. A stale, timed-out, or provider-failed readiness result could therefore block an otherwise valid native launch.

## Validation

- npx tsc --noEmit
- cd ui && npx tsc -b
- targeted readiness, route, API, Chat, Manager, and resume tests: 89 passed
- pnpm test: 3,927 passed; 9 skipped
- real pnpm dev browser check with Pi cached as failed/429: Send remained available and no probe or test Session was created
- dev frontend and backend restarted and healthy