### PR TITLE
Keep Tracked Issue selection in graph

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -151,8 +151,11 @@ Tracked is a global, file-backed index over those durable Workspaces:
   the same selection while retaining one Tracked tab.
 - the relationship graph is a read-time projection of those two canonical
   sources. Shared notes bridge every registered entity they reference, while
-  unlinked entities remain visible. The graph has no second persisted index or
-  layout state to migrate.
+  unlinked entities and Issues remain visible. Selecting either an entity or
+  an Issue preserves the current Detail/Graph mode; in Graph mode both focus
+  their existing graph node and defer navigation to the preview's explicit
+  Details action. The graph has no second persisted index or layout state to
+  migrate.
 - opening a graph material node keeps the same Tracked provenance and return
   path as opening it from the backlink detail list.
 

--- a/plans/tracked-relationship-graph.md
+++ b/plans/tracked-relationship-graph.md
@@ -45,6 +45,11 @@ clusters form, or which tracked anchors have no supporting material.
     Issues work-item surface. Selection is mirrored into `/tracked` query
     parameters without changing the single-tab identity, so reload and browser
     Back can reconstruct the selected anchor.
+11. Sidebar selection does not choose the page's presentation mode. In Graph
+    mode, entity and Issue rows both focus their graph node and open the same
+    preview-first inspector; only its explicit Details action enters the
+    document or canonical Issue surface. The graph projects unlinked Issues as
+    isolated material nodes so this rule applies to the complete Issue index.
 
 ## Work
 
@@ -66,14 +71,17 @@ clusters form, or which tracked anchors have no supporting material.
       complete body rendering, and canonical Issues Details navigation.
 - [x] Persist Tracked entity/Issue selection in the route while preserving the
       single Tracked tab and browser Back behavior.
+- [x] Unify sidebar entity/Issue selection in Graph mode, including isolated
+      graph nodes for Issues without entity backlinks.
 - [x] Complete browser, full-suite, and packaged Electron verification.
 
 ## Verification
 
 - `npx tsc --noEmit`
 - `cd ui && npx tsc -b`
-- focused core, route, layout, component, page, and demo suites (13 tests)
-- `pnpm test` (483 files passed, 1 skipped; 3986 tests passed, 9 skipped)
+- focused core, route, layout, component, page, and demo suites, including
+  sidebar Issue focus and unlinked-Issue graph projection
+- `pnpm test` (484 files passed, 1 skipped; 3995 tests passed, 9 skipped)
 - real `/tracked` route in Day and Auto color modes at desktop, tablet, and
   phone widths, including scope, filters, zoom, detail, source, and Back flows
 - graph entrance and focus states in Day/Night modes and at phone width, with
@@ -83,6 +91,8 @@ clusters form, or which tracked anchors have no supporting material.
   pointer target keeps an identical center and size before and after mark scale
 - Issue and note previews at desktop and phone widths, including explicit
   Details navigation with the graph route preserved until activation
