### PR TITLE
Ignore local Playwright inspection artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,11 @@ coverage/
 # Claude Code — ignore local config, but track shared dev skills/commands
 .claude/*
 !.claude/skills/
+/.claude/skills/playwright-cli/
 .playwright-mcp/
+/.playwright-cli/
+# Local accessibility snapshot exported by Playwright CLI during UI inspection.
+/oa-chat.yaml
 # Stray screenshots at repo root (playwright captures, manual screen grabs).
 # UI assets live under ui/public/ or ui/src/assets/ — never at the root.
 /*.png


### PR DESCRIPTION
## Summary
- ignore Playwright CLI runtime captures
- ignore the local Playwright CLI skill installation
- ignore the root accessibility snapshot used during UI inspection

## Why
These local inspection artifacts were appearing as untracked repository changes because the existing ignore rule only covered the Playwright MCP output directory.

## Verification
- verified all three generated paths with git check-ignore
- verified the tracked shared tool-audit skill remains visible
- git diff --check