### PR TITLE
feat(issues): add Run now for live scheduled Issues

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -200,7 +200,10 @@ The scanner persists only last-fired markers under the launcher state root.
 Schedule semantics remain in the issue file. Markers are written after a
 successful dispatch, meaning a durable run record was accepted. If that worker
 later fails to launch or exits unsuccessfully, the failed run remains the
-single attempt for that occurrence and the operator can use **Retry now**; the
+single attempt for that occurrence and the operator can use **Retry now**.
+**Run now** starts an extra turn without waiting for the next due time and
+without moving that marker, so a missed fire or a prompt test does not steal
+the next scheduled occurrence. The
 scanner does not turn its own tick interval into a retry storm. Capacity or
 another admission rejection that creates no run stays due for retry.
 
@@ -251,12 +254,18 @@ does not write the last-fired marker, so a recovery attempt never shifts the
 Issue's cadence. The backend rejects duplicate/racing retries and returns the
 authoritative running detail immediately; there is no automatic retry storm.
 
+**Run now** is the operator extra-turn control for any live scheduled Issue that
+is not already running. It uses the same dispatch path and confirmation dialog,
+does not require a failed last run, and also leaves the next-fire marker
+untouched. The two buttons stay separate: retry recovers a failed occurrence,
+run-now starts a specified Issue immediately.
+
 Headless runs may overlap with interactive sessions or other runs in the same
 checkout. Agents must tolerate concurrent edits. The launcher currently admits
 at most eight headless processes globally and serializes registry persistence,
 but there is no per-Workspace exclusive lock. One small dispatch-start guard
-prevents a manual retry and a schedule tick from launching the same Issue at the
-same instant; it is released as soon as the run is registered.
+prevents a Run now / Retry now click and a schedule tick from launching the same
+Issue at the same instant; it is released as soon as the run is registered.
 
 Offboarding is the lifecycle exception: a Workspace with a live headless run
 cannot depart. Once its Catalog row enters `offboarding`, new dispatch is

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -67,6 +67,11 @@ function build(inboxReports: InboxEntry[] = []) {
     if (!detail) throw new IssueRetryError('not_found', 'Issue not found.')
     return detail
   })
