### PR TITLE
docs(plans): record accepted PRs and remaining active work

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -21,16 +21,20 @@ the durable truth after it changes.
 
 ## Active
 
-- [[plans/release-feedback-reliability.md]] — Makes packaged release failures
-  deterministic and diagnostic first, then removes desktop matrix fan-in and
-  reuses trusted promotion evidence without weakening release gates.
+- [[plans/release-feedback-reliability.md]] — Batch 1 (deterministic/early
+  release feedback) landed in PR #1061. Batch 2 still needs per-platform N-1
+  fan-in and accepted-tree provenance without weakening release gates.
 - [[plans/electron-runtime-browser-handoff.md]] — Lets Electron detect a
   healthy dev/CLI Runtime already owning the selected data location and hand
-  the user to its verified browser UI without takeover.
+  the user to its verified browser UI without takeover. Not started; Electron
+  still presents a generic owner-conflict dialog.
 - [[plans/shell-first-cli-supervisor.md]] — Delivers a first-class Shell
   Supervisor TUI, persistent Guardian-owned Runtime lifecycle, standalone
   headless release bundle, atomic update/rollback, and real N-1 plus PTY
-  acceptance through serial increments.
+  acceptance through serial increments. Increments 1–2 and most of 4/6/7 are
+  in `dev`; remaining work is the TypeScript CLI conversion, logs/Doctor/update
+  UX, config check, registry deletion, authenticity-hardened updates, and
+  release-gate N-1.
 
 ## Completed
 
@@ -44,8 +48,8 @@ the durable truth after it changes.
   Accepted and delivered in PR #1064.
 - [[plans/alice-project-foundation.md]] — Promotes the existing named Instance,
   complete-home, Guardian, and frontend endpoint topology into the explicit
-  AliceProject product and lifecycle abstraction. Delivered for topic review in
-  Draft PR #1063.
+  AliceProject product and lifecycle abstraction. Accepted and delivered in
+  PR #1063.
 - [[plans/0892-migration-baseline.md]] — Retires the development-era 0001–0038
   migration chain, establishes 0.89.2-beta as the persisted-state baseline, and
   prevents isolated tests from combining a temporary journal with a live
@@ -62,11 +66,11 @@ the durable truth after it changes.
 - [[plans/static-markdown-content-stability.md]] — Keeps Inbox and Tracked
   Markdown DOM stable across unchanged Workspace Manager and Inbox polling so
   text selection, browser translation, and report interactions survive.
-  Delivered for topic review in Draft PR #1030.
+  Accepted and delivered in PR #1030.
 - [[plans/shadcn-resizable-page-sidebar.md]] — Replaced the hand-written
   page-sidebar rail with shadcn Resizable and closed its responsive,
   threshold-motion, resisted-overdrag, repeat-cycle, and rapid-reversal
-  contracts in Draft PR #1025.
+  contracts. Accepted and delivered in PR #1025.
 - [[plans/tracked-relationship-graph.md]] — Adds an Obsidian-style global and
   local relationship graph derived from Tracked entities and authored Workspace
   backlinks, with provenance-preserving material navigation.
@@ -106,8 +110,8 @@ the durable truth after it changes.
 - [[plans/shadcn-overlay-foundation.md]] — Established an OpenAlice-owned
   shadcn/Radix primitive layer, retired representative hand-written overlay
   behavior, and preserved the current product hierarchy and visual language as
-  the foundation for later runtime-selectable style profiles. Implemented in
-  Draft PR #970.
+  the foundation for later runtime-selectable style profiles. Accepted and
+  delivered in PR #970.
 - [[plans/desktop-upgrade-release-gate.md]] — Adds a real N-1 desktop-state
   upgrade journey to the native package matrix and validates final updater
   metadata and artifacts before a release can be published.

--- a/plans/alice-project-foundation.md
+++ b/plans/alice-project-foundation.md
@@ -1,6 +1,6 @@
 # AliceProject Foundation
 
