### PR TITLE
Replace page sidebar resize rail with shadcn

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -32,9 +32,8 @@ the durable truth after it changes.
 ## Completed
 
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
-  page-sidebar drag rail with shadcn Resizable and closed the responsive state
-  contract across enlarged pointer targets, collapse/restore, persisted width,
-  route breakpoints, and real desktop shell geometry in Draft PR #1025.
+  page-sidebar rail with shadcn Resizable and closed its responsive and
+  threshold-motion contracts in Draft PR #1025.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/PLANS.md
+++ b/PLANS.md
@@ -32,8 +32,8 @@ the durable truth after it changes.
 ## Completed
 
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
-  page-sidebar rail with shadcn Resizable and closed its responsive and
-  threshold-motion contracts in Draft PR #1025.
+  page-sidebar rail with shadcn Resizable and closed its responsive,
+  threshold-motion, and resisted-overdrag contracts in Draft PR #1025.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,9 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/shadcn-resizable-page-sidebar.md]] — Replaces the hand-written
-  page-sidebar drag rail with the official shadcn Resizable primitive while
-  preserving OpenAlice focus mode, responsive hierarchy, and stored widths.
 - [[plans/electron-runtime-browser-handoff.md]] — Lets Electron detect a
   healthy dev/CLI Runtime already owning the selected data location and hand
   the user to its verified browser UI without takeover.
@@ -34,6 +31,10 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
+  page-sidebar drag rail with the official shadcn Resizable primitive while
+  preserving OpenAlice focus mode, responsive hierarchy, and stored widths.
+  Implemented in Draft PR #1025 for maintainer acceptance.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/PLANS.md
+++ b/PLANS.md
@@ -33,8 +33,8 @@ the durable truth after it changes.
 
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
   page-sidebar rail with shadcn Resizable and closed its responsive,
-  threshold-motion, resisted-overdrag, and repeat-cycle contracts in Draft PR
-  #1025.
+  threshold-motion, resisted-overdrag, repeat-cycle, and rapid-reversal
+  contracts in Draft PR #1025.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,9 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/shadcn-resizable-page-sidebar.md]] — Replaces the hand-written
+  page-sidebar drag rail with the official shadcn Resizable primitive while
+  preserving OpenAlice focus mode, responsive hierarchy, and stored widths.
 - [[plans/electron-runtime-browser-handoff.md]] — Lets Electron detect a
   healthy dev/CLI Runtime already owning the selected data location and hand
   the user to its verified browser UI without takeover.

--- a/PLANS.md
+++ b/PLANS.md
@@ -33,7 +33,8 @@ the durable truth after it changes.
 
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
   page-sidebar rail with shadcn Resizable and closed its responsive,
-  threshold-motion, and resisted-overdrag contracts in Draft PR #1025.
+  threshold-motion, resisted-overdrag, and repeat-cycle contracts in Draft PR
+  #1025.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/PLANS.md
+++ b/PLANS.md
@@ -32,10 +32,9 @@ the durable truth after it changes.
 ## Completed
 
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
-  page-sidebar drag rail with the official shadcn Resizable primitive while
-  preserving OpenAlice focus mode, stored widths, and a feasible measured-group
-  responsive hierarchy across narrow and wide layouts. Implemented in Draft PR
-  #1025 for maintainer acceptance.
+  page-sidebar drag rail with shadcn Resizable and closed the responsive state
+  contract across enlarged pointer targets, collapse/restore, persisted width,
+  route breakpoints, and real desktop shell geometry in Draft PR #1025.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/PLANS.md
+++ b/PLANS.md
@@ -33,8 +33,9 @@ the durable truth after it changes.
 
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
   page-sidebar drag rail with the official shadcn Resizable primitive while
-  preserving OpenAlice focus mode, responsive hierarchy, and stored widths.
-  Implemented in Draft PR #1025 for maintainer acceptance.
+  preserving OpenAlice focus mode, stored widths, and a feasible measured-group
+  responsive hierarchy across narrow and wide layouts. Implemented in Draft PR
+  #1025 for maintainer acceptance.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -161,7 +161,12 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   such as `PageSidebarLayout` continue to own route content, responsive mode,
   collapse affordances, and persisted preferences; they must not add a second
   visible border or parallel document-level drag listeners beside the shared
-  separator.
+  separator. Responsive min/max values must be derived from the measured split
+  group rather than the window: app-shell chrome sits outside that group. Keep
+  the complete constraint set feasible at every supported width; when there is
+  not enough room for both preferred minimums, preserve the navigator minimum
+  and give the working view the measured remainder instead of sending mutually
+  impossible hard minimums to the primitive.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -183,6 +183,17 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   width changes feel lazy. Do not toggle the primitive's `collapsible`
   metadata during an active pointer transaction; its native midpoint remains
   the single collapse boundary.
+  Keep geometry transactions single-owner: native pointer and keyboard
+  interactions settle through the primitive, while a product collapse or
+  restore affordance issues exactly one imperative geometry call. Product
+  effects may reconcile applied geometry with persisted intent, but must not
+  repeat the same collapse/expand transaction. Because pixel constraint changes
+  can re-register v4 Panels after the group's settled callback, validate both
+  the settled layout and the final Panel ResizeObserver result; reject and
+  repair one-panel `100%` layouts instead of persisting them. A spring cleanup
+  timer begins only after release. When a new drag interrupts a returning
+  spring, cancel that timer and freeze the currently painted edge before
+  resuming direct manipulation so the handle never snaps away from the pointer.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -174,9 +174,15 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   separator's enlarged fine/coarse pointer target behaves like its visible
   one-pixel rule. Persist keyboard changes from the settled layout map rather
   than a pre-paint DOM width, which can lag one key press behind. Direct pointer
-  resizing must stay attached to the cursor; arm the shared motion token only
-  near the discrete minimum-to-collapsed snap so the 200px-to-44px state change
-  retains spatial continuity without making ordinary width changes feel lazy.
+  resizing must stay attached to the cursor above the navigator minimum. Below
+  that minimum, keep the primitive layout and internal content measure fixed,
+  show only a bounded damped overdrag, and spring back on release before the
+  primitive's native collapsed-state midpoint. Arm the shared motion token as
+  that midpoint is crossed so the 200px-to-44px commit retains spatial
+  continuity without squeezing the navigator's controls or making ordinary
+  width changes feel lazy. Do not toggle the primitive's `collapsible`
+  metadata during an active pointer transaction; its native midpoint remains
+  the single collapse boundary.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -194,6 +194,15 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   timer begins only after release. When a new drag interrupts a returning
   spring, cancel that timer and freeze the currently painted edge before
   resuming direct manipulation so the handle never snaps away from the pointer.
+  Registration inputs such as `defaultSize` must remain stable during a held
+  pointer transaction; crossing a collapse midpoint is applied state, not a
+  reason to unregister and rebuild the Panel. If the product tracks gesture
+  state outside the primitive, capture that pointer at the split-group boundary
+  so an out-of-bounds release cannot strand it. A final invariant observer must
+  compare the painted navigator and content flex items, not only the primitive's
+  internal size callback. If those surfaces diverge into an impossible
+  `100%`/`0%` pair, rebuild one coherent group snapshot from the last valid
+  preference; repeating an already-satisfied internal resize is not recovery.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -166,7 +166,14 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   the complete constraint set feasible at every supported width; when there is
   not enough room for both preferred minimums, preserve the navigator minimum
   and give the working view the measured remainder instead of sending mutually
-  impossible hard minimums to the primitive.
+  impossible hard minimums to the primitive. Treat the primitive's applied
+  panel geometry as the authority for which expanded or collapsed surface is
+  interactive; input-source bookkeeping may decide whether a settled width is
+  persisted, but must never gate `aria-hidden`, `inert`, or collapse-state
+  synchronization. Capture resize intent at the split-group boundary so the
+  separator's enlarged fine/coarse pointer target behaves like its visible
+  one-pixel rule. Persist keyboard changes from the settled layout map rather
+  than a pre-paint DOM width, which can lag one key press behind.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -156,6 +156,12 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
 - Delete superseded event plumbing during migration. A component is not
   migrated if its old global Escape/outside-click/focus-loop implementation is
   still running beside the primitive.
+- Shared split layouts use the checked-in shadcn Resizable primitive for their
+  separator, pointer/touch capture, and keyboard resizing. Product adapters
+  such as `PageSidebarLayout` continue to own route content, responsive mode,
+  collapse affordances, and persisted preferences; they must not add a second
+  visible border or parallel document-level drag listeners beside the shared
+  separator.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -173,7 +173,10 @@ keyboard navigation, outside dismissal, scroll locking, and focus return.
   synchronization. Capture resize intent at the split-group boundary so the
   separator's enlarged fine/coarse pointer target behaves like its visible
   one-pixel rule. Persist keyboard changes from the settled layout map rather
