### PR TITLE
Keep polled Markdown reports stable

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,9 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/static-markdown-content-stability.md]] — Keeps Inbox and Tracked
-  Markdown DOM stable across unchanged Workspace Manager and Inbox polling so
-  text selection, browser translation, and report interactions survive.
 - [[plans/electron-runtime-browser-handoff.md]] — Lets Electron detect a
   healthy dev/CLI Runtime already owning the selected data location and hand
   the user to its verified browser UI without takeover.
@@ -34,6 +31,10 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/static-markdown-content-stability.md]] — Keeps Inbox and Tracked
+  Markdown DOM stable across unchanged Workspace Manager and Inbox polling so
+  text selection, browser translation, and report interactions survive.
+  Delivered for topic review in Draft PR #1030.
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
   page-sidebar rail with shadcn Resizable and closed its responsive,
   threshold-motion, resisted-overdrag, repeat-cycle, and rapid-reversal

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,9 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/static-markdown-content-stability.md]] — Keeps Inbox and Tracked
+  Markdown DOM stable across unchanged Workspace Manager and Inbox polling so
+  text selection, browser translation, and report interactions survive.
 - [[plans/electron-runtime-browser-handoff.md]] — Lets Electron detect a
   healthy dev/CLI Runtime already owning the selected data location and hand
   the user to its verified browser UI without takeover.

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -64,6 +64,14 @@ fork Markdown parsing or recreate feature-local heading, list, table, quote, and
 code styles. Long documents remain the dominant page surface rather than being
 wrapped in a decorative card; surrounding shell chrome supplies the context.
 
+Treat the generated Markdown body as a stable DOM island. Live Workspace,
+Manager, Inbox, and provenance state may update the surrounding interaction
+layer, but an unchanged HTML string must preserve the existing report nodes so
+selection, browser translation, find-in-page, and extension annotations remain
+intact. Polling stores must reconcile identical JSON snapshots before
+publication, and content renderers that only need a Workspace action should use
+the action-only hook instead of subscribing to the complete Workspace state.
+
 ### Responsive Behavior
 
 Narrow layouts are a change in information hierarchy, not a compressed desktop.