+- real sidebar entity-to-Issue switching in Graph mode, followed by canonical
+  Issue Details navigation and browser Back to the persisted graph selection
 - `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
 
 ## Completion Criteria

--- a/ui/src/components/TrackedGraphView.spec.tsx
+++ b/ui/src/components/TrackedGraphView.spec.tsx
@@ -20,6 +20,10 @@ const graph: EntityGraph = {
       id: 'artifact:other', kind: 'artifact', label: 'other-note', artifactType: 'note',
       workspaceId: 'ws-1', workspaceTag: 'research', path: 'other-note.md',
     },
+    {
+      id: 'artifact:issue', kind: 'artifact', label: 'Power watch', artifactType: 'issue',
+      workspaceId: 'ws-1', workspaceTag: 'research', path: '.alice/issues/power-watch.md',
+    },
   ],
   edges: [
     { id: 'note-a', source: 'artifact:note', target: 'entity:a' },
@@ -43,8 +47,11 @@ describe('TrackedGraphView', () => {
       <TrackedGraphView
         graph={graph}
         selectedName="asset-a"
+        selectedIssue={null}
         onSelectEntity={onSelectEntity}
+        onSelectIssue={vi.fn()}
         onOpenEntity={vi.fn()}
+        onOpenIssue={vi.fn()}
         onOpenArtifact={onOpenArtifact}
       />,
     )
@@ -70,8 +77,11 @@ describe('TrackedGraphView', () => {
       <TrackedGraphView
         graph={graph}
         selectedName="asset-a"
+        selectedIssue={null}
         onSelectEntity={vi.fn()}
+        onSelectIssue={vi.fn()}
         onOpenEntity={vi.fn()}
+        onOpenIssue={vi.fn()}
         onOpenArtifact={vi.fn()}
       />,
     )
@@ -88,8 +98,11 @@ describe('TrackedGraphView', () => {
       <TrackedGraphView
         graph={graph}
         selectedName={null}
+        selectedIssue={null}
         onSelectEntity={vi.fn()}
+        onSelectIssue={vi.fn()}
         onOpenEntity={vi.fn()}
+        onOpenIssue={vi.fn()}
         onOpenArtifact={vi.fn()}
       />,
     )
@@ -114,5 +127,31 @@ describe('TrackedGraphView', () => {
 
     fireEvent.pointerLeave(assetButton)
     expect(assetNode?.getAttribute('data-focus-state')).toBe('idle')
+  })
+
+  it('focuses a sidebar Issue through the same graph selection and preview path', () => {
+    const onSelectIssue = vi.fn()
+    const onOpenIssue = vi.fn()
+    render(
+      <TrackedGraphView
+        graph={graph}
+        selectedName={null}
+        selectedIssue={{ workspaceId: 'ws-1', issueId: 'power-watch' }}
+        onSelectEntity={vi.fn()}
+        onSelectIssue={onSelectIssue}
+        onOpenEntity={vi.fn()}
+        onOpenIssue={onOpenIssue}
+        onOpenArtifact={vi.fn()}
+      />,
+    )
+
+    const issueButton = screen.getByRole('button', { name: /Power watch, source material/ })
+    expect(issueButton.closest('[data-graph-node]')?.getAttribute('data-focus-state')).toBe('active')
+    expect(screen.getByText('Issue · research')).toBeTruthy()
+
+    fireEvent.click(issueButton)
+    expect(onSelectIssue).toHaveBeenCalledWith({ workspaceId: 'ws-1', issueId: 'power-watch' })
+    fireEvent.click(screen.getByRole('button', { name: 'Open details' }))
+    expect(onOpenIssue).toHaveBeenCalledWith({ workspaceId: 'ws-1', issueId: 'power-watch' })
   })
 })

--- a/ui/src/components/TrackedGraphView.tsx
+++ b/ui/src/components/TrackedGraphView.tsx
@@ -27,6 +27,7 @@ import type {
   EntityGraphNode,
 } from '../api/entities'
 import { layoutTrackedGraph, type GraphPositions } from '../lib/tracked-graph-layout'
+import { issueIdFromGraphNode, trackedIssuePath } from '../lib/tracked-issues'
 import { SegmentedControl } from './SegmentedControl'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 
@@ -57,14 +58,20 @@ const INITIAL_VIEW_BOX: ViewBox = { x: 0, y: 0, width: CANVAS_WIDTH, height: CAN
 export function TrackedGraphView({
   graph,
   selectedName,
+  selectedIssue,
   onSelectEntity,
+  onSelectIssue,
   onOpenEntity,
+  onOpenIssue,
   onOpenArtifact,
 }: {
   graph: EntityGraph
   selectedName: string | null
+  selectedIssue: { workspaceId: string; issueId: string } | null
   onSelectEntity: (name: string) => void
+  onSelectIssue: (issue: { workspaceId: string; issueId: string }) => void
   onOpenEntity: (name: string) => void
+  onOpenIssue: (issue: { workspaceId: string; issueId: string }) => void
   onOpenArtifact: (artifact: EntityGraphArtifactNode, returnEntityName: string) => void
 }) {
   const { t } = useTranslation()
@@ -118,30 +125,48 @@ export function TrackedGraphView({
     const node = graph.nodes.find((candidate) => candidate.kind === 'entity' && candidate.label === selectedName)
     return node?.kind === 'entity' ? node : null
   }, [graph.nodes, selectedName])
+  const selectedIssueArtifact = useMemo(() => {
+    if (!selectedIssue) return null
+    const path = trackedIssuePath(selectedIssue.issueId)
+    const node = graph.nodes.find((candidate) => candidate.kind === 'artifact'
+      && candidate.artifactType === 'issue'
+      && candidate.workspaceId === selectedIssue.workspaceId
+      && candidate.path === path)
+    return node?.kind === 'artifact' ? node : null
+  }, [graph.nodes, selectedIssue])
   const selectedArtifact = useMemo(() => {
     const node = selectedArtifactId ? nodeById.get(selectedArtifactId) : undefined
     return node?.kind === 'artifact' ? node : null
   }, [nodeById, selectedArtifactId])
+  const selectedNode = selectedArtifact ?? selectedIssueArtifact ?? selectedEntity
+  const selectedArtifactNode = selectedNode?.kind === 'artifact' ? selectedNode : null
 
   useEffect(() => {
     setSelectedArtifactId(null)
   }, [selectedName])
 
+  useEffect(() => {
+    if (!selectedIssueArtifact) return
+    setSelectedArtifactId(selectedIssueArtifact.id)
+    setKindFilters((current) => current.artifact ? current : { ...current, artifact: true })
+    setShowUnlinked(true)
+  }, [selectedIssueArtifact])
+
   const neighborhood = useMemo(() => {
-    if (!selectedEntity) return null
-    const ids = new Set<string>([selectedEntity.id])
-    const adjacentArtifacts = new Set<string>()
-    for (const edge of graph.edges) {
-      if (edge.source === selectedEntity.id) adjacentArtifacts.add(edge.target)
-      if (edge.target === selectedEntity.id) adjacentArtifacts.add(edge.source)
-    }
-    for (const artifactId of adjacentArtifacts) ids.add(artifactId)
-    for (const edge of graph.edges) {
-      if (adjacentArtifacts.has(edge.source)) ids.add(edge.target)
-      if (adjacentArtifacts.has(edge.target)) ids.add(edge.source)
+    if (!selectedNode) return null
+    const ids = new Set<string>([selectedNode.id])
+    let frontier = new Set<string>([selectedNode.id])
+    for (let depth = 0; depth < 2; depth += 1) {
+      const next = new Set<string>()
+      for (const edge of graph.edges) {
+        if (frontier.has(edge.source) && !ids.has(edge.target)) next.add(edge.target)
+        if (frontier.has(edge.target) && !ids.has(edge.source)) next.add(edge.source)
+      }
+      for (const id of next) ids.add(id)
+      frontier = next
     }
     return ids
-  }, [graph.edges, selectedEntity])
+  }, [graph.edges, selectedNode])
 
   const visibleNodes = useMemo(() => graph.nodes.filter((node) => {
     if (scope === 'related' && neighborhood && !neighborhood.has(node.id)) return false
@@ -178,16 +203,23 @@ export function TrackedGraphView({
       return
     }
     setSelectedArtifactId(node.id)
-  }, [onSelectEntity])
+    const issueId = issueIdFromGraphNode(node)
+    if (issueId) onSelectIssue({ workspaceId: node.workspaceId, issueId })
+  }, [onSelectEntity, onSelectIssue])
 
   const openPreviewDetails = useCallback(() => {
-    if (selectedArtifact) {
-      const returnEntityName = relatedEntityForArtifact(selectedArtifact.id)
-      if (returnEntityName) onOpenArtifact(selectedArtifact, returnEntityName)
+    if (selectedArtifactNode) {
+      const issueId = issueIdFromGraphNode(selectedArtifactNode)
+      if (issueId) {
+        onOpenIssue({ workspaceId: selectedArtifactNode.workspaceId, issueId })
+        return
+      }
+      const returnEntityName = relatedEntityForArtifact(selectedArtifactNode.id)
+      if (returnEntityName) onOpenArtifact(selectedArtifactNode, returnEntityName)
       return
     }
     if (selectedEntity) onOpenEntity(selectedEntity.label)
-  }, [onOpenArtifact, onOpenEntity, relatedEntityForArtifact, selectedArtifact, selectedEntity])
+  }, [onOpenArtifact, onOpenEntity, onOpenIssue, relatedEntityForArtifact, selectedArtifactNode, selectedEntity])
 
   const fitVisible = useCallback((preferReadable = false) => {
     const points = visibleNodes.flatMap((node) => positions[node.id] ? [positions[node.id]!] : [])
@@ -217,7 +249,7 @@ export function TrackedGraphView({
     if (preferReadable && canvasAspect < 0.82) {
       height = Math.min(720, Math.max(420, height))
       width = height * canvasAspect
-      const selectedPoint = selectedEntity ? positions[selectedEntity.id] : undefined
+      const selectedPoint = selectedNode ? positions[selectedNode.id] : undefined
       if (selectedPoint) {
         // Give the selected anchor's outward-facing label breathing room.
         centerX = selectedPoint.x + (selectedPoint.x < CANVAS_WIDTH / 2 ? -width * 0.14 : width * 0.14)
@@ -225,7 +257,7 @@ export function TrackedGraphView({
       }
     }
     setViewBox({ x: centerX - width / 2, y: centerY - height / 2, width, height })
-  }, [canvasAspect, positions, selectedEntity, visibleNodes])
+  }, [canvasAspect, positions, selectedNode, visibleNodes])
 
   useEffect(() => {
     fitVisible(true)
@@ -293,7 +325,7 @@ export function TrackedGraphView({
     zoom(event.deltaY > 0 ? 1.12 : 0.88, point?.x, point?.y)
   }
 
-  const activeNodeId = hoveredNodeId ?? selectedArtifact?.id ?? selectedEntity?.id ?? null
+  const activeNodeId = hoveredNodeId ?? selectedNode?.id ?? null
   const connectedToActive = useMemo(() => {
     const ids = new Set<string>()
     if (!activeNodeId) return ids
@@ -305,8 +337,8 @@ export function TrackedGraphView({
     return ids
   }, [activeNodeId, visibleEdges])
   const entrancePhaseById = useMemo(() => {
-    const origin = selectedEntity && positions[selectedEntity.id]
-      ? positions[selectedEntity.id]!
+    const origin = selectedNode && positions[selectedNode.id]
+      ? positions[selectedNode.id]!
       : { x: CANVAS_WIDTH / 2, y: CANVAS_HEIGHT / 2 }
     const ordered = [...visibleNodes].sort((left, right) => {
       const leftPoint = positions[left.id] ?? origin
@@ -319,7 +351,7 @@ export function TrackedGraphView({
     const divisor = Math.max(1, ordered.length - 1)
     ordered.forEach((node, index) => phases.set(node.id, Math.min(4, Math.floor((index / divisor) * 5))))
     return { origin, phases }
-  }, [positions, selectedEntity, visibleNodes])
+  }, [positions, selectedNode, visibleNodes])
 
   return (
     <div className="relative h-full min-h-[360px] overflow-hidden bg-background">
@@ -413,7 +445,7 @@ export function TrackedGraphView({
           {visibleNodes.map((node) => {
             const point = positions[node.id]
             if (!point) return null
-            const selected = node.id === selectedEntity?.id || node.id === selectedArtifact?.id
+            const selected = node.id === selectedNode?.id
             const active = connectedToActive.has(node.id)
             const faded = activeNodeId !== null && !active
             const focusState = activeNodeId === null
@@ -425,6 +457,7 @@ export function TrackedGraphView({
             // labels appear on hover (or in a genuinely small graph) so a
             // high-degree selected entity does not turn its cluster into text.
             const showLabel = node.kind === 'entity'
+              || selected
               || (hoveredNodeId !== null && active)
               || visibleNodes.length <= 12
             const labelOnLeft = point.x < CANVAS_WIDTH / 2
@@ -535,27 +568,27 @@ export function TrackedGraphView({
         <LegendDot color="var(--chart-3)" label={t('tracked.graph.issue')} square />
       </div>
 
-      {(selectedArtifact ?? selectedEntity) && (
+      {selectedNode && (
         <div
-          key={(selectedArtifact ?? selectedEntity)?.id}
+          key={selectedNode.id}
           className="oa-tracked-graph-preview-enter absolute bottom-3 right-3 z-10 max-w-[min(420px,calc(100%-1.5rem))] rounded-lg border border-border/70 bg-background/92 px-3 py-2.5 shadow-sm backdrop-blur-sm sm:bottom-4 sm:right-4"
         >
           <div className="flex items-start gap-3">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5 truncate font-mono text-[12px] font-semibold text-foreground">
-                {selectedArtifact && (
-                  selectedArtifact.artifactType === 'issue'
+                {selectedArtifactNode && (
+                  selectedArtifactNode.artifactType === 'issue'
                     ? <ListChecks size={12} className="shrink-0 text-muted-foreground" aria-hidden />
                     : <FileText size={12} className="shrink-0 text-muted-foreground" aria-hidden />
                 )}
-                <span className="truncate">{(selectedArtifact ?? selectedEntity)?.label}</span>
+                <span className="truncate">{selectedNode.label}</span>
               </div>
-              {selectedArtifact ? (
+              {selectedArtifactNode ? (
                 <div className="mt-0.5 min-w-0 text-[11px] leading-relaxed text-muted-foreground">
                   <div className="truncate">
-                    {t(selectedArtifact.artifactType === 'issue' ? 'tracked.graph.issue' : 'tracked.graph.note')} · {selectedArtifact.workspaceTag}
+                    {t(selectedArtifactNode.artifactType === 'issue' ? 'tracked.graph.issue' : 'tracked.graph.note')} · {selectedArtifactNode.workspaceTag}
                   </div>
-                  <div className="truncate font-mono text-[10px] opacity-80">{selectedArtifact.path}</div>
+                  <div className="truncate font-mono text-[10px] opacity-80">{selectedArtifactNode.path}</div>
                 </div>
               ) : (
                 <div className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">{selectedEntity?.description}</div>

--- a/ui/src/lib/tracked-issues.spec.ts
+++ b/ui/src/lib/tracked-issues.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import type { EntityGraph } from '../api/entities'
+import type { IssueSnapshot } from '../api/issues'
+import { graphWithTrackedIssues, trackedIssueAnchors, trackedIssueGraphNodeId } from './tracked-issues'
+
+const snapshot: IssueSnapshot = {
+  workspaces: [{
+    wsId: 'workspace-1',
+    tag: 'research',
+    status: 'ok',
+    issues: [
+      { id: 'linked', title: 'Linked Issue', status: 'todo', priority: 'medium', assignee: '@human' },
+      { id: 'unlinked', title: 'Unlinked Issue', status: 'todo', priority: 'low', assignee: '@human' },
+    ],
+  }],
+}
+
+const graph: EntityGraph = {
+  nodes: [{
+    id: trackedIssueGraphNodeId('workspace-1', 'linked'),
+    kind: 'artifact',
+    label: 'linked',
+    artifactType: 'issue',
+    workspaceId: 'workspace-1',
+    workspaceTag: 'research',
+    path: '.alice/issues/linked.md',
+  }],
+  edges: [],
+}
+
+describe('graphWithTrackedIssues', () => {
+  it('enriches linked Issue nodes and adds unlinked Issues once', () => {
+    const result = graphWithTrackedIssues(graph, trackedIssueAnchors(snapshot))
+
+    expect(result.nodes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: trackedIssueGraphNodeId('workspace-1', 'linked'),
+        label: 'Linked Issue',
+      }),
+      expect.objectContaining({
+        id: trackedIssueGraphNodeId('workspace-1', 'unlinked'),
+        label: 'Unlinked Issue',
+      }),
+    ]))
+    expect(result.nodes).toHaveLength(2)
+    expect(result.edges).toBe(graph.edges)
+  })
+})

--- a/ui/src/lib/tracked-issues.ts
+++ b/ui/src/lib/tracked-issues.ts
@@ -1,9 +1,28 @@
 import type { IssueListItem, IssueSnapshot } from '../api/issues'
+import type { EntityGraph, EntityGraphArtifactNode } from '../api/entities'
 
 export interface TrackedIssueAnchor {
   workspaceId: string
   workspaceTag: string
   issue: IssueListItem
+}
+
+const ISSUE_NOTE_PREFIX = '.alice/issues/'
+
+export function trackedIssuePath(issueId: string): string {
+  return `${ISSUE_NOTE_PREFIX}${issueId}.md`
+}
+
+export function trackedIssueGraphNodeId(workspaceId: string, issueId: string): string {
+  return `artifact:${encodeURIComponent(workspaceId)}:${encodeURIComponent(trackedIssuePath(issueId))}`
+}
+
+export function issueIdFromGraphNode(node: EntityGraphArtifactNode): string | null {
+  if (node.artifactType !== 'issue' || !node.path.startsWith(ISSUE_NOTE_PREFIX) || !node.path.endsWith('.md')) {
+    return null
+  }
+  const issueId = node.path.slice(ISSUE_NOTE_PREFIX.length, -'.md'.length)
+  return issueId && !issueId.includes('/') ? issueId : null
 }
 
 const STATUS_ORDER: Record<IssueListItem['status'], number> = {
@@ -27,4 +46,50 @@ export function trackedIssueAnchors(snapshot: IssueSnapshot | null): TrackedIssu
     .sort((a, b) => STATUS_ORDER[a.issue.status] - STATUS_ORDER[b.issue.status]
       || a.issue.title.localeCompare(b.issue.title)
       || a.workspaceTag.localeCompare(b.workspaceTag))
+}
+
+/**
+ * Add the complete live Issue index to the relationship graph. The backend
+ * graph already contains Issue notes that link an entity; this projection
+ * enriches those nodes with their human title and adds unlinked Issues so the
+ * sidebar and graph share one selection model.
+ */
+export function graphWithTrackedIssues(
+  graph: EntityGraph,
+  anchors: readonly TrackedIssueAnchor[],
+): EntityGraph {
+  const anchorsByKey = new Map<string, TrackedIssueAnchor>(
+    anchors.map((anchor) => [`${anchor.workspaceId}:${anchor.issue.id}`, anchor] as const),
+  )
+  const seen = new Set<string>()
+  const nodes = graph.nodes.map((node) => {
+    if (node.kind !== 'artifact') return node
+    const issueId = issueIdFromGraphNode(node)
+    if (!issueId) return node
+    const key = `${node.workspaceId}:${issueId}`
+    const anchor = anchorsByKey.get(key)
+    if (!anchor) return node
+    seen.add(key)
+    return {
+      ...node,
+      label: anchor.issue.title,
+      workspaceTag: anchor.workspaceTag,
+    }
+  })
+
+  for (const anchor of anchors) {
+    const key = `${anchor.workspaceId}:${anchor.issue.id}`
+    if (seen.has(key)) continue
+    nodes.push({
+      id: trackedIssueGraphNodeId(anchor.workspaceId, anchor.issue.id),
+      kind: 'artifact',
+      label: anchor.issue.title,
+      artifactType: 'issue',
+      workspaceId: anchor.workspaceId,
+      workspaceTag: anchor.workspaceTag,
+      path: trackedIssuePath(anchor.issue.id),
+    })
+  }
+
+  return { nodes, edges: graph.edges }
 }

--- a/ui/src/pages/TrackedPage.spec.tsx
+++ b/ui/src/pages/TrackedPage.spec.tsx
@@ -57,6 +57,7 @@ const mocks = vi.hoisted(() => ({
   getGraph: vi.fn(),
   getIssue: vi.fn(),
   selectTracked: vi.fn(),
+  selectIssue: vi.fn(),
   navigate: vi.fn(),
   openOrFocus: vi.fn(),
   setSidebar: vi.fn(),
@@ -114,7 +115,12 @@ vi.mock('../live/tracked-selection', () => ({
     selectedName: string | null
     selectedIssue: { workspaceId: string; issueId: string } | null
     select: typeof mocks.selectTracked
-  }) => unknown) => selector({ ...mocks.selectionState.current, select: mocks.selectTracked }),
+    selectIssue: typeof mocks.selectIssue
+  }) => unknown) => selector({
+    ...mocks.selectionState.current,
+    select: mocks.selectTracked,
+    selectIssue: mocks.selectIssue,
+  }),
 }))
 
 vi.mock('../hooks/useIssues', () => ({
@@ -219,6 +225,25 @@ describe('TrackedPage Issue anchors', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Details' }))
 
     expect(mocks.getIssue).toHaveBeenCalledWith('workspace-1', 'power-watch')
+    expect(mocks.navigate).toHaveBeenCalledWith('/issues/workspace-1/power-watch')
+  })
+
+  it('keeps an Issue selection inside Graph mode until Details is opened', async () => {
+    window.localStorage.setItem('openalice.tracked.view-mode.v1', 'graph')
+    mocks.issuesState.current = { data: issueSnapshot, error: null, loading: false }
+    mocks.selectionState.current = {
+      selectedName: null,
+      selectedIssue: { workspaceId: 'workspace-1', issueId: 'power-watch' },
+    }
+
+    render(<TrackedPage />)
+
+    expect(await screen.findByRole('button', { name: /Power watch/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Graph' }).getAttribute('aria-pressed')).toBe('true')
+    expect(mocks.getIssue).not.toHaveBeenCalled()
+    expect(screen.getByText('Issue · power')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open details' }))
     expect(mocks.navigate).toHaveBeenCalledWith('/issues/workspace-1/power-watch')
   })
 })

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { TrendingUp, Hash, FileText, ListChecks, CircleAlert, List, Network, ArrowUpRight } from 'lucide-react'
@@ -12,7 +12,7 @@ import { entitiesLive, refreshEntities } from '../live/entities'
 import { useTrackedSelection } from '../live/tracked-selection'
 import { useWorkspace } from '../tabs/store'
 import { useIssues } from '../hooks/useIssues'
-import { trackedIssueAnchors } from '../lib/tracked-issues'
+import { graphWithTrackedIssues, trackedIssueAnchors } from '../lib/tracked-issues'
 import type { EntityDetail, Backlink, EntityGraph, EntityGraphArtifactNode } from '../api/entities'
 import type { IssueDetail as IssueDetailData } from '../api/issues'
 
@@ -45,10 +45,11 @@ export function TrackedPage() {
   const listError = entitiesLive.useStore((s) => s.error)
   const refreshing = entitiesLive.useStore((s) => s.refreshing)
   const { data: issueSnapshot, error: issueListError, loading: issuesLoading } = useIssues()
-  const issueAnchors = trackedIssueAnchors(issueSnapshot)
+  const issueAnchors = useMemo(() => trackedIssueAnchors(issueSnapshot), [issueSnapshot])
   const selectedName = useTrackedSelection((s) => s.selectedName)
   const selectedIssue = useTrackedSelection((s) => s.selectedIssue)
   const selectTracked = useTrackedSelection((s) => s.select)
+  const selectTrackedIssue = useTrackedSelection((s) => s.selectIssue)
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const navigate = useNavigate()
   const [viewMode, setViewModeState] = useState<TrackedViewMode>(readTrackedViewMode)
@@ -61,6 +62,14 @@ export function TrackedPage() {
     openOrFocus({ kind: 'tracked', params: { entity: name } })
   }, [openOrFocus, selectTracked])
 
+  const selectIssue = useCallback((issue: { workspaceId: string; issueId: string }) => {
+    selectTrackedIssue(issue)
+    openOrFocus({
+      kind: 'tracked',
+      params: { workspace: issue.workspaceId, issue: issue.issueId },
+    })
+  }, [openOrFocus, selectTrackedIssue])
+
   const setViewMode = useCallback((mode: TrackedViewMode) => {
     setViewModeState(mode)
     try {
@@ -69,10 +78,6 @@ export function TrackedPage() {
       // View preference persistence is best-effort.
     }
   }, [])
-
-  useEffect(() => {
-    if (selectedIssue) setViewMode('detail')
-  }, [selectedIssue, setViewMode])
 
   const [detail, setDetail] = useState<EntityDetail | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
@@ -164,6 +169,10 @@ export function TrackedPage() {
   const selectedIssueAnchor = selectedIssue
     ? issueAnchors.find((anchor) => anchor.workspaceId === selectedIssue.workspaceId && anchor.issue.id === selectedIssue.issueId)
     : null
+  const graphWithIssues = useMemo(
+    () => graph ? graphWithTrackedIssues(graph, issueAnchors) : null,
+    [graph, issueAnchors],
+  )
   const hasAnchors = entities.length > 0 || issueAnchors.length > 0
 
   return (
@@ -195,18 +204,25 @@ export function TrackedPage() {
         ) : !hasAnchors ? (
           <EmptyState />
         ) : viewMode === 'graph' ? (
-          graphLoading && !graph ? (
+          graphLoading && !graphWithIssues ? (
             <PageLoading />
-          ) : !graph ? (
+          ) : !graphWithIssues ? (
             <GraphLoadError onRetry={() => setGraphRequest((request) => request + 1)} />
           ) : (
             <TrackedGraphView
-              graph={graph}
+              graph={graphWithIssues}
               selectedName={selectedName}
+              selectedIssue={selectedIssue}
               onSelectEntity={selectEntity}
+              onSelectIssue={selectIssue}
               onOpenEntity={(name) => {
                 selectEntity(name)
                 setViewMode('detail')
+              }}
+              onOpenIssue={(issue) => {
+                navigate(
+                  `/issues/${encodeURIComponent(issue.workspaceId)}/${encodeURIComponent(issue.issueId)}`,
+                )
               }}
               onOpenArtifact={openArtifact}
             />


### PR DESCRIPTION
## What changed

- keep the active Detail/Graph presentation when the Tracked sidebar selects an Issue
- project the complete live Issue index into the existing relationship graph, including isolated Issues without entity backlinks
- reuse the graph's existing focus, preview, motion, and explicit Details navigation for Issue nodes
- document the unified selection contract and add focused regressions

## Why

Tracked previously forced every Issue selection back to Detail mode. That disagreed with entity selection and made the graph behave like a separate navigation implementation. The graph backend also only returned Issue notes that contained entity backlinks, so unlinked sidebar Issues could not be focused.

## User impact

With Graph open, clicking either an entity or an Issue now keeps Graph open and focuses the corresponding node. Issue navigation happens only after the user activates **Open details** in the graph preview. The selected Issue remains encoded in the Tracked URL, so browser Back restores the graph context.

## Verification

- `npx tsc --noEmit`
- `pnpm -F open-alice-ui exec tsc -b`
- focused Tracked suites: 16 tests passed
- `pnpm test`: 484 files passed, 1 skipped; 3995 tests passed, 9 skipped
- real `pnpm dev` browser flow: entity → Issue in Graph, Issue preview, Details, browser Back to persisted Graph selection