### PR TITLE
Remove Quick Start scope disclosure

### DIFF
--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -427,6 +427,7 @@ export interface AgentLaunchDetailsProps {
   readonly config: AgentLaunchConfigState
   readonly hasWorkspaceTarget: boolean
   readonly onAdjustAi?: () => void
+  readonly showScopeDisclosure?: boolean
   readonly className?: string
 }
 
@@ -436,6 +437,7 @@ export function AgentLaunchDetails({
   config,
   hasWorkspaceTarget,
   onAdjustAi,
+  showScopeDisclosure = true,
   className = '',
 }: AgentLaunchDetailsProps) {
   const { t } = useTranslation()
@@ -447,7 +449,7 @@ export function AgentLaunchDetails({
     detail?: string
     actionLabel?: string
   } | null = null
-  if (config.aiDetails) {
+  if (showScopeDisclosure && config.aiDetails) {
     const workspaceSaved = config.aiDetails.source === 'workspace'
     const actionLabel = onAdjustAi
       ? hasWorkspaceTarget
@@ -465,7 +467,11 @@ export function AgentLaunchDetails({
           label: t('chatLanding.newSessionAiScope'),
           actionLabel,
         }
-  } else if (config.selectedAgent && (!config.needsCredential || config.selectedRuntimeUsesGlobalConfig)) {
+  } else if (
+    showScopeDisclosure &&
+    config.selectedAgent &&
+    (!config.needsCredential || config.selectedRuntimeUsesGlobalConfig)
+  ) {
     scope = {
       label: t('chatLanding.runtimeAiScope', { runtime: config.selectedAgent.displayName }),
       detail: t('chatLanding.runtimeManagedAi', { runtime: config.selectedAgent.displayName }),

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -407,7 +407,8 @@ describe('ChatLandingPage keyboard submission', () => {
 
     render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
 
-    await screen.findByText('Model, reasoning, and context are managed by Pi')
+    expect((await screen.findByRole('button', { name: 'Select agent' })).textContent).toContain('Pi')
+    expect(screen.queryByText('Model, reasoning, and context are managed by Pi')).toBeNull()
     fireEvent.change(screen.getByPlaceholderText('Ask Alice…'), { target: { value: 'hello' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
@@ -470,7 +471,7 @@ describe('ChatLandingPage keyboard submission', () => {
     fireEvent.click(screen.getByRole('button', { name: 'AI provider' }))
     fireEvent.click(screen.getByRole('menuitem', { name: /deepseek-1/ }))
     expect(await findModelEditor('deepseek-v4-flash')).toBeTruthy()
-    expect(screen.getByText('New Session only')).toBeTruthy()
+    expect(screen.queryByText('New Session only')).toBeNull()
     expect(screen.queryByText(/instead of Workspace/)).toBeNull()
     expect(screen.queryByText('Workspace settings stay unchanged')).toBeNull()
 
@@ -608,7 +609,7 @@ describe('ChatLandingPage AI source disclosure', () => {
 
     render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
 
-    expect(await screen.findByText('New Session only')).toBeTruthy()
+    expect(screen.queryByText('New Session only')).toBeNull()
     expect(screen.queryByText('Workspace settings stay unchanged')).toBeNull()
     expect(await findModelEditor('gemini-3.1-flash-lite')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Configure workspace AI' })).toBeNull()

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -415,6 +415,7 @@ function HarnessLandingPage({
           <AgentLaunchDetails
             config={launchConfig}
             hasWorkspaceTarget={credentialWorkspace !== null && credentialWorkspace !== undefined}
+            showScopeDisclosure={false}
             className="mx-1 mt-2 border-t border-border/50 px-1 pt-2"
           />
         </div>


### PR DESCRIPTION
## Summary
- remove the `New Session only` scope pill from Quick Start
- keep setup-required notices available without rendering normal-state implementation details
- update launch tests to assert that runtime and scope internals stay hidden

## UI review
- removes the redundant launch-scope row so the composer ends at the actual choices and send action
- introduces no new visual vocabulary
- verified the real `/chat` route in the in-app browser

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (3965 passed, 9 skipped)
- targeted Chat Landing, Workspace Manager, and launch-control tests (31 passed)