### PR TITLE
feat(ui): scroll the full Ask Alice session roster

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,9 +21,10 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/session-roster-headless-occupancy.md]] — Ask Alice / Quant list
-  Workspace employees by `resumeId`, including Directory-only colleagues, and
-  lock TUI attach while a headless turn occupies that Session.
+- [[plans/session-presence.md]] — Give product Sessions an in-desk presence
+  (`active` / `archived` / `deleted`) separate from workspace `retired`, uncap
+  the Ask Alice roster, and make Archive the floor action instead of deleting
+  a coworker.
 - [[plans/release-feedback-reliability.md]] — Makes packaged release failures
   deterministic and diagnostic first, then removes desktop matrix fan-in and
   reuses trusted promotion evidence without weakening release gates.
@@ -37,6 +38,10 @@ the durable truth after it changes.
 
 ## Completed
 
+- [[plans/session-roster-headless-occupancy.md]] — Ask Alice / Quant list
+  Workspace employees by `resumeId`, including Directory-only colleagues, and
+  lock TUI attach while a headless turn occupies that Session. Delivered in
+  serial PR #1068.
 - [[plans/nano-alice.md]] — Adds immutable AliceProject product birth through
   `openalice create alice-project`, with atomic first-writer ownership and a
   Guardian contract that never starts UTA for Nano homes. Accepted and

