### PR TITLE
feat(workspaces): edit paused Session AI configuration

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -358,9 +358,12 @@ Choosing an OpenAlice credential is an explicit override. A fresh Session may
 bind that vault reference without writing it into the Workspace or changing the
 runtime's global state. An absent choice means
 “use the runtime default”; it does not mean “pick any compatible credential.”
-Existing Session bindings remain authoritative until that Session is retired,
-and OpenAlice never imports a runtime-global secret into its vault or a
-Workspace.
+Existing Session bindings remain authoritative until that Session is retired
+or the user explicitly replaces the binding while it is paused. A paused edit
+updates the secret-free `.alice/sessions/<resumeId>.json` reference without
+waking the Session; the replacement credential, model, and effort take effect
+on its next resume. OpenAlice never imports a runtime-global secret into its
+vault or a Workspace.
 
 Native “global” state follows the runtime actually launched. A source or
 user-installed Pi uses its own normal global agent directory. Packaged managed
@@ -420,7 +423,7 @@ contain credentials.
 - `src/workspaces/adapters/` — declared runtime compatibility, native projection, and round-trip parsing.
 - `src/workspaces/adapters/owned-toml-config.ts` — reversible Codex project-scalar ownership.
 - `src/workspaces/resume-registry.ts` — durable product Session identity and runtime hydration.
-- `src/workspaces/session-runtime-store.ts` — immutable Workspace-local Session AI configuration.
+- `src/workspaces/session-runtime-store.ts` — Workspace-local Session AI configuration and explicit paused replacement.
 - `src/workspaces/schedule/scanner.ts` — Issue selection to fresh Session creation.
 - `src/workspaces/headless-task-registry.ts` — per-turn execution provenance.
 - `ui/src/components/credentials/` — credential/account setup.

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -43,6 +43,9 @@ function build(
     workspaceAbsorbs?: any;
     availability?: Record<string, { installed: boolean; path: string | null }>;
     spawnPlan?: any;
+    sessionRecord?: any;
+    runtimeBinding?: any;
+    poolLive?: any;
   } = {},
 ) {
   const claude = {
@@ -73,6 +76,12 @@ function build(
     checkedAt: null,
   };
   const getAgentRuntimeReadiness = vi.fn(() => runtimeReadiness);
+  const replaceRuntimeBinding = vi.fn(async (input: any) => ({
+    resumeId: input.resumeId,
+    wsId: input.wsId,
+    agent: input.agent,
+    runtimeBinding: input.runtimeBinding,
+  }));
   const probeAgentRuntimeReadiness = vi.fn(async () => ({
     ...runtimeReadiness,
     overallReady: true,
@@ -143,8 +152,22 @@ function build(
     runHeadlessTask,
     dispatchHeadlessTask,
     resumeRegistry: {
-      get: vi.fn(() => opts.resumeIdentity ?? null),
+      get: vi.fn(() => opts.resumeIdentity ?? (opts.sessionRecord ? {
+        resumeId: opts.sessionRecord.resumeId,
+        wsId: opts.sessionRecord.wsId,
+        agent: opts.sessionRecord.agent,
+        lifecycle: 'active',
+        runtimeBinding: opts.runtimeBinding ?? null,
+      } : null)),
       ensure: vi.fn(async (input: any) => ({ resumeId: input.resumeId ?? 'resume-1', ...input })),
+      replaceRuntimeBinding,
+    },
+    sessionRegistry: {
+      get: vi.fn(() => opts.sessionRecord),
+      update: vi.fn(async () => undefined),
+    },
+    pool: {
+      get: vi.fn(() => opts.poolLive),
     },
     getAgentRuntimeReadiness,
     probeAgentRuntimeReadiness,
@@ -171,6 +194,7 @@ function build(
     lifecycle,
     templateUpgrades,
     workspaceAbsorbs,
+    replaceRuntimeBinding,
   };
 }
 
@@ -918,6 +942,98 @@ describe('POST /:id/headless/:taskId/session', () => {
     expect(opened.status).toBe(409);
     expect(opened.body.error).toBe('run_still_running');
     expect(spawn).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /:id/sessions/:sid/runtime', () => {
+  const TOKEN = 'claude-sunny-amber-spring';
+  const pausedRecord = {
+    id: TOKEN,
+    resumeId: 'resume-session-runtime',
+    wsId: 'ws-1',
+    agent: 'claude',
+    name: 'c1',
+    createdAt: '2026-08-11T00:00:00.000Z',
+    lastActiveAt: '2026-08-11T00:01:00.000Z',
+    state: 'paused',
+    surface: 'terminal',
+  };
+  const adapter = {
+    id: 'claude',
+    displayName: 'Claude Code',
+    capabilities: {
+      aiProvider: {
+        credentialSource: 'runtime-or-workspace',
+        wirePreference: ['anthropic'],
+      },
+    },
+    sessionRuntime: emptyAgentSessionRuntime,
+  };
+
+  it('replaces the persisted binding for a paused Session without resuming it', async () => {
+    const { app, replaceRuntimeBinding } = build({
+      sessionRecord: pausedRecord,
+      adapters: { claude: adapter },
+    });
+
+    const result = await put(app, `/ws-1/sessions/${TOKEN}/runtime`, {
+      credentialSource: 'native',
+      model: 'claude-sonnet-4-5',
+      reasoningEffort: 'low',
+    });
+
+    expect(result).toMatchObject({
+      status: 200,
+      body: {
+        session: {
+          id: TOKEN,
+          state: 'paused',
+          runtime: {
+            credentialSource: 'native',
+            model: 'claude-sonnet-4-5',
+            reasoningEffort: 'low',
+          },
+        },
+      },
+    });
+    expect(replaceRuntimeBinding).toHaveBeenCalledWith(expect.objectContaining({
+      resumeId: 'resume-session-runtime',
+      runtimeBinding: {
+        version: 1,
+        credential: { source: 'native' },
+        model: 'claude-sonnet-4-5',
+        reasoningEffort: 'low',
+      },
+    }));
+  });
+
+  it('rejects edits while the Session is running', async () => {
+    const { app, replaceRuntimeBinding } = build({
+      sessionRecord: { ...pausedRecord, state: 'running' },
+      adapters: { claude: adapter },
+      poolLive: { pid: 42 },
+    });
+
+    const result = await put(app, `/ws-1/sessions/${TOKEN}/runtime`, {
+      credentialSource: 'native',
+    });
+
+    expect(result).toMatchObject({ status: 409, body: { error: 'session_not_paused' } });
+    expect(replaceRuntimeBinding).not.toHaveBeenCalled();
+  });
+
+  it('requires a saved credential when vault management is selected', async () => {
+    const { app, replaceRuntimeBinding } = build({
+      sessionRecord: pausedRecord,
+      adapters: { claude: adapter },
+    });
+
+    const result = await put(app, `/ws-1/sessions/${TOKEN}/runtime`, {
+      credentialSource: 'vault',
+    });
+
+    expect(result).toMatchObject({ status: 400, body: { error: 'bad_request' } });
+    expect(replaceRuntimeBinding).not.toHaveBeenCalled();
   });
 });
 

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -112,6 +112,28 @@ const workspaceRuntimeDefaultsRequestSchema = z.object({
   headless: workspaceRuntimeModeDefaultsRequestSchema,
 }).strict();
 
+const pausedSessionRuntimeRequestSchema = z.object({
+  credentialSource: z.enum(['native', 'vault']),
+  credentialSlug: z.string().trim().min(1).max(128).nullable().optional(),
+  model: z.string().trim().min(1).max(256).nullable().optional(),
+  reasoningEffort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']).nullable().optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.credentialSource === 'vault' && !value.credentialSlug) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['credentialSlug'],
+      message: 'credentialSlug is required for a vault credential',
+    });
+  }
+  if (value.credentialSource === 'native' && value.credentialSlug) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['credentialSlug'],
+      message: 'credentialSlug cannot be combined with native runtime authentication',
+    });
+  }
+});
+
 // The spawn body's `resume` value is an AGENT-side session id, whose shape is
 // adapter-native: uuid for claude/codex/pi, `ses_<base62>` for opencode. This
 // looser shape applies ONLY to the resume intent passed through to the adapter's
