### PR TITLE
feat: add Kimi K3 provider preset

### DIFF
--- a/src/ai-providers/model-semantics.spec.ts
+++ b/src/ai-providers/model-semantics.spec.ts
@@ -28,6 +28,18 @@ describe('model semantics registry', () => {
     expect(modelSupportsReasoning(null)).toBeNull()
   })
 
+  it('records Kimi K3 as an always-thinking 1M model with its native effort tiers', () => {
+    expect(resolveModelSemantics('kimi', 'kimi-k3')).toEqual({
+      contextWindow: 1_048_576,
+      reasoning: {
+        mode: 'required',
+        efforts: ['low', 'high', 'max'],
+        defaultEffort: 'max',
+        interleaved: true,
+      },
+    })
+  })
+
   it('describes registered runtime facts compactly', () => {
     expect(describeModelSemantics(resolveModelSemantics('deepseek', 'deepseek-v4-pro')))
       .toBe('Reasoning optional · default effort high · interleaved thinking · 1M context')

--- a/src/ai-providers/model-semantics.ts
+++ b/src/ai-providers/model-semantics.ts
@@ -80,7 +80,7 @@ const GEMINI_3_CONTEXT = 1_048_576
  * - Gemini thinking: https://ai.google.dev/gemini-api/docs/generate-content/thinking
  * - MiniMax Anthropic API: https://platform.minimax.io/docs/api-reference/text-anthropic-api
  * - MiniMax OpenAI `reasoning_split`: https://platform.minimax.io/docs/api-reference/text-openai-api
- * - Kimi thinking models: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
+ * - Kimi K3/reasoning effort: https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
  * - DeepSeek models/limits: https://api-docs.deepseek.com/quick_start/pricing
  * - DeepSeek thinking: https://api-docs.deepseek.com/guides/thinking_mode
  * - LongCat Chat API: https://longcat.chat/platform/docs/api/chat.html
@@ -224,7 +224,20 @@ export const MODEL_SEMANTICS_BY_VENDOR: Registry = {
     'glm-5.2': { reasoning: { mode: 'adaptive', efforts: ['high', 'max'] } },
   },
   kimi: {
+    'kimi-k3': {
+      contextWindow: 1_048_576,
+      reasoning: {
+        mode: 'required',
+        efforts: ['low', 'high', 'max'],
+        defaultEffort: 'max',
+        interleaved: true,
+      },
+    },
     'kimi-k2.7-code': {
+      contextWindow: 256_000,
+      reasoning: { mode: 'required', interleaved: true },
+    },
+    'kimi-k2.7-code-highspeed': {
       contextWindow: 256_000,
       reasoning: { mode: 'required', interleaved: true },
     },

--- a/src/ai-providers/preset-catalog.spec.ts
+++ b/src/ai-providers/preset-catalog.spec.ts
@@ -8,6 +8,7 @@ import {
   DEEPSEEK,
   DEFAULT_MODEL_BY_VENDOR,
   GEMINI,
+  KIMI,
   LONGCAT,
 } from './preset-catalog.js';
 import { BUILTIN_PRESETS } from './presets.js';
@@ -80,6 +81,25 @@ describe('credential form catalog', () => {
         maxOutputTokens: 384_000,
         reasoning: { efforts: ['low', 'high', 'max'], defaultEffort: 'high' },
       });
+  });
+
+  it('uses Kimi K3 as the Open Platform default while retaining current fallback tiers', () => {
+    expect(KIMI.models?.map((model) => model.id)).toEqual([
+      'kimi-k3',
+      'kimi-k2.7-code',
+      'kimi-k2.7-code-highspeed',
+      'kimi-k2.6',
+    ]);
+    expect(DEFAULT_MODEL_BY_VENDOR['kimi']).toBe('kimi-k3');
+    expect(KIMI.models?.find((model) => model.id === 'kimi-k3')?.semantics).toEqual({
+      contextWindow: 1_048_576,
+      reasoning: {
+        mode: 'required',
+        efforts: ['low', 'high', 'max'],
+        defaultEffort: 'max',
+        interleaved: true,
+      },
+    });
   });
 
   it('serializes provider-aware setup guidance for every API-key preset', () => {

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -324,7 +324,7 @@ export const KIMI: PresetDef = {
     backend: z.literal('agent-sdk'),
     loginMethod: z.literal('api-key'),
     baseUrl: z.string().default('https://api.moonshot.cn/anthropic').describe('API endpoint'),
-    model: z.string().default('kimi-k2.7-code').describe('Model'),
+    model: z.string().default('kimi-k3').describe('Model'),
     apiKey: z.string().min(1).describe('Moonshot API key'),
   }),
   regions: [
@@ -336,7 +336,9 @@ export const KIMI: PresetDef = {
     } },
   ],
   models: withModelSemantics('kimi', [
+    { id: 'kimi-k3', label: 'Kimi K3' },
     { id: 'kimi-k2.7-code', label: 'Kimi K2.7 Code' },
+    { id: 'kimi-k2.7-code-highspeed', label: 'Kimi K2.7 Code HighSpeed' },
     { id: 'kimi-k2.6', label: 'Kimi K2.6' },
   ]),
   setup: {
@@ -473,7 +475,7 @@ export const DEFAULT_MODEL_BY_VENDOR: Record<string, string> = {
   google: 'gemini-3.1-flash-lite',
   minimax: 'MiniMax-M3',
   glm: 'glm-5.2',
-  kimi: 'kimi-k2.7-code',
+  kimi: 'kimi-k3',
   deepseek: 'deepseek-v4-pro',
   longcat: 'LongCat-2.0',
 }


### PR DESCRIPTION
## Summary

- make `kimi-k3` the default for new Kimi Open Platform credentials
- register its 1,048,576-token context and required `low` / `high` / `max` reasoning contract, defaulting to `max`
- add the current K2.7 Code HighSpeed fallback while preserving K2.7 Code and K2.6
- leave existing credential `lastModel` selections unchanged

Official contract:
- https://platform.kimi.ai/docs/models
- https://platform.kimi.ai/docs/guide/kimi-k3-quickstart

## Verification

- npx tsc --noEmit
- pnpm exec vitest run src/ai-providers/model-semantics.spec.ts src/ai-providers/preset-catalog.spec.ts --reporter=dot
- pnpm test --reporter=dot (3964 passed, 9 skipped)