### PR TITLE
Preview Tracked graph materials

### DIFF
--- a/plans/tracked-relationship-graph.md
+++ b/plans/tracked-relationship-graph.md
@@ -32,6 +32,9 @@ clusters form, or which tracked anchors have no supporting material.
    the selected anchor in short waves, edges draw once, and pointer focus
    emphasizes only the hovered node's one-hop neighborhood. Motion tokens and
    reduced-motion preferences remain authoritative.
+8. Material nodes use the same preview-first interaction as entities. Selecting
+   a note or Issue keeps the graph in place, animates a compact inspector into
+   view, and defers provenance navigation to the explicit Details action.
 
 ## Work
 
@@ -45,6 +48,8 @@ clusters form, or which tracked anchors have no supporting material.
 - [x] Add core, route, layout, component, page, and demo regressions.
 - [x] Add token-based entrance and one-hop focus motion with reduced-motion
       handling and no continuous background animation.
+- [x] Add animated material previews that preserve graph context until Details
+      is explicitly requested.
 - [x] Complete browser, full-suite, and packaged Electron verification.
 
 ## Verification
@@ -58,6 +63,8 @@ clusters form, or which tracked anchors have no supporting material.
 - graph entrance and focus states in Day/Night modes and at phone width, with
   motion disabled by both the shared reduced-motion rule and zero-motion style
   profiles
