### PR TITLE
Add source CLI development scripts

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -450,6 +450,21 @@ completion; detailed shell installation remains user-owned.
 
 ## Verification
 
+Run the repository's TypeScript CLI entry directly when developing or
+dogfooding the Supervisor. Bare `pnpm cli` opens the real interactive TUI; any
+following arguments are passed through to the same command surface:
+
+```bash
+pnpm cli
+pnpm cli status --json
+pnpm cli doctor
+pnpm test:cli
+```
+
+This source entry does not install or copy a CLI payload. When `pnpm dev`
+already owns the selected home, the TUI and read-only commands discover that
+live Runtime rather than starting or replacing another owner.
+
 For command-only changes:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/electron/main.js",
   "scripts": {
+    "cli": "node packages/cli/bin/openalice.ts",
     "dev": "tsx scripts/guardian/dev.ts",
     "dev:onboarding": "tsx scripts/onboarding-test-dev.ts",
     "remote:ssh": "node packages/cli/bin/openalice.mjs ssh",
@@ -39,6 +40,7 @@
     "electron:smoke:upgrade": "node scripts/desktop-upgrade-smoke.mjs",
     "vendor:runtime": "node scripts/vendor-managed-runtime.mjs",
     "test": "vitest run",
+    "test:cli": "pnpm -F @traderalice/openalice-cli test",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:uta:live-paper": "vitest run --config vitest.uta-live.config.ts",


### PR DESCRIPTION
## What changed

- add `pnpm cli` as a root-level entry to the real TypeScript Supervisor CLI
- add `pnpm test:cli` for the CLI unit and PTY suite
- document source CLI dogfooding alongside `pnpm dev`

## Why

The repository could already execute and test the CLI itself, but the entry was hidden behind `node packages/cli/bin/openalice.ts`. Developers could easily confuse installer smoke tests with testing the actual interactive CLI.

## Verification

- `pnpm cli --version`
- `pnpm cli status --json` against a live dev-owned Runtime
- interactive `pnpm cli` PTY launch and clean `q` detach
- `pnpm test:cli` (200 passed)
- `npx tsc --noEmit`
- `pnpm test` (3997 passed, 9 skipped)