### PR TITLE
Fix remote runtime bundle smoke fixture

### DIFF
--- a/scripts/remote-smoke/build-runtime-fixture.mjs
+++ b/scripts/remote-smoke/build-runtime-fixture.mjs
@@ -38,6 +38,7 @@ const files = new Map([
   ['default/persona.default.md', '# OpenAlice\n'],
   ['src/workspaces/templates/.keep', 'fixture\n'],
   ['src/workspaces/cli/bin/openalice-cli.cjs', 'module.exports = {}\n'],
+  ['src/workspaces/cli/bin/pi-session-provider.ts', 'export {}\n'],
   ['services/uta/dist/uta.js', 'export {}\n'],
   ['services/connector/dist/connector.cjs', 'module.exports = {}\n'],
   ['packages/guardian-runtime/dist/index.js', 'export {}\n'],


### PR DESCRIPTION
## Summary

- add the Pi Session provider extension to the synthetic remote Runtime bundle fixture
- keep the installer smoke's required-file layout aligned with the production Runtime manifest

## Root cause

PR #985 correctly added `pi-session-provider.ts` to the production Runtime bundle contract, but the clean SSH-host fixture still generated the older minimal layout. Its bundle integrity assertion therefore failed before the remote install could run.

## Verification

- `pnpm test:remote:docker`
- `npx tsc --noEmit`
- `pnpm test` (475 files passed, 1 skipped; 3937 tests passed, 9 skipped)
