### PR TITLE
fix(workspaces): expose persisted session runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,5 +288,9 @@ the tagline, pillars, or other marketing copy.
   `ui/src/components/ui/`. Extend that layer before hand-rolling portals,
   positioning, focus, dismissal, keyboard behavior, or bespoke control styling
   inside a feature component.
+- Frontend reads of backend-owned data must go through a domain hook rather
+  than calling an API or reaching into a transport/polling context from a
+  feature component. Keep presentation components prop-driven, and cover each
+  data hook with unit tests for its selection plus loading/error semantics.
 - Prefer structured Workspace launcher logs; the main process currently uses
   `console` and does not have a universal pino sink.

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -32,6 +32,7 @@ import {
   sessionPreferredTitle,
   type SessionRecord,
 } from '../../workspaces/session-registry.js';
+import { projectPublicSession, type PublicSession } from '../../workspaces/public-session.js';
 import type { WorkspaceMeta } from '../../workspaces/workspace-registry.js';
 import { HeadlessCapacityError, HeadlessResumeError, resumeFromRecord, type SessionFactoryContext, type WorkspaceService } from '../../workspaces/service.js';
 import {
@@ -202,30 +203,8 @@ interface SpawnedSessionBody {
   readonly title: string | null;
 }
 
-interface PublicSessionBody {
-  readonly id: string;
-  readonly wsId: string;
-  readonly agent: string;
-  readonly name: string;
-  readonly createdAt: string;
-  readonly lastActiveAt: string;
-  readonly state: 'running' | 'paused';
-  readonly surface: 'terminal' | 'webpi';
-  readonly resumeId: string;
-  readonly pid: number | null;
-  readonly startedAt: number | null;
-  readonly title: string | null;
-  readonly sourceRunId: string | null;
-  readonly runtime?: {
-    readonly credentialSource: 'native' | 'vault' | 'workspace';
-    readonly credentialSlug?: string;
-    readonly model?: string;
-    readonly reasoningEffort?: ModelReasoningEffort;
-  };
-}
-
 type OpenHeadlessSessionResult =
-  | { readonly ok: true; readonly created: boolean; readonly session: PublicSessionBody }
+  | { readonly ok: true; readonly created: boolean; readonly session: PublicSession }
   | { readonly ok: false; readonly status: 400 | 404 | 409 | 500; readonly body: { error: string; message?: string } };
 
 type SpawnSessionResult =
@@ -535,37 +514,15 @@ export function createWorkspaceRoutes(
     }
   }
 
