### PR TITLE
Refine conversation list footer

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -415,7 +415,12 @@ describe('ChatWorkspaceSection actions', () => {
     expect(screen.getAllByRole('button', { name: /^Conversation/ })).toHaveLength(6)
     expect(screen.queryByRole('button', { name: 'Conversation 3' })).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'View all 9 sessions' }))
+    const browseAll = screen.getByRole('button', { name: 'View all 9 sessions' })
+    expect(browseAll.textContent).toBe('Browse all conversations')
+    expect(browseAll.className).toContain('w-full')
+    expect(browseAll.className).not.toContain('oa-pressable')
+    expect(browseAll.parentElement?.className).toContain('border-t')
+    fireEvent.click(browseAll)
 
     const dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
     const browser = within(dialog)

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -772,16 +772,37 @@ function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
           />
         ))}
         {sessions.length > visibleSessions.length && (
-          <button
-            type="button"
-            onClick={(event) => props.onBrowseSessions(props.workspace!.id, event.currentTarget)}
-            className="oa-pressable mx-2 my-1 flex min-h-8 items-center rounded-md px-2 text-[11px] font-medium text-primary hover:bg-primary/10"
-          >
-            {t('chat.viewAllSessions', { count: sessions.length })}
-          </button>
+          <ConversationListFooter
+            count={sessions.length}
+            onOpen={(restoreFocus) => props.onBrowseSessions(props.workspace!.id, restoreFocus)}
+          />
         )}
       </div>
 
+    </div>
+  )
+}
+
+function ConversationListFooter({
+  count,
+  onOpen,
+}: {
+  count: number
+  onOpen: (restoreFocus: HTMLElement | null) => void
+}): ReactElement {
+  const { t } = useTranslation()
+
+  return (
+    <div className="mx-2 mt-1 border-t border-border/55 pt-1">
+      <button
+        type="button"
+        aria-label={t('chat.viewAllSessions', { count })}
+        onClick={(event) => onOpen(event.currentTarget)}
+        className="flex min-h-9 w-full items-center gap-2 rounded-md px-2 text-left text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35"
+      >
+        <span className="min-w-0 flex-1 truncate">{t('chat.browseWorkspace')}</span>
+        <ChevronRight size={13} strokeWidth={2} className="shrink-0 text-muted-foreground/60" aria-hidden />
+      </button>
     </div>
   )
 }
@@ -1022,13 +1043,10 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
             />
           ))}
           {orderedSessions.length > visibleSessions.length && (
-            <button
-              type="button"
-              onClick={(event) => props.onBrowseSessions(event.currentTarget)}
-              className="oa-pressable ml-2 my-1 flex min-h-7 items-center rounded-md px-2 text-[10.5px] font-medium text-primary hover:bg-primary/10"
-            >
-              {t('chat.viewAllSessions', { count: orderedSessions.length })}
-            </button>
+            <ConversationListFooter
+              count={orderedSessions.length}
+              onOpen={props.onBrowseSessions}
+            />
           )}
         </div>
       )}


### PR DESCRIPTION
## What changed

- replace the compact floating “View all” CTA with a full-width list footer row
- add a subtle divider and trailing chevron so the control reads as continuation navigation
- remove the inherited pressable lift animation and use a quiet full-row hover state
- share the footer component between focused and Workspace-tree conversation lists
- keep the session count in the accessible label without repeating it visually

## Why

The previous button occupied only part of the sidebar width, repeated the count already shown in the section header, and inherited a CTA-style upward hover transform. That made it look like a detached patch rather than the next navigation step after the conversation list.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 4,058 passed, 9 skipped
- `pnpm exec vitest run ui/src/components/workspace/ChatWorkspaceSection.spec.tsx` — 14 passed
- browser walkthrough on `/chat`: default state, full-row hover, no transform, Dialog opening, Escape, and focus restoration