### PR TITLE
Redesign paused Session wake screen

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -134,6 +134,9 @@ native runtime state, an OpenAlice-vault slug plus wire shape, or a fingerprint
 of an explicitly configured Workspace provider. Vault secrets are resolved
 just in time and enter only the child environment. Workspace fingerprints make
 replacement visible instead of silently resuming through a different key.
+Paused Session surfaces may expose that secret-free binding so users can verify
+the credential source, model, and effort that will be replayed before resuming;
+they must never expose resolved keys, endpoints, or native runtime identifiers.
 
 Credential, model, and effort are independent optional launch dimensions. A
 native credential binding means OpenAlice injects no managed key or endpoint;

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -837,6 +837,7 @@ describe('POST /:id/headless/:taskId/session', () => {
     expect(opened.body.session).toMatchObject({
       sourceRunId: 'run-1',
       resumeId: 'resume-run-1',
+      runtime: { credentialSource: 'native' },
     });
   });
 

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -191,6 +191,12 @@ interface PublicSessionBody {
   readonly startedAt: number | null;
   readonly title: string | null;
   readonly sourceRunId: string | null;
+  readonly runtime?: {
+    readonly credentialSource: 'native' | 'vault' | 'workspace';
+    readonly credentialSlug?: string;
+    readonly model?: string;
+    readonly reasoningEffort?: ModelReasoningEffort;
+  };
 }
 
 type OpenHeadlessSessionResult =
