### PR TITLE
fix(claude): isolate managed credential launches

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -77,6 +77,14 @@ Writing the same values into native project files is a deprecated compatibility
 export for users who intentionally start the CLI outside OpenAlice. It is not a
 managed Session default, readiness gate, or launch-time fallback.
 
+Claude Code managed-Vault launches pass an empty `--setting-sources=` selection
+before projecting the Session's endpoint, credential, model, and effort. Claude
+otherwise reapplies provider-shaped `env` from user/project/local settings after
+inheriting the child environment, which can silently replace an immutable
+Session binding. Native-login bindings do not use this isolation: selecting the
+Agent login deliberately leaves Claude's normal global configuration chain in
+control. Launcher-owned explicit `--settings` remain available in both modes.
+
 OpenAlice projects a registered provider default when the exact model contract
 publishes one. This makes a Workspace binding deterministic across Agent
 runtimes without inventing policy: an explicit Workspace preference wins, then

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -201,7 +201,23 @@ export const claudeAdapter: CliAdapter = {
       if (effort && !CLAUDE_RUN_EFFORTS.has(effort)) {
         throw new Error(`Claude Code cannot use Session effort ${effort}`);
       }
+      // Claude Code applies provider-shaped `env` from user/project/local
+      // settings after inheriting the child process environment. A managed
+      // Vault binding must therefore exclude every implicit settings source;
+      // otherwise an unrelated global login (or a deprecated project export)
+      // can replace ANTHROPIC_BASE_URL / auth / model after OpenAlice projects
+      // this immutable Session binding. `--setting-sources=` is Claude Code's
+      // empty-source form. Explicit `--settings` supplied by composeCommand
+      // still loads, so launcher-owned MCP trust remains available.
+      //
+      // Native bindings intentionally keep Claude's normal settings chain:
+      // choosing Agent login means the runtime, not OpenAlice, owns provider
+      // discovery and authentication.
+      const managedCredentialArgs = runtime.binding.credential.source === 'vault'
+        ? ['--setting-sources=']
+        : [];
       const args = [
+        ...managedCredentialArgs,
         ...(runtime.binding.model ? ['--model', runtime.binding.model] : []),
         ...(effort ? ['--effort', effort] : []),
       ];

--- a/src/workspaces/session-runtime-binding.spec.ts
+++ b/src/workspaces/session-runtime-binding.spec.ts
@@ -271,12 +271,28 @@ describe('built-in Agent Session runtime projection', () => {
 
   it('projects the native model and effort flags on every launch surface', () => {
     expect(claudeAdapter.sessionRuntime!.project(ctx, runtime).interactiveArgs)
-      .toEqual(['--model', 'session-model', '--effort', 'high'])
+      .toEqual(['--setting-sources=', '--model', 'session-model', '--effort', 'high'])
     expect(codexAdapter.sessionRuntime!.project(ctx, runtime).headlessArgs)
       .toContain('model_reasoning_effort="high"')
     expect(opencodeAdapter.sessionRuntime!.project(ctx, runtime).headlessArgs)
       .toContain('--variant')
     expect(piAdapter.sessionRuntime!.project(ctx, runtime).webArgs)
       .toContain('--extension')
+  })
+
+  it('isolates Claude settings only for OpenAlice-managed credentials', () => {
+    const managed = claudeAdapter.sessionRuntime!.project(ctx, runtime)
+    expect(managed.interactiveArgs).toContain('--setting-sources=')
+    expect(managed.headlessArgs).toContain('--setting-sources=')
+    expect(managed.webArgs).toContain('--setting-sources=')
+
+    const native = createNativeSessionRuntimeBinding({
+      adapter: claudeAdapter,
+      selection: { model: 'native-model-override', reasoningEffort: 'medium' },
+    })
+    const projectedNative = claudeAdapter.sessionRuntime!.project(ctx, native)
+    expect(projectedNative.interactiveArgs).not.toContain('--setting-sources=')
+    expect(projectedNative.headlessArgs).not.toContain('--setting-sources=')
+    expect(projectedNative.webArgs).not.toContain('--setting-sources=')
   })
 })


### PR DESCRIPTION
## Summary
- isolate Claude Code managed Vault sessions from user, project, and local provider settings
- preserve Claude’s normal settings chain for Agent login/native sessions
- document and test the launch boundary

## Verification
- `npx tsc --noEmit`
- `pnpm test`
- real Claude Code DeepSeek managed-credential smoke returned `OK` while conflicting global settings remained present