### PR TITLE
fix(ui): restore page sidebar collapse controls

### DIFF
--- a/ui/src/components/PageSidebarLayout.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.spec.tsx
@@ -142,7 +142,7 @@ describe('PageSidebarLayout', () => {
     expect(document.activeElement).toBe(contextTrigger)
   })
 
-  it('persists the desktop focus mode and restores the full sidebar', () => {
+  it('persists the desktop focus mode and restores the full sidebar', async () => {
     window.localStorage.setItem('openalice.page-sidebar-width.market.v1', '312')
     const view = render(
       <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
@@ -165,7 +165,9 @@ describe('PageSidebarLayout', () => {
     expect(collapsedSurface.hasAttribute('inert')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
-    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('1')
+    await waitFor(() => {
+      expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('1')
+    })
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
     expect(desktopSidebar.getAttribute('data-state')).toBe('collapsed')
     expect(expandedSurface.hasAttribute('inert')).toBe(true)
@@ -181,7 +183,9 @@ describe('PageSidebarLayout', () => {
     expect(screen.getByRole('button', { name: 'Open Market' })).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Market' }))
-    expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('0')
+    await waitFor(() => {
+      expect(window.localStorage.getItem('openalice.page-sidebar-collapsed.market.v1')).toBe('0')
+    })
     expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('expanded')
     expect(screen.getByTestId('page-sidebar-expanded').hasAttribute('inert')).toBe(false)
     expect(screen.getByText('Market navigation')).toBeTruthy()

--- a/ui/src/components/PageSidebarLayout.state.spec.tsx
+++ b/ui/src/components/PageSidebarLayout.state.spec.tsx
@@ -153,9 +153,12 @@ vi.mock('@/components/ui/resizable', async () => {
         resizableHarness.resizeCalls++
         const parsed = typeof nextSize === 'number' ? nextSize : Number.parseFloat(nextSize)
         if (!Number.isFinite(parsed)) return
-        resizableHarness.navigatorSize = parsed
-        resizableHarness.navigatorCollapsed = parsed <= 45
-        onResize?.({ asPercentage: parsed / 10, inPixels: parsed })
+        const applied = isNavigator && resizableHarness.navigatorCollapsible && parsed < 200
+          ? 44
+          : parsed
+        resizableHarness.navigatorSize = applied
+        resizableHarness.navigatorCollapsed = applied <= 45
+        onResize?.({ asPercentage: applied / 10, inPixels: applied })
       },
     }), [onResize])
 
@@ -716,12 +719,14 @@ describe('PageSidebarLayout applied state', () => {
       </PageSidebarLayout>,
     )
 
+    const resizeCallsBeforeCollapse = resizableHarness.resizeCalls
     fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
 
     expect(requestAnimationFrame).not.toHaveBeenCalled()
     expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
     expect(resizableHarness.navigatorSize).toBe(44)
-    expect(resizableHarness.collapseCalls).toBe(1)
+    expect(resizableHarness.collapseCalls).toBe(0)
+    expect(resizableHarness.resizeCalls).toBe(resizeCallsBeforeCollapse + 1)
   })
 
   it('uses one geometry transaction per repeated collapse and restore cycle', async () => {
@@ -745,12 +750,36 @@ describe('PageSidebarLayout applied state', () => {
       expect(resizableHarness.navigatorSize).toBe(312)
     }
 
-    expect(resizableHarness.collapseCalls).toBe(8)
+    expect(resizableHarness.collapseCalls).toBe(0)
     expect(resizableHarness.expandCalls).toBe(0)
-    expect(resizableHarness.resizeCalls).toBe(8)
+    expect(resizableHarness.resizeCalls).toBe(16)
     expect(resizableHarness.groupMounts).toBe(1)
     expect(resizableHarness.navigatorDefaultSizes).toEqual([312])
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+  })
+
+  it('does not reopen after a collapsed percentage arrives with stale painted pixels', () => {
+    resizableHarness.navigatorSize = 312
+    render(
+      <PageSidebarLayout storageKey="market" title="Market" sidebar={<div>Market navigation</div>}>
+        <div>Market content</div>
+      </PageSidebarLayout>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+
+    // The primitive commits its percentage before the flex item paints. The
+    // callback can briefly pair the collapsed percentage with the previous
+    // expanded offsetWidth; percentage geometry must remain authoritative.
+    act(() => {
+      resizableHarness.onNavigatorResize?.({
+        asPercentage: (44 / (resizableHarness.groupWidth - 1)) * 100,
+        inPixels: 312,
+      })
+    })
+
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
   })
 
   it('repairs an impossible one-panel layout without persisting it', () => {
@@ -816,6 +845,12 @@ describe('PageSidebarLayout applied state', () => {
     expect(resizableHarness.navigatorSize).toBe(312)
     expect(resizableHarness.paintedNavigatorSize).toBeNull()
     expect(window.localStorage.getItem('openalice.page-sidebar-width.market.v1')).toBe('312')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Market' }))
+
+    expect(screen.getByTestId('page-sidebar-desktop').getAttribute('data-state')).toBe('collapsed')
+    expect(resizableHarness.navigatorSize).toBe(44)
+    expect(screen.getByTestId('page-sidebar-collapsed').textContent).toBe('')
   })
 
   it('clears pointer overdrag immediately when reduced motion is requested', () => {

--- a/ui/src/components/PageSidebarLayout.tsx
+++ b/ui/src/components/PageSidebarLayout.tsx
@@ -161,6 +161,7 @@ export function PageSidebarLayout({
   const resizeHandleRef = useRef<HTMLDivElement | null>(null)
   const userResizeIntentRef = useRef(false)
   const userResizeChangedRef = useRef(false)
+  const programmaticCollapseRef = useRef(false)
   const collapseMotionTimerRef = useRef<number | null>(null)
   const overdragMotionTimerRef = useRef<number | null>(null)
   const layoutRepairFrameRef = useRef<number | null>(null)
@@ -283,7 +284,24 @@ export function PageSidebarLayout({
   }, [layoutEpoch])
 
   const handleSidebarResize = useCallback((size: PanelSize) => {
-    const nextCollapsed = size.inPixels <= COLLAPSED_WIDTH + 1
+    const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
+    // react-resizable-panels publishes its percentage layout synchronously,
+    // before the browser paints the matching flex width. During an imperative
+    // collapse, `inPixels` can therefore still be the old expanded DOM width
+    // even though `asPercentage` already represents the 44px rail. Derive the
+    // applied logical width from the settled percentage so the product state
+    // cannot immediately bounce back to "expanded".
+    const logicalPixels = groupWidth > RESIZE_SEPARATOR_WIDTH && Number.isFinite(size.asPercentage)
+      ? ((groupWidth - RESIZE_SEPARATOR_WIDTH) * size.asPercentage) / 100
+      : size.inPixels
+    const nextCollapsed = logicalPixels <= COLLAPSED_WIDTH + 1
+    if (programmaticCollapseRef.current) {
+      // resize(0) may report several interpolated widths while it crosses the
+      // min-size gap. Keep the explicit collapse intent authoritative until
+      // the primitive reaches its configured collapsed size.
+      if (!nextCollapsed) return
+      programmaticCollapseRef.current = false
+    }
     // Applied panel geometry is the source of truth for which surface is
     // interactive. Pointer drags may begin inside react-resizable-panels'
     // enlarged virtual hit region rather than on the one-pixel Separator DOM
@@ -293,11 +311,10 @@ export function PageSidebarLayout({
     // group's own settled-layout callback has already fired. The Panel
     // ResizeObserver is the last reliable boundary for that delayed write.
     if (!nextCollapsed) {
-      const groupWidth = rootRef.current?.getBoundingClientRect().width ?? 0
       const invalidLayout = groupWidth > RESIZE_SEPARATOR_WIDTH && (
-        size.inPixels < MIN_WIDTH - 1 ||
-        size.inPixels > maxWidth + 1 ||
-        groupWidth - RESIZE_SEPARATOR_WIDTH - size.inPixels < contentMinWidth - 1
+        logicalPixels < MIN_WIDTH - 1 ||
+        logicalPixels > maxWidth + 1 ||
+        groupWidth - RESIZE_SEPARATOR_WIDTH - logicalPixels < contentMinWidth - 1
       )
       if (invalidLayout) scheduleExpandedLayoutRepair()
     }
@@ -582,17 +599,20 @@ export function PageSidebarLayout({
 
   const collapseSidebar = useCallback(() => {
     clearOverdragMotion()
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      sidebarPanelRef.current?.collapse()
-      updateCollapsed(true)
-      return
-    }
-    armCollapseMotion()
-    sidebarPanelRef.current?.collapse()
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (!reduceMotion) armCollapseMotion()
+
+    // Asking for zero crosses the primitive's collapse midpoint and lets it
+    // snap to the configured 44px collapsedSize. Its collapse() command can
+    // stop at minSize when pixel constraints are rounded during a recovered
+    // group lifecycle, which is what left the header button looking dead.
+    programmaticCollapseRef.current = true
     updateCollapsed(true)
+    sidebarPanelRef.current?.resize(0)
   }, [armCollapseMotion, clearOverdragMotion, updateCollapsed])
 
   const expandSidebar = useCallback(() => {
+    programmaticCollapseRef.current = false
     const targetWidth = Math.min(latestWidthRef.current, maxWidth)
     disarmCollapseMotion()
     clearOverdragMotion()
@@ -608,7 +628,7 @@ export function PageSidebarLayout({
     const panel = sidebarPanelRef.current
     if (!panel) return
     if (collapsed) {
-      if (!panel.isCollapsed()) panel.collapse()
+      if (!panel.isCollapsed()) panel.resize(0)
       return
     }
     const targetWidth = Math.min(latestWidthRef.current, maxWidth)
@@ -638,6 +658,7 @@ export function PageSidebarLayout({
   }, [isDesktop, layoutEpoch, scheduleExpandedLayoutRepair])
 
   useEffect(() => () => {
+    programmaticCollapseRef.current = false
     if (layoutRepairFrameRef.current !== null) {
       window.cancelAnimationFrame(layoutRepairFrameRef.current)
       layoutRepairFrameRef.current = null
@@ -753,12 +774,6 @@ export function PageSidebarLayout({
               >
                 <PanelLeftOpen size={16} strokeWidth={1.75} aria-hidden />
               </button>
-              <span
-                aria-hidden
-                className="mt-3 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground [writing-mode:vertical-rl] rotate-180"
-              >
-                {title}
-              </span>
             </aside>
           </div>
         </ResizablePanel>


### PR DESCRIPTION
## Summary
- make header collapse controls cross the resizable primitive's collapse threshold reliably
- keep programmatic collapse state stable while pixel geometry catches up with the committed percentage layout
- remove the reversed vertical title from the collapsed rail
- cover repeated cycles, stale painted pixels, recovered layouts, and reduced motion

Addresses #705.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (489 files passed, 1 skipped; 4047 tests passed, 9 skipped)
- real browser: 6 Ask Alice collapse/expand cycles and Inbox collapsed-rail check