-  const publicSession = (record: SessionRecord): PublicSessionBody => {
+  const publicSession = (record: SessionRecord): PublicSession => {
     const terminal = svc.pool.get(record.id);
     const browser = svc.webPi?.get(record.id) ?? null;
     const binding = svc.resumeRegistry.get(record.resumeId)?.runtimeBinding;
-    return {
-      id: record.id,
-      wsId: record.wsId,
-      agent: record.agent,
-      name: record.name,
-      createdAt: record.createdAt,
-      lastActiveAt: record.lastActiveAt,
-      state: record.state === 'running' && (terminal || browser) ? 'running' : 'paused',
-      surface: browser ? 'webpi' : (record.surface ?? 'terminal'),
-      resumeId: record.resumeId,
-      pid: terminal?.pid ?? browser?.pid ?? null,
-      startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
-      title: sessionPreferredTitle(record) ?? null,
-      sourceRunId: record.sourceRunId ?? null,
-      ...(binding
-        ? {
-            runtime: {
-              credentialSource: binding.credential.source,
-              ...(binding.credential.source === 'vault'
-                ? { credentialSlug: binding.credential.credentialSlug }
-                : {}),
-              ...(binding.model ? { model: binding.model } : {}),
-              ...(binding.reasoningEffort ? { reasoningEffort: binding.reasoningEffort } : {}),
-            },
-          }
-        : {}),
-    };
+    return projectPublicSession(record, {
+      terminal,
+      webPi: browser,
+      runtimeBinding: binding,
+    });
   };
 
   const mappedResumeForRecord = (

--- a/src/workspaces/public-session.spec.ts
+++ b/src/workspaces/public-session.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectPublicSession } from './public-session.js';
+import type { SessionRecord } from './session-registry.js';
+
+const record: SessionRecord = {
+  id: 'session-1',
+  resumeId: 'resume-1',
+  wsId: 'workspace-1',
+  agent: 'claude',
+  name: 'c1',
+  createdAt: '2026-08-11T00:00:00.000Z',
+  lastActiveAt: '2026-08-11T00:01:00.000Z',
+  state: 'running',
+  fallbackTitle: 'Investigate the market',
+};
+
+describe('projectPublicSession', () => {
+  it('projects one Vault binding without exposing credential material', () => {
+    expect(projectPublicSession(record, {
+      runtimeBinding: {
+        version: 1,
+        credential: {
+          source: 'vault',
+          credentialSlug: 'deepseek-1',
+          wireShape: 'openai-chat',
+        },
+        model: 'deepseek-v4-flash',
+        reasoningEffort: 'high',
+      },
+    })).toMatchObject({
+      state: 'paused',
+      title: 'Investigate the market',
+      runtime: {
+        credentialSource: 'vault',
+        credentialSlug: 'deepseek-1',
+        model: 'deepseek-v4-flash',
+        reasoningEffort: 'high',
+      },
+    });
+  });
+
+  it('keeps missing historical runtime metadata unknown', () => {
+    const projected = projectPublicSession(record);
+
+    expect(projected).not.toHaveProperty('runtime');
+  });
+
+  it('derives live state and WebPi surface from the same process snapshot', () => {
+    expect(projectPublicSession(record, {
+      webPi: { pid: 42, startedAt: 1_723_337_000_000 },
+    })).toMatchObject({
+      state: 'running',
+      surface: 'webpi',
+      pid: 42,
+      startedAt: 1_723_337_000_000,
+    });
+  });
+});

--- a/src/workspaces/public-session.ts
+++ b/src/workspaces/public-session.ts
@@ -1,0 +1,80 @@
+import type { ModelReasoningEffort } from '../ai-providers/model-semantics.js';
+import type { SessionRuntimeBinding } from './cli-adapter.js';
+import { sessionPreferredTitle, type SessionRecord } from './session-registry.js';
+
+export interface PublicSessionRuntime {
+  readonly credentialSource: 'native' | 'vault' | 'workspace';
+  readonly credentialSlug?: string;
+  readonly model?: string;
+  readonly reasoningEffort?: ModelReasoningEffort;
+}
+
+export interface PublicSession {
+  readonly id: string;
+  readonly wsId: string;
+  readonly agent: string;
+  readonly name: string;
+  readonly createdAt: string;
+  readonly lastActiveAt: string;
+  readonly state: 'running' | 'paused';
+  readonly surface: 'terminal' | 'webpi';
+  readonly resumeId: string;
+  readonly pid: number | null;
+  readonly startedAt: number | null;
+  readonly title: string | null;
+  readonly sourceRunId: string | null;
+  readonly runtime?: PublicSessionRuntime;
+}
+
+interface LiveSessionProjection {
+  readonly pid: number | null;
+  readonly startedAt: number;
+}
+
+export interface PublicSessionProjectionContext {
+  readonly terminal?: LiveSessionProjection | null;
+  readonly webPi?: LiveSessionProjection | null;
+  readonly runtimeBinding?: SessionRuntimeBinding | null;
+}
+
+/**
+ * Canonical secret-free Session projection shared by every Workspace API.
+ * Missing runtime metadata stays missing: callers must not reinterpret an
+ * unknown historical binding as an explicit native/runtime-default choice.
+ */
+export function projectPublicSession(
+  record: SessionRecord,
+  context: PublicSessionProjectionContext = {},
+): PublicSession {
+  const terminal = context.terminal ?? null;
+  const webPi = context.webPi ?? null;
+  const binding = context.runtimeBinding ?? null;
+
+  return {
+    id: record.id,
+    wsId: record.wsId,
+    agent: record.agent,
+    name: record.name,
+    createdAt: record.createdAt,
+    lastActiveAt: record.lastActiveAt,
+    state: record.state === 'running' && (terminal || webPi) ? 'running' : 'paused',
+    surface: webPi ? 'webpi' : (record.surface ?? 'terminal'),
+    resumeId: record.resumeId,
+    pid: terminal?.pid ?? webPi?.pid ?? null,
+    startedAt: terminal?.startedAt ?? webPi?.startedAt ?? null,
+    title: sessionPreferredTitle(record) ?? null,
+    sourceRunId: record.sourceRunId ?? null,
+    ...(binding
+      ? {
+          runtime: {
+            credentialSource: binding.credential.source,
+            ...(binding.credential.source === 'vault'
+              ? { credentialSlug: binding.credential.credentialSlug }
+              : {}),
+            ...(binding.model ? { model: binding.model } : {}),
+            ...(binding.reasoningEffort ? { reasoningEffort: binding.reasoningEffort } : {}),
+          },
+        }
+      : {}),
+  };
+}

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -314,9 +314,9 @@ import { ScrollbackStore } from './scrollback-store.js';
 import { SessionPool, type SessionFactoryContext } from './session-pool.js';
 import {
   SessionRegistry,
-  sessionPreferredTitle,
   type SessionRecord,
 } from './session-registry.js';
+import { projectPublicSession } from './public-session.js';
 import { NativeSessionTitleResolver } from './session-title-resolver.js';
 import { buildCliPath, buildSpawnEnv } from './spawn-env.js';
 import { TemplateRegistry } from './template-registry.js';
@@ -2431,25 +2431,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     const harnessSource = await readHarnessSource(w.dir);
     await sessionRegistry.ensureLoaded(w.id).catch(() => undefined);
     void refreshSessionTitles(w);
-    const sessions = sessionRegistry.listFor(w.id).map((r) => {
-      const terminal = pool.get(r.id);
-      const browser = webPi.get(r.id);
-      return {
-        id: r.id,
-        wsId: r.wsId,
-        agent: r.agent,
-        name: r.name,
-        createdAt: r.createdAt,
-        lastActiveAt: r.lastActiveAt,
-        state: r.state === 'running' && (terminal || browser) ? 'running' : 'paused',
-        surface: browser ? 'webpi' : (r.surface ?? 'terminal'),
-        resumeId: r.resumeId,
-        pid: terminal?.pid ?? browser?.pid ?? null,
-        startedAt: terminal?.startedAt ?? browser?.startedAt ?? null,
-        title: sessionPreferredTitle(r) ?? null,
-        sourceRunId: r.sourceRunId ?? null,
-      };
-    });
+    const sessions = sessionRegistry.listFor(w.id).map((record) =>
+      projectPublicSession(record, {
+        terminal: pool.get(record.id),
+        webPi: webPi.get(record.id),
+        runtimeBinding: resumeRegistry.get(record.resumeId)?.runtimeBinding,
+      }),
+    );
     // Deprecated native-project compatibility-export signals. Retained in the
     // public contract for advanced diagnostics; managed Session defaults come
     // from `runtimeSettings` and primary UI surfaces do not expose these files.

--- a/ui/src/components/workspace/ResumeCta.spec.tsx
+++ b/ui/src/components/workspace/ResumeCta.spec.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionRecord } from './api'
+import { ResumeCta } from './ResumeCta'
+
+function record(runtime?: SessionRecord['runtime']): SessionRecord {
+  return {
+    id: 'session-1',
+    resumeId: 'resume-1',
+    wsId: 'workspace-1',
+    agent: 'claude',
+    name: 'c1',
+    createdAt: '2026-08-11T00:00:00.000Z',
+    lastActiveAt: '2026-08-11T00:01:00.000Z',
+    state: 'paused',
+    surface: 'terminal',
+    pid: null,
+    startedAt: null,
+    title: 'Paused session',
+    ...(runtime ? { runtime } : {}),
+  }
+}
+
+afterEach(cleanup)
+
+describe('ResumeCta runtime facts', () => {
+  it('shows the persisted Vault binding', () => {
+    render(<ResumeCta
+      record={record({
+        credentialSource: 'vault',
+        credentialSlug: 'deepseek-1',
+        model: 'deepseek-v4-flash',
+        reasoningEffort: 'high',
+      })}
+      onResume={vi.fn(async () => {})}
+    />)
+
+    expect(screen.getByText('deepseek-1')).toBeTruthy()
+    expect(screen.getByText('deepseek-v4-flash')).toBeTruthy()
+    expect(screen.getByText('high reasoning')).toBeTruthy()
+  })
+
+  it('does not mislabel missing historical metadata as Runtime defaults', () => {
+    render(<ResumeCta
+      record={record()}
+      onResume={vi.fn(async () => {})}
+    />)
+
+    expect(screen.getAllByText('Unknown')).toHaveLength(3)
+  })
+})

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -228,16 +228,19 @@ function sessionRuntimeFacts(record: SessionRecord): readonly { label: string; v
   const runtime = record.runtime;
   return [
     { label: 'Credential', value: credentialDisplay(runtime) },
-    { label: 'Model', value: runtime?.model?.trim() || 'Runtime default' },
+    { label: 'Model', value: runtime ? runtime.model?.trim() || 'Runtime default' : 'Unknown' },
     {
       label: 'Effort',
-      value: runtime?.reasoningEffort ? `${runtime.reasoningEffort} reasoning` : 'Runtime default',
+      value: runtime
+        ? runtime.reasoningEffort ? `${runtime.reasoningEffort} reasoning` : 'Runtime default'
+        : 'Unknown',
     },
   ];
 }
 
 function credentialDisplay(runtime: SessionRecord['runtime']): string {
-  if (!runtime || runtime.credentialSource === 'native') return 'Runtime login';
+  if (!runtime) return 'Unknown';
+  if (runtime.credentialSource === 'native') return 'Runtime login';
   if (runtime.credentialSource === 'workspace') return 'Workspace config';
   return runtime.credentialSlug?.trim() || 'Saved credential';
 }

