### PR TITLE
feat(ui): autosave workspace AI preferences

### DIFF
--- a/ui/src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
@@ -81,7 +81,7 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('WorkspaceAIPreferencesPanel', () => {
-  it('shows both launch modes together and saves them atomically', async () => {
+  it('shows both launch modes together and saves a runtime choice immediately', async () => {
     const onSaved = vi.fn(async () => undefined)
     render(
       <WorkspaceAIPreferencesPanel
@@ -108,7 +108,6 @@ describe('WorkspaceAIPreferencesPanel', () => {
     const runtime = screen.getByRole('combobox', { name: '无头运行的默认 Agent Runtime' })
     expect((runtime as HTMLSelectElement).value).toBe('')
     fireEvent.change(runtime, { target: { value: 'codex' } })
-    fireEvent.click(screen.getByRole('button', { name: '保存' }))
 
     await waitFor(() => expect(mocks.updateWorkspaceRuntimeDefaults).toHaveBeenCalledWith(
       'chat-1',
@@ -123,9 +122,11 @@ describe('WorkspaceAIPreferencesPanel', () => {
       },
     ))
     expect(onSaved).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('button', { name: '保存' })).toBeNull()
+    expect((await screen.findByRole('status')).textContent).toContain('已保存')
   })
 
-  it('uses a full settings form and opens the portaled AI access menu', async () => {
+  it('saves a runtime preference directly from the full settings form', async () => {
     render(
       <WorkspaceAIPreferencesPanel
         workspace={workspace}
@@ -146,5 +147,31 @@ describe('WorkspaceAIPreferencesPanel', () => {
     expect(screen.getByRole('menuitemradio', { name: /使用 Codex 账号/ })).toBeTruthy()
     fireEvent.click(screen.getByRole('menuitemradio', { name: /DeepSeek API/ }))
     await waitFor(() => expect(screen.queryByRole('menuitemradio', { name: /DeepSeek API/ })).toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: '保存更改' }))
+    await waitFor(() => expect(mocks.updateWorkspaceRuntimeDefaults).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Codex 默认偏好' })).toBeNull())
+  })
+
+  it('rolls back a failed automatic save and allows retrying it', async () => {
+    mocks.updateWorkspaceRuntimeDefaults.mockRejectedValueOnce(new Error('保存失败'))
+    render(
+      <WorkspaceAIPreferencesPanel
+        workspace={workspace}
+        agents={agents}
+        onSaved={vi.fn()}
+        onConfigureProvider={vi.fn()}
+      />,
+    )
+
+    const runtime = screen.getByRole('combobox', { name: '无头运行的默认 Agent Runtime' }) as HTMLSelectElement
+    fireEvent.change(runtime, { target: { value: 'codex' } })
+
+    expect((await screen.findByRole('alert')).textContent).toContain('保存失败')
+    expect(runtime.value).toBe('')
+
+    fireEvent.click(screen.getByRole('button', { name: '重试' }))
+    await waitFor(() => expect(mocks.updateWorkspaceRuntimeDefaults).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(runtime.value).toBe('codex'))
   })
 })

--- a/ui/src/components/workspace/WorkspaceAIPreferencesPanel.tsx
+++ b/ui/src/components/workspace/WorkspaceAIPreferencesPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Bot, BrainCircuit, Check, ChevronDown, Cpu, KeyRound, Pencil, RotateCcw, Settings2 } from 'lucide-react'
 
@@ -49,6 +49,21 @@ const EMPTY_MODE: WorkspaceRuntimeModeSettings = {
   agents: {},
   recent: { agents: {} },
 }
+
+type WorkspaceRuntimeDrafts = Record<WorkspaceRuntimeMode, {
+  defaultAgent: string | null
+  agents: Record<string, WorkspaceRuntimePreference>
+}>
+
+type PreferenceSaveState =
+  | { mode: WorkspaceRuntimeMode; status: 'saving' | 'saved' }
+  | {
+    mode: WorkspaceRuntimeMode
+    status: 'error'
+    message: string
+    next: WorkspaceRuntimeDrafts
+    previous: WorkspaceRuntimeDrafts
+  }
 
 function launchFromPreference(
   agent: string,
@@ -274,11 +289,13 @@ function RuntimePreferenceDialog({
   readonly agent: AgentInfo
   readonly fixed: WorkspaceRuntimePreference | undefined
   readonly recent: WorkspaceRuntimePreference | undefined
-  readonly onApply: (preference: WorkspaceRuntimePreference | null) => void
+  readonly onApply: (preference: WorkspaceRuntimePreference | null) => Promise<string | null>
   readonly onConfigureProvider: () => void
 }) {
   const { t } = useTranslation()
   const [useFixed, setUseFixed] = useState(fixed !== undefined)
+  const [applying, setApplying] = useState(false)
+  const [applyError, setApplyError] = useState<string | null>(null)
   const [draft, setDraft] = useState<QuickChatLaunchPreference>(() => (
     launchFromPreference(agent.id, fixed ?? recent)
   ))
@@ -287,6 +304,7 @@ function RuntimePreferenceDialog({
     if (!open) return
     setUseFixed(fixed !== undefined)
     setDraft(launchFromPreference(agent.id, fixed ?? recent))
+    setApplyError(null)
   }, [agent.id, fixed, open, recent])
 
   const rememberLaunch = useCallback(async (launch: QuickChatLaunchPreference) => {
@@ -310,7 +328,7 @@ function RuntimePreferenceDialog({
   })
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!applying) onOpenChange(nextOpen) }}>
       <DialogContent
         overlayClassName="z-[70]"
         className="z-[70] max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-xl"
@@ -359,13 +377,21 @@ function RuntimePreferenceDialog({
           <RuntimePreferenceFields config={config} onConfigureProvider={onConfigureProvider} />
         )}
 
+        {applyError && <p role="alert" className="text-xs text-destructive">{applyError}</p>}
+
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>{t('common.cancel')}</Button>
-          <Button onClick={() => {
-            onApply(useFixed ? preferenceFromLaunch(draft) : null)
-            onOpenChange(false)
+          <Button variant="outline" disabled={applying} onClick={() => onOpenChange(false)}>{t('common.cancel')}</Button>
+          <Button disabled={applying} onClick={() => {
+            setApplying(true)
+            setApplyError(null)
+            void onApply(useFixed ? preferenceFromLaunch(draft) : null)
+              .then((message) => {
+                if (message) setApplyError(message)
+                else onOpenChange(false)
+              })
+              .finally(() => setApplying(false))
           }}>
-            {t('workspaceSettings.preferences.apply')}
+            {applying ? t('common.saving') : t('workspaceSettings.preferences.apply')}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -383,7 +409,7 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
     interactive: EMPTY_MODE,
     headless: EMPTY_MODE,
   }
-  const [drafts, setDrafts] = useState(() => ({
+  const [drafts, setDrafts] = useState<WorkspaceRuntimeDrafts>(() => ({
     interactive: {
       defaultAgent: persistedRuntime.interactive.defaultAgent ?? null,
       agents: { ...persistedRuntime.interactive.agents },
@@ -395,9 +421,8 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
   }))
   const [editing, setEditing] = useState<{ mode: WorkspaceRuntimeMode; agent: AgentInfo } | null>(null)
   const [credentials, setCredentials] = useState<Record<string, SavedCredential>>({})
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [saveState, setSaveState] = useState<PreferenceSaveState | null>(null)
+  const savedTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
     const next = workspace.runtimeSettings?.runtime ?? {
@@ -414,9 +439,16 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
         agents: { ...next.headless.agents },
       },
     })
-    setSaved(false)
-    setError(null)
   }, [workspace.id, workspace.runtimeSettings])
+
+  useEffect(() => {
+    if (savedTimerRef.current !== null) window.clearTimeout(savedTimerRef.current)
+    setSaveState(null)
+  }, [workspace.id])
+
+  useEffect(() => () => {
+    if (savedTimerRef.current !== null) window.clearTimeout(savedTimerRef.current)
+  }, [])
 
   useEffect(() => {
     let live = true
@@ -428,28 +460,32 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
     return () => { live = false }
   }, [runtimeAgents])
 
-  const dirty = (['interactive', 'headless'] as const).some((mode) => (
-    drafts[mode].defaultAgent !== (persistedRuntime[mode].defaultAgent ?? null) ||
-    JSON.stringify(drafts[mode].agents) !== JSON.stringify(persistedRuntime[mode].agents)
-  ))
-
-  const save = async () => {
-    setSaving(true)
-    setError(null)
+  const persist = useCallback(async (
+    mode: WorkspaceRuntimeMode,
+    next: WorkspaceRuntimeDrafts,
+    previous: WorkspaceRuntimeDrafts,
+  ): Promise<string | null> => {
+    if (savedTimerRef.current !== null) window.clearTimeout(savedTimerRef.current)
+    setDrafts(next)
+    setSaveState({ mode, status: 'saving' })
     try {
       await updateWorkspaceRuntimeDefaults(workspace.id, {
-        interactive: drafts.interactive,
-        headless: drafts.headless,
+        interactive: next.interactive,
+        headless: next.headless,
       })
       await onSaved()
-      setSaved(true)
-      window.setTimeout(() => setSaved(false), 1800)
+      setSaveState({ mode, status: 'saved' })
+      savedTimerRef.current = window.setTimeout(() => setSaveState(null), 1800)
+      return null
     } catch (cause) {
-      setError((cause as Error).message)
-    } finally {
-      setSaving(false)
+      const message = (cause as Error).message
+      setDrafts(previous)
+      setSaveState({ mode, status: 'error', message, next, previous })
+      return message
     }
-  }
+  }, [onSaved, workspace.id])
+
+  const saving = saveState?.status === 'saving'
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -491,10 +527,14 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
                     <select
                       aria-label={t('workspaceSettings.preferences.defaultRuntimeFor', { mode: title })}
                       value={drafts[mode].defaultAgent ?? ''}
-                      onChange={(event) => setDrafts((current) => ({
-                        ...current,
-                        [mode]: { ...current[mode], defaultAgent: event.target.value || null },
-                      }))}
+                      disabled={saving}
+                      onChange={(event) => {
+                        const next = {
+                          ...drafts,
+                          [mode]: { ...drafts[mode], defaultAgent: event.target.value || null },
+                        }
+                        void persist(mode, next, drafts)
+                      }}
                       className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-[13px] text-foreground outline-none focus:border-primary"
                     >
                       <option value="">
@@ -518,6 +558,29 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
                       <span>{recentSummary.access}</span>
                       <span aria-hidden="true">·</span>
                       <span>{recentSummary.inference}</span>
+                    </div>
+                  )}
+
+                  {saveState?.mode === mode && (
+                    <div
+                      role={saveState.status === 'error' ? 'alert' : 'status'}
+                      className={`flex min-h-5 flex-wrap items-center gap-2 text-[11px] ${saveState.status === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}
+                    >
+                      {saveState.status === 'saving' && t('common.saving')}
+                      {saveState.status === 'saved' && t('common.saved')}
+                      {saveState.status === 'error' && (
+                        <>
+                          <span>{saveState.message}</span>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 px-2 text-destructive"
+                            onClick={() => void persist(mode, saveState.next, saveState.previous)}
+                          >
+                            {t('common.retry')}
+                          </Button>
+                        </>
+                      )}
                     </div>
                   )}
 
@@ -552,6 +615,7 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
                           <Button
                             variant="ghost"
                             size="icon-sm"
+                            disabled={saving}
                             onClick={() => setEditing({ mode, agent })}
                             aria-label={t('workspaceSettings.preferences.editRuntimeFor', { runtime: agent.displayName, mode: title })}
                           >
@@ -566,15 +630,6 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
             )
           })}
 
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-h-5 text-[11px]">
-              {saved && <span className="text-success">{t('workspaceSettings.preferences.saved')}</span>}
-              {error && <span className="text-destructive">{error}</span>}
-            </div>
-            <Button disabled={!dirty || saving} onClick={() => void save()}>
-              {saving ? t('common.saving') : t('common.save')}
-            </Button>
-          </div>
         </div>
       </div>
 
@@ -587,12 +642,17 @@ export function WorkspaceAIPreferencesPanel({ workspace, agents, onSaved, onConf
           fixed={drafts[editing.mode].agents[editing.agent.id]}
           recent={persistedRuntime[editing.mode].recent.agents[editing.agent.id]}
           onConfigureProvider={onConfigureProvider}
-          onApply={(preference) => setDrafts((current) => {
-            const agents = { ...current[editing.mode].agents }
+          onApply={(preference) => {
+            const previous = drafts
+            const agents = { ...previous[editing.mode].agents }
             if (preference) agents[editing.agent.id] = preference
             else delete agents[editing.agent.id]
-            return { ...current, [editing.mode]: { ...current[editing.mode], agents } }
-          })}
+            const next = {
+              ...previous,
+              [editing.mode]: { ...previous[editing.mode], agents },
+            }
+            return persist(editing.mode, next, previous)
+          }}
         />
       )}
     </div>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -657,7 +657,7 @@ export const en = {
       fixedDefault: 'Fixed default',
       fixedDefaultHelp: 'Keep this choice stable until it is changed here.',
       nativeAccessHelp: 'Agent login uses the runtime’s own global authentication. Saved access stores only a credential reference; secrets remain in Alice’s vault.',
-      apply: 'Apply to draft',
+      apply: 'Save changes',
       saved: 'Workspace AI preferences saved.',
     },
     launch: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -646,7 +646,7 @@ export const ja: Resources = {
       fixedDefault: '固定デフォルト',
       fixedDefaultHelp: 'ここで変更するまでこの選択を保ちます。',
       nativeAccessHelp: 'Agent のログインは Runtime 自身のグローバル認証を使います。保存済みアクセスは認証情報への参照だけを保持し、秘密は Alice の保管庫に残ります。',
-      apply: '下書きに適用',
+      apply: '変更を保存',
       saved: 'ワークスペースの AI 設定を保存しました。',
     },
     launch: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -653,7 +653,7 @@ export const zhHant: Resources = {
       fixedDefault: '固定預設值',
       fixedDefaultHelp: '在此再次修改前持續使用這組選擇。',
       nativeAccessHelp: 'Agent 自身登入狀態使用 Runtime 的全域驗證。已儲存的存取方式只記錄憑證參照，密鑰仍保存在 Alice 的憑證庫。',
-      apply: '套用到草稿',
+      apply: '儲存變更',
       saved: '工作區 AI 偏好已儲存。',
     },
     launch: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -645,7 +645,7 @@ export const zh: Resources = {
       fixedDefault: '固定默认值',
       fixedDefaultHelp: '在这里再次修改前始终使用这组选择。',
       nativeAccessHelp: 'Agent 自身登录态使用 Runtime 的全局认证。已保存的访问方式只记录凭据引用，密钥仍保存在 Alice 的凭据库中。',
-      apply: '应用到草稿',
+      apply: '保存更改',
       saved: 'Workspace AI 偏好已保存。',
     },
     launch: {


### PR DESCRIPTION
## Summary
- persist default runtime selections immediately and remove the page-level Save action
- make preference-dialog confirmation save directly instead of creating a second unsaved draft
- serialize writes, show local saving/saved feedback, and roll failed selections back with Retry

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm -F open-alice-ui exec vitest run src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
- pnpm test
- real Workspace Settings route: changed headless default to Codex, observed automatic Saved feedback, then restored Follow recent — Pi
- confirmed .alice/settings.json headless.defaultAgent is restored to null