@@ -1713,6 +1735,87 @@ export function createWorkspaceRoutes(
       return c.json({ ok: true, wasRunning });
     });
   }
+
+  app.put('/:id/sessions/:sid/runtime', async (c) => {
+    const id = c.req.param('id');
+    const token = c.req.param('sid');
+    if (!validId(id) || !validId(token)) return c.json({ error: 'not_found' }, 404);
+    const meta = svc.resolveRuntimeWorkspace?.(id) ?? svc.registry.get(id);
+    if (!meta) return c.json({ error: 'workspace_not_found' }, 404);
+    const record = svc.sessionRegistry.get(id, token);
+    if (!record) return c.json({ error: 'not_found' }, 404);
+    if (
+      record.state !== 'paused'
+      || svc.pool.get(token)
+      || svc.webPi?.has(token)
+    ) {
+      return c.json({
+        error: 'session_not_paused',
+        message: 'Pause this Session before changing its credential, model, or effort',
+      }, 409);
+    }
+    const identity = svc.resumeRegistry.get(record.resumeId);
+    if (!identity) {
+      return c.json({
+        error: 'session_identity_missing',
+        message: 'This Session has no durable resume identity',
+      }, 409);
+    }
+    if (identity.lifecycle === 'retired') {
+      return c.json({ error: 'resume_retired', message: 'this Session retired with its Workspace' }, 409);
+    }
+    const adapter = svc.adapters.get(record.agent);
+    if (!adapter || !isAgentRuntime(adapter)) {
+      return c.json({
+        error: 'runtime_selection_unsupported',
+        message: `Session runtime "${record.agent}" does not support managed AI configuration`,
+      }, 400);
+    }
+    const parsed = pausedSessionRuntimeRequestSchema.safeParse(
+      await safeJson(c).catch(() => null),
+    );
+    if (!parsed.success) {
+      return c.json({
+        error: 'bad_request',
+        message: parsed.error.issues[0]?.message ?? 'invalid Session AI configuration',
+      }, 400);
+    }
+    try {
+      const resolved = await createSessionRuntimeBinding({
+        adapter,
+        cwd: meta.dir,
+        selection: {
+          ...(parsed.data.credentialSource === 'native'
+            ? { credentialSource: 'native' as const }
+            : { credentialSlug: parsed.data.credentialSlug! }),
+          ...(parsed.data.model ? { model: parsed.data.model } : {}),
+          ...(parsed.data.reasoningEffort
+            ? { reasoningEffort: parsed.data.reasoningEffort }
+            : {}),
+        },
+      });
+      await svc.resumeRegistry.replaceRuntimeBinding({
+        resumeId: record.resumeId,
+        wsId: record.wsId,
+        agent: record.agent,
+        runtimeBinding: resolved.binding,
+      });
+      return c.json({
+        session: projectPublicSession(record, { runtimeBinding: resolved.binding }),
+      });
+    } catch (err) {
+      if (err instanceof SessionRuntimeBindingError) {
+        return c.json({ error: err.code, message: err.message }, 400);
+      }
+      launcherLogger.warn('session_runtime.replace_failed', {
+        id, sessionId: token, agent: record.agent, err,
+      });
+      return c.json({
+        error: 'session_runtime_update_failed',
+        message: (err as Error).message,
+      }, 500);
+    }
+  });
 
   app.post('/:id/sessions/:sid/resume', async (c) => {
     const id = c.req.param('id');

--- a/src/workspaces/resume-registry.spec.ts
+++ b/src/workspaces/resume-registry.spec.ts
@@ -82,6 +82,39 @@ describe('ResumeRegistry', () => {
     expect(raw).not.toContain('sk-secret')
   })
 
+  it('replaces a paused Session binding only through the explicit registry boundary', async () => {
+    const registry = await ResumeRegistry.load(path, noopLogger, runtimeStore)
+    await registry.ensure({
+      resumeId: 'resume-runtime-edit',
+      wsId: 'ws-1',
+      agent: 'claude',
+      runtimeBinding: { version: 1, credential: { source: 'native' } },
+      now: 1,
+    })
+    const replacement = {
+      version: 1 as const,
+      credential: {
+        source: 'vault' as const,
+        credentialSlug: 'deepseek-1',
+        wireShape: 'anthropic' as const,
+      },
+      model: 'deepseek-v4-flash',
+      reasoningEffort: 'high' as const,
+    }
+
+    const updated = await registry.replaceRuntimeBinding({
+      resumeId: 'resume-runtime-edit',
+      wsId: 'ws-1',
+      agent: 'claude',
+      runtimeBinding: replacement,
+      now: 2,
+    })
+
+    expect(updated).toMatchObject({ runtimeBinding: replacement, updatedAt: 2 })
+    expect((await ResumeRegistry.load(path, noopLogger, runtimeStore))
+      .get('resume-runtime-edit')?.runtimeBinding).toEqual(replacement)
+  })
+
   it('keeps legacy UUID identities valid without rewriting them', async () => {
     const registry = await ResumeRegistry.load(path, noopLogger, runtimeStore)
     const legacyId = '550e8400-e29b-41d4-a716-446655440000'

--- a/src/workspaces/resume-registry.ts
+++ b/src/workspaces/resume-registry.ts
@@ -17,7 +17,9 @@ export interface ResumeIdentityRecord {
   readonly resumeId: string
   readonly wsId: string
   readonly agent: string
-  /** Runtime-only hydration of the immutable Workspace-owned AI config. */
+  /** Runtime-only hydration of the Workspace-owned AI config. Launch paths
+   * keep it immutable; a paused Session may replace it through the explicit
+   * edit boundary. */
   runtimeBinding?: SessionRuntimeBinding
   agentSessionId?: string
   latestTaskId?: string
@@ -194,6 +196,33 @@ export class ResumeRegistry {
     record.agentSessionId = agentSessionId
     record.updatedAt = Date.now()
     await this.flush()
+  }
+
+  async replaceRuntimeBinding(input: {
+    resumeId: string
+    wsId: string
+    agent: string
+    runtimeBinding: SessionRuntimeBinding
+    now?: number
+  }): Promise<ResumeIdentityRecord> {
+    const record = this.records.get(input.resumeId)
+    if (!record) throw new Error(`resume identity ${input.resumeId} was not found`)
+    if (record.wsId !== input.wsId || record.agent !== input.agent) {
+      throw new Error(`resume identity ${input.resumeId} belongs to ${record.wsId}/${record.agent}`)
+    }
+    if (record.lifecycle === 'retired') {
+      throw new Error(`resume identity ${input.resumeId} is retired`)
+    }
+    await this.runtimeBindings.replace({
+      wsId: input.wsId,
+      resumeId: input.resumeId,
+      agent: input.agent,
+      binding: input.runtimeBinding,
+    })
+    record.runtimeBinding = input.runtimeBinding
+    record.updatedAt = input.now ?? Date.now()
+    await this.flush()
+    return record
   }
 
   async retireWorkspace(

--- a/src/workspaces/session-runtime-store.spec.ts
+++ b/src/workspaces/session-runtime-store.spec.ts
@@ -59,6 +59,23 @@ describe('WorkspaceSessionRuntimeStore', () => {
     })).rejects.toThrow(/different runtime binding/)
   })
 
+  it('atomically replaces a binding only through the explicit edit boundary', async () => {
+    await store.ensure({ wsId: 'ws-1', resumeId: 'resume-test', agent: 'codex', binding })
+    const replacement: SessionRuntimeBinding = {
+      version: 1,
+      credential: { source: 'native' },
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'low',
+    }
+
+    await store.replace({
+      wsId: 'ws-1', resumeId: 'resume-test', agent: 'codex', binding: replacement,
+    })
+
+    expect(await store.read({ wsId: 'ws-1', resumeId: 'resume-test', agent: 'codex' }))
+      .toEqual(replacement)
+  })
+
   it('serializes competing first writes so only one binding wins', async () => {
     const results = await Promise.allSettled([
       store.ensure({ wsId: 'ws-1', resumeId: 'resume-race', agent: 'codex', binding }),

--- a/src/workspaces/session-runtime-store.ts
+++ b/src/workspaces/session-runtime-store.ts
@@ -24,6 +24,12 @@ export interface SessionRuntimeBindingStore {
     readonly agent: string
     readonly binding: SessionRuntimeBinding
   }): Promise<void>
+  replace(input: {
+    readonly wsId: string
+    readonly resumeId: string
+    readonly agent: string
+    readonly binding: SessionRuntimeBinding
+  }): Promise<void>
 }
 
 function assertedFileName(resumeId: string): string {
@@ -107,6 +113,20 @@ export class WorkspaceSessionRuntimeStore implements SessionRuntimeBindingStore 
     await next
   }
 
+  /** Explicit paused-Session edit boundary. Normal launch paths keep using
+   * `ensure()` so an existing Session can never change its AI binding merely
+   * because a later launch supplied different defaults. */
+  async replace(input: {
+    readonly wsId: string
+    readonly resumeId: string
+    readonly agent: string
+    readonly binding: SessionRuntimeBinding
+  }): Promise<void> {
+    const next = this.writeChain.then(() => this.writeNow(input))
+    this.writeChain = next.catch(() => undefined)
+    await next
+  }
+
   private async ensureNow(input: {
     readonly wsId: string
     readonly resumeId: string
@@ -121,6 +141,15 @@ export class WorkspaceSessionRuntimeStore implements SessionRuntimeBindingStore 
       return
     }
 
+    await this.writeNow(input)
+  }
+
+  private async writeNow(input: {
+    readonly wsId: string
+    readonly resumeId: string
+    readonly agent: string
+    readonly binding: SessionRuntimeBinding
+  }): Promise<void> {
     const [path] = this.paths(input.wsId, input.resumeId)
     if (!path) throw new Error(`Workspace ${input.wsId} is unavailable for Session AI config storage`)
     const directory = dirname(path)

--- a/ui/src/components/workspace/AgentLaunchControls.spec.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.spec.tsx
@@ -177,7 +177,11 @@ describe('AgentLaunchSelectors keyboard menus', () => {
     expect(screen.queryByRole('menu')).toBeNull()
     expect(document.activeElement).toBe(trigger)
 
-    await user.keyboard('{ArrowDown}{End}{Enter}')
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: /Managed by OpenCode/ }))
+    await user.keyboard('{End}')
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: /Backup/ }))
+    await user.keyboard('{Enter}')
     expect(selectCredential).toHaveBeenCalledWith('backup')
     expect(screen.queryByRole('menu')).toBeNull()
     expect(document.activeElement).toBe(trigger)
@@ -239,6 +243,25 @@ describe('AgentLaunchSelectors keyboard menus', () => {
     const trigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectCredential') })
     expect(trigger.textContent).toContain('DeepSeek API')
     expect(trigger.textContent).toContain('deepseek-1')
+  })
+
+  it('renders paused-session settings as two full-width rows', () => {
+    render(
+      <AgentLaunchSelectors
+        config={launchConfig()}
+        onConfigureProvider={vi.fn()}
+        showRuntime={false}
+        toolbar
+        layout="settings"
+      />,
+    )
+
+    const credentialTrigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectCredential') })
+    const inferenceTrigger = screen.getByRole('button', { name: i18n.t('chatLanding.selectModelAndEffort') })
+    expect(credentialTrigger.className).toContain('w-full')
+    expect(inferenceTrigger.className).toContain('w-full')
+    expect(inferenceTrigger.textContent).toContain('gpt-5')
+    expect(inferenceTrigger.textContent).toContain('Reasoning managed by runtime')
   })
 
   it('combines model and reasoning into a nested toolbar menu', async () => {

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -37,7 +37,9 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -90,6 +92,8 @@ export interface AgentLaunchSelectorsProps {
   readonly labeled?: boolean
   /** Visually recede selectors into a composer toolbar until hover/focus. */
   readonly toolbar?: boolean
+  /** Present AI controls as full-width setting rows instead of composer chips. */
+  readonly layout?: 'inline' | 'settings'
 }
 
 export interface AgentLaunchSelectorsHandle {
@@ -255,9 +259,11 @@ function AgentLaunchEffortEditor({
 function AgentLaunchInferenceMenu({
   config,
   menuPlacement,
+  settings = false,
 }: {
   config: AgentLaunchConfigState
   menuPlacement: 'up' | 'down'
+  settings?: boolean
 }) {
   const { t } = useTranslation()
   const pendingCustomModelRef = useRef(false)
@@ -315,17 +321,33 @@ function AgentLaunchInferenceMenu({
           render={<button
             type="button"
             aria-label={t('chatLanding.selectModelAndEffort')}
-            className="oa-pressable inline-flex min-h-8 max-w-[280px] items-center gap-1.5 rounded-md bg-transparent px-1.5 py-1 text-[11px] text-foreground transition-colors hover:bg-muted/55"
+            className={settings
+              ? 'oa-pressable flex min-h-14 w-full min-w-0 items-center gap-3 rounded-lg border border-border/70 bg-muted/25 px-3 py-2 text-left transition-colors hover:bg-muted/45'
+              : 'oa-pressable inline-flex min-h-8 max-w-[280px] items-center gap-1.5 rounded-md bg-transparent px-1.5 py-1 text-[11px] text-foreground transition-colors hover:bg-muted/55'}
           />}
         >
-          <Cpu className="h-3 w-3 shrink-0 text-muted-foreground" />
-          <span className="min-w-0 truncate">{resolvedModel}</span>
-          <span className="shrink-0 text-muted-foreground">· {resolvedEffort}</span>
-          <ChevronDown className="h-3 w-3 shrink-0 opacity-60" />
+          <Cpu className={settings ? 'h-4 w-4 shrink-0 text-muted-foreground' : 'h-3 w-3 shrink-0 text-muted-foreground'} />
+          {settings ? (
+            <span className="min-w-0 flex-1">
+              <span className="block text-[10px] font-medium text-muted-foreground">
+                {t('chatLanding.modelField')} · {t('chatLanding.effortField')}
+              </span>
+              <span className="flex min-w-0 items-baseline gap-1.5 text-sm text-foreground">
+                <span className="min-w-0 truncate font-medium">{resolvedModel}</span>
+                <span className="shrink-0 text-xs text-muted-foreground">· {resolvedEffort}</span>
+              </span>
+            </span>
+          ) : (
+            <>
+              <span className="min-w-0 truncate">{resolvedModel}</span>
+              <span className="shrink-0 text-muted-foreground">· {resolvedEffort}</span>
+            </>
+          )}
+          <ChevronDown className={settings ? 'h-4 w-4 shrink-0 opacity-60' : 'h-3 w-3 shrink-0 opacity-60'} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          side={menuPlacement === 'down' ? 'bottom' : 'top'}
+          side={settings ? 'top' : menuPlacement === 'down' ? 'bottom' : 'top'}
           sideOffset={6}
           aria-label={t('chatLanding.selectModelAndEffort')}
           className="w-[280px] max-w-[calc(100vw-2rem)] rounded-xl border border-border/70 bg-secondary p-1.5 shadow-lg ring-0"
@@ -449,6 +471,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
     menuPlacement = 'up',
     labeled = false,
     toolbar = false,
+    layout = 'inline',
   },
   ref,
 ) {
@@ -456,13 +479,10 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
   const [agentMenuOpen, setAgentMenuOpen] = useState(false)
   const [credentialMenuOpen, setCredentialMenuOpen] = useState(false)
   const agentBoxRef = useRef<HTMLDivElement>(null)
-  const credentialBoxRef = useRef<HTMLDivElement>(null)
   const agentTriggerRef = useRef<HTMLButtonElement>(null)
-  const credentialTriggerRef = useRef<HTMLButtonElement>(null)
   const agentMenuRef = useRef<HTMLDivElement>(null)
-  const credentialMenuRef = useRef<HTMLDivElement>(null)
   const agentFocusEdgeRef = useRef<'first' | 'last'>('first')
-  const credentialFocusEdgeRef = useRef<'first' | 'last'>('first')
+  const settingsLayout = layout === 'settings'
   const SelectedIcon = config.selectedAgent ? AGENT_ICONS[config.selectedAgent.id] : undefined
   const runtimeName = config.selectedAgent?.displayName ?? t('chatLanding.runtimeFallback')
   const workspaceAccess = config.accessMode === 'auto' && config.detectedCredential?.configured === true
@@ -485,37 +505,27 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
   useImperativeHandle(ref, () => ({
     openAgentMenu() {
       agentFocusEdgeRef.current = 'first'
-      setCredentialMenuOpen(false)
       setAgentMenuOpen(true)
     },
   }), [])
 
   useEffect(() => {
-    if (!agentMenuOpen && !credentialMenuOpen) return
+    if (!agentMenuOpen) return
     const onDown = (event: MouseEvent) => {
       const target = event.target as Node
       if (agentMenuOpen && agentBoxRef.current && !agentBoxRef.current.contains(target)) {
         setAgentMenuOpen(false)
       }
-      if (credentialMenuOpen && credentialBoxRef.current && !credentialBoxRef.current.contains(target)) {
-        setCredentialMenuOpen(false)
-      }
     }
     document.addEventListener('mousedown', onDown)
     return () => document.removeEventListener('mousedown', onDown)
-  }, [agentMenuOpen, credentialMenuOpen])
+  }, [agentMenuOpen])
 
   useEffect(() => {
     if (!agentMenuOpen) return
     focusMenuEdge(agentMenuRef, agentFocusEdgeRef.current)
     agentFocusEdgeRef.current = 'first'
   }, [agentMenuOpen])
-
-  useEffect(() => {
-    if (!credentialMenuOpen) return
-    focusMenuEdge(credentialMenuRef, credentialFocusEdgeRef.current)
-    credentialFocusEdgeRef.current = 'first'
-  }, [credentialMenuOpen])
 
   return (
     <>
@@ -533,13 +543,11 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
           onClick={() => {
             agentFocusEdgeRef.current = 'first'
             setAgentMenuOpen((open) => !open)
-            setCredentialMenuOpen(false)
           }}
           onKeyDown={(event) => {
             if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
             event.preventDefault()
             agentFocusEdgeRef.current = event.key === 'ArrowUp' ? 'last' : 'first'
-            setCredentialMenuOpen(false)
             setAgentMenuOpen(true)
           }}
           disabled={config.agents.length === 0}
@@ -604,77 +612,48 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
       )}
 
       {showAi && config.canSelectCredential && !config.noCredentials && config.credentials && (
-        <div
-          ref={credentialBoxRef}
-          className={`relative ${labeled ? 'w-full sm:w-auto' : ''}`}
-          onBlur={(event) => {
-            const next = event.relatedTarget as Node | null
-            if (!next || !event.currentTarget.contains(next)) setCredentialMenuOpen(false)
-          }}
-        >
-          <button
-            ref={credentialTriggerRef}
+        <DropdownMenu open={credentialMenuOpen} onOpenChange={setCredentialMenuOpen}>
+          <DropdownMenuTrigger
             type="button"
-            onClick={() => {
-              credentialFocusEdgeRef.current = 'first'
-              setCredentialMenuOpen((open) => !open)
-              setAgentMenuOpen(false)
-            }}
-            onKeyDown={(event) => {
-              if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
-              event.preventDefault()
-              credentialFocusEdgeRef.current = event.key === 'ArrowUp' ? 'last' : 'first'
-              setAgentMenuOpen(false)
-              setCredentialMenuOpen(true)
-            }}
-            aria-haspopup="menu"
-            aria-expanded={credentialMenuOpen}
             aria-label={t('chatLanding.selectCredential')}
-            className={`oa-pressable inline-flex items-center gap-2 rounded-md text-left text-muted-foreground transition-colors hover:text-foreground ${toolbar ? 'bg-transparent px-1.5 hover:bg-muted/55' : 'bg-muted px-2.5'} ${labeled ? 'min-h-12 w-full max-w-none py-1.5 sm:w-auto sm:max-w-[240px]' : toolbar ? 'min-h-8 max-w-[200px] py-1' : 'min-h-8 max-w-[240px] py-1'}`}
+            onClick={() => {
+              // Base UI opens menus on pointer-down. Keeping a click fallback
+              // makes the trigger work for synthetic click-only environments
+              // without fighting the native pointer interaction.
+              if (!credentialMenuOpen) setCredentialMenuOpen(true)
+            }}
+            className={`oa-pressable inline-flex min-w-0 items-center gap-2 rounded-lg text-left text-muted-foreground transition-colors hover:text-foreground ${settingsLayout ? 'min-h-14 w-full border border-border/70 bg-muted/25 px-3 py-2 hover:bg-muted/45' : toolbar ? 'min-h-8 max-w-[200px] bg-transparent px-1.5 py-1 hover:bg-muted/55' : labeled ? 'min-h-12 w-full max-w-none bg-muted px-2.5 py-1.5 sm:w-auto sm:max-w-[240px]' : 'min-h-8 max-w-[240px] bg-muted px-2.5 py-1'}`}
           >
-            <KeyRound className="h-3 w-3 shrink-0" />
+            <KeyRound className={settingsLayout ? 'h-4 w-4 shrink-0' : 'h-3 w-3 shrink-0'} />
             <span className="min-w-0 flex-1">
-              {labeled && (
-                <span className="block truncate text-[9.5px] font-medium text-muted-foreground">
+              {(labeled || settingsLayout) && (
+                <span className={`block truncate font-medium text-muted-foreground ${settingsLayout ? 'text-[10px]' : 'text-[9.5px]'}`}>
                   {t('chatLanding.aiAccess')}
                 </span>
               )}
-              <span className="block truncate text-[11px] text-foreground">{selectedAccessLabel}</span>
-              {labeled && (
-                <span className="block truncate text-[9.5px] text-muted-foreground">{selectedAccessDetail}</span>
+              <span className={`block truncate text-foreground ${settingsLayout ? 'text-sm font-medium' : 'text-[11px]'}`}>{selectedAccessLabel}</span>
+              {(labeled || settingsLayout) && (
+                <span className={`block truncate text-muted-foreground ${settingsLayout ? 'text-xs' : 'text-[9.5px]'}`}>{selectedAccessDetail}</span>
               )}
             </span>
-            <ChevronDown className="h-3 w-3 shrink-0 opacity-60" />
-          </button>
-          {credentialMenuOpen && (
-            <div
-              ref={credentialMenuRef}
-              role="menu"
-              onKeyDown={(event) => handleMenuKeyDown(
-                event,
-                credentialMenuRef,
-                () => setCredentialMenuOpen(false),
-                credentialTriggerRef,
-              )}
-              className={`oa-popover-enter absolute left-0 z-20 max-h-[min(24rem,calc(100vh-8rem))] min-w-[240px] overflow-y-auto overscroll-contain rounded-lg border border-border/70 bg-secondary py-1 shadow-lg [scrollbar-gutter:stable] ${menuPlacement === 'down' ? 'top-full mt-1' : 'bottom-full mb-1'}`}
-            >
-              <div
-                role="presentation"
-                className="border-b border-border/60 px-3 py-2 text-[11px] font-medium text-muted-foreground"
-              >
+            <ChevronDown className={settingsLayout ? 'h-4 w-4 shrink-0 opacity-60' : 'h-3 w-3 shrink-0 opacity-60'} />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side={menuPlacement === 'down' ? 'bottom' : 'top'}
+            sideOffset={6}
+            className="w-[min(22rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] rounded-xl border border-border/70 bg-secondary p-1.5 shadow-lg ring-0"
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="border-b border-border/60 px-2.5 py-2 text-[11px]">
                 {t('chatLanding.credentialMenuTitle', { runtime: runtimeName })}
-              </div>
+              </DropdownMenuLabel>
               {config.detectedCredential?.configured === true && (
-                <button
-                  type="button"
-                  role="menuitem"
-                  tabIndex={-1}
+                <DropdownMenuItem
                   onClick={() => {
                     config.selectWorkspaceDefault()
-                    setCredentialMenuOpen(false)
-                    credentialTriggerRef.current?.focus()
                   }}
-                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] transition-colors hover:bg-muted ${config.accessMode === 'auto' ? 'text-primary' : 'text-foreground'}`}
+                  className={`min-h-11 px-2.5 py-2 text-[12px] ${config.accessMode === 'auto' ? 'text-primary' : 'text-foreground'}`}
                 >
                   <span className="min-w-0 flex-1">
                     <span className="block truncate">{t('chatLanding.workspaceAiAccess')}</span>
@@ -683,41 +662,29 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
                     )}
                   </span>
                   {config.accessMode === 'auto' && <Check className="h-3.5 w-3.5 shrink-0" />}
-                </button>
+                </DropdownMenuItem>
               )}
-              {(
-                <button
-                  type="button"
-                  role="menuitem"
-                  tabIndex={-1}
+              <DropdownMenuItem
                   onClick={() => {
                     config.selectRuntimeDefault()
-                    setCredentialMenuOpen(false)
-                    credentialTriggerRef.current?.focus()
                   }}
-                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] transition-colors hover:bg-muted ${config.accessMode === 'native' ? 'text-primary' : 'text-foreground'}`}
+                  className={`min-h-11 px-2.5 py-2 text-[12px] ${config.accessMode === 'native' ? 'text-primary' : 'text-foreground'}`}
                 >
                   <span className="min-w-0 flex-1">
                     <span className="block truncate">{t('chatLanding.runtimeAccount', { runtime: runtimeName })}</span>
                     <span className="block truncate text-[10px] text-muted-foreground">{t('chatLanding.runtimeAccountDetail')}</span>
                   </span>
                   {config.accessMode === 'native' && <Check className="h-3.5 w-3.5 shrink-0" />}
-                </button>
-              )}
+              </DropdownMenuItem>
               {config.credentials.map((credential) => {
                 const active = config.accessMode === 'vault' && credential.slug === config.effectiveCredential
                 return (
-                  <button
+                  <DropdownMenuItem
                     key={credential.slug}
-                    type="button"
-                    role="menuitem"
-                    tabIndex={-1}
                     onClick={() => {
                       config.selectCredential(credential.slug)
-                      setCredentialMenuOpen(false)
-                      credentialTriggerRef.current?.focus()
                     }}
-                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] transition-colors hover:bg-muted ${active ? 'text-primary' : 'text-foreground'}`}
+                    className={`min-h-11 px-2.5 py-2 text-[12px] ${active ? 'text-primary' : 'text-foreground'}`}
                   >
                     <span className="min-w-0 flex-1">
                       <span className="block truncate">{credentialAccessLabel(credential)}</span>
@@ -729,21 +696,21 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
                       <span className="max-w-[100px] shrink-0 truncate text-[10px] text-muted-foreground">{credential.resolvedModel}</span>
                     )}
                     {active && <Check className="h-3.5 w-3.5 shrink-0" />}
-                  </button>
+                  </DropdownMenuItem>
                 )
               })}
-            </div>
-          )}
-        </div>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
       )}
 
       {showAi && config.selectedAgent && (
         <div
           data-testid="agent-launch-inference-group"
-          className={`contents sm:flex sm:shrink-0 sm:items-center ${toolbar ? 'sm:gap-1' : 'sm:gap-2'}`}
+          className={settingsLayout ? 'w-full min-w-0' : `contents sm:flex sm:shrink-0 sm:items-center ${toolbar ? 'sm:gap-1' : 'sm:gap-2'}`}
         >
           {toolbar ? (
-            <AgentLaunchInferenceMenu config={config} menuPlacement={menuPlacement} />
+            <AgentLaunchInferenceMenu config={config} menuPlacement={menuPlacement} settings={settingsLayout} />
           ) : (
             <>
               <AgentLaunchModelEditor config={config} labeled={labeled} />

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -1,12 +1,20 @@
 import { useState } from 'react';
 import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
-import { Bot, ChevronDown, SquareTerminal } from 'lucide-react';
+import { Bot, ChevronDown, Settings2, SquareTerminal } from 'lucide-react';
 
-import type { SessionRecord } from './api';
+import { SessionRuntimeEditorDialog } from './SessionRuntimeEditorDialog';
+import type {
+  AgentInfo,
+  PausedSessionRuntimeUpdate,
+  SessionRecord,
+} from './api';
 
 export interface ResumeCtaProps {
   readonly record: SessionRecord;
+  readonly agents?: readonly AgentInfo[];
+  readonly workspaceId?: string;
+  readonly onUpdateRuntime?: (update: PausedSessionRuntimeUpdate) => Promise<void>;
   readonly onResume: () => Promise<void>;
   readonly onOpenWebPi?: () => Promise<void>;
 }
@@ -32,6 +40,7 @@ export interface ResumeCtaProps {
  */
 export function ResumeCta(props: ResumeCtaProps): ReactElement {
   const [resuming, setResuming] = useState<'terminal' | 'webpi' | null>(null);
+  const [runtimeEditorOpen, setRuntimeEditorOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const r = props.record;
   const sessionTitle = r.title?.trim() || r.name;
@@ -77,6 +86,18 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
             </dl>
 
             <div className="resume-cta-actions">
+              {props.agents && props.workspaceId && props.onUpdateRuntime && r.agent !== 'shell' && (
+                <button
+                  type="button"
+                  className="resume-cta-btn is-config oa-pressable"
+                  onClick={() => setRuntimeEditorOpen(true)}
+                  disabled={resuming !== null}
+                  aria-label="Change Session AI configuration"
+                >
+                  <Settings2 size={14} strokeWidth={2.1} aria-hidden="true" />
+                  <span>Change AI</span>
+                </button>
+              )}
               <button
                 type="button"
                 className="resume-cta-btn oa-pressable"
@@ -137,6 +158,16 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
           </details>
         </section>
       </div>
+      {props.agents && props.workspaceId && props.onUpdateRuntime && (
+        <SessionRuntimeEditorDialog
+          open={runtimeEditorOpen}
+          onOpenChange={setRuntimeEditorOpen}
+          record={r}
+          agents={props.agents}
+          workspaceId={props.workspaceId}
+          onSave={props.onUpdateRuntime}
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/components/workspace/SessionRuntimeEditorDialog.spec.tsx
+++ b/ui/src/components/workspace/SessionRuntimeEditorDialog.spec.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentLaunchConfigState } from '../../hooks/useAgentLaunchConfig'
+import type { SessionRecord } from './api'
+import { SessionRuntimeEditorDialog } from './SessionRuntimeEditorDialog'
+
+const launchConfig = {
+  effectiveAgent: 'claude',
+  accessMode: 'vault',
+  launchCredentialSlug: 'deepseek-1',
+  launchModel: 'deepseek-v4-flash',
+  launchReasoningEffort: 'high',
+  credentialSelectionReady: true,
+  selectRuntimeDefault: vi.fn(),
+} as unknown as AgentLaunchConfigState
+
+vi.mock('../../hooks/useAgentLaunchConfig', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/useAgentLaunchConfig')>()),
+  useAgentLaunchConfig: () => launchConfig,
+}))
+
+vi.mock('./AgentLaunchControls', () => ({
+  AgentLaunchSelectors: () => <div>AI selectors</div>,
+}))
+
+const record: SessionRecord = {
+  id: 'session-1',
+  resumeId: 'resume-1',
+  wsId: 'workspace-1',
+  agent: 'claude',
+  name: 'c1',
+  createdAt: '2026-08-11T00:00:00.000Z',
+  lastActiveAt: '2026-08-11T00:01:00.000Z',
+  state: 'paused',
+  surface: 'terminal',
+  pid: null,
+  startedAt: null,
+  title: 'Paused session',
+  runtime: {
+    credentialSource: 'vault',
+    credentialSlug: 'deepseek-1',
+    model: 'deepseek-v4-flash',
+    reasoningEffort: 'high',
+  },
+}
+
+afterEach(cleanup)
+
+describe('SessionRuntimeEditorDialog', () => {
+  it('saves the selected credential, model, and effort without resuming', async () => {
+    const onOpenChange = vi.fn()
+    const onSave = vi.fn(async () => {})
+
+    render(<SessionRuntimeEditorDialog
+      open
+      onOpenChange={onOpenChange}
+      record={record}
+      agents={[]}
+      workspaceId="workspace-1"
+      onSave={onSave}
+    />)
+
+    expect(screen.getByText('AI selectors')).toBeTruthy()
+    expect(screen.getByText(/stays paused/i)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({
+      credentialSource: 'vault',
+      credentialSlug: 'deepseek-1',
+      model: 'deepseek-v4-flash',
+      reasoningEffort: 'high',
+    }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/ui/src/components/workspace/SessionRuntimeEditorDialog.tsx
+++ b/ui/src/components/workspace/SessionRuntimeEditorDialog.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Info } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { QuickChatLaunchPreference } from '../../api/preferences'
+import {
+  useAgentLaunchConfig,
+  type AgentLaunchPreferencesState,
+} from '../../hooks/useAgentLaunchConfig'
+import { AgentLaunchSelectors } from './AgentLaunchControls'
+import type {
+  AgentInfo,
+  PausedSessionRuntimeUpdate,
+  SessionRecord,
+} from './api'
+
+interface SessionRuntimeEditorDialogProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly record: SessionRecord
+  readonly agents: readonly AgentInfo[]
+  readonly workspaceId: string
+  readonly onSave: (update: PausedSessionRuntimeUpdate) => Promise<void>
+}
+
+function runtimeLaunch(record: SessionRecord): QuickChatLaunchPreference {
+  const runtime = record.runtime
+  const vault = runtime?.credentialSource === 'vault' && Boolean(runtime.credentialSlug)
+  return {
+    agent: record.agent,
+    accessMode: vault ? 'vault' : 'native',
+    credentialSlug: vault ? runtime?.credentialSlug ?? null : null,
+    model: runtime?.model ?? null,
+    reasoningEffort: runtime?.reasoningEffort ?? null,
+  }
+}
+
+/** Transactional editor for the binding persisted beside one paused Session.
+ * Picker changes remain local until Save; they never rewrite Workspace recent
+ * preferences or wake the Session as a side effect. */
+export function SessionRuntimeEditorDialog({
+  open,
+  onOpenChange,
+  record,
+  agents,
+  workspaceId,
+  onSave,
+}: SessionRuntimeEditorDialogProps) {
+  const initial = useMemo(() => runtimeLaunch(record), [record])
+  const initialKey = JSON.stringify(initial)
+  const [draft, setDraft] = useState<QuickChatLaunchPreference>(initial)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setDraft(initial)
+    setError(null)
+    // Reset only when this dialog opens for a different persisted binding.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialKey, open])
+
+  const rememberLaunch = useCallback(async (launch: QuickChatLaunchPreference) => {
+    setDraft(launch)
+  }, [])
+  const preferences = useMemo<AgentLaunchPreferencesState>(() => ({
+    lastCredentialByAgent: draft.credentialSlug
+      ? { [record.agent]: draft.credentialSlug }
+      : {},
+    recentChatWorkspaceId: workspaceId,
+    recentLaunch: draft,
+    loaded: true,
+    rememberLaunch,
+    adoptRecentChatWorkspace: () => undefined,
+  }), [draft, record.agent, rememberLaunch, workspaceId])
+  const runtimeAgents = useMemo(
+    () => agents.filter((agent) => agent.id === record.agent),
+    [agents, record.agent],
+  )
+  const config = useAgentLaunchConfig({
+    agents: runtimeAgents,
+    defaultAgent: record.agent,
+    preferences,
+    workspaceId,
+    hasWorkspace: true,
+    managedWorkspaceLaunch: true,
+  })
+  const runtimeName = runtimeAgents[0]?.displayName ?? record.agent
+
+  const submit = async () => {
+    if (saving || !config.effectiveAgent) return
+    const vault = config.accessMode === 'vault' && Boolean(config.launchCredentialSlug)
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave({
+        credentialSource: vault ? 'vault' : 'native',
+        ...(vault ? { credentialSlug: config.launchCredentialSlug } : {}),
+        model: config.launchModel ?? null,
+        reasoningEffort: config.launchReasoningEffort ?? null,
+      })
+      onOpenChange(false)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !saving && onOpenChange(next)}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Change AI for this Session</DialogTitle>
+          <DialogDescription>
+            Choose the access and inference settings {runtimeName} will receive the next time it resumes.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-w-0 flex-col gap-2">
+          <AgentLaunchSelectors
+            config={config}
+            onConfigureProvider={() => config.selectRuntimeDefault()}
+            showRuntime={false}
+            menuPlacement="down"
+            toolbar
+            layout="settings"
+          />
+        </div>
+
+        <div className="flex items-start gap-2 rounded-md bg-muted/45 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span>
+            This changes only this paused Session. It stays paused, and the new configuration is applied on the next resume.
+          </span>
+        </div>
+
+        {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void submit()}
+            disabled={saving || !config.credentialSelectionReady || !config.effectiveAgent}
+          >
+            {saving ? 'Saving…' : 'Save changes'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -3,7 +3,7 @@ import type { ReactElement, ReactNode } from 'react';
 import { ArrowUpRight, MessageSquarePlus, Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import type { SessionRecord } from './api';
+import type { AgentInfo, PausedSessionRuntimeUpdate, SessionRecord } from './api';
 import { FilesPanel } from './FilesPanel';
 import { ResumeCta, prefixOf } from './ResumeCta';
 import { formatRelativeTime } from '../../lib/intl';
@@ -28,11 +28,16 @@ export interface WorkspaceViewProps {
    * and filters this complete collection.
    */
   readonly sessions: readonly SessionRecord[];
+  readonly agents?: readonly AgentInfo[];
   readonly label?: string;
   /** Actions promoted into the live terminal's shared titlebar. */
   readonly terminalHeaderActions?: ReactNode;
   readonly onSpawnFresh: () => void;
   readonly onResume: (sessionId: string) => Promise<void>;
+  readonly onUpdateSessionRuntime?: (
+    sessionId: string,
+    update: PausedSessionRuntimeUpdate,
+  ) => Promise<void>;
   readonly onOpenWebPi: (sessionId: string) => Promise<void>;
   /** Navigate to an already-running session without re-spawning it. Library
    *  rows call this for running entries; paused entries go through `onResume`. */
@@ -98,6 +103,11 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
         {showPausedCta && props.activeRecord && (
           <ResumeCta
             record={props.activeRecord}
+            agents={props.agents}
+            workspaceId={props.wsId}
+            onUpdateRuntime={props.onUpdateSessionRuntime
+              ? (update) => props.onUpdateSessionRuntime!(props.activeRecord!.id, update)
+              : undefined}
             onResume={() => props.onResume(props.activeRecord!.id)}
             onOpenWebPi={() => props.onOpenWebPi(props.activeRecord!.id)}
           />

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -1019,6 +1019,39 @@ export async function resumeSession(
   return (await res.json()) as SpawnedSession;
 }
 
+export interface PausedSessionRuntimeUpdate {
+  readonly credentialSource: 'native' | 'vault';
+  readonly credentialSlug?: string | null;
+  readonly model?: string | null;
+  readonly reasoningEffort?: ModelReasoningEffort | null;
+}
+
+/** Replace one paused Session's secret-free AI binding. The Session remains
+ * paused; the next resume projects this binding into the native runtime. */
+export async function updatePausedSessionRuntime(
+  wsId: string,
+  sessionId: string,
+  update: PausedSessionRuntimeUpdate,
+): Promise<SessionRecord> {
+  const res = await fetch(
+    `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/runtime`,
+    {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(update),
+    },
+  );
+  const body = (await res.json().catch(() => null)) as {
+    session?: SessionRecord;
+    error?: string;
+    message?: string;
+  } | null;
+  if (!res.ok || !body?.session) {
+    throw new Error(body?.message ?? body?.error ?? `Session AI configuration update failed: ${res.status}`);
+  }
+  return body.session;
+}
+
 export async function openWebPiSession(wsId: string, sessionId: string): Promise<WebPiSnapshot> {
   const res = await fetch(
     `/api/workspaces/${encodeURIComponent(wsId)}/sessions/${encodeURIComponent(sessionId)}/webpi/open`,

--- a/ui/src/components/workspace/workspaces.css
+++ b/ui/src/components/workspace/workspaces.css
@@ -1419,6 +1419,12 @@ button.files-row:focus-visible {
   color: var(--foreground);
 }
 
+.resume-cta-btn.is-config {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--foreground);
+}
+
 /* WebPi is deliberately a surface inside the existing terminal slot. */
 .webpi-shell {
   position: relative;

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -17,6 +17,7 @@ import type {
   AgentConfigBundle,
   AgentId,
   DepartedWorkspace,
+  PausedSessionRuntimeUpdate,
   SessionRecord,
   WebPiSnapshot,
   Workspace,
@@ -1056,6 +1057,44 @@ export const workspacesHandlers = [
     )
   }),
   http.post('/api/workspaces/:id/sessions/:sid/pause', () => HttpResponse.json(true)),
+  http.put('/api/workspaces/:id/sessions/:sid/runtime', async ({ params, request }) => {
+    const workspaceIndex = demoWorkspaces.findIndex((candidate) => candidate.id === String(params.id))
+    const workspace = workspaceIndex >= 0 ? demoWorkspaces[workspaceIndex] : undefined
+    const sessionIndex = workspace?.sessions.findIndex((candidate) => candidate.id === String(params.sid)) ?? -1
+    const session = sessionIndex >= 0 ? workspace?.sessions[sessionIndex] : undefined
+    if (!workspace || !session) {
+      return HttpResponse.json({ error: 'not_found' }, { status: 404 })
+    }
+    if (session.state !== 'paused') {
+      return HttpResponse.json({
+        error: 'session_not_paused',
+        message: 'Pause this Session before changing its credential, model, or effort',
+      }, { status: 409 })
+    }
+    const body = await request.json().catch(() => ({})) as Partial<PausedSessionRuntimeUpdate>
+    if (
+      (body.credentialSource !== 'native' && body.credentialSource !== 'vault')
+      || (body.credentialSource === 'vault' && !body.credentialSlug)
+    ) {
+      return HttpResponse.json({ error: 'bad_request' }, { status: 400 })
+    }
+    const updatedSession: SessionRecord = {
+      ...session,
+      runtime: {
+        credentialSource: body.credentialSource,
+        ...(body.credentialSource === 'vault' ? { credentialSlug: body.credentialSlug! } : {}),
+        ...(body.model ? { model: body.model } : {}),
+        ...(body.reasoningEffort ? { reasoningEffort: body.reasoningEffort } : {}),
+      },
+    }
+    demoWorkspaces[workspaceIndex] = {
+      ...workspace,
+      sessions: workspace.sessions.map((candidate, index) => (
+        index === sessionIndex ? updatedSession : candidate
+      )),
+    }
+    return HttpResponse.json({ session: updatedSession })
+  }),
   http.post('/api/workspaces/:id/sessions/:sid/resume', () => HttpResponse.json(null)),
   http.delete('/api/workspaces/:id/sessions/:sid', ({ params }) => {
     const wsId = String(params.id)

--- a/ui/src/hooks/useWorkspaceData.spec.ts
+++ b/ui/src/hooks/useWorkspaceData.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Workspace } from '../components/workspace/api'
@@ -9,7 +9,13 @@ import { useWorkspaceData, useWorkspaceSessionData } from './useWorkspaceData'
 
 const mocks = vi.hoisted(() => ({
   context: null as WorkspacesContextValue | null,
+  updatePausedSessionRuntime: vi.fn(),
 }))
+
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return { ...actual, updatePausedSessionRuntime: mocks.updatePausedSessionRuntime }
+})
 
 vi.mock('../contexts/workspaces-context', () => ({
   useWorkspaces: () => {
@@ -62,6 +68,7 @@ function context(overrides: Partial<WorkspacesContextValue> = {}): WorkspacesCon
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.context = context()
+  mocks.updatePausedSessionRuntime.mockResolvedValue(workspace().sessions[0])
 })
 
 describe('Workspace data hooks', () => {
@@ -99,5 +106,30 @@ describe('Workspace data hooks', () => {
     )
 
     expect(result.current.session).toBeNull()
+  })
+
+  it('updates a paused Session through the domain hook and refreshes the snapshot', async () => {
+    const { result } = renderHook(() =>
+      useWorkspaceSessionData('workspace-1', 'session-1'),
+    )
+
+    await act(async () => {
+      await result.current.updateRuntime({
+        credentialSource: 'native',
+        model: 'claude-sonnet-4-5',
+        reasoningEffort: 'low',
+      })
+    })
+
+    expect(mocks.updatePausedSessionRuntime).toHaveBeenCalledWith(
+      'workspace-1',
+      'session-1',
+      {
+        credentialSource: 'native',
+        model: 'claude-sonnet-4-5',
+        reasoningEffort: 'low',
+      },
+    )
+    expect(refresh).toHaveBeenCalledOnce()
   })
 })

--- a/ui/src/hooks/useWorkspaceData.ts
+++ b/ui/src/hooks/useWorkspaceData.ts
@@ -1,6 +1,11 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import type { SessionRecord, Workspace } from '../components/workspace/api'
+import {
+  updatePausedSessionRuntime,
+  type PausedSessionRuntimeUpdate,
+  type SessionRecord,
+  type Workspace,
+} from '../components/workspace/api'
 import { useWorkspaces } from '../contexts/workspaces-context'
 
 export interface WorkspaceDataSnapshot {
@@ -13,6 +18,7 @@ export interface WorkspaceDataSnapshot {
 
 export interface WorkspaceSessionDataSnapshot extends WorkspaceDataSnapshot {
   readonly session: SessionRecord | null
+  updateRuntime(update: PausedSessionRuntimeUpdate): Promise<SessionRecord>
 }
 
 /**
@@ -48,6 +54,15 @@ export function useWorkspaceSessionData(
       : null,
     [sessionId, workspace.sessions],
   )
+  const updateRuntime = useCallback(async (update: PausedSessionRuntimeUpdate) => {
+    if (!sessionId) throw new Error('No Session is selected')
+    const updated = await updatePausedSessionRuntime(workspaceId, sessionId, update)
+    await workspace.refresh()
+    return updated
+  }, [sessionId, workspace, workspaceId])
 
-  return useMemo(() => ({ ...workspace, session }), [session, workspace])
+  return useMemo(
+    () => ({ ...workspace, session, updateRuntime }),
+    [session, updateRuntime, workspace],
+  )
 }

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -45,6 +45,7 @@ export function WorkspacePage({ spec, visible }: Props) {
     workspace,
     sessions,
     session: activeRecord,
+    updateRuntime,
   } = useWorkspaceSessionData(wsId, sessionId)
   const effectiveDefaultAgent = workspace?.defaultAgent ?? ctx.defaultAgent
   const defaultAgentEnabled =
@@ -177,10 +178,12 @@ export function WorkspacePage({ spec, visible }: Props) {
           {...(source ? { source } : {})}
           activeRecord={activeRecord}
           sessions={sessions}
+          agents={ctx.agents}
           label={workspaceName}
           terminalHeaderActions={terminalCanvas ? workspaceActions : undefined}
           onSpawnFresh={spawnDefault}
           onResume={(id) => ctx.resumeSession(wsId, id, source)}
+          onUpdateSessionRuntime={(_id, update) => updateRuntime(update).then(() => undefined)}
           onOpenWebPi={(id) => ctx.openWebPiSession(wsId, id, source)}
           onSelectSession={(id) => {
             // Running session — already alive on the server, just


### PR DESCRIPTION
## What changed

- add a paused-only API boundary for replacing a Session credential/model/effort binding
- persist the replacement in the Workspace-owned `.alice/sessions/<resumeId>.json` record without waking the Session
- expose the mutation through the Workspace data hook and demo API
- add a shadcn/Base UI editor with two clear setting rows: AI access and combined model/effort
- show the updated runtime facts on the paused transition surface

## Why

Paused Sessions already resume from a durable Workspace-local AI binding, but users could not correct or intentionally change that binding before resuming. The old UI also embedded composer controls into a settings dialog, causing overflow and inconsistent menu behavior.

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm test` (472 passed, 1 skipped; 4034 tests passed, 9 skipped)
- targeted backend route/store/registry tests
- targeted UI hook/dialog/control tests
- real browser walkthrough on a paused Claude Code Session: AI access menu, model submenu, effort submenu, save, and confirmed the Session stayed paused
