### PR TITLE
fix(workspaces): stop passing run-only flags to OpenCode TUI

### DIFF
--- a/src/workspaces/adapters/opencode-runtime-flags.spec.ts
+++ b/src/workspaces/adapters/opencode-runtime-flags.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ResolvedSessionRuntimeBinding } from '../cli-adapter.js';
+import { opencodeAdapter } from './opencode.js';
+
+const runtime: ResolvedSessionRuntimeBinding = {
+  binding: {
+    version: 1,
+    credential: { source: 'native' },
+    model: 'openai/gpt-5.6-sol',
+    reasoningEffort: 'high',
+  },
+  ai: {
+    model: 'openai/gpt-5.6-sol',
+    reasoningEffort: 'high',
+  },
+};
+
+describe('opencode runtime flags', () => {
+  it('keeps run-only --variant off the interactive and web launch surfaces', () => {
+    const projected = opencodeAdapter.sessionRuntime!.project(
+      { cwd: '/workspace', env: {} },
+      runtime,
+    );
+
+    expect(projected.interactiveArgs).toEqual(['--model', 'openai/gpt-5.6-sol']);
+    expect(projected.webArgs).toEqual(['--model', 'openai/gpt-5.6-sol']);
+    expect(projected.headlessArgs).toEqual([
+      '--model', 'openai/gpt-5.6-sol',
+      '--variant', 'high',
+    ]);
+
+    expect(opencodeAdapter.composeCommand([], {
+      cwd: '/workspace',
+      env: {},
+      resume: 'last',
+      sessionRuntime: projected,
+    })).toEqual(['opencode', '--model', 'openai/gpt-5.6-sol', '--continue']);
+
+    expect(opencodeAdapter.composeHeadlessCommand!([], {
+      cwd: '/workspace',
+      env: {},
+      sessionRuntime: projected,
+    }, 'hello')).toContain('--variant');
+  });
+});

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -321,8 +321,11 @@ export const opencodeAdapter: CliAdapter = {
       const selectedModel = ai && (ai.apiKey || ai.baseUrl) && model
         ? `${OPENCODE_SESSION_PROVIDER_NAME}/${model}`
         : model;
-      const args = [
+      const interactiveArgs = [
         ...(selectedModel ? ['--model', selectedModel] : []),
+      ];
+      const headlessArgs = [
+        ...interactiveArgs,
         ...(runtime.binding.reasoningEffort
           ? ['--variant', runtime.binding.reasoningEffort]
           : []),
@@ -336,7 +339,7 @@ export const opencodeAdapter: CliAdapter = {
           ...(selectedModel ? { model: selectedModel } : {}),
         });
       }
-      return { env, interactiveArgs: args, headlessArgs: args, webArgs: args };
+      return { env, interactiveArgs, headlessArgs, webArgs: interactiveArgs };
     },
   },
 


### PR DESCRIPTION
## What changed

- Keep OpenCode model selection on interactive TUI launches.
- Project reasoning effort as `--variant` only for `opencode run`, where that flag is supported.
- Add a regression test that locks the interactive, web, and headless argument boundaries.

## Root cause

OpenAlice projected one shared argument array onto every OpenCode launch surface. A persisted effort such as `high` therefore produced `opencode --continue --variant high`. OpenCode 1.17.13 only accepts `--variant` under `opencode run`; its TUI entrypoint prints help and exits with code 1, which OpenAlice surfaced as “agent exited within startup window”.

This addresses the immediate launch failure reported around [discussion #718](https://github.com/orgs/TraderAlice/discussions/718). The broader Session activity/lifecycle work is intentionally excluded from this PR.

## Acceptance evidence

- Reproduced the old command directly: `opencode --continue --variant high` exits 1.
- Resumed the affected persisted Session through the real Workspace API after the fix.
- Observed the final child command as `opencode --continue` and confirmed the child remained alive beyond the startup window.
- `npx tsc --noEmit`
- `pnpm test`: 493 files passed, 1 skipped; 4061 tests passed, 9 skipped.