-Status: Completed in Draft PR [#1063](https://github.com/TraderAlice/OpenAlice/pull/1063)
+Status: completed (accepted and delivered in PR #1063)
 
 Owner guides: [[docs/alice-project.md]], [[docs/project-structure.md]], [[docs/cli-supervisor.md]],
 [[docs/data-locations.md]], [[docs/local-runtime.md]],
@@ -110,7 +110,8 @@ status remains derived from the Guardian that owns that home.
 - [x] Complete typecheck, unit, Guardian recovery, browser, Electron PTY, and
   disposable packaged verification appropriate to the touched surfaces.
 - [x] Publish one autonomous-topic Draft PR to `dev` with the required workflow,
-  theme, area, and deep-review labels; leave it unmerged for maintainer acceptance.
+  theme, area, and deep-review labels. Accepted and merged as PR #1063 on
+  2026-08-12.
 
 ## Verification matrix
 

--- a/plans/release-feedback-reliability.md
+++ b/plans/release-feedback-reliability.md
@@ -7,6 +7,7 @@ Related evidence:
 - [0.89.3-beta release run 31495757352](https://github.com/TraderAlice/OpenAlice/actions/runs/31495757352)
 - [master CI run 31495757321](https://github.com/TraderAlice/OpenAlice/actions/runs/31495757321)
 - [promotion PR #1060](https://github.com/TraderAlice/OpenAlice/pull/1060)
+- [Batch 1 serial PR #1061](https://github.com/TraderAlice/OpenAlice/pull/1061) — merged to `dev` on 2026-08-11
 
 Owner guides:
 
@@ -118,6 +119,6 @@ native CI/release evidence.
 
 ## Completion
 
-Batch 1 is complete when all first-batch criteria and local verification pass
-and the serial PR is merged to `dev`. The overall plan remains active until the
-second-batch DAG and provenance criteria are implemented and measured.
+Batch 1 is complete: criteria, local verification, and serial PR #1061 are
+merged to `dev`. The overall plan remains active until the second-batch DAG
+and provenance criteria are implemented and measured.

--- a/plans/shadcn-overlay-foundation.md
+++ b/plans/shadcn-overlay-foundation.md
@@ -1,9 +1,10 @@
 # shadcn Overlay Foundation
 
-- Status: `complete` (implemented in Draft PR #970; awaiting maintainer acceptance)
-- Updated: `2026-08-04`
-- Delivery: one autonomous topic branch and community-facing Draft PR targeting
-  `dev`; the PR remains unmerged until maintainer acceptance.
+- Status: `completed` (accepted and delivered in PR #970)
+- Updated: `2026-08-13`
+- Delivery: autonomous topic PR #970 targeting `dev`; accepted and merged on
+  2026-08-04. Subsequent serial PRs #971 and #973 continued from that
+  foundation.
 - Related issues: none yet.
 - Owner guides: [[docs/ui-interaction-and-motion.md]],
   [[docs/project-structure.md]], and [[docs/development-workflow.md]].
@@ -120,8 +121,8 @@ Win98 skin and broad component restyling are deliberately outside this stage.
 - [x] Run the applicable Electron/package smoke before calling the stage
       complete.
 - [x] Update the owner guide with the durable primitive ownership contract.
-- [x] Publish and maintain one labelled Draft PR against `dev`; do not merge it
-      automatically.
+- [x] Publish and maintain one labelled Draft PR against `dev`. Accepted and
+      merged as PR #970 on 2026-08-04.
 
 ## Verification Evidence
 
@@ -154,5 +155,5 @@ gates, not modal primitives, and remain outside that migration.
 - Nested overlays close one layer at a time and reliably restore focus.
 - Required typechecks, the full test suite, real browser routes, and the chosen
   Electron/package smoke pass.
-- The Draft PR documents remaining custom overlays and names the next bounded
+- PR #970 documents remaining custom overlays and names the next bounded
   migration topic without hiding deferred defects in this plan.

--- a/plans/shadcn-resizable-page-sidebar.md
+++ b/plans/shadcn-resizable-page-sidebar.md
@@ -1,11 +1,11 @@
 # shadcn Resizable Page Sidebar
 
-- Status: `complete` (rapid-reversal repair included in Draft PR #1025; awaiting maintainer acceptance)
-- Updated: `2026-08-08`
-- Delivery: one autonomous topic Draft PR targeting `dev`; merge only after
-  maintainer acceptance.
+- Status: `completed` (accepted and delivered in PR #1025)
+- Updated: `2026-08-13`
+- Delivery: autonomous topic PR #1025 targeting `dev`; accepted and merged on
+  2026-08-08.
 - Related PRs: #1023 established the adjacent long-form reading surface but is
-  not part of this migration; Draft PR #1025 contains this implementation.
+  not part of this migration; PR #1025 contains this implementation.
 - Owner guides: [[docs/ui-interaction-and-motion.md]] and
   [[docs/development-workflow.md]].
 - Upstream reference: [shadcn Resizable](https://ui.shadcn.com/docs/components/base/resizable)
@@ -409,5 +409,5 @@ At every settled desktop layout exactly one surface is interactive:
   mobile routes keep their existing Sheet behavior and focus return.
 - All current shell consumers compile and representative real routes remain
   usable across the responsive and style-profile matrix.
-- Required browser, automated, build, and unsigned Electron checks pass, and a
-  single Draft PR contains the complete topic for maintainer acceptance.
+- Required browser, automated, build, and unsigned Electron checks pass.
+  Accepted and delivered in PR #1025.

--- a/plans/shell-first-cli-supervisor.md
+++ b/plans/shell-first-cli-supervisor.md
@@ -454,8 +454,8 @@ running Guardian, and TUI stop returned the home to absent.
 
 - [x] Inventory server/UI/Guardian outputs, production dependencies, native
   modules, Broker Pack boundary, and managed Pi injection.
-- [ ] Produce deterministic platform/architecture archives.
-- [ ] Define authenticated manifest, version, compatibility, Node requirement,
+- [x] Produce deterministic platform/architecture archives.
+- [x] Define authenticated manifest, version, compatibility, Node requirement,
   file hashes, and content identity.
 - [x] Install immutable Runtime versions and validate without a checkout.
 - [x] Add providers for bundle, source-development, Docker, Electron, and
@@ -805,3 +805,16 @@ This plan is complete only when:
   component health, while deliberately omitting `runtime.stop`. The real dev
   smoke proves CLI discovery, rejected stop, duplicate-writer refusal, and
   survival of the original owner in one isolated journey.
+- 2026-08-13: Plan-index audit against current `dev`. Increment 7's
+  platform/arch archives and hashed `runtime-manifest.json` already ship
+  through `pnpm build:headless-runtime` and the release matrix
+  (darwin/linux × arm64/x64), including an outside-checkout install/boot/
+  Doctor/`down` gate. Remaining increment 7 proof is still clean-host
+  Workspace PTY, optional components, and Pi. Increment 3 is still a hybrid
+  TypeScript/`mjs` CLI without `@xterm/headless`. Increment 4 still lacks a
+  dedicated component panel. Increment 5 still lacks log
+  filter/follow/pause, copyable Doctor remediation, update plan/progress
+  screens, and active-work disclosure. Increment 6 still lacks
+  `openalice config check`, last-known-good live reload, and registry-only
+  deletion. Increments 9–10 (atomic update/rollback and N-1 release gates)
+  remain unstarted. The plan stays Active.

--- a/plans/static-markdown-content-stability.md
+++ b/plans/static-markdown-content-stability.md
@@ -63,7 +63,8 @@ response.
 - [x] Run required TypeScript and test gates.
 - [x] Reproduce the real Inbox and Tracked routes and verify DOM identity over
       repeated polling intervals.
-- [x] Publish one labeled Draft PR to `dev` and keep it open for topic review.
+- [x] Publish one labeled Draft PR to `dev`; accepted and merged as PR #1030
+      on 2026-08-09.
 
 ## Verification
 
@@ -93,9 +94,9 @@ Observed on 2026-08-09:
 
 The plan is complete when the acceptance boundary is covered by tests, real
 route observation shows no Markdown subtree replacement for unchanged polls,
-the required checks pass, and the Draft PR records exact verification and any
+the required checks pass, and the PR records exact verification and any
 residual HTML-iframe risk.
 
-Completed in Draft PR
+Accepted and delivered in PR
 [#1030](https://github.com/TraderAlice/OpenAlice/pull/1030). Arbitrary HTML
 report iframe stability remains an explicit non-goal of this topic.


### PR DESCRIPTION
## Summary
- records accepted topic PRs in the completed plan index
- records Batch 1 of release feedback as landed while keeping Batch 2 active
- audits remaining Shell Supervisor work against current repository truth
- preserves the newly merged session-presence plan and records PR #1069 as increment 1

## Context
This replaces #1067, whose fork branch was based on an older dev and conflicted with the subsequently merged #1068 and #1069 plan updates.

## Verification
- cross-checked the cited PR merge states
- merged current dev into the replacement branch
- verified the final diff against dev contains only plan documentation
- git diff --check origin/dev...HEAD