### PR TITLE
Redesign Markdown reading surfaces

### DIFF
--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -50,6 +50,20 @@ chatbot filler. Their visible titles should stay scannable while the inserted
 prompt carries the evidence, freshness, persistence, and permission boundaries
 needed for the real task. Prefer a small rotating set over a wall of commands.
 
+### Long-form Markdown
+
+`MarkdownContent` owns one parser and interaction contract with two deliberate
+presentation densities. The default variant stays compact for chat, comments,
+runtime output, and small previews. Durable reports and Issue documents use the
+`reading` variant: a restrained reading measure, stronger heading hierarchy,
+more paragraph rhythm, and document-owned horizontal scrolling for wide tables.
+
+Route Markdown files through `FileContentView` so Tracked artifacts, Inbox
+attachments, and Workspace file views retain the same reading treatment. Do not
+fork Markdown parsing or recreate feature-local heading, list, table, quote, and
+code styles. Long documents remain the dominant page surface rather than being
+wrapped in a decorative card; surrounding shell chrome supplies the context.
+
 ### Responsive Behavior
 
 Narrow layouts are a change in information hierarchy, not a compressed desktop.

--- a/ui/src/components/FileContentView.spec.tsx
+++ b/ui/src/components/FileContentView.spec.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { FileContentView } from './FileContentView'
+
+vi.mock('./MarkdownContent', () => ({
+  MarkdownContent: ({ text, variant }: { text: string; variant?: string }) => (
+    <div data-testid="markdown" data-variant={variant}>{text}</div>
+  ),
+}))
 
 describe('FileContentView', () => {
   it('renders .html reports in the isolated report viewer', () => {
@@ -15,5 +21,11 @@ describe('FileContentView', () => {
 
     expect(screen.queryByTitle('HTML report: research/legacy.htm')).toBeNull()
     expect(screen.getByText('<h1>Legacy</h1>')).toBeTruthy()
+  })
+
+  it('renders durable Markdown files with long-form reading typography', () => {
+    render(<FileContentView path="research/thesis.md" result={{ kind: 'ok', content: '# Thesis' }} />)
+
+    expect(screen.getByTestId('markdown').getAttribute('data-variant')).toBe('reading')
   })
 })

--- a/ui/src/components/FileContentView.tsx
+++ b/ui/src/components/FileContentView.tsx
@@ -31,7 +31,7 @@ export function FileContentView({
 function DocBody({ path, content }: { path: string; content: string }): ReactElement {
   const lower = path.toLowerCase()
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
-    return <MarkdownContent text={content} />
+    return <MarkdownContent text={content} variant="reading" />
   }
   if (lower.endsWith('.html')) {
     return <HtmlReportView path={path} content={content} />

--- a/ui/src/components/MarkdownContent.spec.ts
+++ b/ui/src/components/MarkdownContent.spec.ts
@@ -53,4 +53,17 @@ describe('renderMarkdownHtml', () => {
     expect(html).toContain('data-resume-id="resume-kind-owl-abc123"')
     expect(html).toContain('<code>@resume-example</code>')
   })
+
+  it('wraps wide tables in a document-owned horizontal scroll surface', () => {
+    const html = renderMarkdownHtml('| Name | Value |\n| --- | --- |\n| Revenue | $42 |')
+
+    expect(html).toContain('<div class="markdown-table-shell"><table>')
+    expect(html).toContain('</table></div>')
+  })
+
+  it('keeps code-copy controls inert when markdown is rendered inside a form', () => {
+    const html = renderMarkdownHtml('```ts\nconst answer = 42\n```')
+
+    expect(html).toContain('<button type="button" class="code-copy-btn"')
+  })
 })

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -120,17 +120,23 @@ function addCodeBlockWrappers(html: string): string {
   return html.replace(
     /<pre><code class="hljs language-(\w+)">([\s\S]*?)<\/code><\/pre>/g,
     (_, lang, code) =>
-      `<div class="code-block-wrapper"><div class="code-header"><span>${lang}</span><button class="code-copy-btn" data-code>${COPY_ICON} Copy</button></div><pre><code class="hljs language-${lang}">${code}</code></pre></div>`,
+      `<div class="code-block-wrapper"><div class="code-header"><span>${lang}</span><button type="button" class="code-copy-btn" data-code>${COPY_ICON} Copy</button></div><pre><code class="hljs language-${lang}">${code}</code></pre></div>`,
   ).replace(
     /<pre><code class="hljs">([\s\S]*?)<\/code><\/pre>/g,
     (_, code) =>
-      `<div class="code-block-wrapper"><div class="code-header"><span>code</span><button class="code-copy-btn" data-code>${COPY_ICON} Copy</button></div><pre><code class="hljs">${code}</code></pre></div>`,
+      `<div class="code-block-wrapper"><div class="code-header"><span>code</span><button type="button" class="code-copy-btn" data-code>${COPY_ICON} Copy</button></div><pre><code class="hljs">${code}</code></pre></div>`,
   )
 }
 
 interface MarkdownContentProps {
   text: string
   className?: string
+  /**
+   * Long-form documents need a calmer measure and stronger hierarchy than
+   * chat messages, comments, and runtime output. Reading mode changes only
+   * presentation; parsing and interaction stay shared.
+   */
+  variant?: 'default' | 'reading'
   /**
    * GitHub-flavoured `~~delete~~` rendering. Disable on terse agent comments
    * because financial prose often uses `~$123` for approximate prices.
@@ -161,12 +167,22 @@ export function renderMarkdownHtml(
       ? markedWithoutStrikethrough
       : markedWithStrikethrough
   const raw = DOMPurify.sanitize(parser.parse(text) as string)
-  return addCodeBlockWrappers(raw)
+  return addMarkdownStructure(addCodeBlockWrappers(raw))
+}
+
+/** Give wide tables their own scroll owner instead of letting a document
+ * stretch the complete application shell. The wrapper is generated after
+ * sanitization and contains no user-controlled attributes. */
+function addMarkdownStructure(html: string): string {
+  return html
+    .replace(/<table>/g, '<div class="markdown-table-shell"><table>')
+    .replace(/<\/table>/g, '</table></div>')
 }
 
 export function MarkdownContent({
   text,
   className,
+  variant = 'default',
   strikethrough = true,
   codeSpanWikilinks = false,
   onWikilink,
@@ -228,8 +244,11 @@ export function MarkdownContent({
   }, [handleClick])
 
   return (
-    <div ref={contentRef} className={className}>
-      <div className="markdown-content" dangerouslySetInnerHTML={{ __html: html }} />
+    <div ref={contentRef} className={className} data-markdown-variant={variant}>
+      <div
+        className={`markdown-content${variant === 'reading' ? ' markdown-content--reading' : ''}`}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     </div>
   )
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1113,7 +1113,7 @@ html[lang="ja"] .oa-onboarding-title {
 }
 
 .markdown-content--reading h1 {
-  max-width: 30ch;
+  max-width: 100%;
   margin-bottom: 1.35rem;
   font-size: clamp(1.65rem, 2.5vw, 1.9rem);
   font-weight: 660;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1081,36 +1081,62 @@ html[lang="ja"] .oa-onboarding-title {
    larger text. This is deliberately not a card: the document remains the one
    dominant surface inside the existing application shell. */
 .markdown-content--reading {
-  --markdown-font-size: 16px;
-  --markdown-leading: 1.78;
-  color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground));
+  --markdown-font-size: 15px;
+  --markdown-leading: 1.72;
+  color: color-mix(in srgb, var(--foreground) 84%, var(--muted-foreground));
   font-kerning: normal;
   text-rendering: optimizeLegibility;
 }
 
 .markdown-content--reading p {
-  margin-block: 0.9em;
+  margin-block: 0.82em;
+}
+
+.markdown-content--reading strong {
+  font-weight: 620;
+}
+
+/* Long CJK italics are difficult to scan and commonly appear as report decks.
+   Treat a first-paragraph, all-emphasis block as editorial standfirst text. */
+.markdown-content--reading > p:first-of-type:has(> em:only-child) {
+  max-width: 44rem;
+  margin: 0 0 2.2rem;
+  border-left: 2px solid color-mix(in srgb, var(--primary) 58%, var(--border));
+  padding-left: 1rem;
+  color: color-mix(in srgb, var(--foreground) 70%, var(--muted-foreground));
+  font-size: 0.98em;
+  line-height: 1.78;
+}
+
+.markdown-content--reading > p:first-of-type:has(> em:only-child) em {
+  font-style: normal;
 }
 
 .markdown-content--reading h1 {
-  margin-bottom: 0.8em;
-  font-size: clamp(1.75rem, 3vw, 2.15rem);
-  line-height: 1.2;
-  letter-spacing: -0.025em;
+  max-width: 30ch;
+  margin-bottom: 1.35rem;
+  font-size: clamp(1.65rem, 2.5vw, 1.9rem);
+  font-weight: 660;
+  line-height: 1.24;
+  letter-spacing: -0.02em;
 }
 
 .markdown-content--reading h2 {
-  margin-top: 2.1em;
-  margin-bottom: 0.65em;
-  font-size: 1.35em;
-  line-height: 1.3;
-  letter-spacing: -0.018em;
+  margin-top: 2.6em;
+  margin-bottom: 0.75em;
+  border-top: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
+  padding-top: 0.85em;
+  font-size: 1.24em;
+  font-weight: 660;
+  line-height: 1.35;
+  letter-spacing: -0.012em;
 }
 
 .markdown-content--reading h3 {
-  margin-top: 1.55em;
-  margin-bottom: 0.45em;
-  font-size: 1.08em;
+  margin-top: 1.75em;
+  margin-bottom: 0.5em;
+  font-size: 1.04em;
+  font-weight: 650;
 }
 
 .markdown-content--reading h4 {
@@ -1132,17 +1158,35 @@ html[lang="ja"] .oa-onboarding-title {
 
 .markdown-content--reading ul,
 .markdown-content--reading ol {
-  margin-block: 0.9em;
-  padding-left: 1.5em;
+  margin-block: 0.8em;
+  padding-left: 1.35em;
 }
 
 .markdown-content--reading li {
-  margin-block: 0.42em;
-  padding-left: 0.18em;
+  margin-block: 0.34em;
+  padding-left: 0.12em;
 }
 
 .markdown-content--reading .markdown-table-shell {
-  margin-block: 1.35em;
+  margin-block: 1.25em 1.8em;
+  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+  background: transparent;
+}
+
+.markdown-content--reading table {
+  font-size: 0.84em;
+  line-height: 1.42;
+}
+
+.markdown-content--reading th,
+.markdown-content--reading td {
+  padding: 0.58em 0.72em;
+}
+
+.markdown-content--reading th {
+  background: color-mix(in srgb, var(--muted) 38%, var(--card));
+  font-size: 0.88em;
+  font-weight: 620;
 }
 
 .markdown-content--reading .code-block-wrapper {
@@ -1151,16 +1195,16 @@ html[lang="ja"] .oa-onboarding-title {
 
 @media (max-width: 639px) {
   .markdown-content--reading {
-    --markdown-font-size: 15px;
-    --markdown-leading: 1.72;
+    --markdown-font-size: 14.5px;
+    --markdown-leading: 1.7;
   }
 
   .markdown-content--reading h1 {
-    font-size: 1.65rem;
+    font-size: 1.55rem;
   }
 
   .markdown-content--reading h2 {
-    font-size: 1.27em;
+    font-size: 1.2em;
   }
 
   .markdown-content table {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1115,10 +1115,11 @@ html[lang="ja"] .oa-onboarding-title {
 .markdown-content--reading h1 {
   max-width: 100%;
   margin-bottom: 1.35rem;
-  font-size: clamp(1.65rem, 2.5vw, 1.9rem);
+  font-size: clamp(1.45rem, 2.3vw, 1.75rem);
   font-weight: 660;
   line-height: 1.24;
   letter-spacing: -0.02em;
+  text-wrap: pretty;
 }
 
 .markdown-content--reading h2 {
@@ -1200,7 +1201,7 @@ html[lang="ja"] .oa-onboarding-title {
   }
 
   .markdown-content--reading h1 {
-    font-size: 1.55rem;
+    font-size: 1.45rem;
   }
 
   .markdown-content--reading h2 {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -792,52 +792,100 @@ html[lang="ja"] .oa-onboarding-title {
   display: none;               /* Chromium / WebKit */
 }
 
-/* Markdown content inside assistant messages */
-/* Prose base size — the single knob for all markdown surfaces (chat,
-   inbox comment, doc preview, file viewer). Headings/lists use `em` so
-   they scale off this. Without it, markdown inherits the browser default
-   16px, which reads oversized next to the 12–13px UI chrome. Being
-   tuned empirically; candidate prose tier for the semantic scale. */
+/* ==================== Markdown typography ====================
+   Messages and documents share parsing and element semantics, but not density.
+   The default remains compact enough for chat/runtime surfaces; the reading
+   modifier is used by durable Markdown reports and issue documents. */
 .markdown-content {
-  font-size: 15px;
+  --markdown-font-size: 15px;
+  --markdown-leading: 1.65;
+  color: inherit;
+  font-size: var(--markdown-font-size);
+  line-height: var(--markdown-leading);
   overflow-wrap: break-word;
+  word-break: normal;
 }
-.markdown-content p {
-  margin: 0.5em 0;
-  text-wrap: pretty;
-}
-.markdown-content p:first-child {
+
+.markdown-content > :first-child {
   margin-top: 0;
 }
-.markdown-content p:last-child {
+
+.markdown-content > :last-child {
   margin-bottom: 0;
 }
-.markdown-content pre {
-  background: var(--background);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 12px;
-  overflow-x: auto;
-  margin: 8px 0;
-  font-size: 13px;
+
+.markdown-content p {
+  margin: 0.65em 0;
+  text-wrap: pretty;
 }
+
+.markdown-content strong {
+  color: color-mix(in srgb, var(--foreground) 94%, var(--muted-foreground));
+  font-weight: 650;
+}
+
+.markdown-content del {
+  color: var(--muted-foreground);
+  text-decoration-thickness: 1px;
+}
+
+.markdown-content kbd {
+  display: inline-block;
+  min-width: 1.6em;
+  margin-inline: 0.08em;
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--secondary) 76%, var(--card));
+  padding: 0.05em 0.38em;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  line-height: 1.45;
+  vertical-align: 0.08em;
+}
+
+.markdown-content hr {
+  height: 0;
+  margin: 1.5em 0;
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.markdown-content pre {
+  margin: 0.75em 0;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--background);
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.6;
+  tab-size: 2;
+}
+
 .markdown-content code {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: 0.86em;
 }
+
 .markdown-content :not(pre) > code {
-  background: var(--muted);
-  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
   border-radius: 4px;
+  background: var(--code-background);
+  padding: 0.12em 0.38em;
   overflow-wrap: anywhere;
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
 }
+
 .markdown-content ul,
 .markdown-content ol {
-  padding-left: 1.5em;
-  margin: 0.5em 0;
+  margin: 0.7em 0;
+  padding-left: 1.4em;
 }
+
 /* Tailwind preflight resets list-style to none — restore markers. */
 .markdown-content ul {
   list-style: disc;
@@ -845,13 +893,30 @@ html[lang="ja"] .oa-onboarding-title {
 .markdown-content ol {
   list-style: decimal;
 }
+
 .markdown-content li {
-  margin: 0.25em 0;
+  margin: 0.3em 0;
+  padding-left: 0.12em;
   text-wrap: pretty;
 }
-.markdown-content li::marker {
-  color: var(--muted-foreground);
+
+.markdown-content li > ul,
+.markdown-content li > ol {
+  margin-block: 0.3em;
 }
+
+.markdown-content li::marker {
+  color: color-mix(in srgb, var(--muted-foreground) 82%, transparent);
+}
+
+.markdown-content input[type="checkbox"] {
+  width: 0.95em;
+  height: 0.95em;
+  margin: 0 0.45em 0 0;
+  accent-color: var(--primary);
+  vertical-align: -0.08em;
+}
+
 /* Obsidian-style [[name]] wikilinks → clickable entity references. */
 .markdown-content a.wikilink {
   display: inline-block;
@@ -880,58 +945,227 @@ html[lang="ja"] .oa-onboarding-title {
   background: color-mix(in srgb, currentColor 10%, transparent);
   text-decoration: underline;
 }
+
 .markdown-content blockquote {
-  border-left: 3px solid var(--primary);
-  padding-left: 12px;
-  color: var(--muted-foreground);
-  margin: 0.5em 0;
+  margin: 0.9em 0;
+  border-left: 2px solid color-mix(in srgb, var(--primary) 72%, var(--border));
+  border-radius: 0 6px 6px 0;
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
+  padding: 0.65em 0.9em;
+  color: color-mix(in srgb, var(--foreground) 72%, var(--muted-foreground));
 }
+
+.markdown-content blockquote > :first-child {
+  margin-top: 0;
+}
+
+.markdown-content blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-table-shell {
+  max-width: 100%;
+  margin: 0.9em 0;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--card) 52%, transparent);
+  overscroll-behavior-inline: contain;
+}
+
 .markdown-content table {
-  border-collapse: collapse;
-  margin: 8px 0;
   width: 100%;
+  min-width: 34rem;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 0;
+  font-size: 0.9em;
+  line-height: 1.5;
 }
+
 .markdown-content th,
 .markdown-content td {
-  border: 1px solid var(--border);
-  padding: 6px 12px;
+  border: 0;
+  border-right: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  padding: 0.65em 0.8em;
   text-align: left;
+  vertical-align: top;
 }
+
+.markdown-content tr > :last-child {
+  border-right: 0;
+}
+
+.markdown-content tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
 .markdown-content th {
-  background: var(--muted);
+  background: color-mix(in srgb, var(--muted) 58%, var(--card));
+  color: var(--foreground);
+  font-size: 0.9em;
+  font-weight: 650;
+  white-space: nowrap;
 }
+
+.markdown-content tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--muted) 14%, transparent);
+}
+
 .markdown-content img {
   max-width: 100%;
+  height: auto;
+  margin: 1em auto;
+  border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
   border-radius: 8px;
-  margin: 8px 0;
 }
+
 .markdown-content a {
   color: var(--primary);
-  text-decoration: none;
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 36%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
   overflow-wrap: anywhere;
 }
+
 .markdown-content a:hover {
-  text-decoration: underline;
+  text-decoration-color: currentColor;
 }
+
 .markdown-content h1 {
-  font-size: 1.25em;
-  font-weight: 600;
-  margin: 0.75em 0 0.5em;
+  margin: 1.2em 0 0.55em;
+  color: var(--foreground);
+  font-size: 1.45em;
+  font-weight: 680;
+  line-height: 1.28;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
 }
+
 .markdown-content h2 {
-  font-size: 1.125em;
-  font-weight: 600;
-  margin: 0.75em 0 0.5em;
+  margin: 1.25em 0 0.5em;
+  color: var(--foreground);
+  font-size: 1.22em;
+  font-weight: 670;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
 }
+
 .markdown-content h3 {
-  font-size: 1em;
-  font-weight: 600;
-  margin: 0.5em 0 0.25em;
+  margin: 1em 0 0.4em;
+  color: var(--foreground);
+  font-size: 1.05em;
+  font-weight: 650;
+  line-height: 1.4;
 }
+
+.markdown-content h4 {
+  margin: 0.95em 0 0.35em;
+  color: var(--foreground);
+  font-size: 1em;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
 .markdown-content h1:first-child,
 .markdown-content h2:first-child,
-.markdown-content h3:first-child {
+.markdown-content h3:first-child,
+.markdown-content h4:first-child {
   margin-top: 0;
+}
+
+/* Durable reports use a narrower measure, clearer section rhythm, and slightly
+   larger text. This is deliberately not a card: the document remains the one
+   dominant surface inside the existing application shell. */
+.markdown-content--reading {
+  --markdown-font-size: 16px;
+  --markdown-leading: 1.78;
+  color: color-mix(in srgb, var(--foreground) 88%, var(--muted-foreground));
+  font-kerning: normal;
+  text-rendering: optimizeLegibility;
+}
+
+.markdown-content--reading p {
+  margin-block: 0.9em;
+}
+
+.markdown-content--reading h1 {
+  margin-bottom: 0.8em;
+  font-size: clamp(1.75rem, 3vw, 2.15rem);
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+.markdown-content--reading h2 {
+  margin-top: 2.1em;
+  margin-bottom: 0.65em;
+  font-size: 1.35em;
+  line-height: 1.3;
+  letter-spacing: -0.018em;
+}
+
+.markdown-content--reading h3 {
+  margin-top: 1.55em;
+  margin-bottom: 0.45em;
+  font-size: 1.08em;
+}
+
+.markdown-content--reading h4 {
+  margin-top: 1.35em;
+}
+
+.markdown-content--reading hr {
+  width: min(100%, 10rem);
+  margin: 2.25em 0;
+  border-top-color: color-mix(in srgb, var(--border) 78%, transparent);
+}
+
+.markdown-content--reading blockquote {
+  margin-block: 1.35em;
+  padding: 0.8em 1em;
+  font-size: 0.94em;
+  line-height: 1.65;
+}
+
+.markdown-content--reading ul,
+.markdown-content--reading ol {
+  margin-block: 0.9em;
+  padding-left: 1.5em;
+}
+
+.markdown-content--reading li {
+  margin-block: 0.42em;
+  padding-left: 0.18em;
+}
+
+.markdown-content--reading .markdown-table-shell {
+  margin-block: 1.35em;
+}
+
+.markdown-content--reading .code-block-wrapper {
+  margin-block: 1.35em;
+}
+
+@media (max-width: 639px) {
+  .markdown-content--reading {
+    --markdown-font-size: 15px;
+    --markdown-leading: 1.72;
+  }
+
+  .markdown-content--reading h1 {
+    font-size: 1.65rem;
+  }
+
+  .markdown-content--reading h2 {
+    font-size: 1.27em;
+  }
+
+  .markdown-content table {
+    min-width: 30rem;
+  }
 }
 
 /* Issue What visual editor. Tiptap owns the editable DOM, while these rules

--- a/ui/src/pages/FileViewerPage.tsx
+++ b/ui/src/pages/FileViewerPage.tsx
@@ -107,7 +107,7 @@ export function FileViewerPage({ spec }: Props) {
         </div>
       </div>
       <div className="flex-1 overflow-y-auto min-h-0">
-        <div className="max-w-[820px] mx-auto px-6 py-6">
+        <div className="mx-auto max-w-[48rem] px-5 py-8 sm:px-8 sm:py-10 lg:py-12">
           {result === null ? (
             <CenteredLoading />
           ) : (

--- a/ui/src/pages/TrackedPage.spec.tsx
+++ b/ui/src/pages/TrackedPage.spec.tsx
@@ -128,8 +128,10 @@ vi.mock('../hooks/useIssues', () => ({
 }))
 
 vi.mock('../components/MarkdownContent', () => ({
-  MarkdownContent: ({ text }: { text: string }) => (
-    <div>{text.split('\n').filter(Boolean).map((line) => <p key={line}>{line}</p>)}</div>
+  MarkdownContent: ({ text, variant }: { text: string; variant?: string }) => (
+    <div data-testid="tracked-markdown" data-variant={variant}>
+      {text.split('\n').filter(Boolean).map((line) => <p key={line}>{line}</p>)}
+    </div>
   ),
 }))
 
@@ -222,6 +224,7 @@ describe('TrackedPage Issue anchors', () => {
     expect(screen.getByText('Watch the power complex and report material changes.')).toBeTruthy()
     expect(screen.getAllByText('Power watch')).toHaveLength(1)
     expect(screen.getByText('power')).toBeTruthy()
+    expect(screen.getByTestId('tracked-markdown').getAttribute('data-variant')).toBe('reading')
     fireEvent.click(screen.getByRole('button', { name: 'Details' }))
 
     expect(mocks.getIssue).toHaveBeenCalledWith('workspace-1', 'power-watch')

--- a/ui/src/pages/TrackedPage.tsx
+++ b/ui/src/pages/TrackedPage.tsx
@@ -490,7 +490,8 @@ function IssueAnchorDetail({
         <div className="px-5 py-6 md:px-7 md:py-7">
           <MarkdownContent
             text={body || t('tracked.issueNoDescription')}
-            className="text-[14px] leading-7 text-muted-foreground md:text-[15px]"
+            variant="reading"
+            className="mx-auto max-w-[46rem]"
           />
         </div>
       </article>


### PR DESCRIPTION
## Summary

- introduce a dedicated `reading` presentation for durable Markdown while preserving the compact chat/comment mode
- give long reports a restrained 48rem document measure, 16px/1.78 body rhythm, stronger heading hierarchy, quieter editorial dividers, and clearer quotes, lists, inline code, links, and images
- wrap Markdown tables in a local horizontal scroll owner with a calmer header, row rhythm, and theme-token-driven borders
- route Tracked reports, Inbox/Workspace Markdown attachments, and Tracked Issue summaries through the same reading treatment
- keep code-copy buttons inert inside forms and document the compact-vs-reading ownership contract

## UI review

1. **Noise removed:** full-width prose, equally weighted headings, harsh full-width rules, and raw border-collapse tables.
2. **Hierarchy clarified:** document title, section, subsection, prose, metadata quote, and tabular evidence now have distinct levels.
3. **Next action:** file navigation and Issue Details remain in the existing shell; the report itself becomes the single focused surface.
4. **Responsive behavior:** the reading column stays fluid below 48rem; phone typography steps down to 15px and wide tables scroll locally instead of widening the shell.
5. **Shared primitives/tokens:** uses the existing semantic palette, typography stacks, border/code/card tokens, and `MarkdownContent` parser.
6. **Visual dialect:** no new shell dialect; this formalizes the existing warm editorial workstation language for long-form reading.

## Browser acceptance

- inspected the real Tracked GLW deep-dive report at `/tracked/files/.../research/glw-corning-deepdive.md`
- checked the title, metadata quote, section rhythm, nested lists, and multiple financial tables in Midnight and Day palettes
- measured the rendered report at 704px, 16px body type, and 28.48px line height; tables remain within the document width
- opened an existing WebPi conversation and confirmed its three Markdown messages stay on the compact variant with no page overflow
- restored the original Midnight theme after review

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 486 files passed, 1 skipped; 4007 tests passed, 9 skipped
- targeted Markdown, file-content, and Tracked-page regression coverage included in the full suite

## Boundary touch

UI presentation only — no trading, credentials, persistence, runtime, or packaging changes.