+  const runIssueNow = vi.fn(async (wsId: string, id: string) => {
+    const detail = await readDetail(wsId, id)
+    if (!detail) throw new IssueRetryError('not_found', 'Issue not found.')
+    return detail
+  })
   const svc = {
     registry: {
       get: (id: string) => (
@@ -91,9 +96,10 @@ function build(inboxReports: InboxEntry[] = []) {
     },
     issueDetail: readDetail,
     retryIssue,
+    runIssueNow,
     provenanceStore: { append: appendProvenance, list: vi.fn(), latest: vi.fn() },
   } as unknown as WorkspaceService
-  return { app: createIssuesRoutes(svc, { conversation }), appendProvenance, retryIssue, ask }
+  return { app: createIssuesRoutes(svc, { conversation }), appendProvenance, retryIssue, runIssueNow, ask }
 }
 
 async function req(app: any, method: string, path: string, body?: unknown) {
@@ -309,6 +315,29 @@ describe('POST /api/issues/:wsId/:id/retry', () => {
     const { app, retryIssue } = build()
     retryIssue.mockRejectedValueOnce(new IssueRetryError('already_running', 'This Issue already has a run in progress.'))
     const r = await req(app, 'POST', '/ws-1/i1/retry')
+    expect(r.status).toBe(409)
+    expect(r.body).toEqual({
+      error: 'already_running',
+      message: 'This Issue already has a run in progress.',
+    })
+  })
+})
+
+describe('POST /api/issues/:wsId/:id/run', () => {
+  it('returns the authoritative detail with 202', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
+    const { app, runIssueNow } = build()
+    const r = await req(app, 'POST', '/ws-1/i1/run')
+    expect(r.status).toBe(202)
+    expect(r.body.issue.id).toBe('i1')
+    expect(runIssueNow).toHaveBeenCalledWith('ws-1', 'i1')
+  })
+
+  it('maps a live-run conflict to 409', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
+    const { app, runIssueNow } = build()
+    runIssueNow.mockRejectedValueOnce(new IssueRetryError('already_running', 'This Issue already has a run in progress.'))
+    const r = await req(app, 'POST', '/ws-1/i1/run')
     expect(r.status).toBe(409)
     expect(r.body).toEqual({
       error: 'already_running',

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -11,6 +11,7 @@
  *   GET  /api/issues               → list across all workspaces
  *   GET  /api/issues/:wsId/:id      → one issue's detail { issue, activity, runs, inboxReports }
  *   POST /api/issues/:wsId/:id/retry → rerun the latest failed/interrupted schedule now
+ *   POST /api/issues/:wsId/:id/run   → dispatch a scheduled Issue now without a failed last run
  *
  * Phase 2b adds the human/UI WRITE path (the agent edits the files directly /
  * via its own tools). Both writes go through the shared mutation helper
@@ -125,6 +126,35 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
       launcherLogger.warn('issue.retry_failed', { wsId, id, err })
       return c.json({
         error: 'retry_failed',
+        message: err instanceof Error ? err.message : String(err),
+      }, 500)
+    }
+  })
+
+  // POST /api/issues/:wsId/:id/run — operator-started dispatch. Same live Issue
+  // prompt/owner/runtime as the scanner; the cadence marker is not advanced.
+  app.post('/:wsId/:id/run', async (c) => {
+    const wsId = c.req.param('wsId')
+    const id = c.req.param('id')
+    if (!validId(wsId) || !validId(id)) return c.json({ error: 'not_found' }, 404)
+    try {
+      return c.json(await svc.runIssueNow(wsId, id), 202)
+    } catch (err) {
+      if (err instanceof IssueRetryError) {
+        const status = err.code === 'not_found' ? 404
+          : err.code === 'not_scheduled' ? 422
+          : 409
+        return c.json({ error: err.code, message: err.message }, status)
+      }
+      if (err instanceof HeadlessCapacityError) {
+        return c.json({ error: 'capacity_reached', message: err.message }, 429)
+      }
+      if (err instanceof HeadlessResumeError) {
+        return c.json({ error: err.code, message: err.message }, 409)
+      }
+      launcherLogger.warn('issue.run_failed', { wsId, id, err })
+      return c.json({
+        error: 'run_failed',
         message: err instanceof Error ? err.message : String(err),
       }, 500)
     }

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -159,9 +159,9 @@ export class ScheduleScanner {
   }
 
   /** Dispatch one scheduled Issue immediately without touching its firing
-   * marker. This is the authoritative manual-retry path: it re-reads the live
-   * Issue and reuses the exact prompt, owner, runtime, and optional timeout used
-   * by the scanner, while preserving the next scheduled occurrence. */
+   * marker. This is the authoritative manual-run / retry path: it re-reads the
+   * live Issue and reuses the exact prompt, owner, runtime, and optional timeout used by
+   * the scanner, while preserving the next scheduled occurrence. */
   async runIssueNow(wsId: string, issueId: string): Promise<{ taskId: string }> {
     const ws = this.deps.registry.get(wsId)
     if (!ws) throw new ScheduledIssueRunNowError('not_found', 'Workspace not found.')
@@ -171,12 +171,12 @@ export class ScheduleScanner {
     const issue = res.issues.find((candidate) => candidate.id === issueId)
     if (!issue) throw new ScheduledIssueRunNowError('not_found', 'Issue not found.')
     if (!issue.when) {
-      throw new ScheduledIssueRunNowError('not_scheduled', 'Only scheduled Issues can be retried.')
+      throw new ScheduledIssueRunNowError('not_scheduled', 'Only scheduled Issues can be run now.')
     }
     if (!isFireable(issue)) {
       throw new ScheduledIssueRunNowError(
         'not_fireable',
-        `This Issue is ${issue.status}; reopen it before retrying.`,
+        `This Issue is ${issue.status}; reopen it before running.`,
       )
     }
 

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -519,6 +519,9 @@ export interface WorkspaceService {
   /** Retry the latest unsuccessful scheduled execution now. Reuses the live
    * Issue prompt/owner/runtime and never advances its schedule marker. */
   retryIssue(wsId: string, id: string): Promise<IssueDetail>;
+  /** Dispatch a scheduled Issue immediately without requiring a failed last
+   * run and without advancing its next-fire marker. */
+  runIssueNow(wsId: string, id: string): Promise<IssueDetail>;
   /** Safe Workspace Session index. resumeId is the only public conversation handle. */
   sessionDirectory(wsId: string, limit?: number): Promise<WorkspaceSessionDirectory | null>;
   /** Change in-desk floor presence. Does not retire or delete the coworker. */
@@ -2083,7 +2086,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   };
 
   const retryingIssueKeys = new Set<string>();
-  const retryIssue = async (wsId: string, id: string): Promise<IssueDetail> => {
+  const dispatchScheduledIssueNow = async (
+    wsId: string,
+    id: string,
+    kind: 'retry' | 'manual',
+  ): Promise<IssueDetail> => {
     const key = `${wsId}:${id}`;
     const ws = registry.get(wsId);
     if (!ws) throw new IssueRetryError('not_found', 'Workspace not found.');
@@ -2093,19 +2100,19 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       : undefined;
     if (!issue) throw new IssueRetryError('not_found', 'Issue not found.');
     if (!issue.when) {
-      throw new IssueRetryError('not_scheduled', 'Only scheduled Issues can be retried.');
+      throw new IssueRetryError('not_scheduled', 'Only scheduled Issues can be run now.');
     }
     if (issue.status === 'done' || issue.status === 'canceled') {
       throw new IssueRetryError(
         'not_fireable',
-        `This Issue is ${issue.status}; reopen it before retrying.`,
+        `This Issue is ${issue.status}; reopen it before running.`,
       );
     }
     const latest = headlessTasks.list({ issue: { workspaceId: wsId, issueId: id } })[0];
     if (latest?.status === 'running' || retryingIssueKeys.has(key)) {
       throw new IssueRetryError('already_running', 'This Issue already has a run in progress.');
     }
-    if (!latest || (latest.status !== 'failed' && latest.status !== 'interrupted')) {
+    if (kind === 'retry' && (!latest || (latest.status !== 'failed' && latest.status !== 'interrupted'))) {
       throw new IssueRetryError(
         'not_retryable',
         'Only the latest failed or interrupted scheduled run can be retried.',
@@ -2115,10 +2122,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     retryingIssueKeys.add(key);
     try {
       const { taskId } = await scheduleScanner.runIssueNow(wsId, id);
-      launcherLogger.info('issue.retry_dispatched', {
+      launcherLogger.info(kind === 'retry' ? 'issue.retry_dispatched' : 'issue.manual_run_dispatched', {
         wsId,
         issueId: id,
-        previousTaskId: latest.taskId,
+        previousTaskId: latest?.taskId,
         taskId,
       });
     } catch (err) {
@@ -2134,6 +2141,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     if (!detail) throw new IssueRetryError('not_found', 'Issue not found.');
     return detail;
   };
+  const retryIssue = async (wsId: string, id: string): Promise<IssueDetail> =>
+    dispatchScheduledIssueNow(wsId, id, 'retry');
+  const runIssueNow = async (wsId: string, id: string): Promise<IssueDetail> =>
+    dispatchScheduledIssueNow(wsId, id, 'manual');
 
   const setSessionPresence = async (input: {
     wsId: string
@@ -2587,6 +2598,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     issuesSnapshot,
     issueDetail,
     retryIssue,
+    runIssueNow,
     sessionDirectory,
     setSessionPresence,
     resolveIssuesByName,

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -332,4 +332,13 @@ export const issuesApi = {
       { method: 'POST', headers },
     )
   },
+
+  /** Dispatch a scheduled Issue now without requiring a failed last run.
+   * The backend preserves the cadence marker. */
+  async runNow(wsId: string, id: string): Promise<IssueDetail> {
+    return fetchJson<IssueDetail>(
+      `/api/issues/${encodeURIComponent(wsId)}/${encodeURIComponent(id)}/run`,
+      { method: 'POST', headers },
+    )
+  },
 }

--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -196,6 +196,18 @@ describe('IssueDetail manual run', () => {
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
     expect(mocks.runNow).not.toHaveBeenCalled()
   })
+
+  it('closes the confirmation and exposes a dispatch failure in the inspector', async () => {
+    mocks.runNow.mockRejectedValue(new Error('The Issue is already running.'))
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run now' }))
+    fireEvent.click(within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Run now' }))
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(screen.getByRole('alert').textContent).toContain('The Issue is already running.')
+    expect(mocks.mutate).not.toHaveBeenCalled()
+  })
 })
 
 describe('IssueActivity provenance identity', () => {

--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   listAgentCredentials: vi.fn(),
   getPresets: vi.fn(),
   updateIssue: vi.fn(),
+  runNow: vi.fn(),
 }))
 
 const scheduledIssue: IssueDetailData = {
@@ -91,6 +92,7 @@ vi.mock('../api/issues', async (importOriginal) => {
     issuesApi: {
       ...actual.issuesApi,
       update: mocks.updateIssue,
+      runNow: mocks.runNow,
     },
   }
 })
@@ -154,6 +156,46 @@ afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
   vi.clearAllMocks()
+})
+
+describe('IssueDetail manual run', () => {
+  it('confirms before dispatching a scheduled Issue without waiting for failure', async () => {
+    mocks.runNow.mockResolvedValue({
+      ...scheduledIssue,
+      runs: [{
+        taskId: 'run-now-1',
+        resumeId: 'resume-run-now',
+        resumable: false,
+        wsId: 'demo-ws-auto-quant',
+        issueId: 'morning-scan',
+        agent: 'codex',
+        prompt: scheduledIssue.issue.what,
+        status: 'running',
+        startedAt: Date.now(),
+      }],
+    })
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run now' }))
+    const dialog = screen.getByRole('alertdialog', { name: 'Run this Issue now?' })
+    expect(dialog.textContent).toContain('The next scheduled time stays unchanged.')
+    expect(mocks.runNow).not.toHaveBeenCalled()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Run now' }))
+    await waitFor(() => expect(mocks.runNow).toHaveBeenCalledWith('demo-ws-auto-quant', 'morning-scan'))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(mocks.mutate).toHaveBeenCalled()
+  })
+
+  it('does not dispatch when the confirmation is cancelled', async () => {
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run now' }))
+    const dialog = screen.getByRole('alertdialog', { name: 'Run this Issue now?' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(mocks.runNow).not.toHaveBeenCalled()
+  })
 })
 
 describe('IssueActivity provenance identity', () => {

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1750,7 +1750,6 @@ export function IssueDetail({
       mutate(await issuesApi.runNow(wsId, id))
     } catch (e) {
       setActionError(e instanceof Error ? e.message : String(e))
-      throw e
     } finally {
       setRetrying(false)
     }

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Brain, ChevronRight, Clock, Cpu, Hash, History, Inbox, KeyRound, ListChecks, MessageSquare, RotateCcw, Settings, Timer, TrendingUp, X } from 'lucide-react'
+import { ArrowLeft, Brain, ChevronRight, Clock, Cpu, Hash, History, Inbox, KeyRound, ListChecks, MessageSquare, Play, RotateCcw, Settings, Timer, TrendingUp, X } from 'lucide-react'
 
 import type { HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -42,6 +42,7 @@ import { useInboxSelection } from '../live/inbox-selection'
 import { previewForEntry } from '../live/inbox-threads'
 import { useWikilinkHandler } from '../live/wikilink'
 import { useWorkspace } from '../tabs/store'
+import { ConfirmDialog } from './ConfirmDialog'
 import { AutomationHealthPill, CadencePill, CadenceSummary, PriorityIndicator } from './IssuesBoard'
 import { IssueSectionNavigation } from './IssueSectionNavigation'
 import { STATUS_META } from './issue-status-meta'
@@ -566,8 +567,10 @@ function PropertiesRail({
   retrying,
   error,
   canRetry,
+  canRunNow,
   onPatch,
   onRetry,
+  onRunNow,
   onConfigureAgent,
 }: {
   wsId: string
@@ -582,11 +585,14 @@ function PropertiesRail({
   retrying: boolean
   error: string | null
   canRetry: boolean
+  canRunNow: boolean
   onPatch: (patch: IssuePatch) => void
   onRetry: () => void
+  onRunNow: () => Promise<void>
   onConfigureAgent: (agent: AgentId) => void
 }) {
   const { t } = useTranslation()
+  const [confirmRun, setConfirmRun] = useState(false)
   const meta = STATUS_META[issue.status]
   const issueDefaultInOptions = issueDefaultAgent && agentOptions.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
   const defaultInOptions = defaultAgent && agentOptions.some((a) => a.id === defaultAgent) ? defaultAgent : null
@@ -745,6 +751,19 @@ function PropertiesRail({
                   {issue.nextDueAtMs ? formatRelativeTime(issue.nextDueAtMs) : '—'}
                 </span>
               </div>
+              {canRunNow && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={retrying}
+                  onClick={() => setConfirmRun(true)}
+                  className="mt-3 w-full justify-center sm:w-auto"
+                >
+                  <Play size={12} aria-hidden />
+                  {retrying ? t('issues.detail.runningNow') : t('issues.detail.runNow')}
+                </Button>
+              )}
             </InspectorSection>
 
             <InspectorSection title={t('issues.detail.execution')}>
@@ -889,6 +908,21 @@ function PropertiesRail({
         )}
       </div>
       {error && <p role="alert" className="mt-2 text-xs leading-snug text-destructive">{error}</p>}
+      {confirmRun && (
+        <ConfirmDialog
+          title={t('issues.detail.runNowTitle')}
+          message={t('issues.detail.runNowMessage')}
+          confirmLabel={t('issues.detail.runNow')}
+          cancelLabel={t('common.cancel')}
+          workingLabel={t('issues.detail.runningNow')}
+          variant="primary"
+          onConfirm={async () => {
+            await onRunNow()
+            setConfirmRun(false)
+          }}
+          onClose={() => { if (!retrying) setConfirmRun(false) }}
+        />
+      )}
     </aside>
   )
 }
@@ -1708,6 +1742,20 @@ export function IssueDetail({
     }
   }, [retrying, wsId, id, mutate])
 
+  const onRunNow = useCallback(async () => {
+    if (retrying) return
+    setRetrying(true)
+    setActionError(null)
+    try {
+      mutate(await issuesApi.runNow(wsId, id))
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : String(e))
+      throw e
+    } finally {
+      setRetrying(false)
+    }
+  }, [retrying, wsId, id, mutate])
+
   const backToBoard = (
     <button
       type="button"
@@ -1757,6 +1805,12 @@ export function IssueDetail({
     && latestRun?.failure?.retryable
     && (latestRun.status === 'failed' || latestRun.status === 'interrupted'),
   )
+  const canRunNow = Boolean(
+    issue.when
+    && issue.status !== 'done'
+    && issue.status !== 'canceled'
+    && latestRun?.status !== 'running',
+  )
   const comments = data.comments ?? []
   const inboxReports = data.inboxReports ?? []
   const provenance = data.provenance ?? []
@@ -1799,8 +1853,10 @@ export function IssueDetail({
           retrying={retrying}
           error={actionError}
           canRetry={canRetry}
+          canRunNow={canRunNow}
           onPatch={onPatch}
           onRetry={() => void onRetry()}
+          onRunNow={onRunNow}
           onConfigureAgent={(agent) => openAgentConfig(wsId, agent)}
         />
         <div className="min-w-0 lg:col-start-1 lg:row-start-2">

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -609,6 +609,36 @@ export function demoIssueAddComment(
   return demoIssueDetail(wsId, id)
 }
 
+/** POST-run backing: operator-started dispatch without requiring a failed last run. */
+export function demoIssueRunNow(wsId: string, id: string): IssueDetail | null {
+  const boardIssue = findBoardIssue(wsId, id)
+  const extras = demoIssueExtras[`${wsId}/${id}`]
+  if (!boardIssue?.when || boardIssue.status === 'done' || boardIssue.status === 'canceled') {
+    return null
+  }
+  const latest = extras?.runs[0]
+  if (latest?.status === 'running') return null
+  const run: IssueRunRecord = {
+    taskId: `demo-run-${Date.now()}`,
+    resumeId: `demo-resume-run-${Date.now()}`,
+    resumable: false,
+    wsId,
+    issueId: id,
+    agent: boardIssue.agent ?? extras?.agent ?? latest?.agent ?? 'codex',
+    prompt: extras?.runs[0]?.prompt ?? boardIssue.title,
+    status: 'running',
+    startedAt: Date.now(),
+  }
+  if (!extras) return null
+  extras.runs.unshift(run)
+  boardIssue.automationHealth = {
+    state: 'running',
+    message: 'A scheduled run is in progress.',
+    latestTaskId: run.taskId,
+  }
+  return demoIssueDetail(wsId, id)
+}
+
 /** POST-retry backing: add a fresh running execution without changing cadence. */
 export function demoIssueRetry(wsId: string, id: string): IssueDetail | null {
   const boardIssue = findBoardIssue(wsId, id)

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -5,6 +5,7 @@ import {
   demoIssueAddComment,
   demoIssueDetail,
   demoIssueRetry,
+  demoIssueRunNow,
   demoIssueUpdate,
   demoIssuesSnapshot,
 } from '../fixtures/issues'
@@ -222,6 +223,15 @@ export const issuesHandlers = [
       : HttpResponse.json({
           error: 'not_retryable',
           message: 'Only the latest failed or interrupted scheduled run can be retried.',
+        }, { status: 409 })
+  }),
+  http.post('/api/issues/:wsId/:id/run', ({ params }) => {
+    const detail = demoIssueRunNow(String(params.wsId), String(params.id))
+    return detail
+      ? HttpResponse.json(detail, { status: 202 })
+      : HttpResponse.json({
+          error: 'not_fireable',
+          message: 'Only a live scheduled Issue can be run now.',
         }, { status: 409 })
   }),
 ]

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -167,6 +167,11 @@ export const en = {
       applyAiConfiguration: 'Apply configuration',
       retryNow: 'Retry now',
       retrying: 'Retrying…',
+      runNow: 'Run now',
+      runningNow: 'Starting…',
+      runNowTitle: 'Run this Issue now?',
+      runNowMessage:
+        'OpenAlice will start a headless turn with the current What, owner, and runtime. The next scheduled time stays unchanged.',
       healthMessage: {
         inactive: 'Schedule stopped because the Issue is {{status}}.',
         not_started: 'Schedule is valid and has not run yet.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -156,6 +156,11 @@ export const ja: Resources = {
       applyAiConfiguration: '設定を適用',
       retryNow: '今すぐ再試行',
       retrying: '再試行中…',
+      runNow: '今すぐ実行',
+      runningNow: '起動中…',
+      runNowTitle: 'この Issue を今すぐ実行しますか？',
+      runNowMessage:
+        '現在の What、担当、ランタイムでヘッドレス実行を開始します。次の予定時刻は変わりません。',
       healthMessage: {
         inactive: '課題のステータスが「{{status}}」のため、スケジュールは停止しています。',
         not_started: 'スケジュールは有効ですが、まだ実行されていません。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -163,6 +163,11 @@ export const zhHant: Resources = {
       applyAiConfiguration: '套用設定',
       retryNow: '立即重試',
       retrying: '正在重試…',
+      runNow: '立即執行',
+      runningNow: '正在啟動…',
+      runNowTitle: '現在執行這個議題？',
+      runNowMessage:
+        'OpenAlice 會用目前的 What、負責人和執行環境啟動一輪後台任務。下次預定時間不會改變。',
       healthMessage: {
         inactive: '議題狀態為「{{status}}」，執行排程已停止。',
         not_started: '執行排程有效，但尚未執行。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -155,6 +155,11 @@ export const zh: Resources = {
       applyAiConfiguration: '应用配置',
       retryNow: '立即重试',
       retrying: '正在重试…',
+      runNow: '立即运行',
+      runningNow: '正在启动…',
+      runNowTitle: '现在运行这个议题？',
+      runNowMessage:
+        'OpenAlice 会用当前的 What、负责人和运行时启动一轮后台任务。下次预定时间不会改变。',
       healthMessage: {
         inactive: '议题状态为“{{status}}”，运行计划已停止。',
         not_started: '运行计划有效，但尚未执行。',


### PR DESCRIPTION
Closes #1052.

## Summary
Scheduled Issues could only be started by hand after the latest run failed or was interrupted (`Retry now`). A missed fire (machine off) or a What edit left no operator path to start that Issue now.

This adds **Run now** on the Issue detail Schedule rail for any live scheduled Issue that is not already running. The button opens the shared shadcn `ConfirmDialog` (`AlertDialog` wrapper). Confirming calls `POST /api/issues/:wsId/:id/run`, which reuses the scanner's live What / owner / runtime dispatch and does **not** advance the last-fired marker. **Retry now** stays the failure-recovery control.

## Why this shape
- Dedicated `/run` instead of relaxing `/retry`: retry remains a gated recovery verb; run-now is an extra turn.
- Confirm before dispatch: starting a headless CLI is not undoable.
- Shared `ConfirmDialog` rather than a one-off modal: focus, Escape, busy state, and primary (non-destructive) tone already exist.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4132 passed, 9 skipped)
- Demo `http://127.0.0.1:5199`:
  - `morning-scan`: Run now → dialog → Cancel leaves cadence and run list unchanged; confirm POSTs `/run` (202), adds a running run, hides the button, next due stays `in 15h`
  - unscheduled `rebalance-sizing-review`: no Run now
  - interrupted `thesis-watch`: both Run now and Retry now
  - `weekly-digest` at 390×844: same confirm dialog, next due stays `in 4d`
  - Issues board still lists the same scheduled rows

## Residual risk
- Please do not merge from this agent; leave the PR for review.