--- a/plans/session-presence.md
+++ b/plans/session-presence.md
@@ -1,0 +1,133 @@
+# Plan: Session floor presence (active / archived / deleted)
+
+**Status:** active  
+**Owner guides:** [[docs/workspace-lifecycle.md]], [[docs/conversation-provenance.md]]  
+**Delivery:** serial PRs to `dev` (`area:workspace`). Increment 2 is `review:deep`. Open PR, do not merge.
+
+## Goal
+
+Ask Alice / Quant 名册上的「删」不是拆 TUI 座位，也不是把人从世界上抹掉。员工（`resumeId`）在桌内有三档在职状态：
+
+| 状态 | 含义 |
+|---|---|
+| 在职 `active` | 花名册上的同事 |
+| 归档 `archived` | 从名册收进柜子，人还在，痕迹还在，还能找回 |
+| 删除 `deleted` | 软开除：不再上工，但署名和产物仍能找到这个人 |
+
+现有 `lifecycle: retired` **保持原意**：整桌 offboard 时人跟桌子一起走。不拿它当归档。
+
+顺带去掉侧栏截断和行内 Browse（底栏菜单里已有）。
+
+## Why not grow `lifecycle`
+
+`resume-identities.json` 已随 0.89.2+ 发布。`lifecycle` 只有 `active | retired`，且 `retired` 被 offboard / restore / follow-up 写成「跟桌子走了」。
+
+若把 `archived` / `deleted` 塞进同一个字段：
+
+- 旧解析器把未知值当成 `active`（`=== 'retired' ? retired : active`）；
+- `recallWorkspace` 会把归档/软删一律拉回在职。
+
+所以拆第二轴，缺省即在职，旧文件不用 migration：
+
+```ts
+lifecycle: 'active' | 'retired'   // 桌：在岗 / 跟桌走了（已发布）
+presence:  'active' | 'archived' | 'deleted'  // 人：在职 / 归档 / 软删（新，缺省 active）
+```
+
+名册一行：`lifecycle === 'active' && (presence ?? 'active') === 'active'`。
+
+## Product rules
+
+| 表面 | `active` | `archived` | `deleted` | `retired`（跟桌） |
+|---|---|---|---|---|
+| Ask Alice / Quant 侧栏 | 是 | 否 | 否 | 否 |
+| Browse：默认 / Archived 筛 | 默认 | Archived 筛 | 不进 Browse | 否 |
+| Play / 拉 TUI | 是 | Browse 里可以，**不**自动恢复到名册 | 否 | 否 |
+| 新 Issue 选人 | 是 | 否 | 否 | 否 |
+| 已指派的 `@resumeId` 再跑 | 是 | 是（归档不是停工） | 否 | 否 |
+| Follow-up | exact | exact（人还在） | unavailable `deleted-session` | unavailable `retired-session` |
+| 新 headless / `ensure` | 是 | 是 | 拒 | 拒 |
+
+- 侧栏 More 主操作是 **Archive**，不是 Delete。Delete 是二次确认的软开除。
+- 正在占班（TUI 或 headless running）时 Archive / Delete 都锁。
+- Archive / Delete **不**拆 `SessionRecord` 座位；座位仍只是椅子。现有 `DELETE /sessions/:sid` 继续只拆椅子——产品路径改走 presence。
+- 归档可 Restore → `presence=active`。软删可 Undelete → `archived`（先回柜子，不直接站回名册）。
+- 真物理删除不存在。产物、Inbox、run 历史、`resumeId` 署名都留着。
+
+## Alternatives considered
+
+1. **只扩 `lifecycle`** — 和已发布的跟桌 `retired`、restore 全员召回冲突。否。
+2. **侧栏 Delete = 直接 `deleted`** — 日常整理代价太大。否；主操作是 Archive。
+3. **归档即 follow-up unavailable** — 归档只是收纳，不是人走了。否。
+4. **Play 归档行则自动 Restore** — 打开档案夹不应把人弹回工位。否。
+
+## Increments
+
+### 1. 侧栏自己滚（无持久化）
+
+Ask Alice 壳（Quant 共用）：
+
+- 去掉 `FOCUSED_CHAT_SESSION_LIMIT`（8）和 `CHAT_SIDEBAR_SESSION_LIMIT`（6）以及行内 `ConversationListFooter`。
+- Focused / Workspace 树下列完整名册，现有 `overflow-y-auto` 自己滚。
+- Recent across Workspaces 去掉 `ALL_WORKSPACES_SESSION_LIMIT`（30），同样滚。
+- Browse 只留在底栏折叠菜单。不在列表底下再放一颗。
+
+验收：60 人的 desk 可以一滚到底；底栏仍能打开 Browse。
+
+### 2. `presence` + Archive（`review:deep`）
+
+- `ResumeIdentityRecord.presence?`；读写缺省 `active`。不改 `resume-identities.json` version，不加 migration。
+- `ResumeRegistry.setPresence({ resumeId, presence, now })`：`retired` 身份拒绝改 presence。
+- `PATCH /api/workspaces/:id/resumes/:resumeId` body `{ presence }`。409：running / retired / 非法迁移（例如 `deleted → active` 必须先 undelete）。
+- Directory 投影 `presence`。Join 仍藏 `retired`；名册再滤非 `active` presence。
+- SessionRow More：在职 → Archive；归档行（Browse）→ Restore + Delete。
+- `conversation-control`：`deleted` → `deleted-session`；`archived` 仍 exact。
+- Issue 选人列表只出在职。owner guide 补 presence 与 `retired` 的分工。
+- Demo `/resumes` 带一条 archived 同事，确认不进 Recent。
+
+### 3. Soft-delete 收尾（可与 2 同 PR，若 2 已过大则拆）
+
+- More → Delete（二次确认）→ `deleted`。
+- Undelete → `archived`。
+- Browse 仍不列出 `deleted`。署名 / 产物 follow-up 走 `deleted-session`，不新雇一个人顶上。
+- `ensure` / 新 headless / 新指派拒绝 `deleted`。
+
+## Out of scope
+
+- 物理删 identity / 原生 transcript
+- Manager 名册、Automation 调度页
+- 侧栏 `createdBy` 徽章
+- 把 `DELETE /sessions/:sid` 重解释成 Archive
+- 独立「已归档员工」活动页
+
+## Verification
+
+```text
+npx tsc --noEmit
+cd ui && npx tsc -b
+pnpm test
+```
+
+浏览器（5175 Chat + 一眼 Quant）：
+
+1. 名册可滚完全部在职员工；列表下没有 Browse。
+2. Archive 后行消失；Browse → Archived 能 Restore。
+3. 占班中不能 Archive。
+4. Soft-delete 后 Browse / 名册都没有；`@resumeId` 仍解析为这个人，只是不可上工。
+5. Offboard / restore 桌仍只动 `lifecycle`，不把归档人洗成在职。
+
+## Acceptance
+
+- [x] 侧栏按最近占班列出全部在职员工，不再截断
+- [x] 行内 Browse 去掉；查找只走底栏
+- [ ] Archive 把人移出名册，不毁掉 `resumeId`
+- [ ] Deleted 是软开除，工作留痕仍找得到人
+- [ ] `retired` 仍只表示跟桌走了
+- [ ] PR 开出后交给审查，不合
+
+## Checklist
+
+- [x] Increment 1：去掉截断和行内 Browse + 单测
+- [ ] Increment 2：`presence` + PATCH + 名册/Browse/follow-up + owner guide
+- [ ] Increment 3：soft-delete / undelete（若未并进 2）
+- [ ] 浏览器走 Chat 与 Quant