--- a/plans/static-markdown-content-stability.md
+++ b/plans/static-markdown-content-stability.md
@@ -1,0 +1,97 @@
+# Static Markdown Content Stability
+
+Status: Active
+
+Related issue: [#712](https://github.com/TraderAlice/OpenAlice/issues/712)
+
+Owner guides: [[docs/project-structure.md]],
+[[docs/ui-interaction-and-motion.md]], and [[docs/development-workflow.md]].
+
+## Outcome
+
+Keep long-form Markdown reports stable while unrelated live Workspace and Inbox
+state refreshes. Selecting text, using browser translation, and interacting
+with rendered report content must not be interrupted by an unchanged polling
+response.
+
+## Acceptance Boundary
+
+- An identical Workspace Manager or Inbox history response preserves the
+  existing state and row identities.
+- An unrelated parent/context update does not replace the rendered Markdown
+  child DOM when the generated HTML is unchanged.
+- A real Markdown content change still updates the document immediately.
+- Session signatures, wikilinks, and code-copy actions retain their current
+  behavior.
+- Inbox and Tracked/file-viewer routes keep text selection and injected
+  browser/translation nodes intact across at least two polling intervals.
+
+## Non-goals
+
+- Replacing the complete Workspaces context with another state library.
+- Changing polling intervals or transport protocols.
+- Preserving a selection by recording and restoring DOM ranges after a rewrite.
+- Redesigning Markdown typography, report chrome, or Inbox information
+  hierarchy.
+- Proving third-party HTML report iframe stability beyond guarding the shared
+  Markdown paths covered by issue #712.
+
+## Decisions
+
+1. Treat identical server snapshots as no state change. Reuse one generic
+   JSON-only reconciliation helper for single snapshots and keyed collections;
+   do not maintain fragile per-field equality lists.
+2. Keep Inbox on the existing Zustand-backed `createLiveStore`. Reconcile its
+   history response before publishing so selectors receive stable identities.
+3. Keep Workspace Manager ownership in `WorkspacesProvider` for this topic,
+   but reconcile its three-second response before setting state. A full store
+   migration is independent architecture work.
+4. Split Markdown into an interaction owner and a memoized static HTML leaf.
+   Context/action changes may update event handlers, but unchanged generated
+   HTML must not be committed to `innerHTML` again.
+5. Test DOM node identity directly. Selection loss and browser translation
+   breakage are consequences of node replacement, so stable node identity is
+   the deterministic regression contract.
+
+## Work
+
+- [x] Add and test generic JSON snapshot/collection reconciliation.
+- [x] Reconcile Workspace Manager polling and Inbox history publication.
+- [x] Introduce a stable Markdown DOM leaf without forking parsing or styles.
+- [x] Add regression coverage for unchanged parent updates, injected DOM nodes,
+      and actual Markdown updates.
+- [x] Run required TypeScript and test gates.
+- [x] Reproduce the real Inbox and Tracked routes and verify DOM identity over
+      repeated polling intervals.
+- [ ] Publish one labeled Draft PR to `dev` and keep it open for topic review.
+
+## Verification
+
+```bash
+npx tsc --noEmit
+pnpm test
+cd ui && npx tsc -b
+```
+
+Focused checks additionally exercise the reconciliation helpers and Markdown
+render identity. Browser acceptance uses realistic Inbox and Tracked reports,
+not an empty/demo-only surface.
+
+Observed on 2026-08-09:
+
+- Tracked report DOM retained its root, first heading, and an injected
+  translation marker through seven Workspace/Manager polling responses with
+  zero child-list mutations.
+- Inbox message and expanded attachment DOM retained both injected markers
+  through two Inbox history polls and repeated Manager polls, again with zero
+  child-list mutations.
+- `npx tsc --noEmit`, `cd ui && npx tsc -b`, and the complete `pnpm test`
+  suite passed (492 files / 4057 tests passed; repository-declared skips
+  remained unchanged).
+
+## Completion
+
+The plan is complete when the acceptance boundary is covered by tests, real
+route observation shows no Markdown subtree replacement for unchanged polls,
+the required checks pass, and the Draft PR records exact verification and any
+residual HTML-iframe risk.

--- a/plans/static-markdown-content-stability.md
+++ b/plans/static-markdown-content-stability.md
@@ -1,6 +1,6 @@
 # Static Markdown Content Stability
 
-Status: Active
+Status: Completed
 
 Related issue: [#712](https://github.com/TraderAlice/OpenAlice/issues/712)
 
@@ -63,7 +63,7 @@ response.
 - [x] Run required TypeScript and test gates.
 - [x] Reproduce the real Inbox and Tracked routes and verify DOM identity over
       repeated polling intervals.
-- [ ] Publish one labeled Draft PR to `dev` and keep it open for topic review.
+- [x] Publish one labeled Draft PR to `dev` and keep it open for topic review.
 
 ## Verification
 
@@ -95,3 +95,7 @@ The plan is complete when the acceptance boundary is covered by tests, real
 route observation shows no Markdown subtree replacement for unchanged polls,
 the required checks pass, and the Draft PR records exact verification and any
 residual HTML-iframe risk.
+
+Completed in Draft PR
+[#1030](https://github.com/TraderAlice/OpenAlice/pull/1030). Arbitrary HTML
+report iframe stability remains an explicit non-goal of this topic.

--- a/ui/src/components/MarkdownContent.dom.spec.tsx
+++ b/ui/src/components/MarkdownContent.dom.spec.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { WorkspaceActionsContext } from '../contexts/workspace-actions-context'
+import { MarkdownContent } from './MarkdownContent'
+
+afterEach(cleanup)
+
+function Report({ text, actionVersion }: { text: string; actionVersion: number }) {
+  return (
+    <WorkspaceActionsContext.Provider
+      value={{
+        openHeadlessRun: vi.fn(async () => {
+          void actionVersion
+        }),
+      }}
+    >
+      <MarkdownContent text={text} variant="reading" onWikilink={vi.fn()} />
+    </WorkspaceActionsContext.Provider>
+  )
+}
+
+describe('MarkdownContent DOM stability', () => {
+  it('preserves report nodes and browser-injected annotations across unrelated updates', () => {
+    const text = '# Stable report\n\nA paragraph selected for translation.'
+    const view = render(<Report text={text} actionVersion={1} />)
+    const body = view.container.querySelector<HTMLElement>('.markdown-content')!
+    const heading = body.querySelector('h1')!
+    const annotation = document.createElement('span')
+    annotation.dataset.browserTranslation = 'true'
+    annotation.textContent = ' translated'
+    body.querySelector('p')!.appendChild(annotation)
+
+    view.rerender(<Report text={text} actionVersion={2} />)
+
+    expect(view.container.querySelector('.markdown-content')).toBe(body)
+    expect(view.container.querySelector('.markdown-content h1')).toBe(heading)
+    expect(view.container.querySelector('[data-browser-translation="true"]')).toBe(annotation)
+  })
+
+  it('replaces generated content when the Markdown actually changes', () => {
+    const view = render(<Report text="# First report" actionVersion={1} />)
+    const body = view.container.querySelector<HTMLElement>('.markdown-content')!
+    const firstHeading = body.querySelector('h1')!
+    const annotation = document.createElement('span')
+    annotation.dataset.browserTranslation = 'true'
+    body.appendChild(annotation)
+
+    view.rerender(<Report text="# Revised report" actionVersion={1} />)
+
+    expect(view.container.querySelector('.markdown-content')).toBe(body)
+    expect(body.querySelector('h1')).not.toBe(firstHeading)
+    expect(body.querySelector('h1')?.textContent).toBe('Revised report')
+    expect(body.querySelector('[data-browser-translation="true"]')).toBeNull()
+  })
+})

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -5,7 +5,7 @@
  * the same typography without inheriting chat chrome.
  */
 
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { Marked, type TokenizerAndRendererExtension } from 'marked'
 import { markedHighlight } from 'marked-highlight'
 import hljs from 'highlight.js'
@@ -13,7 +13,7 @@ import DOMPurify from 'dompurify'
 import 'highlight.js/styles/github-dark.min.css'
 
 import { useWikilinkHandler } from '../live/wikilink'
-import { useWorkspaces } from '../contexts/workspaces-context'
+import { useWorkspaceActions } from '../contexts/workspace-actions-context'
 import { resolveSessionSignature } from './workspace/api'
 
 function escapeHtml(s: string): string {
@@ -189,7 +189,7 @@ export function MarkdownContent({
 }: MarkdownContentProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const defaultWikilink = useWikilinkHandler()
-  const { openHeadlessRun } = useWorkspaces()
+  const { openHeadlessRun } = useWorkspaceActions()
   const wikilink = onWikilink ?? defaultWikilink
 
   const html = useMemo(() => {
@@ -245,10 +245,27 @@ export function MarkdownContent({
 
   return (
     <div ref={contentRef} className={className} data-markdown-variant={variant}>
-      <div
-        className={`markdown-content${variant === 'reading' ? ' markdown-content--reading' : ''}`}
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      <StaticMarkdownBody html={html} variant={variant} />
     </div>
   )
 }
+
+/**
+ * Keep browser-owned state inside an unchanged report intact. Selection,
+ * translation overlays, find-in-page markers, and extension annotations all
+ * live in this subtree; unrelated parent/context updates must not replace it.
+ */
+const StaticMarkdownBody = memo(function StaticMarkdownBody({
+  html,
+  variant,
+}: {
+  html: string
+  variant: NonNullable<MarkdownContentProps['variant']>
+}) {
+  return (
+    <div
+      className={`markdown-content${variant === 'reading' ? ' markdown-content--reading' : ''}`}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+})

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -19,6 +19,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useState,
   type ReactNode,
 } from 'react'
@@ -66,8 +67,14 @@ import {
 } from '../components/workspace/api'
 import { useWorkspace } from '../tabs/store'
 import type { WorkspaceSource } from '../tabs/types'
-import { WorkspacesContext, type SpawnOpts } from './workspaces-context'
+import {
+  WorkspacesContext,
+  type SpawnOpts,
+  type WorkspacesContextValue,
+} from './workspaces-context'
+import { WorkspaceActionsContext } from './workspace-actions-context'
 import { reconcileWorkspaceList } from './workspace-list-reconcile'
+import { reconcileJsonSnapshot } from '../lib/reconcile-json-state'
 
 const LIST_POLL_MS = 3000
 
@@ -132,7 +139,8 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
 
   const refreshWorkspaceManager = useCallback(async (): Promise<void> => {
     try {
-      setWorkspaceManager(await getWorkspaceManager())
+      const incoming = await getWorkspaceManager()
+      setWorkspaceManager((current) => reconcileJsonSnapshot(current, incoming))
       setWorkspaceManagerError(null)
     } catch (err) {
       setWorkspaceManagerError((err as Error).message)
@@ -602,6 +610,92 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     setPendingSessionDelete({ wsId, sessionId })
   }, [])
 
+  const openAgentConfig = useCallback((
+    wsId: string,
+    agent?: AgentId,
+    section?: 'general' | 'launch' | 'ai' | 'template' | 'absorb',
+  ): void => {
+    setConfiguringAgentTarget({
+      wsId,
+      ...(agent ? { agent } : {}),
+      ...(section ? { section } : {}),
+    })
+  }, [])
+
+  const workspaceActions = useMemo(() => ({ openHeadlessRun }), [openHeadlessRun])
+
+  const contextValue = useMemo<WorkspacesContextValue>(() => ({
+    workspaces,
+    templates,
+    agents,
+    defaultAgent,
+    issueDefaultAgent,
+    listError,
+    workspaceManager,
+    workspaceManagerLoaded,
+    workspaceManagerError,
+    hasLoaded,
+    templatesLoaded,
+    templatesError,
+    autoQuantDefaultWorkspaceId,
+    autoQuantPreferenceLoaded,
+    autoQuantPreferenceError,
+    refresh,
+    refreshTemplates,
+    refreshAutoQuantPreference,
+    refreshWorkspaceManager,
+    quickStartWorkspaceManager,
+    spawn,
+    openHeadlessRun,
+    setDefaultAgent,
+    setIssueDefaultAgent,
+    initializeAutoQuant,
+    setAutoQuantDefaultWorkspace,
+    quickChat,
+    pauseSession,
+    resumeSession,
+    openWebPiSession,
+    requestDeleteSession,
+    openAgentConfig,
+    saveWorkspaceMetadata,
+    renameWorkspace,
+  }), [
+    agents,
+    autoQuantDefaultWorkspaceId,
+    autoQuantPreferenceError,
+    autoQuantPreferenceLoaded,
+    defaultAgent,
+    hasLoaded,
+    initializeAutoQuant,
+    issueDefaultAgent,
+    listError,
+    openAgentConfig,
+    openHeadlessRun,
+    openWebPiSession,
+    pauseSession,
+    quickChat,
+    quickStartWorkspaceManager,
+    refresh,
+    refreshAutoQuantPreference,
+    refreshTemplates,
+    refreshWorkspaceManager,
+    renameWorkspace,
+    requestDeleteSession,
+    resumeSession,
+    saveWorkspaceMetadata,
+    setAutoQuantDefaultWorkspace,
+    setDefaultAgent,
+    setIssueDefaultAgent,
+    spawn,
+    templates,
+    templatesError,
+    templatesLoaded,
+    workspaceManager,
+    workspaceManagerError,
+    workspaceManagerLoaded,
+    workspaces,
+  ])
+
   const pendingDeleteSession = pendingSessionDelete
     ? (pendingSessionDelete.wsId === MANAGER_WORKSPACE_ID
         ? workspaceManager?.sessions.find((s) => s.id === pendingSessionDelete.sessionId) ?? null
@@ -612,85 +706,45 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     pendingDeleteSession?.title?.trim() || pendingDeleteSession?.name || ''
 
   return (
-    <WorkspacesContext.Provider
-      value={{
-        workspaces,
-        templates,
-        agents,
-        defaultAgent,
-        issueDefaultAgent,
-        listError,
-        workspaceManager,
-        workspaceManagerLoaded,
-        workspaceManagerError,
-        hasLoaded,
-        templatesLoaded,
-        templatesError,
-        autoQuantDefaultWorkspaceId,
-        autoQuantPreferenceLoaded,
-        autoQuantPreferenceError,
-        refresh,
-        refreshTemplates,
-        refreshAutoQuantPreference,
-        refreshWorkspaceManager,
-        quickStartWorkspaceManager,
-        spawn,
-        openHeadlessRun,
-        setDefaultAgent,
-        setIssueDefaultAgent,
-        initializeAutoQuant,
-        setAutoQuantDefaultWorkspace,
-        quickChat,
-        pauseSession,
-        resumeSession,
-        openWebPiSession,
-        requestDeleteSession,
-        openAgentConfig: (wsId: string, agent?: AgentId, section?: 'general' | 'launch' | 'ai' | 'template' | 'absorb') =>
-          setConfiguringAgentTarget({
-            wsId,
-            ...(agent ? { agent } : {}),
-            ...(section ? { section } : {}),
-          }),
-        saveWorkspaceMetadata,
-        renameWorkspace,
-      }}
-    >
-      {children}
-      {configuringAgentTarget !== null && (
-        <WorkspaceAIConfigModal
-          wsId={configuringAgentTarget.wsId}
-          initialAgent={configuringAgentTarget.agent}
-          initialSection={configuringAgentTarget.section ?? (configuringAgentTarget.agent ? 'ai' : 'general')}
-          onAiSaved={({ model, runtimeLabel, workspaceLabel }) => {
-            toast.success(model
-              ? t('workspaceSettings.ai.savedModelToast', {
-                  model,
-                  runtime: runtimeLabel,
-                  workspace: workspaceLabel,
-                })
-              : t('workspaceSettings.ai.savedConfigToast', {
-                  runtime: runtimeLabel,
-                  workspace: workspaceLabel,
-                }))
-          }}
-          onClose={() => setConfiguringAgentTarget(null)}
-        />
-      )}
-      {pendingSessionDelete !== null && (
-        <ConfirmDialog
-          title={t('chat.deleteSessionTitle')}
-          message={t('chat.deleteSessionMessage', {
-            title: pendingDeleteLabel || pendingSessionDelete.sessionId,
-          })}
-          confirmLabel={t('common.delete')}
-          onConfirm={async () => {
-            await deleteSession(pendingSessionDelete.wsId, pendingSessionDelete.sessionId)
-            setPendingSessionDelete(null)
-          }}
-          onClose={() => setPendingSessionDelete(null)}
-        />
-      )}
-    </WorkspacesContext.Provider>
+    <WorkspaceActionsContext.Provider value={workspaceActions}>
+      <WorkspacesContext.Provider value={contextValue}>
+        {children}
+        {configuringAgentTarget !== null && (
+          <WorkspaceAIConfigModal
+            wsId={configuringAgentTarget.wsId}
+            initialAgent={configuringAgentTarget.agent}
+            initialSection={configuringAgentTarget.section ?? (configuringAgentTarget.agent ? 'ai' : 'general')}
+            onAiSaved={({ model, runtimeLabel, workspaceLabel }) => {
+              toast.success(model
+                ? t('workspaceSettings.ai.savedModelToast', {
+                    model,
+                    runtime: runtimeLabel,
+                    workspace: workspaceLabel,
+                  })
+                : t('workspaceSettings.ai.savedConfigToast', {
+                    runtime: runtimeLabel,
+                    workspace: workspaceLabel,
+                  }))
+            }}
+            onClose={() => setConfiguringAgentTarget(null)}
+          />
+        )}
+        {pendingSessionDelete !== null && (
+          <ConfirmDialog
+            title={t('chat.deleteSessionTitle')}
+            message={t('chat.deleteSessionMessage', {
+              title: pendingDeleteLabel || pendingSessionDelete.sessionId,
+            })}
+            confirmLabel={t('common.delete')}
+            onConfirm={async () => {
+              await deleteSession(pendingSessionDelete.wsId, pendingSessionDelete.sessionId)
+              setPendingSessionDelete(null)
+            }}
+            onClose={() => setPendingSessionDelete(null)}
+          />
+        )}
+      </WorkspacesContext.Provider>
+    </WorkspaceActionsContext.Provider>
   )
 }
 

--- a/ui/src/contexts/workspace-actions-context.ts
+++ b/ui/src/contexts/workspace-actions-context.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+
+import type { WorkspacesContextValue } from './workspaces-context'
+
+/**
+ * Stable action-only surface for content renderers. Consumers that only need
+ * to open a Session should not subscribe to every polled Workspace snapshot.
+ * Keeping this contract in its own module also lets feature tests replace the
+ * broad Workspace state context without erasing the action boundary.
+ */
+export interface WorkspaceActionsContextValue {
+  openHeadlessRun: WorkspacesContextValue['openHeadlessRun']
+}
+
+const unavailableActions: WorkspaceActionsContextValue = {
+  async openHeadlessRun() {
+    throw new Error('openHeadlessRun is unavailable outside WorkspacesProvider')
+  },
+}
+
+export const WorkspaceActionsContext = createContext<WorkspaceActionsContextValue>(unavailableActions)
+
+export function useWorkspaceActions(): WorkspaceActionsContextValue {
+  return useContext(WorkspaceActionsContext)
+}

--- a/ui/src/contexts/workspace-list-reconcile.ts
+++ b/ui/src/contexts/workspace-list-reconcile.ts
@@ -1,11 +1,5 @@
 import type { Workspace } from '../components/workspace/api'
-
-function sameSnapshot(a: Workspace, b: Workspace): boolean {
-  // Workspace DTOs are JSON-only and arrive from the same endpoint. Comparing
-  // their serialized snapshots lets a polling refresh preserve object identity
-  // without maintaining a second, inevitably incomplete field checklist.
-  return JSON.stringify(a) === JSON.stringify(b)
-}
+import { reconcileJsonCollection } from '../lib/reconcile-json-state'
 
 /**
  * Preserve stable Workspace identities across the three-second list poll.
@@ -16,18 +10,5 @@ export function reconcileWorkspaceList(
   current: Workspace[],
   incoming: Workspace[],
 ): Workspace[] {
-  const currentById = new Map(current.map((workspace) => [workspace.id, workspace]))
-  let changed = current.length !== incoming.length
-
-  const next = incoming.map((workspace, index) => {
-    const previous = currentById.get(workspace.id)
-    if (!previous || !sameSnapshot(previous, workspace)) {
-      changed = true
-      return workspace
-    }
-    if (current[index] !== previous) changed = true
-    return previous
-  })
-
-  return changed ? next : current
+  return reconcileJsonCollection(current, incoming, (workspace) => workspace.id)
 }

--- a/ui/src/lib/reconcile-json-state.spec.ts
+++ b/ui/src/lib/reconcile-json-state.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { reconcileJsonCollection, reconcileJsonSnapshot } from './reconcile-json-state'
+
+interface Row {
+  id: string
+  nested: { value: number }
+}
+
+function row(id: string, value: number): Row {
+  return { id, nested: { value } }
+}
+
+describe('reconcileJsonSnapshot', () => {
+  it('preserves the current identity for an identical JSON snapshot', () => {
+    const current = { id: 'manager', sessions: [row('s1', 1)] }
+
+    expect(reconcileJsonSnapshot(current, structuredClone(current))).toBe(current)
+  })
+
+  it('publishes a genuinely changed snapshot', () => {
+    const current = { id: 'manager', sessions: [row('s1', 1)] }
+    const incoming = { id: 'manager', sessions: [row('s1', 2)] }
+
+    expect(reconcileJsonSnapshot(current, incoming)).toBe(incoming)
+  })
+})
+
+describe('reconcileJsonCollection', () => {
+  it('preserves the array and row identities for an identical response', () => {
+    const current = [row('a', 1), row('b', 2)]
+
+    const reconciled = reconcileJsonCollection(current, structuredClone(current), (value) => value.id)
+
+    expect(reconciled).toBe(current)
+    expect(reconciled[0]).toBe(current[0])
+    expect(reconciled[1]).toBe(current[1])
+  })
+
+  it('publishes order changes while reusing unchanged rows', () => {
+    const current = [row('a', 1), row('b', 2)]
+    const incoming = [structuredClone(current[1]!), structuredClone(current[0]!)]
+
+    const reconciled = reconcileJsonCollection(current, incoming, (value) => value.id)
+
+    expect(reconciled).not.toBe(current)
+    expect(reconciled).toEqual([current[1], current[0]])
+    expect(reconciled[0]).toBe(current[1])
+    expect(reconciled[1]).toBe(current[0])
+  })
+
+  it('replaces only changed rows', () => {
+    const current = [row('a', 1), row('b', 2)]
+    const incoming = [structuredClone(current[0]!), row('b', 3)]
+
+    const reconciled = reconcileJsonCollection(current, incoming, (value) => value.id)
+
+    expect(reconciled[0]).toBe(current[0])
+    expect(reconciled[1]).toBe(incoming[1])
+  })
+})

--- a/ui/src/lib/reconcile-json-state.ts
+++ b/ui/src/lib/reconcile-json-state.ts
@@ -1,0 +1,34 @@
+/**
+ * Polling endpoints in OpenAlice return JSON-only DTOs. A successful request
+ * is not automatically a state change: preserve the current identity when the
+ * serialized snapshot is unchanged so React/Zustand selectors stay quiet.
+ */
+export function reconcileJsonSnapshot<T>(current: T, incoming: T): T {
+  return JSON.stringify(current) === JSON.stringify(incoming) ? current : incoming
+}
+
+/**
+ * Reconcile a keyed JSON collection while preserving unchanged row identities.
+ * Order remains server-authoritative; reordering publishes a new array while
+ * reusing the existing objects.
+ */
+export function reconcileJsonCollection<T, K>(
+  current: T[],
+  incoming: T[],
+  keyOf: (value: T) => K,
+): T[] {
+  const currentByKey = new Map(current.map((value) => [keyOf(value), value]))
+  let changed = current.length !== incoming.length
+
+  const next = incoming.map((value, index) => {
+    const previous = currentByKey.get(keyOf(value))
+    if (previous === undefined || reconcileJsonSnapshot(previous, value) !== previous) {
+      changed = true
+      return value
+    }
+    if (current[index] !== previous) changed = true
+    return previous
+  })
+
+  return changed ? next : current
+}

--- a/ui/src/live/inbox.spec.ts
+++ b/ui/src/live/inbox.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import type { InboxEntry } from '../api/inbox'
+import { reconcileInboxHistoryState, type InboxState } from './inbox'
+
+function entry(id: string, comments: string): InboxEntry {
+  return {
+    id,
+    ts: 1,
+    workspaceId: 'research-desk',
+    comments,
+  }
+}
+
+describe('reconcileInboxHistoryState', () => {
+  it('settles loading while preserving incoming entries', () => {
+    const current: InboxState = { entries: [], loading: true }
+    const incoming = [entry('report-1', 'Ready')]
+
+    const next = reconcileInboxHistoryState(current, incoming)
+
+    expect(next).not.toBe(current)
+    expect(next.entries).toEqual(incoming)
+    expect(next.entries[0]).toBe(incoming[0])
+    expect(next.loading).toBe(false)
+  })
+
+  it('does not publish an identical polling response', () => {
+    const current: InboxState = { entries: [entry('report-1', 'Ready')], loading: false }
+
+    const next = reconcileInboxHistoryState(current, structuredClone(current.entries))
+
+    expect(next).toBe(current)
+    expect(next.entries).toBe(current.entries)
+  })
+
+  it('reuses unchanged entries when one report changes', () => {
+    const current: InboxState = {
+      entries: [entry('report-1', 'Ready'), entry('report-2', 'Waiting')],
+      loading: false,
+    }
+    const incoming = [structuredClone(current.entries[0]!), entry('report-2', 'Complete')]
+
+    const next = reconcileInboxHistoryState(current, incoming)
+
+    expect(next).not.toBe(current)
+    expect(next.entries[0]).toBe(current.entries[0])
+    expect(next.entries[1]).toBe(incoming[1])
+  })
+})

--- a/ui/src/live/inbox.ts
+++ b/ui/src/live/inbox.ts
@@ -2,6 +2,7 @@ import { api } from '../api'
 import type { InboxEntry } from '../api/inbox'
 import { createLiveStore } from './createLiveStore'
 import { reloadOnHotUpdate } from '../lib/hmr'
+import { reconcileJsonCollection } from '../lib/reconcile-json-state'
 
 reloadOnHotUpdate('live/inbox')
 
@@ -25,6 +26,15 @@ export interface InboxState {
   loading: boolean
 }
 
+export function reconcileInboxHistoryState(
+  current: InboxState,
+  incomingEntries: InboxEntry[],
+): InboxState {
+  const entries = reconcileJsonCollection(current.entries, incomingEntries, (entry) => entry.id)
+  if (entries === current.entries && !current.loading) return current
+  return { ...current, entries, loading: false }
+}
+
 const POLL_INTERVAL_MS = 20_000
 
 /** Module-level setter populated by the subscribe callback so external
@@ -44,10 +54,10 @@ export const inboxLive = createLiveStore<InboxState>({
       try {
         const { entries } = await api.inbox.history({ limit: 100 })
         if (disposed) return
-        apply((prev) => ({ ...prev, entries, loading: false }))
+        apply((prev) => reconcileInboxHistoryState(prev, entries))
       } catch {
         if (disposed) return
-        apply((prev) => ({ ...prev, loading: false }))
+        apply((prev) => prev.loading ? { ...prev, loading: false } : prev)
       }
     }
 


### PR DESCRIPTION
## Summary

- treat identical Workspace Manager and Inbox polling snapshots as no state change
- isolate rendered Markdown inside a stable DOM leaf with an action-only Workspace hook
- preserve selection, browser translation nodes, and other DOM-local state while unrelated live data refreshes

## Root cause

Polling produced fresh object graphs even when their JSON payload was unchanged. Those values flowed through a broad Workspace context into `MarkdownContent`, causing React to replace its `dangerouslySetInnerHTML` subtree. Browser translation wrappers, selections, and other DOM-local state were therefore discarded on every poll.

## User impact

Markdown reports in Inbox and Tracked no longer visually refresh or lose browser-injected translation markup when unrelated Workspace/Inbox polling succeeds with unchanged data. Real content changes still replace the Markdown body.

Fixes #712

## Included increments

- [x] shared JSON snapshot and collection reconciliation
- [x] stable Inbox history and Workspace Manager identities
- [x] action-only Workspace context for Markdown actions
- [x] memoized static Markdown DOM boundary
- [x] identity-focused unit and browser verification

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 492 files / 4057 tests passed; existing skips unchanged
- Tracked report: 7 Workspace list/manager poll responses, 0 Markdown child mutations; injected marker and heading identities preserved
- Inbox message + Markdown attachment: 2 Inbox history polls plus repeated Manager polls, 0 Markdown child mutations; injected markers preserved in both bodies

## Boundaries and non-goals

This changes UI live-state reconciliation and Markdown rendering only. It does not change polling cadence/transport, trading, credentials, persisted data, runtime startup, or packaging. Full arbitrary-HTML iframe behavior remains outside this topic.