### PR TITLE
Stabilize Tracked graph hover

### DIFF
--- a/plans/tracked-relationship-graph.md
+++ b/plans/tracked-relationship-graph.md
@@ -35,6 +35,9 @@ clusters form, or which tracked anchors have no supporting material.
 8. Material nodes use the same preview-first interaction as entities. Selecting
    a note or Issue keeps the graph in place, animates a compact inspector into
    view, and defers provenance navigation to the explicit Details action.
+9. Pointer focus uses a fixed, native-button hit target. Only the centered node
+   mark scales; labels stay outside that transform so long names cannot shift
+   the hover boundary and cause edge jitter.
 
 ## Work
 
@@ -50,6 +53,8 @@ clusters form, or which tracked anchors have no supporting material.
       handling and no continuous background animation.
 - [x] Add animated material previews that preserve graph context until Details
       is explicitly requested.
+- [x] Stabilize node-edge hover by separating hit testing, mark motion, and
+      label geometry.
 - [x] Complete browser, full-suite, and packaged Electron verification.
 
 ## Verification
@@ -63,6 +68,8 @@ clusters form, or which tracked anchors have no supporting material.
 - graph entrance and focus states in Day/Night modes and at phone width, with
   motion disabled by both the shared reduced-motion rule and zero-motion style
   profiles
+- long-label node focus on the real `/tracked` route, confirming the fixed
+  pointer target keeps an identical center and size before and after mark scale
 - Issue and note previews at desktop and phone widths, including explicit
   Details navigation with the graph route preserved until activation
 - `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`

