### PR TITLE
Refine Quick Start suggestion strip

### DIFF
--- a/plans/quick-start-launch-context.md
+++ b/plans/quick-start-launch-context.md
@@ -40,6 +40,8 @@ the primary send path.
       access choice.
 - [x] Give the AI-access menu a runtime-aware context line without adding a
       focusable setting or implementation-detail explanation.
+- [x] Restyle example prompts as a labeled, responsive suggestion strip with
+      one-shot staggered entrance and reduced-motion fallback.
 - [x] Persist and migrate the recent access mode without storing secrets.
 - [x] Carry explicit native access through every Quick Start launch route and
       Session runtime binding.

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -239,6 +239,17 @@ body {
   }
 }
 
+@keyframes oa-suggestion-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 .oa-view-enter {
   animation: oa-view-enter var(--motion-standard) var(--motion-ease-out) both;
 }
@@ -286,6 +297,10 @@ body {
 .oa-popover-enter {
   transform-origin: top;
   animation: oa-popover-enter var(--motion-standard) var(--motion-ease-out) both;
+}
+
+.oa-suggestion-enter {
+  animation: oa-suggestion-enter var(--motion-standard) var(--motion-ease-out) backwards;
 }
 
 /* ==================== Typography scale ====================
@@ -589,7 +604,8 @@ html[lang="ja"] .oa-onboarding-title {
   .oa-dialog-surface,
   .oa-dialog-backdrop,
   .oa-disclosure-enter,
-  .oa-popover-enter {
+  .oa-popover-enter,
+  .oa-suggestion-enter {
     animation: none;
   }
   .oa-pressable,

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -341,6 +341,23 @@ describe('ChatLandingPage adapter inventory', () => {
   })
 })
 
+describe('ChatLandingPage suggestion strip', () => {
+  it('separates the label from the staggered prompt actions and fills the composer', () => {
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    const strip = screen.getByTestId('harness-landing-suggestions')
+    expect(strip.textContent).toContain('Try asking')
+    const suggestions = strip.querySelectorAll('button')
+    expect(suggestions).toHaveLength(3)
+    expect(suggestions[0]?.className).toContain('oa-suggestion-enter')
+    expect(suggestions[1]?.style.animationDelay).toBe('55ms')
+
+    fireEvent.click(suggestions[0]!)
+    expect((screen.getByPlaceholderText('Ask Alice…') as HTMLTextAreaElement).value)
+      .toBe("What's moving in semiconductors today?")
+  })
+})
+
 describe('ChatLandingPage keyboard submission', () => {
   it('does not submit when Enter confirms an IME composition candidate', async () => {
     render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   MessageSquare,
   Paperclip,
+  Sparkles,
   X,
 } from 'lucide-react'
 
@@ -493,16 +494,23 @@ function HarnessLandingPage({
           </div>
         )}
 
-        <div className="relative -mx-4 md:mx-0">
-          <div className="scrollbar-hide flex items-center gap-2 overflow-x-auto px-4 pb-1 pr-14 md:flex-wrap md:overflow-visible md:px-1 md:pr-1 md:pb-0">
-            <span className="shrink-0 text-[11px] font-medium text-muted-foreground">{t(`${copyKey}.examplesLabel`)}</span>
-            {[t(`${copyKey}.ex1`), t(`${copyKey}.ex2`), t(`${copyKey}.ex3`)].map((ex) => (
+        <div data-testid="harness-landing-suggestions" className="relative -mx-4 md:mx-0">
+          <div className="flex items-center gap-2 px-4 pb-2 md:px-1">
+            <Sparkles aria-hidden className="h-3 w-3 shrink-0 text-primary/75" />
+            <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {t(`${copyKey}.examplesLabel`)}
+            </span>
+            <span aria-hidden className="h-px min-w-4 flex-1 bg-border/45" />
+          </div>
+          <div className="scrollbar-hide flex gap-2 overflow-x-auto px-4 pb-1 pr-14 md:flex-wrap md:overflow-visible md:px-1 md:pr-1 md:pb-0">
+            {[t(`${copyKey}.ex1`), t(`${copyKey}.ex2`), t(`${copyKey}.ex3`)].map((ex, index) => (
               <button
                 key={ex}
                 type="button"
                 onClick={() => useExample(ex)}
                 disabled={launching}
-                className="min-h-8 shrink-0 rounded-full border border-border/70 bg-secondary/75 px-3 py-1 text-[12px] text-muted-foreground transition-colors hover:border-primary/50 hover:bg-secondary hover:text-foreground disabled:opacity-40"
+                style={{ animationDelay: `${index * 55}ms` }}
+                className="oa-pressable oa-suggestion-enter min-h-9 shrink-0 rounded-lg border border-border/45 bg-secondary/45 px-3.5 py-1.5 text-left text-[12px] text-muted-foreground hover:border-border hover:bg-muted/70 hover:text-foreground focus-visible:border-primary/60 disabled:opacity-40"
               >
                 {ex}
               </button>


### PR DESCRIPTION
## Summary
- separate the Try asking label from prompt actions so wrapping stays intentional
- replace outlined pills with quieter workstation-style suggestion blocks
- add a short staggered one-shot entrance using shared motion timing
- preserve horizontal prompt browsing on narrow screens and disable the entrance under reduced motion

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (3978 passed, 9 skipped)
- pnpm exec vitest run ui/src/pages/ChatLandingPage.render.spec.tsx (18 passed)
- real /chat browser walk at 1280px, 720px, and 390px; checked row hierarchy, overflow containment, animation timing, and prompt insertion/focus