### PR TITLE
Fix dev Runtime discovery Web endpoint

### DIFF
--- a/scripts/guardian/smoke.ts
+++ b/scripts/guardian/smoke.ts
@@ -205,9 +205,10 @@ async function main(): Promise<void> {
   // Alice tsx spawn worked → web plugin bound its port.
   await waitFor('Alice listening (alice child spawned)', () => portBound(webPort))
 
-  // Vite pnpm spawn worked → it announces a Local URL.
-  await waitFor('Vite dev server up (vite child spawned)', () => /\[vite\][^\n]*localhost:\d+/i.test(out))
-  const uiPort = Number(/\[vite\][^\n]*localhost:(\d+)/i.exec(out)?.[1])
+  // Vite pnpm spawn worked → it announces the stable IPv4 loopback URL that
+  // Guardian exposes to other local surfaces through Runtime discovery.
+  await waitFor('Vite dev server up (vite child spawned)', () => /\[vite\][^\n]*127\.0\.0\.1:\d+/i.test(out))
+  const uiPort = Number(/\[vite\][^\n]*127\.0\.0\.1:(\d+)/i.exec(out)?.[1])
   if (!uiPort) fail(`could not parse Vite port from output:\n${out.slice(-600)}`)
 
   // A second process may inspect and open this dev-owned Runtime, but may not
@@ -225,6 +226,10 @@ async function main(): Promise<void> {
   }
   if (discovered.endpoints.web !== `http://127.0.0.1:${uiPort}`) {
     fail(`dev discovery advertised ${String(discovered.endpoints.web)} instead of Vite ${uiPort}`)
+  }
+  const discoveredWeb = await fetch(`${discovered.endpoints.web}/api/auth/status`)
+  if (!discoveredWeb.ok) {
+    fail(`dev discovery Web endpoint returned HTTP ${discoveredWeb.status}`)
   }
   if (!discovered.control.capabilities.includes('runtime.status')) {
     fail('dev discovery did not advertise runtime.status')

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -83,6 +83,11 @@ export default defineConfig({
   // Backend port is read from `data/config/ports.json` (web.port) so
   // changing the backend port in one place propagates to Vite automatically.
   server: {
+    // Runtime discovery intentionally advertises an IPv4 loopback URL. Vite's
+    // default `localhost` binding may resolve to IPv6-only on macOS, leaving
+    // the installed CLI unable to open or diagnose an otherwise healthy dev
+    // Runtime through the advertised 127.0.0.1 endpoint.
+    host: '127.0.0.1',
     port: uiPort,
     strictPort,
     proxy: {


### PR DESCRIPTION
## What changed

- bind the Vite development server explicitly to the IPv4 loopback advertised by Runtime discovery
- make the Guardian smoke test fetch the discovered Web health endpoint
- update smoke parsing to enforce the stable IPv4 discovery contract

## Why

On macOS, Vite could bind `localhost` as IPv6-only while Guardian advertised `http://127.0.0.1:<port>`. The installed global CLI could discover a healthy dev Runtime, but `open` and the `runtime.web` doctor check still failed.

## Verification

- `cd ui && npx tsc -b`
- `npx tsc --noEmit`
- `pnpm test` (3997 passed, 9 skipped)
- `pnpm test:smoke`
- full Guardian recovery check suite
- actual installed `openalice status`, `doctor`, `open`, `up`, and `down` while `pnpm dev` remained running
- browser reload of `/tracked?entity=stock-glw` with no console errors