### PR TITLE
Restore Codex smart session titles

### DIFF
--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -397,17 +397,43 @@ describe('codexAdapter AI-config', () => {
     expect(await codexAdapter.listOnDisk!(dir)).toEqual([]);
   });
 
-  it('reads Codex native titles from its session index', async () => {
+  it('prefers Codex Desktop generated titles from its local thread catalog', async () => {
     await codexAdapter.writeAiConfig!(dir, { baseUrl: 'https://oai.test/v1', model: 'gpt-x' });
     const home = join(dir, '.codex', 'openalice-home');
     await mkdir(home, { recursive: true });
     await writeFile(join(home, 'session_index.jsonl'), [
-      JSON.stringify({ id: 'native-1', thread_name: '  Native Codex title  ', updated_at: '2026-07-30' }),
+      JSON.stringify({ id: 'native-1', thread_name: 'Legacy Codex title', updated_at: '2026-07-30' }),
       '{"partially-written":',
       '',
     ].join('\n'));
-    expect(await codexAdapter.readSessionTitle!(dir, 'native-1')).toBe('Native Codex title');
+
+    const sqliteDir = join(home, 'sqlite');
+    await mkdir(sqliteDir, { recursive: true });
+    const { DatabaseSync } = process.getBuiltinModule('node:sqlite') as typeof import('node:sqlite');
+    const database = new DatabaseSync(join(sqliteDir, 'codex-dev.db'));
+    database.exec(`
+      CREATE TABLE local_thread_catalog (
+        thread_id TEXT NOT NULL,
+        display_title TEXT NOT NULL
+      )
+    `);
+    database.prepare(
+      'INSERT INTO local_thread_catalog (thread_id, display_title) VALUES (?, ?)',
+    ).run('native-1', '  Generated investigation title  ');
+    database.close();
+
+    expect(await codexAdapter.readSessionTitle!(dir, 'native-1')).toBe('Generated investigation title');
     expect(await codexAdapter.readSessionTitle!(dir, 'missing')).toBeNull();
+  });
+
+  it('keeps reading Codex native titles from the legacy session index', async () => {
+    await codexAdapter.writeAiConfig!(dir, { baseUrl: 'https://oai.test/v1', model: 'gpt-x' });
+    const home = join(dir, '.codex', 'openalice-home');
+    await mkdir(home, { recursive: true });
+    await writeFile(join(home, 'session_index.jsonl'),
+      `${JSON.stringify({ id: 'native-legacy', thread_name: 'Legacy Codex title' })}\n`);
+
+    expect(await codexAdapter.readSessionTitle!(dir, 'native-legacy')).toBe('Legacy Codex title');
   });
 });
 

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -41,18 +41,71 @@ function codexHome(cwd: string): string {
 
 const codexTitleIndexInFlight = new Map<string, Promise<ReadonlyMap<string, string>>>();
 
+type NodeSqliteModule = typeof import('node:sqlite');
+
+let nodeSqliteModule: NodeSqliteModule | null | undefined;
+
+/**
+ * Node 22 still labels the built-in SQLite module experimental and emits one
+ * process warning when it is first loaded. OPENALICE requires Node >=22.19,
+ * where the synchronous read-only API we use is present. Load it lazily so
+ * non-Codex users never touch the module; suppress only the module-load warning
+ * in this synchronous section so a background title refresh stays silent.
+ */
+function loadNodeSqlite(): NodeSqliteModule | null {
+  if (nodeSqliteModule !== undefined) return nodeSqliteModule;
+  const originalEmitWarning = process.emitWarning;
+  try {
+    process.emitWarning = (() => undefined) as typeof process.emitWarning;
+    nodeSqliteModule = process.getBuiltinModule('node:sqlite') as NodeSqliteModule;
+  } catch {
+    nodeSqliteModule = null;
+  } finally {
+    process.emitWarning = originalEmitWarning;
+  }
+  return nodeSqliteModule;
+}
+
+function readCodexDesktopTitleCatalog(home: string): ReadonlyMap<string, string> {
+  const sqlite = loadNodeSqlite();
+  if (!sqlite) return new Map<string, string>();
+  const path = join(home, 'sqlite', 'codex-dev.db');
+  if (!existsSync(path)) return new Map<string, string>();
+
+  let database: InstanceType<NodeSqliteModule['DatabaseSync']> | undefined;
+  try {
+    database = new sqlite.DatabaseSync(path, { readOnly: true });
+    const rows = database.prepare(
+      'SELECT thread_id, display_title FROM local_thread_catalog',
+    ).all() as Array<{ thread_id?: unknown; display_title?: unknown }>;
+    const titles = new Map<string, string>();
+    for (const row of rows) {
+      const id = typeof row.thread_id === 'string' ? row.thread_id : null;
+      const title = typeof row.display_title === 'string' ? row.display_title.trim() : '';
+      if (id && title) titles.set(id, title);
+    }
+    return titles;
+  } catch {
+    // Codex owns this private catalog and may migrate or lock it. A title is
+    // presentation metadata only, so fall through to the legacy index/fallback.
+    return new Map<string, string>();
+  } finally {
+    database?.close();
+  }
+}
+
 function readCodexSessionTitleIndex(cwd: string): Promise<ReadonlyMap<string, string>> {
   const home = codexHome(cwd);
   const existing = codexTitleIndexInFlight.get(home);
   if (existing) return existing;
   const read = (async () => {
+    const titles = new Map<string, string>();
     let raw: string;
     try {
       raw = await readFile(join(home, 'session_index.jsonl'), 'utf8');
     } catch {
-      return new Map<string, string>();
+      raw = '';
     }
-    const titles = new Map<string, string>();
     for (const line of raw.split(/\r?\n/)) {
       if (!line.trim()) continue;
       try {
@@ -64,6 +117,10 @@ function readCodexSessionTitleIndex(cwd: string): Promise<ReadonlyMap<string, st
         // A partially-written tail must not hide the rest of the index.
       }
     }
+    // Current Codex Desktop keeps its generated short titles in the local
+    // thread catalog. Prefer that newer projection when both stores know the
+    // same native thread id, while retaining session_index.jsonl compatibility.
+    for (const [id, title] of readCodexDesktopTitleCatalog(home)) titles.set(id, title);
     return titles;
   })().finally(() => codexTitleIndexInFlight.delete(home));
   codexTitleIndexInFlight.set(home, read);


### PR DESCRIPTION
## Summary
- read Codex Desktop generated `display_title` values from its local thread catalog using the native thread id
- persist recovered titles through the existing OpenAlice Session title resolver
- keep the legacy `session_index.jsonl` title source as a fallback and fail soft when the private catalog is unavailable

## Root cause
OpenAlice only inspected Codex's legacy `session_index.jsonl`. The current Codex Desktop smart titles visible to the user are stored in `sqlite/codex-dev.db` under `local_thread_catalog.display_title`, so valid native session IDs never found their titles.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (492 files passed, 1 skipped; 4059 tests passed, 9 skipped)
- targeted adapter/title resolver tests after rebasing onto current `dev` (103 tests passed)
- read-only validation against existing local state: 3 of 14 Codex Sessions had catalog titles, all distinct from OpenAlice fallback titles

## Boundary touch
- Workspace session presentation metadata only; no trading, auth, credential, migration, or packaging changes
