### PR TITLE
Explain Quick Start AI access choices

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -146,7 +146,9 @@ projection is empty.
 Compact launch surfaces may present model and effort through one disclosure,
 but the nested choices must remain independently selectable and preserve the
 credential-to-model-to-effort dependency order. Free-typed model ids remain
-available because registry suggestions are not an allowlist.
+available because registry suggestions are not an allowlist. Credential menus
+should state which runtime is receiving AI access before listing Workspace,
+native-login, and saved-vault choices.
 
 Legacy resume identities that predate this binding contract are upgraded to an
 explicit native binding on their next activation. They must not inspect and

--- a/plans/quick-start-launch-context.md
+++ b/plans/quick-start-launch-context.md
@@ -38,6 +38,8 @@ the primary send path.
       keyboard-accessible menus while preserving free-typed model ids.
 - [x] Add human-readable provider identity and an explicit native-runtime
       access choice.
+- [x] Give the AI-access menu a runtime-aware context line without adding a
+      focusable setting or implementation-detail explanation.
 - [x] Persist and migrate the recent access mode without storing secrets.
 - [x] Carry explicit native access through every Quick Start launch route and
       Session runtime binding.

--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -169,6 +169,7 @@ describe('AgentLaunchSelectors keyboard menus', () => {
     const trigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectCredential') })
     trigger.focus()
     await user.keyboard('{ArrowUp}')
+    expect(screen.getByText(i18n.t('chatLanding.credentialMenuTitle', { runtime: 'OpenCode' }))).toBeTruthy()
     expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: /Backup/ }))
 
     await user.keyboard('{Escape}')

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -658,6 +658,12 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
               )}
               className={`oa-popover-enter absolute left-0 z-20 max-h-[min(24rem,calc(100vh-8rem))] min-w-[240px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-secondary py-1 shadow-lg [scrollbar-gutter:stable] ${menuPlacement === 'down' ? 'top-full mt-1' : 'bottom-full mb-1'}`}
             >
+              <div
+                role="presentation"
+                className="border-b border-border/60 px-3 py-2 text-[11px] font-medium text-muted-foreground"
+              >
+                {t('chatLanding.credentialMenuTitle', { runtime: runtimeName })}
+              </div>
               {config.detectedCredential?.configured === true && (
                 <button
                   type="button"

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -898,6 +898,7 @@ export const en = {
     noAgentsBody: 'OpenAlice normally includes Pi for workspace chat. If this appears in a packaged build, the runtime bundle needs attention; you can continue in Lite while setup is checked.',
     selectCredential: 'AI access',
     aiAccess: 'AI access',
+    credentialMenuTitle: 'How should {{runtime}} access AI?',
     modelField: 'Model',
     effortField: 'Effort',
     runtimeFallback: 'Runtime',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -887,6 +887,7 @@ export const ja: Resources = {
     noAgentsBody: 'OpenAlice には通常、ワークスペースチャット用の Pi が同梱されます。パッケージ版でこの表示が出る場合は、ランタイム同梱を確認してください。確認中も Lite モードで続行できます。',
     selectCredential: 'AI アクセス',
     aiAccess: 'AI アクセス',
+    credentialMenuTitle: '{{runtime}} はどの方法で AI にアクセスしますか？',
     modelField: 'モデル',
     effortField: '推論強度',
     runtimeFallback: 'ランタイム',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -894,6 +894,7 @@ export const zhHant: Resources = {
     noAgentsBody: 'OpenAlice 通常會自帶 Pi 用於工作區對話。如果打包版出現這個提示，表示執行環境包需要檢查；你仍然可以先以 Lite 模式繼續使用。',
     selectCredential: 'AI 存取',
     aiAccess: 'AI 存取',
+    credentialMenuTitle: '{{runtime}} 要如何存取 AI？',
     modelField: '模型',
     effortField: '推理強度',
     runtimeFallback: '執行環境',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -886,6 +886,7 @@ export const zh: Resources = {
     noAgentsBody: 'OpenAlice 通常会自带 Pi 用于工作区对话。如果打包版出现这个提示，说明运行时包需要检查；你仍然可以先以 Lite 模式继续使用。',
     selectCredential: 'AI 访问',
     aiAccess: 'AI 访问',
+    credentialMenuTitle: '{{runtime}} 要如何访问 AI？',
     modelField: '模型',
     effortField: '推理强度',
     runtimeFallback: '运行时',


### PR DESCRIPTION
## Summary
- add a runtime-aware context line above Quick Start AI-access choices
- keep the header outside the menuitem focus order
- localize the question across supported UI languages
- document the access-menu hierarchy

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (3977 passed, 9 skipped)
- pnpm exec vitest run ui/src/components/workspace/AgentLaunchControls.spec.tsx ui/src/pages/ChatLandingPage.render.spec.tsx (25 passed)
- real /chat browser walk at 1280px and 390px; checked upward placement, no horizontal overflow, and keyboard focus order