### PR TITLE
fix(claude): restore workspace skills for vault sessions

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -81,11 +81,15 @@ Claude Code managed-Vault launches pass an empty `--setting-sources=` selection
 before projecting the Session's endpoint, credential, model, and effort. Claude
 otherwise reapplies provider-shaped `env` from user/project/local settings after
 inheriting the child environment, which can silently replace an immutable
-Session binding. Runtime-managed bindings do not use this isolation: OpenAlice
-deliberately leaves Claude's complete authentication and configuration chain in
-control, whether it resolves from login, environment, user settings, or local
-project files. Launcher-owned explicit `--settings` remain available in both
-modes.
+Session binding. Because the empty source selection also disables ordinary
+project-skill discovery, OpenAlice-managed launches explicitly load the
+Workspace `.claude` directory as a local plugin. This restores the Workspace's
+skills under Claude's plugin-scoped namespace without re-enabling user or
+project settings. Runtime-managed bindings do not use either override:
+OpenAlice deliberately leaves Claude's complete authentication, configuration,
+and skill discovery chain in control, whether it resolves from login,
+environment, user settings, or local project files. Launcher-owned explicit
+`--settings` remain available in both modes.
 
 OpenAlice projects a registered provider default when the exact model contract
 publishes one. This makes a Workspace binding deterministic across Agent

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -196,7 +196,7 @@ export const claudeAdapter: CliAdapter = {
   },
 
   sessionRuntime: {
-    project(_ctx, runtime: ResolvedSessionRuntimeBinding) {
+    project(ctx, runtime: ResolvedSessionRuntimeBinding) {
       const effort = runtime.binding.reasoningEffort;
       if (effort && !CLAUDE_RUN_EFFORTS.has(effort)) {
         throw new Error(`Claude Code cannot use Session effort ${effort}`);
@@ -207,14 +207,19 @@ export const claudeAdapter: CliAdapter = {
       // otherwise an unrelated global login (or a deprecated project export)
       // can replace ANTHROPIC_BASE_URL / auth / model after OpenAlice projects
       // this immutable Session binding. `--setting-sources=` is Claude Code's
-      // empty-source form. Explicit `--settings` supplied by composeCommand
-      // still loads, so launcher-owned MCP trust remains available.
+      // empty-source form. It also disables Claude's ordinary project-skill
+      // discovery, so expose the Workspace `.claude` directory explicitly as
+      // a local plugin. Plugin loading does not re-enable project/user settings
+      // and therefore preserves both the immutable Vault binding and the
+      // Workspace's bundled skills. Explicit `--settings` supplied by
+      // composeCommand still loads, so launcher-owned MCP trust remains
+      // available.
       //
       // Native bindings intentionally keep Claude's normal settings chain:
       // choosing Agent login means the runtime, not OpenAlice, owns provider
       // discovery and authentication.
       const managedCredentialArgs = runtime.binding.credential.source === 'vault'
-        ? ['--setting-sources=']
+        ? ['--setting-sources=', '--plugin-dir', join(ctx.cwd, '.claude')]
         : [];
       const args = [
         ...managedCredentialArgs,

--- a/src/workspaces/session-runtime-binding.spec.ts
+++ b/src/workspaces/session-runtime-binding.spec.ts
@@ -271,7 +271,15 @@ describe('built-in Agent Session runtime projection', () => {
 
   it('projects the native model and effort flags on every launch surface', () => {
     expect(claudeAdapter.sessionRuntime!.project(ctx, runtime).interactiveArgs)
-      .toEqual(['--setting-sources=', '--model', 'session-model', '--effort', 'high'])
+      .toEqual([
+        '--setting-sources=',
+        '--plugin-dir',
+        '/workspace/.claude',
+        '--model',
+        'session-model',
+        '--effort',
+        'high',
+      ])
     expect(codexAdapter.sessionRuntime!.project(ctx, runtime).headlessArgs)
       .toContain('model_reasoning_effort="high"')
     expect(opencodeAdapter.sessionRuntime!.project(ctx, runtime).headlessArgs)
@@ -280,19 +288,27 @@ describe('built-in Agent Session runtime projection', () => {
       .toContain('--extension')
   })
 
-  it('isolates Claude settings only for OpenAlice-managed credentials', () => {
+  it('isolates Claude settings and restores Workspace skills only for OpenAlice-managed credentials', () => {
     const managed = claudeAdapter.sessionRuntime!.project(ctx, runtime)
-    expect(managed.interactiveArgs).toContain('--setting-sources=')
-    expect(managed.headlessArgs).toContain('--setting-sources=')
-    expect(managed.webArgs).toContain('--setting-sources=')
+    for (const args of [managed.interactiveArgs, managed.headlessArgs, managed.webArgs]) {
+      expect(args).toContain('--setting-sources=')
+      expect(args).toContain('--plugin-dir')
+      expect(args).toContain('/workspace/.claude')
+    }
 
     const native = createNativeSessionRuntimeBinding({
       adapter: claudeAdapter,
       selection: { model: 'native-model-override', reasoningEffort: 'medium' },
     })
     const projectedNative = claudeAdapter.sessionRuntime!.project(ctx, native)
-    expect(projectedNative.interactiveArgs).not.toContain('--setting-sources=')
-    expect(projectedNative.headlessArgs).not.toContain('--setting-sources=')
-    expect(projectedNative.webArgs).not.toContain('--setting-sources=')
+    for (const args of [
+      projectedNative.interactiveArgs,
+      projectedNative.headlessArgs,
+      projectedNative.webArgs,
+    ]) {
+      expect(args).not.toContain('--setting-sources=')
+      expect(args).not.toContain('--plugin-dir')
+      expect(args).not.toContain('/workspace/.claude')
+    }
   })
 })


### PR DESCRIPTION
## What changed

- load each Workspace `.claude` directory as a local Claude plugin for OpenAlice Vault launches
- keep `--setting-sources=` isolation so global/project provider settings cannot override the durable Session binding
- leave Agent-managed Claude launches untouched
- document and test the credential-mode boundary across interactive, headless, and Web launch surfaces

## Root cause

Claude Code uses `--setting-sources=` to isolate Vault-managed credentials, but the empty source list also disables ordinary project skill discovery. Explicit `--plugin-dir` restores only the Workspace skills without restoring user/project settings.

## Validation

- `npx tsc --noEmit`
- `pnpm vitest run src/workspaces/session-runtime-binding.spec.ts`
- `pnpm test` (468 passed, 1 skipped; 4018 tests passed, 9 skipped)
- real Quick Chat launch with Claude Code + DeepSeek Vault credential: request completed on `deepseek-v4-flash` and transcript exposed all 12 Workspace skills under the plugin namespace
