### PR TITLE
chore(release): prepare 0.89.2-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.89.1-beta",
+  "version": "0.89.2-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.89.1-beta",
+  "version": "0.89.2-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump OpenAlice product version to `0.89.2-beta`
- keep the standalone CLI manifest on the exact same release version

## Local release gates

- `npx tsc --noEmit`
- `pnpm test` (477 files passed, 1 skipped; 3956 tests passed, 9 skipped)
- `pnpm build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- `pnpm test:install:docker`
- `pnpm docker:smoke`

The signed/notarized multi-platform artifacts remain gated by the master release workflow.