--- a/ui/src/hooks/useWorkspaceData.spec.ts
+++ b/ui/src/hooks/useWorkspaceData.spec.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Workspace } from '../components/workspace/api'
+import type { WorkspacesContextValue } from '../contexts/workspaces-context'
+import { useWorkspaceData, useWorkspaceSessionData } from './useWorkspaceData'
+
+const mocks = vi.hoisted(() => ({
+  context: null as WorkspacesContextValue | null,
+}))
+
+vi.mock('../contexts/workspaces-context', () => ({
+  useWorkspaces: () => {
+    if (!mocks.context) throw new Error('missing test context')
+    return mocks.context
+  },
+}))
+
+const refresh = vi.fn(async () => {})
+
+function workspace(): Workspace {
+  return {
+    id: 'workspace-1',
+    tag: 'chat-aug11',
+    dir: '/tmp/chat-aug11',
+    createdAt: '2026-08-11T00:00:00.000Z',
+    sessions: [{
+      id: 'session-1',
+      resumeId: 'resume-1',
+      wsId: 'workspace-1',
+      agent: 'claude',
+      name: 'c1',
+      createdAt: '2026-08-11T00:00:00.000Z',
+      lastActiveAt: '2026-08-11T00:01:00.000Z',
+      state: 'paused',
+      surface: 'terminal',
+      pid: null,
+      startedAt: null,
+      title: 'Vault-backed session',
+      runtime: {
+        credentialSource: 'vault',
+        credentialSlug: 'deepseek-1',
+        model: 'deepseek-v4-flash',
+        reasoningEffort: 'high',
+      },
+    }],
+  }
+}
+
+function context(overrides: Partial<WorkspacesContextValue> = {}): WorkspacesContextValue {
+  return {
+    workspaces: [workspace()],
+    hasLoaded: true,
+    listError: null,
+    refresh,
+    ...overrides,
+  } as WorkspacesContextValue
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.context = context()
+})
+
+describe('Workspace data hooks', () => {
+  it('selects the Workspace and its secret-free Session binding', () => {
+    const { result } = renderHook(() =>
+      useWorkspaceSessionData('workspace-1', 'session-1'),
+    )
+
+    expect(result.current.workspace?.tag).toBe('chat-aug11')
+    expect(result.current.session?.runtime).toEqual({
+      credentialSource: 'vault',
+      credentialSlug: 'deepseek-1',
+      model: 'deepseek-v4-flash',
+      reasoningEffort: 'high',
+    })
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(result.current.refresh).toBe(refresh)
+  })
+
+  it('preserves loading and backend error semantics for a missing Workspace', () => {
+    mocks.context = context({ workspaces: [], hasLoaded: false, listError: 'offline' })
+
+    const { result } = renderHook(() => useWorkspaceData('missing'))
+
+    expect(result.current.workspace).toBeNull()
+    expect(result.current.sessions).toEqual([])
+    expect(result.current.loading).toBe(true)
+    expect(result.current.error).toBe('offline')
+  })
+
+  it('does not fall back to another Session when the requested id is missing', () => {
+    const { result } = renderHook(() =>
+      useWorkspaceSessionData('workspace-1', 'missing'),
+    )
+
+    expect(result.current.session).toBeNull()
+  })
+})

