### PR TITLE
Keep launch model and effort together

### DIFF
--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -99,6 +99,15 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('AgentLaunchSelectors keyboard menus', () => {
+  it('keeps model and effort together above the phone breakpoint', () => {
+    render(<AgentLaunchSelectors config={launchConfig()} onConfigureProvider={vi.fn()} />)
+
+    const group = screen.getByTestId('agent-launch-inference-group')
+    expect(group.className).toContain('contents')
+    expect(group.className).toContain('sm:flex')
+    expect(group.className).toContain('sm:shrink-0')
+  })
+
   it('moves through the agent menu and returns focus on Escape', async () => {
     const user = userEvent.setup()
     render(<AgentLaunchSelectors config={launchConfig()} onConfigureProvider={vi.fn()} />)

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -410,8 +410,15 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
         </div>
       )}
 
-      {config.selectedAgent && <AgentLaunchModelEditor config={config} />}
-      {config.selectedAgent && <AgentLaunchEffortEditor config={config} />}
+      {config.selectedAgent && (
+        <div
+          data-testid="agent-launch-inference-group"
+          className="contents sm:flex sm:shrink-0 sm:items-center sm:gap-2"
+        >
+          <AgentLaunchModelEditor config={config} />
+          <AgentLaunchEffortEditor config={config} />
+        </div>
+      )}
     </>
   )
 })


### PR DESCRIPTION
## What changed

- treat Model and Effort as one responsive launch-control group above the phone breakpoint
- keep the existing per-control flow on narrow phones
- add a focused regression assertion for the grouping contract

## Why

Natural flex wrapping could leave Effort alone on a new row while Model stayed with Workspace, Runtime, and Credential. The resulting 4+1 layout looked accidental. The grouped control now produces an intentional 3+2 composition at tablet widths.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (478 files passed, 1 skipped; 3965 tests passed, 9 skipped)
- real `/chat` browser walkthrough at desktop, 700×900, and 390×844 viewports