### PR TITLE
Add motion to Tracked graph

### DIFF
--- a/plans/tracked-relationship-graph.md
+++ b/plans/tracked-relationship-graph.md
@@ -28,6 +28,10 @@ clusters form, or which tracked anchors have no supporting material.
 5. Source-node navigation reuses the existing Tracked file/Issue provenance.
 6. Narrow canvases prioritize a readable window around the selected entity;
    the explicit Fit action retains a complete bird's-eye view.
+7. Graph motion is contextual rather than ambient: nodes settle outward from
+   the selected anchor in short waves, edges draw once, and pointer focus
+   emphasizes only the hovered node's one-hop neighborhood. Motion tokens and
+   reduced-motion preferences remain authoritative.
 
 ## Work
 
@@ -39,16 +43,21 @@ clusters form, or which tracked anchors have no supporting material.
       fit, entity selection, and source navigation.
 - [x] Mirror the contract in the demo surface and all shipped locales.
 - [x] Add core, route, layout, component, page, and demo regressions.
+- [x] Add token-based entrance and one-hop focus motion with reduced-motion
+      handling and no continuous background animation.
 - [x] Complete browser, full-suite, and packaged Electron verification.
 
 ## Verification
 
 - `npx tsc --noEmit`
 - `cd ui && npx tsc -b`
-- focused core, route, layout, component, page, and demo suites (12 tests)
-- `pnpm test` (483 files passed, 1 skipped; 3985 tests passed, 9 skipped)
+- focused core, route, layout, component, page, and demo suites (13 tests)
+- `pnpm test` (483 files passed, 1 skipped; 3986 tests passed, 9 skipped)
 - real `/tracked` route in Day and Auto color modes at desktop, tablet, and
   phone widths, including scope, filters, zoom, detail, source, and Back flows
