### PR TITLE
feat(ui): list Workspace sessions by resumeId occupancy

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,6 +21,9 @@ the durable truth after it changes.
 
 ## Active
 
+- [[plans/session-roster-headless-occupancy.md]] — Ask Alice / Quant list
+  Workspace employees by `resumeId`, including Directory-only colleagues, and
+  lock TUI attach while a headless turn occupies that Session.
 - [[plans/release-feedback-reliability.md]] — Makes packaged release failures
   deterministic and diagnostic first, then removes desktop matrix fan-in and
   reuses trusted promotion evidence without weakening release gates.

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -65,6 +65,12 @@ In the office analogy, the Workspace is the desk and the product Session is one
 particular colleague-with-context. `pi`, `codex`, `opencode`, and `claude` are
 worker kinds, not unique colleagues.
 
+Ask Alice and AutoQuant list those colleagues from the Workspace Session
+Directory (`GET /api/workspaces/:id/resumes`), joined to any materialized
+`SessionRecord` by `resumeId`. Birth method does not hide a row. A headless
+turn occupying that `resumeId` locks TUI spawn/resume; Automation continues to
+list dispatch records (`taskId`), not this roster.
+
 ## Session birth metadata
 
 Product Sessions may carry an optional, immutable `metadata.createdBy` bag on

--- a/plans/session-roster-headless-occupancy.md
+++ b/plans/session-roster-headless-occupancy.md
@@ -1,0 +1,81 @@
+# Plan: Session roster by resumeId (lock TUI while headless)
+
+**Status:** active  
+**Owner guides:** [[docs/conversation-provenance.md]], [[docs/workspace-issues-and-scheduling.md]]  
+**Delivery:** serial PR to `dev` (`area:workspace`)
+
+## Goal
+
+Ask Alice / Quant 侧栏列出 **Workspace 里的员工（`resumeId`）**，不按是否 headless 过滤。  
+headless 只是这一班怎么上工：在跑则 **锁住拉 TUI**，显示运行中。列表按 **最近一次占班** 排序。
+
+Automation 继续只看调度（`taskId`），不进这条花名册。
+
+## Product rules
+
+| 规则 | 含义 |
+|---|---|
+| 一行 = 一个 `resumeId` | 交互 + 后台回合是同一个人 |
+| 显不显示与出生方式无关 | TUI / Issue / conversation_ask 都上名册 |
+| 同时一班工 | `latestExecution.status === 'running'` 或 Directory `active`（且不是 TUI running）→ 禁止 spawn/resume/WebPi |
+| 播放键 | 锁住，文案「运行中」；点标题也不 attach TUI |
+| 结束后 | 锁解开；失败只淡标记，不继续锁 |
+| 排序 | `max(interactive.lastActiveAt, latestExecution.startedAt/finishedAt)`，running 仍置顶 |
+| 退休 | `lifecycle === 'retired'` 不进侧栏 |
+
+后端已有互斥（interactive 开着不能 headless，resume 上有 turn 会 `busy`）。本增量补 **名册 + 锁的可见性**，不新造调度页。
+
+## Data
+
+已有 `GET /api/workspaces/:id/resumes`（`WorkspaceSessionDirectory`）：
+
+- `resumeId`, `active`, `resumable`, `createdBy?`
+- `interactive?`（title / state / lastActiveAt）
+- `latestExecution?`（status / startedAt / finishedAt / issueId / assistantPreview）
+
+Workspace 列表里的 `sessions[]` 仍是材质化 `SessionRecord`。侧栏改为：
+
+```text
+directory.sessions (active lifecycle)
+  ⋈ workspace.sessions by resumeId
+```
+
+无 `SessionRecord` 的 Directory 行也要出现。Directory 尚未返回时回退到材质化列表。
+
+**标题：** interactive title → assistantPreview → issueId → `resumeId` 短号。  
+不要把整段 Issue What 塞进侧栏。
+
+## UI（只动 Ask Alice 壳）
+
+Quant 已共用 `ChatWorkspaceSection`，改这一处两边都有。
+
+1. Domain hook `useWorkspaceSessionDirectory(ies)`  
+2. Join + 排序纯函数 `orderHarnessSessions` / `joinWorkspaceHarnessSessions`  
+3. `SessionRow` busy 时禁用 Resume/Play  
+4. Browse all 同一 join；Running 筛包含 headless running  
+5. Demo `/resumes` 补 Directory-only 同事
+
+## Out of scope
+
+- Automation 改版
+- 侧栏 `createdBy` 徽章
+- headless 输出面板 / 点标题看 transcript
+- Manager Workspace 名册
+- 生命周期独立活动页
+
+## Checklist
+
+- [x] hook + join/sort 纯函数 + 单测
+- [x] SessionRow busy / ChatWorkspaceSection 数据源
+- [x] Browse 同步
+- [x] Demo + 锁按钮
+- [x] 浏览器走 Chat（及一眼 Quant）
+
+## Acceptance
+
+- [x] 侧栏按 `resumeId` 列员工，含从未开过 TUI 的
+- [x] headless running 时 TUI 激活锁定并显示运行中
+- [x] 结束后可拉起 TUI
+- [x] 按最近占班排序
+- [x] Automation 职能不混进侧栏
+- [x] Ask Alice 与 Quant 仍是同一套组件

--- a/ui/src/components/workspace/ChatWorkspaceSection.auto-quant.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.auto-quant.spec.tsx
@@ -31,6 +31,15 @@ vi.mock('../../tabs/types', () => ({
   }),
 }))
 
