### PR TITLE
feat(workspace): Session birth metadata (createdBy)

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,9 +21,6 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/session-birth-metadata.md]] — Stamps immutable product-Session
-  `metadata.createdBy` at allocation so interactive, Issue, conversation, and
-  headless births are distinguishable without inventing execution-level origin.
 - [[plans/release-feedback-reliability.md]] — Makes packaged release failures
   deterministic and diagnostic first, then removes desktop matrix fan-in and
   reuses trusted promotion evidence without weakening release gates.
@@ -37,6 +34,10 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/session-birth-metadata.md]] — Stamps immutable product-Session
+  `metadata.createdBy` at allocation so interactive, Issue, conversation, and
+  headless births are distinguishable without inventing execution-level origin.
+  Accepted and delivered in PR #1064.
 - [[plans/alice-project-foundation.md]] — Promotes the existing named Instance,
   complete-home, Guardian, and frontend endpoint topology into the explicit
   AliceProject product and lifecycle abstraction. Delivered for topic review in

--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,9 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/session-birth-metadata.md]] — Stamps immutable product-Session
+  `metadata.createdBy` at allocation so interactive, Issue, conversation, and
+  headless births are distinguishable without inventing execution-level origin.
 - [[plans/release-feedback-reliability.md]] — Makes packaged release failures
   deterministic and diagnostic first, then removes desktop matrix fan-in and
   reuses trusted promotion evidence without weakening release gates.

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -65,6 +65,28 @@ In the office analogy, the Workspace is the desk and the product Session is one
 particular colleague-with-context. `pi`, `codex`, `opencode`, and `claude` are
 worker kinds, not unique colleagues.
 
+## Session birth metadata
+
+Product Sessions may carry an optional, immutable `metadata.createdBy` bag on
+the `ResumeIdentityRecord`. It answers how the coworker was hired, not what a
+later turn is doing:
+
+| `createdBy.kind` | Meaning |
+|---|---|
+| `interactive` | Frontend interactive spawn (`spawn` / `quick-chat` / `auto-quant` / `manager`) |
+| `issue` | Scheduled or retried Issue that recruited a fresh Session (`new-each-run` or first `new-then-resume`) |
+| `headless` | Direct async headless API dispatch without Issue/conversation wrapper |
+| `conversation` | Fresh worker from `conversation_ask` / UI inquiry / Issue comment reply |
+
+Rules:
+
+- stamped only when `ResumeRegistry.ensure` allocates a new `resumeId`;
+- first-write-wins; continue/resume never rewrites birth;
+- historical identities without metadata are unknown;
+- headless `trigger` / `inquiry` remain execution-level sources and do not
+  replace birth;
+- Session Directory projects secret-free `createdBy` for product surfaces.
+
 ## Layered Index
 
 OpenAlice should resolve provenance through five layers rather than treating

--- a/plans/session-birth-metadata.md
+++ b/plans/session-birth-metadata.md
@@ -1,0 +1,33 @@
+# Session birth metadata
+
+Status: active (Draft PR for audit; not merge-authorized)
+
+Owner guides: [[docs/conversation-provenance.md]]
+
+## Goal
+
+Stamp immutable `metadata.createdBy` on product Sessions (`resumeId`) at
+allocation so operators can tell how a coworker was hired: interactive spawn /
+quick-chat / Issue recruit / agent conversation / manual headless.
+
+## Decisions
+
+- Hang birth on `ResumeIdentityRecord.metadata`, not `SessionRecord`.
+- First-write-wins inside `ResumeRegistry.ensure`.
+- Server-stamped only; agents cannot claim birth via tool args.
+- Historical identities without metadata remain valid (unknown birth).
+- No UI badge in this topic; Session Directory projects `createdBy`.
+
+## Checklist
+
+- [x] `session-metadata.ts` types + parse
+- [x] ResumeRegistry persist / ignore rewrite
+- [x] Interactive spawn hooks
+- [x] Headless dispatch + Issue scanner + conversation control
+- [x] Session Directory + owner-guide note
+- [x] Verification (`tsc` + targeted tests)
+- [ ] Draft PR labelled for parallel audit (do not merge)
+
+## Residual risk
+
+Pre-ship Sessions have no birth bag. Exact continues never rewrite birth.

--- a/plans/session-birth-metadata.md
+++ b/plans/session-birth-metadata.md
@@ -26,7 +26,7 @@ quick-chat / Issue recruit / agent conversation / manual headless.
 - [x] Headless dispatch + Issue scanner + conversation control
 - [x] Session Directory + owner-guide note
 - [x] Verification (`tsc` + targeted tests)
-- [ ] Draft PR labelled for parallel audit (do not merge)
+- [x] Draft PR labelled for parallel audit (do not merge) — #1064
 
 ## Residual risk
 

--- a/plans/session-birth-metadata.md
+++ b/plans/session-birth-metadata.md
@@ -1,6 +1,6 @@
 # Session birth metadata
 
