### PR TITLE
Deemphasize Workspace AI in Quick Start

### DIFF
--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -426,7 +426,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
 export interface AgentLaunchDetailsProps {
   readonly config: AgentLaunchConfigState
   readonly hasWorkspaceTarget: boolean
-  readonly onAdjustAi: () => void
+  readonly onAdjustAi?: () => void
   readonly className?: string
 }
 
@@ -449,11 +449,13 @@ export function AgentLaunchDetails({
   } | null = null
   if (config.aiDetails) {
     const workspaceSaved = config.aiDetails.source === 'workspace'
-    const actionLabel = hasWorkspaceTarget
-      ? workspaceSaved
-        ? t('chatLanding.adjustWorkspaceAi')
-        : t('chatLanding.configureWorkspaceAi')
-      : t('chatLanding.providerSettings')
+    const actionLabel = onAdjustAi
+      ? hasWorkspaceTarget
+        ? workspaceSaved
+          ? t('chatLanding.adjustWorkspaceAi')
+          : t('chatLanding.configureWorkspaceAi')
+        : t('chatLanding.providerSettings')
+      : undefined
     scope = workspaceSaved
       ? {
           label: t('chatLanding.workspaceAiScope'),
@@ -475,7 +477,7 @@ export function AgentLaunchDetails({
     scope = {
       label: t('chatLanding.runtimeAiScope', { runtime: config.selectedAgent.displayName }),
       detail: t('chatLanding.runtimeManagedAi', { runtime: config.selectedAgent.displayName }),
-      ...(!config.needsCredential && hasWorkspaceTarget
+      ...(!config.needsCredential && hasWorkspaceTarget && onAdjustAi
         ? { actionLabel: t('chatLanding.configureWorkspaceAi') }
         : {}),
     }
@@ -502,7 +504,7 @@ export function AgentLaunchDetails({
               {scope.detail}
             </span>
           )}
-          {scope.actionLabel && (
+          {scope.actionLabel && onAdjustAi && (
             <button
               type="button"
               onClick={onAdjustAi}

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -577,7 +577,7 @@ describe('ChatLandingPage AI source disclosure', () => {
     expect(await findModelEditor('gemini-3.1-flash-lite')).toBeTruthy()
     expect(screen.queryByText('Saved in this workspace')).toBeNull()
     expect(screen.queryByText(/Sending will configure this workspace/)).toBeNull()
-    expect(screen.getByRole('button', { name: 'Adjust workspace AI' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Adjust workspace AI' })).toBeNull()
     expectDefaultEffort('minimal reasoning')
   })
 
@@ -610,7 +610,7 @@ describe('ChatLandingPage AI source disclosure', () => {
     expect(await screen.findByText('New Session only')).toBeTruthy()
     expect(screen.getByText('Workspace settings stay unchanged')).toBeTruthy()
     expect(await findModelEditor('gemini-3.1-flash-lite')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Configure workspace AI' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Configure workspace AI' })).toBeNull()
     expectDefaultEffort('minimal reasoning')
   })
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -30,7 +30,6 @@ import {
   useAgentLaunchConfig,
   useAgentLaunchPreferences,
 } from '../hooks/useAgentLaunchConfig'
-import { isWorkspaceAiAgent } from '../lib/agentRuntime'
 import { AutoQuantSetupPage } from './AutoQuantSetupPage'
 
 export { resolveAgentRuntime as resolveChatAgent } from '../lib/agentRuntime'
@@ -94,7 +93,6 @@ function HarnessLandingPage({
     agents,
     workspaces,
     defaultAgent,
-    openAgentConfig,
     hasLoaded,
     listError,
     refresh,
@@ -156,14 +154,6 @@ function HarnessLandingPage({
 
   const goConfigureProvider = () => {
     openOrFocus({ kind: 'settings', params: { category: 'ai-provider' } })
-  }
-
-  const adjustQuickChatAi = () => {
-    if (credentialWorkspace && isWorkspaceAiAgent(effectiveAgent)) {
-      openAgentConfig(credentialWorkspace.id, effectiveAgent, 'ai')
-      return
-    }
-    goConfigureProvider()
   }
 
   // A missing runtime choice should open the picker, not leave a mysteriously
@@ -425,7 +415,6 @@ function HarnessLandingPage({
           <AgentLaunchDetails
             config={launchConfig}
             hasWorkspaceTarget={credentialWorkspace !== null && credentialWorkspace !== undefined}
-            onAdjustAi={adjustQuickChatAi}
             className="mx-1 mt-2 border-t border-border/50 px-1 pt-2"
           />
         </div>


### PR DESCRIPTION
## What changed

- remove the Configure/Adjust Workspace AI action from Quick Start launch details
- retain the compact Session/Workspace scope disclosure and credential divergence
- keep the persistent Workspace AI action available to management surfaces such as Workspace Manager
- keep the missing-provider recovery CTA in Quick Start

## Why

Quick Start already exposes the complete per-Session runtime, credential, model, and effort tuple. Linking directly from that flow into persisted Workspace injection settings mixed one-run launch choices with durable configuration and overemphasized the legacy file-injection path.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (478 files passed, 1 skipped; 3965 tests passed, 9 skipped)
- targeted Quick Start / Workspace Manager tests (31 passed)
- real `/chat` browser walkthrough at desktop and 390×844