### PR TITLE
fix: polish Workspace AI preferences and migrate settings

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -32,8 +32,8 @@ the durable truth after it changes.
 ## Completed
 
 - [[plans/workspace-ai-preferences.md]] — Separates Agent runtime diagnostics
-  from scenario-aware AI defaults, with fixed Workspace preferences layered
-  over recent successful Ask Alice and Issue launches.
+  from scenario-aware AI defaults, with a responsive preferences editor and
+  one-time migration 0037 for legacy Workspace settings.
 - [[plans/workspace-runtime-settings.md]] — Adds portable, secret-free
   interactive/headless runtime preferences to each Workspace and demotes native
   project credential injection to an explicit deprecated compatibility export.

--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -117,10 +117,12 @@ for creating a product Session. Version 2 stores separate `askAlice` and
 
 "Follow recent" means the fixed field is absent. A successful launch updates
 only the recent layer and therefore cannot overwrite a user-pinned default.
-Version 1 `interactive` and `headless` entries are read as Ask Alice and Issues
-recent state respectively, then upgraded on the next atomic write. They never
-become fixed defaults merely because an older release remembered them. Vault
-choices store only the credential slug and wire shape; keys and resolved
+Migration `0037_workspace_runtime_settings_v2` converts version 1
+`interactive` and `headless` entries into Ask Alice and Issues recent state.
+They never become fixed defaults merely because an older release remembered
+them. Normal runtime reads accept only the current shape, so legacy-format
+handling remains an upgrade concern rather than a permanent dual-read path.
+Vault choices store only the credential slug and wire shape; keys and resolved
 provider payloads never enter the Workspace file.
 
 A fresh Session resolves that surface/Agent preference together with any

--- a/plans/workspace-ai-preferences.md
+++ b/plans/workspace-ai-preferences.md
@@ -47,9 +47,9 @@ default runtime, and per-runtime access/model/effort editing.
 1. Evolve `.alice/settings.json` to version 2. Each `askAlice` and `issues`
    scenario stores optional fixed defaults plus a separate automatically
    maintained recent layer.
-2. Read version 1 files compatibly: `interactive` becomes Ask Alice recent
-   state and `headless` becomes Issues recent state. The next write upgrades the
-   file atomically without treating old recents as fixed defaults.
+2. Migrate version 1 files once: `interactive` becomes Ask Alice recent state
+   and `headless` becomes Issues recent state. Normal runtime reads accept only
+   version 2 and never carry a permanent legacy branch.
 3. Resolve a fresh launch in this order: explicit one-launch fields, fixed
    scenario/runtime preference, matching recent preference, then native Agent
    state. Resolve the Agent runtime from explicit input, fixed scenario default,
@@ -70,11 +70,15 @@ default runtime, and per-runtime access/model/effort editing.
 8. Credential rows show human-readable AI access labels and keep native/global
    Agent authentication as an explicit valid option. No secret, endpoint, or
    resolved credential payload enters Workspace settings or UI responses.
+9. The settings editor owns a form layout rather than reusing Quick Chat's
+   compact toolbar layout. AI access is one full-width, portaled menu; model and
+   effort form a balanced responsive pair below it. Selection state and model
+   semantics remain owned by the shared launch-configuration hook.
 
 ## Work
 
-- [x] Add the v2 settings schema, v1 compatibility reader, atomic default
-      updates, and focused precedence tests.
+- [x] Add the v2 settings schema, one-time v1 migration, atomic default updates,
+      and focused precedence tests.
 - [x] Apply scenario Agent/default resolution to Ask Alice, sidebar Session
       starts, Issues, generic headless dispatch, probes, and exact resume.
 - [x] Add a secret-free Workspace scenario-preferences API and demo handler.
@@ -85,6 +89,12 @@ default runtime, and per-runtime access/model/effort editing.
       demo fixtures, and tests.
 - [x] Verify TypeScript, full tests, real browser behavior, PTY, and packaged
       Workspace acceptance; then deliver serially to `dev`.
+- [x] Replace the compact launch toolbar embedded in the runtime-preference
+      dialog with a responsive settings form and portaled access menu.
+- [x] Register and exercise migration 0037 against active and departed
+      Workspaces, then remove the runtime v1 compatibility reader.
+- [x] Re-run real Workspace browser, focused migration/UI, typecheck, full test,
+      and packaged Workspace acceptance for the follow-up.
 
 ## Verification
 
@@ -101,4 +111,7 @@ default runtime, and per-runtime access/model/effort editing.
 Workspace Settings clearly separates runtime mechanics from AI policy. Ask
 Alice and Issues can each pin a default Agent and one secret-free preference per
 runtime, while recent successful launches remain available as the zero-config