+vi.mock('../../hooks/useWorkspaceSessionDirectory', () => ({
+  useWorkspaceSessionDirectories: () => ({
+    directories: new Map(),
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}))
+
 const template: TemplateInfo = {
   name: 'auto-quant-v2',
   defaultAgents: ['pi'],

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -20,10 +20,23 @@ const actions = vi.hoisted(() => ({
   pauseSession: vi.fn(async () => undefined),
   resumeSession: vi.fn(async () => undefined),
   openWebPiSession: vi.fn(async () => undefined),
+  openHeadlessRun: vi.fn(async () => undefined),
   requestDeleteSession: vi.fn(),
   openAgentConfig: vi.fn(),
 }))
+const directoryState = vi.hoisted(() => ({
+  directories: new Map(),
+}))
 const { openOrFocus } = actions
+
+vi.mock('../../hooks/useWorkspaceSessionDirectory', () => ({
+  useWorkspaceSessionDirectories: () => ({
+    directories: directoryState.directories,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}))
 
 vi.mock('../../tabs/store', () => ({
   useWorkspace: (selector: (state: { openOrFocus: typeof openOrFocus }) => unknown) =>
@@ -93,7 +106,7 @@ function workspaceContext(
     refreshWorkspaceManager: vi.fn(async () => undefined),
     quickStartWorkspaceManager: vi.fn(async () => { throw new Error('not used') }),
     spawn: vi.fn(async () => undefined),
-    openHeadlessRun: vi.fn(async () => undefined),
+    openHeadlessRun: actions.openHeadlessRun,
     setDefaultAgent: vi.fn(async () => undefined),
     setIssueDefaultAgent: vi.fn(async () => undefined),
     initializeAutoQuant: vi.fn(async () => { throw new Error('not used') }),
@@ -129,6 +142,7 @@ function renderSection(
 
 beforeEach(async () => {
   for (const mock of Object.values(actions)) mock.mockClear()
+  directoryState.directories = new Map()
   window.localStorage.clear()
   await i18n.changeLanguage('en')
 })
@@ -558,5 +572,101 @@ describe('ChatWorkspaceSection actions', () => {
     fireEvent.click(managerUi.getByRole('button', { name: 'Collapse sessions' }))
     expect(managerUi.queryByRole('button', { name: 'Inspect the floor' })).toBeNull()
     expect(onNavigate).toHaveBeenCalledTimes(2)
+  })
+
+  it('lists Directory-only colleagues and locks TUI while headless occupies them', () => {
+    const onNavigate = vi.fn()
+    directoryState.directories = new Map([[chatWorkspace.id, {
+      workspace: { id: chatWorkspace.id, tag: chatWorkspace.tag },
+      sessions: [
+        {
+          resumeId: 'resume-headless-colleague',
+          agent: 'codex',
+          createdAt: Date.parse('2026-08-01T00:00:00.000Z'),
+          updatedAt: Date.parse('2026-08-02T00:00:00.000Z'),
+          lifecycle: 'active',
+          resumable: true,
+          active: false,
+          latestExecution: {
+            taskId: 'task-done',
+            status: 'done',
+            startedAt: Date.parse('2026-08-02T00:00:00.000Z'),
+            finishedAt: Date.parse('2026-08-02T00:05:00.000Z'),
+            assistantPreview: 'Morning scan complete. Semis still lead.',
+          },
+        },
+        {
+          resumeId: 'resume-headless-running',
+          agent: 'claude',
+          createdAt: Date.parse('2026-08-03T00:00:00.000Z'),
+          updatedAt: Date.parse('2026-08-03T01:00:00.000Z'),
+          lifecycle: 'active',
+          resumable: true,
+          active: true,
+          latestExecution: {
+            taskId: 'task-run',
+            status: 'running',
+            startedAt: Date.parse('2026-08-03T01:00:00.000Z'),
+            issueId: 'scan-open',
+          },
+        },
+      ],
+    }]])
+
+    renderSection([chatWorkspace], null, onNavigate, 'focused')
+
+    expect(screen.getByRole('button', { name: 'Morning scan complete. Semis still lead.' })).toBeTruthy()
+    const [runningTitle, runningPlay] = screen.getAllByRole('button', { name: 'Running · scan-open' })
+    expect(runningTitle).toHaveProperty('disabled', true)
+    expect(runningPlay).toHaveProperty('disabled', true)
+    fireEvent.click(runningTitle!)
+    expect(openOrFocus).not.toHaveBeenCalled()
+    expect(actions.openHeadlessRun).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume Morning scan complete. Semis still lead.' }))
+    expect(actions.openHeadlessRun).toHaveBeenCalledWith(
+      chatWorkspace.id,
+      'resume-headless-colleague',
+      { title: 'Morning scan complete. Semis still lead.' },
+    )
+    expect(onNavigate).toHaveBeenCalledOnce()
+  })
+
+  it('keeps headless occupancy inside Browse Running without a Headless filter', () => {
+    directoryState.directories = new Map([[chatWorkspace.id, {
+      workspace: { id: chatWorkspace.id, tag: chatWorkspace.tag },
+      sessions: [{
+        resumeId: 'resume-headless-running',
+        agent: 'claude',
+        createdAt: Date.parse('2026-08-03T00:00:00.000Z'),
+        updatedAt: Date.parse('2026-08-03T01:00:00.000Z'),
+        lifecycle: 'active',
+        resumable: true,
+        active: true,
+        latestExecution: {
+          taskId: 'task-run',
+          status: 'running',
+          startedAt: Date.parse('2026-08-03T01:00:00.000Z'),
+          issueId: 'scan-open',
+        },
+      }],
+    }]])
+    const pausedWorkspace = {
+      ...chatWorkspace,
+      sessions: [{ ...chatSession(1), title: 'Paused thesis' }],
+    }
+    renderSection([pausedWorkspace], null, undefined, 'focused')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chat context: chat-jul11' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Browse all conversations' }))
+    const dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
+    const browser = within(dialog)
+    expect(browser.getByRole('button', { name: 'Paused thesis' })).toBeTruthy()
+    expect(browser.getByRole('button', { name: 'Running · scan-open' })).toBeTruthy()
+
+    fireEvent.click(browser.getByRole('button', { name: /^Running$/ }))
+    expect(browser.queryByRole('button', { name: 'Paused thesis' })).toBeNull()
+    expect(browser.getByRole('button', { name: 'Running · scan-open' })).toBeTruthy()
+    expect(browser.queryByRole('button', { name: 'Headless' })).toBeNull()
   })
 })

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -44,7 +44,14 @@ import {
 import { SessionRow } from './Sidebar'
 import { SidebarActionMenu } from './SidebarActionMenu'
 import { workspaceDisplayName, workspaceDisplayTitle } from './display'
+import {
+  flattenHarnessSessions,
+  joinWorkspaceHarnessSessions,
+  sessionRecordForRow,
+  type HarnessSession,
+} from './harness-sessions'
 import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order'
+import { useWorkspaceSessionDirectories } from '../../hooks/useWorkspaceSessionDirectory'
 import { useReorderMotion } from './useReorderMotion'
 import { preferencesApi } from '../../api/preferences'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -101,6 +108,28 @@ export function ChatWorkspaceSection({
     ),
     [ctx.workspaces, templateName],
   )
+  const chatWorkspaceIds = useMemo(
+    () => chatWorkspaces.map((workspace) => workspace.id),
+    [chatWorkspaces],
+  )
+  const sessionDirectories = useWorkspaceSessionDirectories(chatWorkspaceIds)
+  const rosterByWorkspace = useMemo(() => {
+    const next = new Map<string, HarnessSession[]>()
+    for (const workspace of chatWorkspaces) {
+      next.set(
+        workspace.id,
+        joinWorkspaceHarnessSessions(
+          workspace,
+          sessionDirectories.directories.get(workspace.id) ?? null,
+        ),
+      )
+    }
+    return next
+  }, [chatWorkspaces, sessionDirectories.directories])
+  const recentRoster = useMemo(
+    () => flattenHarnessSessions(chatWorkspaces, sessionDirectories.directories),
+    [chatWorkspaces, sessionDirectories.directories],
+  )
   const workspaceListRef = useReorderMotion<HTMLUListElement>(
     chatWorkspaces.map((workspace) => workspace.id),
   )
@@ -144,6 +173,60 @@ export function ChatWorkspaceSection({
     if (mode === 'auto-quant') return
     setRecentWorkspaceId(workspaceId)
     void preferencesApi.rememberRecentChatWorkspace(workspaceId).catch(() => undefined)
+  }
+
+  const activeResumeId = useMemo(() => {
+    if (!selection?.sessionId) return null
+    const workspace = chatWorkspaces.find((candidate) => candidate.id === selection.wsId)
+    return workspace?.sessions.find((session) => session.id === selection.sessionId)?.resumeId
+      ?? null
+  }, [chatWorkspaces, selection])
+
+  const isRosterRowActive = (row: HarnessSession): boolean => {
+    if (!selection || selection.wsId !== row.workspaceId) return false
+    if (row.session && selection.sessionId === row.session.id) return true
+    return activeResumeId !== null && row.resumeId === activeResumeId
+  }
+
+  const activateRosterSession = (row: HarnessSession): void => {
+    if (row.headlessOccupying) return
+    if (row.session) {
+      rememberViewedWorkspace(row.workspaceId)
+      navigate({
+        kind: 'workspace',
+        params: { wsId: row.workspaceId, sessionId: row.session.id, source },
+      })
+      return
+    }
+    if (!row.resumable) return
+    void ctx.openHeadlessRun(row.workspaceId, row.resumeId, { title: row.title })
+    onNavigate()
+  }
+
+  const resumeRosterSession = (row: HarnessSession): void => {
+    if (row.headlessOccupying || !row.resumable) return
+    if (row.session) {
+      rememberViewedWorkspace(row.workspaceId)
+      if (row.session.surface === 'webpi') {
+        void ctx.openWebPiSession(row.workspaceId, row.session.id, source)
+      } else {
+        void ctx.resumeSession(row.workspaceId, row.session.id, source)
+      }
+      onNavigate()
+      return
+    }
+    void ctx.openHeadlessRun(row.workspaceId, row.resumeId, { title: row.title })
+    onNavigate()
+  }
+
+  const deleteRosterSession = (row: HarnessSession): void => {
+    if (!row.session) return
+    ctx.requestDeleteSession(row.workspaceId, row.session.id)
+  }
+
+  const pauseRosterSession = (row: HarnessSession): void => {
+    if (!row.session) return
+    void ctx.pauseSession(row.workspaceId, row.session.id)
   }
 
   const selectHarnessWorkspace = (
@@ -226,27 +309,15 @@ export function ChatWorkspaceSection({
         <FocusedChatWorkspace
           harness={mode}
           workspace={focusedWorkspace}
+          sessions={focusedWorkspace ? rosterByWorkspace.get(focusedWorkspace.id) ?? [] : []}
           loading={!ctx.hasLoaded && !showListError}
           unavailable={showListError}
           emptyCopy={mode === 'auto-quant' ? t('autoQuant.noResearchYet') : undefined}
-          activeSessionId={selection !== null && selection.wsId === focusedWorkspace?.id
-            ? selection.sessionId
-            : null}
-          onOpenSession={(workspaceId, sessionId) => {
-            rememberViewedWorkspace(workspaceId)
-            navigate({ kind: 'workspace', params: { wsId: workspaceId, sessionId, source } })
-          }}
-          onPauseSession={(workspaceId, sessionId) => void ctx.pauseSession(workspaceId, sessionId)}
-          onResumeSession={(workspaceId, session) => {
-            rememberViewedWorkspace(workspaceId)
-            if (session.surface === 'webpi') {
-              void ctx.openWebPiSession(workspaceId, session.id, source)
-            } else {
-              void ctx.resumeSession(workspaceId, session.id, source)
-            }
-            onNavigate()
-          }}
-          onDeleteSession={(workspaceId, sessionId) => ctx.requestDeleteSession(workspaceId, sessionId)}
+          isRowActive={isRosterRowActive}
+          onOpenSession={activateRosterSession}
+          onPauseSession={pauseRosterSession}
+          onResumeSession={resumeRosterSession}
+          onDeleteSession={deleteRosterSession}
           onBrowseSessions={(workspaceId, restoreFocus) => openConversationBrowser(workspaceId, restoreFocus)}
           onCreateWorkspace={() => setShowCreate(true)}
         />
@@ -254,24 +325,14 @@ export function ChatWorkspaceSection({
         <AllWorkspaceRecentSessions
           harness={mode}
           workspaces={chatWorkspaces}
+          sessions={recentRoster}
           loading={!ctx.hasLoaded && !showListError}
           unavailable={showListError}
-          selection={selection}
-          onOpenSession={(workspaceId, sessionId) => {
-            rememberViewedWorkspace(workspaceId)
-            navigate({ kind: 'workspace', params: { wsId: workspaceId, sessionId, source } })
-          }}
-          onPauseSession={(workspaceId, sessionId) => void ctx.pauseSession(workspaceId, sessionId)}
-          onResumeSession={(workspaceId, session) => {
-            rememberViewedWorkspace(workspaceId)
-            if (session.surface === 'webpi') {
-              void ctx.openWebPiSession(workspaceId, session.id, source)
-            } else {
-              void ctx.resumeSession(workspaceId, session.id, source)
-            }
-            onNavigate()
-          }}
-          onDeleteSession={(workspaceId, sessionId) => ctx.requestDeleteSession(workspaceId, sessionId)}
+          isRowActive={isRosterRowActive}
+          onOpenSession={activateRosterSession}
+          onPauseSession={pauseRosterSession}
+          onResumeSession={resumeRosterSession}
+          onDeleteSession={deleteRosterSession}
           onCreateWorkspace={() => setShowCreate(true)}
         />
       ) : (
@@ -337,24 +398,19 @@ export function ChatWorkspaceSection({
             key={w.id}
             harness={mode}
             workspace={w}
+            sessions={rosterByWorkspace.get(w.id) ?? []}
             label={workspaceDisplayName(w)}
             selection={selection}
+            isRowActive={isRosterRowActive}
             onOpen={() => {
               selectHarnessWorkspace(w.id, () => {
                 navigate({ kind: landingKind, params: { targetWsId: w.id } })
               })
             }}
-            onOpenSession={(sid) => {
-              rememberViewedWorkspace(w.id)
-              navigate({ kind: 'workspace', params: { wsId: w.id, sessionId: sid, source } })
-            }}
-            onPauseSession={(sid) => void ctx.pauseSession(w.id, sid)}
-            onResumeSession={(sid) => {
-              rememberViewedWorkspace(w.id)
-              void ctx.resumeSession(w.id, sid, source)
-              onNavigate()
-            }}
-            onDeleteSession={(sid) => ctx.requestDeleteSession(w.id, sid)}
+            onOpenSession={activateRosterSession}
+            onPauseSession={pauseRosterSession}
+            onResumeSession={resumeRosterSession}
+            onDeleteSession={deleteRosterSession}
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}
             onSpawn={() => navigate({ kind: landingKind, params: { targetWsId: w.id } })}
@@ -401,14 +457,15 @@ export function ChatWorkspaceSection({
         harness={mode}
         open={conversationBrowserOpen}
         workspaces={chatWorkspaces}
+        directories={sessionDirectories.directories}
         currentWorkspaceId={conversationWorkspaceId}
-        activeSessionId={selection?.wsId === conversationWorkspaceId ? selection.sessionId : null}
+        isRowActive={isRosterRowActive}
         restoreFocusRef={dialogRestoreFocusRef}
         onOpenChange={setConversationBrowserOpen}
-        onSelectSession={(workspaceId, sessionId) => {
+        onSelectSession={(row) => {
+          if (row.headlessOccupying) return
           setConversationBrowserOpen(false)
-          rememberViewedWorkspace(workspaceId)
-          navigate({ kind: 'workspace', params: { wsId: workspaceId, sessionId, source } })
+          activateRosterSession(row)
         }}
       />
 
@@ -621,14 +678,15 @@ function ChatWorkspaceContextFooter(props: ChatWorkspaceContextFooterProps): Rea
 interface FocusedChatWorkspaceProps {
   harness: 'chat' | 'auto-quant'
   workspace: Workspace | null
+  sessions: readonly HarnessSession[]
   loading: boolean
   unavailable: boolean
   emptyCopy?: string
-  activeSessionId: string | null
-  onOpenSession: (workspaceId: string, sessionId: string) => void
-  onPauseSession: (workspaceId: string, sessionId: string) => void
-  onResumeSession: (workspaceId: string, session: SessionRecord) => void
-  onDeleteSession: (workspaceId: string, sessionId: string) => void
+  isRowActive: (row: HarnessSession) => boolean
+  onOpenSession: (row: HarnessSession) => void
+  onPauseSession: (row: HarnessSession) => void
+  onResumeSession: (row: HarnessSession) => void
+  onDeleteSession: (row: HarnessSession) => void
   onBrowseSessions: (workspaceId: string, restoreFocus: HTMLElement | null) => void
   onCreateWorkspace: () => void
 }
@@ -636,30 +694,27 @@ interface FocusedChatWorkspaceProps {
 interface AllWorkspaceRecentSessionsProps {
   harness: 'chat' | 'auto-quant'
   workspaces: readonly Workspace[]
+  sessions: readonly HarnessSession[]
   loading: boolean
   unavailable: boolean
-  selection: { wsId: string; sessionId: string | null } | null
-  onOpenSession: (workspaceId: string, sessionId: string) => void
-  onPauseSession: (workspaceId: string, sessionId: string) => void
-  onResumeSession: (workspaceId: string, session: SessionRecord) => void
-  onDeleteSession: (workspaceId: string, sessionId: string) => void
+  isRowActive: (row: HarnessSession) => boolean
+  onOpenSession: (row: HarnessSession) => void
+  onPauseSession: (row: HarnessSession) => void
+  onResumeSession: (row: HarnessSession) => void
+  onDeleteSession: (row: HarnessSession) => void
   onCreateWorkspace: () => void
 }
 
 function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): ReactElement {
   const { t } = useTranslation()
-  const sessions = useMemo(() => props.workspaces
-    .flatMap((workspace) => workspace.sessions.map((session) => ({ workspace, session })))
-    .sort((a, b) => {
-      const activity = Date.parse(b.session.lastActiveAt) - Date.parse(a.session.lastActiveAt)
-      if (activity !== 0) return activity
-      const created = Date.parse(b.session.createdAt) - Date.parse(a.session.createdAt)
-      if (created !== 0) return created
-      return a.session.id.localeCompare(b.session.id)
-    }), [props.workspaces])
+  const workspaceName = useMemo(
+    () => new Map(props.workspaces.map((workspace) => [workspace.id, workspaceDisplayTitle(workspace)])),
+    [props.workspaces],
+  )
+  const sessions = props.sessions
   const visibleSessions = sessions.slice(0, ALL_WORKSPACES_SESSION_LIMIT)
   const sessionListRef = useReorderMotion<HTMLDivElement>(
-    visibleSessions.map(({ workspace, session }) => `${workspace.id}:${session.id}`),
+    visibleSessions.map((row) => `${row.workspaceId}:${row.resumeId}`),
   )
 
   if (props.loading) {
@@ -697,17 +752,16 @@ function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): Rea
           <p className="px-3 py-3 text-xs leading-relaxed text-muted-foreground/60">
             {props.harness === 'auto-quant' ? t('autoQuant.noResearchYet') : t('chat.noRecentConversations')}
           </p>
-        ) : visibleSessions.map(({ workspace, session }) => (
-          <SessionRow
-            key={`${workspace.id}:${session.id}`}
-            reorderId={`${workspace.id}:${session.id}`}
-            session={session}
-            subtitle={workspaceDisplayTitle(workspace)}
-            isActive={props.selection?.wsId === workspace.id && props.selection.sessionId === session.id}
-            onSelect={() => props.onOpenSession(workspace.id, session.id)}
-            onPause={() => props.onPauseSession(workspace.id, session.id)}
-            onResume={() => props.onResumeSession(workspace.id, session)}
-            onDelete={() => props.onDeleteSession(workspace.id, session.id)}
+        ) : visibleSessions.map((row) => (
+          <HarnessSessionRow
+            key={`${row.workspaceId}:${row.resumeId}`}
+            row={row}
+            subtitle={workspaceName.get(row.workspaceId)}
+            isActive={props.isRowActive(row)}
+            onSelect={() => props.onOpenSession(row)}
+            onPause={() => props.onPauseSession(row)}
+            onResume={() => props.onResumeSession(row)}
+            onDelete={() => props.onDeleteSession(row)}
           />
         ))}
       </div>
@@ -730,13 +784,10 @@ function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): Rea
 
 function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
   const { t } = useTranslation()
-  const sessions = useMemo(
-    () => orderSessionsForSidebar(props.workspace?.sessions ?? []),
-    [props.workspace?.sessions],
-  )
+  const sessions = props.sessions
   const visibleSessions = sessions.slice(0, FOCUSED_CHAT_SESSION_LIMIT)
   const sessionListRef = useReorderMotion<HTMLDivElement>(
-    visibleSessions.map((session) => session.id),
+    visibleSessions.map((row) => row.resumeId),
   )
 
   if (props.loading) {
@@ -789,16 +840,15 @@ function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
           <p className="px-3 py-3 text-xs text-muted-foreground/60">
             {props.emptyCopy ?? t('chat.noConversationsYet')}
           </p>
-        ) : visibleSessions.map((session) => (
-          <SessionRow
-            key={session.id}
-            reorderId={session.id}
-            session={session}
-            isActive={props.activeSessionId === session.id}
-            onSelect={() => props.onOpenSession(props.workspace!.id, session.id)}
-            onPause={() => props.onPauseSession(props.workspace!.id, session.id)}
-            onResume={() => props.onResumeSession(props.workspace!.id, session)}
-            onDelete={() => props.onDeleteSession(props.workspace!.id, session.id)}
+        ) : visibleSessions.map((row) => (
+          <HarnessSessionRow
+            key={row.resumeId}
+            row={row}
+            isActive={props.isRowActive(row)}
+            onSelect={() => props.onOpenSession(row)}
+            onPause={() => props.onPauseSession(row)}
+            onResume={() => props.onResumeSession(row)}
+            onDelete={() => props.onDeleteSession(row)}
           />
         ))}
         {sessions.length > visibleSessions.length && (
@@ -940,13 +990,15 @@ function ManagerWorkspaceRow(props: ManagerWorkspaceRowProps): ReactElement {
 interface ChatWorkspaceRowProps {
   harness: 'chat' | 'auto-quant'
   workspace: Workspace
+  sessions: readonly HarnessSession[]
   label: string
   selection: { wsId: string; sessionId: string | null } | null
+  isRowActive: (row: HarnessSession) => boolean
   onOpen: () => void
-  onOpenSession: (sid: string) => void
-  onPauseSession: (sid: string) => void
-  onResumeSession: (sid: string) => void
-  onDeleteSession: (sid: string) => void
+  onOpenSession: (row: HarnessSession) => void
+  onPauseSession: (row: HarnessSession) => void
+  onResumeSession: (row: HarnessSession) => void
+  onDeleteSession: (row: HarnessSession) => void
   onConfigure: () => void
   onDelete: () => void
   /** Spawn a fresh agent session in THIS workspace (and open it). */
@@ -955,27 +1007,53 @@ interface ChatWorkspaceRowProps {
   onBrowseSessions: (restoreFocus: HTMLElement | null) => void
 }
 
+function HarnessSessionRow(props: {
+  row: HarnessSession
+  subtitle?: string
+  isActive: boolean
+  onSelect: () => void
+  onPause: () => void
+  onResume: () => void
+  onDelete: () => void
+}): ReactElement {
+  const row = props.row
+  return (
+    <SessionRow
+      reorderId={`${row.workspaceId}:${row.resumeId}`}
+      session={sessionRecordForRow(row)}
+      displayTitle={row.title}
+      subtitle={props.subtitle}
+      isActive={props.isActive}
+      headlessOccupying={row.headlessOccupying}
+      resumable={row.resumable}
+      failed={row.failed}
+      canDelete={row.session !== null}
+      onSelect={props.onSelect}
+      onPause={props.onPause}
+      onResume={props.onResume}
+      onDelete={props.onDelete}
+    />
+  )
+}
+
 function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   const { t } = useTranslation()
   const w = props.workspace
-  const hasRunning = w.sessions.some((s) => s.state === 'running')
+  const orderedSessions = props.sessions
+  const hasRunning = orderedSessions.some((row) => row.occupancyRunning)
   const [expanded, setExpanded] = useState(true)
   const isSelected = props.selection?.wsId === w.id && props.selection.sessionId === null
   const displayName = w.displayName?.trim()
   const subtitle = displayName && displayName !== w.tag ? w.tag : null
   const actionWorkspace = subtitle ? `${props.label} (${w.tag})` : w.tag
-  const orderedSessions = useMemo(
-    () => orderSessionsForSidebar(w.sessions),
-    [w.sessions],
-  )
   const visibleSessions = orderedSessions.slice(0, CHAT_SIDEBAR_SESSION_LIMIT)
   const sessionListRef = useReorderMotion<HTMLDivElement>(
-    visibleSessions.map((session) => session.id),
+    visibleSessions.map((row) => row.resumeId),
   )
 
   const statusClass = hasRunning
     ? 'bg-success'
-    : w.sessions.length > 0
+    : orderedSessions.length > 0
       ? 'bg-muted-foreground/40'
       : 'border border-border'
 
@@ -1026,9 +1104,9 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               </span>
             )}
           </span>
-          {w.sessions.length > 0 && (
+          {orderedSessions.length > 0 && (
             <span className="text-[11px] text-muted-foreground/45 tabular-nums shrink-0">
-              {w.sessions.length}
+              {orderedSessions.length}
             </span>
           )}
         </button>
@@ -1068,16 +1146,15 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
       </div>
       {expanded && orderedSessions.length > 0 && (
         <div ref={sessionListRef} className="oa-disclosure-enter ml-[18px] border-l border-border/50">
-          {visibleSessions.map((s) => (
-            <SessionRow
-              key={s.id}
-              reorderId={s.id}
-              session={s}
-              isActive={props.selection?.sessionId === s.id}
-              onSelect={() => props.onOpenSession(s.id)}
-              onPause={() => props.onPauseSession(s.id)}
-              onResume={() => props.onResumeSession(s.id)}
-              onDelete={() => props.onDeleteSession(s.id)}
+          {visibleSessions.map((row) => (
+            <HarnessSessionRow
+              key={row.resumeId}
+              row={row}
+              isActive={props.isRowActive(row)}
+              onSelect={() => props.onOpenSession(row)}
+              onPause={() => props.onPauseSession(row)}
+              onResume={() => props.onResumeSession(row)}
+              onDelete={() => props.onDeleteSession(row)}
             />
           ))}
           {orderedSessions.length > visibleSessions.length && (

--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -212,4 +212,28 @@ describe('SessionRow actions', () => {
     expect(main.parentElement?.className).toContain('oa-session-row')
     expect(main.parentElement?.getAttribute('data-active')).toBe('true')
   })
+
+  it('locks Play while a headless turn occupies the Session', () => {
+    const onSelect = vi.fn()
+    const onResume = vi.fn()
+    render(
+      <SessionRow
+        session={{ ...session, state: 'paused', pid: null, startedAt: null }}
+        isActive={false}
+        headlessOccupying
+        onSelect={onSelect}
+        onPause={vi.fn()}
+        onResume={onResume}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    const [title, play] = screen.getAllByRole('button', { name: 'Running · Review AAPL earnings' })
+    expect(title).toHaveProperty('disabled', true)
+    expect(play).toHaveProperty('disabled', true)
+    fireEvent.click(title!)
+    fireEvent.click(play!)
+    expect(onSelect).not.toHaveBeenCalled()
+    expect(onResume).not.toHaveBeenCalled()
+  })
 })

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -629,6 +629,12 @@ export interface SessionRowProps {
   session: SessionRecord;
   subtitle?: string;
   isActive: boolean;
+  /** Headless turn currently occupies this resumeId — lock TUI attach. */
+  headlessOccupying?: boolean;
+  resumable?: boolean;
+  failed?: boolean;
+  canDelete?: boolean;
+  displayTitle?: string;
   onSelect: () => void;
   onPause: () => void;
   onResume: () => void;
@@ -639,15 +645,25 @@ export function SessionRow(props: SessionRowProps): ReactElement {
   const { t } = useTranslation();
   const s = props.session;
   const isPaused = s.state === 'paused';
+  const headlessOccupying = props.headlessOccupying === true;
+  const resumable = props.resumable !== false;
+  const canDelete = props.canDelete !== false;
   // The server resolves native title → launch prompt → sticky name.
-  const display = s.title?.trim() || s.name;
-  const resumeLabel = t('workspace.resumeSession', { title: display });
+  const display = props.displayTitle?.trim() || s.title?.trim() || s.name;
+  const resumeLocked = headlessOccupying || !resumable;
+  const resumeLabel = headlessOccupying
+    ? t('workspace.sessionRunning', { title: display })
+    : resumable
+      ? t('workspace.resumeSession', { title: display })
+      : t('workspace.sessionNotResumable', { title: display });
   const stopLabel = t('workspace.stopSession', { title: display });
   const deleteLabel = t('workspace.deleteSession', { title: display });
+  const selectLabel = headlessOccupying ? t('workspace.sessionRunning', { title: display }) : display;
   const metaParts: string[] = [`agent ${s.agent}`];
   if (s.pid !== null) metaParts.push(`pid ${s.pid}`);
   if (s.resumeId) metaParts.push(s.resumeId);
-  if (isPaused) metaParts.push(t('workspace.paused'));
+  if (headlessOccupying) metaParts.push(t('workspace.running'));
+  else if (isPaused) metaParts.push(t('workspace.paused'));
   const meta = metaParts.join(' · ');
   // Full message on hover when it's been truncated, then the technical meta.
   const tooltipParts = [s.title?.trim() || null, props.subtitle, meta].filter(Boolean);
@@ -657,6 +673,7 @@ export function SessionRow(props: SessionRowProps): ReactElement {
     <div
       data-reorder-id={props.reorderId}
       data-active={props.isActive}
+      aria-busy={headlessOccupying || undefined}
       className={`oa-session-row group relative flex items-center gap-1.5 pl-3 pr-2 py-1.5 text-[12px] transition-colors ${
         props.isActive ? 'bg-muted' : 'hover:bg-muted/50'
       }`}
@@ -664,17 +681,22 @@ export function SessionRow(props: SessionRowProps): ReactElement {
       {props.isActive && <span aria-hidden="true" className="absolute left-0 top-0 bottom-0 w-[2px] bg-primary" />}
       <button
         type="button"
-        className="oa-session-row-main flex-1 min-w-0 flex items-center gap-1.5 text-left"
+        className="oa-session-row-main flex-1 min-w-0 flex items-center gap-1.5 text-left disabled:cursor-default"
         onClick={props.onSelect}
+        disabled={headlessOccupying}
         title={tooltip}
-        aria-label={display}
+        aria-label={selectLabel}
         aria-current={props.isActive ? 'page' : undefined}
       >
-        <span className={`shrink-0 flex items-center justify-center w-3.5 ${isPaused ? 'text-muted-foreground/40' : 'text-muted-foreground/70'}`}>
+        <span className={`shrink-0 flex items-center justify-center w-3.5 ${isPaused && !headlessOccupying ? 'text-muted-foreground/40' : 'text-muted-foreground/70'}`}>
           <AgentBadgeGlyph agentId={s.agent} />
         </span>
         <span className="min-w-0 flex-1">
-          <span className={`block truncate ${isPaused ? 'text-muted-foreground' : 'text-foreground'}`}>{display}</span>
+          <span className={`block truncate ${
+            props.failed ? 'text-muted-foreground/70'
+              : isPaused && !headlessOccupying ? 'text-muted-foreground'
+                : 'text-foreground'
+          }`}>{display}</span>
           {props.subtitle && (
             <span className="mt-0.5 block truncate text-[10px] leading-3 text-muted-foreground/55">
               {props.subtitle}
@@ -684,16 +706,17 @@ export function SessionRow(props: SessionRowProps): ReactElement {
       </button>
       {/* Right-aligned, always-visible state-as-action: a running session shows
           STOP (■, click to pause it); a paused one shows PLAY (▶, click to
-          resume). The glyph is the at-a-glance state AND the action. */}
-      {isPaused ? (
+          resume). Headless occupancy locks Play instead of offering Stop. */}
+      {isPaused || headlessOccupying ? (
         <button
           type="button"
-          className={rowAction()}
+          className={`${rowAction()} disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/70`}
           title={resumeLabel}
           aria-label={resumeLabel}
+          disabled={resumeLocked}
           onClick={(e) => {
             e.stopPropagation();
-            props.onResume();
+            if (!resumeLocked) props.onResume();
           }}
         >
           <Play size={11} strokeWidth={0} fill="currentColor" />
@@ -712,16 +735,18 @@ export function SessionRow(props: SessionRowProps): ReactElement {
           <Square size={10} strokeWidth={0} fill="currentColor" />
         </button>
       )}
-      <SidebarActionMenu
-        label={t('common.moreActions', { target: display })}
-        items={[{
-          label: t('workspace.deleteSessionAction'),
-          ariaLabel: deleteLabel,
-          icon: <X size={13} strokeWidth={2.5} />,
-          onSelect: props.onDelete,
-          danger: true,
-        }]}
-      />
+      {canDelete && (
+        <SidebarActionMenu
+          label={t('common.moreActions', { target: display })}
+          items={[{
+            label: t('workspace.deleteSessionAction'),
+            ariaLabel: deleteLabel,
+            icon: <X size={13} strokeWidth={2.5} />,
+            onSelect: props.onDelete,
+            danger: true,
+          }]}
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/components/workspace/WorkspaceNavigationDialogs.tsx
+++ b/ui/src/components/workspace/WorkspaceNavigationDialogs.tsx
@@ -17,8 +17,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { formatRelativeTime } from '../../lib/intl'
-import type { SessionRecord, Workspace } from './api'
+import type { SessionRecord, Workspace, WorkspaceSessionDirectory } from './api'
 import { workspaceDisplayName, workspaceDisplayTitle } from './display'
+import {
+  joinWorkspaceHarnessSessions,
+  type HarnessSession,
+} from './harness-sessions'
 import { orderSessionsForSidebar } from './sidebar-order'
 
 interface DialogFocusProps {
@@ -150,10 +154,12 @@ export interface ConversationBrowserDialogProps extends DialogFocusProps {
   harness?: 'chat' | 'auto-quant'
   open: boolean
   workspaces: readonly Workspace[]
+  directories?: ReadonlyMap<string, WorkspaceSessionDirectory>
   currentWorkspaceId: string | null
-  activeSessionId: string | null
+  isRowActive?: (row: HarnessSession) => boolean
+  activeSessionId?: string | null
   onOpenChange: (open: boolean) => void
-  onSelectSession: (workspaceId: string, sessionId: string) => void
+  onSelectSession: (row: HarnessSession) => void
 }
 
 export function ConversationBrowserDialog(props: ConversationBrowserDialogProps): ReactElement {
@@ -173,22 +179,34 @@ export function ConversationBrowserDialog(props: ConversationBrowserDialogProps)
 
   const sessions = useMemo(() => props.workspaces
     .filter((workspace) => scope === 'all' || workspace.id === props.currentWorkspaceId)
-    .flatMap((workspace) => workspace.sessions.map((session) => ({ workspace, session })))
-    .sort((a, b) => {
-      const active = Date.parse(b.session.lastActiveAt) - Date.parse(a.session.lastActiveAt)
-      if (active !== 0) return active
-      return b.session.id.localeCompare(a.session.id)
-    }), [props.currentWorkspaceId, props.workspaces, scope])
+    .flatMap((workspace) => {
+      const rows = joinWorkspaceHarnessSessions(
+        workspace,
+        props.directories?.get(workspace.id) ?? null,
+      )
+      return rows.map((row) => ({ workspace, row }))
+    })
+    .sort((left, right) => {
+      const running = Number(right.row.occupancyRunning) - Number(left.row.occupancyRunning)
+      if (running !== 0) return running
+      const occupancy = right.row.occupancyAt - left.row.occupancyAt
+      if (occupancy !== 0) return occupancy
+      return left.row.resumeId.localeCompare(right.row.resumeId)
+    }), [props.currentWorkspaceId, props.directories, props.workspaces, scope])
 
   const visibleSessions = useMemo(() => {
     const normalized = query.trim().toLocaleLowerCase()
-    return sessions.filter(({ workspace, session }) => {
-      if (stateFilter !== 'all' && session.state !== stateFilter) return false
+    return sessions.filter(({ workspace, row }) => {
+      if (stateFilter === 'running' && !row.occupancyRunning) return false
+      if (stateFilter === 'paused' && row.occupancyRunning) return false
       if (!normalized) return true
       return [
-        session.title,
-        session.name,
-        session.agent,
+        row.title,
+        row.resumeId,
+        row.agent,
+        row.directory?.latestExecution?.issueId,
+        row.directory?.latestExecution?.assistantPreview,
+        row.session?.name,
         workspace.displayName,
         workspace.tag,
       ].some((value) => value?.toLocaleLowerCase().includes(normalized))
@@ -283,42 +301,51 @@ export function ConversationBrowserDialog(props: ConversationBrowserDialogProps)
             </div>
           ) : (
             <ul className="space-y-1">
-              {visibleSessions.map(({ workspace, session }) => {
-                const title = session.title?.trim() || session.name
-                const active = workspace.id === props.currentWorkspaceId && session.id === props.activeSessionId
+              {visibleSessions.map(({ workspace, row }) => {
+                const title = row.headlessOccupying
+                  ? t('workspace.sessionRunning', { title: row.title })
+                  : row.title
+                const active = props.isRowActive?.(row)
+                  ?? (workspace.id === props.currentWorkspaceId && row.session?.id === props.activeSessionId)
+                const occupancyIso = row.occupancyAt > 0
+                  ? new Date(row.occupancyAt).toISOString()
+                  : row.session?.lastActiveAt
                 return (
-                  <li key={`${workspace.id}:${session.id}`}>
+                  <li key={`${workspace.id}:${row.resumeId}`}>
                     <button
                       type="button"
-                      onClick={() => props.onSelectSession(workspace.id, session.id)}
+                      onClick={() => {
+                        if (!row.headlessOccupying) props.onSelectSession(row)
+                      }}
+                      disabled={row.headlessOccupying}
                       aria-label={title}
                       aria-current={active ? 'page' : undefined}
                       className={`oa-nav-row flex min-h-16 w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
                         active ? 'bg-primary/10 text-foreground' : 'text-foreground hover:bg-muted'
-                      }`}
+                      } disabled:cursor-default disabled:opacity-70`}
                     >
                       <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border ${
-                        session.state === 'running'
+                        row.occupancyRunning
                           ? 'border-success/25 bg-success/10 text-success'
                           : 'border-border/70 bg-secondary text-muted-foreground'
                       }`}>
                         <Bot size={16} strokeWidth={2} aria-hidden />
                       </span>
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium" title={title}>{title}</span>
+                        <span className={`block truncate text-sm font-medium ${row.failed ? 'text-muted-foreground/70' : ''}`} title={row.title}>{row.title}</span>
                         <span className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 text-[11px] text-muted-foreground">
                           <span className="truncate">{workspaceDisplayName(workspace)}</span>
-                          <span className="font-mono">{session.agent}</span>
-                          <span>{formatRelativeTime(session.lastActiveAt)}</span>
+                          <span className="font-mono">{row.agent}</span>
+                          {occupancyIso && <span>{formatRelativeTime(occupancyIso)}</span>}
                         </span>
                       </span>
                       <span className={`hidden shrink-0 items-center gap-1.5 rounded-full px-2 py-1 text-[10px] font-medium sm:inline-flex ${
-                        session.state === 'running'
+                        row.occupancyRunning
                           ? 'bg-success/10 text-success'
                           : 'bg-muted text-muted-foreground'
                       }`}>
-                        <span className={`h-1.5 w-1.5 rounded-full ${session.state === 'running' ? 'bg-success' : 'bg-muted-foreground/45'}`} aria-hidden />
-                        {session.state === 'running' ? t('workspace.filterRunning') : t('workspace.paused')}
+                        <span className={`h-1.5 w-1.5 rounded-full ${row.occupancyRunning ? 'bg-success' : 'bg-muted-foreground/45'}`} aria-hidden />
+                        {row.occupancyRunning ? t('workspace.filterRunning') : t('workspace.paused')}
                       </span>
                       <Clock3 size={14} strokeWidth={2} className="shrink-0 text-muted-foreground/50" aria-hidden />
                     </button>

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -762,6 +762,8 @@ export interface WorkspaceSessionDirectoryEntry {
   readonly agent: string;
   readonly createdAt: number;
   readonly updatedAt: number;
+  readonly lifecycle?: 'active' | 'retired';
+  readonly successorResumeId?: string;
   readonly resumable: boolean;
   readonly active: boolean;
   /** Present when this product Session was allocated after birth metadata shipped. */
@@ -776,6 +778,8 @@ export interface WorkspaceSessionDirectoryEntry {
     readonly taskId: string;
     readonly status: 'running' | 'done' | 'failed' | 'interrupted';
     readonly startedAt: number;
+    readonly finishedAt?: number;
+    readonly durationMs?: number;
     readonly issueId?: string;
     readonly assistantPreview?: string;
   };

--- a/ui/src/components/workspace/harness-sessions.spec.ts
+++ b/ui/src/components/workspace/harness-sessions.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionRecord, Workspace, WorkspaceSessionDirectoryEntry } from './api'
+import {
+  flattenHarnessSessions,
+  harnessSessionTitle,
+  joinWorkspaceHarnessSessions,
+  orderHarnessSessions,
+  shortResumeId,
+  toHarnessSession,
+} from './harness-sessions'
+
+function session(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'session-1',
+    resumeId: 'resume-interactive',
+    wsId: 'ws-1',
+    agent: 'pi',
+    name: 'p1',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    lastActiveAt: '2026-08-01T01:00:00.000Z',
+    state: 'paused',
+    pid: null,
+    startedAt: null,
+    title: 'Interactive thesis',
+    ...overrides,
+  }
+}
+
+function workspace(sessions: readonly SessionRecord[] = [session()]): Workspace {
+  return {
+    id: 'ws-1',
+    tag: 'chat-aug1',
+    dir: '/tmp/chat-aug1',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    template: 'chat',
+    sessions: [...sessions],
+  }
+}
+
+function entry(overrides: Partial<WorkspaceSessionDirectoryEntry> = {}): WorkspaceSessionDirectoryEntry {
+  return {
+    resumeId: 'resume-headless-only',
+    agent: 'codex',
+    createdAt: Date.parse('2026-08-02T00:00:00.000Z'),
+    updatedAt: Date.parse('2026-08-02T02:00:00.000Z'),
+    lifecycle: 'active',
+    resumable: true,
+    active: false,
+    latestExecution: {
+      taskId: 'task-1',
+      status: 'done',
+      startedAt: Date.parse('2026-08-02T01:50:00.000Z'),
+      finishedAt: Date.parse('2026-08-02T02:00:00.000Z'),
+      assistantPreview: 'Morning scan complete. Semis still lead.',
+    },
+    ...overrides,
+  }
+}
+
+describe('harness session titles', () => {
+  it('prefers the interactive title, then preview, issue, then a short resume id', () => {
+    expect(harnessSessionTitle(session(), entry({ resumeId: 'resume-interactive' }))).toBe('Interactive thesis')
+    expect(harnessSessionTitle(null, entry())).toBe('Morning scan complete. Semis still lead.')
+    expect(harnessSessionTitle(null, entry({
+      latestExecution: { taskId: 'task-1', status: 'done', startedAt: 1, issueId: 'scan-open' },
+    }))).toBe('scan-open')
+    expect(harnessSessionTitle(null, entry({
+      resumeId: 'resume-calm-amber-river-a1b2c3',
+      latestExecution: undefined,
+    }))).toBe(shortResumeId('resume-calm-amber-river-a1b2c3'))
+  })
+})
+
+describe('joinWorkspaceHarnessSessions', () => {
+  it('falls back to materialized Sessions until Directory arrives', () => {
+    const rows = joinWorkspaceHarnessSessions(workspace(), null)
+    expect(rows.map((row) => row.resumeId)).toEqual(['resume-interactive'])
+    expect(rows[0]?.session?.id).toBe('session-1')
+  })
+
+  it('keeps Directory-only colleagues and hides retired identities', () => {
+    const rows = joinWorkspaceHarnessSessions(workspace(), {
+      workspace: { id: 'ws-1', tag: 'chat-aug1' },
+      sessions: [
+        entry({ resumeId: 'resume-interactive', interactive: {
+          name: 'p1',
+          title: 'Interactive thesis',
+          state: 'paused',
+          lastActiveAt: '2026-08-01T01:00:00.000Z',
+        } }),
+        entry(),
+        entry({ resumeId: 'resume-retired', lifecycle: 'retired' }),
+      ],
+    })
+
+    expect(rows.map((row) => row.resumeId)).toEqual([
+      'resume-headless-only',
+      'resume-interactive',
+    ])
+    expect(rows[0]?.session).toBeNull()
+    expect(rows[0]?.title).toBe('Morning scan complete. Semis still lead.')
+  })
+
+  it('locks TUI while headless occupies and sorts running occupancy first', () => {
+    const paused = session({ lastActiveAt: '2026-08-03T00:00:00.000Z' })
+    const runningHeadless = entry({
+      resumeId: 'resume-running',
+      active: true,
+      latestExecution: { taskId: 'task-run', status: 'running', startedAt: Date.parse('2026-08-02T12:00:00.000Z') },
+    })
+    const failed = entry({
+      resumeId: 'resume-failed',
+      latestExecution: {
+        taskId: 'task-fail',
+        status: 'failed',
+        startedAt: Date.parse('2026-08-04T11:00:00.000Z'),
+        finishedAt: Date.parse('2026-08-04T11:05:00.000Z'),
+      },
+    })
+
+    const rows = joinWorkspaceHarnessSessions(workspace([paused]), {
+      workspace: { id: 'ws-1', tag: 'chat-aug1' },
+      sessions: [
+        entry({ resumeId: paused.resumeId }),
+        runningHeadless,
+        failed,
+      ],
+    })
+
+    expect(rows.map((row) => row.resumeId)).toEqual([
+      'resume-running',
+      'resume-failed',
+      'resume-interactive',
+    ])
+    expect(rows[0]).toMatchObject({
+      occupancyRunning: true,
+      headlessOccupying: true,
+      resumable: true,
+    })
+    expect(toHarnessSession('ws-1', paused, runningHeadless).headlessOccupying).toBe(true)
+    expect(rows.find((row) => row.resumeId === 'resume-failed')?.failed).toBe(true)
+  })
+
+  it('does not lock an interactive TUI that is already the occupant', () => {
+    const live = session({ state: 'running', pid: 9, startedAt: 1 })
+    const row = toHarnessSession('ws-1', live, entry({
+      resumeId: live.resumeId,
+      active: true,
+      latestExecution: { taskId: 'old', status: 'done', startedAt: 1 },
+    }))
+    expect(row.occupancyRunning).toBe(true)
+    expect(row.headlessOccupying).toBe(false)
+  })
+})
+
+describe('orderHarnessSessions', () => {
+  it('keeps one resumeId as one row when flattening several desks', () => {
+    const other: Workspace = { ...workspace([]), id: 'ws-2', tag: 'chat-aug2', dir: '/tmp/chat-aug2' }
+    const rows = flattenHarnessSessions(
+      [workspace(), other],
+      new Map([
+        ['ws-2', {
+          workspace: { id: 'ws-2', tag: 'chat-aug2' },
+          sessions: [entry({
+            latestExecution: {
+              taskId: 'task-new',
+              status: 'done',
+              startedAt: Date.parse('2026-08-04T00:00:00.000Z'),
+              finishedAt: Date.parse('2026-08-04T00:10:00.000Z'),
+              assistantPreview: 'Newer occupancy',
+            },
+          })],
+        }],
+      ]),
+    )
+    expect(rows.map((row) => `${row.workspaceId}:${row.resumeId}`)).toEqual([
+      'ws-2:resume-headless-only',
+      'ws-1:resume-interactive',
+    ])
+  })
+})

--- a/ui/src/components/workspace/harness-sessions.ts
+++ b/ui/src/components/workspace/harness-sessions.ts
@@ -1,0 +1,173 @@
+import type { SessionRecord, Workspace, WorkspaceSessionDirectory, WorkspaceSessionDirectoryEntry } from './api'
+
+const PREVIEW_TITLE_LIMIT = 48
+
+export interface HarnessSession {
+  readonly workspaceId: string
+  readonly resumeId: string
+  readonly agent: string
+  readonly title: string
+  readonly occupancyAt: number
+  readonly occupancyRunning: boolean
+  readonly headlessOccupying: boolean
+  readonly failed: boolean
+  readonly resumable: boolean
+  readonly session: SessionRecord | null
+  readonly directory: WorkspaceSessionDirectoryEntry | null
+}
+
+function timestamp(value: string | number | undefined): number {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0
+  if (typeof value !== 'string') return 0
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export function shortResumeId(resumeId: string): string {
+  const trimmed = resumeId.replace(/^resume-/, '')
+  return trimmed.length <= 12 ? trimmed : trimmed.slice(0, 12)
+}
+
+export function harnessSessionTitle(
+  session: SessionRecord | null,
+  entry: WorkspaceSessionDirectoryEntry | null,
+): string {
+  const interactiveTitle = session?.title?.trim() || entry?.interactive?.title?.trim()
+  if (interactiveTitle) return interactiveTitle
+
+  const preview = entry?.latestExecution?.assistantPreview?.replace(/\s+/g, ' ').trim()
+  if (preview) {
+    return preview.length > PREVIEW_TITLE_LIMIT
+      ? `${preview.slice(0, PREVIEW_TITLE_LIMIT - 1)}…`
+      : preview
+  }
+
+  const issueId = entry?.latestExecution?.issueId?.trim()
+  if (issueId) return issueId
+
+  if (session?.name.trim()) return session.name.trim()
+  return shortResumeId(session?.resumeId ?? entry?.resumeId ?? 'session')
+}
+
+export function harnessOccupancyAt(
+  session: SessionRecord | null,
+  entry: WorkspaceSessionDirectoryEntry | null,
+): number {
+  const times = [
+    timestamp(session?.lastActiveAt),
+    timestamp(session?.createdAt),
+    timestamp(entry?.interactive?.lastActiveAt),
+    entry?.latestExecution?.finishedAt ?? 0,
+    entry?.latestExecution?.startedAt ?? 0,
+    entry?.updatedAt ?? 0,
+    entry?.createdAt ?? 0,
+  ]
+  return times.reduce((latest, value) => Math.max(latest, value), 0)
+}
+
+export function isHeadlessOccupying(
+  session: SessionRecord | null,
+  entry: WorkspaceSessionDirectoryEntry | null,
+): boolean {
+  if (entry?.latestExecution?.status === 'running') return true
+  return Boolean(entry?.active && session?.state !== 'running')
+}
+
+export function toHarnessSession(
+  workspaceId: string,
+  session: SessionRecord | null,
+  entry: WorkspaceSessionDirectoryEntry | null,
+): HarnessSession {
+  const resumeId = session?.resumeId ?? entry?.resumeId ?? ''
+  const interactiveRunning = session?.state === 'running'
+  const headlessOccupying = isHeadlessOccupying(session, entry)
+  return {
+    workspaceId,
+    resumeId,
+    agent: session?.agent ?? entry?.agent ?? 'pi',
+    title: harnessSessionTitle(session, entry),
+    occupancyAt: harnessOccupancyAt(session, entry),
+    occupancyRunning: interactiveRunning || headlessOccupying,
+    headlessOccupying,
+    failed: entry?.latestExecution?.status === 'failed',
+    resumable: entry ? entry.resumable : session !== null,
+    session,
+    directory: entry,
+  }
+}
+
+/** Running occupancy first (TUI or headless), then latest occupancy. */
+export function orderHarnessSessions<T extends {
+  occupancyRunning: boolean
+  occupancyAt: number
+  resumeId: string
+}>(rows: readonly T[]): T[] {
+  return [...rows].sort((left, right) => {
+    const running = Number(right.occupancyRunning) - Number(left.occupancyRunning)
+    if (running !== 0) return running
+    const occupancy = right.occupancyAt - left.occupancyAt
+    if (occupancy !== 0) return occupancy
+    return left.resumeId.localeCompare(right.resumeId)
+  })
+}
+
+/**
+ * Join Directory identities with materialized SessionRecords.
+ * Directory-only colleagues stay visible. Until Directory arrives, the
+ * materialized list is the fallback roster.
+ */
+export function joinWorkspaceHarnessSessions(
+  workspace: Workspace,
+  directory: WorkspaceSessionDirectory | null,
+): HarnessSession[] {
+  const sessionsByResume = new Map(
+    workspace.sessions.map((session) => [session.resumeId, session]),
+  )
+
+  if (!directory) {
+    return orderHarnessSessions(
+      workspace.sessions.map((session) => toHarnessSession(workspace.id, session, null)),
+    )
+  }
+
+  const seen = new Set<string>()
+  const rows: HarnessSession[] = []
+  for (const entry of directory.sessions) {
+    if ((entry.lifecycle ?? 'active') === 'retired') continue
+    seen.add(entry.resumeId)
+    rows.push(toHarnessSession(workspace.id, sessionsByResume.get(entry.resumeId) ?? null, entry))
+  }
+  for (const session of workspace.sessions) {
+    if (seen.has(session.resumeId)) continue
+    rows.push(toHarnessSession(workspace.id, session, null))
+  }
+  return orderHarnessSessions(rows)
+}
+
+export function sessionRecordForRow(row: HarnessSession): SessionRecord {
+  if (row.session) {
+    return row.session.title === row.title ? row.session : { ...row.session, title: row.title }
+  }
+  const occupancy = row.occupancyAt > 0 ? new Date(row.occupancyAt).toISOString() : new Date().toISOString()
+  return {
+    id: `resume:${row.resumeId}`,
+    resumeId: row.resumeId,
+    wsId: row.workspaceId,
+    agent: row.agent,
+    name: row.title,
+    createdAt: occupancy,
+    lastActiveAt: occupancy,
+    state: 'paused',
+    pid: null,
+    startedAt: null,
+    title: row.title,
+  }
+}
+
+export function flattenHarnessSessions(
+  workspaces: readonly Workspace[],
+  directories: ReadonlyMap<string, WorkspaceSessionDirectory>,
+): HarnessSession[] {
+  return orderHarnessSessions(workspaces.flatMap((workspace) =>
+    joinWorkspaceHarnessSessions(workspace, directories.get(workspace.id) ?? null)))
+}

--- a/ui/src/demo/handlers/workspaces-resume.spec.ts
+++ b/ui/src/demo/handlers/workspaces-resume.spec.ts
@@ -5,6 +5,7 @@ import { setupServer } from 'msw/node'
 
 import {
   DEMO_AUTO_QUANT_WORKSPACE_ID,
+  DEMO_CHAT_WORKSPACE_ID,
   DEMO_MACRO_WORKSPACE_ID,
 } from '../fixtures/workspaces'
 import { resetDemoWorkspaceWebPiState, workspacesHandlers } from './workspaces'
@@ -64,5 +65,31 @@ describe('demo Workspace resume handlers', () => {
       (candidate: { id: string }) => candidate.id === DEMO_AUTO_QUANT_WORKSPACE_ID,
     )
     expect(workspace.sessions).toContainEqual(expect.objectContaining({ id: `run-${resumeId}` }))
+  })
+
+  it('lists Directory-only Chat colleagues without inventing SessionRecords', async () => {
+    const response = await fetch(`${baseUrl}/api/workspaces/${DEMO_CHAT_WORKSPACE_ID}/resumes`)
+    expect(response.status).toBe(200)
+    const body = await response.json() as {
+      sessions: Array<{ resumeId: string; lifecycle?: string; active?: boolean; latestExecution?: { status: string } }>
+    }
+    expect(body.sessions.map((session) => session.resumeId)).toEqual(expect.arrayContaining([
+      'demo-resume-chat',
+      'resume-demo-headless-colleague',
+      'resume-demo-headless-running',
+      'resume-demo-headless-retired',
+    ]))
+    expect(body.sessions.find((session) => session.resumeId === 'resume-demo-headless-colleague'))
+      .toMatchObject({ active: false, latestExecution: { status: 'done' } })
+    expect(body.sessions.find((session) => session.resumeId === 'resume-demo-headless-running'))
+      .toMatchObject({ active: true, latestExecution: { status: 'running' } })
+
+    const workspaces = await fetch(`${baseUrl}/api/workspaces`).then((response) => response.json())
+    const chat = workspaces.workspaces.find(
+      (candidate: { id: string }) => candidate.id === DEMO_CHAT_WORKSPACE_ID,
+    )
+    expect(chat.sessions.map((session: { resumeId: string }) => session.resumeId)).not.toEqual(
+      expect.arrayContaining(['resume-demo-headless-colleague', 'resume-demo-headless-running']),
+    )
   })
 })

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
 import {
   DEMO_AUTO_QUANT_WORKSPACE_ID,
+  DEMO_CHAT_WORKSPACE_ID,
   demoChatWorkspace,
   demoWorkspaces,
   demoTemplates,
@@ -916,30 +917,98 @@ export const workspacesHandlers = [
           lifecycle: 'active', resumable: true, active: false,
           latestExecution: {
             taskId: 'demo-thesis-owner-run', status: 'done',
-            startedAt: Date.now() - 60_000,
+            startedAt: Date.now() - 180_000,
+            finishedAt: Date.now() - 60_000,
             assistantPreview: 'Reviewed the active thesis invalidation rules.',
           },
         }],
       })
     }
     const workspace = demoWorkspaces.find((candidate) => candidate.id === wsId)
+    const sessions: Array<{
+      resumeId: string
+      agent: string
+      createdAt: number
+      updatedAt: number
+      lifecycle: 'active' | 'retired'
+      resumable: boolean
+      active: boolean
+      interactive?: {
+        name: string
+        title?: string
+        state: 'running' | 'paused'
+        lastActiveAt: string
+      }
+      latestExecution?: {
+        taskId: string
+        status: 'running' | 'done' | 'failed' | 'interrupted'
+        startedAt: number
+        finishedAt?: number
+        issueId?: string
+        assistantPreview?: string
+      }
+    }> = (workspace?.sessions ?? []).map((session) => ({
+      resumeId: session.resumeId,
+      agent: session.agent,
+      createdAt: Date.parse(session.createdAt),
+      updatedAt: Date.parse(session.lastActiveAt),
+      lifecycle: 'active',
+      resumable: session.agent !== 'shell',
+      active: session.state === 'running',
+      interactive: {
+        name: session.name,
+        ...(session.title ? { title: session.title } : {}),
+        state: session.state,
+        lastActiveAt: session.lastActiveAt,
+      },
+    }))
+    if (wsId === DEMO_CHAT_WORKSPACE_ID) {
+      sessions.push(
+        {
+          resumeId: 'resume-demo-headless-colleague',
+          agent: 'codex',
+          createdAt: Date.now() - 3_600_000,
+          updatedAt: Date.now() - 120_000,
+          lifecycle: 'active',
+          resumable: true,
+          active: false,
+          latestExecution: {
+            taskId: 'demo-headless-colleague-run',
+            status: 'done',
+            startedAt: Date.now() - 180_000,
+            finishedAt: Date.now() - 120_000,
+            assistantPreview: 'Morning scan complete. Semis still lead.',
+          },
+        },
+        {
+          resumeId: 'resume-demo-headless-running',
+          agent: 'claude',
+          createdAt: Date.now() - 720_000,
+          updatedAt: Date.now() - 5_000,
+          lifecycle: 'active',
+          resumable: true,
+          active: true,
+          latestExecution: {
+            taskId: 'demo-headless-running',
+            status: 'running',
+            startedAt: Date.now() - 30_000,
+            issueId: 'scan-open',
+          },
+        },
+        {
+          resumeId: 'resume-demo-headless-retired',
+          agent: 'pi',
+          createdAt: Date.now() - 86_400_000,
+          updatedAt: Date.now() - 86_000_000,
+          lifecycle: 'retired',
+          resumable: false,
+          active: false,
+        },
+      )
+    }
     return HttpResponse.json({
       workspace: { id: wsId, tag: workspace?.tag ?? wsId },
-      sessions: (workspace?.sessions ?? []).map((session) => ({
-        resumeId: session.resumeId,
-        agent: session.agent,
-        createdAt: Date.parse(session.createdAt),
-        updatedAt: Date.parse(session.lastActiveAt),
-        lifecycle: 'active',
-        resumable: session.agent !== 'shell',
-        active: session.state === 'running',
-        interactive: {
-          name: session.name,
-          ...(session.title ? { title: session.title } : {}),
-          state: session.state,
-          lastActiveAt: session.lastActiveAt,
-        },
-      })),
+      sessions,
     })
   }),
   http.post('/api/workspaces/:id/resumes/:resumeId/session', async ({ params, request }) => {

--- a/ui/src/hooks/useWorkspaceSessionDirectory.spec.ts
+++ b/ui/src/hooks/useWorkspaceSessionDirectory.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WorkspaceSessionDirectory } from '../components/workspace/api'
+import {
+  useWorkspaceSessionDirectories,
+  useWorkspaceSessionDirectory,
+} from './useWorkspaceSessionDirectory'
+
+const mocks = vi.hoisted(() => ({
+  getWorkspaceSessionDirectory: vi.fn(),
+}))
+
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return {
+    ...actual,
+    getWorkspaceSessionDirectory: mocks.getWorkspaceSessionDirectory,
+  }
+})
+
+function directory(workspaceId: string): WorkspaceSessionDirectory {
+  return {
+    workspace: { id: workspaceId, tag: workspaceId },
+    sessions: [{
+      resumeId: `resume-${workspaceId}`,
+      agent: 'codex',
+      createdAt: 1,
+      updatedAt: 2,
+      lifecycle: 'active',
+      resumable: true,
+      active: false,
+    }],
+  }
+}
+
+beforeEach(() => {
+  mocks.getWorkspaceSessionDirectory.mockImplementation(async (workspaceId: string) =>
+    directory(workspaceId))
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useWorkspaceSessionDirectory', () => {
+  it('loads and exposes Directory occupancy for one Workspace', async () => {
+    const { result } = renderHook(() => useWorkspaceSessionDirectory('ws-1'))
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.directory?.workspace.id).toBe('ws-1')
+    expect(result.current.directory?.sessions[0]?.resumeId).toBe('resume-ws-1')
+    expect(result.current.error).toBeNull()
+    expect(mocks.getWorkspaceSessionDirectory).toHaveBeenCalledWith('ws-1')
+  })
+
+  it('covers loading and error semantics for the selected desks', async () => {
+    mocks.getWorkspaceSessionDirectory.mockRejectedValue(new Error('directory offline'))
+    const { result } = renderHook(() => useWorkspaceSessionDirectories(['ws-1', 'ws-2']))
+
+    await waitFor(() => expect(result.current.error).toBe('directory offline'))
+    expect(result.current.directories.size).toBe(0)
+
+    mocks.getWorkspaceSessionDirectory.mockImplementation(async (workspaceId: string) =>
+      directory(workspaceId))
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.error).toBeNull()
+    expect([...result.current.directories.keys()]).toEqual(['ws-1', 'ws-2'])
+  })
+
+  it('does not fetch while no Workspace is in view', async () => {
+    const { result } = renderHook(() => useWorkspaceSessionDirectories([]))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.directories.size).toBe(0)
+    expect(mocks.getWorkspaceSessionDirectory).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/hooks/useWorkspaceSessionDirectory.ts
+++ b/ui/src/hooks/useWorkspaceSessionDirectory.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  getWorkspaceSessionDirectory,
+  type WorkspaceSessionDirectory,
+} from '../components/workspace/api'
+
+const POLL_MS = 3000
+
+export interface WorkspaceSessionDirectorySnapshot {
+  readonly directory: WorkspaceSessionDirectory | null
+  readonly loading: boolean
+  readonly error: string | null
+  refresh(): Promise<void>
+}
+
+export interface WorkspaceSessionDirectoriesSnapshot {
+  readonly directories: ReadonlyMap<string, WorkspaceSessionDirectory>
+  readonly loading: boolean
+  readonly error: string | null
+  refresh(): Promise<void>
+}
+
+function sortedIds(workspaceIds: readonly string[]): string[] {
+  return [...new Set(workspaceIds.filter(Boolean))].sort()
+}
+
+/**
+ * Domain read for one Workspace Session Directory (`GET /resumes`).
+ * Presentation components consume this hook instead of fetching Directory
+ * rows from a feature file.
+ */
+export function useWorkspaceSessionDirectory(
+  workspaceId: string | null,
+): WorkspaceSessionDirectorySnapshot {
+  const snapshot = useWorkspaceSessionDirectories(workspaceId ? [workspaceId] : [])
+  return useMemo(() => ({
+    directory: workspaceId ? snapshot.directories.get(workspaceId) ?? null : null,
+    loading: snapshot.loading,
+    error: snapshot.error,
+    refresh: snapshot.refresh,
+  }), [snapshot, workspaceId])
+}
+
+/**
+ * Directory snapshots for the desks currently visible in Ask Alice / Quant.
+ * Polls with the Workspace list so occupancy locks stay live.
+ */
+export function useWorkspaceSessionDirectories(
+  workspaceIds: readonly string[],
+): WorkspaceSessionDirectoriesSnapshot {
+  const ids = useMemo(() => sortedIds(workspaceIds), [workspaceIds])
+  const idsKey = ids.join('|')
+  const [directories, setDirectories] = useState<ReadonlyMap<string, WorkspaceSessionDirectory>>(
+    () => new Map(),
+  )
+  const [error, setError] = useState<string | null>(null)
+  const mounted = useRef(true)
+  const directoriesRef = useRef(directories)
+  directoriesRef.current = directories
+
+  const refresh = useCallback(async () => {
+    const requested = idsKey.length === 0 ? [] : idsKey.split('|')
+    if (requested.length === 0) {
+      if (mounted.current) {
+        setDirectories(new Map())
+        setError(null)
+      }
+      return
+    }
+
+    const results = await Promise.allSettled(
+      requested.map(async (workspaceId) => {
+        const directory = await getWorkspaceSessionDirectory(workspaceId)
+        return { workspaceId, directory }
+      }),
+    )
+    if (!mounted.current) return
+
+    const next = new Map(directoriesRef.current)
+    const failures: string[] = []
+    for (const key of next.keys()) {
+      if (!requested.includes(key)) next.delete(key)
+    }
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        next.set(result.value.workspaceId, result.value.directory)
+      } else {
+        failures.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
+      }
+    }
+    const missing = requested.filter((workspaceId) => !next.has(workspaceId))
+    setDirectories(next)
+    setError(missing.length === requested.length
+      ? failures[0] ?? 'Failed to load Workspace Sessions'
+      : null)
+  }, [idsKey])
+
+  useEffect(() => {
+    mounted.current = true
+    void refresh()
+    const timer = setInterval(() => void refresh(), POLL_MS)
+    return () => {
+      mounted.current = false
+      clearInterval(timer)
+    }
+  }, [refresh])
+
+  const loading = ids.some((workspaceId) => !directories.has(workspaceId)) && error === null
+
+  return useMemo(
+    () => ({ directories, loading, error, refresh }),
+    [directories, error, loading, refresh],
+  )
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1956,6 +1956,8 @@ export const en = {
     active: 'active',
     running: 'running',
     resumeSession: 'Resume {{title}}',
+    sessionRunning: 'Running · {{title}}',
+    sessionNotResumable: 'Cannot resume {{title}}',
     stopSession: 'Stop {{title}}',
     deleteSession: 'Delete {{title}}',
     deleteSessionAction: 'Delete session',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1945,6 +1945,8 @@ export const ja: Resources = {
     active: '実行中',
     running: '実行中',
     resumeSession: '「{{title}}」を再開',
+    sessionRunning: '実行中 · {{title}}',
+    sessionNotResumable: '「{{title}}」は再開できません',
     stopSession: '「{{title}}」を停止',
     deleteSession: '「{{title}}」を削除',
     deleteSessionAction: 'セッションを削除',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1952,6 +1952,8 @@ export const zhHant: Resources = {
     active: '執行中',
     running: '執行中',
     resumeSession: '繼續「{{title}}」',
+    sessionRunning: '執行中 · {{title}}',
+    sessionNotResumable: '無法繼續「{{title}}」',
     stopSession: '暫停「{{title}}」',
     deleteSession: '刪除「{{title}}」',
     deleteSessionAction: '刪除工作階段',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1944,6 +1944,8 @@ export const zh: Resources = {
     active: '运行中',
     running: '运行中',
     resumeSession: '继续“{{title}}”',
+    sessionRunning: '运行中 · {{title}}',
+    sessionNotResumable: '无法继续“{{title}}”',
     stopSession: '暂停“{{title}}”',
     deleteSession: '删除“{{title}}”',
     deleteSessionAction: '删除会话',


### PR DESCRIPTION
## Summary
- Ask Alice / Quant now list Workspace employees by `resumeId`, joining `GET /api/workspaces/:id/resumes` with materialized `SessionRecord`s.
- Directory-only colleagues (never opened in TUI) appear on the same roster. Birth method does not hide a row.
- While a headless turn occupies that `resumeId` (`latestExecution.status === 'running'` or Directory `active` without a live TUI), Play/title cannot attach TUI and the row reads as running.
- Browse all uses the same join. Running includes headless occupancy. Automation stays a `taskId` dispatch list.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4100 passed)
- Live `http://127.0.0.1:5175/chat`: chat-jun15 roster went from 26 materialized conversations to 60 Directory employees; Directory-only rows have Resume and no Delete; opening `你好喵` still attaches the existing Session.
- Quant uses the same shell (16 research rows). Automation still shows 248 runs.

## Residual risk
- No live headless-running occupancy was on the desk during browser verification. The TUI lock is covered by hook/join/SessionRow/ChatWorkspaceSection unit tests and demo Directory fixtures.
- Persisted shapes are unchanged.