--- a/ui/src/hooks/useWorkspaceData.ts
+++ b/ui/src/hooks/useWorkspaceData.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react'
+
+import type { SessionRecord, Workspace } from '../components/workspace/api'
+import { useWorkspaces } from '../contexts/workspaces-context'
+
+export interface WorkspaceDataSnapshot {
+  readonly workspace: Workspace | null
+  readonly sessions: readonly SessionRecord[]
+  readonly loading: boolean
+  readonly error: string | null
+  refresh(): Promise<void>
+}
+
+export interface WorkspaceSessionDataSnapshot extends WorkspaceDataSnapshot {
+  readonly session: SessionRecord | null
+}
+
+/**
+ * Domain read boundary for one backend-backed Workspace snapshot.
+ * Presentation components consume this hook (or props selected by a parent)
+ * instead of reaching into the polling context or calling the API directly.
+ */
+export function useWorkspaceData(workspaceId: string): WorkspaceDataSnapshot {
+  const context = useWorkspaces()
+  const workspace = useMemo(
+    () => context.workspaces.find((candidate) => candidate.id === workspaceId) ?? null,
+    [context.workspaces, workspaceId],
+  )
+
+  return useMemo(() => ({
+    workspace,
+    sessions: workspace?.sessions ?? [],
+    loading: !context.hasLoaded && workspace === null,
+    error: context.listError,
+    refresh: context.refresh,
+  }), [context.hasLoaded, context.listError, context.refresh, workspace])
+}
+
+/** Select one Session without duplicating Workspace lookup/error semantics. */
+export function useWorkspaceSessionData(
+  workspaceId: string,
+  sessionId: string | null,
+): WorkspaceSessionDataSnapshot {
+  const workspace = useWorkspaceData(workspaceId)
+  const session = useMemo(
+    () => sessionId
+      ? workspace.sessions.find((candidate) => candidate.id === sessionId) ?? null
+      : null,
+    [sessionId, workspace.sessions],
+  )
+
+  return useMemo(() => ({ ...workspace, session }), [session, workspace])
+}

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from 'react-i18next'
 import '@xterm/xterm/css/xterm.css'
 
 import { useWorkspaces } from '../contexts/workspaces-context'
