### PR TITLE
Compact Quick Start AI controls

### DIFF
--- a/plans/quick-start-launch-context.md
+++ b/plans/quick-start-launch-context.md
@@ -32,6 +32,8 @@ the primary send path.
 
 - [x] Split Session context from AI execution controls and make the layout
       responsive from phone through desktop widths.
+- [x] Keep AI execution controls as a compact composer toolbar instead of
+      expanding them into labeled settings fields.
 - [x] Add human-readable provider identity and an explicit native-runtime
       access choice.
 - [x] Persist and migrate the recent access mode without storing secrets.

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -66,6 +66,8 @@ export interface AgentLaunchSelectorsProps {
   readonly showAi?: boolean
   readonly menuPlacement?: 'up' | 'down'
   readonly labeled?: boolean
+  /** Visually recede selectors into a composer toolbar until hover/focus. */
+  readonly toolbar?: boolean
 }
 
 export interface AgentLaunchSelectorsHandle {
@@ -116,9 +118,11 @@ function handleMenuKeyDown(
 function AgentLaunchModelEditor({
   config,
   labeled = false,
+  toolbar = false,
 }: {
   config: AgentLaunchConfigState
   labeled?: boolean
+  toolbar?: boolean
 }) {
   const { t } = useTranslation()
   const listId = useId()
@@ -140,7 +144,7 @@ function AgentLaunchModelEditor({
     : undefined
 
   return (
-    <label className={`relative inline-flex min-w-0 items-center rounded-md bg-muted text-[11px] text-muted-foreground focus-within:ring-1 focus-within:ring-primary/50 ${labeled ? 'min-h-12 w-full max-w-none sm:w-auto sm:max-w-[220px]' : 'min-h-8 max-w-[220px]'}`}>
+    <label className={`relative inline-flex min-w-0 items-center rounded-md text-[11px] text-muted-foreground transition-colors focus-within:bg-muted/70 focus-within:ring-1 focus-within:ring-primary/50 ${toolbar ? 'bg-transparent hover:bg-muted/55' : 'bg-muted'} ${labeled ? 'min-h-12 w-full max-w-none sm:w-auto sm:max-w-[220px]' : 'min-h-8 max-w-[220px]'}`}>
       <Cpu className={`pointer-events-none absolute left-2.5 h-3 w-3 shrink-0 ${labeled ? 'top-6' : ''}`} />
       {labeled && (
         <span className="pointer-events-none absolute left-2.5 top-1.5 text-[9.5px] font-medium text-muted-foreground">
@@ -162,7 +166,7 @@ function AgentLaunchModelEditor({
         aria-label={t('chatLanding.selectModel')}
         title={contextLabel}
         placeholder={defaultLabel}
-        className={`min-w-0 bg-transparent pl-7 pr-2 text-[11px] text-foreground outline-none placeholder:text-muted-foreground ${labeled ? 'w-full pb-1 pt-5 sm:w-[190px]' : 'w-[190px] py-1'}`}
+        className={`min-w-0 bg-transparent pl-7 pr-2 text-[11px] text-foreground outline-none placeholder:text-muted-foreground ${labeled ? 'w-full pb-1 pt-5 sm:w-[190px]' : toolbar ? 'w-[150px] py-1' : 'w-[190px] py-1'}`}
       />
       <datalist id={listId}>
         {config.modelOptions.map((model) => (
@@ -176,9 +180,11 @@ function AgentLaunchModelEditor({
 function AgentLaunchEffortEditor({
   config,
   labeled = false,
+  toolbar = false,
 }: {
   config: AgentLaunchConfigState
   labeled?: boolean
+  toolbar?: boolean
 }) {
   const { t } = useTranslation()
   const current = config.launchReasoningEffort
@@ -200,10 +206,12 @@ function AgentLaunchEffortEditor({
               ? t('chatLanding.reasoningOptionalSummary')
               : t('chatLanding.reasoningRuntimeSummary')
   const defaultLabel = details
-    ? t('chatLanding.defaultEffortValue', { effort: resolvedDefault })
+    ? toolbar
+      ? resolvedDefault
+      : t('chatLanding.defaultEffortValue', { effort: resolvedDefault })
     : t('chatLanding.defaultEffort')
   return (
-    <label className={`relative inline-flex min-w-0 items-center rounded-md bg-muted text-[11px] text-muted-foreground focus-within:ring-1 focus-within:ring-primary/50 ${labeled ? 'min-h-12 w-full max-w-none sm:w-auto sm:max-w-[190px]' : 'min-h-8 max-w-[190px]'}`}>
+    <label className={`relative inline-flex min-w-0 items-center rounded-md text-[11px] text-muted-foreground transition-colors focus-within:bg-muted/70 focus-within:ring-1 focus-within:ring-primary/50 ${toolbar ? 'bg-transparent hover:bg-muted/55' : 'bg-muted'} ${labeled ? 'min-h-12 w-full max-w-none sm:w-auto sm:max-w-[190px]' : toolbar ? 'min-h-8 max-w-[175px]' : 'min-h-8 max-w-[190px]'}`}>
       <BrainCircuit className={`pointer-events-none absolute left-2.5 h-3 w-3 shrink-0 ${labeled ? 'top-6' : ''}`} />
       {labeled && (
         <span className="pointer-events-none absolute left-2.5 top-1.5 text-[9.5px] font-medium text-muted-foreground">
@@ -218,7 +226,7 @@ function AgentLaunchEffortEditor({
             : null,
         )}
         aria-label={t('chatLanding.selectEffort')}
-        className={`min-w-0 appearance-none bg-transparent pl-7 pr-7 text-[11px] text-foreground outline-none ${labeled ? 'w-full max-w-none pb-1 pt-5 sm:max-w-[190px]' : 'max-w-[190px] py-1'}`}
+        className={`min-w-0 appearance-none bg-transparent pl-7 pr-7 text-[11px] text-foreground outline-none ${labeled ? 'w-full max-w-none pb-1 pt-5 sm:max-w-[190px]' : toolbar ? 'max-w-[175px] py-1' : 'max-w-[190px] py-1'}`}
       >
         <option value="">{defaultLabel}</option>
         {options.map((effort) => <option key={effort} value={effort}>{effort}</option>)}
@@ -238,6 +246,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
     showAi = true,
     menuPlacement = 'up',
     labeled = false,
+    toolbar = false,
   },
   ref,
 ) {
@@ -419,7 +428,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
             aria-haspopup="menu"
             aria-expanded={credentialMenuOpen}
             aria-label={t('chatLanding.selectCredential')}
-            className={`oa-pressable inline-flex items-center gap-2 rounded-md bg-muted px-2.5 text-left text-muted-foreground hover:text-foreground ${labeled ? 'min-h-12 w-full max-w-none py-1.5 sm:w-auto sm:max-w-[240px]' : 'min-h-8 max-w-[240px] py-1'}`}
+            className={`oa-pressable inline-flex items-center gap-2 rounded-md text-left text-muted-foreground transition-colors hover:text-foreground ${toolbar ? 'bg-transparent px-1.5 hover:bg-muted/55' : 'bg-muted px-2.5'} ${labeled ? 'min-h-12 w-full max-w-none py-1.5 sm:w-auto sm:max-w-[240px]' : toolbar ? 'min-h-8 max-w-[200px] py-1' : 'min-h-8 max-w-[240px] py-1'}`}
           >
             <KeyRound className="h-3 w-3 shrink-0" />
             <span className="min-w-0 flex-1">
@@ -523,10 +532,10 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
       {showAi && config.selectedAgent && (
         <div
           data-testid="agent-launch-inference-group"
-          className="contents sm:flex sm:shrink-0 sm:items-center sm:gap-2"
+          className={`contents sm:flex sm:shrink-0 sm:items-center ${toolbar ? 'sm:gap-1' : 'sm:gap-2'}`}
         >
-          <AgentLaunchModelEditor config={config} labeled={labeled} />
-          <AgentLaunchEffortEditor config={config} labeled={labeled} />
+          <AgentLaunchModelEditor config={config} labeled={labeled} toolbar={toolbar} />
+          <AgentLaunchEffortEditor config={config} labeled={labeled} toolbar={toolbar} />
         </div>
       )}
     </>

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -331,6 +331,8 @@ describe('ChatLandingPage adapter inventory', () => {
     expect(inferenceRow.contains(await screen.findByRole('button', { name: 'AI access' }))).toBe(true)
     expect(inferenceRow.contains(screen.getByRole('combobox', { name: 'AI model' }))).toBe(true)
     expect(inferenceRow.contains(screen.getByRole('combobox', { name: 'Reasoning effort' }))).toBe(true)
+    expect(inferenceRow.textContent).not.toContain('Model')
+    expect(inferenceRow.textContent).not.toContain('Effort')
   })
 })
 

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -401,12 +401,12 @@ function HarnessLandingPage({
             data-testid="harness-landing-controls"
             className="flex items-end justify-between gap-2 px-1 pt-1"
           >
-            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
               <AgentLaunchSelectors
                 config={launchConfig}
                 onConfigureProvider={goConfigureProvider}
                 showRuntime={false}
-                labeled
+                toolbar
               />
             </div>
             <div className="flex shrink-0 items-center justify-end gap-1.5">


### PR DESCRIPTION
## Summary

- turn the large labeled AI settings fields into a single compact composer toolbar
- remove persistent control fills so access, model, and effort recede until hover or focus
- shorten the resolved default effort label while preserving the full selector behavior

## Verification

- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (479 files passed; 3975 tests passed)
- real pnpm dev browser walk at desktop, 720px, and 390px widths
- AI access menu containment and provider identity check