@@ -465,6 +471,7 @@ export function createWorkspaceRoutes(
   const publicSession = (record: SessionRecord): PublicSessionBody => {
     const terminal = svc.pool.get(record.id);
     const browser = svc.webPi?.get(record.id) ?? null;
+    const binding = svc.resumeRegistry.get(record.resumeId)?.runtimeBinding;
     return {
       id: record.id,
       wsId: record.wsId,
@@ -479,6 +486,18 @@ export function createWorkspaceRoutes(
       startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
       title: sessionPreferredTitle(record) ?? null,
       sourceRunId: record.sourceRunId ?? null,
+      ...(binding
+        ? {
+            runtime: {
+              credentialSource: binding.credential.source,
+              ...(binding.credential.source === 'vault'
+                ? { credentialSlug: binding.credential.credentialSlug }
+                : {}),
+              ...(binding.model ? { model: binding.model } : {}),
+              ...(binding.reasoningEffort ? { reasoningEffort: binding.reasoningEffort } : {}),
+            },
+          }
+        : {}),
     };
   };
 

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
-import { Bot, MessageSquare } from 'lucide-react';
+import { Bot, ChevronDown, SquareTerminal } from 'lucide-react';
 
 import type { SessionRecord } from './api';
 
@@ -16,18 +16,16 @@ export interface ResumeCtaProps {
  *
  * Two layers:
  *
- *   1. **Faux-TUI backdrop** — a blurred, heavily-dimmed mock of the
+ *   1. **Faux-TUI backdrop** — a sleeping, low-contrast mock of the
  *      Claude Code / Codex TUI shape: header strip, conversation
  *      bubbles, status lines, bottom prompt + status bar. It's the
  *      same placeholder content for every session — the goal is not
  *      to show what was there (we don't persist agent-CLI scrollback;
  *      the CLI re-renders its own transcript on resume), but to make
- *      the paused state visually read as "a paused chat" rather than
- *      a bare button. Anyone who isn't a developer should be able to
- *      look at this and understand "I clicked the agent, here's the
- *      conversation, click to continue".
+ *      the paused state visually read as a native terminal waiting to
+ *      be restored rather than a disabled webpage.
  *
- *   2. **Resume card** centered on top — the actual CTA. Clicking it
+ *   2. **Wake strip** docked to the terminal footer — the actual CTA. Clicking it
  *      asks the server to re-spawn the PTY using the adapter's resume
  *      semantic (claude `--resume <uuid>` / `--continue`; codex
  *      `resume --last`; shell fresh + scrollback restore).
@@ -36,6 +34,8 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
   const [resuming, setResuming] = useState<'terminal' | 'webpi' | null>(null);
   const [error, setError] = useState<string | null>(null);
   const r = props.record;
+  const sessionTitle = r.title?.trim() || r.name;
+  const runtimeFacts = sessionRuntimeFacts(r);
 
   const run = async (surface: 'terminal' | 'webpi'): Promise<void> => {
     if (resuming) return;
@@ -51,43 +51,56 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
   };
 
   return (
-    <div className="resume-cta-frame">
+    <div className={`resume-cta-frame${resuming ? ' is-resuming' : ''}`}>
       <FauxTuiBackdrop />
       <div className="resume-cta-overlay">
-        <div className="resume-cta-card">
-          <div className="resume-cta-card-header">
-            <span className="resume-cta-badge">
-              {prefixOf(r.agent)}
-            </span>
-            <div className="resume-cta-card-title">
-              <span className="resume-cta-name">{r.name}</span>
-              <span className="resume-cta-state">paused · {formatRelativeTime(r.lastActiveAt)}</span>
+        <section className="resume-cta-card" aria-label="Paused Session">
+          <div className="resume-cta-card-main">
+            <div className="resume-cta-card-header">
+              <div className="resume-cta-kicker">
+                <span className="resume-cta-state-dot" aria-hidden="true" />
+                <span>Session paused</span>
+              </div>
+              <h2 className="resume-cta-name">{sessionTitle}</h2>
+              <p className="resume-cta-state">
+                {agentDisplayName(r.agent)} · {formatRelativeTime(r.lastActiveAt)}
+              </p>
             </div>
-          </div>
 
-          <div className="resume-cta-actions">
-            <button
-              type="button"
-              className="resume-cta-btn"
-              onClick={() => void run('terminal')}
-              disabled={resuming !== null}
-              aria-label={resuming ? 'Resuming conversation…' : 'Continue in terminal'}
-            >
-              <MessageSquare size={14} strokeWidth={2.25} aria-hidden="true" />
-              <span>{resuming === 'terminal' ? 'Opening…' : 'Open TUI'}</span>
-            </button>
-            {r.agent === 'pi' && props.onOpenWebPi && (
+            <dl className="resume-cta-runtime" aria-label="Session runtime">
+              {runtimeFacts.map((fact) => (
+                <div className="resume-cta-runtime-fact" key={fact.label}>
+                  <dt>{fact.label}</dt>
+                  <dd title={fact.value}>{fact.value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            <div className="resume-cta-actions">
               <button
                 type="button"
-                className="resume-cta-btn is-webpi"
-                onClick={() => void run('webpi')}
+                className="resume-cta-btn oa-pressable"
+                onClick={() => void run('terminal')}
                 disabled={resuming !== null}
+                aria-label="Resume in TUI"
               >
-                <Bot size={14} strokeWidth={2.25} aria-hidden="true" />
-                <span>{resuming === 'webpi' ? 'Opening…' : 'Open WebPi'}</span>
-                {resuming !== 'webpi' && <span className="resume-cta-beta">Beta</span>}
+                <SquareTerminal size={15} strokeWidth={2.1} aria-hidden="true" />
+                <span>{resuming === 'terminal' ? 'Restoring…' : 'Resume in TUI'}</span>
               </button>
-            )}
+              {r.agent === 'pi' && props.onOpenWebPi && (
+                <button
+                  type="button"
+                  className="resume-cta-btn is-webpi oa-pressable"
+                  onClick={() => void run('webpi')}
+                  disabled={resuming !== null}
+                  aria-label="Open in WebPi"
+                >
+                  <Bot size={14} strokeWidth={2.25} aria-hidden="true" />
+                  <span>{resuming === 'webpi' ? 'Opening…' : 'Open in WebPi'}</span>
+                  {resuming !== 'webpi' && <span className="resume-cta-beta">Beta</span>}
+                </button>
+              )}
+            </div>
           </div>
 
           {error && (
@@ -96,25 +109,33 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
             </p>
           )}
 
-          <dl className="resume-cta-meta">
-            <dt>Agent</dt>
-            <dd>{r.agent}</dd>
-            <dt>Created</dt>
-            <dd>{absoluteTime(r.createdAt)}</dd>
-            {r.resumeId && (
-              <>
-                <dt>Transcript</dt>
-                <dd className="mono">{r.resumeId}</dd>
-              </>
-            )}
-          </dl>
-
           {r.agent === 'shell' && (
             <p className="resume-cta-hint">
               Your previous screen will be restored above the new prompt.
             </p>
           )}
-        </div>
+
+          <details className="resume-cta-details">
+            <summary>
+              <span>Session details</span>
+              <ChevronDown size={13} strokeWidth={2} aria-hidden="true" />
+            </summary>
+            <div className="resume-cta-details-body oa-disclosure-enter">
+              <dl className="resume-cta-meta">
+                <dt>Runtime</dt>
+                <dd>{agentDisplayName(r.agent)}</dd>
+                <dt>Created</dt>
+                <dd>{absoluteTime(r.createdAt)}</dd>
+                {r.resumeId && (
+                  <>
+                    <dt>Transcript</dt>
+                    <dd className="mono">{r.resumeId}</dd>
+                  </>
+                )}
+              </dl>
+            </div>
+          </details>
+        </section>
       </div>
     </div>
   );
@@ -122,10 +143,9 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
 
 /**
  * CSS-only placeholder TUI. No real session content — we use generic
- * filler so heavy backdrop blur turns each line into a soft horizontal
- * band, conveying "text exchange" without claiming to show anything
- * specific. Structural Unicode characters (●, ›, •, *, ▶▶) survive
- * the blur partially and give the "this is a terminal" tell.
+ * filler so the shape remains recognizably terminal-like without claiming
+ * to show the actual transcript. Structural Unicode characters (●, ›, •,
+ * *, ▶▶) provide the browser-to-TUI handoff cue.
  */
 function FauxTuiBackdrop(): ReactElement {
   return (
@@ -193,6 +213,33 @@ export function prefixOf(agent: string): string {
   if (agent === 'codex') return 'x';
   if (agent === 'shell') return 'sh';
   return agent[0] ?? '?';
+}
+
+function agentDisplayName(agent: string): string {
+  if (agent === 'claude') return 'Claude Code';
+  if (agent === 'codex') return 'Codex';
+  if (agent === 'opencode') return 'OpenCode';
+  if (agent === 'pi') return 'Pi';
+  if (agent === 'shell') return 'Shell';
+  return agent;
+}
+
+function sessionRuntimeFacts(record: SessionRecord): readonly { label: string; value: string }[] {
+  const runtime = record.runtime;
+  return [
+    { label: 'Credential', value: credentialDisplay(runtime) },
+    { label: 'Model', value: runtime?.model?.trim() || 'Runtime default' },
+    {
+      label: 'Effort',
+      value: runtime?.reasoningEffort ? `${runtime.reasoningEffort} reasoning` : 'Runtime default',
+    },
+  ];
+}
+
+function credentialDisplay(runtime: SessionRecord['runtime']): string {
+  if (!runtime || runtime.credentialSource === 'native') return 'Runtime login';
+  if (runtime.credentialSource === 'workspace') return 'Workspace config';
+  return runtime.credentialSlug?.trim() || 'Saved credential';
 }
 
 function absoluteTime(iso: string): string {

--- a/ui/src/components/workspace/WorkspaceView.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceView.spec.tsx
@@ -166,7 +166,15 @@ describe('WorkspaceView Files panel', () => {
 
 describe('WorkspaceView paused Session recovery', () => {
   it('shows a failed resume and lets the user retry instead of staying on Opening', async () => {
-    const paused = session(2, 'paused')
+    const paused: SessionRecord = {
+      ...session(2, 'paused'),
+      runtime: {
+        credentialSource: 'vault',
+        credentialSlug: 'deepseek-1',
+        model: 'deepseek-v4-flash',
+        reasoningEffort: 'high',
+      },
+    }
     const onResume = vi.fn(async () => { throw new Error('Pi CLI login is required') })
 
     render(
@@ -183,10 +191,23 @@ describe('WorkspaceView paused Session recovery', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Continue in terminal' }))
+    expect(screen.getByText('Session paused')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Conversation 2' })).toBeTruthy()
+    expect(screen.getByText('deepseek-1')).toBeTruthy()
+    expect(screen.getByText('deepseek-v4-flash')).toBeTruthy()
+    expect(screen.getByText('high reasoning')).toBeTruthy()
+    const details = screen.getByText('Session details').closest('details') as HTMLDetailsElement
+    expect(details.open).toBe(false)
+
+    fireEvent.click(screen.getByText('Session details'))
+    expect(details.open).toBe(true)
+    expect(screen.getByText('Transcript')).toBeTruthy()
+    expect(screen.getByText('resume-2')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume in TUI' }))
 
     expect((await screen.findByRole('alert')).textContent).toContain('Pi CLI login is required')
-    expect((screen.getByRole('button', { name: 'Continue in terminal' }) as HTMLButtonElement).disabled).toBe(false)
+    expect((screen.getByRole('button', { name: 'Resume in TUI' }) as HTMLButtonElement).disabled).toBe(false)
   })
 })
 

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -655,6 +655,13 @@ export interface SessionRecord {
   readonly title: string | null;
   /** Headless run this stable Alice Session was materialized from. */
   readonly sourceRunId?: string | null;
+  /** Secret-free launch semantics pinned to this resumable Session. */
+  readonly runtime?: {
+    readonly credentialSource: 'native' | 'vault' | 'workspace';
+    readonly credentialSlug?: string;
+    readonly model?: string;
+    readonly reasoningEffort?: ModelReasoningEffort;
+  };
 }
 
 export interface SpawnedSession {

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -14,9 +14,9 @@
 
 /* ── Right-pane Resume CTA ─────────────────────────────────────────────────
  *
- * Two-layer design: a heavily-blurred faux-TUI backdrop owns the pane
+ * Two-layer design: a sleeping faux-TUI backdrop owns the pane
  * to telegraph the handoff from the browser to a native agent TUI, with a
- * focused Resume control centered on top. The faux-TUI is decorative (no
+ * focused Resume strip docked to its footer. The faux-TUI is decorative (no
  * real session content — we don't persist agent-CLI scrollback); its job is
  * to make the otherwise-unusual browser-to-terminal transition legible.
  */
@@ -26,6 +26,7 @@
   position: relative;
   overflow: hidden;
   background: var(--secondary);
+  container: resume-cta / inline-size;
 }
 
 /* Faux-TUI backdrop ------------------------------------------------------- */
@@ -41,13 +42,15 @@
   line-height: 1.6;
   color: var(--foreground);
   background: var(--secondary);
-  /* Blur softens individual characters into "text-shaped bands"; the
-   * brightness drop pushes it visually to the back layer so the Resume
-   * card pops. opacity helps tune presence without crushing color. */
-  filter: blur(5px) brightness(0.7);
-  opacity: 0.55;
+  /* The placeholder stays recognizable as a terminal without pretending to
+   * be the real transcript. Restore makes it sharpen as the PTY takes over. */
+  filter: blur(0.9px) saturate(0.78) brightness(0.86);
+  opacity: 0.54;
   pointer-events: none;
   user-select: none;
+  transition:
+    filter var(--motion-slow) ease,
+    opacity var(--motion-slow) ease;
 }
 
 .resume-tui-titlebar {
@@ -141,6 +144,15 @@
   opacity: 0.7;
 }
 
+.resume-cta-frame.is-resuming .resume-tui {
+  filter: blur(0.35px) saturate(0.9) brightness(0.92);
+  opacity: 0.72;
+}
+
+.resume-cta-frame.is-resuming .resume-tui-input-cursor {
+  animation: resume-tui-cursor 0.75s steps(1, end) infinite;
+}
+
 .resume-tui-statusbar {
   display: flex;
   justify-content: space-between;
@@ -149,67 +161,127 @@
   color: var(--muted-foreground);
 }
 
-/* Foreground Resume card ------------------------------------------------- */
+/* Foreground terminal wake control --------------------------------------- */
 
 .resume-cta-overlay {
   position: absolute;
   inset: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
-  /* Subtle vignette pushes the eye to center, where the card lives. */
-  background: radial-gradient(
-    ellipse at center,
-    transparent 0%,
-    color-mix(in srgb, var(--shadow-color) 35%, transparent) 60%,
-    color-mix(in srgb, var(--shadow-color) 55%, transparent) 100%
+  padding: clamp(16px, 3vw, 32px);
+  background: linear-gradient(
+    to bottom,
+    transparent 36%,
+    color-mix(in srgb, var(--background) 18%, transparent) 70%,
+    color-mix(in srgb, var(--background) 38%, transparent) 100%
   );
 }
 
 .resume-cta-card {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 14px;
-  padding: 24px 28px;
-  width: min(380px, calc(100% - 32px));
+  gap: 10px;
+  padding: 14px 16px 9px;
+  width: min(960px, 100%);
   min-width: 0;
-  background: var(--background);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow-color) 26%, transparent);
+  background: color-mix(in srgb, var(--background) 80%, var(--secondary));
+  border-block: 1px solid var(--border);
+  box-shadow: 0 -18px 44px -38px color-mix(in srgb, var(--shadow-color) 58%, transparent);
+  transition:
+    opacity var(--motion-standard) ease,
+    transform var(--motion-standard) ease;
+}
+
+.resume-cta-card-main {
+  display: grid;
+  grid-template-columns: minmax(170px, 1.15fr) minmax(340px, 2fr) auto;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
 }
 
 .resume-cta-card-header {
   display: flex;
-  align-items: center;
-  gap: 12px;
-}
-.resume-cta-card-title {
-  display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
   min-width: 0;
+  text-align: left;
 }
 
-.resume-cta-badge {
-  width: 22px;
-  height: 20px;
-  font-size: 12px;
-  flex-shrink: 0;
+.resume-cta-kicker {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 1px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.resume-cta-state-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.72;
 }
 
 .resume-cta-name {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  margin: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--foreground);
   font-size: 16px;
   font-weight: 600;
-  color: var(--foreground);
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .resume-cta-state {
-  font-size: 11px;
+  margin: 0;
   color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.resume-cta-runtime {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  min-width: 0;
+  margin: 0;
+}
+
+.resume-cta-runtime-fact {
+  min-width: 0;
+  padding: 1px 14px;
+  border-left: 1px solid var(--border);
+}
+
+.resume-cta-runtime-fact dt {
+  margin: 0 0 2px;
+  color: var(--muted-foreground);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+}
+
+.resume-cta-runtime-fact dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .resume-cta-meta {
@@ -218,8 +290,7 @@
   column-gap: 14px;
   row-gap: 4px;
   margin: 0;
-  padding: 10px 0 0;
-  border-top: 1px solid var(--border);
+  padding: 8px 2px 2px;
   font-size: 12px;
 }
 .resume-cta-error {
@@ -238,9 +309,11 @@
   margin: 0;
 }
 .resume-cta-meta dd {
+  min-width: 0;
   color: var(--foreground);
   margin: 0;
   font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
 }
 .resume-cta-meta dd.mono {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
@@ -261,7 +334,9 @@
   font-weight: 600;
   white-space: nowrap;
   cursor: pointer;
-  transition: filter 0.12s;
+  transition:
+    filter var(--motion-fast) ease,
+    opacity var(--motion-fast) ease;
 }
 .resume-cta-beta {
   padding: 1px 4px;
@@ -287,6 +362,107 @@
   font-size: 11px;
   font-style: italic;
   text-align: center;
+}
+
+.resume-cta-details {
+  border-top: 1px solid var(--border);
+}
+
+.resume-cta-details > summary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  min-height: 30px;
+  margin-bottom: -5px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.resume-cta-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.resume-cta-details > summary svg {
+  transition: transform var(--motion-standard) ease;
+}
+
+.resume-cta-details[open] > summary svg {
+  transform: rotate(180deg);
+}
+
+.resume-cta-details-body {
+  display: none;
+  padding-top: 5px;
+}
+
+.resume-cta-details[open] > .resume-cta-details-body {
+  display: block;
+}
+
+.resume-cta-frame.is-resuming .resume-cta-card {
+  opacity: 0.78;
+  transform: translateY(4px);
+}
+
+@keyframes resume-tui-cursor {
+  0%, 48% { opacity: 0.82; }
+  49%, 100% { opacity: 0.18; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resume-tui,
+  .resume-cta-card,
+  .resume-cta-details > summary svg {
+    transition: none;
+  }
+
+  .resume-cta-frame.is-resuming .resume-tui-input-cursor {
+    animation: none;
+  }
+}
+
+@container resume-cta (max-width: 760px) {
+  .resume-cta-card-main {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .resume-cta-runtime {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .resume-cta-runtime-fact:first-child {
+    border-left: 0;
+    padding-left: 0;
+  }
+}
+
+@container resume-cta (max-width: 480px) {
+  .resume-cta-overlay {
+    padding: 12px;
+  }
+
+  .resume-cta-card-main {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 11px;
+  }
+
+  .resume-cta-runtime,
+  .resume-cta-actions {
+    grid-column: 1;
+  }
+
+  .resume-cta-runtime {
+    grid-row: auto;
+  }
+
+  .resume-cta-actions {
+    width: 100%;
+    flex-direction: column;
+  }
 }
 
 /* ── Main pane ────────────────────────────────────────────────────────────── */
@@ -1229,10 +1405,11 @@ button.files-row:focus-visible {
 .resume-cta-actions {
   display: flex;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .resume-cta-actions .resume-cta-btn {
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 0;
   padding-inline: 14px;
 }
@@ -1461,5 +1638,5 @@ button.files-row:focus-visible {
 }
 
 @media (max-width: 720px) {
-  .resume-cta-actions { flex-direction: column; }
+  .resume-cta-actions .resume-cta-btn { flex: 1; }
 }

--- a/ui/src/pages/WorkspaceManagerPage.spec.tsx
+++ b/ui/src/pages/WorkspaceManagerPage.spec.tsx
@@ -567,7 +567,7 @@ describe('WorkspaceManagerPage runtime selection', () => {
     expect(screen.queryByTestId('terminal-view')).toBeNull()
     expect(container.firstElementChild?.classList.contains('workspaces-root')).toBe(true)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Continue in terminal' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Resume in TUI' }))
 
     expect(mocks.resumeSession).toHaveBeenCalledWith(
       'workspace-manager',
@@ -630,7 +630,7 @@ describe('WorkspaceManagerPage runtime selection', () => {
     }} />)
 
     expect(mocks.openWebPiSession).not.toHaveBeenCalled()
-    const openWebPi = screen.getByText('Open WebPi').closest('button')
+    const openWebPi = screen.getByText('Open in WebPi').closest('button')
     expect(openWebPi).toBeTruthy()
     fireEvent.click(openWebPi as HTMLButtonElement)
 


### PR DESCRIPTION
## What changed

- replace the centered paused-session modal card with a bottom-docked terminal wake strip
- keep the faux TUI recognizable during the browser-to-TUI handoff
- show the Session credential source, model, and effort by default
- keep runtime diagnostics, creation time, and transcript identity in an optional disclosure
- expose only the secret-free persisted runtime binding through the Session API
- make the wake strip responsive to its actual pane width, including Pi dual actions

## Why

The old centered card obscured the terminal metaphor and hid the launch configuration users need to verify before resuming. The new hierarchy keeps the TUI transition understandable while making the persisted Session semantics visible without exposing secrets or internal runtime identifiers.

## Verification

- `git diff --check`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 492 files passed, 1 skipped; 4060 tests passed, 9 skipped
- browser walkthrough at the real `/chat/workspaces/.../s/...` route in day and night themes
- verified narrow main-pane layout, diagnostics disclosure, OpenCode single action, and Pi dual actions without overflow
- verified reduced-motion behavior and container-query breakpoints