--- a/ui/src/components/TrackedGraphView.spec.tsx
+++ b/ui/src/components/TrackedGraphView.spec.tsx
@@ -95,9 +95,16 @@ describe('TrackedGraphView', () => {
     )
 
     const assetButton = screen.getByRole('button', { name: /asset-a, linked/ })
+    const assetNode = assetButton.closest('[data-graph-node]')
+    const visualMark = assetNode?.querySelector('.oa-tracked-graph-node-mark')
+    expect(visualMark).toBeTruthy()
+    expect(visualMark?.querySelector('button')).toBeNull()
+    expect(visualMark?.querySelector('text')).toBeNull()
+    expect(assetNode?.querySelector('.oa-tracked-graph-label')).toBeTruthy()
+
     fireEvent.pointerEnter(assetButton)
 
-    expect(assetButton.closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('active')
+    expect(assetNode?.getAttribute('data-focus-state')).toBe('active')
     expect(screen.getByRole('button', { name: /shared-note, source material/ })
       .closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('related')
     expect(screen.getByRole('button', { name: /topic-b, linked/ })
@@ -106,6 +113,6 @@ describe('TrackedGraphView', () => {
       .closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('dimmed')
 
     fireEvent.pointerLeave(assetButton)
-    expect(assetButton.closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('idle')
+    expect(assetNode?.getAttribute('data-focus-state')).toBe('idle')
   })
 })

--- a/ui/src/components/TrackedGraphView.tsx
+++ b/ui/src/components/TrackedGraphView.tsx
@@ -439,8 +439,6 @@ export function TrackedGraphView({
                 data-focus-state={focusState}
                 data-hovered={node.id === hoveredNodeId ? 'true' : 'false'}
                 className="oa-tracked-graph-node"
-                onPointerEnter={() => setHoveredNodeId(node.id)}
-                onPointerLeave={() => setHoveredNodeId((value) => value === node.id ? null : value)}
               >
                 <g
                   data-enter-phase={entrancePhaseById.phases.get(node.id) ?? 0}
@@ -450,8 +448,11 @@ export function TrackedGraphView({
                     '--oa-graph-enter-y': `${enterY}px`,
                   } as CSSProperties}
                 >
-                  <g className="oa-tracked-graph-node-focus">
-                    <title>{nodeTitle(node)}</title>
+                  <title>{nodeTitle(node)}</title>
+                  {/* Keep the visual transform independent from the fixed hit
+                      target and label. Otherwise scaling a long, off-centre
+                      label can move the node out from under the pointer. */}
+                  <g className="oa-tracked-graph-node-mark pointer-events-none">
                     <circle
                       r={radius + 7}
                       fill="var(--accent)"
@@ -467,16 +468,7 @@ export function TrackedGraphView({
                       width={(radius + 8) * 2}
                       height={(radius + 8) * 2}
                     >
-                      <button
-                        type="button"
-                        aria-label={node.kind === 'entity'
-                          ? t('tracked.graph.entityNodeLabel', { name: node.label, count: degree })
-                          : t('tracked.graph.artifactNodeLabel', { name: node.label, workspace: node.workspaceTag })}
-                        title={nodeTitle(node)}
-                        onPointerDown={(event) => event.stopPropagation()}
-                        onClick={() => activateNode(node)}
-                        className="flex h-full w-full items-center justify-center rounded-full bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
-                      >
+                      <div className="flex h-full w-full items-center justify-center">
                         <span
                           aria-hidden
                           className={node.kind === 'artifact' && node.artifactType === 'issue' ? 'rounded-[1.5px]' : 'rounded-full'}
@@ -489,25 +481,46 @@ export function TrackedGraphView({
                             boxShadow: `0 0 0 ${node.kind === 'entity' ? 2 : 1.25}px var(--background)`,
                           }}
                         />
-                      </button>
+                      </div>
                     </foreignObject>
-                    <text
-                      x={labelOnLeft ? -(radius + 6) : radius + 6}
-                      y={node.kind === 'entity' ? 4 : 3}
-                      textAnchor={labelOnLeft ? 'end' : 'start'}
-                      fill="var(--foreground)"
-                      fontSize={node.kind === 'entity' ? 12 : 10}
-                      fontWeight={node.kind === 'entity' ? 600 : 450}
-                      paintOrder="stroke"
-                      stroke="var(--background)"
-                      strokeWidth={4}
-                      strokeLinejoin="round"
-                      opacity={showLabel ? 1 : 0}
-                      className="oa-tracked-graph-label pointer-events-none"
-                    >
-                      {node.label}
-                    </text>
                   </g>
+                  <foreignObject
+                    x={-(radius + 8)}
+                    y={-(radius + 8)}
+                    width={(radius + 8) * 2}
+                    height={(radius + 8) * 2}
+                  >
+                    <button
+                      type="button"
+                      aria-label={node.kind === 'entity'
+                        ? t('tracked.graph.entityNodeLabel', { name: node.label, count: degree })
+                        : t('tracked.graph.artifactNodeLabel', { name: node.label, workspace: node.workspaceTag })}
+                      title={nodeTitle(node)}
+                      onPointerEnter={() => setHoveredNodeId(node.id)}
+                      onPointerLeave={() => setHoveredNodeId((value) => value === node.id ? null : value)}
+                      onPointerDown={(event) => event.stopPropagation()}
+                      onClick={() => activateNode(node)}
+                      className="h-full w-full rounded-full bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
+                    >
+                      <span className="sr-only">{node.label}</span>
+                    </button>
+                  </foreignObject>
+                  <text
+                    x={labelOnLeft ? -(radius + 6) : radius + 6}
+                    y={node.kind === 'entity' ? 4 : 3}
+                    textAnchor={labelOnLeft ? 'end' : 'start'}
+                    fill="var(--foreground)"
+                    fontSize={node.kind === 'entity' ? 12 : 10}
+                    fontWeight={node.kind === 'entity' ? 600 : 450}
+                    paintOrder="stroke"
+                    stroke="var(--background)"
+                    strokeWidth={4}
+                    strokeLinejoin="round"
+                    opacity={showLabel ? 1 : 0}
+                    className="oa-tracked-graph-label pointer-events-none"
+                  >
+                    {node.label}
+                  </text>
                 </g>
               </g>
             )

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -302,17 +302,17 @@ body {
     stroke-width var(--motion-fast) var(--motion-ease-standard);
 }
 
-.oa-tracked-graph-node-focus {
+.oa-tracked-graph-node-mark {
   transform-box: fill-box;
   transform-origin: center;
   transition: transform var(--motion-fast) var(--motion-ease-out);
 }
 
-.oa-tracked-graph-node[data-focus-state="active"] .oa-tracked-graph-node-focus {
+.oa-tracked-graph-node[data-focus-state="active"] .oa-tracked-graph-node-mark {
   transform: scale(1.14);
 }
 
-.oa-tracked-graph-node[data-focus-state="related"] .oa-tracked-graph-node-focus {
+.oa-tracked-graph-node[data-focus-state="related"] .oa-tracked-graph-node-mark {
   transform: scale(1.035);
 }
 
@@ -715,7 +715,7 @@ html[lang="ja"] .oa-onboarding-title {
   }
   .oa-tracked-graph-node,
   .oa-tracked-graph-edge,
-  .oa-tracked-graph-node-focus,
+  .oa-tracked-graph-node-mark,
   .oa-tracked-graph-hover-halo,
   .oa-tracked-graph-label {
     transition-duration: 0.01ms;


### PR DESCRIPTION
## What changed

- separate each Tracked graph node's fixed native-button hit target from its animated visual mark
- keep labels outside the mark transform so long names cannot affect its scale origin
- add a structural regression for the hit-target, mark, and label boundaries
- record the interaction invariant in the relationship-graph plan

## Why

Hovering near the edge of a graph node could visibly oscillate between focused and idle states. The scale transform previously wrapped both the node and its off-centre label, so a long label shifted the transform centre. That movement could carry the hover target away from a stationary pointer, trigger pointer leave, shrink it back under the pointer, and repeat.

The pointer target is now geometrically stable while only the visual mark animates.

## Verification

- `cd ui && npx tsc -b`
- `cd ui && pnpm vitest run src/components/TrackedGraphView.spec.tsx` (3 passed)
- `npx tsc --noEmit`
- `pnpm test` (483 files passed, 1 skipped; 3986 tests passed, 9 skipped)
- real `/tracked` route: selected `copper-electrification-chain` and measured its native hit target before and after focus; centre delta was `0 × 0 px` and dimensions were unchanged
