### PR TITLE
Fix Codex GPT-5.6 preset identities

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -37,7 +37,7 @@ assignee: "@new-then-resume"
 when: { kind: cron, cron: "30 8 * * 1-5", timezone: America/New_York }
 agent: codex
 credential: openai-primary
-model: gpt-5.6
+model: gpt-5.6-sol
 effort: high
 ---
 
@@ -155,8 +155,8 @@ Agents normally use:
 ```bash
 alice-workspace issue list
 alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @new-each-run --agent codex --credential openai-primary --model gpt-5.6 --effort high
-alice-workspace issue update --id <id> --credential openai-primary --model gpt-5.6 --effort high
+alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @new-each-run --agent codex --credential openai-primary --model gpt-5.6-sol --effort high
+alice-workspace issue update --id <id> --credential openai-primary --model gpt-5.6-sol --effort high
 alice-workspace issue comment --id <id> --text "..."
 ```
 

--- a/src/ai-providers/model-semantics.spec.ts
+++ b/src/ai-providers/model-semantics.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   describeModelSemantics,
+  isModelReasoningEffort,
   modelSupportsReasoning,
   resolveModelSemantics,
 } from './model-semantics.js'
@@ -9,13 +10,27 @@ import { DEFAULT_MODEL_BY_VENDOR } from './preset-catalog.js'
 
 describe('model semantics registry', () => {
   it('keeps exact known facts distinct from unknown models and aliases', () => {
-    expect(resolveModelSemantics('openai', 'gpt-5.6')).toMatchObject({
+    expect(resolveModelSemantics('openai', 'gpt-5.6-sol')).toMatchObject({
       contextWindow: 1_050_000,
       reasoning: { mode: 'optional', defaultEffort: 'medium' },
     })
     expect(resolveModelSemantics('anthropic', 'default')).toBeNull()
+    expect(resolveModelSemantics('openai', 'gpt-5.6')).toEqual(
+      resolveModelSemantics('openai', 'gpt-5.6-sol'),
+    )
     expect(resolveModelSemantics('custom', 'gpt-5.6')).toBeNull()
     expect(resolveModelSemantics('openai', 'future-model')).toBeNull()
+  })
+
+  it('keeps Luna\'s smaller API context distinct from Sol and Terra', () => {
+    expect(resolveModelSemantics('openai', 'gpt-5.6-luna')?.contextWindow).toBe(400_000)
+    expect(resolveModelSemantics('openai', 'gpt-5.6-terra')?.contextWindow).toBe(1_050_000)
+  })
+
+  it('accepts Codex subscription ultra effort without adding it to API model semantics', () => {
+    expect(isModelReasoningEffort('ultra')).toBe(true)
+    expect(resolveModelSemantics('openai', 'gpt-5.6-sol')?.reasoning?.efforts)
+      .not.toContain('ultra')
   })
 
   it('records required versus optional reasoning without collapsing either to unknown', () => {

--- a/src/ai-providers/model-semantics.ts
+++ b/src/ai-providers/model-semantics.ts
@@ -21,6 +21,7 @@ export type ModelReasoningEffort =
   | 'high'
   | 'xhigh'
   | 'max'
+  | 'ultra'
 
 export const MODEL_REASONING_EFFORTS = [
   'none',
@@ -30,6 +31,7 @@ export const MODEL_REASONING_EFFORTS = [
   'high',
   'xhigh',
   'max',
+  'ultra',
 ] as const satisfies readonly ModelReasoningEffort[]
 
 export function isModelReasoningEffort(value: unknown): value is ModelReasoningEffort {
@@ -137,7 +139,7 @@ export const MODEL_SEMANTICS_BY_VENDOR: Registry = {
     'gpt-5.6': { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: OPENAI_56_REASONING },
     'gpt-5.6-sol': { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: OPENAI_56_REASONING },
     'gpt-5.6-terra': { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: OPENAI_56_REASONING },
-    'gpt-5.6-luna': { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: OPENAI_56_REASONING },
+    'gpt-5.6-luna': { contextWindow: 400_000, maxOutputTokens: 128_000, reasoning: OPENAI_56_REASONING },
     'gpt-5.5': {
       contextWindow: 1_050_000,
       maxOutputTokens: 128_000,

--- a/src/ai-providers/preset-catalog.spec.ts
+++ b/src/ai-providers/preset-catalog.spec.ts
@@ -53,10 +53,25 @@ describe('credential form catalog', () => {
   });
 
   it('offers the GPT 5.6 family to Codex subscriptions and OpenAI API keys', () => {
-    const expected = ['gpt-5.6', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4'];
+    const expected = ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4'];
     expect(CODEX_OAUTH.models?.map((model) => model.id)).toEqual(expected);
     expect(CODEX_API.models?.map((model) => model.id)).toEqual(expected);
-    expect(DEFAULT_MODEL_BY_VENDOR['openai']).toBe('gpt-5.6');
+    expect(DEFAULT_MODEL_BY_VENDOR['openai']).toBe('gpt-5.6-sol');
+    expect(CODEX_OAUTH.models?.find((model) => model.id === 'gpt-5.6-sol')?.semantics)
+      .toMatchObject({
+        contextWindow: 272_000,
+        reasoning: {
+          efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+          defaultEffort: 'low',
+        },
+      });
+    expect(CODEX_OAUTH.models?.find((model) => model.id === 'gpt-5.6-luna')?.semantics)
+      .toMatchObject({
+        reasoning: {
+          efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+          defaultEffort: 'medium',
+        },
+      });
   });
 
   it('offers current general-purpose Gemini tiers without mixing in media-only models', () => {
@@ -151,13 +166,13 @@ describe('credential form catalog', () => {
 
   it('serializes rich semantics beside the backwards-compatible model oneOf', () => {
     const openai = BUILTIN_PRESETS.find((preset) => preset.id === 'codex-api')!;
-    expect(openai.models?.find((model) => model.id === 'gpt-5.6')?.semantics).toMatchObject({
+    expect(openai.models?.find((model) => model.id === 'gpt-5.6-sol')?.semantics).toMatchObject({
       contextWindow: 1_050_000,
       reasoning: { mode: 'optional', defaultEffort: 'medium' },
     });
     const properties = openai.schema['properties'] as Record<string, Record<string, unknown>>;
     expect(properties['model']?.['oneOf']).toEqual(expect.arrayContaining([
-      expect.objectContaining({ const: 'gpt-5.6' }),
+      expect.objectContaining({ const: 'gpt-5.6-sol' }),
     ]));
   });
 });

--- a/src/ai-providers/preset-catalog.ts
+++ b/src/ai-providers/preset-catalog.ts
@@ -8,7 +8,11 @@
  */
 
 import { z } from 'zod'
-import { resolveModelSemantics, type ModelSemantics } from './model-semantics.js'
+import {
+  resolveModelSemantics,
+  type ModelReasoningEffort,
+  type ModelSemantics,
+} from './model-semantics.js'
 
 // ==================== Types ====================
 
@@ -24,6 +28,27 @@ function withModelSemantics(vendor: string, models: ModelOption[]): ModelOption[
     const semantics = resolveModelSemantics(vendor, model.id)
     return semantics ? { ...model, semantics } : model
   })
+}
+
+const CODEX_56_CONTEXT_WINDOW = 272_000
+
+function codexSubscriptionModel(
+  id: string,
+  label: string,
+  input: { efforts: ModelReasoningEffort[]; defaultEffort: ModelReasoningEffort },
+): ModelOption {
+  return {
+    id,
+    label,
+    semantics: {
+      contextWindow: CODEX_56_CONTEXT_WINDOW,
+      reasoning: {
+        mode: 'required',
+        efforts: input.efforts,
+        defaultEffort: input.defaultEffort,
+      },
+    },
+  }
 }
 
 /**
@@ -149,15 +174,24 @@ export const CODEX_OAUTH: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('codex'),
     loginMethod: z.literal('codex-oauth'),
-    model: z.string().default('gpt-5.6').describe('Model'),
+    model: z.string().default('gpt-5.6-sol').describe('Model'),
   }),
-  models: withModelSemantics('openai', [
-    { id: 'gpt-5.6', label: 'GPT 5.6 (Power · Sol)' },
-    { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra (Balanced)' },
-    { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna (Fastest)' },
+  models: [
+    codexSubscriptionModel('gpt-5.6-sol', 'GPT 5.6 Sol (Power)', {
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      defaultEffort: 'low',
+    }),
+    codexSubscriptionModel('gpt-5.6-terra', 'GPT 5.6 Terra (Balanced)', {
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      defaultEffort: 'medium',
+    }),
+    codexSubscriptionModel('gpt-5.6-luna', 'GPT 5.6 Luna (Fastest)', {
+      efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      defaultEffort: 'medium',
+    }),
     { id: 'gpt-5.5', label: 'GPT 5.5 (Previous generation)' },
     { id: 'gpt-5.4', label: 'GPT 5.4 (Previous generation)' },
-  ]),
+  ],
 }
 
 export const CODEX_API: PresetDef = {
@@ -169,11 +203,11 @@ export const CODEX_API: PresetDef = {
   zodSchema: z.object({
     backend: z.literal('codex'),
     loginMethod: z.literal('api-key'),
-    model: z.string().default('gpt-5.6').describe('Model'),
+    model: z.string().default('gpt-5.6-sol').describe('Model'),
     apiKey: z.string().min(1).describe('OpenAI API key'),
   }),
   models: withModelSemantics('openai', [
-    { id: 'gpt-5.6', label: 'GPT 5.6 (Sol alias)' },
+    { id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol (Power)' },
     { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra (Balanced)' },
     { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna (Cost-efficient)' },
     { id: 'gpt-5.5', label: 'GPT 5.5 (Previous generation)' },
@@ -187,7 +221,7 @@ export const CODEX_API: PresetDef = {
     apiKeyLabel: 'OpenAI API key',
     apiKeyPlaceholder: 'sk-...',
     apiKeyHelp: 'Use an OpenAI Platform API key. A ChatGPT subscription is a separate Codex CLI login and does not belong in this field.',
-    modelHelp: 'Choose a model enabled for this API project, or paste another exact ID. GPT 5.6 is the current Sol alias; Terra balances capability and cost, while Luna favors efficient high-volume work.',
+    modelHelp: 'Choose a model enabled for this API project, or paste another exact ID. Sol is the flagship tier, Terra balances capability and cost, and Luna favors efficient high-volume work.',
   },
   writeOnlyFields: ['apiKey'],
 }
@@ -471,7 +505,7 @@ export const PRESET_CATALOG: PresetDef[] = [
  */
 export const DEFAULT_MODEL_BY_VENDOR: Record<string, string> = {
   anthropic: 'claude-opus-4-8',
-  openai: 'gpt-5.6',
+  openai: 'gpt-5.6-sol',
   google: 'gemini-3.1-flash-lite',
   minimax: 'MiniMax-M3',
   glm: 'glm-5.2',

--- a/src/core/preferences.ts
+++ b/src/core/preferences.ts
@@ -14,7 +14,7 @@ import { z } from 'zod'
 import { dataPath } from './paths.js'
 
 const modelReasoningEffortSchema = z.enum([
-  'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max',
+  'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra',
 ])
 
 const quickChatLaunchSchema = z.object({

--- a/src/migrations/0036_codex_56_subscription_model.spec.ts
+++ b/src/migrations/0036_codex_56_subscription_model.spec.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { migrateCodex56SubscriptionModel } from './0036_codex_56_subscription_model/index.js'
+
+const roots: string[] = []
+
+async function fixture(input: { recentLaunch: unknown; records: unknown[] }) {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-codex-56-model-'))
+  roots.push(root)
+  const preferencesPath = join(root, 'preferences.json')
+  const resumeIdentitiesPath = join(root, 'resume-identities.json')
+  await writeFile(preferencesPath, JSON.stringify({ quickChat: { recentLaunch: input.recentLaunch } }))
+  await writeFile(resumeIdentitiesPath, JSON.stringify({ version: 2, records: input.records }))
+  return { preferencesPath, resumeIdentitiesPath }
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('0036_codex_56_subscription_model', () => {
+  it('repairs native Quick Start and native Codex Session bindings', async () => {
+    const paths = await fixture({
+      recentLaunch: {
+        agent: 'codex',
+        accessMode: 'auto',
+        credentialSlug: null,
+        model: 'gpt-5.6',
+        reasoningEffort: null,
+      },
+      records: [{
+        resumeId: 'resume-test',
+        agent: 'codex',
+        runtimeBinding: {
+          version: 1,
+          credential: { source: 'native' },
+          model: 'gpt-5.6',
+        },
+      }],
+    })
+
+    expect(await migrateCodex56SubscriptionModel(paths)).toEqual({
+      preferencesUpdated: true,
+      sessionsUpdated: true,
+    })
+    expect(JSON.parse(await readFile(paths.preferencesPath, 'utf8')).quickChat.recentLaunch.model)
+      .toBe('gpt-5.6-sol')
+    expect(JSON.parse(await readFile(paths.resumeIdentitiesPath, 'utf8')).records[0].runtimeBinding.model)
+      .toBe('gpt-5.6-sol')
+    expect(await migrateCodex56SubscriptionModel(paths)).toEqual({
+      preferencesUpdated: false,
+      sessionsUpdated: false,
+    })
+  })
+
+  it('preserves the valid API alias for vault and Workspace-owned launches', async () => {
+    const paths = await fixture({
+      recentLaunch: {
+        agent: 'codex',
+        accessMode: 'vault',
+        credentialSlug: 'openai-primary',
+        model: 'gpt-5.6',
+        reasoningEffort: 'medium',
+      },
+      records: [
+        {
+          resumeId: 'resume-vault',
+          agent: 'codex',
+          runtimeBinding: {
+            version: 1,
+            credential: {
+              source: 'vault',
+              credentialSlug: 'openai-primary',
+              wireShape: 'openai-responses',
+            },
+            model: 'gpt-5.6',
+          },
+        },
+        {
+          resumeId: 'resume-workspace',
+          agent: 'codex',
+          runtimeBinding: {
+            version: 1,
+            credential: { source: 'workspace', fingerprint: 'fingerprint' },
+            model: 'gpt-5.6',
+          },
+        },
+      ],
+    })
+
+    expect(await migrateCodex56SubscriptionModel(paths)).toEqual({
+      preferencesUpdated: false,
+      sessionsUpdated: false,
+    })
+    expect(JSON.parse(await readFile(paths.preferencesPath, 'utf8')).quickChat.recentLaunch.model)
+      .toBe('gpt-5.6')
+    expect(JSON.parse(await readFile(paths.resumeIdentitiesPath, 'utf8')).records)
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ runtimeBinding: expect.objectContaining({ model: 'gpt-5.6' }) }),
+      ]))
+  })
+})

--- a/src/migrations/0036_codex_56_subscription_model/index.ts
+++ b/src/migrations/0036_codex_56_subscription_model/index.ts
@@ -1,0 +1,117 @@
+/**
+ * 0036_codex_56_subscription_model — replace the API-only GPT-5.6 family alias
+ * in native Codex subscription launches.
+ *
+ * OpenAI's API accepts `gpt-5.6` as a moving alias for Sol, but Codex sessions
+ * authenticated through a ChatGPT account require the explicit model slug.
+ * Keep API-key and Workspace-owned choices untouched: the alias remains valid
+ * there and may be intentional.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+
+import type { Migration } from '../types.js'
+
+const LEGACY_MODEL = 'gpt-5.6'
+const CODEX_SUBSCRIPTION_MODEL = 'gpt-5.6-sol'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+async function readJson(path: string): Promise<unknown | undefined> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as unknown
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    return undefined
+  }
+}
+
+async function writeAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tempPath = join(dirname(path), `.${randomUUID()}.tmp`)
+  await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  await rename(tempPath, path)
+}
+
+function migratedPreferences(value: unknown): unknown | null {
+  if (!isRecord(value)) return null
+  const quickChat = value['quickChat']
+  if (!isRecord(quickChat)) return null
+  const recentLaunch = quickChat['recentLaunch']
+  if (
+    !isRecord(recentLaunch)
+    || recentLaunch['agent'] !== 'codex'
+    || recentLaunch['model'] !== LEGACY_MODEL
+    || recentLaunch['credentialSlug'] !== null
+    || recentLaunch['accessMode'] === 'vault'
+  ) return null
+  return {
+    ...value,
+    quickChat: {
+      ...quickChat,
+      recentLaunch: {
+        ...recentLaunch,
+        model: CODEX_SUBSCRIPTION_MODEL,
+      },
+    },
+  }
+}
+
+function migratedResumeIdentities(value: unknown): unknown | null {
+  if (!isRecord(value) || !Array.isArray(value['records'])) return null
+  let updated = false
+  const records = value['records'].map((candidate) => {
+    if (!isRecord(candidate) || candidate['agent'] !== 'codex') return candidate
+    const runtimeBinding = candidate['runtimeBinding']
+    if (!isRecord(runtimeBinding) || runtimeBinding['model'] !== LEGACY_MODEL) return candidate
+    const credential = runtimeBinding['credential']
+    if (!isRecord(credential) || credential['source'] !== 'native') return candidate
+    updated = true
+    return {
+      ...candidate,
+      runtimeBinding: {
+        ...runtimeBinding,
+        model: CODEX_SUBSCRIPTION_MODEL,
+      },
+    }
+  })
+  return updated ? { ...value, records } : null
+}
+
+export async function migrateCodex56SubscriptionModel(input: {
+  preferencesPath: string
+  resumeIdentitiesPath: string
+}): Promise<{ preferencesUpdated: boolean; sessionsUpdated: boolean }> {
+  const preferences = migratedPreferences(await readJson(input.preferencesPath))
+  if (preferences) await writeAtomic(input.preferencesPath, preferences)
+
+  const resumeIdentities = migratedResumeIdentities(await readJson(input.resumeIdentitiesPath))
+  if (resumeIdentities) await writeAtomic(input.resumeIdentitiesPath, resumeIdentities)
+
+  return {
+    preferencesUpdated: preferences !== null,
+    sessionsUpdated: resumeIdentities !== null,
+  }
+}
+
+export const migration: Migration = {
+  id: '0036_codex_56_subscription_model',
+  appVersion: '0.89.3-beta',
+  introducedAt: '2026-08-07',
+  affects: ['data/preferences.json', 'workspaces/state/resume-identities.json'],
+  summary: 'Use the explicit GPT-5.6 Sol slug for native Codex subscription Sessions.',
+  rationale:
+    'The OpenAI API accepts the bare GPT-5.6 alias, while ChatGPT-authenticated Codex rejects it; old Quick Start presets persisted that incompatible alias.',
+  up: async (ctx) => {
+    const userDataHome = resolve(ctx.configDir(), '..', '..')
+    const launcherRoot = resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(userDataHome, 'workspaces'))
+    await migrateCodex56SubscriptionModel({
+      preferencesPath: join(ctx.configDir(), '..', 'preferences.json'),
+      resumeIdentitiesPath: join(launcherRoot, 'state', 'resume-identities.json'),
+    })
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -35,3 +35,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0033_semantic_issue_assignees` | 0.90.0-beta | 2026-08-06 | workspaces/<id>/.alice/issues/*.md | Replace deprecated @workspace/@new Issue aliases with behavior-named assignee tokens. |
 | `0034_quick_chat_recent_launch` | 0.89.3-beta | 2026-08-06 | data/preferences.json | Remember Quick Start runtime, credential, model, and effort as one Session-only launch tuple. |
 | `0035_quick_chat_access_mode` | 0.89.3-beta | 2026-08-06 | data/preferences.json | Distinguish Workspace AI, saved credentials, and native runtime accounts in Quick Start. |
+| `0036_codex_56_subscription_model` | 0.89.3-beta | 2026-08-07 | data/preferences.json, workspaces/state/resume-identities.json | Use the explicit GPT-5.6 Sol slug for native Codex subscription Sessions. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -14,7 +14,7 @@
  * deletion + Workspace pivot turned the pre-0.40 data shapes over completely, so
  * pre-0.40 installs rebuild `data/` rather than migrate. The framework stays for
  * future upgrades. Numbering continues FORWARD from the highest id ever shipped
- * (next: 0035) — never reuse a retired id, since existing installs' journals
+ * (next: 0037) — never reuse a retired id, since existing installs' journals
  * recorded the old ones.
  */
 
@@ -47,6 +47,7 @@ import { migration as migration_0032_session_runtime_bindings } from './0032_ses
 import { migration as migration_0033_semantic_issue_assignees } from './0033_semantic_issue_assignees/index.js'
 import { migration as migration_0034_quick_chat_recent_launch } from './0034_quick_chat_recent_launch/index.js'
 import { migration as migration_0035_quick_chat_access_mode } from './0035_quick_chat_access_mode/index.js'
+import { migration as migration_0036_codex_56_subscription_model } from './0036_codex_56_subscription_model/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -77,4 +78,5 @@ export const REGISTRY: Migration[] = [
   migration_0033_semantic_issue_assignees,
   migration_0034_quick_chat_recent_launch,
   migration_0035_quick_chat_access_mode,
+  migration_0036_codex_56_subscription_model,
 ]

--- a/src/workspaces/agent-credential-readiness.spec.ts
+++ b/src/workspaces/agent-credential-readiness.spec.ts
@@ -158,11 +158,11 @@ describe('agent credential readiness', () => {
     expect(a.writeAiConfig).toHaveBeenCalledOnce();
     expect(a.writeAiConfig).toHaveBeenCalledWith('/tmp/ws-1', expect.objectContaining({
       apiKey: 'sk-oa',
-      model: 'gpt-5.6',
+      model: 'gpt-5.6-sol',
       wireShape: 'openai-chat',
       contextWindow: 1_050_000,
     }));
-    expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.6');
+    expect(vi.mocked(setCredentialLastModel)).toHaveBeenCalledWith('openai-1', 'gpt-5.6-sol');
   });
 
   it('keeps native login ready but rejects an explicit credential without a model', async () => {

--- a/src/workspaces/credential-injection.spec.ts
+++ b/src/workspaces/credential-injection.spec.ts
@@ -485,7 +485,7 @@ describe('resolveInjectionModel', () => {
 
   it('falls back to the vendor recommendation when no lastModel', () => {
     expect(resolveInjectionModel({ vendor: 'anthropic' })).toBe('claude-opus-4-8')
-    expect(resolveInjectionModel({ vendor: 'openai' })).toBe('gpt-5.6')
+    expect(resolveInjectionModel({ vendor: 'openai' })).toBe('gpt-5.6-sol')
     expect(resolveInjectionModel({ vendor: 'glm' })).toBe('glm-5.2')
     expect(resolveInjectionModel({ vendor: 'longcat' })).toBe('LongCat-2.0')
   })

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -86,7 +86,7 @@ export interface CredentialSetupGuide {
 }
 
 export type ModelReasoningMode = 'none' | 'optional' | 'adaptive' | 'required'
-export type ModelReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+export type ModelReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
 
 export interface ModelSemantics {
   contextWindow?: number

--- a/ui/src/components/issue-runtime-options.ts
+++ b/ui/src/components/issue-runtime-options.ts
@@ -7,7 +7,7 @@ import type {
 import type { SavedCredential } from './workspace/api'
 
 const ALL_RUNTIME_EFFORTS: readonly ModelReasoningEffort[] = [
-  'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max',
+  'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra',
 ]
 
 const CLAUDE_RUNTIME_EFFORTS: readonly ModelReasoningEffort[] = [

--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -250,7 +250,7 @@ describe('AgentLaunchSelectors keyboard menus', () => {
           defaultModel: 'gpt-5',
           modelOptions: [
             { id: 'gpt-5', label: 'GPT-5' },
-            { id: 'gpt-5.6', label: 'GPT-5.6' },
+            { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
           ],
           aiDetails: {
             model: 'gpt-5',
@@ -277,7 +277,7 @@ describe('AgentLaunchSelectors keyboard menus', () => {
     await user.keyboard('{ArrowDown}')
     await user.click(screen.getByRole('menuitem', { name: /Model/ }))
     fireEvent.click(await screen.findByRole('menuitemradio', { name: /GPT-5.6/ }))
-    expect(selectModel).toHaveBeenCalledWith('gpt-5.6')
+    expect(selectModel).toHaveBeenCalledWith('gpt-5.6-sol')
 
     await user.keyboard('{Escape}{Escape}')
     trigger.focus()

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.render.spec.tsx
@@ -291,7 +291,7 @@ describe('WorkspaceAIConfigModal local model metadata', () => {
     )
 
     fireEvent.change(await screen.findByPlaceholderText('gpt-5.5'), {
-      target: { value: 'gpt-5.6' },
+      target: { value: 'gpt-5.6-sol' },
     })
     fireEvent.click(screen.getByRole('button', { name: '保存' }))
 
@@ -301,7 +301,7 @@ describe('WorkspaceAIConfigModal local model metadata', () => {
       expect.objectContaining({
         baseUrl: null,
         apiKey: null,
-        model: 'gpt-5.6',
+        model: 'gpt-5.6-sol',
       }),
     ))
     expect(mocks.testAgentConfig).not.toHaveBeenCalled()
@@ -379,7 +379,7 @@ describe('WorkspaceAIConfigModal local model metadata', () => {
     const openAiPi = {
       ...savedPi,
       baseUrl: 'https://api.openai.com/v1',
-      model: 'gpt-5.6',
+      model: 'gpt-5.6-sol',
     }
     mocks.getAgentConfig.mockReset()
       .mockResolvedValueOnce({ claude: null, codex: null, opencode: null, pi: openAiPi })
@@ -397,7 +397,7 @@ describe('WorkspaceAIConfigModal local model metadata', () => {
         defaultName: 'OpenAI',
         description: '',
         models: [{
-          id: 'gpt-5.6',
+          id: 'gpt-5.6-sol',
           label: 'GPT 5.6',
           semantics: {
             reasoning: {

--- a/ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts
+++ b/ui/src/components/workspace/WorkspaceAIConfigModal.spec.ts
@@ -117,7 +117,7 @@ describe('WorkspaceAIConfigModal Pi model capability mapping', () => {
     'lets %s native-login model and effort changes save without an HTTP probe',
     (agent) => {
       const form = configToForm(null, nativeCapabilities)
-      form.model = agent === 'codex' ? 'gpt-5.6' : 'claude-opus-4-8'
+      form.model = agent === 'codex' ? 'gpt-5.6-sol' : 'claude-opus-4-8'
       form.reasoningEffort = 'high'
 
       expect(connectionFieldsChanged(null, form, nativeCapabilities)).toBe(false)

--- a/ui/src/demo/handlers/configKeys.spec.ts
+++ b/ui/src/demo/handlers/configKeys.spec.ts
@@ -22,7 +22,7 @@ function modelIds(presetId: string): string[] {
 describe('demo credential catalog', () => {
   it('covers the current OpenAI and Anthropic forms instead of falling back to Custom', () => {
     expect(modelIds('codex-api')).toEqual([
-      'gpt-5.6',
+      'gpt-5.6-sol',
       'gpt-5.6-terra',
       'gpt-5.6-luna',
       'gpt-5.5',

--- a/ui/src/demo/handlers/configKeys.ts
+++ b/ui/src/demo/handlers/configKeys.ts
@@ -61,9 +61,9 @@ export const demoCredentialPresets = [
       modelHelp: 'Choose a model enabled for this API project, or paste another exact ID.',
     },
     models: [
-      { id: 'gpt-5.6', label: 'GPT 5.6 (Sol alias)', semantics: { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'], defaultEffort: 'medium' } } },
+      { id: 'gpt-5.6-sol', label: 'GPT 5.6 Sol (Power)', semantics: { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'], defaultEffort: 'medium' } } },
       { id: 'gpt-5.6-terra', label: 'GPT 5.6 Terra (Balanced)', semantics: { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'], defaultEffort: 'medium' } } },
-      { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna (Cost-efficient)', semantics: { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'], defaultEffort: 'medium' } } },
+      { id: 'gpt-5.6-luna', label: 'GPT 5.6 Luna (Cost-efficient)', semantics: { contextWindow: 400_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'], defaultEffort: 'medium' } } },
       { id: 'gpt-5.5', label: 'GPT 5.5 (Previous generation)', semantics: { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh'], defaultEffort: 'medium' } } },
       { id: 'gpt-5.4', label: 'GPT 5.4 (Previous generation)', semantics: { contextWindow: 1_050_000, maxOutputTokens: 128_000, reasoning: { mode: 'optional', efforts: ['none', 'low', 'medium', 'high', 'xhigh'], defaultEffort: 'none' } } },
     ],
@@ -73,9 +73,9 @@ export const demoCredentialPresets = [
         apiKey: { type: 'string' },
         model: {
           type: 'string',
-          default: 'gpt-5.6',
+          default: 'gpt-5.6-sol',
           oneOf: [
-            { const: 'gpt-5.6', title: 'GPT 5.6 (Sol alias)' },
+            { const: 'gpt-5.6-sol', title: 'GPT 5.6 Sol (Power)' },
             { const: 'gpt-5.6-terra', title: 'GPT 5.6 Terra (Balanced)' },
             { const: 'gpt-5.6-luna', title: 'GPT 5.6 Luna (Cost-efficient)' },
             { const: 'gpt-5.5', title: 'GPT 5.5 (Previous generation)' },
@@ -206,7 +206,7 @@ export const configKeysHandlers = [
     HttpResponse.json({
       credentials: [
         { slug: 'anthropic-1', vendor: 'anthropic', label: 'Anthropic', authType: 'api-key', wires: { anthropic: '' }, apiKey: null, hasApiKey: true, lastModel: 'claude-opus-4-8' },
-        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true, lastModel: 'gpt-5.6' },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-responses': '', 'openai-chat': '' }, apiKey: null, hasApiKey: true, lastModel: 'gpt-5.6-sol' },
       ],
     }),
   ),

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -35,6 +35,7 @@ const MODEL_REASONING_EFFORTS = [
   'high',
   'xhigh',
   'max',
+  'ultra',
 ] as const satisfies readonly ModelReasoningEffort[]
 
 const COMMENT_MAX = 16_000

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -806,7 +806,7 @@ export const workspacesHandlers = [
   http.get('/api/workspaces/credentials', () =>
     HttpResponse.json({
       credentials: [
-        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-chat': 'https://api.openai.com/v1' }, lastModel: 'gpt-5.6', resolvedModel: 'gpt-5.6', apiKey: 'demo-openai-key-not-secret' },
+        { slug: 'openai-1', vendor: 'openai', label: 'OpenAI', authType: 'api-key', wires: { 'openai-chat': 'https://api.openai.com/v1' }, lastModel: 'gpt-5.6-sol', resolvedModel: 'gpt-5.6-sol', apiKey: 'demo-openai-key-not-secret' },
         { slug: 'minimax-1', vendor: 'minimax', label: 'MiniMax', authType: 'api-key', wires: { 'openai-chat': 'https://api.minimax.io/v1' }, lastModel: 'MiniMax-M2.1', resolvedModel: 'MiniMax-M2.1', apiKey: 'demo-minimax-key-not-secret' },
       ],
     }),


### PR DESCRIPTION
## What changed

- replace the API-only bare GPT-5.6 alias with explicit Sol, Terra, and Luna model IDs in Codex subscription and API presets
- keep Codex subscription effort capabilities separate from OpenAI API capabilities, including Ultra for Sol and Terra
- migrate only native Codex Quick Chat preferences and Session bindings that persisted the incompatible bare alias
- update demo contracts, docs, and model metadata including Lunas smaller API context

## Root cause

OpenAlice reused the OpenAI API family alias as the native Codex preset default. The API resolves that alias to Sol, but ChatGPT-authenticated Codex sessions require an explicit model slug and reject the alias.

## Validation

- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (4001 passed, 9 skipped)
- focused preset, migration, credential injection, and UI tests (97 passed)
- real Quick Chat browser verification for Sol, Terra, Luna, and subscription effort options