### PR TITLE
fix(workspaces): keep probe auth single-header

### DIFF
--- a/src/workspaces/agent-probe.ts
+++ b/src/workspaces/agent-probe.ts
@@ -63,9 +63,13 @@ export async function probeAnthropic(input: ClaudeProbeInput): Promise<ProbeResu
   // `authToken` makes the SDK send `Authorization: Bearer`; `apiKey` makes it
   // send `x-api-key`. Pick exactly one — sending both can trip gateways that
   // reject ambiguous auth, and Anthropic's own API now 401s OAuth-via-Bearer.
+  // The SDK silently falls back to the ambient ANTHROPIC_API_KEY /
+  // ANTHROPIC_AUTH_TOKEN env vars when the matching option is `undefined`, so
+  // pin the unused credential to `null` (null skips the env fallback) to keep
+  // the wire carrying the configured key only.
   const client = input.authMode === 'bearer'
-    ? new Anthropic({ authToken: input.apiKey, baseURL: input.baseUrl, timeout: PROBE_TIMEOUT_MS, maxRetries: 0 })
-    : new Anthropic({ apiKey: input.apiKey, baseURL: input.baseUrl, timeout: PROBE_TIMEOUT_MS, maxRetries: 0 });
+    ? new Anthropic({ authToken: input.apiKey, apiKey: null, baseURL: input.baseUrl, timeout: PROBE_TIMEOUT_MS, maxRetries: 0 })
+    : new Anthropic({ apiKey: input.apiKey, authToken: null, baseURL: input.baseUrl, timeout: PROBE_TIMEOUT_MS, maxRetries: 0 });
 
   const extract = (msg: Anthropic.Message): string => msg.content
     .filter((b): b is Anthropic.TextBlock => b.type === 'text')


### PR DESCRIPTION
## What

The Workspace/credential "Test" button (probeAnthropic) could send **two** auth headers at once:

- `Authorization: Bearer <key>` **and** `x-api-key: <ambient key>` in bearer mode
- `x-api-key: <key>` **and** `Authorization: Bearer <ambient token>` in x-api-key mode

whenever `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` exist in the environment. The @anthropic-ai/sdk falls back to those env vars when the matching constructor option is `undefined` (client.mjs:70-75), and the probe only set one option — the other came from the environment.

Dual auth is exactly what agent-probe.spec.ts pins against: gateways like MiniMax's international endpoint 401 ambiguous dual-header requests, and Anthropic's own API 401s OAuth-via-Bearer. The failure was reproducible on any machine with the env vars set (local repro confirmed both headers on the wire).

## Fix

Pass the unused credential explicitly as `null` — the SDK's env fallback only applies when the option is `undefined`, so `null` keeps the wire carrying only the configured key:

- bearer mode: `{ authToken: key, apiKey: null }`
- x-api-key mode: `{ apiKey: key, authToken: null }`

## Verification

- `agent-probe.spec.ts`: 6/6 pass locally (3/6 before the fix on a machine with ANTHROPIC_* env vars set)
- `npx tsc --noEmit`: clean
- Full `pnpm test`: 4014 passed / 2 failed / 39 skipped — both residual failures are environmental on Windows (symlink EPERM without Developer Mode; timing flake), unrelated to this change