-Status: active (Draft PR for audit; not merge-authorized)
+Status: completed (accepted and delivered in PR #1064)
 
 Owner guides: [[docs/conversation-provenance.md]]
 
@@ -25,8 +25,9 @@ quick-chat / Issue recruit / agent conversation / manual headless.
 - [x] Interactive spawn hooks
 - [x] Headless dispatch + Issue scanner + conversation control
 - [x] Session Directory + owner-guide note
+- [x] Session Directory projection regression coverage
 - [x] Verification (`tsc` + targeted tests)
-- [x] Draft PR labelled for parallel audit (do not merge) — #1064
+- [x] Topic accepted and delivered — #1064
 
 ## Residual risk
 

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -13,12 +13,13 @@ function build(opts: { assignee?: string } = {}) {
     _meta: unknown,
     _adapter: unknown,
     _prompt: string,
-    _timeout: number,
+    _timeout?: number,
     _issueId?: string,
     _resumeId?: string,
     _inquiry?: HeadlessTaskInquiry,
     _overrides?: unknown,
     _conversation?: unknown,
+    _createdBy?: unknown,
   ) => ({ taskId: 'run-new', resumeId: _resumeId ?? 'resume-new' }))
   const list = vi.fn((_filters: unknown) => [] as HeadlessTaskRecord[])
   const svc = {
@@ -82,7 +83,22 @@ describe('business inquiry routes', () => {
         deliveredPrompt: 'Why?',
         promptMode: 'plain',
       }),
+      undefined,
     )
