### PR TITLE
fix(ui): auto-grow WebPi composer

### DIFF
--- a/ui/src/components/ui/textarea.tsx
+++ b/ui/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/ui/src/components/workspace/WebPiView.spec.tsx
+++ b/ui/src/components/workspace/WebPiView.spec.tsx
@@ -112,6 +112,18 @@ describe('WebPi transcript scrolling', () => {
 })
 
 describe('WebPi composer keyboard submission', () => {
+  it('uses the shared content-sized textarea so multiline prompts grow until the CSS cap', async () => {
+    mocks.getWebPiSession.mockResolvedValue(snapshot('idle'))
+    render(
+      <WebPiView wsId="workspace-manager" sessionId="p1" onSessionLost={vi.fn()} />,
+    )
+
+    const composer = await screen.findByPlaceholderText('Message Pi…')
+    expect(composer.getAttribute('data-slot')).toBe('textarea')
+    expect(composer.className).toContain('field-sizing-content')
+    expect(composer.getAttribute('rows')).toBe('1')
+  })
+
   it('does not submit when Enter confirms an IME composition candidate', async () => {
     mocks.getWebPiSession.mockResolvedValue(snapshot('idle'))
     render(

--- a/ui/src/components/workspace/WebPiView.tsx
+++ b/ui/src/components/workspace/WebPiView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } 
 import { Check, ChevronRight, CircleAlert, CircleDashed, LoaderCircle, Send, Square } from 'lucide-react'
 
 import { MarkdownContent } from '../MarkdownContent'
+import { Textarea } from '@/components/ui/textarea'
 import {
   abortWebPiSession,
   getWebPiSession,
@@ -185,7 +186,7 @@ export function WebPiView({ wsId, sessionId, label, onSessionLost }: Props): Rea
 
       <div className="webpi-composer-wrap">
         <div className="webpi-composer">
-          <textarea
+          <Textarea
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={(event) => {

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1422,7 +1422,7 @@ button.files-row:focus-visible {
 .webpi-composer-wrap { width: 100%; max-width: 100%; min-width: 0; padding: 10px max(18px, calc((100% - 760px) / 2)) 14px; border-top: 1px solid var(--border); background: color-mix(in srgb, var(--background) 88%, transparent); }
 .webpi-composer { width: 100%; max-width: 100%; min-width: 0; display: flex; align-items: flex-end; gap: 8px; padding: 9px 10px 9px 13px; border: 1px solid var(--border); border-radius: 14px; background: var(--secondary); box-shadow: 0 6px 24px color-mix(in srgb, var(--shadow-color) 9%, transparent); }
 .webpi-composer:focus-within { border-color: color-mix(in srgb, var(--primary) 60%, var(--border)); }
-.webpi-composer textarea { width: 100%; min-width: 0; flex: 1; min-height: 25px; max-height: 150px; resize: none; border: 0; outline: 0; color: var(--foreground); background: transparent; font: inherit; font-size: 13px; line-height: 1.6; }
+.webpi-composer [data-slot="textarea"] { width: 100%; min-width: 0; flex: 1; min-height: 25px; max-height: 150px; overflow-y: auto; resize: none; border: 0; border-radius: 0; padding: 0; outline: 0; color: var(--foreground); background: transparent; box-shadow: none; font: inherit; font-size: 13px; line-height: 1.6; }
 .webpi-send { width: 30px; height: 30px; flex: 0 0 30px; display: grid; place-items: center; border-radius: 9px; color: var(--primary-foreground); background: var(--primary); }
 .webpi-send:disabled { opacity: .35; }
 .webpi-composer-hint { padding: 5px 3px 0; text-align: right; color: var(--muted-foreground); font-size: 9px; }


### PR DESCRIPTION
## Summary

- replace WebPi’s raw textarea with the shared shadcn/Base UI `Textarea` primitive
- let multiline prompts grow with their content, cap the composer at 150px, then scroll internally
- preserve the existing Enter-to-send and Shift+Enter newline behavior
- add regression coverage for the shared content-sized textarea contract

## Root cause

The composer already declared a one-line minimum and a 150px maximum, but the textarea itself remained `rows={1}` with no content-sizing behavior. Its scroll height changed while its rendered height did not.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 4004 passed, 9 skipped
- real WebPi route in `pnpm dev`:
  - 1 line: 25px
  - 4 lines: 83px
  - 20 lines: capped at 150px with 416px internal scroll content
  - cleared: returns to 25px

Fixes #711