-fallback and never overwrite an explicit default.
+fallback and never overwrite an explicit default. The follow-up replaced the
+embedded Quick Chat toolbar with a responsive settings form, verified its
+portaled credential menu on desktop and narrow layouts, and moved all legacy
+settings conversion into idempotent migration 0037.

--- a/src/migrations/0037_workspace_runtime_settings_v2.spec.ts
+++ b/src/migrations/0037_workspace_runtime_settings_v2.spec.ts
@@ -1,0 +1,99 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { migrateWorkspaceRuntimeSettingsV2 } from './0037_workspace_runtime_settings_v2/index.js'
+
+async function fixture(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'workspace-runtime-settings-v2-'))
+}
+
+async function writeSettings(root: string, kind: 'workspaces' | 'departed-workspaces', name: string, value: unknown) {
+  const dir = join(root, kind, name, '.alice')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'settings.json'), `${JSON.stringify(value, null, 2)}\n`)
+}
+
+describe('0037 Workspace runtime settings v2 migration', () => {
+  it('moves legacy interactive/headless choices into recent scenario fallbacks', async () => {
+    const root = await fixture()
+    const backupRoot = join(root, 'backups')
+    const legacy = {
+      version: 1,
+      runtime: {
+        interactive: {
+          recentAgent: 'pi',
+          agents: { pi: { accessMode: 'native', model: 'pi-model' } },
+        },
+        headless: {
+          recentAgent: 'codex',
+          agents: { codex: { accessMode: 'native', model: 'codex-model' } },
+        },
+      },
+    }
+    await writeSettings(root, 'workspaces', 'active-one', legacy)
+    await writeSettings(root, 'departed-workspaces', 'departed-one', legacy)
+
+    expect(await migrateWorkspaceRuntimeSettingsV2(root, { backupRoot })).toEqual({
+      scanned: 2,
+      migrated: 2,
+      current: 0,
+      skipped: 0,
+    })
+    const migrated = JSON.parse(await readFile(
+      join(root, 'workspaces', 'active-one', '.alice', 'settings.json'),
+      'utf8',
+    )) as Record<string, unknown>
+    expect(migrated).toMatchObject({
+      version: 2,
+      runtime: {
+        askAlice: {
+          agents: {},
+          recent: { agent: 'pi', agents: { pi: { accessMode: 'native', model: 'pi-model' } } },
+        },
+        issues: {
+          agents: {},
+          recent: { agent: 'codex', agents: { codex: { accessMode: 'native', model: 'codex-model' } } },
+        },
+      },
+    })
+    expect(JSON.parse(await readFile(
+      join(backupRoot, 'active', 'active-one', '.alice', 'settings.json'),
+      'utf8',
+    ))).toEqual(legacy)
+
+    expect(await migrateWorkspaceRuntimeSettingsV2(root, { backupRoot })).toEqual({
+      scanned: 2,
+      migrated: 0,
+      current: 2,
+      skipped: 0,
+    })
+  })
+
+  it('leaves current and malformed files untouched', async () => {
+    const root = await fixture()
+    await writeSettings(root, 'workspaces', 'current', {
+      version: 2,
+      runtime: {
+        askAlice: { agents: {}, recent: { agents: {} } },
+        issues: { agents: {}, recent: { agents: {} } },
+      },
+    })
+    const malformedPath = join(root, 'workspaces', 'malformed', '.alice', 'settings.json')
+    await mkdir(dirname(malformedPath), { recursive: true })
+    await writeFile(malformedPath, '{ definitely not json')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    expect(await migrateWorkspaceRuntimeSettingsV2(root)).toEqual({
+      scanned: 2,
+      migrated: 0,
+      current: 1,
+      skipped: 1,
+    })
+    expect(await readFile(malformedPath, 'utf8')).toBe('{ definitely not json')
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+})

--- a/src/migrations/0037_workspace_runtime_settings_v2/index.ts
+++ b/src/migrations/0037_workspace_runtime_settings_v2/index.ts
@@ -1,0 +1,208 @@
+import { copyFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+
+import { z } from 'zod'
+
+import type { Migration } from '../types.js'
+
+const WORKSPACE_RUNTIME_SETTINGS_REL = '.alice/settings.json'
+const runtimeIdSchema = z.string().trim().min(1).max(64)
+const modelSchema = z.string().trim().min(1).max(512)
+const credentialSlugSchema = z.string().trim().min(1).max(128)
+const reasoningEffortSchema = z.enum([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+])
+const wireShapeSchema = z.enum([
+  'anthropic',
+  'google-generative-ai',
+  'openai-chat',
+  'openai-responses',
+])
+const workspaceRuntimePreferenceSchema = z.discriminatedUnion('accessMode', [
+  z.object({
+    accessMode: z.literal('native'),
+    model: modelSchema.optional(),
+    reasoningEffort: reasoningEffortSchema.optional(),
+  }).strict(),
+  z.object({
+    accessMode: z.literal('vault'),
+    credentialSlug: credentialSlugSchema,
+    wireShape: wireShapeSchema.optional(),
+    model: modelSchema.optional(),
+    reasoningEffort: reasoningEffortSchema.optional(),
+  }).strict(),
+])
+const currentRecentSchema = z.object({
+  agent: runtimeIdSchema.optional(),
+  agents: z.record(runtimeIdSchema, workspaceRuntimePreferenceSchema).default({}),
+}).strict()
+const currentScenarioSchema = z.object({
+  defaultAgent: runtimeIdSchema.optional(),
+  agents: z.record(runtimeIdSchema, workspaceRuntimePreferenceSchema).default({}),
+  recent: currentRecentSchema.default({ agents: {} }),
+}).strict()
+const workspaceRuntimeSettingsSchema = z.object({
+  version: z.literal(2),
+  runtime: z.object({
+    askAlice: currentScenarioSchema.default({ agents: {}, recent: { agents: {} } }),
+    issues: currentScenarioSchema.default({ agents: {}, recent: { agents: {} } }),
+  }).strict(),
+}).strict()
+type WorkspaceRuntimeSettings = z.infer<typeof workspaceRuntimeSettingsSchema>
+
+const legacyScenarioSchema = z.object({
+  recentAgent: runtimeIdSchema.optional(),
+  agents: z.record(runtimeIdSchema, workspaceRuntimePreferenceSchema).default({}),
+}).strict().default({ agents: {} })
+
+const legacySettingsSchema = z.object({
+  version: z.literal(1),
+  runtime: z.object({
+    interactive: legacyScenarioSchema,
+    headless: legacyScenarioSchema,
+  }).strict().default({ interactive: { agents: {} }, headless: { agents: {} } }),
+}).strict()
+
+interface WorkspaceDirectory {
+  readonly kind: 'active' | 'departed'
+  readonly name: string
+  readonly dir: string
+}
+
+interface MigrationOptions {
+  readonly backupRoot?: string
+}
+
+async function workspaceDirectories(
+  root: string,
+  kind: WorkspaceDirectory['kind'],
+): Promise<WorkspaceDirectory[]> {
+  try {
+    return (await readdir(root, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => ({ kind, name: entry.name, dir: join(root, entry.name) }))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+function upgradeLegacySettings(
+  legacy: z.infer<typeof legacySettingsSchema>,
+): WorkspaceRuntimeSettings {
+  return workspaceRuntimeSettingsSchema.parse({
+    version: 2,
+    runtime: {
+      askAlice: {
+        agents: {},
+        recent: {
+          ...(legacy.runtime.interactive.recentAgent
+            ? { agent: legacy.runtime.interactive.recentAgent }
+            : {}),
+          agents: legacy.runtime.interactive.agents,
+        },
+      },
+      issues: {
+        agents: {},
+        recent: {
+          ...(legacy.runtime.headless.recentAgent
+            ? { agent: legacy.runtime.headless.recentAgent }
+            : {}),
+          agents: legacy.runtime.headless.agents,
+        },
+      },
+    },
+  })
+}
+
+async function atomicWrite(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const temporary = `${path}.${process.pid}.${Date.now()}.tmp`
+  await writeFile(temporary, contents, { encoding: 'utf8', mode: 0o600 })
+  await rename(temporary, path)
+}
+
+export async function migrateWorkspaceRuntimeSettingsV2(
+  launcherRoot: string,
+  options: MigrationOptions = {},
+): Promise<{ scanned: number; migrated: number; current: number; skipped: number }> {
+  const workspaces = [
+    ...await workspaceDirectories(join(launcherRoot, 'workspaces'), 'active'),
+    ...await workspaceDirectories(join(launcherRoot, 'departed-workspaces'), 'departed'),
+  ]
+  let migrated = 0
+  let current = 0
+  let skipped = 0
+
+  for (const workspace of workspaces) {
+    const path = join(workspace.dir, WORKSPACE_RUNTIME_SETTINGS_REL)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(await readFile(path, 'utf8')) as unknown
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+      skipped += 1
+      console.warn(
+        `[migration] kept invalid Workspace runtime settings at ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      continue
+    }
+
+    if (workspaceRuntimeSettingsSchema.safeParse(parsed).success) {
+      current += 1
+      continue
+    }
+    const legacy = legacySettingsSchema.safeParse(parsed)
+    if (!legacy.success) {
+      skipped += 1
+      console.warn(`[migration] kept unrecognized Workspace runtime settings at ${path}`)
+      continue
+    }
+
+    if (options.backupRoot) {
+      const backup = join(
+        options.backupRoot,
+        workspace.kind,
+        workspace.name,
+        WORKSPACE_RUNTIME_SETTINGS_REL,
+      )
+      await mkdir(dirname(backup), { recursive: true })
+      await copyFile(path, backup)
+    }
+    await atomicWrite(path, `${JSON.stringify(upgradeLegacySettings(legacy.data), null, 2)}\n`)
+    migrated += 1
+  }
+
+  return { scanned: workspaces.length, migrated, current, skipped }
+}
+
+export const migration: Migration = {
+  id: '0037_workspace_runtime_settings_v2',
+  appVersion: '0.89.2-beta',
+  introducedAt: '2026-08-10',
+  affects: [
+    'workspaces/workspaces/*/.alice/settings.json',
+    'workspaces/departed-workspaces/*/.alice/settings.json',
+  ],
+  summary: 'Convert legacy interactive/headless Workspace runtime preferences to scenario-aware settings.',
+  rationale: 'A one-time migration keeps the normal runtime reader single-version while preserving prior successful launch choices as recent fallbacks.',
+  up: async (ctx) => {
+    const userDataHome = resolve(ctx.configDir(), '..', '..')
+    const launcherRoot = resolve(process.env['AQ_LAUNCHER_ROOT'] ?? join(userDataHome, 'workspaces'))
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const backupRoot = join(
+      dirname(ctx.configDir()),
+      '_backup',
+      `${timestamp}-pre-0037_workspace_runtime_settings_v2`,
+      'workspace-runtime-settings',
+    )
+    await migrateWorkspaceRuntimeSettingsV2(launcherRoot, { backupRoot })
+  },
+}

--- a/src/migrations/INDEX.md
+++ b/src/migrations/INDEX.md
@@ -36,3 +36,4 @@ Each row corresponds to one migration in `src/migrations/`. The runner applies p
 | `0034_quick_chat_recent_launch` | 0.89.3-beta | 2026-08-06 | data/preferences.json | Remember Quick Start runtime, credential, model, and effort as one Session-only launch tuple. |
 | `0035_quick_chat_access_mode` | 0.89.3-beta | 2026-08-06 | data/preferences.json | Distinguish Workspace AI, saved credentials, and native runtime accounts in Quick Start. |
 | `0036_codex_56_subscription_model` | 0.89.3-beta | 2026-08-07 | data/preferences.json, workspaces/state/resume-identities.json | Use the explicit GPT-5.6 Sol slug for native Codex subscription Sessions. |
+| `0037_workspace_runtime_settings_v2` | 0.89.2-beta | 2026-08-10 | workspaces/workspaces/*/.alice/settings.json, workspaces/departed-workspaces/*/.alice/settings.json | Convert legacy interactive/headless Workspace runtime preferences to scenario-aware settings. |

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -14,7 +14,7 @@
  * deletion + Workspace pivot turned the pre-0.40 data shapes over completely, so
  * pre-0.40 installs rebuild `data/` rather than migrate. The framework stays for
  * future upgrades. Numbering continues FORWARD from the highest id ever shipped
- * (next: 0037) — never reuse a retired id, since existing installs' journals
+ * (next: 0038) — never reuse a retired id, since existing installs' journals
  * recorded the old ones.
  */
 
@@ -48,6 +48,7 @@ import { migration as migration_0033_semantic_issue_assignees } from './0033_sem
 import { migration as migration_0034_quick_chat_recent_launch } from './0034_quick_chat_recent_launch/index.js'
 import { migration as migration_0035_quick_chat_access_mode } from './0035_quick_chat_access_mode/index.js'
 import { migration as migration_0036_codex_56_subscription_model } from './0036_codex_56_subscription_model/index.js'
+import { migration as migration_0037_workspace_runtime_settings_v2 } from './0037_workspace_runtime_settings_v2/index.js'
 
 export const REGISTRY: Migration[] = [
   migration_0008_disable_targetless_cron_jobs,
@@ -79,4 +80,5 @@ export const REGISTRY: Migration[] = [
   migration_0034_quick_chat_recent_launch,
   migration_0035_quick_chat_access_mode,
   migration_0036_codex_56_subscription_model,
+  migration_0037_workspace_runtime_settings_v2,
 ]

--- a/src/workspaces/workspace-runtime-settings.spec.ts
+++ b/src/workspaces/workspace-runtime-settings.spec.ts
@@ -45,36 +45,6 @@ describe('Workspace runtime settings', () => {
     expect(await readFile(join(dir, WORKSPACE_RUNTIME_SETTINGS_REL), 'utf8')).not.toContain('apiKey')
   })
 
-  it('reads v1 recents as recents without turning them into fixed defaults', async () => {
-    const dir = await fixture()
-    await mkdir(join(dir, '.alice'), { recursive: true })
-    await writeFile(join(dir, WORKSPACE_RUNTIME_SETTINGS_REL), JSON.stringify({
-      version: 1,
-      runtime: {
-        interactive: {
-          recentAgent: 'pi',
-          agents: { pi: { accessMode: 'native', model: 'pi-model' } },
-        },
-        headless: {
-          recentAgent: 'codex',
-          agents: { codex: { accessMode: 'native', model: 'codex-model' } },
-        },
-      },
-    }))
-
-    const read = await readWorkspaceRuntimeSettings(dir)
-    expect(read).toMatchObject({
-      ok: true,
-      settings: {
-        version: 2,
-        runtime: {
-          askAlice: { agents: {}, recent: { agent: 'pi', agents: { pi: { model: 'pi-model' } } } },
-          issues: { agents: {}, recent: { agent: 'codex', agents: { codex: { model: 'codex-model' } } } },
-        },
-      },
-    })
-  })
-
   it('rejects secret-shaped and contradictory native fields', async () => {
     const dir = await fixture()
     await mkdir(join(dir, '.alice'), { recursive: true })

--- a/src/workspaces/workspace-runtime-settings.ts
+++ b/src/workspaces/workspace-runtime-settings.ts
@@ -58,20 +58,6 @@ export const workspaceRuntimeSettingsSchema = z.object({
   }),
 }).strict()
 
-const workspaceRuntimeSettingsV1Schema = z.object({
-  version: z.literal(1),
-  runtime: z.object({
-    interactive: z.object({
-      recentAgent: runtimeIdSchema.optional(),
-      agents: z.record(runtimeIdSchema, workspaceRuntimePreferenceSchema).default({}),
-    }).strict().default({ agents: {} }),
-    headless: z.object({
-      recentAgent: runtimeIdSchema.optional(),
-      agents: z.record(runtimeIdSchema, workspaceRuntimePreferenceSchema).default({}),
-    }).strict().default({ agents: {} }),
-  }).strict().default({ interactive: { agents: {} }, headless: { agents: {} } }),
-}).strict()
-
 export type WorkspaceRuntimePreference = z.infer<typeof workspaceRuntimePreferenceSchema>
 export type WorkspaceRuntimeSettings = z.infer<typeof workspaceRuntimeSettingsSchema>
 export type WorkspaceRuntimeScenario = keyof WorkspaceRuntimeSettings['runtime']
@@ -87,34 +73,6 @@ export function emptyWorkspaceRuntimeSettings(): WorkspaceRuntimeSettings {
     runtime: {
       askAlice: { agents: {}, recent: { agents: {} } },
       issues: { agents: {}, recent: { agents: {} } },
-    },
-  }
-}
-
-function upgradeV1Settings(
-  legacy: z.infer<typeof workspaceRuntimeSettingsV1Schema>,
-): WorkspaceRuntimeSettings {
-  return {
-    version: 2,
-    runtime: {
-      askAlice: {
-        agents: {},
-        recent: {
-          ...(legacy.runtime.interactive.recentAgent
-            ? { agent: legacy.runtime.interactive.recentAgent }
-            : {}),
-          agents: legacy.runtime.interactive.agents,
-        },
-      },
-      issues: {
-        agents: {},
-        recent: {
-          ...(legacy.runtime.headless.recentAgent
-            ? { agent: legacy.runtime.headless.recentAgent }
-            : {}),
-          agents: legacy.runtime.headless.agents,
-        },
-      },
     },
   }
 }
@@ -141,15 +99,11 @@ export async function readWorkspaceRuntimeSettings(
   }
   const result = workspaceRuntimeSettingsSchema.safeParse(parsed)
   if (result.success) return { ok: true, settings: result.data }
-  const legacy = workspaceRuntimeSettingsV1Schema.safeParse(parsed)
-  if (!legacy.success) {
-    return {
-      ok: false,
-      reason: 'invalid',
-      error: result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; '),
-    }
+  return {
+    ok: false,
+    reason: 'invalid',
+    error: result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; '),
   }
-  return { ok: true, settings: upgradeV1Settings(legacy.data) }
 }
 
 export async function writeWorkspaceRuntimeSettings(

--- a/ui/src/components/ui/dropdown-menu.tsx
+++ b/ui/src/components/ui/dropdown-menu.tsx
@@ -21,17 +21,20 @@ function DropdownMenuContent({
   alignOffset = 0,
   side = "bottom",
   sideOffset = 4,
+  positionerClassName,
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & {
+    positionerClassName?: string
+  }) {
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
-        className="isolate z-50 outline-none"
+        className={cn("isolate z-50 outline-none", positionerClassName)}
         align={align}
         alignOffset={alignOffset}
         side={side}

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -73,7 +73,7 @@ export function credentialAccessLabel(credential: AgentLaunchConfigState['creden
     || credential.vendor
 }
 
-function credentialAccessDetail(credential: AgentLaunchConfigState['credential']): string {
+export function credentialAccessDetail(credential: AgentLaunchConfigState['credential']): string {
   if (!credential) return ''
   const label = credential.label?.trim()
   return label && label !== credentialAccessLabel(credential)

--- a/ui/src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
@@ -10,6 +10,8 @@ import type { AgentInfo, Workspace } from './api'
 const mocks = vi.hoisted(() => ({
   listAgentCredentials: vi.fn(),
   updateWorkspaceRuntimeDefaults: vi.fn(),
+  getAgentRuntimeReadiness: vi.fn(),
+  getPresets: vi.fn(),
 }))
 
 vi.mock('./api', async (importOriginal) => {
@@ -18,7 +20,13 @@ vi.mock('./api', async (importOriginal) => {
     ...actual,
     listAgentCredentials: mocks.listAgentCredentials,
     updateWorkspaceRuntimeDefaults: mocks.updateWorkspaceRuntimeDefaults,
+    getAgentRuntimeReadiness: mocks.getAgentRuntimeReadiness,
   }
+})
+
+vi.mock('@/api/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/config')>()
+  return { ...actual, getPresets: mocks.getPresets }
 })
 
 const agents: AgentInfo[] = [
@@ -55,6 +63,14 @@ beforeEach(async () => {
   await i18n.changeLanguage('zh')
   mocks.listAgentCredentials.mockResolvedValue([{ slug: 'deepseek-1', vendor: 'deepseek', authType: 'api-key', label: 'DeepSeek API' }])
   mocks.updateWorkspaceRuntimeDefaults.mockResolvedValue(workspace)
+  mocks.getAgentRuntimeReadiness.mockResolvedValue({
+    checkedAt: '2026-08-10T00:00:00.000Z',
+    agents: {
+      pi: { agent: 'pi', ready: true, source: 'global-login' },
+      codex: { agent: 'codex', ready: true, source: 'global-login' },
+    },
+  })
+  mocks.getPresets.mockResolvedValue({ presets: [] })
 })
 
 afterEach(cleanup)
@@ -87,5 +103,28 @@ describe('WorkspaceAIPreferencesPanel', () => {
       { defaultAgent: 'codex', agents: {} },
     ))
     expect(onSaved).toHaveBeenCalledOnce()
+  })
+
+  it('uses a full settings form and opens the portaled AI access menu', async () => {
+    render(
+      <WorkspaceAIPreferencesPanel
+        workspace={workspace}
+        agents={agents}
+        onSaved={vi.fn()}
+        onConfigureProvider={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '编辑 Codex 偏好' }))
+    fireEvent.click(screen.getByRole('radio', { name: /固定默认值/ }))
+    const access = await screen.findByRole('button', { name: 'AI 访问' })
+    expect(screen.getByRole('combobox', { name: 'AI 模型' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: '思考强度' })).toBeTruthy()
+
+    fireEvent.click(access)
+    expect(await screen.findByText('Codex 要如何访问 AI？')).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: /使用 Codex 账号/ })).toBeTruthy()
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /DeepSeek API/ }))
+    await waitFor(() => expect(screen.queryByRole('menuitemradio', { name: /DeepSeek API/ })).toBeNull())
   })
 })

--- a/ui/src/components/workspace/WorkspaceAIPreferencesPanel.tsx
+++ b/ui/src/components/workspace/WorkspaceAIPreferencesPanel.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Bot, Check, Cpu, KeyRound, Pencil, RotateCcw } from 'lucide-react'
+import { Bot, BrainCircuit, Check, ChevronDown, Cpu, KeyRound, Pencil, RotateCcw, Settings2 } from 'lucide-react'
 
 import type { QuickChatLaunchPreference } from '@/api/preferences'
 import { Button } from '@/components/ui/button'
@@ -12,12 +12,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   useAgentLaunchConfig,
+  type AgentLaunchConfigState,
   type AgentLaunchPreferencesState,
 } from '@/hooks/useAgentLaunchConfig'
-import { AgentLaunchSelectors, credentialAccessLabel } from './AgentLaunchControls'
+import { credentialAccessDetail, credentialAccessLabel } from './AgentLaunchControls'
 import {
   listAgentCredentials,
   updateWorkspaceRuntimeDefaults,
@@ -80,6 +90,175 @@ function preferenceSummary(
   return { access, inference }
 }
 
+function RuntimePreferenceFields({
+  config,
+  onConfigureProvider,
+}: {
+  readonly config: AgentLaunchConfigState
+  readonly onConfigureProvider: () => void
+}) {
+  const { t } = useTranslation()
+  const modelListId = useId()
+  const [accessMenuOpen, setAccessMenuOpen] = useState(false)
+  const [modelDraft, setModelDraft] = useState(config.launchModel ?? '')
+  const runtimeName = config.selectedAgent?.displayName ?? t('chatLanding.runtimeFallback')
+  const nativeAccess = config.accessMode === 'native' || config.effectiveCredential === null
+  const selectedAccessLabel = nativeAccess
+    ? t('chatLanding.runtimeAccount', { runtime: runtimeName })
+    : credentialAccessLabel(config.credential)
+  const selectedAccessDetail = nativeAccess
+    ? t('chatLanding.runtimeAccountDetail')
+    : t('chatLanding.savedAccessDetail', { credential: credentialAccessDetail(config.credential) })
+  const effortOptions = config.selectedReasoningEffort
+    && !config.effortOptions.includes(config.selectedReasoningEffort)
+    ? [config.selectedReasoningEffort, ...config.effortOptions]
+    : config.effortOptions
+  const defaultModelLabel = config.defaultModel
+    ? t('chatLanding.defaultModelValue', { model: config.defaultModel })
+    : t('chatLanding.runtimeDefaultModel')
+
+  useEffect(() => setModelDraft(config.launchModel ?? ''), [config.launchModel])
+
+  const commitModel = () => {
+    const next = modelDraft.trim()
+    if (next !== (config.launchModel ?? '')) config.selectModel(next || null)
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-3">
+      <div className="space-y-1.5">
+        <span className="text-[11px] font-medium text-muted-foreground">{t('chatLanding.aiAccess')}</span>
+        <DropdownMenu open={accessMenuOpen} onOpenChange={setAccessMenuOpen}>
+          <DropdownMenuTrigger
+            render={<button
+              type="button"
+              aria-label={t('chatLanding.selectCredential')}
+              className="oa-pressable flex min-h-14 w-full items-center gap-3 rounded-md border border-border bg-background px-3 py-2 text-left outline-none transition-colors hover:bg-muted/35 focus-visible:ring-2 focus-visible:ring-primary/40"
+            />}
+          >
+            <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[13px] font-medium text-foreground">{selectedAccessLabel}</span>
+              <span className="mt-0.5 block truncate text-[10.5px] text-muted-foreground">{selectedAccessDetail}</span>
+            </span>
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            side="bottom"
+            align="start"
+            sideOffset={6}
+            positionerClassName="z-[80]"
+            className="z-[80] max-h-52 min-w-[min(28rem,calc(100vw-3rem))] sm:max-h-64"
+          >
+            <div className="px-1.5 py-1 text-xs font-medium text-muted-foreground">
+              {t('chatLanding.credentialMenuTitle', { runtime: runtimeName })}
+            </div>
+            <DropdownMenuSeparator />
+            <DropdownMenuRadioGroup
+              value={nativeAccess ? 'native' : `vault:${config.effectiveCredential ?? ''}`}
+              onValueChange={(value) => {
+                const selected = String(value)
+                if (selected === 'native') config.selectRuntimeDefault()
+                else if (selected.startsWith('vault:')) config.selectCredential(selected.slice('vault:'.length))
+                setAccessMenuOpen(false)
+              }}
+            >
+              <DropdownMenuRadioItem value="native" className="py-2">
+                <span className="min-w-0">
+                  <span className="block truncate text-[12px] font-medium">{t('chatLanding.runtimeAccount', { runtime: runtimeName })}</span>
+                  <span className="block truncate text-[10px] text-muted-foreground">{t('chatLanding.runtimeAccountDetail')}</span>
+                </span>
+              </DropdownMenuRadioItem>
+              {config.credentials?.map((credential) => (
+                <DropdownMenuRadioItem
+                  key={credential.slug}
+                  value={`vault:${credential.slug}`}
+                  className="py-2"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[12px] font-medium">{credentialAccessLabel(credential)}</span>
+                    <span className="block truncate text-[10px] text-muted-foreground">
+                      {t('chatLanding.savedAccessDetail', { credential: credentialAccessDetail(credential) })}
+                    </span>
+                  </span>
+                  {credential.resolvedModel && (
+                    <span className="max-w-32 shrink-0 truncate text-[10px] text-muted-foreground">{credential.resolvedModel}</span>
+                  )}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+            {config.credentials !== null && config.credentials.length === 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={onConfigureProvider}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[12px] text-primary hover:bg-muted"
+                >
+                  <Settings2 className="h-4 w-4" />
+                  {t('chatLanding.configureProvider')}
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="space-y-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">{t('chatLanding.modelField')}</span>
+          <span className="flex min-h-11 items-center gap-2 rounded-md border border-border bg-background px-3 focus-within:ring-2 focus-within:ring-primary/40">
+            <Cpu className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <input
+              list={modelListId}
+              value={modelDraft}
+              onChange={(event) => setModelDraft(event.target.value)}
+              onBlur={commitModel}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') event.currentTarget.blur()
+                if (event.key === 'Escape') {
+                  setModelDraft(config.launchModel ?? '')
+                  event.currentTarget.blur()
+                }
+              }}
+              aria-label={t('chatLanding.selectModel')}
+              placeholder={defaultModelLabel}
+              className="min-w-0 flex-1 bg-transparent py-2 text-[12px] text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            <datalist id={modelListId}>
+              {config.modelOptions.map((model) => <option key={model.id} value={model.id}>{model.label}</option>)}
+            </datalist>
+          </span>
+        </label>
+
+        <label className="space-y-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">{t('chatLanding.effortField')}</span>
+          <span className="relative flex min-h-11 items-center gap-2 rounded-md border border-border bg-background px-3 focus-within:ring-2 focus-within:ring-primary/40">
+            <BrainCircuit className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <select
+              value={config.selectedReasoningEffort ?? ''}
+              onChange={(event) => config.selectReasoningEffort(
+                event.target.value
+                  ? event.target.value as NonNullable<AgentLaunchConfigState['launchReasoningEffort']>
+                  : null,
+              )}
+              aria-label={t('chatLanding.selectEffort')}
+              className="min-w-0 flex-1 appearance-none bg-transparent py-2 pr-5 text-[12px] text-foreground outline-none"
+            >
+              <option value="">{t('chatLanding.defaultEffort')}</option>
+              {effortOptions.map((effort) => <option key={effort} value={effort}>{effort}</option>)}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-3 h-4 w-4 text-muted-foreground" />
+          </span>
+        </label>
+      </div>
+
+      <p className="text-[10.5px] leading-relaxed text-muted-foreground">
+        {t('workspaceSettings.preferences.nativeAccessHelp')}
+      </p>
+    </div>
+  )
+}
+
 function RuntimePreferenceDialog({
   open,
   onOpenChange,
@@ -135,7 +314,7 @@ function RuntimePreferenceDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         overlayClassName="z-[70]"
-        className="z-[70] max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
+        className="z-[70] max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-xl"
       >
         <DialogHeader>
           <DialogTitle>{t('workspaceSettings.preferences.editTitle', { runtime: agent.displayName })}</DialogTitle>
@@ -178,19 +357,7 @@ function RuntimePreferenceDialog({
         </div>
 
         {useFixed && (
-          <div className="rounded-lg border border-border bg-muted/20 p-3">
-            <AgentLaunchSelectors
-              config={config}
-              showRuntime={false}
-              showAi
-              labeled
-              menuPlacement="down"
-              onConfigureProvider={onConfigureProvider}
-            />
-            <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground">
-              {t('workspaceSettings.preferences.nativeAccessHelp')}
-            </p>
-          </div>
+          <RuntimePreferenceFields config={config} onConfigureProvider={onConfigureProvider} />
         )}
 
         <DialogFooter>


### PR DESCRIPTION
## Summary
- replace the compact Quick Chat controls in Workspace AI preferences with a responsive settings form
- keep credential menus portaled above nested dialogs and close them deterministically after selection
- migrate legacy Workspace runtime settings through migration 0037 and remove the runtime dual-reader

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4,075 passed, 9 skipped)
- focused migration and Workspace AI preferences UI specs
- real `pnpm dev` walkthrough at `/chat` on desktop and narrow viewports
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`

The real development runtime remains running for maintainer testing.