+  })
+
+  it('stamps conversation birth for an unattributed Inbox reconstruction', async () => {
+    const { app, inboxStore, dispatchHeadlessTask } = build()
+    const entry = await inboxStore.append({ workspaceId: 'ws-1', comments: 'manual note' })
+    await app.request(`/inbox/${entry.id}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt: 'Recover context' }),
+    })
+    expect(dispatchHeadlessTask.mock.calls[0]?.[9]).toMatchObject({
+      kind: 'conversation',
+      caller: { kind: 'human' },
+      reason: 'missing-origin',
+      subject: { kind: 'inbox', entryId: entry.id },
+    })
   })
 
   it('keeps reconstruction provenance without changing an unattributed Inbox prompt by default', async () => {

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -741,9 +741,31 @@ describe('POST /:id/headless', () => {
   it('enables the watchdog only for an explicit timeoutMs', async () => {
     const { app, dispatchHeadlessTask } = build();
     await post(app, '/ws-1/headless', { prompt: 'x', timeoutMs: 42_000 });
-    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 'x', 42_000);
+    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'x',
+      42_000,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'headless', surface: 'api' },
+    );
     await post(app, '/ws-1/headless', { prompt: 'x' });
-    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 'x', undefined);
+    expect(dispatchHeadlessTask).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'x',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'headless', surface: 'api' },
+    );
   });
 
   it('continues a headless conversation by product resumeId only', async () => {
@@ -757,6 +779,23 @@ describe('POST /:id/headless', () => {
     expect(response.body).toMatchObject({ taskId: 'task-1', resumeId: 'resume-1' });
     expect(dispatchHeadlessTask).toHaveBeenCalledWith(
       expect.anything(), expect.anything(), 'follow up', undefined, undefined, 'resume-1',
+    );
+  });
+
+  it('stamps headless birth when allocating a fresh product Session', async () => {
+    const { app, dispatchHeadlessTask } = build();
+    await post(app, '/ws-1/headless', { prompt: 'one-shot' });
+    expect(dispatchHeadlessTask).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'one-shot',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'headless', surface: 'api' },
     );
   });
 

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -64,6 +64,8 @@ import {
   resolveSessionRuntimeBinding,
   SessionRuntimeBindingError,
 } from '../../workspaces/session-runtime-binding.js';
+import type { SessionCreatedBy } from '../../workspaces/session-metadata.js';
+import { sessionMetadata } from '../../workspaces/session-metadata.js';
 import {
   readWorkspaceRuntimeSettings,
   rememberWorkspaceRuntimeBinding,
@@ -298,6 +300,8 @@ export function createWorkspaceRoutes(
       readonly credentialSlug?: string;
       readonly model?: string;
       readonly reasoningEffort?: ModelReasoningEffort;
+      /** Birth stamp when allocating a new product Session (omit when resuming). */
+      readonly createdBy?: SessionCreatedBy;
     },
   ): Promise<SpawnSessionResult> {
     const id = meta.id;
@@ -456,6 +460,10 @@ export function createWorkspaceRoutes(
         agent: adapter.id,
         ...(resume && resume !== 'last' ? { agentSessionId: resume.sessionId } : {}),
         ...(sessionRuntime ? { runtimeBinding: sessionRuntime.binding } : {}),
+        // Birth is first-write-wins; only stamp when allocating a new identity.
+        ...(!opts.resumeId && opts.createdBy
+          ? { metadata: sessionMetadata(opts.createdBy) }
+          : {}),
       });
     } catch (err) {
       releaseClaim();
@@ -712,6 +720,7 @@ export function createWorkspaceRoutes(
       ...(reasoningEffort ? { reasoningEffort } : {}),
       ...(resolvedAgentId === 'pi' ? {} : { initialPrompt: managerTerminalPrompt(prompt) }),
       title: prompt,
+      createdBy: { kind: 'interactive', surface: 'manager' },
     });
     if (!spawned.ok) return c.json(spawned.body, spawned.status as 400 | 409 | 500);
 
@@ -1559,6 +1568,10 @@ export function createWorkspaceRoutes(
       ...(credentialSlug !== undefined ? { credentialSlug } : {}),
       ...(model !== undefined ? { model } : {}),
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+      // Resume reuses an existing product Session; only fresh spawns stamp birth.
+      ...(resumeId === undefined
+        ? { createdBy: { kind: 'interactive' as const, surface: 'spawn' as const } }
+        : {}),
     });
     if (!result.ok) return c.json(result.body, result.status as 400 | 500);
     return c.json(result.session, 201);
@@ -1687,6 +1700,10 @@ export function createWorkspaceRoutes(
       ...(model !== undefined ? { model } : {}),
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
       initialPrompt: prompt,
+      createdBy: {
+        kind: 'interactive',
+        surface: templateName === 'auto-quant-v2' ? 'auto-quant' : 'quick-chat',
+      },
     });
     if (!spawn.ok) return c.json(spawn.body, spawn.status as 400 | 500);
     return c.json({ workspace: await svc.publicMeta(meta), session: spawn.session }, 201);
@@ -2397,7 +2414,18 @@ export function createWorkspaceRoutes(
     try {
       const dispatched = resumeId
         ? await svc.dispatchHeadlessTask(meta, adapter, prompt, timeoutMs, undefined, resumeId)
-        : await svc.dispatchHeadlessTask(meta, adapter, prompt, timeoutMs);
+        : await svc.dispatchHeadlessTask(
+            meta,
+            adapter,
+            prompt,
+            timeoutMs,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { kind: 'headless', surface: 'api' },
+          );
       return c.json({ ...dispatched, status: 'running' }, 202);
     } catch (err) {
       if (err instanceof HeadlessCapacityError) {

--- a/src/workspaces/conversation-control.spec.ts
+++ b/src/workspaces/conversation-control.spec.ts
@@ -179,6 +179,11 @@ describe('Workspace conversation control', () => {
       undefined,
       undefined,
       expect.anything(),
+      {
+        kind: 'conversation',
+        caller: { kind: 'human' },
+        reason: 'harness-chat',
+      },
     )
   })
 
@@ -247,6 +252,7 @@ describe('Workspace conversation control', () => {
         deliveredPrompt: 'Why did you create this?',
         promptMode: 'plain',
       }),
+      undefined,
     )
   })
 
@@ -269,6 +275,11 @@ describe('Workspace conversation control', () => {
       promptMode: 'plain',
       originalPrompt: 'Why did the report reach this conclusion?',
       deliveredPrompt: 'Why did the report reach this conclusion?',
+    })
+    expect((dispatchHeadlessTask.mock.calls as unknown[][])[0]?.[9]).toEqual({
+      kind: 'conversation',
+      caller: { kind: 'human' },
+      reason: 'missing-origin',
     })
     expect(appendProvenance).toHaveBeenCalledWith(expect.objectContaining({
       action: 'reconstructed',

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -7,6 +7,7 @@ import {
 } from '../core/preferences.js'
 import type {
   WorkspaceConversationAskResult,
+  WorkspaceConversationCaller,
   WorkspaceConversationControl,
   WorkspaceConversationResolution,
   WorkspaceConversationTarget,
@@ -16,7 +17,15 @@ import type { ArtifactRef, ProvenanceAction, SessionOrigin } from '../core/prove
 import type { AgentConversationDispatch } from './agent-conversation-log.js'
 import { isAgentRuntime } from './cli-adapter.js'
 import type { HeadlessStructuredOutput } from './headless-output.js'
-import { headlessLogPaths } from './headless-task-registry.js'
+import {
+  headlessLogPaths,
+  type HeadlessInquirySubject,
+} from './headless-task-registry.js'
+import type {
+  SessionConversationBirthReason,
+  SessionConversationCaller,
+  SessionCreatedBy,
+} from './session-metadata.js'
 import { logger as launcherLogger } from './logger.js'
 import type { WorkspaceService } from './service.js'
 import { AUTO_QUANT_WORKSPACE_TEMPLATE } from './chat-workspace-resolver.js'
@@ -285,6 +294,16 @@ export function createWorkspaceConversationControl(
             },
           }
         : undefined
+      // Exact continue reuses resumeId — birth is already fixed. Fresh workers
+      // get a conversation birth stamp from the authoritative ask source.
+      const createdBy = continuingOrigin
+        ? undefined
+        : conversationSessionCreatedBy({
+            source: conversation.source,
+            target: input.target,
+            resolution,
+            subject: input.subject,
+          })
       const dispatched = inquiry
         ? await svc.dispatchHeadlessTask(
             meta,
@@ -296,6 +315,7 @@ export function createWorkspaceConversationControl(
             inquiry,
             undefined,
             conversation,
+            createdBy,
           )
         : await svc.dispatchHeadlessTask(
             meta,
@@ -307,6 +327,7 @@ export function createWorkspaceConversationControl(
             undefined,
             undefined,
             conversation,
+            createdBy,
           )
       let effectiveResolution = resolution
       if (resolution.mode === 'reconstructed' && resolution.artifact && !resolution.origin) {
@@ -362,6 +383,60 @@ export function createWorkspaceConversationControl(
       }
       return result
     },
+  }
+}
+
+function conversationSessionCreatedBy(input: {
+  source: WorkspaceConversationCaller
+  target: WorkspaceConversationTarget
+  resolution: Exclude<WorkspaceConversationResolution, { mode: 'unavailable' }>
+  subject?: HeadlessInquirySubject
+}): SessionCreatedBy {
+  const caller = conversationBirthCaller(input.source)
+  const reason = conversationBirthReason(input.target, input.resolution, input.subject)
+  return {
+    kind: 'conversation',
+    caller,
+    reason,
+    ...(input.subject ? { subject: input.subject } : {}),
+  }
+}
+
+function conversationBirthCaller(source: WorkspaceConversationCaller): SessionConversationCaller {
+  if (source.kind === 'session') {
+    return {
+      kind: 'agent',
+      resumeId: source.resumeId,
+      workspaceId: source.workspaceId,
+    }
+  }
+  // workspace-scoped callers and explicit humans are human/control-plane.
+  return { kind: 'human' }
+}
+
+function conversationBirthReason(
+  target: WorkspaceConversationTarget,
+  resolution: Exclude<WorkspaceConversationResolution, { mode: 'unavailable' }>,
+  subject?: HeadlessInquirySubject,
+): SessionConversationBirthReason {
+  if (subject?.kind === 'issue' && subject.commentId) return 'issue-comment'
+  if (resolution.mode === 'exact') return 'explicit-workspace'
+  if (target.kind === 'harness') {
+    return target.harness === 'autoquant' ? 'harness-autoquant' : 'harness-chat'
+  }
+  switch (resolution.reason) {
+    case 'explicit-workspace':
+    case 'missing-origin':
+    case 'non-session-origin':
+    case 'unavailable-reconstruction':
+    case 'prior-reconstruction':
+      return resolution.reason
+    case 'harness-default':
+      // Harness targets are handled above; keep a safe fallback if resolution
+      // reason is harness-default without a harness target shape.
+      return 'harness-chat'
+    default:
+      return 'missing-origin'
   }
 }
 

--- a/src/workspaces/resume-registry.spec.ts
+++ b/src/workspaces/resume-registry.spec.ts
@@ -36,6 +36,54 @@ describe('ResumeRegistry', () => {
     })
   })
 
+  it('persists immutable birth metadata on first create only', async () => {
+    const registry = await ResumeRegistry.load(path, noopLogger, runtimeStore)
+    const created = await registry.ensure({
+      wsId: 'ws-1',
+      agent: 'pi',
+      now: 1,
+      metadata: { createdBy: { kind: 'interactive', surface: 'quick-chat' } },
+    })
+    expect(created.metadata).toEqual({
+      createdBy: { kind: 'interactive', surface: 'quick-chat' },
+    })
+
+    const again = await registry.ensure({
+      resumeId: created.resumeId,
+      wsId: 'ws-1',
+      agent: 'pi',
+      now: 2,
+      metadata: { createdBy: { kind: 'headless', surface: 'api' } },
+    })
+    expect(again.metadata).toEqual({
+      createdBy: { kind: 'interactive', surface: 'quick-chat' },
+    })
+
+    const reloaded = await ResumeRegistry.load(path, noopLogger, runtimeStore)
+    expect(reloaded.get(created.resumeId)?.metadata).toEqual({
+      createdBy: { kind: 'interactive', surface: 'quick-chat' },
+    })
+  })
+
+  it('loads identities with malformed metadata by dropping only the bag', async () => {
+    await writeFile(path, JSON.stringify({
+      version: 1,
+      records: [{
+        resumeId: 'resume-calm-amber-river-a1b2c3',
+        wsId: 'ws-1',
+        agent: 'pi',
+        createdAt: 1,
+        updatedAt: 1,
+        lifecycle: 'active',
+        metadata: { createdBy: { kind: 'interactive', surface: 'not-a-surface' } },
+      }],
+    }, null, 2), 'utf8')
+    const registry = await ResumeRegistry.load(path, noopLogger, runtimeStore)
+    const record = registry.get('resume-calm-amber-river-a1b2c3')
+    expect(record).toMatchObject({ wsId: 'ws-1', agent: 'pi', lifecycle: 'active' })
+    expect(record?.metadata).toBeUndefined()
+  })
+
   it('refuses to move an identity across workspace or runtime boundaries', async () => {
     const registry = await ResumeRegistry.load(path, noopLogger, runtimeStore)
     const created = await registry.ensure({ wsId: 'ws-1', agent: 'pi' })

--- a/src/workspaces/resume-registry.ts
+++ b/src/workspaces/resume-registry.ts
@@ -11,6 +11,8 @@ import { dirname } from 'node:path'
 import type { Logger } from './logger.js'
 import { generateResumeId } from './resume-id.js'
 import type { SessionRuntimeBinding } from './cli-adapter.js'
+import type { SessionMetadata } from './session-metadata.js'
+import { parseSessionMetadata } from './session-metadata.js'
 import type { SessionRuntimeBindingStore } from './session-runtime-store.js'
 
 export interface ResumeIdentityRecord {
@@ -30,6 +32,11 @@ export interface ResumeIdentityRecord {
   retiredAt?: number
   retirementReason?: string
   successorResumeId?: string
+  /**
+   * Immutable product bag (birth first). Written only when the identity is
+   * created; later ensure() calls never rewrite it. Historical records omit it.
+   */
+  metadata?: SessionMetadata
 }
 
 export class ResumeRegistry {
@@ -73,6 +80,7 @@ export class ResumeRegistry {
           resumeId: record['resumeId'],
           agent: record['agent'],
         })
+        const metadata = parseSessionMetadata(record['metadata'])
         this.records.set(record['resumeId'], {
           resumeId: record['resumeId'],
           wsId: record['wsId'],
@@ -96,6 +104,7 @@ export class ResumeRegistry {
           ...(typeof record['successorResumeId'] === 'string'
             ? { successorResumeId: record['successorResumeId'] }
             : {}),
+          ...(metadata ? { metadata } : {}),
         })
       }
     } catch (err) {
@@ -130,6 +139,8 @@ export class ResumeRegistry {
     agentSessionId?: string
     latestTaskId?: string
     runtimeBinding?: SessionRuntimeBinding
+    /** Birth bag for a newly allocated identity. Ignored when resuming existing. */
+    metadata?: SessionMetadata
     now?: number
   }): Promise<ResumeIdentityRecord> {
     const resumeId = input.resumeId ?? generateResumeId({
@@ -161,6 +172,8 @@ export class ResumeRegistry {
       }
       if (input.agentSessionId) existing.agentSessionId = input.agentSessionId
       if (input.latestTaskId) existing.latestTaskId = input.latestTaskId
+      // metadata.createdBy is first-write-wins: never rewrite on ensure of an
+      // existing identity, even when callers pass a different stamp.
       existing.updatedAt = input.now ?? Date.now()
       await this.flush()
       return existing
@@ -184,6 +197,7 @@ export class ResumeRegistry {
       ...(input.agentSessionId ? { agentSessionId: input.agentSessionId } : {}),
       ...(input.latestTaskId ? { latestTaskId: input.latestTaskId } : {}),
       ...(input.runtimeBinding ? { runtimeBinding: input.runtimeBinding } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
     }
     this.records.set(resumeId, record)
     await this.flush()

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -173,6 +173,17 @@ describe('ScheduleScanner', () => {
       'same exact prompt',
       30 * 60_000,
       { kind: 'issue', workspaceId: 'w1', issueId: 'retry-me' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'retry-me',
+        policy: 'new-each-run',
+        fire: 'retry',
+      },
     )
     expect(markers.get('w1', 'retry-me')).toBeUndefined()
   })
@@ -193,9 +204,24 @@ describe('ScheduleScanner', () => {
     await scanner.scan()
     expect(dispatch).toHaveBeenCalledTimes(1)
     // 5th arg = the firing issue's id, threaded so the run records its origin.
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), {
-      kind: 'issue', workspaceId: 'w1', issueId: 't1',
-    })
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'go',
+      expect.any(Number),
+      { kind: 'issue', workspaceId: 'w1', issueId: 't1' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 't1',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
+    )
     expect(markers.get('w1', 't1')).toBe(NOW)
   })
 
@@ -242,6 +268,14 @@ describe('ScheduleScanner', () => {
       undefined,
       undefined,
       { credentialSlug: 'anthropic-primary', model: 'claude-opus-4-8', reasoningEffort: 'high' },
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'tuned',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
     )
   })
 
@@ -267,6 +301,14 @@ describe('ScheduleScanner', () => {
       undefined,
       undefined,
       { credentialSource: 'native', model: 'gpt-5.6-sol', reasoningEffort: 'low' },
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'native',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
     )
   })
 
@@ -314,6 +356,17 @@ describe('ScheduleScanner', () => {
       'own this work from now on',
       expect.any(Number),
       { kind: 'issue', workspaceId: 'w1', issueId: 'sticky' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'sticky',
+        policy: 'new-then-resume',
+        fire: 'schedule',
+      },
     )
     expect(claimFreshSession).toHaveBeenCalledWith({
       issueWorkspace: ws,
@@ -381,9 +434,24 @@ describe('ScheduleScanner', () => {
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
     expect(dispatch).toHaveBeenCalledTimes(1)
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'go', expect.any(Number), {
-      kind: 'issue', workspaceId: 'w1', issueId: 'sched',
-    })
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'go',
+      expect.any(Number),
+      { kind: 'issue', workspaceId: 'w1', issueId: 'sched' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'sched',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
+    )
     expect(scanner.snapshot()!.workspaces[0].tasks.map((t) => t.id)).toEqual(['sched'])
   })
 
@@ -393,9 +461,24 @@ describe('ScheduleScanner', () => {
     ])
     const { scanner, dispatch } = scannerFor([ws])
     await scanner.scan()
-    expect(dispatch).toHaveBeenCalledWith(ws, headlessAdapter, 'scan movers', expect.any(Number), {
-      kind: 'issue', workspaceId: 'w1', issueId: 't1',
-    })
+    expect(dispatch).toHaveBeenCalledWith(
+      ws,
+      headlessAdapter,
+      'scan movers',
+      expect.any(Number),
+      { kind: 'issue', workspaceId: 'w1', issueId: 't1' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 't1',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
+    )
   })
 
   it('fires a never-fired cron issue whose occurrence is within the last tick (not never)', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -31,6 +31,7 @@ import type { SessionRuntimeSelection } from '../session-runtime-binding.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
 import type { HeadlessTaskTrigger } from '../headless-task-registry.js'
+import type { SessionCreatedBy } from '../session-metadata.js'
 
 import {
   isFireable,
@@ -96,6 +97,9 @@ export interface ScheduleScannerDeps {
     inquiry?: undefined,
     /** Fresh-Session credential/model/effort selection inherited from Issue frontmatter. */
     selection?: SessionRuntimeSelection,
+    conversation?: undefined,
+    /** Birth stamp when this fire allocates a new product Session. */
+    createdBy?: SessionCreatedBy,
   ) => Promise<{ taskId: string; resumeId: string }>
   /** Persist @new-then-resume -> exact @resumeId after the first fresh dispatch. */
   claimFreshSession?: (input: {
@@ -366,6 +370,16 @@ export class ScheduleScanner {
         workspaceId: issueWorkspace.id,
         issueId,
       }
+      // Fresh recruits only: exact @resumeId continues an existing Session.
+      const createdBy: SessionCreatedBy | undefined = resumeId
+        ? undefined
+        : {
+            kind: 'issue',
+            workspaceId: issueWorkspace.id,
+            issueId,
+            policy: claimFreshSession ? 'new-then-resume' : 'new-each-run',
+            fire: manual ? 'retry' : 'schedule',
+          }
       const result = resumeId
         ? selection
           ? await this.deps.dispatch(
@@ -396,6 +410,8 @@ export class ScheduleScanner {
               undefined,
               undefined,
               selection,
+              undefined,
+              createdBy,
             )
           : await this.deps.dispatch(
               executionWorkspace,
@@ -403,6 +419,11 @@ export class ScheduleScanner {
               what,
               SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
               trigger,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              createdBy,
             )
       if (claimFreshSession) {
         if (!this.deps.claimFreshSession) {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -42,6 +42,8 @@ import {
   resolveSessionRuntimeBinding,
   type SessionRuntimeSelection,
 } from './session-runtime-binding.js';
+import type { SessionCreatedBy } from './session-metadata.js';
+import { sessionMetadata } from './session-metadata.js';
 import {
   readWorkspaceRuntimeSettings,
   rememberWorkspaceRuntimeBinding,
@@ -492,6 +494,8 @@ export interface WorkspaceService {
     selection?: SessionRuntimeSelection,
     /** Cross-Agent message metadata for the independent conversation log. */
     conversation?: AgentConversationDispatch,
+    /** Birth stamp when this dispatch allocates a new product Session. */
+    createdBy?: SessionCreatedBy,
   ): Promise<{ taskId: string; resumeId: string }>;
   /** Read-only scheduling projection of every workspace's `.alice/issues/`
    *  directory (scheduled issues only) + each task's last-fired marker and
@@ -1542,6 +1546,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     inquiry?: HeadlessTaskInquiry,
     selection?: SessionRuntimeSelection,
     conversation?: AgentConversationDispatch,
+    /** Birth stamp when this dispatch allocates a new product Session. */
+    createdBy?: SessionCreatedBy,
   ): Promise<{ taskId: string; resumeId: string }> => {
     if (catalog.get(ws.id)?.lifecycle !== 'active') {
       throw new Error(`workspace is not active: ${ws.id}`);
@@ -1608,11 +1614,14 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     try {
       // ResumeRegistry is the sole allocator for product conversation ids.
       // HeadlessTaskRegistry only records executions against that identity.
+      // Birth metadata is first-write-wins inside ensure(); only pass it when
+      // this dispatch is allocating a fresh product Session.
       const identity = await resumeRegistry.ensure({
         ...(resumeId ? { resumeId } : {}),
         wsId: ws.id,
         agent: adapter.id,
         runtimeBinding: sessionRuntime.binding,
+        ...(!resumeId && createdBy ? { metadata: sessionMetadata(createdBy) } : {}),
       });
       if (catalog.get(ws.id)?.lifecycle !== 'active') {
         throw new Error(`workspace stopped accepting work during dispatch: ${ws.id}`);

--- a/src/workspaces/session-directory.spec.ts
+++ b/src/workspaces/session-directory.spec.ts
@@ -15,6 +15,15 @@ describe('buildWorkspaceSessionDirectory', () => {
         createdAt: 1,
         updatedAt: 2,
         lifecycle: 'active',
+        metadata: {
+          createdBy: {
+            kind: 'issue',
+            workspaceId: 'ws-1',
+            issueId: 'daily-market-close',
+            policy: 'new-then-resume',
+            fire: 'schedule',
+          },
+        },
         runtimeBinding: {
           version: 1,
           credential: { source: 'vault', credentialSlug: 'secret-slug', wireShape: 'openai-responses' },
@@ -50,6 +59,13 @@ describe('buildWorkspaceSessionDirectory', () => {
     expect(result.sessions[0]).toMatchObject({
       resumeId: 'resume-kind-owl-abc123',
       resumable: true,
+      createdBy: {
+        kind: 'issue',
+        workspaceId: 'ws-1',
+        issueId: 'daily-market-close',
+        policy: 'new-then-resume',
+        fire: 'schedule',
+      },
       runtime: { credentialSource: 'vault', credentialSlug: 'secret-slug', model: 'gpt-5.6-terra', reasoningEffort: 'high' },
       interactive: { name: 'c1', title: 'Investigate provenance' },
       latestExecution: { taskId: 'task-1', assistantPreview: 'done' },

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -1,6 +1,7 @@
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from './headless-task-registry.js'
 import type { ResumeIdentityRecord } from './resume-registry.js'
 import { sessionPreferredTitle, type SessionRecord } from './session-registry.js'
+import type { SessionCreatedBy } from './session-metadata.js'
 import type { ModelReasoningEffort } from '@/ai-providers/model-semantics.js'
 
 export interface WorkspaceSessionDirectoryEntry {
@@ -12,6 +13,8 @@ export interface WorkspaceSessionDirectoryEntry {
   successorResumeId?: string
   resumable: boolean
   active: boolean
+  /** Secret-free birth stamp when this product Session was first allocated. */
+  createdBy?: SessionCreatedBy
   runtime?: {
     credentialSource: 'native' | 'vault' | 'workspace'
     credentialSlug?: string
@@ -65,6 +68,7 @@ export function buildWorkspaceSessionDirectory(input: {
         ...(identity.successorResumeId ? { successorResumeId: identity.successorResumeId } : {}),
         resumable: identity.lifecycle !== 'retired' && Boolean(identity.agentSessionId),
         active: identity.lifecycle !== 'retired' && input.isActive(identity.resumeId),
+        ...(identity.metadata?.createdBy ? { createdBy: identity.metadata.createdBy } : {}),
         ...(identity.runtimeBinding
           ? {
               runtime: {

--- a/src/workspaces/session-metadata.spec.ts
+++ b/src/workspaces/session-metadata.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseSessionCreatedBy, parseSessionMetadata, sessionMetadata } from './session-metadata.js'
+
+describe('session-metadata', () => {
+  it('wraps createdBy into the metadata bag', () => {
+    expect(sessionMetadata({ kind: 'headless', surface: 'api' })).toEqual({
+      createdBy: { kind: 'headless', surface: 'api' },
+    })
+  })
+
+  it('parses every product birth kind', () => {
+    expect(parseSessionCreatedBy({ kind: 'interactive', surface: 'quick-chat' })).toEqual({
+      kind: 'interactive',
+      surface: 'quick-chat',
+    })
+    expect(parseSessionCreatedBy({
+      kind: 'issue',
+      workspaceId: 'ws-1',
+      issueId: 'daily',
+      policy: 'new-each-run',
+      fire: 'schedule',
+    })).toEqual({
+      kind: 'issue',
+      workspaceId: 'ws-1',
+      issueId: 'daily',
+      policy: 'new-each-run',
+      fire: 'schedule',
+    })
+    expect(parseSessionCreatedBy({
+      kind: 'conversation',
+      caller: { kind: 'agent', resumeId: 'resume-a', workspaceId: 'ws-a' },
+      reason: 'explicit-workspace',
+      subject: { kind: 'inbox', entryId: 'entry-1' },
+    })).toEqual({
+      kind: 'conversation',
+      caller: { kind: 'agent', resumeId: 'resume-a', workspaceId: 'ws-a' },
+      reason: 'explicit-workspace',
+      subject: { kind: 'inbox', entryId: 'entry-1' },
+    })
+  })
+
+  it('rejects malformed birth stamps without throwing', () => {
+    expect(parseSessionMetadata(null)).toBeNull()
+    expect(parseSessionMetadata({ createdBy: { kind: 'interactive', surface: 'nope' } })).toBeNull()
+    expect(parseSessionMetadata({ createdBy: { kind: 'issue', workspaceId: 'ws' } })).toBeNull()
+    expect(parseSessionMetadata({ createdBy: { kind: 'conversation', caller: { kind: 'human' } } })).toBeNull()
+  })
+})

--- a/src/workspaces/session-metadata.ts
+++ b/src/workspaces/session-metadata.ts
@@ -1,0 +1,189 @@
+/**
+ * Product-Session metadata bag.
+ *
+ * First field is immutable birth provenance (`createdBy`): who/what allocated
+ * this `resumeId`. Stamped only on first ResumeRegistry create; never rewritten.
+ * Execution-level sources (issue trigger, inquiry subject) stay on headless
+ * task records — birth answers "how was this coworker hired".
+ */
+import type { HeadlessInquirySubject } from './headless-task-registry.js'
+
+export type SessionInteractiveSurface = 'spawn' | 'quick-chat' | 'auto-quant' | 'manager'
+
+export type SessionIssueBirthPolicy = 'new-each-run' | 'new-then-resume'
+
+export type SessionIssueFire = 'schedule' | 'retry'
+
+export type SessionConversationCaller =
+  | { readonly kind: 'agent'; readonly resumeId: string; readonly workspaceId?: string }
+  | { readonly kind: 'human' }
+
+export type SessionConversationBirthReason =
+  | 'explicit-workspace'
+  | 'harness-chat'
+  | 'harness-autoquant'
+  | 'missing-origin'
+  | 'non-session-origin'
+  | 'unavailable-reconstruction'
+  | 'prior-reconstruction'
+  | 'issue-comment'
+
+export type SessionCreatedBy =
+  | {
+      readonly kind: 'interactive'
+      readonly surface: SessionInteractiveSurface
+    }
+  | {
+      readonly kind: 'issue'
+      readonly workspaceId: string
+      readonly issueId: string
+      readonly policy: SessionIssueBirthPolicy
+      readonly fire: SessionIssueFire
+    }
+  | {
+      readonly kind: 'headless'
+      readonly surface: 'api'
+    }
+  | {
+      readonly kind: 'conversation'
+      readonly caller: SessionConversationCaller
+      readonly reason: SessionConversationBirthReason
+      readonly subject?: HeadlessInquirySubject
+    }
+
+/** Immutable product-Session bag. Birth is first-write-wins. */
+export interface SessionMetadata {
+  readonly createdBy: SessionCreatedBy
+}
+
+export function sessionMetadata(createdBy: SessionCreatedBy): SessionMetadata {
+  return { createdBy }
+}
+
+/** Loose parse for resume-identities.json. Invalid shapes return null. */
+export function parseSessionMetadata(value: unknown): SessionMetadata | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const createdBy = parseSessionCreatedBy((value as Record<string, unknown>)['createdBy'])
+  return createdBy ? { createdBy } : null
+}
+
+export function parseSessionCreatedBy(value: unknown): SessionCreatedBy | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const kind = record['kind']
+  if (kind === 'interactive') {
+    const surface = record['surface']
+    if (
+      surface === 'spawn'
+      || surface === 'quick-chat'
+      || surface === 'auto-quant'
+      || surface === 'manager'
+    ) {
+      return { kind: 'interactive', surface }
+    }
+    return null
+  }
+  if (kind === 'issue') {
+    const workspaceId = record['workspaceId']
+    const issueId = record['issueId']
+    const policy = record['policy']
+    const fire = record['fire']
+    if (
+      typeof workspaceId === 'string'
+      && workspaceId.length > 0
+      && typeof issueId === 'string'
+      && issueId.length > 0
+      && (policy === 'new-each-run' || policy === 'new-then-resume')
+      && (fire === 'schedule' || fire === 'retry')
+    ) {
+      return { kind: 'issue', workspaceId, issueId, policy, fire }
+    }
+    return null
+  }
+  if (kind === 'headless') {
+    if (record['surface'] === 'api') return { kind: 'headless', surface: 'api' }
+    return null
+  }
+  if (kind === 'conversation') {
+    const caller = parseConversationCaller(record['caller'])
+    const reason = parseConversationReason(record['reason'])
+    if (!caller || !reason) return null
+    const subject = parseInquirySubject(record['subject'])
+    return {
+      kind: 'conversation',
+      caller,
+      reason,
+      ...(subject ? { subject } : {}),
+    }
+  }
+  return null
+}
+
+function parseConversationCaller(value: unknown): SessionConversationCaller | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (record['kind'] === 'human') return { kind: 'human' }
+  if (record['kind'] === 'agent') {
+    const resumeId = record['resumeId']
+    if (typeof resumeId !== 'string' || resumeId.length === 0) return null
+    const workspaceId = record['workspaceId']
+    return {
+      kind: 'agent',
+      resumeId,
+      ...(typeof workspaceId === 'string' && workspaceId.length > 0 ? { workspaceId } : {}),
+    }
+  }
+  return null
+}
+
+function parseConversationReason(value: unknown): SessionConversationBirthReason | null {
+  switch (value) {
+    case 'explicit-workspace':
+    case 'harness-chat':
+    case 'harness-autoquant':
+    case 'missing-origin':
+    case 'non-session-origin':
+    case 'unavailable-reconstruction':
+    case 'prior-reconstruction':
+    case 'issue-comment':
+      return value
+    default:
+      return null
+  }
+}
+
+function parseInquirySubject(value: unknown): HeadlessInquirySubject | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (record['kind'] === 'inbox') {
+    const entryId = record['entryId']
+    return typeof entryId === 'string' && entryId.length > 0
+      ? { kind: 'inbox', entryId }
+      : null
+  }
+  if (record['kind'] === 'issue') {
+    const workspaceId = record['workspaceId']
+    const issueId = record['issueId']
+    const relation = record['relation']
+    if (
+      typeof workspaceId !== 'string'
+      || workspaceId.length === 0
+      || typeof issueId !== 'string'
+      || issueId.length === 0
+      || (relation !== 'creator' && relation !== 'owner' && relation !== 'run')
+    ) {
+      return null
+    }
+    const runId = record['runId']
+    const commentId = record['commentId']
+    return {
+      kind: 'issue',
+      workspaceId,
+      issueId,
+      relation,
+      ...(typeof runId === 'string' && runId.length > 0 ? { runId } : {}),
+      ...(typeof commentId === 'string' && commentId.length > 0 ? { commentId } : {}),
+    }
+  }
+  return null
+}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -737,6 +737,26 @@ export interface SpawnOptions {
   readonly initialPrompt?: string;
 }
 
+/** Secret-free product-Session birth stamp (mirrors backend SessionCreatedBy). */
+export type SessionCreatedBy =
+  | { readonly kind: 'interactive'; readonly surface: 'spawn' | 'quick-chat' | 'auto-quant' | 'manager' }
+  | {
+      readonly kind: 'issue';
+      readonly workspaceId: string;
+      readonly issueId: string;
+      readonly policy: 'new-each-run' | 'new-then-resume';
+      readonly fire: 'schedule' | 'retry';
+    }
+  | { readonly kind: 'headless'; readonly surface: 'api' }
+  | {
+      readonly kind: 'conversation';
+      readonly caller:
+        | { readonly kind: 'agent'; readonly resumeId: string; readonly workspaceId?: string }
+        | { readonly kind: 'human' };
+      readonly reason: string;
+      readonly subject?: unknown;
+    };
+
 export interface WorkspaceSessionDirectoryEntry {
   readonly resumeId: string;
   readonly agent: string;
@@ -744,6 +764,8 @@ export interface WorkspaceSessionDirectoryEntry {
   readonly updatedAt: number;
   readonly resumable: boolean;
   readonly active: boolean;
+  /** Present when this product Session was allocated after birth metadata shipped. */
+  readonly createdBy?: SessionCreatedBy;
   readonly runtime?: {
     readonly credentialSource: 'native' | 'vault' | 'workspace';
     readonly credentialSlug?: string;


### PR DESCRIPTION
## Summary

Product Sessions (`resumeId`) now carry an optional immutable `metadata.createdBy` bag stamped at first allocation. This answers how a coworker was hired without conflating execution-level `trigger` / `inquiry` on headless runs.

**Birth kinds**

| kind | When |
|---|---|
| `interactive` | `spawn` / `quick-chat` / `auto-quant` / `manager` |
| `issue` | Schedule or retry recruits a fresh Session (`new-each-run` or first `new-then-resume`) |
| `headless` | Direct async `POST .../headless` without Issue/conversation wrapper |
| `conversation` | Fresh worker from `conversation_ask` / UI inquiry / Issue comment (caller agent vs human) |

**Invariants**

- First-write-wins inside `ResumeRegistry.ensure` (never rewritten on continue/resume)
- Server-stamped only (agents cannot claim birth via tool args)
- Historical identities without metadata remain valid (unknown birth)
- No UI badge in this PR; Session Directory projects secret-free `createdBy`

## Plan / docs

- `plans/session-birth-metadata.md`
- `docs/conversation-provenance.md` — Session birth metadata section

## Test plan

- [x] `npx tsc --noEmit`
- [x] `cd ui && npx tsc -b`
- [x] Targeted vitest: `session-metadata`, `resume-registry`, `conversation-control`, `schedule/scanner`, `webui/routes/workspaces`, `webui/routes/inquiries`
- [ ] CI on Draft PR
- [ ] Manual: spawn + quick-chat + headless + scheduled Issue + inquiry → inspect Session Directory `createdBy`

## Residual risk

- Pre-ship Sessions have no birth bag
- Exact continues never rewrite birth
- UI list badges deferred

## Delivery

Draft PR for concurrent audit. **Do not merge** until maintainer accepts the topic.