### PR TITLE
Fix Quick Chat default effort projection

### DIFF
--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -72,6 +72,7 @@ function launchConfig(overrides: Partial<AgentLaunchConfigState> = {}): AgentLau
     modelOptions: [],
     launchModel: undefined,
     effortOptions: ['low', 'medium', 'high'],
+    selectedReasoningEffort: undefined,
     launchReasoningEffort: undefined,
     aiDetails: null,
     selectedRuntimeUsesGlobalConfig: false,

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -205,7 +205,7 @@ function AgentLaunchEffortEditor({
   labeled?: boolean
 }) {
   const { t } = useTranslation()
-  const current = config.launchReasoningEffort
+  const current = config.selectedReasoningEffort
   const options = current && !config.effortOptions.includes(current)
     ? [current, ...config.effortOptions]
     : config.effortOptions
@@ -284,10 +284,10 @@ function AgentLaunchInferenceMenu({
     ?? config.defaultModel
     ?? t('chatLanding.runtimeDefaultModel')
   const modelValue = config.launchModel ?? ''
-  const effortValue = config.launchReasoningEffort ?? ''
-  const effortOptions = config.launchReasoningEffort
-    && !config.effortOptions.includes(config.launchReasoningEffort)
-    ? [config.launchReasoningEffort, ...config.effortOptions]
+  const effortValue = config.selectedReasoningEffort ?? ''
+  const effortOptions = config.selectedReasoningEffort
+    && !config.effortOptions.includes(config.selectedReasoningEffort)
+    ? [config.selectedReasoningEffort, ...config.effortOptions]
     : config.effortOptions
   const knownModels = config.modelOptions.filter((model) => model.id !== config.defaultModel)
   const customCurrentModel = config.launchModel

--- a/ui/src/hooks/useAgentLaunchConfig.ts
+++ b/ui/src/hooks/useAgentLaunchConfig.ts
@@ -331,6 +331,9 @@ export interface AgentLaunchConfigState {
   readonly modelOptions: readonly PresetModel[]
   readonly launchModel: string | undefined
   readonly effortOptions: readonly ModelReasoningEffort[]
+  /** Explicit picker value. Undefined means use the selected model's registered default. */
+  readonly selectedReasoningEffort: ModelReasoningEffort | undefined
+  /** Effective value frozen into a fresh Session launch. */
   readonly launchReasoningEffort: ModelReasoningEffort | undefined
   readonly aiDetails: AgentLaunchAiDetails | null
   readonly selectedRuntimeUsesGlobalConfig: boolean
@@ -572,7 +575,7 @@ export function useAgentLaunchConfig({
   const launchModel = recentTupleMatchesCredential
     ? scopedRecentLaunch.model ?? undefined
     : undefined
-  const launchReasoningEffort = recentTupleMatchesCredential
+  const selectedReasoningEffort = recentTupleMatchesCredential
     ? scopedRecentLaunch.reasoningEffort ?? undefined
     : undefined
   const baseAiDetails = accessMode === 'native'
@@ -596,6 +599,8 @@ export function useAgentLaunchConfig({
   })
   const effectiveModel = launchModel ?? defaultModel
   const selectedModelSemantics = runtimeModelSemantics(effectiveModel, modelOptions)
+  const launchReasoningEffort = selectedReasoningEffort
+    ?? (launchModel ? selectedModelSemantics?.reasoning?.defaultEffort : undefined)
   const effortOptions = runtimeEffortOptions({
     agent: effectiveAgent,
     semantics: selectedModelSemantics,
@@ -734,6 +739,7 @@ export function useAgentLaunchConfig({
     modelOptions,
     launchModel,
     effortOptions,
+    selectedReasoningEffort,
     launchReasoningEffort,
     aiDetails,
     selectedRuntimeUsesGlobalConfig,
@@ -766,6 +772,7 @@ export function useAgentLaunchConfig({
     effectiveCredential,
     launchCredentialSlug,
     launchModel,
+    selectedReasoningEffort,
     launchReasoningEffort,
     modelOptions,
     needsCredential,

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -84,6 +84,19 @@ const opencodeAgent: AgentInfo = {
   displayName: 'opencode',
 }
 
+const codexAgent: AgentInfo = {
+  ...piAgent,
+  id: 'codex',
+  displayName: 'Codex',
+  capabilities: {
+    ...piAgent.capabilities,
+    aiProvider: {
+      credentialSource: 'runtime-or-workspace',
+      wirePreference: ['openai-responses'],
+    },
+  },
+}
+
 function chatWorkspace(): Workspace {
   return {
     id: 'chat-1',
@@ -678,6 +691,77 @@ describe('ChatLandingPage AI source disclosure', () => {
       'chat',
       'deepseek-v4-flash',
       'high',
+      undefined,
+    ))
+  })
+
+  it('projects a registered model default into the new Session launch', async () => {
+    mocks.useWorkspaces.mockImplementation(() => ({
+      ...context(workspaces),
+      agents: [codexAgent],
+      defaultAgent: 'codex',
+    }))
+    mocks.detectWorkspaceCredential.mockResolvedValue(null)
+    mocks.getAgentRuntimeReadiness.mockResolvedValue({
+      agents: {
+        codex: {
+          agent: 'codex',
+          displayName: 'Codex',
+          installed: true,
+          binPath: '/tmp/codex',
+          status: 'ready',
+          ready: true,
+          source: 'global-login',
+          checkedAt: '2026-08-07T00:00:00.000Z',
+          durationMs: 1,
+        },
+      },
+      overallReady: true,
+      checkedAt: '2026-08-07T00:00:00.000Z',
+    })
+    mocks.getPresets.mockResolvedValue({
+      presets: [{
+        id: 'codex-oauth',
+        label: 'OpenAI Codex (Subscription)',
+        models: [{
+          id: 'gpt-5.6-sol',
+          label: 'GPT 5.6 Sol (Power)',
+          semantics: {
+            reasoning: {
+              mode: 'required',
+              efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+              defaultEffort: 'low',
+            },
+          },
+        }],
+      }],
+    })
+    mocks.getQuickChat.mockResolvedValue({
+      lastCredentialByAgent: {},
+      recentChatWorkspaceId: 'chat-1',
+      recentLaunch: {
+        agent: 'codex',
+        accessMode: 'auto',
+        credentialSlug: null,
+        model: 'gpt-5.6-sol',
+        reasoningEffort: null,
+      },
+    })
+
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+
+    expect((await findInferenceTrigger('gpt-5.6-sol')).textContent).toContain('low reasoning')
+    fireEvent.change(screen.getByPlaceholderText('Ask Alice…'), { target: { value: 'Use model defaults.' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => expect(mocks.quickChat).toHaveBeenCalledWith(
+      'Use model defaults.',
+      'codex',
+      undefined,
+      'chat-1',
+      'chat',
+      'gpt-5.6-sol',
+      'low',
       undefined,
     ))
   })


### PR DESCRIPTION
## Summary
- distinguish the picker’s implicit model default from an explicit effort selection
- project a registered model default into every fresh Session launch
- keep the Default option selected while displaying and launching its effective effort

## Verification
- `pnpm vitest run ui/src/pages/ChatLandingPage.render.spec.tsx ui/src/components/workspace/AgentLaunchControls.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4002 passed, 9 skipped)
- manually verified `/chat`: Codex shows `gpt-5.6-sol · low reasoning` and `Default · low reasoning` remains checked