+- Issue and note previews at desktop and phone widths, including explicit
+  Details navigation with the graph route preserved until activation
 - `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
 
 ## Completion Criteria

--- a/ui/src/components/TrackedGraphView.spec.tsx
+++ b/ui/src/components/TrackedGraphView.spec.tsx
@@ -36,7 +36,7 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('TrackedGraphView', () => {
-  it('uses native node controls and opens source material with Tracked context', () => {
+  it('uses native node controls and previews source material before opening it', () => {
     const onSelectEntity = vi.fn()
     const onOpenArtifact = vi.fn()
     render(
@@ -55,6 +55,10 @@ describe('TrackedGraphView', () => {
     expect(onSelectEntity).toHaveBeenCalledWith('topic-b')
 
     fireEvent.click(screen.getByRole('button', { name: /shared-note, source material/ }))
+    expect(onOpenArtifact).not.toHaveBeenCalled()
+    expect(screen.getByText('Note · research')).toBeTruthy()
+    expect(screen.getByText('shared-note.md')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Open details' }))
     expect(onOpenArtifact).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'shared-note.md' }),
       'asset-a',

--- a/ui/src/components/TrackedGraphView.tsx
+++ b/ui/src/components/TrackedGraphView.tsx
@@ -81,6 +81,7 @@ export function TrackedGraphView({
     artifact: true,
   })
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null)
+  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null)
 
   useEffect(() => {
     setPositions(layoutTrackedGraph(graph))
@@ -113,10 +114,18 @@ export function TrackedGraphView({
     }
     return degree
   }, [graph.edges])
-  const selectedEntity = useMemo(
-    () => graph.nodes.find((node) => node.kind === 'entity' && node.label === selectedName) ?? null,
-    [graph.nodes, selectedName],
-  )
+  const selectedEntity = useMemo(() => {
+    const node = graph.nodes.find((candidate) => candidate.kind === 'entity' && candidate.label === selectedName)
+    return node?.kind === 'entity' ? node : null
+  }, [graph.nodes, selectedName])
+  const selectedArtifact = useMemo(() => {
+    const node = selectedArtifactId ? nodeById.get(selectedArtifactId) : undefined
+    return node?.kind === 'artifact' ? node : null
+  }, [nodeById, selectedArtifactId])
+
+  useEffect(() => {
+    setSelectedArtifactId(null)
+  }, [selectedName])
 
   const neighborhood = useMemo(() => {
     if (!selectedEntity) return null
@@ -146,6 +155,10 @@ export function TrackedGraphView({
     [graph.edges, visibleIds],
   )
 
+  useEffect(() => {
+    if (selectedArtifactId && !visibleIds.has(selectedArtifactId)) setSelectedArtifactId(null)
+  }, [selectedArtifactId, visibleIds])
+
   const relatedEntityForArtifact = useCallback((artifactId: string): string | null => {
     const selectedId = selectedEntity?.id
     const entityIds = graph.edges.flatMap((edge) => {
@@ -160,12 +173,21 @@ export function TrackedGraphView({
 
   const activateNode = useCallback((node: EntityGraphNode) => {
     if (node.kind === 'entity') {
+      setSelectedArtifactId(null)
       onSelectEntity(node.label)
       return
     }
-    const returnEntityName = relatedEntityForArtifact(node.id)
-    if (returnEntityName) onOpenArtifact(node, returnEntityName)
-  }, [onOpenArtifact, onSelectEntity, relatedEntityForArtifact])
+    setSelectedArtifactId(node.id)
+  }, [onSelectEntity])
+
+  const openPreviewDetails = useCallback(() => {
+    if (selectedArtifact) {
+      const returnEntityName = relatedEntityForArtifact(selectedArtifact.id)
+      if (returnEntityName) onOpenArtifact(selectedArtifact, returnEntityName)
+      return
+    }
+    if (selectedEntity) onOpenEntity(selectedEntity.label)
+  }, [onOpenArtifact, onOpenEntity, relatedEntityForArtifact, selectedArtifact, selectedEntity])
 
   const fitVisible = useCallback((preferReadable = false) => {
     const points = visibleNodes.flatMap((node) => positions[node.id] ? [positions[node.id]!] : [])
@@ -271,7 +293,7 @@ export function TrackedGraphView({
     zoom(event.deltaY > 0 ? 1.12 : 0.88, point?.x, point?.y)
   }
 
-  const activeNodeId = hoveredNodeId ?? selectedEntity?.id ?? null
+  const activeNodeId = hoveredNodeId ?? selectedArtifact?.id ?? selectedEntity?.id ?? null
   const connectedToActive = useMemo(() => {
     const ids = new Set<string>()
     if (!activeNodeId) return ids
@@ -391,7 +413,7 @@ export function TrackedGraphView({
           {visibleNodes.map((node) => {
             const point = positions[node.id]
             if (!point) return null
-            const selected = node.id === selectedEntity?.id
+            const selected = node.id === selectedEntity?.id || node.id === selectedArtifact?.id
             const active = connectedToActive.has(node.id)
             const faded = activeNodeId !== null && !active
             const focusState = activeNodeId === null
@@ -500,16 +522,35 @@ export function TrackedGraphView({
         <LegendDot color="var(--chart-3)" label={t('tracked.graph.issue')} square />
       </div>
 
-      {selectedEntity?.kind === 'entity' && (
-        <div className="absolute bottom-3 right-3 z-10 max-w-[min(420px,calc(100%-1.5rem))] rounded-lg border border-border/70 bg-background/92 px-3 py-2.5 shadow-sm backdrop-blur-sm sm:bottom-4 sm:right-4">
+      {(selectedArtifact ?? selectedEntity) && (
+        <div
+          key={(selectedArtifact ?? selectedEntity)?.id}
+          className="oa-tracked-graph-preview-enter absolute bottom-3 right-3 z-10 max-w-[min(420px,calc(100%-1.5rem))] rounded-lg border border-border/70 bg-background/92 px-3 py-2.5 shadow-sm backdrop-blur-sm sm:bottom-4 sm:right-4"
+        >
           <div className="flex items-start gap-3">
             <div className="min-w-0 flex-1">
-              <div className="truncate font-mono text-[12px] font-semibold text-foreground">{selectedEntity.label}</div>
-              <div className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">{selectedEntity.description}</div>
+              <div className="flex items-center gap-1.5 truncate font-mono text-[12px] font-semibold text-foreground">
+                {selectedArtifact && (
+                  selectedArtifact.artifactType === 'issue'
+                    ? <ListChecks size={12} className="shrink-0 text-muted-foreground" aria-hidden />
+                    : <FileText size={12} className="shrink-0 text-muted-foreground" aria-hidden />
+                )}
+                <span className="truncate">{(selectedArtifact ?? selectedEntity)?.label}</span>
+              </div>
+              {selectedArtifact ? (
+                <div className="mt-0.5 min-w-0 text-[11px] leading-relaxed text-muted-foreground">
+                  <div className="truncate">
+                    {t(selectedArtifact.artifactType === 'issue' ? 'tracked.graph.issue' : 'tracked.graph.note')} · {selectedArtifact.workspaceTag}
+                  </div>
+                  <div className="truncate font-mono text-[10px] opacity-80">{selectedArtifact.path}</div>
+                </div>
+              ) : (
+                <div className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">{selectedEntity?.description}</div>
+              )}
             </div>
             <button
               type="button"
-              onClick={() => onOpenEntity(selectedEntity.label)}
+              onClick={openPreviewDetails}
               className="oa-pressable shrink-0 rounded-md border border-border bg-secondary px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:border-primary/40 hover:bg-accent"
             >
               {t('tracked.graph.openDetails')}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -266,8 +266,26 @@ body {
   to { stroke-dashoffset: 0; }
 }
 
+@keyframes oa-tracked-graph-preview-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+    border-color: color-mix(in srgb, var(--primary) 58%, var(--border));
+  }
+  to {
+    opacity: 1;
+    transform: none;
+    border-color: var(--border);
+  }
+}
+
 .oa-tracked-graph-node {
   transition: opacity var(--motion-standard) var(--motion-ease-standard);
+}
+
+.oa-tracked-graph-preview-enter {
+  animation: oa-tracked-graph-preview-enter var(--motion-slow) var(--motion-ease-out) backwards;
+  transform-origin: bottom right;
 }
 
 .oa-tracked-graph-node-enter {
@@ -682,7 +700,8 @@ html[lang="ja"] .oa-onboarding-title {
     animation: none;
   }
   .oa-tracked-graph-node-enter,
-  .oa-tracked-graph-edge {
+  .oa-tracked-graph-edge,
+  .oa-tracked-graph-preview-enter {
     animation: none;
   }
   .oa-pressable,


### PR DESCRIPTION
## What

- make Tracked graph material nodes preview-first instead of navigating immediately
- show the selected Issue or note in the existing bottom-right inspector with type, Workspace, path, and an explicit Details action
- animate the inspector into view and focus the selected material's one-hop neighborhood
- preserve the current graph route, viewport, filters, and scope until Details is activated
- cover the two-step interaction in the graph component regression suite

## Why

Material nodes previously behaved differently from entity nodes: a single click pulled the user out of the graph with no opportunity to inspect what had been selected. The preview-first flow keeps spatial context and makes provenance navigation deliberate.

## UI review

- reuses the existing entity inspector instead of adding a second card pattern
- the selected material receives the same ring and one-hop focus treatment as an entity
- a short token-based entrance and primary-tinted border makes the preview noticeable without looping
- the compact inspector remains usable at 390×844 and respects reduced motion

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `cd ui && pnpm vitest run src/components/TrackedGraphView.spec.tsx` (3 tests)
- `pnpm test` (483 files passed, 1 skipped; 3986 tests passed, 9 skipped)
- real `/tracked` browser flow: Issue click stays on `/tracked`, preview renders, Details opens the original Issue route
- real phone-width flow: related Note preview and Details action at 390×844

The previous merged increment's PR checks and post-merge `dev` CI run were green before this PR was published.