+import { useWorkspaceSessionData } from '../hooks/useWorkspaceData'
 import { useWorkspace } from '../tabs/store'
 import { workspaceDisplayName, workspaceDisplayTitle } from '../components/workspace/display'
 import { WorkspaceView } from '../components/workspace/WorkspaceView'
@@ -40,12 +41,11 @@ export function WorkspacePage({ spec, visible }: Props) {
   const wsId = spec.params.wsId
   const sessionId = spec.params.sessionId ?? null
   const source = spec.params.source
-
-  const workspace = ctx.workspaces.find((w) => w.id === wsId)
-  const sessions = workspace?.sessions ?? []
-  const activeRecord = sessionId
-    ? sessions.find((s) => s.id === sessionId) ?? null
-    : null
+  const {
+    workspace,
+    sessions,
+    session: activeRecord,
+  } = useWorkspaceSessionData(wsId, sessionId)
   const effectiveDefaultAgent = workspace?.defaultAgent ?? ctx.defaultAgent
   const defaultAgentEnabled =
     effectiveDefaultAgent !== null &&
@@ -176,7 +176,7 @@ export function WorkspacePage({ spec, visible }: Props) {
           sessionId={sessionId}
           {...(source ? { source } : {})}
           activeRecord={activeRecord}
-          sessions={workspace.sessions}
+          sessions={sessions}
           label={workspaceName}
           terminalHeaderActions={terminalCanvas ? workspaceActions : undefined}
           onSpawnFresh={spawnDefault}


### PR DESCRIPTION
## Summary
- centralize the secret-free Session API projection so every Workspace endpoint includes the persisted runtime binding
- add a tested Workspace/Session data hook and route the paused Session page through it
- distinguish unavailable historical runtime metadata from an explicit runtime default
- document that frontend backend reads belong in tested domain hooks

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (472 files, 4026 tests passed)
- browser: paused Claude Session displays `deepseek-1`, `deepseek-v4-flash`, and `high reasoning`