+- graph entrance and focus states in Day/Night modes and at phone width, with
+  motion disabled by both the shared reduced-motion rule and zero-motion style
+  profiles
 - `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
 
 ## Completion Criteria

--- a/ui/src/components/TrackedGraphView.spec.tsx
+++ b/ui/src/components/TrackedGraphView.spec.tsx
@@ -78,4 +78,30 @@ describe('TrackedGraphView', () => {
     expect(screen.queryByRole('button', { name: /second-hop-c, linked/ })).toBeNull()
     expect(screen.queryByRole('button', { name: /other-note, source material/ })).toBeNull()
   })
+
+  it('focuses one-hop relationships when a node is hovered', () => {
+    render(
+      <TrackedGraphView
+        graph={graph}
+        selectedName={null}
+        onSelectEntity={vi.fn()}
+        onOpenEntity={vi.fn()}
+        onOpenArtifact={vi.fn()}
+      />,
+    )
+
+    const assetButton = screen.getByRole('button', { name: /asset-a, linked/ })
+    fireEvent.pointerEnter(assetButton)
+
+    expect(assetButton.closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('active')
+    expect(screen.getByRole('button', { name: /shared-note, source material/ })
+      .closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('related')
+    expect(screen.getByRole('button', { name: /topic-b, linked/ })
+      .closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('dimmed')
+    expect(screen.getByRole('button', { name: /other-note, source material/ })
+      .closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('dimmed')
+
+    fireEvent.pointerLeave(assetButton)
+    expect(assetButton.closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('idle')
+  })
 })

--- a/ui/src/components/TrackedGraphView.tsx
+++ b/ui/src/components/TrackedGraphView.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type WheelEvent as ReactWheelEvent,
 } from 'react'
@@ -281,6 +282,22 @@ export function TrackedGraphView({
     }
     return ids
   }, [activeNodeId, visibleEdges])
+  const entrancePhaseById = useMemo(() => {
+    const origin = selectedEntity && positions[selectedEntity.id]
+      ? positions[selectedEntity.id]!
+      : { x: CANVAS_WIDTH / 2, y: CANVAS_HEIGHT / 2 }
+    const ordered = [...visibleNodes].sort((left, right) => {
+      const leftPoint = positions[left.id] ?? origin
+      const rightPoint = positions[right.id] ?? origin
+      const leftDistance = Math.hypot(leftPoint.x - origin.x, leftPoint.y - origin.y)
+      const rightDistance = Math.hypot(rightPoint.x - origin.x, rightPoint.y - origin.y)
+      return leftDistance - rightDistance || left.id.localeCompare(right.id)
+    })
+    const phases = new Map<string, number>()
+    const divisor = Math.max(1, ordered.length - 1)
+    ordered.forEach((node, index) => phases.set(node.id, Math.min(4, Math.floor((index / divisor) * 5))))
+    return { origin, phases }
+  }, [positions, selectedEntity, visibleNodes])
 
   return (
     <div className="relative h-full min-h-[360px] overflow-hidden bg-background">
@@ -356,8 +373,16 @@ export function TrackedGraphView({
                 y2={target.y}
                 stroke="var(--chart-axis)"
                 strokeWidth={emphasized ? 1.8 : 1}
-                opacity={activeNodeId ? (emphasized ? 0.7 : 0.1) : 0.24}
+                opacity={activeNodeId
+                  ? (emphasized ? (hoveredNodeId ? 0.82 : 0.7) : (hoveredNodeId ? 0.06 : 0.1))
+                  : 0.24}
+                pathLength={1}
                 vectorEffect="non-scaling-stroke"
+                data-enter-phase={Math.max(
+                  entrancePhaseById.phases.get(edge.source) ?? 0,
+                  entrancePhaseById.phases.get(edge.target) ?? 0,
+                )}
+                className="oa-tracked-graph-edge"
               />
             )
           })}
@@ -369,72 +394,99 @@ export function TrackedGraphView({
             const selected = node.id === selectedEntity?.id
             const active = connectedToActive.has(node.id)
             const faded = activeNodeId !== null && !active
+            const focusState = activeNodeId === null
+              ? 'idle'
+              : node.id === activeNodeId ? 'active' : active ? 'related' : 'dimmed'
             const degree = degreeById.get(node.id) ?? 0
             const radius = node.kind === 'entity' ? Math.min(14, 8.5 + degree * 0.45) : node.artifactType === 'issue' ? 5.5 : 4.2
             // Entity names carry the graph's meaning and stay visible. Source
             // labels appear on hover (or in a genuinely small graph) so a
             // high-degree selected entity does not turn its cluster into text.
-            const showLabel = node.kind === 'entity' || node.id === hoveredNodeId || visibleNodes.length <= 12
+            const showLabel = node.kind === 'entity'
+              || (hoveredNodeId !== null && active)
+              || visibleNodes.length <= 12
             const labelOnLeft = point.x < CANVAS_WIDTH / 2
+            const enterX = Math.max(-54, Math.min(54, (entrancePhaseById.origin.x - point.x) * 0.18))
+            const enterY = Math.max(-42, Math.min(42, (entrancePhaseById.origin.y - point.y) * 0.18))
             return (
               <g
                 key={node.id}
                 transform={`translate(${point.x} ${point.y})`}
-                opacity={faded ? 0.32 : 1}
+                opacity={faded ? (hoveredNodeId ? 0.14 : 0.32) : 1}
+                data-graph-node={node.id}
+                data-focus-state={focusState}
+                data-hovered={node.id === hoveredNodeId ? 'true' : 'false'}
+                className="oa-tracked-graph-node"
                 onPointerEnter={() => setHoveredNodeId(node.id)}
                 onPointerLeave={() => setHoveredNodeId((value) => value === node.id ? null : value)}
               >
-                <title>{nodeTitle(node)}</title>
-                {selected && (
-                  <circle r={radius + 5} fill="none" stroke="var(--primary)" strokeWidth={2} opacity={0.45} vectorEffect="non-scaling-stroke" />
-                )}
-                <foreignObject
-                  x={-(radius + 8)}
-                  y={-(radius + 8)}
-                  width={(radius + 8) * 2}
-                  height={(radius + 8) * 2}
+                <g
+                  data-enter-phase={entrancePhaseById.phases.get(node.id) ?? 0}
+                  className="oa-tracked-graph-node-enter"
+                  style={{
+                    '--oa-graph-enter-x': `${enterX}px`,
+                    '--oa-graph-enter-y': `${enterY}px`,
+                  } as CSSProperties}
                 >
-                  <button
-                    type="button"
-                    aria-label={node.kind === 'entity'
-                      ? t('tracked.graph.entityNodeLabel', { name: node.label, count: degree })
-                      : t('tracked.graph.artifactNodeLabel', { name: node.label, workspace: node.workspaceTag })}
-                    title={nodeTitle(node)}
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onClick={() => activateNode(node)}
-                    className="flex h-full w-full items-center justify-center rounded-full bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
-                  >
-                    <span
-                      aria-hidden
-                      className={node.kind === 'artifact' && node.artifactType === 'issue' ? 'rounded-[1.5px]' : 'rounded-full'}
-                      style={{
-                        width: radius * 2,
-                        height: radius * 2,
-                        backgroundColor: node.kind === 'entity'
-                          ? node.entityType === 'asset' ? 'var(--chart-1)' : 'var(--chart-4)'
-                          : node.artifactType === 'issue' ? 'var(--chart-3)' : 'var(--muted-foreground)',
-                        boxShadow: `0 0 0 ${node.kind === 'entity' ? 2 : 1.25}px var(--background)`,
-                      }}
+                  <g className="oa-tracked-graph-node-focus">
+                    <title>{nodeTitle(node)}</title>
+                    <circle
+                      r={radius + 7}
+                      fill="var(--accent)"
+                      opacity={node.id === hoveredNodeId ? 0.72 : 0}
+                      className="oa-tracked-graph-hover-halo"
                     />
-                  </button>
-                </foreignObject>
-                {showLabel && (
-                  <text
-                    x={labelOnLeft ? -(radius + 6) : radius + 6}
-                    y={node.kind === 'entity' ? 4 : 3}
-                    textAnchor={labelOnLeft ? 'end' : 'start'}
-                    fill="var(--foreground)"
-                    fontSize={node.kind === 'entity' ? 12 : 10}
-                    fontWeight={node.kind === 'entity' ? 600 : 450}
-                    paintOrder="stroke"
-                    stroke="var(--background)"
-                    strokeWidth={4}
-                    strokeLinejoin="round"
-                    className="pointer-events-none"
-                  >
-                    {node.label}
-                  </text>
-                )}
+                    {selected && (
+                      <circle r={radius + 5} fill="none" stroke="var(--primary)" strokeWidth={2} opacity={0.45} vectorEffect="non-scaling-stroke" />
+                    )}
+                    <foreignObject
+                      x={-(radius + 8)}
+                      y={-(radius + 8)}
+                      width={(radius + 8) * 2}
+                      height={(radius + 8) * 2}
+                    >
+                      <button
+                        type="button"
+                        aria-label={node.kind === 'entity'
+                          ? t('tracked.graph.entityNodeLabel', { name: node.label, count: degree })
+                          : t('tracked.graph.artifactNodeLabel', { name: node.label, workspace: node.workspaceTag })}
+                        title={nodeTitle(node)}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={() => activateNode(node)}
+                        className="flex h-full w-full items-center justify-center rounded-full bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
+                      >
+                        <span
+                          aria-hidden
+                          className={node.kind === 'artifact' && node.artifactType === 'issue' ? 'rounded-[1.5px]' : 'rounded-full'}
+                          style={{
+                            width: radius * 2,
+                            height: radius * 2,
+                            backgroundColor: node.kind === 'entity'
+                              ? node.entityType === 'asset' ? 'var(--chart-1)' : 'var(--chart-4)'
+                              : node.artifactType === 'issue' ? 'var(--chart-3)' : 'var(--muted-foreground)',
+                            boxShadow: `0 0 0 ${node.kind === 'entity' ? 2 : 1.25}px var(--background)`,
+                          }}
+                        />
+                      </button>
+                    </foreignObject>
+                    <text
+                      x={labelOnLeft ? -(radius + 6) : radius + 6}
+                      y={node.kind === 'entity' ? 4 : 3}
+                      textAnchor={labelOnLeft ? 'end' : 'start'}
+                      fill="var(--foreground)"
+                      fontSize={node.kind === 'entity' ? 12 : 10}
+                      fontWeight={node.kind === 'entity' ? 600 : 450}
+                      paintOrder="stroke"
+                      stroke="var(--background)"
+                      strokeWidth={4}
+                      strokeLinejoin="round"
+                      opacity={showLabel ? 1 : 0}
+                      className="oa-tracked-graph-label pointer-events-none"
+                    >
+                      {node.label}
+                    </text>
+                  </g>
+                </g>
               </g>
             )
           })}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -250,6 +250,79 @@ body {
   }
 }
 
+@keyframes oa-tracked-graph-node-enter {
+  from {
+    opacity: 0;
+    transform: translate(var(--oa-graph-enter-x), var(--oa-graph-enter-y)) scale(0.72);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes oa-tracked-graph-edge-enter {
+  from { stroke-dashoffset: 1; }
+  to { stroke-dashoffset: 0; }
+}
+
+.oa-tracked-graph-node {
+  transition: opacity var(--motion-standard) var(--motion-ease-standard);
+}
+
+.oa-tracked-graph-node-enter {
+  animation: oa-tracked-graph-node-enter var(--motion-slow) var(--motion-ease-out) backwards;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.oa-tracked-graph-edge {
+  stroke-dasharray: 1;
+  animation: oa-tracked-graph-edge-enter var(--motion-slow) var(--motion-ease-out) backwards;
+  transition:
+    opacity var(--motion-standard) var(--motion-ease-standard),
+    stroke-width var(--motion-fast) var(--motion-ease-standard);
+}
+
+.oa-tracked-graph-node-focus {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform var(--motion-fast) var(--motion-ease-out);
+}
+
+.oa-tracked-graph-node[data-focus-state="active"] .oa-tracked-graph-node-focus {
+  transform: scale(1.14);
+}
+
+.oa-tracked-graph-node[data-focus-state="related"] .oa-tracked-graph-node-focus {
+  transform: scale(1.035);
+}
+
+.oa-tracked-graph-hover-halo,
+.oa-tracked-graph-label {
+  transition: opacity var(--motion-standard) var(--motion-ease-standard);
+}
+
+.oa-tracked-graph-node-enter[data-enter-phase="1"],
+.oa-tracked-graph-edge[data-enter-phase="1"] {
+  animation-delay: calc(var(--motion-fast) / 4);
+}
+
+.oa-tracked-graph-node-enter[data-enter-phase="2"],
+.oa-tracked-graph-edge[data-enter-phase="2"] {
+  animation-delay: calc(var(--motion-fast) / 2);
+}
+
+.oa-tracked-graph-node-enter[data-enter-phase="3"],
+.oa-tracked-graph-edge[data-enter-phase="3"] {
+  animation-delay: calc(var(--motion-fast) - var(--motion-fast) / 4);
+}
+
+.oa-tracked-graph-node-enter[data-enter-phase="4"],
+.oa-tracked-graph-edge[data-enter-phase="4"] {
+  animation-delay: var(--motion-fast);
+}
+
 .oa-view-enter {
   animation: oa-view-enter var(--motion-standard) var(--motion-ease-out) both;
 }
@@ -608,6 +681,10 @@ html[lang="ja"] .oa-onboarding-title {
   .oa-suggestion-enter {
     animation: none;
   }
+  .oa-tracked-graph-node-enter,
+  .oa-tracked-graph-edge {
+    animation: none;
+  }
   .oa-pressable,
   .oa-icon-action,
   .oa-icon-action > svg,
@@ -615,6 +692,13 @@ html[lang="ja"] .oa-onboarding-title {
   .oa-nav-row,
   .oa-nav-icon,
   .oa-status-surface {
+    transition-duration: 0.01ms;
+  }
+  .oa-tracked-graph-node,
+  .oa-tracked-graph-edge,
+  .oa-tracked-graph-node-focus,
+  .oa-tracked-graph-hover-halo,
+  .oa-tracked-graph-label {
     transition-duration: 0.01ms;
   }
   .oa-pressable:hover,


### PR DESCRIPTION
## What

- settle Tracked graph nodes outward from the selected anchor in five short entrance waves
- draw relationship edges once as the graph arrives
- smoothly focus the hovered node and its one-hop neighborhood while fading unrelated nodes
- reveal related material labels during pointer focus and add a restrained hover halo
- honor shared motion tokens, reduced-motion preferences, and zero-motion UI styles

## Why

The relationship graph was functionally complete but arrived as a static diagnostic surface. Contextual motion now explains how the graph forms and makes dense neighborhoods easier to inspect without adding continuous ambient animation.

## UI review

- removes hard opacity cuts and replaces them with token-based transitions
- keeps entities and their immediate materials as the focus hierarchy
- leaves pan, zoom, node activation, and provenance navigation unchanged
- uses existing theme and motion tokens in Day, Night, and narrow layouts
- does not introduce a new visual dialect or persistent animation loop

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `cd ui && pnpm vitest run src/components/TrackedGraphView.spec.tsx` (3 tests)
- `pnpm test` (483 files passed, 1 skipped; 3986 tests passed, 9 skipped)
- real `/tracked` browser inspection: entrance start/end, focus state, Day/Night, 390×844 narrow viewport, Auto restored
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`

The previous merged increment's post-merge `dev` CI run completed successfully before this PR was published.
