### PR TITLE
fix(claude): preserve project context for vault sessions

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -77,19 +77,18 @@ Writing the same values into native project files is a deprecated compatibility
 export for users who intentionally start the CLI outside OpenAlice. It is not a
 managed Session default, readiness gate, or launch-time fallback.
 
-Claude Code managed-Vault launches pass an empty `--setting-sources=` selection
+Claude Code managed-Vault launches select only the `project` settings source
 before projecting the Session's endpoint, credential, model, and effort. Claude
-otherwise reapplies provider-shaped `env` from user/project/local settings after
+otherwise reapplies provider-shaped `env` from user and local settings after
 inheriting the child environment, which can silently replace an immutable
-Session binding. Because the empty source selection also disables ordinary
-project-skill discovery, OpenAlice-managed launches explicitly load the
-Workspace `.claude` directory as a local plugin. This restores the Workspace's
-skills under Claude's plugin-scoped namespace without re-enabling user or
-project settings. Runtime-managed bindings do not use either override:
-OpenAlice deliberately leaves Claude's complete authentication, configuration,
-and skill discovery chain in control, whether it resolves from login,
-environment, user settings, or local project files. Launcher-owned explicit
-`--settings` remain available in both modes.
+Session binding. Keeping the project source enabled preserves Claude's native
+Workspace `CLAUDE.md` persona and `.claude/skills` discovery without importing
+an unrelated global login or deprecated `.claude/settings.local.json` export.
+Runtime-managed bindings do not restrict the source chain: OpenAlice deliberately
+leaves Claude's complete authentication, configuration, and skill discovery in
+control, whether it resolves from login, environment, user settings, or local
+project files. Launcher-owned explicit `--settings` remain available in both
+modes.
 
 A registered provider default is descriptive model metadata, not an implicit
 Session launch parameter. OpenAlice may label that default in selection help,

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -203,23 +203,21 @@ export const claudeAdapter: CliAdapter = {
       }
       // Claude Code applies provider-shaped `env` from user/project/local
       // settings after inheriting the child process environment. A managed
-      // Vault binding must therefore exclude every implicit settings source;
-      // otherwise an unrelated global login (or a deprecated project export)
-      // can replace ANTHROPIC_BASE_URL / auth / model after OpenAlice projects
-      // this immutable Session binding. `--setting-sources=` is Claude Code's
-      // empty-source form. It also disables Claude's ordinary project-skill
-      // discovery, so expose the Workspace `.claude` directory explicitly as
-      // a local plugin. Plugin loading does not re-enable project/user settings
-      // and therefore preserves both the immutable Vault binding and the
-      // Workspace's bundled skills. Explicit `--settings` supplied by
-      // composeCommand still loads, so launcher-owned MCP trust remains
-      // available.
+      // Vault binding must exclude user and local sources so an unrelated
+      // global login or deprecated `.claude/settings.local.json` export cannot
+      // replace ANTHROPIC_BASE_URL / auth / model after OpenAlice projects the
+      // immutable Session binding. Keep the project source enabled: Claude
+      // owns the native loading semantics for the Workspace's CLAUDE.md and
+      // `.claude/skills`, and treating those files as a synthetic plugin loses
+      // their normal project scope and persona behavior. Explicit `--settings`
+      // supplied by composeCommand still loads, so launcher-owned MCP trust
+      // remains available.
       //
       // Native bindings intentionally keep Claude's normal settings chain:
       // choosing Agent login means the runtime, not OpenAlice, owns provider
       // discovery and authentication.
       const managedCredentialArgs = runtime.binding.credential.source === 'vault'
-        ? ['--setting-sources=', '--plugin-dir', join(ctx.cwd, '.claude')]
+        ? ['--setting-sources=project']
         : [];
       const args = [
         ...managedCredentialArgs,

--- a/src/workspaces/session-runtime-binding.spec.ts
+++ b/src/workspaces/session-runtime-binding.spec.ts
@@ -286,9 +286,7 @@ describe('built-in Agent Session runtime projection', () => {
   it('projects the native model and effort flags on every launch surface', () => {
     expect(claudeAdapter.sessionRuntime!.project(ctx, runtime).interactiveArgs)
       .toEqual([
-        '--setting-sources=',
-        '--plugin-dir',
-        '/workspace/.claude',
+        '--setting-sources=project',
         '--model',
         'session-model',
         '--effort',
@@ -326,12 +324,11 @@ describe('built-in Agent Session runtime projection', () => {
     },
   )
 
-  it('isolates Claude settings and restores Workspace skills only for OpenAlice-managed credentials', () => {
+  it('keeps only Claude project settings for OpenAlice-managed credentials', () => {
     const managed = claudeAdapter.sessionRuntime!.project(ctx, runtime)
     for (const args of [managed.interactiveArgs, managed.headlessArgs, managed.webArgs]) {
-      expect(args).toContain('--setting-sources=')
-      expect(args).toContain('--plugin-dir')
-      expect(args).toContain('/workspace/.claude')
+      expect(args).toContain('--setting-sources=project')
+      expect(args).not.toContain('--plugin-dir')
     }
 
     const native = createNativeSessionRuntimeBinding({
@@ -344,9 +341,8 @@ describe('built-in Agent Session runtime projection', () => {
       projectedNative.headlessArgs,
       projectedNative.webArgs,
     ]) {
-      expect(args).not.toContain('--setting-sources=')
+      expect(args).not.toContain('--setting-sources=project')
       expect(args).not.toContain('--plugin-dir')
-      expect(args).not.toContain('/workspace/.claude')
     }
   })
 })


### PR DESCRIPTION
## Summary
- use Claude's project-only settings source for OpenAlice Vault sessions
- restore native Workspace CLAUDE.md persona and .claude/skills discovery
- keep user and local settings isolated from immutable Vault bindings

## Verification
- npx tsc --noEmit
- pnpm test
- pnpm vitest run src/workspaces/session-runtime-binding.spec.ts
- pnpm electron:smoke:pty
- real pnpm dev Vault Claude session: confirmed --setting-sources=project, CLAUDE.md persona, alice-workspace and traderhub skills