--- a/plans/session-roster-headless-occupancy.md
+++ b/plans/session-roster-headless-occupancy.md
@@ -1,6 +1,6 @@
 # Plan: Session roster by resumeId (lock TUI while headless)
 
-**Status:** active  
+**Status:** completed (delivered in PR #1068)  
 **Owner guides:** [[docs/conversation-provenance.md]], [[docs/workspace-issues-and-scheduling.md]]  
 **Delivery:** serial PR to `dev` (`area:workspace`)
 

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -421,24 +421,21 @@ describe('ChatWorkspaceSection actions', () => {
     expect(retryTemplates).toHaveBeenCalledOnce()
   })
 
-  it('bounds expanded Workspace history and opens the complete conversation Dialog', () => {
+  it('scrolls the full Workspace roster and keeps Browse in the context menu', () => {
     const sessions = Array.from({ length: 9 }, (_, index) => chatSession(index + 1))
     const onNavigate = vi.fn()
     renderSection([{ ...chatWorkspace, sessions }], null, onNavigate)
 
-    expect(screen.getAllByRole('button', { name: /^Conversation/ })).toHaveLength(6)
-    expect(screen.queryByRole('button', { name: 'Conversation 3' })).toBeNull()
+    expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(9)
+    expect(screen.getByRole('button', { name: 'Conversation 3' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'View all 9 sessions' })).toBeNull()
 
-    const browseAll = screen.getByRole('button', { name: 'View all 9 sessions' })
-    expect(browseAll.textContent).toBe('Browse all conversations')
-    expect(browseAll.className).toContain('w-full')
-    expect(browseAll.className).not.toContain('oa-pressable')
-    expect(browseAll.parentElement?.className).toContain('border-t')
-    fireEvent.click(browseAll)
+    fireEvent.click(screen.getByRole('button', { name: 'Chat context: Workspaces' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Browse all conversations' }))
 
     const dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
     const browser = within(dialog)
-    expect(browser.getAllByRole('button', { name: /^Conversation/ })).toHaveLength(9)
+    expect(browser.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(9)
     expect(openOrFocus).not.toHaveBeenCalled()
 
     fireEvent.click(browser.getByRole('button', { name: 'Conversation 3' }))

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -59,9 +59,6 @@ import type { ChatDisplayMode } from './chat-display-mode'
 
 const CHAT_TEMPLATE = 'chat'
 const AUTO_QUANT_TEMPLATE = 'auto-quant-v2'
-const CHAT_SIDEBAR_SESSION_LIMIT = 6
-const FOCUSED_CHAT_SESSION_LIMIT = 8
-const ALL_WORKSPACES_SESSION_LIMIT = 30
 
 function nextWorkspaceTag(workspaces: readonly Workspace[], base: string): string {
   const tags = new Set(workspaces.map((workspace) => workspace.tag))
@@ -318,7 +315,6 @@ export function ChatWorkspaceSection({
           onPauseSession={pauseRosterSession}
           onResumeSession={resumeRosterSession}
           onDeleteSession={deleteRosterSession}
-          onBrowseSessions={(workspaceId, restoreFocus) => openConversationBrowser(workspaceId, restoreFocus)}
           onCreateWorkspace={() => setShowCreate(true)}
         />
       ) : displayMode === 'recent' ? (
@@ -396,7 +392,6 @@ export function ChatWorkspaceSection({
         {chatWorkspaces.map((w) => (
           <ChatWorkspaceRow
             key={w.id}
-            harness={mode}
             workspace={w}
             sessions={rosterByWorkspace.get(w.id) ?? []}
             label={workspaceDisplayName(w)}
@@ -414,7 +409,6 @@ export function ChatWorkspaceSection({
             onConfigure={() => ctx.openAgentConfig(w.id)}
             onDelete={() => setPendingDelete(w)}
             onSpawn={() => navigate({ kind: landingKind, params: { targetWsId: w.id } })}
-            onBrowseSessions={(restoreFocus) => openConversationBrowser(w.id, restoreFocus)}
           />
         ))}
       </ul>
@@ -687,7 +681,6 @@ interface FocusedChatWorkspaceProps {
   onPauseSession: (row: HarnessSession) => void
   onResumeSession: (row: HarnessSession) => void
   onDeleteSession: (row: HarnessSession) => void
-  onBrowseSessions: (workspaceId: string, restoreFocus: HTMLElement | null) => void
   onCreateWorkspace: () => void
 }
 
@@ -712,9 +705,8 @@ function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): Rea
     [props.workspaces],
   )
   const sessions = props.sessions
-  const visibleSessions = sessions.slice(0, ALL_WORKSPACES_SESSION_LIMIT)
   const sessionListRef = useReorderMotion<HTMLDivElement>(
-    visibleSessions.map((row) => `${row.workspaceId}:${row.resumeId}`),
+    sessions.map((row) => `${row.workspaceId}:${row.resumeId}`),
   )
 
   if (props.loading) {
@@ -752,7 +744,7 @@ function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): Rea
           <p className="px-3 py-3 text-xs leading-relaxed text-muted-foreground/60">
             {props.harness === 'auto-quant' ? t('autoQuant.noResearchYet') : t('chat.noRecentConversations')}
           </p>
-        ) : visibleSessions.map((row) => (
+        ) : sessions.map((row) => (
           <HarnessSessionRow
             key={`${row.workspaceId}:${row.resumeId}`}
             row={row}
@@ -785,9 +777,8 @@ function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): Rea
 function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
   const { t } = useTranslation()
   const sessions = props.sessions
-  const visibleSessions = sessions.slice(0, FOCUSED_CHAT_SESSION_LIMIT)
   const sessionListRef = useReorderMotion<HTMLDivElement>(
-    visibleSessions.map((row) => row.resumeId),
+    sessions.map((row) => row.resumeId),
   )
 
   if (props.loading) {
@@ -840,7 +831,7 @@ function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
           <p className="px-3 py-3 text-xs text-muted-foreground/60">
             {props.emptyCopy ?? t('chat.noConversationsYet')}
           </p>
-        ) : visibleSessions.map((row) => (
+        ) : sessions.map((row) => (
           <HarnessSessionRow
             key={row.resumeId}
             row={row}
@@ -851,45 +842,8 @@ function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
             onDelete={() => props.onDeleteSession(row)}
           />
         ))}
-        {sessions.length > visibleSessions.length && (
-          <ConversationListFooter
-            harness={props.harness}
-            count={sessions.length}
-            onOpen={(restoreFocus) => props.onBrowseSessions(props.workspace!.id, restoreFocus)}
-          />
-        )}
       </div>
 
-    </div>
-  )
-}
-
-function ConversationListFooter({
-  harness,
-  count,
-  onOpen,
-}: {
-  harness: 'chat' | 'auto-quant'
-  count: number
-  onOpen: (restoreFocus: HTMLElement | null) => void
-}): ReactElement {
-  const { t } = useTranslation()
-
-  return (
-    <div className="mx-2 mt-1 border-t border-border/55 pt-1">
-      <button
-        type="button"
-        aria-label={harness === 'auto-quant'
-          ? t('autoQuant.viewAllResearch', { count })
-          : t('chat.viewAllSessions', { count })}
-        onClick={(event) => onOpen(event.currentTarget)}
-        className="flex min-h-9 w-full items-center gap-2 rounded-md px-2 text-left text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35"
-      >
-        <span className="min-w-0 flex-1 truncate">
-          {harness === 'auto-quant' ? t('autoQuant.browseResearch') : t('chat.browseWorkspace')}
-        </span>
-        <ChevronRight size={13} strokeWidth={2} className="shrink-0 text-muted-foreground/60" aria-hidden />
-      </button>
     </div>
   )
 }
@@ -988,7 +942,6 @@ function ManagerWorkspaceRow(props: ManagerWorkspaceRowProps): ReactElement {
 }
 
 interface ChatWorkspaceRowProps {
-  harness: 'chat' | 'auto-quant'
   workspace: Workspace
   sessions: readonly HarnessSession[]
   label: string
@@ -1003,8 +956,6 @@ interface ChatWorkspaceRowProps {
   onDelete: () => void
   /** Spawn a fresh agent session in THIS workspace (and open it). */
   onSpawn: () => void
-  /** Open the scalable conversation browser scoped to this Workspace. */
-  onBrowseSessions: (restoreFocus: HTMLElement | null) => void
 }
 
 function HarnessSessionRow(props: {
@@ -1046,9 +997,8 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
   const displayName = w.displayName?.trim()
   const subtitle = displayName && displayName !== w.tag ? w.tag : null
   const actionWorkspace = subtitle ? `${props.label} (${w.tag})` : w.tag
-  const visibleSessions = orderedSessions.slice(0, CHAT_SIDEBAR_SESSION_LIMIT)
   const sessionListRef = useReorderMotion<HTMLDivElement>(
-    visibleSessions.map((row) => row.resumeId),
+    orderedSessions.map((row) => row.resumeId),
   )
 
   const statusClass = hasRunning
@@ -1146,7 +1096,7 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
       </div>
       {expanded && orderedSessions.length > 0 && (
         <div ref={sessionListRef} className="oa-disclosure-enter ml-[18px] border-l border-border/50">
-          {visibleSessions.map((row) => (
+          {orderedSessions.map((row) => (
             <HarnessSessionRow
               key={row.resumeId}
               row={row}
@@ -1157,13 +1107,6 @@ function ChatWorkspaceRow(props: ChatWorkspaceRowProps): ReactElement {
               onDelete={() => props.onDeleteSession(row)}
             />
           ))}
-          {orderedSessions.length > visibleSessions.length && (
-            <ConversationListFooter
-              harness={props.harness}
-              count={orderedSessions.length}
-              onOpen={props.onBrowseSessions}
-            />
-          )}
         </div>
       )}
     </li>


### PR DESCRIPTION
## Summary
- Ask Alice / Quant no longer cap the session roster at 8 / 6 / 30 rows or hide the rest behind an inline Browse footer.
- The list scrolls in place. Search stays in the Workspace context menu, which already had Browse all.
- Records `plans/session-presence.md`: in-desk `presence` (`active` / `archived` / `deleted`) is a later increment, separate from workspace `retired`.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4100 passed)
- Live 5175 Chat: `chat-jun15` shows all 60 employees, no "View all"; Browse remains in the context menu. Quant Recent research (16) likewise has no inline Browse.

## Residual risk
- Archive / soft-delete are **not** in this PR. Headless-only rows still have no More menu; that waits on increment 2 (`review:deep`).
- Please do not merge from this agent. Leave for PR review.