-  than a pre-paint DOM width, which can lag one key press behind.
+  than a pre-paint DOM width, which can lag one key press behind. Direct pointer
+  resizing must stay attached to the cursor; arm the shared motion token only
+  near the discrete minimum-to-collapsed snap so the 200px-to-44px state change
+  retains spatial continuity without making ordinary width changes feel lazy.
 
 The `@/` alias resolves to `ui/src` in Vite, TypeScript, and the UI Vitest
 project. Backend tests keep their existing root `@` alias.

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,0 +1,157 @@
+# shadcn Resizable Page Sidebar
+
+- Status: `active`
+- Updated: `2026-08-08`
+- Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
+  maintainer acceptance.
+- Related PR: #1023 established the adjacent long-form reading surface but is
+  not part of this migration.
+- Owner guides: [[docs/ui-interaction-and-motion.md]] and
+  [[docs/development-workflow.md]].
+- Upstream reference: [shadcn Resizable](https://ui.shadcn.com/docs/components/base/resizable)
+  on `react-resizable-panels` v4.
+
+## Outcome
+
+Every page-owned desktop navigator uses the checked-in shadcn Resizable
+primitive instead of OpenAlice-owned pointer listeners and a separately drawn
+resize rail. The page keeps one visible separator, native mouse/touch/keyboard
+resizing, the existing pixel width preference and focus-mode state, and the
+current mobile Sheet hierarchy.
+
+## Current Evidence
+
+- `PageSidebarLayout` gives its outer desktop container a right border, then
+  allocates a second 10px `ResizeHandle` column whose center draws another
+  one-pixel rule. That composition creates the visible double separator.
+- The custom separator is focusable and exposes ARIA min/max/value metadata,
+  but has no keyboard resize implementation.
+- Dragging is implemented with document-level pointer listeners and manual
+  cursor/user-select mutation.
+- `react-resizable-panels@4.11.0` is already installed but has no consumer and
+  `ui/src/components/ui/resizable.tsx` does not exist.
+- The official current `base-nova` registry source wraps v4 `Group`, `Panel`,
+  and `Separator` as stable shadcn components and supplies an enlarged invisible
+  hit target around a single visible rule.
+
+## Scope
+
+### In scope
+
+- Add the official `base-nova` shadcn Resizable source under
+  `ui/src/components/ui/resizable.tsx` with the repository's existing `cn`
+  alias and semantic tokens.
+- Recompose the desktop branch of `PageSidebarLayout` with
+  `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle`.
+- Preserve the existing 200–420px navigator constraints, the 500px minimum
+  working pane, responsive maximum width, per-page pixel width persistence,
+  44px focus mode, collapse/restore controls, and hidden-surface `inert`
+  contract.
+- Keep one separator exactly at the navigator/content boundary; its visual
+  rule and resize hit target must not consume two distinct layout columns.
+- Exercise every current shell consumer through representative Chat,
+  AutoQuant, Inbox, Tracked, Market, Portfolio, Automation, Settings,
+  Workspaces, and Dev Panel routes. Issues and Trading-as-Git remain full-width
+  surfaces and do not consume `PageSidebarLayout`.
+- Delete the superseded pointermove/pointerup plumbing, body cursor mutation,
+  custom resize component, and constants that no longer own behavior.
+- Record the stable primitive ownership boundary in the UI owner guide.
+
+### Not in scope
+
+- Replacing OpenAlice's product `Sidebar` navigation composition with the
+  generic shadcn Sidebar block.
+- Changing ActivityBar geometry, route hierarchy, row styling, palettes, or
+  information architecture.
+- Replacing the mobile `Sheet`; it remains the narrow-layout owner.
+- Adding a third-party layout store or migrating unrelated split panes.
+- Changing backend, Workspace, trading, credential, or persisted data formats.
+
+## Decisions
+
+1. Use the official checked-in shadcn wrapper rather than importing
+   `react-resizable-panels` directly from product code. `data-slot` remains the
+   styling seam for Default, Windows 98, and Broker Classic profiles.
+2. Keep `PageSidebarLayout` as the product adapter. shadcn owns separator
+   pointer/touch/keyboard behavior; the adapter owns responsive mode, content,
+   collapse affordances, and OpenAlice preference keys.
+3. Preserve the existing localStorage keys and pixel values. Configure the
+   navigator panel with pixel sizes and `preserve-pixel-size`; persist the
+   applied pixel width only from the settled layout callback, not every pointer
+   move.
+4. Use the panel imperative API for focus-mode collapse and restore. Derive
+   visible/hidden content from the applied panel state so pointer collapse,
+   button collapse, stored state, and assistive semantics cannot diverge.
+5. Keep the main panel's 500px minimum as the authoritative protection for the
+   working view. Retain the current responsive cap only where it is stricter
+   than that invariant.
+6. Do not reproduce upstream separator behavior in tests. Product tests cover
+   composition, persisted state, focus-mode semantics, and the single-divider
+   contract; real browser acceptance covers pointer and keyboard resizing.
+
+## Work
+
+- [x] Generate and review the official `base-nova` Resizable primitive without
+      allowing the CLI to replace theme CSS or existing owned primitives.
+- [x] Migrate the desktop `PageSidebarLayout` composition and remove the custom
+      resize event plumbing and duplicate border.
+- [x] Preserve width and collapsed-state preferences across remounts, container
+      resize, and custom desktop breakpoints.
+- [x] Update focused tests for panel composition, single separator, collapse /
+      restore, inert hidden surfaces, persisted preferences, and mobile Sheet
+      non-regression.
+- [x] Walk representative real-data routes in `pnpm dev` with pointer and
+      keyboard at narrow, medium, and wide desktop widths in Day and Night
+      palettes; verify reduced-motion behavior and browser console health.
+- [x] Run root/UI typechecks, the complete Vitest suite, production UI build,
+      and unsigned packaged Electron Workspace smoke.
+- [ ] Open and maintain one labeled autonomous Draft PR to `dev`; present it
+      for maintainer acceptance without merging it from the goal.
+
+## Verification Evidence
+
+- Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
+  reload; focus mode stayed at 44px over reload and restored the prior expanded
+  pixel width.
+- Responsive acceptance: 740px used the existing mobile Sheet, 768px kept a
+  500px working pane while temporarily capping the navigator, and 900/1200px
+  restored the saved wider preference without overwriting it.
+- Route walk: Chat, AutoQuant, Inbox, Tracked, Market, Portfolio, Automation,
+  Settings, Workspaces, and Dev Panel each rendered two panels with one shared
+  separator. The full-width Issues and Trading-as-Git routes remained outside
+  this shell as designed.
+- Appearance and access: Default Day/Auto and Windows 98 Night kept one rule;
+  the separator exposed a localized accessible name and keyboard behavior;
+  reduced motion removed the sidebar surface transition; browser console had
+  no warnings or errors.
+- Automated/build: `npx tsc --noEmit`, `cd ui && npx tsc -b`, focused sidebar
+  tests, `pnpm test` (487 files, 4007 passing tests), `cd ui && pnpm build`, and
+  `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` passed.
+
+## Verification Matrix
+
+| Contract | Automated evidence | Real-surface evidence |
+|---|---|---|
+| One separator | shared layout DOM/class assertion | Inbox and Tracked visual inspection |
+| Pointer resize | upstream primitive + product persistence callback | mouse/trackpad drag in Chat and Inbox |
+| Keyboard resize | separator role/focus composition | focus handle and use arrow keys |
+| Responsive constraints | stored/default/max-size unit cases | 740px, 900px, and 1200px widths |
+| Focus mode | collapse/restore and `inert` tests | collapse, navigate, reload, restore |
+| Mobile ownership | existing Sheet focus/dismissal suite | phone drawer selection and Escape |
+| Theme/style profiles | semantic `data-slot` source review | Day/Night plus Windows 98 spot check |
+| Desktop shell | UI/build/full suite | unsigned `electron:smoke:workspace` |
+
+## Completion Criteria
+
+- Expanded page navigators expose exactly one visible boundary rule and no
+  dedicated blank resize column.
+- Mouse, touch, and keyboard resizing work through the shared primitive without
+  OpenAlice document-level resize listeners.
+- Page-specific widths and focus mode survive reloads without changing their
+  existing storage contract.
+- The working pane never drops below its current minimum; mobile routes keep
+  their existing Sheet behavior and focus return.
+- All current shell consumers compile and representative real routes remain
+  usable across the responsive and style-profile matrix.
+- Required browser, automated, build, and unsigned Electron checks pass, and a
+  single Draft PR contains the complete topic for maintainer acceptance.

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,6 +1,6 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (resisted overdrag included in Draft PR #1025; awaiting maintainer acceptance)
+- Status: `complete` (repeat-cycle repair included in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
@@ -43,6 +43,14 @@ current mobile Sheet hierarchy.
   `PageSidebarLayout` still rendered `data-state="expanded"` and left the full
   navigator surface accessible. The expanded sidebar was therefore compressed
   into the collapsed rail instead of switching surfaces.
+- Repeated narrow/wide responsive cycles exposed a delayed v4 registration
+  race: the route first recovered to 200px, then a stale one-panel layout wrote
+  `flex: 100` after the group's settled callback, leaving content at 0px while
+  the separator still advertised the correct 33.936% maximum.
+- The first overdrag implementation also started its 280ms visual cleanup while
+  the pointer was still held. That timer could erase the active gesture, and a
+  new press during the returning spring snapped the transformed handle away
+  from the pointer before the next drag had captured it.
 - `react-resizable-panels` deliberately expands the one-pixel separator into a
   10px fine-pointer and 28px coarse-pointer hit region. A pointer can begin in
   that virtual region without firing React's `pointerdown` handler on the
@@ -224,6 +232,24 @@ At every settled desktop layout exactly one surface is interactive:
 - [x] Add focused state/motion regressions and measure both return and commit
       trajectories in the real `pnpm dev` Chat route.
 
+### Repeat-cycle state-machine repair
+
+- [x] Reproduce the delayed 100% navigator / 0px content layout in the real
+      in-app browser and distinguish it from persisted width corruption.
+- [x] Remove duplicate pointer fallback, button, and effect geometry calls so
+      every collapse or restore has one owner and one primitive transaction.
+- [x] Move overdrag cleanup to pointer release; cancel and visually freeze an
+      interrupted spring before a new drag begins.
+- [x] Reject impossible geometry in both the settled group callback and the
+      later Panel resize callback, then restore the last valid pixel preference
+      without persisting the 100% layout.
+- [x] Add focused regressions for eight collapse/restore cycles, interrupted
+      spring timers, and both immediate and delayed impossible layouts.
+- [x] Verify ten repeated resisted drags, ten drag-collapse/drag-reopen cycles,
+      and ten narrow/wide responsive cycles in the real Chat route.
+- [x] Re-run complete typecheck, Vitest, UI build, and unsigned Electron smoke;
+      update Draft PR #1025 with the repaired evidence.
+
 ## Verification Evidence
 
 - Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
@@ -295,6 +321,18 @@ At every settled desktop layout exactly one surface is interactive:
   skipped), UI production build, and unsigned packaged Electron Workspace
   smoke. Browser acceptance also covered pointer cancel and emulated
   `prefers-reduced-motion: reduce`, which clears the overdrag immediately.
+- Repeat-cycle repair acceptance first reproduced the delayed failure as a
+  940px navigator / 0px content layout with `flex: 100`, while persisted Chat
+  width remained a valid 200px. The repaired route held 200px / 740px through
+  ten drag-collapse/drag-reopen cycles and ten 800px/1093px responsive cycles,
+  then remained stable through a further 1.5-second delayed-write window.
+  Ten independent resisted drags each produced the same 23.596px displacement;
+  a returning spring interrupted after 50ms remained resisted after a 350ms
+  hold instead of being erased by the previous cleanup timer.
+- Final repeat-cycle checks passed on 2026-08-08: 23 focused sidebar tests,
+  root/UI typechecks, the complete Vitest suite (488 files, 4025 passing tests,
+  9 skipped), UI production build, and unsigned packaged Electron Workspace
+  smoke with managed Pi acceptance.
 
 ## Verification Matrix
 

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,6 +1,6 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (responsive state-consistency hardening included in Draft PR #1025; awaiting maintainer acceptance)
+- Status: `complete` (responsive and collapse-motion hardening included in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
@@ -197,6 +197,20 @@ At every settled desktop layout exactly one surface is interactive:
 - [x] Re-run root/UI typechecks, focused and full Vitest, UI production build,
       and unsigned Electron Workspace smoke before updating Draft PR #1025.
 
+### Collapse-motion follow-up
+
+- [x] Measure the real 200px-to-44px threshold transition in `pnpm dev` rather
+      than inferring motion from classes; the pre-change route sampled 44px at
+      every 20ms interval and therefore had no spatial transition.
+- [x] Keep ordinary pointer resizing unanimated and arm width motion only while
+      approaching the discrete collapse threshold, plus explicit button and
+      keyboard collapse actions.
+- [x] Use the shared 180ms motion token and the product-owned group seam rather
+      than styling react-resizable-panels' nested content wrapper.
+- [x] Add motion-arming regression coverage and verify reduced-motion fallback.
+- [x] Re-run real browser sampling, focused/full tests, typechecks, and UI build
+      before pushing the follow-up commit to Draft PR #1025.
+
 ## Verification Evidence
 
 - Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
@@ -239,6 +253,17 @@ At every settled desktop layout exactly one surface is interactive:
   focused sidebar tests; the complete Vitest suite (487 files, 4014 passing
   tests); UI production build; and unsigned packaged Electron Workspace smoke
   including its managed Pi acceptance flow.
+- Collapse-motion browser sampling first proved the existing snap had no
+  intermediate frame: every 20ms sample went directly from 200px to 44px. The
+  follow-up samples now read 200 -> 128 -> 94 -> 72 -> 59 -> 52 -> 48 -> 46 ->
+  45 -> 44px over the shared 180ms token, while ordinary expanded resizing
+  retains a zero-second transition. Reload after the animation stayed at 44px
+  and the collapsed interactive surface remained authoritative.
+- Final motion checks passed on 2026-08-08: root/UI typechecks, 14 focused
+  sidebar tests, the complete Vitest suite (487 files, 4016 passing tests), and
+  the UI production build. The regression also proves distant pointer movement
+  does not arm motion, the 24px approach zone does, and reduced-motion button
+  collapse bypasses both animation frames.
 
 ## Verification Matrix
 

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,11 +1,11 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `active`
+- Status: `complete` (implemented in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
-- Related PR: #1023 established the adjacent long-form reading surface but is
-  not part of this migration.
+- Related PRs: #1023 established the adjacent long-form reading surface but is
+  not part of this migration; Draft PR #1025 contains this implementation.
 - Owner guides: [[docs/ui-interaction-and-motion.md]] and
   [[docs/development-workflow.md]].
 - Upstream reference: [shadcn Resizable](https://ui.shadcn.com/docs/components/base/resizable)
@@ -105,7 +105,7 @@ current mobile Sheet hierarchy.
       palettes; verify reduced-motion behavior and browser console health.
 - [x] Run root/UI typechecks, the complete Vitest suite, production UI build,
       and unsigned packaged Electron Workspace smoke.
-- [ ] Open and maintain one labeled autonomous Draft PR to `dev`; present it
+- [x] Open and maintain one labeled autonomous Draft PR to `dev`; present it
       for maintainer acceptance without merging it from the goal.
 
 ## Verification Evidence

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,6 +1,6 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (implemented in Draft PR #1025; awaiting maintainer acceptance)
+- Status: `complete` (responsive hardening included in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
@@ -33,6 +33,10 @@ current mobile Sheet hierarchy.
 - The official current `base-nova` registry source wraps v4 `Group`, `Panel`,
   and `Separator` as stable shadcn components and supplies an enlarged invisible
   hit target around a single visible rule.
+- The first migration increment combined the navigator's responsive maximum
+  with an unconditional 500px content-panel minimum. Once the page-owned group
+  became narrower than 700px after app-shell chrome, those constraints were
+  impossible; a resize could leave the navigator at 100% and content at 0%.
 
 ## Scope
 
@@ -82,12 +86,15 @@ current mobile Sheet hierarchy.
 4. Use the panel imperative API for focus-mode collapse and restore. Derive
    visible/hidden content from the applied panel state so pointer collapse,
    button collapse, stored state, and assistive semantics cannot diverge.
-5. Keep the main panel's 500px minimum as the authoritative protection for the
-   working view. Retain the current responsive cap only where it is stricter
-   than that invariant.
+5. Preserve the former responsive contract as a feasible pair: keep the
+   navigator at least 200px, reserve up to 500px for content, and let that
+   content minimum shrink to the actual remainder when the page-owned group is
+   narrower than 701px. The group must never receive contradictory minimums.
 6. Do not reproduce upstream separator behavior in tests. Product tests cover
    composition, persisted state, focus-mode semantics, and the single-divider
    contract; real browser acceptance covers pointer and keyboard resizing.
+7. Measure the page-owned group before applying responsive constraints. Window
+   width includes app-shell chrome and is not a valid initial substitute.
 
 ## Work
 
@@ -107,15 +114,30 @@ current mobile Sheet hierarchy.
       and unsigned packaged Electron Workspace smoke.
 - [x] Open and maintain one labeled autonomous Draft PR to `dev`; present it
       for maintainer acceptance without merging it from the goal.
+- [x] Reproduce the responsive failure in the real Chat route and identify the
+      infeasible 200px navigator + 500px content minimum pair.
+- [x] Make the responsive constraints feasible at every desktop group width and
+      remove resize-settle state races.
+- [x] Add focused constraint regression coverage for narrow, boundary, medium,
+      and wide group widths.
+- [x] Re-run narrow/wide drag, collapse/expand, reload, browser, full automated,
+      build, and unsigned Electron acceptance on the repaired increment.
 
 ## Verification Evidence
 
 - Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
   reload; focus mode stayed at 44px over reload and restored the prior expanded
   pixel width.
-- Responsive acceptance: 740px used the existing mobile Sheet, 768px kept a
-  500px working pane while temporarily capping the navigator, and 900/1200px
-  restored the saved wider preference without overwriting it.
+- Previous responsive acceptance missed the page-owned group width after app
+  chrome. The reopened regression was reproduced with the navigator at 940px
+  and content at 0px in a 941px group. After repair, the same group recovered
+  to 319px / 621px, a real pointer drag persisted 268px over reload, and a
+  collapsed-state reload restored 44px before expanding back to 268px.
+- A temporary viewport acceptance shell loaded the real `pnpm dev` route (not
+  demo data): 740px used the mobile Sheet; a 768px viewport produced a 708px
+  split group with a feasible 207px navigator + 500px content pair; narrowing,
+  collapsing to 44px, expanding to the responsive cap, and returning to a
+  1200px viewport restored the untouched 260px preference.
 - Route walk: Chat, AutoQuant, Inbox, Tracked, Market, Portfolio, Automation,
   Settings, Workspaces, and Dev Panel each rendered two panels with one shared
   separator. The full-width Issues and Trading-as-Git routes remained outside
@@ -125,7 +147,7 @@ current mobile Sheet hierarchy.
   reduced motion removed the sidebar surface transition; browser console had
   no warnings or errors.
 - Automated/build: `npx tsc --noEmit`, `cd ui && npx tsc -b`, focused sidebar
-  tests, `pnpm test` (487 files, 4007 passing tests), `cd ui && pnpm build`, and
+  tests, `pnpm test` (487 files, 4008 passing tests), `cd ui && pnpm build`, and
   `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` passed.
 
 ## Verification Matrix
@@ -135,7 +157,7 @@ current mobile Sheet hierarchy.
 | One separator | shared layout DOM/class assertion | Inbox and Tracked visual inspection |
 | Pointer resize | upstream primitive + product persistence callback | mouse/trackpad drag in Chat and Inbox |
 | Keyboard resize | separator role/focus composition | focus handle and use arrow keys |
-| Responsive constraints | stored/default/max-size unit cases | 740px, 900px, and 1200px widths |
+| Responsive constraints | feasible-pair sweep from 201–1600px plus boundary cases | real 740px mobile, 708px split-group, 941px split-group, and 1200px viewport paths |
 | Focus mode | collapse/restore and `inert` tests | collapse, navigate, reload, restore |
 | Mobile ownership | existing Sheet focus/dismissal suite | phone drawer selection and Escape |
 | Theme/style profiles | semantic `data-slot` source review | Day/Night plus Windows 98 spot check |
@@ -149,8 +171,9 @@ current mobile Sheet hierarchy.
   OpenAlice document-level resize listeners.
 - Page-specific widths and focus mode survive reloads without changing their
   existing storage contract.
-- The working pane never drops below its current minimum; mobile routes keep
-  their existing Sheet behavior and focus return.
+- The working pane keeps its 500px minimum whenever geometry permits and gets
+  the measured remainder beside the 200px navigator below that boundary;
+  mobile routes keep their existing Sheet behavior and focus return.
 - All current shell consumers compile and representative real routes remain
   usable across the responsive and style-profile matrix.
 - Required browser, automated, build, and unsigned Electron checks pass, and a

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,6 +1,6 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (responsive hardening included in Draft PR #1025; awaiting maintainer acceptance)
+- Status: `complete` (responsive state-consistency hardening included in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
@@ -37,6 +37,19 @@ current mobile Sheet hierarchy.
   with an unconditional 500px content-panel minimum. Once the page-owned group
   became narrower than 700px after app-shell chrome, those constraints were
   impossible; a resize could leave the navigator at 100% and content at 0%.
+- The repaired constraint pair exposed a second, independent state bug. In a
+  real 941px Chat split group the primitive reported the navigator at its 44px
+  collapsed minimum (`aria-valuenow` equalled `aria-valuemin`), while
+  `PageSidebarLayout` still rendered `data-state="expanded"` and left the full
+  navigator surface accessible. The expanded sidebar was therefore compressed
+  into the collapsed rail instead of switching surfaces.
+- `react-resizable-panels` deliberately expands the one-pixel separator into a
+  10px fine-pointer and 28px coarse-pointer hit region. A pointer can begin in
+  that virtual region without firing React's `pointerdown` handler on the
+  separator element itself. The primitive still resizes and collapses the
+  panel, but the current `userResizeRef` gate suppresses product-state sync and
+  persistence. Previous browser acceptance clicked the visible one-pixel rule
+  and did not cover this normal human acquisition path.
 
 ## Scope
 
@@ -95,6 +108,41 @@ current mobile Sheet hierarchy.
    contract; real browser acceptance covers pointer and keyboard resizing.
 7. Measure the page-owned group before applying responsive constraints. Window
    width includes app-shell chrome and is not a valid initial substitute.
+8. Keep three state layers explicit and one-directional:
+   - **applied geometry** is the primitive's current panel size and collapsed
+     state;
+   - **interactive surface** is derived from applied geometry and controls
+     expanded/collapsed rendering, `aria-hidden`, and `inert`;
+   - **user preference** is the last settled expanded width plus the deliberate
+     focus-mode choice, persisted without being overwritten by responsive caps.
+9. A pointer or keyboard interaction marker may decide whether a settled width
+   becomes the next user preference, but it must never gate geometry-to-surface
+   synchronization. Pointer acquisition is observed at the split-group capture
+   boundary so the primitive's enlarged hit region and the visible separator
+   behave identically; shadcn continues to own actual drag capture and motion.
+
+## Responsive State Contract
+
+| Input or transition | Applied geometry | Interactive surface | Persisted preference |
+|---|---|---|---|
+| Collapse button | 44px | collapsed rail only | store focus mode; retain prior expanded width |
+| Expand button | responsive cap of saved width | expanded navigator only | clear focus mode; retain saved width |
+| Pointer drag from visible 1px rule | primitive result | derive from result on every resize | commit settled expanded width; collapsed drag retains prior width |
+| Pointer drag from 10px/28px virtual hit region | identical to visible-rule drag | identical to visible-rule drag | identical to visible-rule drag |
+| Arrow/Home/End on separator | primitive result | derive from result | commit settled expanded width or focus mode |
+| Container narrows while expanded | clamp to measured feasible maximum, never below 200px | remain expanded | do not overwrite the wider preference |
+| Container widens again | restore saved width when feasible | remain expanded | unchanged |
+| Reload in focus mode | 44px from first stable layout | collapsed rail only | unchanged |
+| Reload expanded | saved width capped by current group | expanded navigator only | unchanged until user resizes |
+| Viewport crosses below route breakpoint | desktop group unmounts; mobile Sheet owns navigation | no compressed desktop navigator | desktop width/focus preference unchanged |
+
+At every settled desktop layout exactly one surface is interactive:
+
+- `inPixels <= 45`: collapsed surface visible and interactive; expanded surface
+  hidden and inert;
+- `inPixels >= 200`: expanded surface visible and interactive; collapsed surface
+  hidden and inert;
+- no stable layout may render the expanded surface between 45px and 200px.
 
 ## Work
 
@@ -123,6 +171,32 @@ current mobile Sheet hierarchy.
 - [x] Re-run narrow/wide drag, collapse/expand, reload, browser, full automated,
       build, and unsigned Electron acceptance on the repaired increment.
 
+### Responsive state-consistency increment
+
+- [x] Replace separator-element `pointerdown` authority with split-group input
+      capture that covers the primitive's complete fine/coarse hit region.
+- [x] Synchronize the product collapsed surface from applied panel geometry on
+      every resize, independently of whether the change came from pointer,
+      keyboard, button, restore, or responsive constraints.
+- [x] Keep width persistence scoped to a settled user resize; prove that
+      responsive caps and programmatic restore do not overwrite the user's
+      wider expanded preference.
+- [x] Add focused state-transition tests for geometry/surface agreement,
+      collapsed-width retention, expanded-width persistence, and passive
+      responsive non-persistence.
+- [x] Reproduce pointer acquisition from both sides of the visible separator,
+      including 2–4px offsets inside the 10px fine-pointer virtual hit region
+      and wider coarse-pointer acquisition, then verify the same contract with
+      keyboard Home/End/Arrow input.
+- [x] Exercise desktop widths around the route breakpoint and the 701px
+      feasibility boundary, then round-trip narrow -> wide -> narrow with both
+      expanded and focus-mode preferences.
+- [x] Re-walk Chat, Inbox, Tracked, Settings, AutoQuant, and one dense shell
+      route in Default Day/Night plus Windows 98; verify reduced-motion,
+      console health, focus order, and exactly one interactive surface.
+- [x] Re-run root/UI typechecks, focused and full Vitest, UI production build,
+      and unsigned Electron Workspace smoke before updating Draft PR #1025.
+
 ## Verification Evidence
 
 - Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
@@ -149,6 +223,22 @@ current mobile Sheet hierarchy.
 - Automated/build: `npx tsc --noEmit`, `cd ui && npx tsc -b`, focused sidebar
   tests, `pnpm test` (487 files, 4008 passing tests), `cd ui && pnpm build`, and
   `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` passed.
+- State-consistency reproduction and repair used the live `pnpm dev` Chat
+  route. Before the repair, a 941px group exposed a 44px navigator with
+  `data-state="expanded"`; after the repair, Home produced 44px with only the
+  collapsed surface interactive, reload retained 44px, and Expand restored
+  the prior 294px preference. ArrowRight then settled at 319px and a second
+  reload restored exactly 319px rather than the previous painted width.
+- The same live-runtime geometry/ARIA/inert invariant passed on Chat (319px),
+  Inbox (200px), Tracked (257px), Settings (200px), AutoQuant (218px), and
+  Automation Runs (220px), each with exactly one separator. Focused state tests
+  cover fine-pointer acquisition 3px beside the rule, a 12px coarse-pointer
+  acquisition, passive responsive caps, collapsed-width retention, and the
+  pre-paint keyboard-width race.
+- Final hardening checks passed on 2026-08-08: root and UI typechecks; 12
+  focused sidebar tests; the complete Vitest suite (487 files, 4014 passing
+  tests); UI production build; and unsigned packaged Electron Workspace smoke
+  including its managed Pi acceptance flow.
 
 ## Verification Matrix
 
@@ -156,8 +246,11 @@ current mobile Sheet hierarchy.
 |---|---|---|
 | One separator | shared layout DOM/class assertion | Inbox and Tracked visual inspection |
 | Pointer resize | upstream primitive + product persistence callback | mouse/trackpad drag in Chat and Inbox |
+| Enlarged hit target | group-capture and state-transition regression | start mouse drags 2–4px on either side of the one-pixel rule; cover the wider coarse target separately |
 | Keyboard resize | separator role/focus composition | focus handle and use arrow keys |
 | Responsive constraints | feasible-pair sweep from 201–1600px plus boundary cases | real 740px mobile, 708px split-group, 941px split-group, and 1200px viewport paths |
+| Geometry/surface agreement | collapsed/expanded state-transition assertions | inspect applied panel pixels, `data-state`, `aria-hidden`, and `inert` together |
+| Preference isolation | passive-cap and settled-user-resize assertions | narrow/wide/reload round trip without preference drift |
 | Focus mode | collapse/restore and `inert` tests | collapse, navigate, reload, restore |
 | Mobile ownership | existing Sheet focus/dismissal suite | phone drawer selection and Escape |
 | Theme/style profiles | semantic `data-slot` source review | Day/Night plus Windows 98 spot check |
@@ -171,6 +264,11 @@ current mobile Sheet hierarchy.
   OpenAlice document-level resize listeners.
 - Page-specific widths and focus mode survive reloads without changing their
   existing storage contract.
+- Applied geometry and rendered interaction state cannot diverge: a 44px panel
+  always exposes only the collapsed rail, and an expanded surface never renders
+  below the 200px navigator minimum.
+- Visible-rule, adjacent fine-pointer, coarse-pointer, and keyboard resize paths
+  produce the same settled state and preference behavior.
 - The working pane keeps its 500px minimum whenever geometry permits and gets
   the measured remainder beside the 200px navigator below that boundary;
   mobile routes keep their existing Sheet behavior and focus return.

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,6 +1,6 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (responsive and collapse-motion hardening included in Draft PR #1025; awaiting maintainer acceptance)
+- Status: `complete` (resisted overdrag included in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
@@ -211,6 +211,19 @@ At every settled desktop layout exactly one surface is interactive:
 - [x] Re-run real browser sampling, focused/full tests, typechecks, and UI build
       before pushing the follow-up commit to Draft PR #1025.
 
+### Resisted-overdrag follow-up
+
+- [x] Keep direct resizing cursor-attached above 200px, then hold primitive
+      layout at the expanded minimum while presenting a damped visual overdrag.
+- [x] Keep the navigator's internal content at its 200px layout width so the
+      transient gesture clips content rather than squeezing controls and text.
+- [x] Require a deliberate raw pointer overdrag before collapse; release below
+      that boundary must spring back to 200px without changing focus mode.
+- [x] Preserve button and keyboard collapse behavior, pointer-cancel recovery,
+      width persistence, and reduced-motion behavior.
+- [x] Add focused state/motion regressions and measure both return and commit
+      trajectories in the real `pnpm dev` Chat route.
+
 ## Verification Evidence
 
 - Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
@@ -264,6 +277,24 @@ At every settled desktop layout exactly one surface is interactive:
   the UI production build. The regression also proves distant pointer movement
   does not arm motion, the 24px approach zone does, and reduced-motion button
   collapse bypasses both animation frames.
+- Resisted-overdrag acceptance used CDP pointer events against the live Chat
+  route so geometry could be measured while the pointer remained down. A raw
+  40px pull beyond the 200px minimum produced 22.133px of visual displacement,
+  while both the primitive panel and its internal content stayed exactly
+  200px. Release returned the separator through 338.63 -> 344.77 -> 350.78 ->
+  351.92px, made one sub-pixel overshoot, and settled back at 352px without
+  entering focus mode.
+- The collapse boundary is the primitive's native `(200 - 44) / 2 = 78px`
+  midpoint rather than a second product threshold. Crossing it blended the
+  damped preview into the existing spatial collapse, sampled 128.13 -> 58.97
+  -> 47.61 -> 45.52 -> 44.13 -> 44px, and changed the interactive product
+  surface only when applied geometry reached the collapsed width. Reload kept
+  44px; Expand restored 200px; explicit button collapse still reached 44px.
+- Final overdrag checks passed on 2026-08-08: 19 focused sidebar tests, root and
+  UI typechecks, the complete Vitest suite (488 files, 4021 passing tests, 9
+  skipped), UI production build, and unsigned packaged Electron Workspace
+  smoke. Browser acceptance also covered pointer cancel and emulated
+  `prefers-reduced-motion: reduce`, which clears the overdrag immediately.
 
 ## Verification Matrix
 

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,6 +1,6 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (repeat-cycle repair included in Draft PR #1025; awaiting maintainer acceptance)
+- Status: `complete` (rapid-reversal repair included in Draft PR #1025; awaiting maintainer acceptance)
 - Updated: `2026-08-08`
 - Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
   maintainer acceptance.
@@ -51,6 +51,17 @@ current mobile Sheet hierarchy.
   the pointer was still held. That timer could erase the active gesture, and a
   new press during the returning spring snapped the transformed handle away
   from the pointer before the next drag had captured it.
+- A later manual stress pass found a deeper same-gesture race. `defaultSize`
+  was derived from product collapse state, so every midpoint crossing changed
+  a Panel registration prop. React-resizable-panels v4 unregisters and
+  re-registers that Panel while the pointer is still active; rapid reversals
+  could therefore strand a valid internal max beside stale `flex: 100` / `0`
+  DOM styles. The collapse transition also remained armed after reversing back
+  above the midpoint, allowing painted flex width to lag pointer-owned layout.
+- Product pointer bookkeeping lived on the split-group element while the
+  primitive finishes drags at `document`. Throwing the pointer outside the
+  group could leave the product gesture ref active after the primitive had
+  settled, suppressing later geometry recovery.
 - `react-resizable-panels` deliberately expands the one-pixel separator into a
   10px fine-pointer and 28px coarse-pointer hit region. A pointer can begin in
   that virtual region without firing React's `pointerdown` handler on the
@@ -250,6 +261,24 @@ At every settled desktop layout exactly one surface is interactive:
 - [x] Re-run complete typecheck, Vitest, UI build, and unsigned Electron smoke;
       update Draft PR #1025 with the repaired evidence.
 
+### Rapid-reversal registration repair
+
+- [x] Preserve the user's full-screen failure before reload and confirm a
+      940px / 0px painted flex pair beside a still-valid 33.936% separator max.
+- [x] Keep `defaultSize` stable for each mounted primitive group so midpoint
+      crossings cannot unregister and rebuild Panels during a held gesture.
+- [x] Remove collapse flex transition immediately when the held pointer
+      reverses above the midpoint; start its cleanup timer only after release.
+- [x] Capture the pointer on the product split group so movement and release
+      outside its bounds cannot strand product gesture state.
+- [x] Observe both painted flex items independently from the primitive store;
+      rebuild the group from the last valid preference when DOM geometry is
+      impossible instead of issuing an internal resize that may be a no-op.
+- [x] Add focused coverage for stable registration defaults, held reversal,
+      pointer capture/release, and store-valid / DOM-invalid recovery.
+- [x] Re-run full automated, browser, build, and unsigned Electron verification
+      and update Draft PR #1025.
+
 ## Verification Evidence
 
 - Real `pnpm dev` data: Chat pointer and keyboard resizing both persisted over
@@ -333,6 +362,18 @@ At every settled desktop layout exactly one surface is interactive:
   root/UI typechecks, the complete Vitest suite (488 files, 4025 passing tests,
   9 skipped), UI production build, and unsigned packaged Electron Workspace
   smoke with managed Pi acceptance.
+- Rapid-reversal acceptance preserved the user's second failure before reload:
+  a 941px group painted the navigator/content at 940px/0px (`flex: 100`/`0`)
+  while the separator still advertised a valid 33.936% maximum. After repair,
+  one held gesture survived 80 alternating left/right crossings and returned to
+  200px/740px. Twenty more gestures threw the pointer outside the split group
+  twice per gesture and returned with clean gesture/motion state. Twelve settled
+  reversal-collapse/restore cycles produced exactly 44px/896px then
+  200px/740px every time.
+- Final rapid-reversal checks passed on 2026-08-08: 26 focused sidebar tests;
+  root/UI typechecks; the complete Vitest suite (488 files, 4028 passing tests,
+  9 skipped); production build; and unsigned packaged Electron Workspace smoke
+  with managed Pi acceptance.
 
 ## Verification Matrix
 

--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -6,7 +6,7 @@ import { useMobilePageNavigation, MobilePageNavigationProvider } from '../contex
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../i18n'
-import { PageSidebarLayout } from './PageSidebarLayout'
+import { calculatePageSidebarConstraints, PageSidebarLayout } from './PageSidebarLayout'
 
 class ResizeObserverStub {
   observe() {}
@@ -36,6 +36,45 @@ afterEach(() => {
 })
 
 describe('PageSidebarLayout', () => {
+  it('keeps responsive panel minimums feasible while preserving the former content reserve', () => {
+    expect(calculatePageSidebarConstraints(0)).toEqual({
+      navigatorMaxWidth: 420,
+      contentMinWidth: 0,
+    })
+
+    expect(calculatePageSidebarConstraints(616)).toEqual({
+      navigatorMaxWidth: 200,
+      contentMinWidth: 415,
+    })
+    expect(calculatePageSidebarConstraints(700)).toEqual({
+      navigatorMaxWidth: 200,
+      contentMinWidth: 499,
+    })
+    expect(calculatePageSidebarConstraints(701)).toEqual({
+      navigatorMaxWidth: 200,
+      contentMinWidth: 500,
+    })
+    expect(calculatePageSidebarConstraints(941)).toEqual({
+      navigatorMaxWidth: 319,
+      contentMinWidth: 500,
+    })
+    expect(calculatePageSidebarConstraints(1_200)).toEqual({
+      navigatorMaxWidth: 420,
+      contentMinWidth: 500,
+    })
+
+    for (let containerWidth = 201; containerWidth <= 1_600; containerWidth += 7) {
+      const { navigatorMaxWidth, contentMinWidth } = calculatePageSidebarConstraints(containerWidth)
+      const panelBudget = containerWidth - 1
+
+      expect(navigatorMaxWidth).toBeGreaterThanOrEqual(200)
+      expect(navigatorMaxWidth).toBeLessThanOrEqual(420)
+      expect(contentMinWidth).toBeGreaterThanOrEqual(0)
+      expect(contentMinWidth).toBeLessThanOrEqual(500)
+      expect(200 + contentMinWidth).toBeLessThanOrEqual(panelBudget)
+    }
+  })
+
   it('registers its phone navigator into the app context bar without rendering a second bar', async () => {
     const user = userEvent.setup()
     vi.stubGlobal('matchMedia', vi.fn().mockImplementation(() => ({

--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -6,7 +6,12 @@ import { useMobilePageNavigation, MobilePageNavigationProvider } from '../contex
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../i18n'
-import { calculatePageSidebarConstraints, PageSidebarLayout } from './PageSidebarLayout'
+import {
+  calculatePageSidebarConstraints,
+  calculatePageSidebarOverdrag,
+  PageSidebarLayout,
+  shouldCollapsePageSidebar,
+} from './PageSidebarLayout'
 
 class ResizeObserverStub {
   observe() {}
@@ -36,6 +41,17 @@ afterEach(() => {
 })
 
 describe('PageSidebarLayout', () => {
+  it('applies diminishing resistance and a deliberate overdrag commit boundary', () => {
+    expect(calculatePageSidebarOverdrag(-1)).toBe(0)
+    expect(calculatePageSidebarOverdrag(0)).toBe(0)
+    expect(calculatePageSidebarOverdrag(16)).toBeCloseTo(11.67, 1)
+    expect(calculatePageSidebarOverdrag(40)).toBeCloseTo(22.14, 1)
+    expect(calculatePageSidebarOverdrag(64)).toBeCloseTo(27.69, 1)
+    expect(calculatePageSidebarOverdrag(200)).toBeLessThanOrEqual(34)
+    expect(shouldCollapsePageSidebar(77.9)).toBe(false)
+    expect(shouldCollapsePageSidebar(78)).toBe(true)
+  })
+
   it('keeps responsive panel minimums feasible while preserving the former content reserve', () => {
     expect(calculatePageSidebarConstraints(0)).toEqual({
       navigatorMaxWidth: 420,

--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -88,6 +88,7 @@ describe('PageSidebarLayout', () => {
   })
 
   it('persists the desktop focus mode and restores the full sidebar', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
     const view = render(
       <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
         <div>Market content</div>
@@ -97,17 +98,21 @@ describe('PageSidebarLayout', () => {
     const desktopSidebar = screen.getByTestId('page-sidebar-desktop')
     const expandedSurface = screen.getByTestId('page-sidebar-expanded')
     const collapsedSurface = screen.getByTestId('page-sidebar-collapsed')
+    const separator = screen.getByRole('separator')
     expect(desktopSidebar.getAttribute('data-state')).toBe('expanded')
-    expect(desktopSidebar.getAttribute('style')).toContain('width: 270px')
-    expect(desktopSidebar.className).toContain('transition-[width]')
-    expect(desktopSidebar.className).toContain('motion-reduce:transition-none')
+    expect(screen.getAllByRole('separator')).toHaveLength(1)
+    expect(separator.getAttribute('data-slot')).toBe('resizable-handle')
+    expect(separator.getAttribute('aria-label')).toBe('Resize Market')
+    expect(separator.className).toContain('w-px')
+    expect(desktopSidebar.className).not.toContain('border-r')
+    expect(separator.tabIndex).toBe(0)
     expect(expandedSurface.hasAttribute('inert')).toBe(false)
     expect(collapsedSurface.hasAttribute('inert')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
     expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('1')
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
     expect(desktopSidebar.getAttribute('data-state')).toBe('collapsed')
-    expect(desktopSidebar.getAttribute('style')).toContain('width: 44px')
     expect(expandedSurface.hasAttribute('inert')).toBe(true)
     expect(collapsedSurface.hasAttribute('inert')).toBe(false)
     expect(screen.getByRole('button', { name: 'Open Market' })).toBeTruthy()

--- a/ui/src/components/PageSidebarLayout.state.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.state.spec.tsx
@@ -28,6 +28,7 @@ vi.mock('@/components/ui/resizable', async () => {
     elementRef,
     onLayoutChanged,
     onPointerDownCapture,
+    onPointerMoveCapture,
     onPointerUpCapture,
     onPointerCancelCapture,
   }: {
@@ -36,6 +37,7 @@ vi.mock('@/components/ui/resizable', async () => {
     elementRef?: React.Ref<HTMLDivElement>
     onLayoutChanged?: (layout: Record<string, number>) => void
     onPointerDownCapture?: React.PointerEventHandler<HTMLDivElement>
+    onPointerMoveCapture?: React.PointerEventHandler<HTMLDivElement>
     onPointerUpCapture?: React.PointerEventHandler<HTMLDivElement>
     onPointerCancelCapture?: React.PointerEventHandler<HTMLDivElement>
   }) {
@@ -60,6 +62,7 @@ vi.mock('@/components/ui/resizable', async () => {
         }}
         data-testid={id}
         onPointerDownCapture={onPointerDownCapture}
+        onPointerMoveCapture={onPointerMoveCapture}
         onPointerUpCapture={onPointerUpCapture}
         onPointerCancelCapture={onPointerCancelCapture}
       >
@@ -204,6 +207,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 
@@ -279,6 +283,82 @@ describe('PageSidebarLayout applied state', () => {
     settleNavigatorLayout(276)
 
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('276')
+  })
+
+  it('arms collapse motion only near the minimum-width threshold', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const contentPanel = screen.getByTestId('page-sidebar-market-content')
+    const group = screen.getByTestId('page-sidebar-market')
+    fireEvent.pointerDown(contentPanel, {
+      button: 0,
+      buttons: 1,
+      clientX: 315,
+      isPrimary: true,
+      pointerId: 14,
+      pointerType: 'mouse',
+    })
+
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 250,
+      isPrimary: true,
+      pointerId: 14,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-collapse-motion')).toBeNull()
+
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 223,
+      isPrimary: true,
+      pointerId: 14,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-collapse-motion')).toBe('armed')
+
+    fireEvent.pointerUp(group, {
+      button: 0,
+      buttons: 0,
+      clientX: 223,
+      isPrimary: true,
+      pointerId: 14,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-collapse-motion')).toBeNull()
+
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'Home' })
+    expect(group.getAttribute('data-collapse-motion')).toBe('armed')
+  })
+
+  it('collapses immediately when reduced motion is requested', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(min-width: 768px)' || query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })))
+    const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
+
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+    expect(resizableHarness.navigatorSize).toBe(44)
   })
 
   it('does not persist a passive responsive cap or a pointer click without resize', () => {

--- a/ui/src/components/PageSidebarLayout.state.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.state.spec.tsx
@@ -1,0 +1,358 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
+
+import { i18n } from '../i18n'
+
+const resizableHarness = vi.hoisted(() => ({
+  groupWidth: 941,
+  navigatorSize: 312,
+  navigatorCollapsed: false,
+  onNavigatorResize: undefined as ((size: PanelSize) => void) | undefined,
+  onLayoutChanged: undefined as ((layout: Record<string, number>) => void) | undefined,
+}))
+
+vi.mock('@/components/ui/resizable', async () => {
+  const React = await import('react')
+
+  function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null) {
+    if (typeof ref === 'function') ref(value)
+    else if (ref) ref.current = value
+  }
+
+  function ResizablePanelGroup({
+    children,
+    id,
+    elementRef,
+    onLayoutChanged,
+    onPointerDownCapture,
+    onPointerUpCapture,
+    onPointerCancelCapture,
+  }: {
+    children?: React.ReactNode
+    id?: string
+    elementRef?: React.Ref<HTMLDivElement>
+    onLayoutChanged?: (layout: Record<string, number>) => void
+    onPointerDownCapture?: React.PointerEventHandler<HTMLDivElement>
+    onPointerUpCapture?: React.PointerEventHandler<HTMLDivElement>
+    onPointerCancelCapture?: React.PointerEventHandler<HTMLDivElement>
+  }) {
+    resizableHarness.onLayoutChanged = onLayoutChanged
+    return (
+      <div
+        ref={(element) => {
+          if (element) {
+            element.getBoundingClientRect = () => ({
+              x: 0,
+              y: 0,
+              width: resizableHarness.groupWidth,
+              height: 800,
+              top: 0,
+              right: resizableHarness.groupWidth,
+              bottom: 800,
+              left: 0,
+              toJSON: () => ({}),
+            })
+          }
+          assignRef(elementRef, element)
+        }}
+        data-testid={id}
+        onPointerDownCapture={onPointerDownCapture}
+        onPointerUpCapture={onPointerUpCapture}
+        onPointerCancelCapture={onPointerCancelCapture}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  function ResizablePanel({
+    children,
+    id,
+    panelRef,
+    onResize,
+  }: {
+    children?: React.ReactNode
+    id?: string
+    panelRef?: React.Ref<PanelImperativeHandle>
+    onResize?: (size: PanelSize) => void
+  }) {
+    const isNavigator = id?.endsWith('-navigator') === true
+    if (isNavigator) resizableHarness.onNavigatorResize = onResize
+
+    React.useImperativeHandle(panelRef, () => ({
+      collapse() {
+        resizableHarness.navigatorCollapsed = true
+        resizableHarness.navigatorSize = 44
+        onResize?.({ asPercentage: 4.4, inPixels: 44 })
+      },
+      expand() {
+        resizableHarness.navigatorCollapsed = false
+        resizableHarness.navigatorSize = Math.max(200, resizableHarness.navigatorSize)
+        onResize?.({
+          asPercentage: resizableHarness.navigatorSize / 10,
+          inPixels: resizableHarness.navigatorSize,
+        })
+      },
+      getSize() {
+        return {
+          asPercentage: resizableHarness.navigatorSize / 10,
+          inPixels: resizableHarness.navigatorSize,
+        }
+      },
+      isCollapsed() {
+        return resizableHarness.navigatorCollapsed
+      },
+      resize(nextSize) {
+        const parsed = typeof nextSize === 'number' ? nextSize : Number.parseFloat(nextSize)
+        if (!Number.isFinite(parsed)) return
+        resizableHarness.navigatorSize = parsed
+        resizableHarness.navigatorCollapsed = parsed <= 45
+        onResize?.({ asPercentage: parsed / 10, inPixels: parsed })
+      },
+    }), [onResize])
+
+    return <div data-testid={id}>{children}</div>
+  }
+
+  function ResizableHandle({
+    id,
+    elementRef,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    id?: string
+    elementRef?: React.Ref<HTMLDivElement>
+  }) {
+    return (
+      <div
+        {...props}
+        ref={(element) => {
+          if (element) {
+            element.getBoundingClientRect = () => ({
+              x: resizableHarness.navigatorSize,
+              y: 0,
+              width: 1,
+              height: 800,
+              top: 0,
+              right: resizableHarness.navigatorSize + 1,
+              bottom: 800,
+              left: resizableHarness.navigatorSize,
+              toJSON: () => ({}),
+            })
+          }
+          assignRef(elementRef, element)
+        }}
+        id={id}
+        data-testid={id}
+        role="separator"
+        tabIndex={0}
+      />
+    )
+  }
+
+  return { ResizableHandle, ResizablePanel, ResizablePanelGroup }
+})
+
+import { PageSidebarLayout } from './PageSidebarLayout'
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function driveNavigatorGeometry(inPixels: number, collapsed: boolean) {
+  resizableHarness.navigatorSize = inPixels
+  resizableHarness.navigatorCollapsed = collapsed
+  act(() => {
+    resizableHarness.onNavigatorResize?.({
+      asPercentage: inPixels / 10,
+      inPixels,
+    })
+  })
+}
+
+function settleNavigatorLayout(inPixels: number) {
+  const percentage = (inPixels / (resizableHarness.groupWidth - 1)) * 100
+  act(() => resizableHarness.onLayoutChanged?.({
+    'page-sidebar-market-navigator': percentage,
+    'page-sidebar-market-content': 100 - percentage,
+  }))
+}
+
+beforeEach(async () => {
+  resizableHarness.navigatorSize = 312
+  resizableHarness.navigatorCollapsed = false
+  resizableHarness.onNavigatorResize = undefined
+  resizableHarness.onLayoutChanged = undefined
+  window.localStorage.clear()
+  await i18n.changeLanguage('en')
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+  vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(min-width: 768px)',
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('PageSidebarLayout applied state', () => {
+  it('derives the interactive surface from panel geometry without overwriting width preference', async () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    driveNavigatorGeometry(44, true)
+    await waitFor(() => {
+      expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+    })
+    expect(screen.getByTestId('page-sidebar-expanded').hasAttribute('inert')).toBe(true)
+    expect(screen.getByTestId('page-sidebar-collapsed').hasAttribute('inert')).toBe(false)
+    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('1')
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+
+    driveNavigatorGeometry(220, false)
+    await waitFor(() => {
+      expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
+    })
+    expect(screen.getByTestId('page-sidebar-expanded').hasAttribute('inert')).toBe(false)
+    expect(screen.getByTestId('page-sidebar-collapsed').hasAttribute('inert')).toBe(true)
+    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('0')
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+
+  it('captures resize intent from a neighboring panel inside the enlarged hit region', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const contentPanel = screen.getByTestId('page-sidebar-market-content')
+    fireEvent.pointerDown(contentPanel, {
+      button: 0,
+      buttons: 1,
+      clientX: 315,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: 'mouse',
+    })
+    driveNavigatorGeometry(268, false)
+    settleNavigatorLayout(268)
+
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('268')
+    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).not.toBe('1')
+  })
+
+  it('captures coarse-pointer resize intent from the navigator side of the separator', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    fireEvent.pointerDown(screen.getByTestId('page-sidebar-market-navigator'), {
+      button: 0,
+      buttons: 1,
+      clientX: 300,
+      isPrimary: true,
+      pointerId: 12,
+      pointerType: 'touch',
+    })
+    driveNavigatorGeometry(276, false)
+    settleNavigatorLayout(276)
+
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('276')
+  })
+
+  it('does not persist a passive responsive cap or a pointer click without resize', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    driveNavigatorGeometry(200, false)
+    settleNavigatorLayout(200)
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+
+    const contentPanel = screen.getByTestId('page-sidebar-market-content')
+    const group = screen.getByTestId('page-sidebar-market')
+    fireEvent.pointerDown(contentPanel, {
+      button: 0,
+      buttons: 1,
+      clientX: 700,
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerUp(group, {
+      button: 0,
+      buttons: 0,
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: 'mouse',
+    })
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+
+  it('persists the settled keyboard layout instead of the previous painted width', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '247')
+    resizableHarness.navigatorSize = 247
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' })
+    // The primitive has settled its internal layout at 294px, but the browser
+    // has not painted that flex width yet and the imperative handle still reads
+    // the previous 247px DOM width.
+    settleNavigatorLayout(294)
+
+    expect(resizableHarness.navigatorSize).toBe(247)
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('294')
+  })
+
+  it('keeps the last expanded width when a pointer resize settles collapsed', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    fireEvent.pointerDown(screen.getByTestId('page-sidebar-market-content'), {
+      button: 0,
+      buttons: 1,
+      clientX: 315,
+      isPrimary: true,
+      pointerId: 9,
+      pointerType: 'mouse',
+    })
+    driveNavigatorGeometry(44, true)
+    settleNavigatorLayout(44)
+
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('1')
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+})

--- a/ui/src/components/PageSidebarLayout.state.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.state.spec.tsx
@@ -11,6 +11,9 @@ const resizableHarness = vi.hoisted(() => ({
   navigatorSize: 312,
   navigatorCollapsed: false,
   navigatorCollapsible: true,
+  collapseCalls: 0,
+  expandCalls: 0,
+  resizeCalls: 0,
   onNavigatorResize: undefined as ((size: PanelSize) => void) | undefined,
   onLayoutChanged: undefined as ((layout: Record<string, number>) => void) | undefined,
 }))
@@ -95,11 +98,13 @@ vi.mock('@/components/ui/resizable', async () => {
 
     React.useImperativeHandle(panelRef, () => ({
       collapse() {
+        resizableHarness.collapseCalls++
         resizableHarness.navigatorCollapsed = true
         resizableHarness.navigatorSize = 44
         onResize?.({ asPercentage: 4.4, inPixels: 44 })
       },
       expand() {
+        resizableHarness.expandCalls++
         resizableHarness.navigatorCollapsed = false
         resizableHarness.navigatorSize = Math.max(200, resizableHarness.navigatorSize)
         onResize?.({
@@ -117,6 +122,7 @@ vi.mock('@/components/ui/resizable', async () => {
         return resizableHarness.navigatorCollapsed
       },
       resize(nextSize) {
+        resizableHarness.resizeCalls++
         const parsed = typeof nextSize === 'number' ? nextSize : Number.parseFloat(nextSize)
         if (!Number.isFinite(parsed)) return
         resizableHarness.navigatorSize = parsed
@@ -197,6 +203,9 @@ beforeEach(async () => {
   resizableHarness.navigatorSize = 312
   resizableHarness.navigatorCollapsed = false
   resizableHarness.navigatorCollapsible = true
+  resizableHarness.collapseCalls = 0
+  resizableHarness.expandCalls = 0
+  resizableHarness.resizeCalls = 0
   resizableHarness.onNavigatorResize = undefined
   resizableHarness.onLayoutChanged = undefined
   window.localStorage.clear()
@@ -343,6 +352,68 @@ describe('PageSidebarLayout applied state', () => {
     expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).not.toBe('1')
   })
 
+  it('keeps resistance when a new drag interrupts the previous spring', () => {
+    vi.useFakeTimers()
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
+    const handle = screen.getByRole('separator')
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 30,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 160,
+      isPrimary: true,
+      pointerId: 30,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerUp(group, {
+      buttons: 0,
+      clientX: 160,
+      isPrimary: true,
+      pointerId: 30,
+      pointerType: 'mouse',
+    })
+    act(() => vi.advanceTimersByTime(50))
+
+    fireEvent.pointerDown(handle, {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 31,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 155,
+      isPrimary: true,
+      pointerId: 31,
+      pointerType: 'mouse',
+    })
+    act(() => vi.advanceTimersByTime(350))
+
+    expect(group.getAttribute('data-overdrag-state')).toBe('resisting')
+    expect(Number.parseFloat(group.style.getPropertyValue('--oa-page-sidebar-overdrag'))).toBeCloseTo(23.6, 1)
+    vi.useRealTimers()
+  })
+
   it('commits collapse only after deliberate pointer overdrag', async () => {
     resizableHarness.navigatorSize = 200
     window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
@@ -374,6 +445,11 @@ describe('PageSidebarLayout applied state', () => {
     })
     expect(group.getAttribute('data-overdrag-state')).toBe('armed')
 
+    // react-resizable-panels owns the actual midpoint transition. Product
+    // code observes that applied geometry but must not issue a second collapse
+    // after pointer-up.
+    driveNavigatorGeometry(44, true)
+
     fireEvent.pointerUp(group, {
       button: 0,
       buttons: 0,
@@ -384,6 +460,7 @@ describe('PageSidebarLayout applied state', () => {
     })
     expect(group.getAttribute('data-overdrag-motion')).toBe('committing')
     await waitFor(() => expect(resizableHarness.navigatorSize).toBe(44))
+    expect(resizableHarness.collapseCalls).toBe(0)
     expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('200')
   })
@@ -466,6 +543,76 @@ describe('PageSidebarLayout applied state', () => {
     expect(requestAnimationFrame).not.toHaveBeenCalled()
     expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
     expect(resizableHarness.navigatorSize).toBe(44)
+    expect(resizableHarness.collapseCalls).toBe(1)
+  })
+
+  it('uses one geometry transaction per repeated collapse and restore cycle', async () => {
+    resizableHarness.navigatorSize = 312
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    for (let cycle = 0; cycle < 8; cycle++) {
+      fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
+      await waitFor(() => {
+        expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Open Market' }))
+      await waitFor(() => {
+        expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
+      })
+      expect(resizableHarness.navigatorSize).toBe(312)
+    }
+
+    expect(resizableHarness.collapseCalls).toBe(8)
+    expect(resizableHarness.expandCalls).toBe(0)
+    expect(resizableHarness.resizeCalls).toBe(8)
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+
+  it('repairs an impossible one-panel layout without persisting it', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    resizableHarness.navigatorSize = 940
+    act(() => resizableHarness.onLayoutChanged?.({
+      'page-sidebar-market-navigator': 100,
+      'page-sidebar-market-content': 0,
+    }))
+
+    expect(resizableHarness.navigatorSize).toBe(312)
+    expect(resizableHarness.resizeCalls).toBe(1)
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+
+  it('repairs a delayed impossible resize after the settled layout callback', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    driveNavigatorGeometry(940, false)
+
+    expect(resizableHarness.navigatorSize).toBe(312)
+    expect(resizableHarness.resizeCalls).toBe(1)
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
   })
 
   it('clears pointer overdrag immediately when reduced motion is requested', () => {

--- a/ui/src/components/PageSidebarLayout.state.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.state.spec.tsx
@@ -10,6 +10,7 @@ const resizableHarness = vi.hoisted(() => ({
   groupWidth: 941,
   navigatorSize: 312,
   navigatorCollapsed: false,
+  navigatorCollapsible: true,
   onNavigatorResize: undefined as ((size: PanelSize) => void) | undefined,
   onLayoutChanged: undefined as ((layout: Record<string, number>) => void) | undefined,
 }))
@@ -76,14 +77,21 @@ vi.mock('@/components/ui/resizable', async () => {
     id,
     panelRef,
     onResize,
+    collapsible,
+    'data-page-sidebar-panel': pageSidebarPanel,
   }: {
     children?: React.ReactNode
     id?: string
     panelRef?: React.Ref<PanelImperativeHandle>
     onResize?: (size: PanelSize) => void
+    collapsible?: boolean
+    'data-page-sidebar-panel'?: string
   }) {
     const isNavigator = id?.endsWith('-navigator') === true
-    if (isNavigator) resizableHarness.onNavigatorResize = onResize
+    if (isNavigator) {
+      resizableHarness.onNavigatorResize = onResize
+      resizableHarness.navigatorCollapsible = collapsible ?? false
+    }
 
     React.useImperativeHandle(panelRef, () => ({
       collapse() {
@@ -117,7 +125,7 @@ vi.mock('@/components/ui/resizable', async () => {
       },
     }), [onResize])
 
-    return <div data-testid={id}>{children}</div>
+    return <div data-testid={id} data-page-sidebar-panel={pageSidebarPanel}>{children}</div>
   }
 
   function ResizableHandle({
@@ -188,6 +196,7 @@ function settleNavigatorLayout(inPixels: number) {
 beforeEach(async () => {
   resizableHarness.navigatorSize = 312
   resizableHarness.navigatorCollapsed = false
+  resizableHarness.navigatorCollapsible = true
   resizableHarness.onNavigatorResize = undefined
   resizableHarness.onLayoutChanged = undefined
   window.localStorage.clear()
@@ -285,53 +294,151 @@ describe('PageSidebarLayout applied state', () => {
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('276')
   })
 
-  it('arms collapse motion only near the minimum-width threshold', () => {
-    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+  it('resists pointer overdrag and springs back before the commit boundary', () => {
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
     render(
       <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
         <div>Market content</div>
       </PageSidebarLayout>,
     )
 
-    const contentPanel = screen.getByTestId('page-sidebar-market-content')
     const group = screen.getByTestId('page-sidebar-market')
-    fireEvent.pointerDown(contentPanel, {
+    const handle = screen.getByRole('separator')
+    fireEvent.pointerDown(handle, {
       button: 0,
       buttons: 1,
-      clientX: 315,
+      clientX: 200,
       isPrimary: true,
       pointerId: 14,
       pointerType: 'mouse',
     })
+    expect(resizableHarness.navigatorCollapsible).toBe(true)
 
     fireEvent.pointerMove(group, {
       buttons: 1,
-      clientX: 250,
+      clientX: 160,
       isPrimary: true,
       pointerId: 14,
       pointerType: 'mouse',
     })
-    expect(group.getAttribute('data-collapse-motion')).toBeNull()
-
-    fireEvent.pointerMove(group, {
-      buttons: 1,
-      clientX: 223,
-      isPrimary: true,
-      pointerId: 14,
-      pointerType: 'mouse',
-    })
-    expect(group.getAttribute('data-collapse-motion')).toBe('armed')
+    expect(group.getAttribute('data-overdrag-state')).toBe('resisting')
+    expect(Number.parseFloat(group.style.getPropertyValue('--oa-page-sidebar-overdrag'))).toBeCloseTo(22.14, 1)
 
     fireEvent.pointerUp(group, {
       button: 0,
       buttons: 0,
-      clientX: 223,
+      clientX: 160,
       isPrimary: true,
       pointerId: 14,
       pointerType: 'mouse',
     })
-    expect(group.getAttribute('data-collapse-motion')).toBeNull()
+    expect(group.getAttribute('data-overdrag-motion')).toBe('returning')
+    expect(group.style.getPropertyValue('--oa-page-sidebar-overdrag')).toBe('0px')
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
+    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).not.toBe('1')
+  })
 
+  it('commits collapse only after deliberate pointer overdrag', async () => {
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
+    fireEvent.pointerDown(screen.getByRole('separator'), {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 110,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-overdrag-state')).toBe('armed')
+
+    fireEvent.pointerUp(group, {
+      button: 0,
+      buttons: 0,
+      clientX: 110,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-overdrag-motion')).toBe('committing')
+    await waitFor(() => expect(resizableHarness.navigatorSize).toBe(44))
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('200')
+  })
+
+  it('cancels an armed overdrag without collapsing', () => {
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
+    fireEvent.pointerDown(screen.getByRole('separator'), {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 130,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-overdrag-state')).toBe('armed')
+
+    fireEvent.pointerCancel(group, {
+      buttons: 0,
+      clientX: 130,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-overdrag-motion')).toBe('returning')
+    expect(resizableHarness.navigatorSize).toBe(200)
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
+  })
+
+  it('keeps keyboard collapse motion independent from pointer overdrag', () => {
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
     fireEvent.keyDown(screen.getByRole('separator'), { key: 'Home' })
     expect(group.getAttribute('data-collapse-motion')).toBe('armed')
   })
@@ -359,6 +466,58 @@ describe('PageSidebarLayout applied state', () => {
     expect(requestAnimationFrame).not.toHaveBeenCalled()
     expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
     expect(resizableHarness.navigatorSize).toBe(44)
+  })
+
+  it('clears pointer overdrag immediately when reduced motion is requested', () => {
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(min-width: 768px)' || query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })))
+    const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
+    fireEvent.pointerDown(screen.getByRole('separator'), {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 17,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 160,
+      isPrimary: true,
+      pointerId: 17,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-overdrag-state')).toBe('resisting')
+
+    fireEvent.pointerUp(group, {
+      buttons: 0,
+      clientX: 160,
+      isPrimary: true,
+      pointerId: 17,
+      pointerType: 'mouse',
+    })
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+    expect(group.getAttribute('data-overdrag-state')).toBeNull()
+    expect(group.getAttribute('data-overdrag-motion')).toBeNull()
+    expect(group.style.getPropertyValue('--oa-page-sidebar-overdrag')).toBe('')
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
   })
 
   it('does not persist a passive responsive cap or a pointer click without resize', () => {

--- a/ui/src/components/PageSidebarLayout.state.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.state.spec.tsx
@@ -9,13 +9,24 @@ import { i18n } from '../i18n'
 const resizableHarness = vi.hoisted(() => ({
   groupWidth: 941,
   navigatorSize: 312,
+  paintedNavigatorSize: null as number | null,
   navigatorCollapsed: false,
   navigatorCollapsible: true,
   collapseCalls: 0,
   expandCalls: 0,
   resizeCalls: 0,
+  groupMounts: 0,
+  navigatorMounts: 0,
+  navigatorDefaultSizes: [] as number[],
   onNavigatorResize: undefined as ((size: PanelSize) => void) | undefined,
   onLayoutChanged: undefined as ((layout: Record<string, number>) => void) | undefined,
+}))
+
+const resizeObserverHarness = vi.hoisted(() => ({
+  instances: [] as Array<{
+    callback: ResizeObserverCallback
+    elements: Element[]
+  }>,
 }))
 
 vi.mock('@/components/ui/resizable', async () => {
@@ -46,6 +57,9 @@ vi.mock('@/components/ui/resizable', async () => {
     onPointerCancelCapture?: React.PointerEventHandler<HTMLDivElement>
   }) {
     resizableHarness.onLayoutChanged = onLayoutChanged
+    React.useEffect(() => {
+      resizableHarness.groupMounts++
+    }, [])
     return (
       <div
         ref={(element) => {
@@ -79,6 +93,8 @@ vi.mock('@/components/ui/resizable', async () => {
     children,
     id,
     panelRef,
+    elementRef,
+    defaultSize,
     onResize,
     collapsible,
     'data-page-sidebar-panel': pageSidebarPanel,
@@ -86,6 +102,8 @@ vi.mock('@/components/ui/resizable', async () => {
     children?: React.ReactNode
     id?: string
     panelRef?: React.Ref<PanelImperativeHandle>
+    elementRef?: React.Ref<HTMLDivElement>
+    defaultSize?: number
     onResize?: (size: PanelSize) => void
     collapsible?: boolean
     'data-page-sidebar-panel'?: string
@@ -95,6 +113,16 @@ vi.mock('@/components/ui/resizable', async () => {
       resizableHarness.onNavigatorResize = onResize
       resizableHarness.navigatorCollapsible = collapsible ?? false
     }
+
+    React.useEffect(() => {
+      if (isNavigator && typeof defaultSize === 'number') {
+        resizableHarness.navigatorMounts++
+        if (resizableHarness.navigatorMounts > 1) {
+          resizableHarness.paintedNavigatorSize = null
+        }
+        resizableHarness.navigatorDefaultSizes.push(defaultSize)
+      }
+    }, [defaultSize, isNavigator])
 
     React.useImperativeHandle(panelRef, () => ({
       collapse() {
@@ -131,7 +159,37 @@ vi.mock('@/components/ui/resizable', async () => {
       },
     }), [onResize])
 
-    return <div data-testid={id} data-page-sidebar-panel={pageSidebarPanel}>{children}</div>
+    return (
+      <div
+        ref={(element) => {
+          if (element) {
+            element.getBoundingClientRect = () => {
+              const paintedNavigatorSize = resizableHarness.paintedNavigatorSize ?? resizableHarness.navigatorSize
+              const width = isNavigator
+                ? paintedNavigatorSize
+                : Math.max(0, resizableHarness.groupWidth - 1 - paintedNavigatorSize)
+              const left = isNavigator ? 0 : paintedNavigatorSize + 1
+              return {
+                x: left,
+                y: 0,
+                width,
+                height: 800,
+                top: 0,
+                right: left + width,
+                bottom: 800,
+                left,
+                toJSON: () => ({}),
+              }
+            }
+          }
+          assignRef(elementRef, element)
+        }}
+        data-testid={id}
+        data-page-sidebar-panel={pageSidebarPanel}
+      >
+        {children}
+      </div>
+    )
   }
 
   function ResizableHandle({
@@ -175,9 +233,27 @@ vi.mock('@/components/ui/resizable', async () => {
 import { PageSidebarLayout } from './PageSidebarLayout'
 
 class ResizeObserverStub {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  private readonly record: {
+    callback: ResizeObserverCallback
+    elements: Element[]
+  }
+
+  constructor(callback: ResizeObserverCallback) {
+    this.record = { callback, elements: [] }
+    resizeObserverHarness.instances.push(this.record)
+  }
+
+  observe(element: Element) {
+    this.record.elements.push(element)
+  }
+
+  unobserve(element: Element) {
+    this.record.elements = this.record.elements.filter((candidate) => candidate !== element)
+  }
+
+  disconnect() {
+    this.record.elements = []
+  }
 }
 
 function driveNavigatorGeometry(inPixels: number, collapsed: boolean) {
@@ -199,15 +275,30 @@ function settleNavigatorLayout(inPixels: number) {
   }))
 }
 
+function notifyPaintedPanelResize() {
+  const navigator = screen.getByTestId('page-sidebar-market-navigator')
+  const content = screen.getByTestId('page-sidebar-market-content')
+  const observer = resizeObserverHarness.instances.find(({ elements }) => (
+    elements.includes(navigator) && elements.includes(content)
+  ))
+  if (!observer) throw new Error('Panel geometry ResizeObserver was not registered')
+  act(() => observer.callback([], {} as ResizeObserver))
+}
+
 beforeEach(async () => {
   resizableHarness.navigatorSize = 312
+  resizableHarness.paintedNavigatorSize = null
   resizableHarness.navigatorCollapsed = false
   resizableHarness.navigatorCollapsible = true
   resizableHarness.collapseCalls = 0
   resizableHarness.expandCalls = 0
   resizableHarness.resizeCalls = 0
+  resizableHarness.groupMounts = 0
+  resizableHarness.navigatorMounts = 0
+  resizableHarness.navigatorDefaultSizes = []
   resizableHarness.onNavigatorResize = undefined
   resizableHarness.onLayoutChanged = undefined
+  resizeObserverHarness.instances = []
   window.localStorage.clear()
   await i18n.changeLanguage('en')
   vi.stubGlobal('ResizeObserver', ResizeObserverStub)
@@ -352,6 +443,42 @@ describe('PageSidebarLayout applied state', () => {
     expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).not.toBe('1')
   })
 
+  it('captures the active pointer so an outside release cannot strand gesture state', () => {
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
+    const setPointerCapture = vi.fn()
+    const releasePointerCapture = vi.fn()
+    group.setPointerCapture = setPointerCapture
+    group.hasPointerCapture = vi.fn(() => true)
+    group.releasePointerCapture = releasePointerCapture
+
+    fireEvent.pointerDown(screen.getByRole('separator'), {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 41,
+      pointerType: 'mouse',
+    })
+    expect(setPointerCapture).toHaveBeenCalledWith(41)
+
+    fireEvent.pointerUp(group, {
+      buttons: 0,
+      clientX: -40,
+      isPrimary: true,
+      pointerId: 41,
+      pointerType: 'mouse',
+    })
+    expect(releasePointerCapture).toHaveBeenCalledWith(41)
+  })
+
   it('keeps resistance when a new drag interrupts the previous spring', () => {
     vi.useFakeTimers()
     resizableHarness.navigatorSize = 200
@@ -411,6 +538,57 @@ describe('PageSidebarLayout applied state', () => {
 
     expect(group.getAttribute('data-overdrag-state')).toBe('resisting')
     expect(Number.parseFloat(group.style.getPropertyValue('--oa-page-sidebar-overdrag'))).toBeCloseTo(23.6, 1)
+    vi.useRealTimers()
+  })
+
+  it('keeps collapse motion cursor-attached when a held drag reverses direction', () => {
+    vi.useFakeTimers()
+    resizableHarness.navigatorSize = 200
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '200')
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    const group = screen.getByTestId('page-sidebar-market')
+    fireEvent.pointerDown(screen.getByRole('separator'), {
+      button: 0,
+      buttons: 1,
+      clientX: 200,
+      isPrimary: true,
+      pointerId: 42,
+      pointerType: 'mouse',
+    })
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 110,
+      isPrimary: true,
+      pointerId: 42,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-collapse-motion')).toBe('armed')
+
+    act(() => vi.advanceTimersByTime(400))
+    expect(group.getAttribute('data-collapse-motion')).toBe('armed')
+
+    fireEvent.pointerMove(group, {
+      buttons: 1,
+      clientX: 160,
+      isPrimary: true,
+      pointerId: 42,
+      pointerType: 'mouse',
+    })
+    expect(group.getAttribute('data-collapse-motion')).toBeNull()
+    expect(group.getAttribute('data-overdrag-state')).toBe('resisting')
+
+    fireEvent.pointerUp(group, {
+      buttons: 0,
+      clientX: 160,
+      isPrimary: true,
+      pointerId: 42,
+      pointerType: 'mouse',
+    })
     vi.useRealTimers()
   })
 
@@ -570,6 +748,8 @@ describe('PageSidebarLayout applied state', () => {
     expect(resizableHarness.collapseCalls).toBe(8)
     expect(resizableHarness.expandCalls).toBe(0)
     expect(resizableHarness.resizeCalls).toBe(8)
+    expect(resizableHarness.groupMounts).toBe(1)
+    expect(resizableHarness.navigatorDefaultSizes).toEqual([312])
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
   })
 
@@ -612,6 +792,29 @@ describe('PageSidebarLayout applied state', () => {
 
     expect(resizableHarness.navigatorSize).toBe(312)
     expect(resizableHarness.resizeCalls).toBe(1)
+    expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+
+  it('rebuilds the group when painted flex geometry diverges from a valid panel store', () => {
+    window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0)
+      return 1
+    })
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    // The imperative store still reports the valid 312px size, but a stale
+    // registration write has left the actual flex items at 940px / 0px.
+    resizableHarness.paintedNavigatorSize = 940
+    notifyPaintedPanelResize()
+
+    expect(resizableHarness.groupMounts).toBe(2)
+    expect(resizableHarness.navigatorSize).toBe(312)
+    expect(resizableHarness.paintedNavigatorSize).toBeNull()
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
   })
 

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -25,8 +25,24 @@ const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
 const RESIZE_SEPARATOR_WIDTH = 1
-const COLLAPSE_MOTION_ARM_DISTANCE = 24
 const COLLAPSE_MOTION_CLEANUP_MS = 260
+const OVERDRAG_ARM_DISTANCE = 64
+const OVERDRAG_COLLAPSE_DISTANCE = (MIN_WIDTH - COLLAPSED_WIDTH) / 2
+const OVERDRAG_DAMPING_DISTANCE = 38
+const OVERDRAG_MAX_VISUAL_DISTANCE = 34
+const OVERDRAG_RETURN_CLEANUP_MS = 280
+
+export function calculatePageSidebarOverdrag(rawDistance: number): number {
+  if (!Number.isFinite(rawDistance) || rawDistance <= 0) return 0
+  return OVERDRAG_MAX_VISUAL_DISTANCE * (
+    1 - Math.exp(-rawDistance / OVERDRAG_DAMPING_DISTANCE)
+  )
+}
+
+export function shouldCollapsePageSidebar(rawDistance: number): boolean {
+  return Number.isFinite(rawDistance) && rawDistance >= OVERDRAG_COLLAPSE_DISTANCE
+}
+
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
   return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Math.round(value)))
@@ -144,12 +160,20 @@ export function PageSidebarLayout({
   const userResizeIntentRef = useRef(false)
   const userResizeChangedRef = useRef(false)
   const collapseMotionTimerRef = useRef<number | null>(null)
+  const overdragMotionTimerRef = useRef<number | null>(null)
+  const pointerGestureRef = useRef<{
+    pointerId: number
+    startX: number
+    startWidth: number
+    rawOverdrag: number
+  } | null>(null)
   const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null)
   const mobileDrawerId = useId()
   const navigatorPanelId = `page-sidebar-${storageKey}-navigator`
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))
+  const [pointerCollapseRequested, setPointerCollapseRequested] = useState(false)
   const collapsedRef = useRef(collapsed)
   const [preferredWidth, setPreferredWidth] = useState(() =>
     readStoredWidth(storageKey, clampWidth(defaultWidth, defaultWidth)),
@@ -247,6 +271,32 @@ export function PageSidebarLayout({
     rootRef.current?.removeAttribute('data-collapse-motion')
   }, [])
 
+  const clearOverdragMotion = useCallback(() => {
+    if (overdragMotionTimerRef.current !== null) {
+      window.clearTimeout(overdragMotionTimerRef.current)
+      overdragMotionTimerRef.current = null
+    }
+    const root = rootRef.current
+    if (!root) return
+    root.removeAttribute('data-overdrag-motion')
+    root.removeAttribute('data-overdrag-state')
+    root.style.removeProperty('--oa-page-sidebar-overdrag')
+  }, [])
+
+  const scheduleOverdragCleanup = useCallback(() => {
+    if (overdragMotionTimerRef.current !== null) {
+      window.clearTimeout(overdragMotionTimerRef.current)
+    }
+    overdragMotionTimerRef.current = window.setTimeout(() => {
+      overdragMotionTimerRef.current = null
+      const root = rootRef.current
+      if (!root) return
+      root.removeAttribute('data-overdrag-motion')
+      root.removeAttribute('data-overdrag-state')
+      root.style.removeProperty('--oa-page-sidebar-overdrag')
+    }, OVERDRAG_RETURN_CLEANUP_MS)
+  }, [])
+
   const armCollapseMotion = useCallback(() => {
     const root = rootRef.current
     if (!root) return
@@ -269,19 +319,67 @@ export function PageSidebarLayout({
     const hitSlop = Math.max(0, (targetSize - rect.width) / 2)
     if (event.clientX < rect.left - hitSlop || event.clientX > rect.right + hitSlop) return
     beginUserResize()
-  }, [beginUserResize])
-
-  const preparePointerCollapseMotion = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!userResizeIntentRef.current) return
-    const root = rootRef.current
-    if (!root) return
-    const collapseThreshold = root.getBoundingClientRect().left + MIN_WIDTH
-    if (event.clientX <= collapseThreshold + COLLAPSE_MOTION_ARM_DISTANCE) {
-      armCollapseMotion()
-    } else if (!sidebarPanelRef.current?.isCollapsed()) {
-      disarmCollapseMotion()
+    const panel = sidebarPanelRef.current
+    if (!panel || panel.isCollapsed()) return
+    clearOverdragMotion()
+    pointerGestureRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: panel.getSize().inPixels,
+      rawOverdrag: 0,
     }
-  }, [armCollapseMotion, disarmCollapseMotion])
+  }, [beginUserResize, clearOverdragMotion])
+
+  const updatePointerOverdrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const gesture = pointerGestureRef.current
+    const root = rootRef.current
+    if (!gesture || !root || event.pointerId !== gesture.pointerId || event.buttons !== 1) return
+
+    const rawWidth = gesture.startWidth + event.clientX - gesture.startX
+    const rawOverdrag = Math.max(0, MIN_WIDTH - rawWidth)
+    gesture.rawOverdrag = rawOverdrag
+
+    if (rawOverdrag === 0) {
+      root.removeAttribute('data-overdrag-state')
+      root.style.setProperty('--oa-page-sidebar-overdrag', '0px')
+      return
+    }
+
+    if (shouldCollapsePageSidebar(rawOverdrag)) {
+      root.setAttribute('data-overdrag-state', 'armed')
+      root.setAttribute('data-overdrag-motion', 'committing')
+      root.style.setProperty('--oa-page-sidebar-overdrag', '0px')
+      armCollapseMotion()
+      scheduleOverdragCleanup()
+      return
+    }
+
+    if (root.hasAttribute('data-overdrag-motion')) clearOverdragMotion()
+    const visualDistance = calculatePageSidebarOverdrag(rawOverdrag)
+    root.style.setProperty('--oa-page-sidebar-overdrag', `${visualDistance.toFixed(3)}px`)
+    root.setAttribute(
+      'data-overdrag-state',
+      rawOverdrag >= OVERDRAG_ARM_DISTANCE ? 'armed' : 'resisting',
+    )
+  }, [armCollapseMotion, clearOverdragMotion, scheduleOverdragCleanup])
+
+  const returnFromOverdrag = useCallback(() => {
+    const root = rootRef.current
+    if (!root || !root.hasAttribute('data-overdrag-state')) {
+      clearOverdragMotion()
+      return
+    }
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      clearOverdragMotion()
+      return
+    }
+    root.setAttribute('data-overdrag-motion', 'returning')
+    root.removeAttribute('data-overdrag-state')
+    window.requestAnimationFrame(() => {
+      root.style.setProperty('--oa-page-sidebar-overdrag', '0px')
+    })
+    scheduleOverdragCleanup()
+  }, [clearOverdragMotion, scheduleOverdragCleanup])
 
   const finishUserResize = useCallback(() => {
     if (!sidebarPanelRef.current?.isCollapsed()) disarmCollapseMotion()
@@ -293,6 +391,33 @@ export function PageSidebarLayout({
     userResizeIntentRef.current = false
     userResizeChangedRef.current = false
   }, [commitPreferredWidth, disarmCollapseMotion])
+
+  const finishPointerResize = useCallback(() => {
+    const gesture = pointerGestureRef.current
+    pointerGestureRef.current = null
+
+    if (gesture && shouldCollapsePageSidebar(gesture.rawOverdrag)) {
+      userResizeIntentRef.current = false
+      userResizeChangedRef.current = false
+      // The primitive normally commits at the same midpoint. Keep an
+      // imperative fallback for coarse rounding, but let pointer-up settlement
+      // finish first so it cannot overwrite that fallback.
+      setPointerCollapseRequested(true)
+      return
+    }
+
+    returnFromOverdrag()
+    finishUserResize()
+  }, [
+    finishUserResize,
+    returnFromOverdrag,
+  ])
+
+  const cancelPointerResize = useCallback(() => {
+    pointerGestureRef.current = null
+    returnFromOverdrag()
+    finishUserResize()
+  }, [finishUserResize, returnFromOverdrag])
 
   const collapseSidebar = useCallback(() => {
     updateCollapsed(true)
@@ -327,7 +452,38 @@ export function PageSidebarLayout({
     if (isDesktop) setDrawerOpen(false)
   }, [isDesktop])
 
-  useEffect(() => disarmCollapseMotion, [disarmCollapseMotion])
+  useEffect(() => {
+    if (!pointerCollapseRequested) return
+    setPointerCollapseRequested(false)
+    const root = rootRef.current
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      clearOverdragMotion()
+      window.setTimeout(() => sidebarPanelRef.current?.collapse(), 0)
+      return
+    }
+    root?.setAttribute('data-overdrag-motion', 'committing')
+    root?.removeAttribute('data-overdrag-state')
+    root?.style.setProperty('--oa-page-sidebar-overdrag', '0px')
+    armCollapseMotion()
+    scheduleOverdragCleanup()
+    // A macrotask boundary guarantees that the primitive's pointer-up
+    // settlement finishes before the rounding fallback runs.
+    window.setTimeout(() => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => sidebarPanelRef.current?.collapse())
+      })
+    }, 0)
+  }, [
+    armCollapseMotion,
+    clearOverdragMotion,
+    pointerCollapseRequested,
+    scheduleOverdragCleanup,
+  ])
+
+  useEffect(() => () => {
+    disarmCollapseMotion()
+    clearOverdragMotion()
+  }, [clearOverdragMotion, disarmCollapseMotion])
 
   useEffect(() => {
     if (!isDesktop) return
@@ -378,14 +534,15 @@ export function PageSidebarLayout({
         orientation="horizontal"
         onLayoutChanged={handleLayoutChanged}
         onPointerDownCapture={beginPointerResize}
-        onPointerMoveCapture={preparePointerCollapseMotion}
-        onPointerUpCapture={finishUserResize}
-        onPointerCancelCapture={finishUserResize}
+        onPointerMoveCapture={updatePointerOverdrag}
+        onPointerUpCapture={finishPointerResize}
+        onPointerCancelCapture={cancelPointerResize}
         resizeTargetMinimumSize={{ fine: 10, coarse: 28 }}
         className="oa-page-sidebar-resizable min-h-0 min-w-0 overflow-hidden"
       >
         <ResizablePanel
           id={navigatorPanelId}
+          data-page-sidebar-panel="navigator"
           data-collapse-state={collapsed ? 'collapsed' : 'expanded'}
           panelRef={sidebarPanelRef}
           defaultSize={collapsed ? COLLAPSED_WIDTH : width}
@@ -460,6 +617,7 @@ export function PageSidebarLayout({
         />
         <ResizablePanel
           id={`page-sidebar-${storageKey}-content`}
+          data-page-sidebar-panel="content"
           minSize={contentMinWidth}
           groupResizeBehavior="preserve-relative-size"
           className="min-h-0 min-w-0"

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -25,6 +25,8 @@ const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
 const RESIZE_SEPARATOR_WIDTH = 1
+const COLLAPSE_MOTION_ARM_DISTANCE = 24
+const COLLAPSE_MOTION_CLEANUP_MS = 260
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
   return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Math.round(value)))
@@ -141,6 +143,7 @@ export function PageSidebarLayout({
   const resizeHandleRef = useRef<HTMLDivElement | null>(null)
   const userResizeIntentRef = useRef(false)
   const userResizeChangedRef = useRef(false)
+  const collapseMotionTimerRef = useRef<number | null>(null)
   const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null)
   const mobileDrawerId = useId()
@@ -236,6 +239,27 @@ export function PageSidebarLayout({
     userResizeChangedRef.current = false
   }, [])
 
+  const disarmCollapseMotion = useCallback(() => {
+    if (collapseMotionTimerRef.current !== null) {
+      window.clearTimeout(collapseMotionTimerRef.current)
+      collapseMotionTimerRef.current = null
+    }
+    rootRef.current?.removeAttribute('data-collapse-motion')
+  }, [])
+
+  const armCollapseMotion = useCallback(() => {
+    const root = rootRef.current
+    if (!root) return
+    root.setAttribute('data-collapse-motion', 'armed')
+    if (collapseMotionTimerRef.current !== null) {
+      window.clearTimeout(collapseMotionTimerRef.current)
+    }
+    collapseMotionTimerRef.current = window.setTimeout(() => {
+      collapseMotionTimerRef.current = null
+      root.removeAttribute('data-collapse-motion')
+    }, COLLAPSE_MOTION_CLEANUP_MS)
+  }, [])
+
   const beginPointerResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (!event.isPrimary || event.button !== 0) return
     const handle = resizeHandleRef.current
@@ -247,7 +271,20 @@ export function PageSidebarLayout({
     beginUserResize()
   }, [beginUserResize])
 
+  const preparePointerCollapseMotion = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!userResizeIntentRef.current) return
+    const root = rootRef.current
+    if (!root) return
+    const collapseThreshold = root.getBoundingClientRect().left + MIN_WIDTH
+    if (event.clientX <= collapseThreshold + COLLAPSE_MOTION_ARM_DISTANCE) {
+      armCollapseMotion()
+    } else if (!sidebarPanelRef.current?.isCollapsed()) {
+      disarmCollapseMotion()
+    }
+  }, [armCollapseMotion, disarmCollapseMotion])
+
   const finishUserResize = useCallback(() => {
+    if (!sidebarPanelRef.current?.isCollapsed()) disarmCollapseMotion()
     if (!userResizeIntentRef.current) return
     const panel = sidebarPanelRef.current
     if (userResizeChangedRef.current && panel && !panel.isCollapsed()) {
@@ -255,12 +292,19 @@ export function PageSidebarLayout({
     }
     userResizeIntentRef.current = false
     userResizeChangedRef.current = false
-  }, [commitPreferredWidth])
+  }, [commitPreferredWidth, disarmCollapseMotion])
 
   const collapseSidebar = useCallback(() => {
     updateCollapsed(true)
-    sidebarPanelRef.current?.collapse()
-  }, [updateCollapsed])
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      sidebarPanelRef.current?.collapse()
+      return
+    }
+    armCollapseMotion()
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => sidebarPanelRef.current?.collapse())
+    })
+  }, [armCollapseMotion, updateCollapsed])
 
   const expandSidebar = useCallback(() => {
     const targetWidth = Math.min(latestWidthRef.current, maxWidth)
@@ -282,6 +326,8 @@ export function PageSidebarLayout({
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
   }, [isDesktop])
+
+  useEffect(() => disarmCollapseMotion, [disarmCollapseMotion])
 
   useEffect(() => {
     if (!isDesktop) return
@@ -332,13 +378,15 @@ export function PageSidebarLayout({
         orientation="horizontal"
         onLayoutChanged={handleLayoutChanged}
         onPointerDownCapture={beginPointerResize}
+        onPointerMoveCapture={preparePointerCollapseMotion}
         onPointerUpCapture={finishUserResize}
         onPointerCancelCapture={finishUserResize}
         resizeTargetMinimumSize={{ fine: 10, coarse: 28 }}
-        className="min-h-0 min-w-0 overflow-hidden"
+        className="oa-page-sidebar-resizable min-h-0 min-w-0 overflow-hidden"
       >
         <ResizablePanel
           id={navigatorPanelId}
+          data-collapse-state={collapsed ? 'collapsed' : 'expanded'}
           panelRef={sidebarPanelRef}
           defaultSize={collapsed ? COLLAPSED_WIDTH : width}
           minSize={MIN_WIDTH}
@@ -401,6 +449,9 @@ export function PageSidebarLayout({
           onKeyDownCapture={(event) => {
             if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
               beginUserResize()
+            }
+            if (event.key === 'ArrowLeft' || event.key === 'Home') {
+              armCollapseMotion()
             }
           }}
           onKeyUp={finishUserResize}

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -1,7 +1,16 @@
-import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react'
 import { PanelLeftClose, PanelLeftOpen, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
+import type { Layout, PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 import {
   ResizableHandle,
   ResizablePanel,
@@ -129,10 +138,13 @@ export function PageSidebarLayout({
   const isAppDesktop = useIsDesktop(768)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const sidebarPanelRef = useRef<PanelImperativeHandle | null>(null)
-  const userResizeRef = useRef(false)
+  const resizeHandleRef = useRef<HTMLDivElement | null>(null)
+  const userResizeIntentRef = useRef(false)
+  const userResizeChangedRef = useRef(false)
   const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null)
   const mobileDrawerId = useId()
+  const navigatorPanelId = `page-sidebar-${storageKey}-navigator`
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))
   const collapsedRef = useRef(collapsed)
@@ -185,33 +197,64 @@ export function PageSidebarLayout({
 
   const handleSidebarResize = useCallback((size: PanelSize) => {
     const nextCollapsed = size.inPixels <= COLLAPSED_WIDTH + 1
-    if (userResizeRef.current) {
-      updateCollapsed(nextCollapsed)
-      if (!nextCollapsed) {
-        latestWidthRef.current = clampWidth(size.inPixels, MIN_WIDTH)
-      }
+    // Applied panel geometry is the source of truth for which surface is
+    // interactive. Pointer drags may begin inside react-resizable-panels'
+    // enlarged virtual hit region rather than on the one-pixel Separator DOM
+    // node, so interaction bookkeeping must never gate this synchronization.
+    updateCollapsed(nextCollapsed)
+    if (userResizeIntentRef.current) {
+      userResizeChangedRef.current = true
     }
   }, [updateCollapsed])
 
-  const handleLayoutChanged = useCallback(() => {
-    if (!userResizeRef.current) return
+  const handleLayoutChanged = useCallback((layout: Layout) => {
+    if (!userResizeIntentRef.current) return
     const panel = sidebarPanelRef.current
     if (!panel || panel.isCollapsed()) {
-      userResizeRef.current = false
+      userResizeIntentRef.current = false
+      userResizeChangedRef.current = false
       return
     }
-    const nextWidth = clampWidth(panel.getSize().inPixels, MIN_WIDTH)
+    // Keyboard layout callbacks run before the browser has painted the new
+    // flex width, so offsetWidth can lag one key press behind. The settled
+    // layout map is already authoritative; convert its percentage using the
+    // measured group budget and keep the imperative size as a cancellation
+    // fallback only.
+    const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
+    const percentage = layout[navigatorPanelId]
+    const settledPixels = groupWidth > RESIZE_SEPARATOR_WIDTH && Number.isFinite(percentage)
+      ? ((groupWidth - RESIZE_SEPARATOR_WIDTH) * percentage) / 100
+      : panel.getSize().inPixels
+    const nextWidth = clampWidth(settledPixels, MIN_WIDTH)
     commitPreferredWidth(nextWidth)
-    userResizeRef.current = false
-  }, [commitPreferredWidth])
+    userResizeIntentRef.current = false
+    userResizeChangedRef.current = false
+  }, [commitPreferredWidth, navigatorPanelId])
+
+  const beginUserResize = useCallback(() => {
+    userResizeIntentRef.current = true
+    userResizeChangedRef.current = false
+  }, [])
+
+  const beginPointerResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!event.isPrimary || event.button !== 0) return
+    const handle = resizeHandleRef.current
+    if (!handle) return
+    const rect = handle.getBoundingClientRect()
+    const targetSize = event.pointerType === 'mouse' ? 10 : 28
+    const hitSlop = Math.max(0, (targetSize - rect.width) / 2)
+    if (event.clientX < rect.left - hitSlop || event.clientX > rect.right + hitSlop) return
+    beginUserResize()
+  }, [beginUserResize])
 
   const finishUserResize = useCallback(() => {
-    if (!userResizeRef.current) return
+    if (!userResizeIntentRef.current) return
     const panel = sidebarPanelRef.current
-    if (panel && !panel.isCollapsed()) {
+    if (userResizeChangedRef.current && panel && !panel.isCollapsed()) {
       commitPreferredWidth(clampWidth(panel.getSize().inPixels, MIN_WIDTH))
     }
-    userResizeRef.current = false
+    userResizeIntentRef.current = false
+    userResizeChangedRef.current = false
   }, [commitPreferredWidth])
 
   const collapseSidebar = useCallback(() => {
@@ -232,7 +275,7 @@ export function PageSidebarLayout({
   }, [collapsed, containerWidth, isDesktop])
 
   useLayoutEffect(() => {
-    if (!isDesktop || containerWidth <= 0 || collapsed || userResizeRef.current) return
+    if (!isDesktop || containerWidth <= 0 || collapsed || userResizeIntentRef.current) return
     sidebarPanelRef.current?.resize(Math.min(latestWidthRef.current, maxWidth))
   }, [collapsed, containerWidth, isDesktop, maxWidth])
 
@@ -288,11 +331,14 @@ export function PageSidebarLayout({
         elementRef={rootRef}
         orientation="horizontal"
         onLayoutChanged={handleLayoutChanged}
+        onPointerDownCapture={beginPointerResize}
+        onPointerUpCapture={finishUserResize}
+        onPointerCancelCapture={finishUserResize}
         resizeTargetMinimumSize={{ fine: 10, coarse: 28 }}
         className="min-h-0 min-w-0 overflow-hidden"
       >
         <ResizablePanel
-          id={`page-sidebar-${storageKey}-navigator`}
+          id={navigatorPanelId}
           panelRef={sidebarPanelRef}
           defaultSize={collapsed ? COLLAPSED_WIDTH : width}
           minSize={MIN_WIDTH}
@@ -350,15 +396,11 @@ export function PageSidebarLayout({
         </ResizablePanel>
         <ResizableHandle
           id={`page-sidebar-${storageKey}-handle`}
+          elementRef={resizeHandleRef}
           aria-label={t('common.resizePanel', { title })}
-          onPointerDown={() => {
-            userResizeRef.current = true
-          }}
-          onPointerUp={finishUserResize}
-          onPointerCancel={finishUserResize}
-          onKeyDown={(event) => {
+          onKeyDownCapture={(event) => {
             if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
-              userResizeRef.current = true
+              beginUserResize()
             }
           }}
           onKeyUp={finishUserResize}

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, useId, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { PanelLeftClose, PanelLeftOpen, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@/components/ui/resizable'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Sidebar } from './Sidebar'
 import { useRegisterMobilePageNavigation } from '../contexts/MobilePageNavigationContext'
@@ -9,7 +15,6 @@ const MIN_WIDTH = 200
 const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
-const RESIZE_HANDLE_WIDTH = 10
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
   return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Math.round(value)))
@@ -97,14 +102,19 @@ export function PageSidebarLayout({
   const isDesktop = useIsDesktop(desktopMinWidth)
   const isAppDesktop = useIsDesktop(768)
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const sidebarPanelRef = useRef<PanelImperativeHandle | null>(null)
+  const widthPersistTimerRef = useRef<number | null>(null)
+  const userResizeRef = useRef(false)
   const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null)
   const mobileDrawerId = useId()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))
+  const collapsedRef = useRef(collapsed)
   const [preferredWidth, setPreferredWidth] = useState(() =>
     readStoredWidth(storageKey, clampWidth(defaultWidth, defaultWidth)),
   )
+  const latestWidthRef = useRef(preferredWidth)
   const [containerWidth, setContainerWidth] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth : 0,
   )
@@ -130,39 +140,91 @@ export function PageSidebarLayout({
     window.localStorage.setItem(storageName(storageKey), String(next))
   }, [storageKey])
 
+  const commitPreferredWidth = useCallback((next: number) => {
+    if (widthPersistTimerRef.current !== null) {
+      window.clearTimeout(widthPersistTimerRef.current)
+      widthPersistTimerRef.current = null
+    }
+    latestWidthRef.current = next
+    setPreferredWidth(next)
+    persistWidth(next)
+  }, [persistWidth])
+
+  const queuePreferredWidth = useCallback((next: number) => {
+    latestWidthRef.current = next
+    if (widthPersistTimerRef.current !== null) {
+      window.clearTimeout(widthPersistTimerRef.current)
+    }
+    widthPersistTimerRef.current = window.setTimeout(() => {
+      widthPersistTimerRef.current = null
+      userResizeRef.current = false
+      setPreferredWidth(next)
+      persistWidth(next)
+    }, 150)
+  }, [persistWidth])
+
   const updateCollapsed = useCallback((next: boolean) => {
+    if (collapsedRef.current === next) return
+    collapsedRef.current = next
     setCollapsed(next)
     window.localStorage.setItem(collapsedStorageName(storageKey), next ? '1' : '0')
   }, [storageKey])
 
-  const beginResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    event.stopPropagation()
-
-    const startX = event.clientX
-    const startWidth = width
-    let nextWidth = startWidth
-
-    const onPointerMove = (moveEvent: PointerEvent) => {
-      nextWidth = Math.max(MIN_WIDTH, Math.min(maxWidth, Math.round(startWidth + moveEvent.clientX - startX)))
-      setPreferredWidth(nextWidth)
+  const handleSidebarResize = useCallback((size: PanelSize) => {
+    const nextCollapsed = size.inPixels <= COLLAPSED_WIDTH + 1
+    if (userResizeRef.current) {
+      updateCollapsed(nextCollapsed)
+      if (!nextCollapsed) {
+        queuePreferredWidth(clampWidth(size.inPixels, MIN_WIDTH))
+      }
     }
+  }, [queuePreferredWidth, updateCollapsed])
 
-    const onPointerUp = () => {
-      persistWidth(nextWidth)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-      window.removeEventListener('pointermove', onPointerMove)
-      window.removeEventListener('pointerup', onPointerUp)
-      window.removeEventListener('pointercancel', onPointerUp)
+  const handleLayoutChanged = useCallback(() => {
+    if (!userResizeRef.current) return
+    const panel = sidebarPanelRef.current
+    if (!panel || panel.isCollapsed()) return
+    const nextWidth = clampWidth(panel.getSize().inPixels, MIN_WIDTH)
+    commitPreferredWidth(nextWidth)
+    userResizeRef.current = false
+  }, [commitPreferredWidth])
+
+  const finishUserResize = useCallback(() => {
+    if (!userResizeRef.current) return
+    const panel = sidebarPanelRef.current
+    if (panel && !panel.isCollapsed()) {
+      commitPreferredWidth(clampWidth(panel.getSize().inPixels, MIN_WIDTH))
     }
+    userResizeRef.current = false
+  }, [commitPreferredWidth])
 
-    document.body.style.cursor = 'col-resize'
-    document.body.style.userSelect = 'none'
-    window.addEventListener('pointermove', onPointerMove)
-    window.addEventListener('pointerup', onPointerUp)
-    window.addEventListener('pointercancel', onPointerUp)
-  }, [maxWidth, persistWidth, width])
+  const collapseSidebar = useCallback(() => {
+    updateCollapsed(true)
+    sidebarPanelRef.current?.collapse()
+  }, [updateCollapsed])
+
+  const expandSidebar = useCallback(() => {
+    const targetWidth = Math.min(latestWidthRef.current, maxWidth)
+    updateCollapsed(false)
+    sidebarPanelRef.current?.expand()
+    sidebarPanelRef.current?.resize(targetWidth)
+  }, [maxWidth, updateCollapsed])
+
+  useLayoutEffect(() => {
+    if (!isDesktop || !collapsed) return
+    sidebarPanelRef.current?.collapse()
+  }, [collapsed, isDesktop])
+
+  useLayoutEffect(() => {
+    if (!isDesktop || collapsed || userResizeRef.current) return
+    sidebarPanelRef.current?.resize(Math.min(latestWidthRef.current, maxWidth))
+  }, [collapsed, isDesktop, maxWidth])
+
+  useEffect(() => () => {
+    if (widthPersistTimerRef.current !== null) {
+      window.clearTimeout(widthPersistTimerRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
@@ -193,7 +255,7 @@ export function PageSidebarLayout({
       {actionContent}
       <button
         type="button"
-        onClick={() => updateCollapsed(true)}
+        onClick={collapseSidebar}
         className="oa-icon-action flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         aria-label={t('common.collapsePanel', { title })}
         title={t('common.focusContent')}
@@ -211,64 +273,97 @@ export function PageSidebarLayout({
 
   if (isDesktop) {
     return (
-      <div ref={rootRef} className="flex h-full min-h-0 w-full overflow-hidden">
-        <div
-          data-testid="page-sidebar-desktop"
-          data-state={collapsed ? 'collapsed' : 'expanded'}
-          className="relative h-full min-h-0 shrink-0 overflow-hidden border-r border-border/80 bg-secondary transition-[width] duration-[var(--motion-slow)] [transition-timing-function:var(--motion-ease-out)] motion-reduce:transition-none"
-          style={{ width: collapsed ? COLLAPSED_WIDTH : width + RESIZE_HANDLE_WIDTH }}
+      <ResizablePanelGroup
+        id={`page-sidebar-${storageKey}`}
+        elementRef={rootRef}
+        orientation="horizontal"
+        onLayoutChanged={handleLayoutChanged}
+        resizeTargetMinimumSize={{ fine: 10, coarse: 28 }}
+        className="min-h-0 min-w-0 overflow-hidden"
+      >
+        <ResizablePanel
+          id={`page-sidebar-${storageKey}-navigator`}
+          panelRef={sidebarPanelRef}
+          defaultSize={width}
+          minSize={MIN_WIDTH}
+          maxSize={maxWidth}
+          collapsedSize={COLLAPSED_WIDTH}
+          collapsible
+          groupResizeBehavior="preserve-pixel-size"
+          onResize={handleSidebarResize}
+          className="h-full min-h-0 overflow-hidden bg-secondary"
         >
           <div
-            data-testid="page-sidebar-expanded"
-            aria-hidden={collapsed}
-            inert={collapsed ? true : undefined}
-            className={`absolute inset-y-0 left-0 flex transition-opacity duration-[var(--motion-fast)] [transition-timing-function:var(--motion-ease-standard)] motion-reduce:delay-0 motion-reduce:transition-none ${
-              collapsed
-                ? 'pointer-events-none opacity-0'
-                : 'opacity-100 delay-[60ms]'
-            }`}
-            style={{ width: width + RESIZE_HANDLE_WIDTH }}
+            data-testid="page-sidebar-desktop"
+            data-state={collapsed ? 'collapsed' : 'expanded'}
+            className="relative h-full min-h-0 w-full overflow-hidden bg-secondary"
           >
             <div
-              className="h-full min-h-0 shrink-0"
-              style={{ width }}
+              data-testid="page-sidebar-expanded"
+              aria-hidden={collapsed}
+              inert={collapsed ? true : undefined}
+              className={`absolute inset-0 transition-opacity duration-[var(--motion-fast)] [transition-timing-function:var(--motion-ease-standard)] motion-reduce:delay-0 motion-reduce:transition-none ${
+                collapsed
+                  ? 'pointer-events-none opacity-0'
+                  : 'opacity-100 delay-[60ms]'
+              }`}
             >
               {sidebarPanel}
             </div>
-            <ResizeHandle width={width} maxWidth={maxWidth} onPointerDown={beginResize} />
+            <aside
+              data-testid="page-sidebar-collapsed"
+              aria-hidden={!collapsed}
+              inert={!collapsed ? true : undefined}
+              className={`absolute inset-0 flex flex-col items-center bg-secondary py-1.5 transition-opacity duration-[var(--motion-fast)] [transition-timing-function:var(--motion-ease-standard)] motion-reduce:delay-0 motion-reduce:transition-none ${
+                collapsed
+                  ? 'opacity-100 delay-[80ms]'
+                  : 'pointer-events-none opacity-0'
+              }`}
+            >
+              <button
+                type="button"
+                onClick={expandSidebar}
+                className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label={t('common.openPanel', { title })}
+                title={t('common.openPanel', { title })}
+              >
+                <PanelLeftOpen size={16} strokeWidth={1.75} aria-hidden />
+              </button>
+              <span
+                aria-hidden
+                className="mt-3 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground [writing-mode:vertical-rl] rotate-180"
+              >
+                {title}
+              </span>
+            </aside>
           </div>
-          <aside
-            data-testid="page-sidebar-collapsed"
-            aria-hidden={!collapsed}
-            inert={!collapsed ? true : undefined}
-            className={`absolute inset-y-0 left-0 flex shrink-0 flex-col items-center bg-secondary py-1.5 transition-opacity duration-[var(--motion-fast)] [transition-timing-function:var(--motion-ease-standard)] motion-reduce:delay-0 motion-reduce:transition-none ${
-              collapsed
-                ? 'opacity-100 delay-[80ms]'
-                : 'pointer-events-none opacity-0'
-            }`}
-            style={{ width: COLLAPSED_WIDTH }}
-          >
-            <button
-              type="button"
-              onClick={() => updateCollapsed(false)}
-              className="oa-icon-action flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              aria-label={t('common.openPanel', { title })}
-              title={t('common.openPanel', { title })}
-            >
-              <PanelLeftOpen size={16} strokeWidth={1.75} aria-hidden />
-            </button>
-            <span
-              aria-hidden
-              className="mt-3 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground [writing-mode:vertical-rl] rotate-180"
-            >
-              {title}
-            </span>
-          </aside>
-        </div>
-        <div className="min-h-0 min-w-0 flex flex-1 flex-col">
-          {children}
-        </div>
-      </div>
+        </ResizablePanel>
+        <ResizableHandle
+          id={`page-sidebar-${storageKey}-handle`}
+          aria-label={t('common.resizePanel', { title })}
+          onPointerDown={() => {
+            userResizeRef.current = true
+          }}
+          onPointerUp={finishUserResize}
+          onPointerCancel={finishUserResize}
+          onKeyDown={(event) => {
+            if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+              userResizeRef.current = true
+            }
+          }}
+          onKeyUp={finishUserResize}
+          onBlur={finishUserResize}
+          className="z-10 bg-border/80 transition-colors hover:bg-primary/50 active:bg-primary/70"
+        />
+        <ResizablePanel
+          id={`page-sidebar-${storageKey}-content`}
+          minSize={MAIN_PANE_MIN_WIDTH}
+          groupResizeBehavior="preserve-relative-size"
+          className="min-h-0 min-w-0"
+        >
+          <div className="flex h-full min-h-0 min-w-0 flex-col">{children}</div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     )
   }
 
@@ -343,34 +438,6 @@ export function PageSidebarLayout({
           </Sidebar>
         </SheetContent>
       </Sheet>
-    </div>
-  )
-}
-
-function ResizeHandle({
-  width,
-  maxWidth,
-  onPointerDown,
-}: {
-  width: number
-  maxWidth: number
-  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void
-}) {
-  return (
-    <div
-      role="separator"
-      aria-orientation="vertical"
-      aria-valuemin={MIN_WIDTH}
-      aria-valuemax={maxWidth}
-      aria-valuenow={width}
-      tabIndex={0}
-      onPointerDown={onPointerDown}
-      className="group relative z-10 w-2.5 shrink-0 cursor-col-resize touch-none select-none bg-transparent"
-    >
-      <span
-        aria-hidden
-        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/80 transition-colors group-hover:bg-primary/50 group-active:bg-primary/70"
-      />
     </div>
   )
 }

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -155,6 +155,8 @@ export function PageSidebarLayout({
   const isDesktop = useIsDesktop(desktopMinWidth)
   const isAppDesktop = useIsDesktop(768)
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const navigatorElementRef = useRef<HTMLDivElement | null>(null)
+  const contentElementRef = useRef<HTMLDivElement | null>(null)
   const sidebarPanelRef = useRef<PanelImperativeHandle | null>(null)
   const resizeHandleRef = useRef<HTMLDivElement | null>(null)
   const userResizeIntentRef = useRef(false)
@@ -162,6 +164,7 @@ export function PageSidebarLayout({
   const collapseMotionTimerRef = useRef<number | null>(null)
   const overdragMotionTimerRef = useRef<number | null>(null)
   const layoutRepairFrameRef = useRef<number | null>(null)
+  const layoutRecoveryInFlightRef = useRef(false)
   const pointerGestureRef = useRef<{
     pointerId: number
     startX: number
@@ -179,6 +182,16 @@ export function PageSidebarLayout({
     readStoredWidth(storageKey, clampWidth(defaultWidth, defaultWidth)),
   )
   const latestWidthRef = useRef(preferredWidth)
+  // `react-resizable-panels` unregisters and re-registers a Panel whenever its
+  // defaultSize prop changes. A pointer may cross the collapse midpoint more
+  // than once before release, so deriving this prop from `collapsed` tears the
+  // active group apart mid-gesture and can leave a stale 100% / 0% flex pair.
+  // Keep the registration default stable for the lifetime of a group instance;
+  // an explicit recovery changes the key and supplies a new stable default.
+  const groupDefaultSizeRef = useRef(
+    collapsed ? COLLAPSED_WIDTH : preferredWidth,
+  )
+  const [layoutEpoch, setLayoutEpoch] = useState(0)
   // The page-owned group is narrower than window.innerWidth because the app
   // rail remains outside it. Wait for the real group measurement before
   // applying responsive constraints; using the viewport here can briefly make
@@ -188,7 +201,6 @@ export function PageSidebarLayout({
     navigatorMaxWidth: maxWidth,
     contentMinWidth,
   } = calculatePageSidebarConstraints(containerWidth)
-  const width = Math.min(preferredWidth, maxWidth)
   const closeMobileDrawer = useCallback(() => setDrawerOpen(false), [])
   const openMobileDrawer = useCallback(() => setDrawerOpen(true), [])
   const controls = { closeMobileDrawer }
@@ -222,22 +234,53 @@ export function PageSidebarLayout({
     window.localStorage.setItem(collapsedStorageName(storageKey), next ? '1' : '0')
   }, [storageKey])
 
+  const hasInvalidExpandedLayout = useCallback(() => {
+    const root = rootRef.current
+    const navigator = navigatorElementRef.current
+    const content = contentElementRef.current
+    const groupWidth = root?.getBoundingClientRect().width ?? 0
+    if (
+      !root ||
+      !navigator ||
+      !content ||
+      collapsedRef.current ||
+      groupWidth <= RESIZE_SEPARATOR_WIDTH ||
+      pointerGestureRef.current ||
+      layoutRecoveryInFlightRef.current
+    ) return false
+
+    // Read painted geometry rather than the imperative Panel size. During a
+    // registration race the library's layout store and ARIA metadata can be
+    // valid while the flex styles left on the DOM are still 100% / 0%.
+    const currentWidth = navigator.getBoundingClientRect().width
+    const currentContentWidth = content.getBoundingClientRect().width
+    const collapseIsAnimating = root.hasAttribute('data-collapse-motion')
+    return currentWidth > maxWidth + 1 ||
+      currentContentWidth < contentMinWidth - 1 ||
+      (!collapseIsAnimating && currentWidth < MIN_WIDTH - 1)
+  }, [contentMinWidth, maxWidth])
+
   const scheduleExpandedLayoutRepair = useCallback(() => {
-    if (layoutRepairFrameRef.current !== null) return
+    if (
+      layoutRepairFrameRef.current !== null ||
+      !hasInvalidExpandedLayout()
+    ) return
     layoutRepairFrameRef.current = window.requestAnimationFrame(() => {
       layoutRepairFrameRef.current = null
-      const panel = sidebarPanelRef.current
-      const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
-      if (!panel || panel.isCollapsed() || groupWidth <= RESIZE_SEPARATOR_WIDTH) return
-      const currentWidth = panel.getSize().inPixels
-      const invalidLayout =
-        currentWidth < MIN_WIDTH - 1 ||
-        currentWidth > maxWidth + 1 ||
-        groupWidth - RESIZE_SEPARATOR_WIDTH - currentWidth < contentMinWidth - 1
-      if (!invalidLayout) return
-      panel.resize(Math.min(latestWidthRef.current, maxWidth))
+      if (!hasInvalidExpandedLayout()) return
+
+      // A second resize request may be ignored when the internal layout already
+      // equals the desired size. Rebuild the primitive group instead so its DOM
+      // styles are derived from one coherent registration snapshot.
+      layoutRecoveryInFlightRef.current = true
+      groupDefaultSizeRef.current = Math.min(latestWidthRef.current, maxWidth)
+      setLayoutEpoch((current) => current + 1)
     })
-  }, [contentMinWidth, maxWidth])
+  }, [hasInvalidExpandedLayout, maxWidth])
+
+  useLayoutEffect(() => {
+    layoutRecoveryInFlightRef.current = false
+  }, [layoutEpoch])
 
   const handleSidebarResize = useCallback((size: PanelSize) => {
     const nextCollapsed = size.inPixels <= COLLAPSED_WIDTH + 1
@@ -369,17 +412,19 @@ export function PageSidebarLayout({
     }, OVERDRAG_RETURN_CLEANUP_MS)
   }, [])
 
-  const armCollapseMotion = useCallback(() => {
+  const armCollapseMotion = useCallback((scheduleCleanup = true) => {
     const root = rootRef.current
     if (!root) return
     root.setAttribute('data-collapse-motion', 'armed')
     if (collapseMotionTimerRef.current !== null) {
       window.clearTimeout(collapseMotionTimerRef.current)
     }
-    collapseMotionTimerRef.current = window.setTimeout(() => {
-      collapseMotionTimerRef.current = null
-      root.removeAttribute('data-collapse-motion')
-    }, COLLAPSE_MOTION_CLEANUP_MS)
+    if (scheduleCleanup) {
+      collapseMotionTimerRef.current = window.setTimeout(() => {
+        collapseMotionTimerRef.current = null
+        root.removeAttribute('data-collapse-motion')
+      }, COLLAPSE_MOTION_CLEANUP_MS)
+    }
   }, [])
 
   const beginPointerResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
@@ -391,6 +436,17 @@ export function PageSidebarLayout({
     const hitSlop = Math.max(0, (targetSize - rect.width) / 2)
     if (event.clientX < rect.left - hitSlop || event.clientX > rect.right + hitSlop) return
     beginUserResize()
+    // The primitive tracks pointer movement at the document level. Capture the
+    // same pointer on the product-owned group so a fast throw outside the
+    // navigator still delivers pointerup/cancel and cannot strand our gesture
+    // refs or block geometry recovery indefinitely.
+    if (typeof event.currentTarget.setPointerCapture === 'function') {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId)
+      } catch {
+        // The pointer may already have ended between native capture phases.
+      }
+    }
     // A return/commit cleanup from the previous gesture must not be allowed to
     // erase the next gesture. This is also required when the next gesture
     // starts from the collapsed rail and re-opens the panel.
@@ -415,6 +471,7 @@ export function PageSidebarLayout({
     gesture.rawOverdrag = rawOverdrag
 
     if (rawOverdrag === 0) {
+      disarmCollapseMotion()
       root.removeAttribute('data-overdrag-state')
       root.style.setProperty('--oa-page-sidebar-overdrag', '0px')
       return
@@ -423,10 +480,16 @@ export function PageSidebarLayout({
     if (shouldCollapsePageSidebar(rawOverdrag)) {
       root.setAttribute('data-overdrag-state', 'armed')
       root.style.setProperty('--oa-page-sidebar-overdrag', '0px')
-      armCollapseMotion()
+      // Keep the transition armed for the held gesture, but do not let a timer
+      // remove it underneath a slow drag. Pointer release owns cleanup.
+      armCollapseMotion(false)
       return
     }
 
+    // Reversing back across the collapse boundary must make flex geometry
+    // cursor-attached again. Leaving the transition active makes painted width
+    // lag the primitive's layout and is the main trigger for rapid-drag drift.
+    disarmCollapseMotion()
     if (root.hasAttribute('data-overdrag-motion')) clearOverdragMotion()
     const visualDistance = calculatePageSidebarOverdrag(rawOverdrag)
     root.style.setProperty('--oa-page-sidebar-overdrag', `${visualDistance.toFixed(3)}px`)
@@ -434,7 +497,7 @@ export function PageSidebarLayout({
       'data-overdrag-state',
       rawOverdrag >= OVERDRAG_ARM_DISTANCE ? 'armed' : 'resisting',
     )
-  }, [armCollapseMotion, clearOverdragMotion, scheduleOverdragCleanup])
+  }, [armCollapseMotion, clearOverdragMotion, disarmCollapseMotion])
 
   const returnFromOverdrag = useCallback(() => {
     const root = rootRef.current
@@ -465,7 +528,13 @@ export function PageSidebarLayout({
     userResizeChangedRef.current = false
   }, [commitPreferredWidth, disarmCollapseMotion])
 
-  const finishPointerResize = useCallback(() => {
+  const finishPointerResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (
+      typeof event.currentTarget.hasPointerCapture === 'function' &&
+      event.currentTarget.hasPointerCapture(event.pointerId)
+    ) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
     const gesture = pointerGestureRef.current
     pointerGestureRef.current = null
 
@@ -474,27 +543,42 @@ export function PageSidebarLayout({
       root?.setAttribute('data-overdrag-motion', 'committing')
       root?.removeAttribute('data-overdrag-state')
       root?.style.setProperty('--oa-page-sidebar-overdrag', '0px')
+      armCollapseMotion()
       scheduleOverdragCleanup()
       // The shadcn primitive owns the threshold geometry. Calling collapse()
       // again here races its pointer-up settlement and can overwrite the
       // primitive's remembered expanded layout.
       finishUserResize()
+      scheduleExpandedLayoutRepair()
       return
     }
 
+    disarmCollapseMotion()
     returnFromOverdrag()
     finishUserResize()
+    scheduleExpandedLayoutRepair()
   }, [
+    armCollapseMotion,
+    disarmCollapseMotion,
     finishUserResize,
     returnFromOverdrag,
+    scheduleExpandedLayoutRepair,
     scheduleOverdragCleanup,
   ])
 
-  const cancelPointerResize = useCallback(() => {
+  const cancelPointerResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (
+      typeof event.currentTarget.hasPointerCapture === 'function' &&
+      event.currentTarget.hasPointerCapture(event.pointerId)
+    ) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
     pointerGestureRef.current = null
+    disarmCollapseMotion()
     returnFromOverdrag()
     finishUserResize()
-  }, [finishUserResize, returnFromOverdrag])
+    scheduleExpandedLayoutRepair()
+  }, [disarmCollapseMotion, finishUserResize, returnFromOverdrag, scheduleExpandedLayoutRepair])
 
   const collapseSidebar = useCallback(() => {
     clearOverdragMotion()
@@ -532,11 +616,26 @@ export function PageSidebarLayout({
     if (panel.isCollapsed() || Math.abs(currentWidth - targetWidth) > 1) {
       panel.resize(targetWidth)
     }
-  }, [collapsed, containerWidth, contentMinWidth, isDesktop, maxWidth])
+  }, [collapsed, containerWidth, contentMinWidth, isDesktop, layoutEpoch, maxWidth])
 
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
   }, [isDesktop])
+
+  useEffect(() => {
+    if (!isDesktop || typeof ResizeObserver === 'undefined') return
+    const navigator = navigatorElementRef.current
+    const content = contentElementRef.current
+    if (!navigator || !content) return
+
+    // The primitive's onResize callback is store-driven. Observe the actual
+    // flex items as an independent invariant boundary so a stale DOM write can
+    // never remain full-screen merely because the store reports a valid size.
+    const observer = new ResizeObserver(scheduleExpandedLayoutRepair)
+    observer.observe(navigator)
+    observer.observe(content)
+    return () => observer.disconnect()
+  }, [isDesktop, layoutEpoch, scheduleExpandedLayoutRepair])
 
   useEffect(() => () => {
     if (layoutRepairFrameRef.current !== null) {
@@ -565,7 +664,7 @@ export function PageSidebarLayout({
     const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [isDesktop])
+  }, [isDesktop, layoutEpoch])
 
   const desktopActions = (
     <>
@@ -591,6 +690,7 @@ export function PageSidebarLayout({
   if (isDesktop) {
     return (
       <ResizablePanelGroup
+        key={layoutEpoch}
         id={`page-sidebar-${storageKey}`}
         elementRef={rootRef}
         orientation="horizontal"
@@ -606,8 +706,9 @@ export function PageSidebarLayout({
           id={navigatorPanelId}
           data-page-sidebar-panel="navigator"
           data-collapse-state={collapsed ? 'collapsed' : 'expanded'}
+          elementRef={navigatorElementRef}
           panelRef={sidebarPanelRef}
-          defaultSize={collapsed ? COLLAPSED_WIDTH : width}
+          defaultSize={groupDefaultSizeRef.current}
           minSize={MIN_WIDTH}
           maxSize={maxWidth}
           collapsedSize={COLLAPSED_WIDTH}
@@ -680,6 +781,7 @@ export function PageSidebarLayout({
         <ResizablePanel
           id={`page-sidebar-${storageKey}-content`}
           data-page-sidebar-panel="content"
+          elementRef={contentElementRef}
           minSize={contentMinWidth}
           groupResizeBehavior="preserve-relative-size"
           className="min-h-0 min-w-0"

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -161,6 +161,7 @@ export function PageSidebarLayout({
   const userResizeChangedRef = useRef(false)
   const collapseMotionTimerRef = useRef<number | null>(null)
   const overdragMotionTimerRef = useRef<number | null>(null)
+  const layoutRepairFrameRef = useRef<number | null>(null)
   const pointerGestureRef = useRef<{
     pointerId: number
     startX: number
@@ -173,7 +174,6 @@ export function PageSidebarLayout({
   const navigatorPanelId = `page-sidebar-${storageKey}-navigator`
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(() => readStoredCollapsed(storageKey))
-  const [pointerCollapseRequested, setPointerCollapseRequested] = useState(false)
   const collapsedRef = useRef(collapsed)
   const [preferredWidth, setPreferredWidth] = useState(() =>
     readStoredWidth(storageKey, clampWidth(defaultWidth, defaultWidth)),
@@ -222,6 +222,23 @@ export function PageSidebarLayout({
     window.localStorage.setItem(collapsedStorageName(storageKey), next ? '1' : '0')
   }, [storageKey])
 
+  const scheduleExpandedLayoutRepair = useCallback(() => {
+    if (layoutRepairFrameRef.current !== null) return
+    layoutRepairFrameRef.current = window.requestAnimationFrame(() => {
+      layoutRepairFrameRef.current = null
+      const panel = sidebarPanelRef.current
+      const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
+      if (!panel || panel.isCollapsed() || groupWidth <= RESIZE_SEPARATOR_WIDTH) return
+      const currentWidth = panel.getSize().inPixels
+      const invalidLayout =
+        currentWidth < MIN_WIDTH - 1 ||
+        currentWidth > maxWidth + 1 ||
+        groupWidth - RESIZE_SEPARATOR_WIDTH - currentWidth < contentMinWidth - 1
+      if (!invalidLayout) return
+      panel.resize(Math.min(latestWidthRef.current, maxWidth))
+    })
+  }, [contentMinWidth, maxWidth])
+
   const handleSidebarResize = useCallback((size: PanelSize) => {
     const nextCollapsed = size.inPixels <= COLLAPSED_WIDTH + 1
     // Applied panel geometry is the source of truth for which surface is
@@ -229,15 +246,53 @@ export function PageSidebarLayout({
     // enlarged virtual hit region rather than on the one-pixel Separator DOM
     // node, so interaction bookkeeping must never gate this synchronization.
     updateCollapsed(nextCollapsed)
+    // Constraint re-registration may write a stale one-panel layout after the
+    // group's own settled-layout callback has already fired. The Panel
+    // ResizeObserver is the last reliable boundary for that delayed write.
+    if (!nextCollapsed) {
+      const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
+      const invalidLayout = groupWidth > RESIZE_SEPARATOR_WIDTH && (
+        size.inPixels < MIN_WIDTH - 1 ||
+        size.inPixels > maxWidth + 1 ||
+        groupWidth - RESIZE_SEPARATOR_WIDTH - size.inPixels < contentMinWidth - 1
+      )
+      if (invalidLayout) scheduleExpandedLayoutRepair()
+    }
     if (userResizeIntentRef.current) {
       userResizeChangedRef.current = true
     }
-  }, [updateCollapsed])
+  }, [contentMinWidth, maxWidth, scheduleExpandedLayoutRepair, updateCollapsed])
 
   const handleLayoutChanged = useCallback((layout: Layout) => {
-    if (!userResizeIntentRef.current) return
     const panel = sidebarPanelRef.current
-    if (!panel || panel.isCollapsed()) {
+    if (!panel) return
+
+    const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
+    const percentage = layout[navigatorPanelId]
+    const settledPixels = groupWidth > RESIZE_SEPARATOR_WIDTH && Number.isFinite(percentage)
+      ? ((groupWidth - RESIZE_SEPARATOR_WIDTH) * percentage) / 100
+      : panel.getSize().inPixels
+    const appliedCollapsed = panel.isCollapsed()
+
+    // react-resizable-panels re-registers a Panel when a pixel constraint
+    // changes. During that registration window it can briefly settle a
+    // one-panel layout at 100%, even though the rebuilt separator still
+    // advertises the correct max. Never persist that impossible geometry.
+    // Restore the product preference after registration has settled instead.
+    const invalidExpandedLayout = !appliedCollapsed && (
+      settledPixels < MIN_WIDTH - 1 ||
+      settledPixels > maxWidth + 1 ||
+      groupWidth - RESIZE_SEPARATOR_WIDTH - settledPixels < contentMinWidth - 1
+    )
+    if (invalidExpandedLayout) {
+      userResizeIntentRef.current = false
+      userResizeChangedRef.current = false
+      scheduleExpandedLayoutRepair()
+      return
+    }
+
+    if (!userResizeIntentRef.current) return
+    if (appliedCollapsed) {
       userResizeIntentRef.current = false
       userResizeChangedRef.current = false
       return
@@ -247,16 +302,11 @@ export function PageSidebarLayout({
     // layout map is already authoritative; convert its percentage using the
     // measured group budget and keep the imperative size as a cancellation
     // fallback only.
-    const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
-    const percentage = layout[navigatorPanelId]
-    const settledPixels = groupWidth > RESIZE_SEPARATOR_WIDTH && Number.isFinite(percentage)
-      ? ((groupWidth - RESIZE_SEPARATOR_WIDTH) * percentage) / 100
-      : panel.getSize().inPixels
     const nextWidth = clampWidth(settledPixels, MIN_WIDTH)
     commitPreferredWidth(nextWidth)
     userResizeIntentRef.current = false
     userResizeChangedRef.current = false
-  }, [commitPreferredWidth, navigatorPanelId])
+  }, [commitPreferredWidth, contentMinWidth, maxWidth, navigatorPanelId, scheduleExpandedLayoutRepair])
 
   const beginUserResize = useCallback(() => {
     userResizeIntentRef.current = true
@@ -271,17 +321,39 @@ export function PageSidebarLayout({
     rootRef.current?.removeAttribute('data-collapse-motion')
   }, [])
 
-  const clearOverdragMotion = useCallback(() => {
+  const cancelOverdragCleanup = useCallback(() => {
     if (overdragMotionTimerRef.current !== null) {
       window.clearTimeout(overdragMotionTimerRef.current)
       overdragMotionTimerRef.current = null
     }
+  }, [])
+
+  const clearOverdragMotion = useCallback(() => {
+    cancelOverdragCleanup()
     const root = rootRef.current
     if (!root) return
     root.removeAttribute('data-overdrag-motion')
     root.removeAttribute('data-overdrag-state')
     root.style.removeProperty('--oa-page-sidebar-overdrag')
-  }, [])
+  }, [cancelOverdragCleanup])
+
+  const interruptOverdragMotion = useCallback(() => {
+    cancelOverdragCleanup()
+    const root = rootRef.current
+    const navigator = root?.querySelector<HTMLElement>('[data-page-sidebar-panel="navigator"]')
+    const handle = resizeHandleRef.current
+    if (!root || !navigator || !handle) return
+    // Freeze the currently painted spring position before removing its
+    // transition. Snapping the handle back under an active pointer can cancel
+    // pointer capture, which made an immediately repeated drag lose resistance.
+    const visualOffset = Math.max(
+      0,
+      navigator.getBoundingClientRect().right - handle.getBoundingClientRect().left,
+    )
+    root.style.setProperty('--oa-page-sidebar-overdrag', `${visualOffset.toFixed(3)}px`)
+    root.removeAttribute('data-overdrag-motion')
+    root.removeAttribute('data-overdrag-state')
+  }, [cancelOverdragCleanup])
 
   const scheduleOverdragCleanup = useCallback(() => {
     if (overdragMotionTimerRef.current !== null) {
@@ -319,16 +391,19 @@ export function PageSidebarLayout({
     const hitSlop = Math.max(0, (targetSize - rect.width) / 2)
     if (event.clientX < rect.left - hitSlop || event.clientX > rect.right + hitSlop) return
     beginUserResize()
+    // A return/commit cleanup from the previous gesture must not be allowed to
+    // erase the next gesture. This is also required when the next gesture
+    // starts from the collapsed rail and re-opens the panel.
+    interruptOverdragMotion()
     const panel = sidebarPanelRef.current
     if (!panel || panel.isCollapsed()) return
-    clearOverdragMotion()
     pointerGestureRef.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
       startWidth: panel.getSize().inPixels,
       rawOverdrag: 0,
     }
-  }, [beginUserResize, clearOverdragMotion])
+  }, [beginUserResize, interruptOverdragMotion])
 
   const updatePointerOverdrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     const gesture = pointerGestureRef.current
@@ -347,10 +422,8 @@ export function PageSidebarLayout({
 
     if (shouldCollapsePageSidebar(rawOverdrag)) {
       root.setAttribute('data-overdrag-state', 'armed')
-      root.setAttribute('data-overdrag-motion', 'committing')
       root.style.setProperty('--oa-page-sidebar-overdrag', '0px')
       armCollapseMotion()
-      scheduleOverdragCleanup()
       return
     }
 
@@ -397,12 +470,15 @@ export function PageSidebarLayout({
     pointerGestureRef.current = null
 
     if (gesture && shouldCollapsePageSidebar(gesture.rawOverdrag)) {
-      userResizeIntentRef.current = false
-      userResizeChangedRef.current = false
-      // The primitive normally commits at the same midpoint. Keep an
-      // imperative fallback for coarse rounding, but let pointer-up settlement
-      // finish first so it cannot overwrite that fallback.
-      setPointerCollapseRequested(true)
+      const root = rootRef.current
+      root?.setAttribute('data-overdrag-motion', 'committing')
+      root?.removeAttribute('data-overdrag-state')
+      root?.style.setProperty('--oa-page-sidebar-overdrag', '0px')
+      scheduleOverdragCleanup()
+      // The shadcn primitive owns the threshold geometry. Calling collapse()
+      // again here races its pointer-up settlement and can overwrite the
+      // primitive's remembered expanded layout.
+      finishUserResize()
       return
     }
 
@@ -411,6 +487,7 @@ export function PageSidebarLayout({
   }, [
     finishUserResize,
     returnFromOverdrag,
+    scheduleOverdragCleanup,
   ])
 
   const cancelPointerResize = useCallback(() => {
@@ -420,67 +497,52 @@ export function PageSidebarLayout({
   }, [finishUserResize, returnFromOverdrag])
 
   const collapseSidebar = useCallback(() => {
-    updateCollapsed(true)
+    clearOverdragMotion()
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       sidebarPanelRef.current?.collapse()
+      updateCollapsed(true)
       return
     }
     armCollapseMotion()
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => sidebarPanelRef.current?.collapse())
-    })
-  }, [armCollapseMotion, updateCollapsed])
+    sidebarPanelRef.current?.collapse()
+    updateCollapsed(true)
+  }, [armCollapseMotion, clearOverdragMotion, updateCollapsed])
 
   const expandSidebar = useCallback(() => {
     const targetWidth = Math.min(latestWidthRef.current, maxWidth)
-    updateCollapsed(false)
-    sidebarPanelRef.current?.expand()
+    disarmCollapseMotion()
+    clearOverdragMotion()
+    // resize() expands a collapsed primitive and restores the exact persisted
+    // pixel preference in one transaction. expand()+resize() creates two
+    // competing layouts and can poison the next collapse cycle.
     sidebarPanelRef.current?.resize(targetWidth)
-  }, [maxWidth, updateCollapsed])
+    updateCollapsed(false)
+  }, [clearOverdragMotion, disarmCollapseMotion, maxWidth, updateCollapsed])
 
   useLayoutEffect(() => {
-    if (!isDesktop || containerWidth <= 0 || !collapsed) return
-    sidebarPanelRef.current?.collapse()
-  }, [collapsed, containerWidth, isDesktop])
-
-  useLayoutEffect(() => {
-    if (!isDesktop || containerWidth <= 0 || collapsed || userResizeIntentRef.current) return
-    sidebarPanelRef.current?.resize(Math.min(latestWidthRef.current, maxWidth))
-  }, [collapsed, containerWidth, isDesktop, maxWidth])
+    if (!isDesktop || containerWidth <= 0 || userResizeIntentRef.current) return
+    const panel = sidebarPanelRef.current
+    if (!panel) return
+    if (collapsed) {
+      if (!panel.isCollapsed()) panel.collapse()
+      return
+    }
+    const targetWidth = Math.min(latestWidthRef.current, maxWidth)
+    const currentWidth = panel.getSize().inPixels
+    if (panel.isCollapsed() || Math.abs(currentWidth - targetWidth) > 1) {
+      panel.resize(targetWidth)
+    }
+  }, [collapsed, containerWidth, contentMinWidth, isDesktop, maxWidth])
 
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
   }, [isDesktop])
 
-  useEffect(() => {
-    if (!pointerCollapseRequested) return
-    setPointerCollapseRequested(false)
-    const root = rootRef.current
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      clearOverdragMotion()
-      window.setTimeout(() => sidebarPanelRef.current?.collapse(), 0)
-      return
-    }
-    root?.setAttribute('data-overdrag-motion', 'committing')
-    root?.removeAttribute('data-overdrag-state')
-    root?.style.setProperty('--oa-page-sidebar-overdrag', '0px')
-    armCollapseMotion()
-    scheduleOverdragCleanup()
-    // A macrotask boundary guarantees that the primitive's pointer-up
-    // settlement finishes before the rounding fallback runs.
-    window.setTimeout(() => {
-      window.requestAnimationFrame(() => {
-        window.requestAnimationFrame(() => sidebarPanelRef.current?.collapse())
-      })
-    }, 0)
-  }, [
-    armCollapseMotion,
-    clearOverdragMotion,
-    pointerCollapseRequested,
-    scheduleOverdragCleanup,
-  ])
-
   useEffect(() => () => {
+    if (layoutRepairFrameRef.current !== null) {
+      window.cancelAnimationFrame(layoutRepairFrameRef.current)
+      layoutRepairFrameRef.current = null
+    }
     disarmCollapseMotion()
     clearOverdragMotion()
   }, [clearOverdragMotion, disarmCollapseMotion])

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -15,6 +15,7 @@ const MIN_WIDTH = 200
 const MAX_WIDTH = 420
 const MAIN_PANE_MIN_WIDTH = 500
 const COLLAPSED_WIDTH = 44
+const RESIZE_SEPARATOR_WIDTH = 1
 function clampWidth(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
   return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Math.round(value)))
@@ -40,15 +41,40 @@ function readStoredCollapsed(storageKey: string): boolean {
   return window.localStorage.getItem(collapsedStorageName(storageKey)) === '1'
 }
 
-function responsiveMaxWidth(containerWidth: number): number {
-  if (!Number.isFinite(containerWidth) || containerWidth <= 0) return MAX_WIDTH
+export function calculatePageSidebarConstraints(containerWidth: number): {
+  navigatorMaxWidth: number
+  contentMinWidth: number
+} {
+  if (!Number.isFinite(containerWidth) || containerWidth <= 0) {
+    return {
+      navigatorMaxWidth: MAX_WIDTH,
+      contentMinWidth: 0,
+    }
+  }
+
+  const panelBudget = Math.max(0, Math.floor(containerWidth) - RESIZE_SEPARATOR_WIDTH)
   const ratio =
     containerWidth < 900 ? 0.30 :
       containerWidth < 1180 ? 0.34 :
         0.36
   const proportional = Math.floor(containerWidth * ratio)
-  const reserveMain = Math.floor(containerWidth - MAIN_PANE_MIN_WIDTH)
-  return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, proportional, reserveMain))
+  const reserveMain = panelBudget - MAIN_PANE_MIN_WIDTH
+  const navigatorMaxWidth = Math.max(
+    MIN_WIDTH,
+    Math.min(MAX_WIDTH, proportional, reserveMain),
+  )
+
+  // The former flex layout reserved 500px for content only when the container
+  // had enough room. Below that point the navigator kept its 200px minimum and
+  // content received the remainder. Keep the two panel constraints feasible at
+  // every desktop width instead of asking the resizable group to satisfy two
+  // contradictory hard minimums.
+  const contentMinWidth = Math.max(
+    0,
+    Math.min(MAIN_PANE_MIN_WIDTH, panelBudget - MIN_WIDTH),
+  )
+
+  return { navigatorMaxWidth, contentMinWidth }
 }
 
 function useIsDesktop(minWidth: number): boolean {
@@ -103,7 +129,6 @@ export function PageSidebarLayout({
   const isAppDesktop = useIsDesktop(768)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const sidebarPanelRef = useRef<PanelImperativeHandle | null>(null)
-  const widthPersistTimerRef = useRef<number | null>(null)
   const userResizeRef = useRef(false)
   const mobileTriggerRef = useRef<HTMLButtonElement | null>(null)
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null)
@@ -115,10 +140,15 @@ export function PageSidebarLayout({
     readStoredWidth(storageKey, clampWidth(defaultWidth, defaultWidth)),
   )
   const latestWidthRef = useRef(preferredWidth)
-  const [containerWidth, setContainerWidth] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth : 0,
-  )
-  const maxWidth = responsiveMaxWidth(containerWidth)
+  // The page-owned group is narrower than window.innerWidth because the app
+  // rail remains outside it. Wait for the real group measurement before
+  // applying responsive constraints; using the viewport here can briefly make
+  // the panel minimums impossible and poison the group's restored layout.
+  const [containerWidth, setContainerWidth] = useState(0)
+  const {
+    navigatorMaxWidth: maxWidth,
+    contentMinWidth,
+  } = calculatePageSidebarConstraints(containerWidth)
   const width = Math.min(preferredWidth, maxWidth)
   const closeMobileDrawer = useCallback(() => setDrawerOpen(false), [])
   const openMobileDrawer = useCallback(() => setDrawerOpen(true), [])
@@ -141,26 +171,9 @@ export function PageSidebarLayout({
   }, [storageKey])
 
   const commitPreferredWidth = useCallback((next: number) => {
-    if (widthPersistTimerRef.current !== null) {
-      window.clearTimeout(widthPersistTimerRef.current)
-      widthPersistTimerRef.current = null
-    }
     latestWidthRef.current = next
     setPreferredWidth(next)
     persistWidth(next)
-  }, [persistWidth])
-
-  const queuePreferredWidth = useCallback((next: number) => {
-    latestWidthRef.current = next
-    if (widthPersistTimerRef.current !== null) {
-      window.clearTimeout(widthPersistTimerRef.current)
-    }
-    widthPersistTimerRef.current = window.setTimeout(() => {
-      widthPersistTimerRef.current = null
-      userResizeRef.current = false
-      setPreferredWidth(next)
-      persistWidth(next)
-    }, 150)
   }, [persistWidth])
 
   const updateCollapsed = useCallback((next: boolean) => {
@@ -175,15 +188,18 @@ export function PageSidebarLayout({
     if (userResizeRef.current) {
       updateCollapsed(nextCollapsed)
       if (!nextCollapsed) {
-        queuePreferredWidth(clampWidth(size.inPixels, MIN_WIDTH))
+        latestWidthRef.current = clampWidth(size.inPixels, MIN_WIDTH)
       }
     }
-  }, [queuePreferredWidth, updateCollapsed])
+  }, [updateCollapsed])
 
   const handleLayoutChanged = useCallback(() => {
     if (!userResizeRef.current) return
     const panel = sidebarPanelRef.current
-    if (!panel || panel.isCollapsed()) return
+    if (!panel || panel.isCollapsed()) {
+      userResizeRef.current = false
+      return
+    }
     const nextWidth = clampWidth(panel.getSize().inPixels, MIN_WIDTH)
     commitPreferredWidth(nextWidth)
     userResizeRef.current = false
@@ -211,20 +227,14 @@ export function PageSidebarLayout({
   }, [maxWidth, updateCollapsed])
 
   useLayoutEffect(() => {
-    if (!isDesktop || !collapsed) return
+    if (!isDesktop || containerWidth <= 0 || !collapsed) return
     sidebarPanelRef.current?.collapse()
-  }, [collapsed, isDesktop])
+  }, [collapsed, containerWidth, isDesktop])
 
   useLayoutEffect(() => {
-    if (!isDesktop || collapsed || userResizeRef.current) return
+    if (!isDesktop || containerWidth <= 0 || collapsed || userResizeRef.current) return
     sidebarPanelRef.current?.resize(Math.min(latestWidthRef.current, maxWidth))
-  }, [collapsed, isDesktop, maxWidth])
-
-  useEffect(() => () => {
-    if (widthPersistTimerRef.current !== null) {
-      window.clearTimeout(widthPersistTimerRef.current)
-    }
-  }, [])
+  }, [collapsed, containerWidth, isDesktop, maxWidth])
 
   useEffect(() => {
     if (isDesktop) setDrawerOpen(false)
@@ -284,7 +294,7 @@ export function PageSidebarLayout({
         <ResizablePanel
           id={`page-sidebar-${storageKey}-navigator`}
           panelRef={sidebarPanelRef}
-          defaultSize={width}
+          defaultSize={collapsed ? COLLAPSED_WIDTH : width}
           minSize={MIN_WIDTH}
           maxSize={maxWidth}
           collapsedSize={COLLAPSED_WIDTH}
@@ -357,7 +367,7 @@ export function PageSidebarLayout({
         />
         <ResizablePanel
           id={`page-sidebar-${storageKey}-content`}
-          minSize={MAIN_PANE_MIN_WIDTH}
+          minSize={contentMinWidth}
           groupResizeBehavior="preserve-relative-size"
           className="min-h-0 min-w-0"
         >

--- a/ui/src/components/ui/resizable.tsx
+++ b/ui/src/components/ui/resizable.tsx
@@ -1,0 +1,48 @@
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "relative flex w-px items-center justify-center bg-border ring-offset-background after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border" />
+      )}
+    </ResizablePrimitive.Separator>
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -767,6 +767,7 @@ export const en = {
     testConnection: 'Test connection',
     collapsePanel: 'Collapse {{title}}',
     openPanel: 'Open {{title}}',
+    resizePanel: 'Resize {{title}}',
     closePanel: 'Close {{title}}',
     focusContent: 'Focus content',
     moreActions: 'More actions for {{target}}',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -756,6 +756,7 @@ export const ja: Resources = {
     testConnection: '接続をテスト',
     collapsePanel: '{{title}}を折りたたむ',
     openPanel: '{{title}}を開く',
+    resizePanel: '{{title}}の幅を調整',
     closePanel: '{{title}}を閉じる',
     focusContent: 'コンテンツに集中',
     moreActions: '{{target}}のその他の操作',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -763,6 +763,7 @@ export const zhHant: Resources = {
     testConnection: '測試連線',
     collapsePanel: '收合{{title}}',
     openPanel: '開啟{{title}}',
+    resizePanel: '調整{{title}}寬度',
     closePanel: '關閉{{title}}',
     focusContent: '聚焦內容區',
     moreActions: '{{target}}的更多操作',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -755,6 +755,7 @@ export const zh: Resources = {
     testConnection: '测试连接',
     collapsePanel: '收起{{title}}',
     openPanel: '打开{{title}}',
+    resizePanel: '调整{{title}}宽度',
     closePanel: '关闭{{title}}',
     focusContent: '聚焦内容区',
     moreActions: '{{target}}的更多操作',

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -353,6 +353,15 @@ body {
   animation: oa-backdrop-enter var(--motion-standard) ease-out both;
 }
 
+/* Keep direct pointer resizing attached to the cursor, then soften only the
+   primitive's discrete 200px -> 44px collapse snap. Panel classes are applied
+   to react-resizable-panels' nested content element, so this rule deliberately
+   targets the direct flex item from the product-owned group seam. */
+.oa-page-sidebar-resizable[data-collapse-motion="armed"]
+  > [data-panel][data-collapse-state] {
+  transition: flex-grow var(--motion-standard) var(--motion-ease-out);
+}
+
 /* Page-owned navigators become touch surfaces inside the phone drawer.
    A 40px height floor removes the old 18–28px rows; icon controls keep 36px
    of horizontal room so adjacent workspace names remain distinguishable. */

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -362,6 +362,47 @@ body {
   transition: flex-grow var(--motion-standard) var(--motion-ease-out);
 }
 
+/* The expanded navigator keeps a hard 200px layout floor. Pointer travel past
+   that floor is represented as a damped, clipped overdrag: content retains its
+   layout width, the separator follows the resisted edge, and the working pane
+   shifts only for the duration of the gesture. Releasing before the commit
+   boundary uses a deliberately light spring; a committed gesture blends this
+   offset back into the primitive-owned 200px -> 44px collapse. */
+.oa-page-sidebar-resizable {
+  --oa-page-sidebar-overdrag: 0px;
+}
+
+.oa-page-sidebar-resizable > [data-page-sidebar-panel="navigator"] {
+  clip-path: inset(0 var(--oa-page-sidebar-overdrag) 0 0);
+}
+
+.oa-page-sidebar-resizable > [data-slot="resizable-handle"],
+.oa-page-sidebar-resizable > [data-page-sidebar-panel="content"] {
+  transform: translateX(calc(-1 * var(--oa-page-sidebar-overdrag)));
+}
+
+.oa-page-sidebar-resizable[data-overdrag-motion]
+  > [data-page-sidebar-panel="navigator"] {
+  transition: clip-path 240ms cubic-bezier(0.2, 1.3, 0.35, 1);
+}
+
+.oa-page-sidebar-resizable[data-overdrag-motion]
+  > [data-slot="resizable-handle"],
+.oa-page-sidebar-resizable[data-overdrag-motion]
+  > [data-page-sidebar-panel="content"] {
+  transition: transform 240ms cubic-bezier(0.2, 1.3, 0.35, 1);
+}
+
+.oa-page-sidebar-resizable[data-overdrag-state="resisting"]
+  > [data-slot="resizable-handle"] {
+  background-color: color-mix(in srgb, var(--primary) 48%, var(--border));
+}
+
+.oa-page-sidebar-resizable[data-overdrag-state="armed"]
+  > [data-slot="resizable-handle"] {
+  background-color: color-mix(in srgb, var(--primary) 78%, var(--border));
+}
+
 /* Page-owned navigators become touch surfaces inside the phone drawer.
    A 40px height floor removes the old 18–28px rows; icon controls keep 36px
    of horizontal room so adjacent workspace names remain distinguishable. */


### PR DESCRIPTION
## Summary

- adds the official shadcn `base-nova` Resizable primitive on top of the existing `react-resizable-panels` dependency
- recomposes the shared desktop `PageSidebarLayout` as two panels with one semantic separator
- preserves the existing pixel-width and focus-mode storage keys, responsive caps, 44px collapse/restore, and mobile Sheet hierarchy
- derives feasible navigator/content constraints from the measured split group rather than the wider browser window
- makes applied panel geometry authoritative for the expanded/collapsed interactive surface
- captures pointer intent across the primitive's complete fine/coarse hit region and persists keyboard width from the settled layout map
- adds spatial collapse motion plus a damped overdrag below the 200px expanded minimum

## Why

The old page sidebar rendered an outer border plus a second centered rule inside a custom resize column. Its focusable separator had no keyboard resizing and each shell consumer inherited bespoke document-level drag plumbing.

The migration exposed two responsive failures. First, a 200px navigator minimum plus an unconditional 500px content minimum could become impossible after app-shell chrome was removed from the available width, producing a navigator `100%` / content `0%` layout. Second, the primitive could correctly collapse the navigator to 44px while product state remained `expanded`, squeezing the full navigator into the collapsed rail.

The adapter now keeps primitive-applied geometry, the interactive product surface, and the last settled user preference separate. Responsive caps do not overwrite the wider preference. Above 200px direct resizing stays cursor-attached. Below 200px, the panel and its internal content keep their layout width while the edge shows bounded exponential resistance. Release before the primitive's native 78px midpoint springs back; crossing that single boundary blends into the existing 200px-to-44px collapse.

## Included increments

- [x] Replace the custom resize rail with the checked-in shadcn Resizable primitive
- [x] Preserve focus mode, mobile Sheet behavior, accessibility, and existing preference keys
- [x] Make measured constraints feasible across the desktop range
- [x] Synchronize `data-state`, `aria-hidden`, and `inert` from applied geometry on every resize
- [x] Cover the 10px fine-pointer and 28px coarse-pointer virtual hit regions from the split-group capture boundary
- [x] Persist keyboard changes from the settled layout rather than the previous pre-paint DOM width
- [x] Animate the minimum-to-collapsed snap with shared motion and reduced-motion semantics
- [x] Add resisted overdrag without dynamically replacing the primitive's collapse metadata
- [x] Add state-transition, preference-isolation, overdrag, cancel, commit, and reduced-motion regression coverage

## Product impact

Chat, AutoQuant, Inbox, Tracked, Market, Portfolio, Automation, Settings, Workspaces, and Dev Panel share one accessible resize boundary. A 44px panel exposes only the collapsed rail; an expanded surface never lays out below 200px. The user can pull beyond that floor with increasing resistance, release to spring back, or deliberately cross the native collapse boundary. Internal labels and controls are clipped transiently rather than squeezed into a narrower layout.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- focused sidebar suite: 2 files, 19 tests passed
- `pnpm test` — 488 files, 4021 passing tests, 9 skipped
- `cd ui && pnpm build`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- live state round trip: collapse -> 44px -> reload 44px -> Expand 200px -> button collapse 44px
- live route invariant walk from the structural increment: Chat, Inbox, Tracked, Settings, AutoQuant, and Automation Runs each had one separator and exactly one interactive surface
- pre-motion browser sampling jumped directly from 200px to 44px; the spatial curve now settles through 128 -> 94 -> 72 -> 59 -> 52 -> 48 -> 46 -> 45 -> 44px
- live held-pointer measurement: raw 40px overdrag -> 22.133px visual movement while primitive and internal content both stayed 200px
- live return trajectory: 338.63 -> 344.77 -> 350.78 -> 351.92px, one sub-pixel overshoot, then the 352px resting edge
- live commit trajectory across the native 78px midpoint: 128.13 -> 58.97 -> 47.61 -> 45.52 -> 44.13 -> 44px
- emulated reduced motion clears the transient overdrag immediately on release

## Boundary touch

- app-shell UI and local display preferences only
- no trading, auth, credential, migration, runtime, or persisted data-format changes

## Non-goals

- replacing OpenAlice's product Sidebar composition with the generic shadcn Sidebar block
- changing ActivityBar geometry, route hierarchy, mobile Sheet ownership, palettes, or information architecture
- migrating unrelated split panes

The checked-in shadcn layer owns separator pointer/touch/keyboard mechanics and the native collapse midpoint. `PageSidebarLayout` owns route content, measured-group responsive policy, collapse controls, OpenAlice preferences, and the damped visual overdrag.

Plan: `plans/shadcn-resizable-page-sidebar.md`
