### PR TITLE
Refine paused TUI handoff surface

### DIFF
--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -14,19 +14,17 @@
 
 /* ── Right-pane Resume CTA ─────────────────────────────────────────────────
  *
- * Two-layer design: a heavily-blurred faux-TUI backdrop fills the pane
- * to telegraph "paused conversation" at a glance, with a focused Resume
- * card centered on top. The faux-TUI is decorative (no real session
- * content — we don't persist agent-CLI scrollback); its job is to make
- * the paused state read as a chat to anyone, not just developers.
+ * Two-layer design: a heavily-blurred faux-TUI backdrop owns the pane
+ * to telegraph the handoff from the browser to a native agent TUI, with a
+ * focused Resume control centered on top. The faux-TUI is decorative (no
+ * real session content — we don't persist agent-CLI scrollback); its job is
+ * to make the otherwise-unusual browser-to-terminal transition legible.
  */
 
 .resume-cta-frame {
   flex: 1 1 auto;
   position: relative;
   overflow: hidden;
-  border: 1px dashed var(--border);
-  border-radius: 8px;
   background: var(--secondary);
 }
 
@@ -174,12 +172,12 @@
   align-items: stretch;
   gap: 14px;
   padding: 24px 28px;
-  min-width: 320px;
-  max-width: 420px;
+  width: min(380px, calc(100% - 32px));
+  min-width: 0;
   background: var(--background);
   border: 1px solid var(--border);
-  border-radius: 10px;
-  box-shadow: 0 8px 32px color-mix(in srgb, var(--shadow-color) 40%, transparent);
+  border-radius: 6px;
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow-color) 26%, transparent);
 }
 
 .resume-cta-card-header {
@@ -258,7 +256,7 @@
   color: var(--primary-foreground);
   border: 0;
   padding: 10px 20px;
-  border-radius: 6px;
+  border-radius: 4px;
   font-size: 13px;
   font-weight: 600;
   white-space: nowrap;

--- a/ui/src/pages/WorkspacePage.spec.tsx
+++ b/ui/src/pages/WorkspacePage.spec.tsx
@@ -149,4 +149,38 @@ describe('WorkspacePage identity', () => {
       terminalHeaderActions: expect.anything(),
     }))
   })
+
+  it('lets a paused TUI handoff own the pane without removing the page header', () => {
+    mocks.workspaces = [workspace({
+      displayName: 'Optical Networking Follow-up',
+      sessions: [{
+        id: 'paused-session',
+        resumeId: 'resume-paused',
+        wsId: 'chat-1',
+        agent: 'codex',
+        name: 'x4',
+        createdAt: '2026-07-31T00:00:00.000Z',
+        lastActiveAt: '2026-07-31T00:00:00.000Z',
+        state: 'paused',
+        surface: 'terminal',
+        pid: null,
+        startedAt: null,
+        title: null,
+      }],
+    })]
+
+    const { container } = render(
+      <WorkspacePage
+        spec={{ kind: 'workspace', params: { wsId: 'chat-1', sessionId: 'paused-session' } }}
+        visible
+      />,
+    )
+
+    const shell = container.querySelector('.workspace-page-shell')
+    expect(shell?.classList.contains('is-paused-canvas')).toBe(true)
+    expect(shell?.classList.contains('is-terminal-canvas')).toBe(false)
+    expect(screen.getByText('Optical Networking Follow-up').parentElement?.getAttribute('title'))
+      .toBe('Optical Networking Follow-up\nchat-jun30')
+    expect(screen.getByRole('button', { name: 'Files' })).toBeTruthy()
+  })
 })

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -100,6 +100,8 @@ export function WorkspacePage({ spec, visible }: Props) {
     !import.meta.env.VITE_DEMO_MODE &&
     activeRecord?.state === 'running' &&
     (activeRecord.surface ?? 'terminal') === 'terminal'
+  const pausedCanvas = activeRecord?.state === 'paused'
+  const workspaceCanvas = terminalCanvas || pausedCanvas
   const workspaceActions = (
     <>
       {activeRecord?.agent === 'pi' && activeRecord.state === 'running' && (
@@ -143,7 +145,7 @@ export function WorkspacePage({ spec, visible }: Props) {
   // holds for the active path); when sessionId is null, the empty
   // state needs the full list to render resume/continue cards.
   return (
-    <div className={`workspaces-root workspace-page-shell flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden${terminalCanvas ? ' is-terminal-canvas' : ''}`}>
+    <div className={`workspaces-root workspace-page-shell flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden${terminalCanvas ? ' is-terminal-canvas' : ''}${pausedCanvas ? ' is-paused-canvas' : ''}`}>
       {/* Library, paused, WebPi, and demo surfaces keep a page-level header.
        * A live TUI promotes these actions into the terminal's own titlebar so
        * the primary canvas does not sit inside a second shell. */}
@@ -168,7 +170,7 @@ export function WorkspacePage({ spec, visible }: Props) {
         </div>
       )}
 
-      <div className={`flex min-h-0 min-w-0 flex-1 flex-col${terminalCanvas ? '' : ' p-3'}`}>
+      <div className={`flex min-h-0 min-w-0 flex-1 flex-col${workspaceCanvas ? '' : ' p-3'}`}>
         <WorkspaceView
           wsId={wsId}
           sessionId={sessionId}


### PR DESCRIPTION
## Summary

- let the faux TUI own the paused Workspace pane instead of sitting inside a rounded, dashed frame
- keep the Workspace header and recovery controls while reducing nested radius and shadow weight
- add coverage for the paused-canvas shell contract

## Why

The paused state intentionally prepares users for OpenAlice handing control from the browser to a native TUI. The previous outer padding, dashed border, and rounded frame made that TUI read as another card inside the page, then nested a second card and button inside it.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4059 passed, 9 skipped)
- browser verification on the real paused Session route in Day, Night, and Files-open states