### PR TITLE
feat(issues): optional scheduled run timeout

### DIFF
--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -43,7 +43,7 @@ You have two equivalent paths, and both write the **same**
    with no separate path.
 2. **Editing the file directly** with your normal file tools. Reach for this when
    you are writing rich markdown **What** or scheduling frontmatter
-  (`when` / `assignee` / `agent` / `credential` / `credentialSource` / `model` / `effort`) — the CLI verbs cover the board fields, What, and
+  (`when` / `assignee` / `agent` / `credential` / `credentialSource` / `model` / `effort` / `timeout`) — the CLI verbs cover the board fields, What, timeout, and
    comments, but the document and schedule shape read most clearly as text. The
    file is always the single source of truth either way.
 
@@ -64,10 +64,11 @@ alice-workspace issue create --title "Split the data fetcher" \
   --priority medium \
   --what "src/fetch.ts mixes the HTTP call with the normalization step."
 
-# update — patch board fields or canonical What; scheduling frontmatter is left
-# untouched. Setting status done|canceled is how
+# update — patch board fields, canonical What, or the optional run timeout;
+# scheduling cadence (`when`) is left untouched. Setting status done|canceled is how
 # you silence a self-scheduled issue (there is no separate enabled flag).
 alice-workspace issue update --id morning-scan --status done
+alice-workspace issue update --id morning-scan --timeout 30m
 
 # comment — append markdown to the structured `<id>.comments.json` sidecar. An
 # attributable Session signs with @resumeId. If somebody else comments on an
@@ -192,6 +193,9 @@ plain tracked item; add a `when` and it starts firing.
 - **`effort`** *(optional)* — one-run reasoning effort: `none`, `minimal`,
   `low`, `medium`, `high`, `xhigh`, or `max`. Use a level supported by the
   selected runtime; omit it to inherit.
+- **`timeout`** *(optional)* — scheduled-run watchdog: `15m`, `30m`, `45m`, or
+  `60m`. Omit it for no limit (the agent may run until it exits). This is a run
+  budget, not Session birth, so an exact `@resumeId` owner may still set it.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 They are valid only for `@new-then-resume` / `@new-each-run`; an exact `@resumeId` Session owns

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -82,6 +82,9 @@ The filename stem is the stable issue id. Frontmatter:
 - `effort` — optional one-run reasoning effort:
   `none | minimal | low | medium | high | xhigh | max`. The chosen runtime must
   expose that level; omission inherits its Workspace/native default.
+- `timeout` — optional scheduled-run watchdog: `15m | 30m | 45m | 60m`. Omission
+  means no limit: the headless child runs until the agent exits. This is a run
+  budget, not Session birth, so an exact `@resumeId` owner may still set it.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 Only the credential slug is persisted; endpoint and key material remain in the
@@ -154,15 +157,16 @@ Agents normally use:
 ```bash
 alice-workspace issue list
 alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @new-each-run --agent codex --credential openai-primary --model gpt-5.6-sol --effort high
+alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @new-each-run --agent codex --credential openai-primary --model gpt-5.6-sol --effort high --timeout 30m
 alice-workspace issue update --id <id> --credential openai-primary --model gpt-5.6-sol --effort high
+alice-workspace issue update --id <id> --timeout 45m
 alice-workspace issue comment --id <id> --text "..."
 ```
 
 The CLI and MCP tools use the same implementation and write the same files.
 Direct file editing is also valid and is the clearest way to author rich What
-markdown plus `when` / `assignee` / `agent` / `credential` / `model` / `effort`
-frontmatter.
+markdown plus `when` / `assignee` / `agent` / `credential` / `model` / `effort` /
+`timeout` frontmatter.
 
 `issue comment` is preferable to a generic `issue ask --owner` for normal
 collaboration because it leaves the question and answer in the Issue Activity
@@ -212,9 +216,9 @@ the latest scheduled run, and the assignee's resume availability. It is not
 persisted in markdown and does not create another Issue workflow status:
 
 - `not_started`, `due`, `running`, and `healthy` describe normal progress;
-- `interrupted` means the work was cut off by launcher restart, or its 30-minute
-  watchdog itself woke substantially late (usually computer sleep / launcher
-  suspension); this is operational interruption, not an agent-work failure;
+- `interrupted` means the work was cut off by launcher restart, or an optional
+  run-timeout watchdog itself woke substantially late (usually computer sleep /
+  launcher suspension); this is operational interruption, not an agent-work failure;
 - `failed` retains a real timeout, launch error, runtime error, or non-zero
   process exit until a later success;
 - `blocked` means the schedule has no future fire, or an exact Session owner is
@@ -227,9 +231,11 @@ not a health prerequisite.
 
 Failure explanations are read-side projections from the durable run record.
 Old runs therefore gain structured `failure.kind/title/message/retryable`
-diagnostics without migration. A killed run close to 30 minutes is a timeout;
-a killed run whose watchdog closes much later is described conservatively as a
-paused computer/launcher rather than falsely blaming the agent.
+diagnostics without migration. A killed run close to its configured budget is a
+timeout; historical records that omit a stored budget still use the former
+30-minute default. A killed run whose watchdog closes much later is described
+conservatively as a paused computer/launcher rather than falsely blaming the
+agent.
 
 Startup evidence is explicit on new run records. `processStarted` becomes true
 only after the OS child emits `spawn`; `launchErrorCode` distinguishes an
@@ -240,7 +246,7 @@ rather than the misleading `process_exit` used by older `exitCode: -1` records.
 
 The Issue detail offers **Retry now** only for the latest failed or interrupted
 scheduled run. Retry re-reads the live Issue and uses the same markdown What,
-assignee, runtime, resume mapping, and 30-minute budget as a scheduled fire. It
+assignee, runtime, resume mapping, and optional run timeout as a scheduled fire. It
 does not write the last-fired marker, so a recovery attempt never shifts the
 Issue's cadence. The backend rejects duplicate/racing retries and returns the
 authoritative running detail immediately; there is no automatic retry storm.

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -82,6 +82,18 @@ describe('issue_create', () => {
     })
   })
 
+  it('creates and returns an optional run timeout', async () => {
+    const res = await run(issueCreateFactory.build(ctx()), {
+      id: 'budgeted',
+      title: 'Budgeted run',
+      when: { kind: 'every', every: '30m' },
+      assignee: '@new-each-run',
+      timeout: '45m',
+    })
+    expect(res.issue).toMatchObject({ timeout: '45m' })
+    expect(await readBack('budgeted')).toMatchObject({ timeout: '45m' })
+  })
+
   it('records the creating product Session without accepting identity args', async () => {
     const append = vi.fn(async (input) => ({ id: 'p-1', ...input }))
     const context = ctx({
@@ -278,6 +290,19 @@ describe('issue_update', () => {
     const cleared = await readBack('runtime-fields')
     expect(cleared?.model).toBeUndefined()
     expect(cleared?.effort).toBeUndefined()
+  })
+
+  it('updates and clears an optional run timeout', async () => {
+    await run(issueCreateFactory.build(ctx()), {
+      id: 'budget-fields',
+      title: 'Budget fields',
+      when: { kind: 'every', every: '30m' },
+      assignee: '@new-each-run',
+    })
+    await run(issueUpdateFactory.build(ctx()), { id: 'budget-fields', timeout: '15m' })
+    expect(await readBack('budget-fields')).toMatchObject({ timeout: '15m' })
+    await run(issueUpdateFactory.build(ctx()), { id: 'budget-fields', timeout: null })
+    expect((await readBack('budget-fields'))?.timeout).toBeUndefined()
   })
 
   it('records successful mutations but not rejected ones', async () => {

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -38,6 +38,7 @@ import {
   ISSUES_DIR_REL,
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
+  ISSUE_TIMEOUTS,
   issueAssigneeResumeId,
   issueAssigneeSchema,
   issueWhenSchema,
@@ -218,6 +219,7 @@ function rowOf(issue: IssueRecord) {
     ...(issue.credentialSource ? { credentialSource: issue.credentialSource } : {}),
     ...(issue.model ? { model: issue.model } : {}),
     ...(issue.effort ? { effort: issue.effort } : {}),
+    ...(issue.timeout ? { timeout: issue.timeout } : {}),
     scheduled: issue.when !== undefined,
   }
 }
@@ -310,11 +312,12 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         "Update one of THIS workspace's issues — its board fields.",
         '',
         'Patch any subset of `status`, `priority`, `assignee`, `agent`, `credential`, `credentialSource`, `model`,',
-        '`effort`, or `what`; omitted fields are',
+        '`effort`, `timeout`, or `what`; omitted fields are',
         'left untouched. `assignee:"@me"` binds this current product',
         'Session; `@new-then-resume` recruits once and assigns that first Session permanently;',
         'pass an exact `@resumeId` to assign another known Session. What is the',
-        'canonical markdown work definition and exact scheduled prompt. Other scheduling',
+        'canonical markdown work definition and exact scheduled prompt. `timeout` is an optional',
+        'scheduled-run watchdog (`15m`/`30m`/`45m`/`60m`); omit or null means no limit. Other',
         'schedule timing (`when`) is preserved — edit it by writing the file directly',
         '(`.alice/issues/<id>.md`).',
         '',
@@ -333,9 +336,10 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
         credentialSource: z.literal('native').nullable().optional().describe('Use the Agent runtime login explicitly; null inherits the Workspace headless preference.'),
         model: z.string().min(1).nullable().optional().describe('Native one-run model id; null inherits the Workspace/runtime default.'),
         effort: z.enum(MODEL_REASONING_EFFORTS).nullable().optional().describe('One-run reasoning effort; null inherits the Workspace/runtime default.'),
+        timeout: z.enum(ISSUE_TIMEOUTS).nullable().optional().describe('Optional scheduled-run watchdog; null removes the limit so the agent may run until it exits.'),
         what: z.string().min(1).optional().describe('Canonical markdown work definition; exact scheduled prompt.'),
       }),
-      execute: async ({ id, status, priority, assignee, agent, credential, credentialSource, model, effort, what }) => {
+      execute: async ({ id, status, priority, assignee, agent, credential, credentialSource, model, effort, timeout, what }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         const resolvedAssignee = resolveIssueAssignee(ctx, assignee)
@@ -349,11 +353,12 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           credentialSource === undefined &&
           model === undefined &&
           effort === undefined &&
+          timeout === undefined &&
           what === undefined
         ) {
           return {
             ok: false as const,
-            error: 'no fields to update (pass status/priority/assignee/agent/credential/credentialSource/model/effort/what)',
+            error: 'no fields to update (pass status/priority/assignee/agent/credential/credentialSource/model/effort/timeout/what)',
           }
         }
         const res = await updateIssueFields(dir.dir, id, {
@@ -365,6 +370,7 @@ export const issueUpdateFactory: WorkspaceToolFactory = {
           credentialSource,
           model,
           effort,
+          timeout,
           what,
         })
         if (res.ok) {
@@ -505,8 +511,9 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         credentialSource: z.literal('native').optional().describe('Use the Agent runtime login explicitly instead of inheriting Workspace access.'),
         model: z.string().min(1).optional().describe('Native model id for the selected credential/runtime source.'),
         effort: z.enum(MODEL_REASONING_EFFORTS).optional().describe('Reasoning effort for one scheduled run.'),
+        timeout: z.enum(ISSUE_TIMEOUTS).optional().describe('Optional scheduled-run watchdog (15m/30m/45m/60m). Omit for no limit.'),
       }),
-      execute: async ({ title, id, status, priority, assignee, when, what, agent, credential, credentialSource, model, effort }) => {
+      execute: async ({ title, id, status, priority, assignee, when, what, agent, credential, credentialSource, model, effort, timeout }) => {
         const dir = selfDir(ctx)
         if (!dir.ok) return { ok: false as const, error: dir.error }
         // Structured creation is attributable: "who creates it owns it". A
@@ -528,6 +535,7 @@ export const issueCreateFactory: WorkspaceToolFactory = {
           credentialSource,
           model,
           effort,
+          timeout,
         })
         if (res.ok) {
           await recordIssueProvenance(ctx, res.issue.id, 'created')

--- a/src/webui/routes/issues.spec.ts
+++ b/src/webui/routes/issues.spec.ts
@@ -148,6 +148,14 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     expect(r.body.error).toBe('invalid_effort')
   })
 
+  it('400 invalid_timeout for an unsupported value', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T' })
+    const { app } = build()
+    const r = await req(app, 'PATCH', '/ws-1/i1', { timeout: '12m' })
+    expect(r.status).toBe(400)
+    expect(r.body.error).toBe('invalid_timeout')
+  })
+
   it('validates and persists explicit scheduled ownership', async () => {
     await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '1h' } })
     const { app } = build()
@@ -252,6 +260,17 @@ describe('PATCH /api/issues/:wsId/:id', () => {
     expect(r.body.issue.agent).toBeUndefined()
     const re = await readWorkspaceIssues(wsDir)
     expect(re.ok && re.issues[0].agent).toBeUndefined()
+  })
+
+  it('sets and clears an optional scheduled-run timeout', async () => {
+    await createIssue(wsDir, { id: 'i1', title: 'T', when: { kind: 'every', every: '30m' } })
+    const { app } = build()
+    const set = await req(app, 'PATCH', '/ws-1/i1', { timeout: '60m' })
+    expect(set.status).toBe(200)
+    expect(set.body.issue.timeout).toBe('60m')
+    const cleared = await req(app, 'PATCH', '/ws-1/i1', { timeout: null })
+    expect(cleared.status).toBe(200)
+    expect(cleared.body.issue.timeout).toBeUndefined()
   })
 })
 

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -16,7 +16,9 @@
  * via its own tools). Both writes go through the shared mutation helper
  * (`workspaces/issues/mutate.ts`) so the human and agent surfaces can never
  * drift on file format or validation; writes are working-tree only (no commit):
- *   PATCH /api/issues/:wsId/:id           body { status?, priority?, assignee?, what? }
+ *   PATCH /api/issues/:wsId/:id           body { status?, priority?, assignee?,
+ *                                          agent?, credential?, model?, effort?,
+ *                                          timeout?, what? }
  *   POST  /api/issues/:wsId/:id/comments  body { text }  (author = 'human';
  *     exact Session owners are notified and their final reply returns here)
  *
@@ -40,10 +42,12 @@ import { updateIssueCommentDelivery } from '../../workspaces/issues/comments.js'
 import {
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
+  isIssueTimeout,
   issueAssigneeResumeId,
   issueAssigneeSchema,
   type IssuePriority,
   type IssueStatus,
+  type IssueTimeout,
 } from '../../workspaces/issues/declaration.js'
 import { appendIssueComment, updateIssueFields } from '../../workspaces/issues/mutate.js'
 import { deprecatedIssueAssigneeReplacement } from '../../workspaces/session-signature.js'
@@ -127,10 +131,10 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
   })
 
   // PATCH /api/issues/:wsId/:id — patch board fields { status?, priority?,
-  // assignee? } plus the scheduled runtime override { agent? } on one issue
-  // (the human/UI path). `agent: null` removes the override so future fires use
-  // the workspace default runtime. Other scheduling frontmatter (`when`)
-  // stays file-owned. Returns the updated detail shape; 404 when missing.
+  // assignee? } plus scheduled runtime { agent?, credential?, model?, effort?,
+  // timeout? } on one issue (the human/UI path). `timeout: null` removes the
+  // optional run watchdog. Other scheduling frontmatter (`when`) stays
+  // file-owned. Returns the updated detail shape; 404 when missing.
   app.patch('/:wsId/:id', async (c) => {
     const wsId = c.req.param('wsId')
     const id = c.req.param('id')
@@ -149,6 +153,7 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
       credentialSource?: 'native' | null
       model?: string | null
       effort?: ModelReasoningEffort | null
+      timeout?: IssueTimeout | null
       what?: string
     } = {}
     if ('status' in fields) {
@@ -261,6 +266,19 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
         patch.effort = raw
       }
     }
+    if ('timeout' in fields) {
+      const raw = fields['timeout']
+      if (raw === null || raw === '') {
+        patch.timeout = null
+      } else if (!isIssueTimeout(raw)) {
+        return c.json({
+          error: 'invalid_timeout',
+          message: 'timeout must be 15m, 30m, 45m, 60m, or null',
+        }, 400)
+      } else {
+        patch.timeout = raw
+      }
+    }
     if ('what' in fields) {
       const what = fields['what']
       if (typeof what !== 'string' || what.trim().length === 0) {
@@ -274,7 +292,7 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
     if (Object.keys(patch).length === 0) {
       return c.json({
         error: 'no_fields',
-        message: 'provide at least one of status, priority, assignee, agent, credential, model, effort, what',
+        message: 'provide at least one of status, priority, assignee, agent, credential, model, effort, timeout, what',
       }, 400)
     }
 

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -109,6 +109,24 @@ describe('HeadlessTaskRegistry', () => {
     expect(reg2.get(fired.taskId)?.trigger?.issueId).toBe('daily-scan')
   })
 
+  it('persists an explicit unlimited watchdog separately from historical absence', async () => {
+    const reg = await HeadlessTaskRegistry.load(path, noopLogger)
+    const unlimited = await createTask(reg, {
+      wsId: 'w1',
+      agent: 'codex',
+      prompt: 'x',
+      startedAt: 1,
+      trigger: { kind: 'issue', workspaceId: 'home', issueId: 'daily-scan' },
+    })
+    const manual = await createTask(reg, {
+      wsId: 'w1', agent: 'codex', prompt: 'y', startedAt: 2,
+    })
+
+    const reg2 = await HeadlessTaskRegistry.load(path, noopLogger)
+    expect(reg2.get(unlimited.taskId)).toHaveProperty('timeoutMs', null)
+    expect(reg2.get(manual.taskId)).not.toHaveProperty('timeoutMs')
+  })
+
   it('persists requested one-run model and effort', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
     const task = await createTask(reg, {

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -114,9 +114,10 @@ export interface HeadlessTaskRecord {
   signal?: string | null
   killed?: boolean
   error?: string
-  /** Watchdog budget when this dispatch armed one. Absent means no limit, or a
-   * historical record that used the former 30-minute scheduled-Issue default. */
-  timeoutMs?: number
+  /** Watchdog policy recorded at dispatch time. A positive number is the armed
+   * budget, `null` explicitly records a new unlimited scheduled-Issue run, and
+   * absence is reserved for historical records or non-Issue dispatches. */
+  timeoutMs?: number | null
   /**
    * The agent CLI's OWN session id, captured from the run's stdout (adapter's
    * `extractHeadlessSessionId`). This is what makes a headless run REOPENABLE:
@@ -219,7 +220,11 @@ export class HeadlessTaskRegistry {
       // Keep the field absent (not `undefined`) on manual runs so the JSON stays clean.
       ...(input.trigger ? { trigger: input.trigger } : {}),
       ...(input.inquiry ? { inquiry: input.inquiry } : {}),
-      ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.timeoutMs !== undefined
+        ? { timeoutMs: input.timeoutMs }
+        : input.trigger?.kind === 'issue'
+          ? { timeoutMs: null }
+          : {}),
     }
     this.tasks.push(rec)
     await this.flush()

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -114,6 +114,9 @@ export interface HeadlessTaskRecord {
   signal?: string | null
   killed?: boolean
   error?: string
+  /** Watchdog budget when this dispatch armed one. Absent means no limit, or a
+   * historical record that used the former 30-minute scheduled-Issue default. */
+  timeoutMs?: number
   /**
    * The agent CLI's OWN session id, captured from the run's stdout (adapter's
    * `extractHeadlessSessionId`). This is what makes a headless run REOPENABLE:
@@ -197,6 +200,8 @@ export class HeadlessTaskRegistry {
     trigger?: HeadlessTaskTrigger
     /** Business follow-up metadata; omitted for automation/manual runs. */
     inquiry?: HeadlessTaskInquiry
+    /** Watchdog budget when this dispatch armed one. */
+    timeoutMs?: number
   }): Promise<HeadlessTaskRecord> {
     let taskId = randomTaskId()
     while (this.tasks.some((task) => task.taskId === taskId)) taskId = randomTaskId()
@@ -214,6 +219,7 @@ export class HeadlessTaskRegistry {
       // Keep the field absent (not `undefined`) on manual runs so the JSON stays clean.
       ...(input.trigger ? { trigger: input.trigger } : {}),
       ...(input.inquiry ? { inquiry: input.inquiry } : {}),
+      ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
     }
     this.tasks.push(rec)
     await this.flush()

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -341,7 +341,9 @@ export interface IssueRunRecord {
   signal?: string | null
   killed?: boolean
   error?: string
-  timeoutMs?: number
+  /** Positive watchdog budget, `null` for an explicitly unlimited new run,
+   * absent only on historical records. */
+  timeoutMs?: number | null
   output?: HeadlessTaskOutputSummary
   /** Read-side explanation for non-successful scheduled execution. Derived
    * from durable fields so old registry entries need no migration. */

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -27,7 +27,7 @@ import type {
   HeadlessTaskRecord,
   HeadlessTaskStatus,
 } from '../headless-task-registry.js'
-import type { IssuePriority, IssueRecord, IssueStatus } from './declaration.js'
+import type { IssuePriority, IssueRecord, IssueStatus, IssueTimeout } from './declaration.js'
 import type { IssueComment } from './comments.js'
 import type { IssueAutomationHealth } from './automation-health.js'
 import { issueRunFailure, type IssueRunFailure } from './run-failure.js'
@@ -48,6 +48,8 @@ export interface IssuesSnapshotIssue {
   credentialSource?: 'native'
   model?: string
   effort?: ModelReasoningEffort
+  /** Optional scheduled-run watchdog; omit for no limit. */
+  timeout?: IssueTimeout
   /** Present iff the issue self-schedules. */
   when?: Schedule
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
@@ -149,6 +151,7 @@ export interface BoardRow {
   credentialSource?: 'native'
   model?: string
   effort?: ModelReasoningEffort
+  timeout?: IssueTimeout
   /** True iff the issue self-schedules (snapshot `when` present). */
   scheduled: boolean
   /** Live scheduler/worker health for scheduled rows. */
@@ -193,6 +196,7 @@ export function flattenBoardRows(snapshot: IssuesSnapshot): {
         ...(issue.credentialSource ? { credentialSource: issue.credentialSource } : {}),
         ...(issue.model ? { model: issue.model } : {}),
         ...(issue.effort ? { effort: issue.effort } : {}),
+        ...(issue.timeout ? { timeout: issue.timeout } : {}),
         scheduled: issue.when !== undefined,
         ...(issue.automationHealth ? { automationHealth: issue.automationHealth } : {}),
         workspace: { wsId: ws.wsId, tag: ws.tag },
@@ -246,6 +250,7 @@ export interface IssueDetailIssue {
   credentialSource?: 'native'
   model?: string
   effort?: ModelReasoningEffort
+  timeout?: IssueTimeout
   /** When the scanner last fired this issue (epoch ms); only for scheduled issues. */
   lastFiredAtMs?: number | null
   /** When it is next due (epoch ms); only for scheduled issues. */
@@ -336,6 +341,7 @@ export interface IssueRunRecord {
   signal?: string | null
   killed?: boolean
   error?: string
+  timeoutMs?: number
   output?: HeadlessTaskOutputSummary
   /** Read-side explanation for non-successful scheduled execution. Derived
    * from durable fields so old registry entries need no migration. */
@@ -368,6 +374,7 @@ export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): Is
     ...(task.signal !== undefined ? { signal: task.signal } : {}),
     ...(task.killed !== undefined ? { killed: task.killed } : {}),
     ...(task.error !== undefined ? { error: task.error } : {}),
+    ...(task.timeoutMs !== undefined ? { timeoutMs: task.timeoutMs } : {}),
     ...(task.output !== undefined ? { output: task.output } : {}),
     ...(failure ? { failure } : {}),
     resumable,
@@ -432,6 +439,7 @@ export function detailIssue(
     ...(issue.credentialSource ? { credentialSource: issue.credentialSource } : {}),
     ...(issue.model ? { model: issue.model } : {}),
     ...(issue.effort ? { effort: issue.effort } : {}),
+    ...(issue.timeout ? { timeout: issue.timeout } : {}),
     ...(markers ? {
       lastFiredAtMs: markers.lastFiredAtMs,
       nextDueAtMs: markers.nextDueAtMs,
@@ -458,6 +466,7 @@ export function snapshotBoardIssue(
     ...(issue.credentialSource ? { credentialSource: issue.credentialSource } : {}),
     ...(issue.model ? { model: issue.model } : {}),
     ...(issue.effort ? { effort: issue.effort } : {}),
+    ...(issue.timeout ? { timeout: issue.timeout } : {}),
     ...(issue.when ? { when: issue.when } : {}),
     ...(markers ? {
       lastFiredAtMs: markers.lastFiredAtMs,

--- a/src/workspaces/issues/change-tracker.ts
+++ b/src/workspaces/issues/change-tracker.ts
@@ -32,6 +32,7 @@ export interface IssueAuditSnapshot {
   credentialSource?: string
   model?: string
   effort?: string
+  timeout?: string
   whatHash: string
 }
 
@@ -60,6 +61,7 @@ export function issueAuditSnapshot(issue: IssueRecord): IssueAuditSnapshot {
     ...(issue.credentialSource ? { credentialSource: issue.credentialSource } : {}),
     ...(issue.model ? { model: issue.model } : {}),
     ...(issue.effort ? { effort: issue.effort } : {}),
+    ...(issue.timeout ? { timeout: issue.timeout } : {}),
     whatHash: digest(issue.what),
   }
 }
@@ -93,6 +95,7 @@ export function issueMutation(
   valueField('credential source', left.credentialSource, right.credentialSource)
   valueField('model', left.model, right.model)
   valueField('effort', left.effort, right.effort)
+  valueField('timeout', left.timeout, right.timeout)
   if (left.whatHash !== right.whatHash) fields.push({ field: 'what' })
   return fields.length > 0 ? { fields } : null
 }

--- a/src/workspaces/issues/declaration.spec.ts
+++ b/src/workspaces/issues/declaration.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { issueAssigneeResumeId, issueFirePrompt, isFireable, readWorkspaceIssues } from './declaration.js'
+import { issueAssigneeResumeId, issueFirePrompt, issueTimeoutMs, isFireable, readWorkspaceIssues } from './declaration.js'
 
 let dir: string
 beforeEach(async () => {
@@ -178,6 +178,41 @@ describe('readWorkspaceIssues', () => {
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.invalid[0]?.error).toMatch(/agent.*credential.*model.*effort/)
+  })
+
+  it('accepts an optional run timeout, including on an exact Session owner', async () => {
+    await writeIssue('budget', fm([
+      'title: Budgeted run',
+      'when: { kind: every, every: 30m }',
+      'timeout: 45m',
+    ].join('\n')))
+    await writeIssue('owned-budget', fm([
+      'title: Owned budget',
+      'when: { kind: every, every: 30m }',
+      'assignee: "@resume-kind-owl-abc123"',
+      'timeout: 15m',
+    ].join('\n')))
+    const result = await readWorkspaceIssues(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const byId = Object.fromEntries(result.issues.map((issue) => [issue.id, issue]))
+    expect(byId['budget']?.timeout).toBe('45m')
+    expect(byId['owned-budget']?.timeout).toBe('15m')
+    expect(issueTimeoutMs(byId['budget']?.timeout)).toBe(45 * 60_000)
+    expect(issueTimeoutMs(undefined)).toBeUndefined()
+  })
+
+  it('rejects an unknown timeout instead of silently ignoring it', async () => {
+    await writeIssue('bad-timeout', fm([
+      'title: Bad timeout',
+      'when: { kind: every, every: 30m }',
+      'timeout: 12m',
+    ].join('\n')))
+    const result = await readWorkspaceIssues(dir)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.issues).toEqual([])
+    expect(result.invalid[0]?.error).toMatch(/timeout/)
   })
 
   it('distinguishes explicit native login from inherited Workspace access', async () => {

--- a/src/workspaces/issues/declaration.ts
+++ b/src/workspaces/issues/declaration.ts
@@ -31,6 +31,7 @@
  *   credentialSource: native <optional explicit Agent-runtime login>
  *   model: <optional native model id for one scheduled run>
  *   effort: none | minimal | low | medium | high | xhigh | max
+ *   timeout: 15m | 30m | 45m | 60m  (optional run budget; omit = no watchdog)
  *   ---
  *   <markdown What — the exact work definition and scheduled prompt>
  *
@@ -71,8 +72,29 @@ const MAX_BYTES = 64 * 1024
 
 export const ISSUE_STATUSES = ['backlog', 'todo', 'in_progress', 'done', 'canceled'] as const
 export const ISSUE_PRIORITIES = ['urgent', 'high', 'medium', 'low', 'none'] as const
+/** Optional scheduled-run watchdog. Omission means the agent may run until it exits. */
+export const ISSUE_TIMEOUTS = ['15m', '30m', '45m', '60m'] as const
 export type IssueStatus = (typeof ISSUE_STATUSES)[number]
 export type IssuePriority = (typeof ISSUE_PRIORITIES)[number]
+export type IssueTimeout = (typeof ISSUE_TIMEOUTS)[number]
+
+const ISSUE_TIMEOUT_SET: ReadonlySet<string> = new Set(ISSUE_TIMEOUTS)
+const ISSUE_TIMEOUT_MS: Record<IssueTimeout, number> = {
+  '15m': 15 * 60_000,
+  '30m': 30 * 60_000,
+  '45m': 45 * 60_000,
+  '60m': 60 * 60_000,
+}
+
+export function isIssueTimeout(value: unknown): value is IssueTimeout {
+  return typeof value === 'string' && ISSUE_TIMEOUT_SET.has(value)
+}
+
+/** Convert a declared Issue timeout into the headless watchdog budget.
+ *  `undefined` means do not arm a watchdog. */
+export function issueTimeoutMs(timeout?: IssueTimeout): number | undefined {
+  return timeout === undefined ? undefined : ISSUE_TIMEOUT_MS[timeout]
+}
 
 /** Statuses at which a scheduled issue stops firing (it's resolved/abandoned).
  *  This is how a schedule is turned off under the board model — there is no
@@ -157,6 +179,9 @@ const issueFrontmatterObjectSchema = z.object({
   effort: z.custom<ModelReasoningEffort>(isModelReasoningEffort, {
     message: 'effort must be none, minimal, low, medium, high, xhigh, or max',
   }).optional(),
+  /** Optional headless watchdog for a scheduled fire. Omission means no limit.
+   * This is a run budget, not Session birth, so an exact `@resumeId` may set it. */
+  timeout: z.enum(ISSUE_TIMEOUTS).optional(),
   /** The former parallel ownership field is outside the baseline. Keeping a
    * `never` key makes stale files fail loudly instead of being silently read. */
   execution: z.never().optional(),

--- a/src/workspaces/issues/mutate.spec.ts
+++ b/src/workspaces/issues/mutate.spec.ts
@@ -189,6 +189,27 @@ describe('updateIssueFields', () => {
     expect(issue?.agent).toBeUndefined()
   })
 
+  it('sets and clears an optional scheduled-run timeout', async () => {
+    await createIssue(dir, {
+      id: 'budget',
+      title: 'Budget',
+      when: { kind: 'every', every: '15m' },
+      timeout: '45m',
+    })
+    let { issue } = await readBack('budget')
+    expect(issue?.timeout).toBe('45m')
+
+    const cleared = await updateIssueFields(dir, 'budget', { timeout: null })
+    expect(cleared.ok).toBe(true)
+    ;({ issue } = await readBack('budget'))
+    expect(issue?.timeout).toBeUndefined()
+
+    const set = await updateIssueFields(dir, 'budget', { timeout: '15m' })
+    expect(set.ok).toBe(true)
+    ;({ issue } = await readBack('budget'))
+    expect(issue?.timeout).toBe('15m')
+  })
+
   it('switches atomically between vault access, native login, and inheritance', async () => {
     await createIssue(dir, { id: 'access', title: 'Access', credential: 'openai-primary' })
     const native = await updateIssueFields(dir, 'access', { credentialSource: 'native' })
@@ -220,6 +241,7 @@ describe('updateIssueFields', () => {
       credential: 'openai-primary',
       model: 'gpt-5.6',
       effort: 'high',
+      timeout: '30m',
     })
     const res = await updateIssueFields(dir, 'owned', {
       assignee: '@resume-kind-owl-abc123',
@@ -232,6 +254,7 @@ describe('updateIssueFields', () => {
     expect(issue?.credentialSource).toBeUndefined()
     expect(issue?.model).toBeUndefined()
     expect(issue?.effort).toBeUndefined()
+    expect(issue?.timeout).toBe('30m')
     expect(issue?.when).toEqual({ kind: 'every', every: '15m' })
   })
 

--- a/src/workspaces/issues/mutate.ts
+++ b/src/workspaces/issues/mutate.ts
@@ -30,6 +30,7 @@ import {
   ISSUE_PRIORITIES,
   ISSUE_STATUSES,
   ISSUES_DIR_REL,
+  isIssueTimeout,
   issueAssigneeResumeId,
   issueAssigneeSchema,
   issueFrontmatterSchema,
@@ -39,12 +40,14 @@ import {
   type IssuePriority,
   type IssueRecord,
   type IssueStatus,
+  type IssueTimeout,
 } from './declaration.js'
 export { appendIssueComment } from './comments.js'
 
 /** Fields a human/agent may patch on an existing issue. Most scheduling
- *  frontmatter is preserved untouched; `agent` is intentionally editable from
- *  the UI because it controls which runtime the scheduler uses next fire. */
+ *  frontmatter is preserved untouched; `agent` and `timeout` are intentionally
+ *  editable from the UI because they control the next scheduled fire's runtime
+ *  and optional watchdog. */
 export interface IssueFieldPatch {
   status?: IssueStatus
   priority?: IssuePriority
@@ -59,6 +62,8 @@ export interface IssueFieldPatch {
   model?: string | null
   /** Reasoning effort for one scheduled fire; null inherits Workspace/runtime. */
   effort?: ModelReasoningEffort | null
+  /** Optional scheduled-run watchdog; null removes the limit. */
+  timeout?: IssueTimeout | null
   /** Canonical markdown work definition; exact scheduled prompt. */
   what?: string
 }
@@ -78,6 +83,7 @@ export interface CreateIssueInput {
   credentialSource?: 'native'
   model?: string
   effort?: ModelReasoningEffort
+  timeout?: IssueTimeout
   /** @deprecated Compatibility alias for callers written before What became the
    * sole markdown document. New callers must use `what`. */
   body?: string
@@ -190,6 +196,7 @@ export async function updateIssueFields(
       delete data.credentialSource
       delete data.model
       delete data.effort
+      // `timeout` is a run budget, not Session birth — keep it.
     }
   }
   if (patch.agent !== undefined) {
@@ -237,6 +244,15 @@ export async function updateIssueFields(
       return { ok: false, reason: 'invalid', error: 'invalid effort' }
     } else {
       data.effort = patch.effort
+    }
+  }
+  if (patch.timeout !== undefined) {
+    if (patch.timeout === null) {
+      delete data.timeout
+    } else if (!isIssueTimeout(patch.timeout)) {
+      return { ok: false, reason: 'invalid', error: 'timeout must be 15m, 30m, 45m, or 60m' }
+    } else {
+      data.timeout = patch.timeout
     }
   }
   let what = current.issue.what
@@ -304,6 +320,7 @@ export async function createIssue(wsDir: string, input: CreateIssueInput): Promi
   if (input.credentialSource !== undefined) data.credentialSource = input.credentialSource
   if (input.model !== undefined) data.model = input.model
   if (input.effort !== undefined) data.effort = input.effort
+  if (input.timeout !== undefined) data.timeout = input.timeout
 
   const parsed = issueFrontmatterSchema.safeParse(data)
   if (!parsed.success) {

--- a/src/workspaces/issues/run-failure.spec.ts
+++ b/src/workspaces/issues/run-failure.spec.ts
@@ -38,6 +38,13 @@ describe('issueRunFailure', () => {
     expect(issueRunFailure({ status: 'failed', exitCode: 2 })).toMatchObject({ kind: 'process_exit' })
     expect(issueRunFailure({
       status: 'failed',
+      timeoutMs: null,
+      killed: true,
+      signal: 'SIGKILL',
+      durationMs: SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+    })).toMatchObject({ kind: 'process_exit' })
+    expect(issueRunFailure({
+      status: 'failed',
       processStarted: true,
       exitCode: 7,
     })).toMatchObject({ kind: 'process_exit' })

--- a/src/workspaces/issues/run-failure.spec.ts
+++ b/src/workspaces/issues/run-failure.spec.ts
@@ -18,6 +18,16 @@ describe('issueRunFailure', () => {
       killed: true,
       durationMs: SCHEDULED_ISSUE_RUN_TIMEOUT_MS + 5_000,
     })).toMatchObject({ kind: 'timeout', retryable: true })
+
+    expect(issueRunFailure({
+      status: 'failed',
+      killed: true,
+      timeoutMs: 15 * 60_000,
+      durationMs: 15 * 60_000 + 2_000,
+    })).toMatchObject({
+      kind: 'timeout',
+      message: expect.stringContaining('15m'),
+    })
   })
 
   it('explains restart reconciliation, launch errors, and process exits', () => {

--- a/src/workspaces/issues/run-failure.ts
+++ b/src/workspaces/issues/run-failure.ts
@@ -1,8 +1,10 @@
 import type { HeadlessTaskRecord } from '../headless-task-registry.js'
+import { issueTimeoutMs } from './declaration.js'
 
-/** Scheduled Issue runs share one watchdog budget. Keeping the value here lets
- * dispatch and the read-side failure projection explain the same deadline. */
-export const SCHEDULED_ISSUE_RUN_TIMEOUT_MS = 30 * 60_000
+/** Historical scheduled Issue runs that omitted `timeoutMs` on the durable
+ * record used this 30-minute budget. New fires persist the Issue's actual
+ * watchdog (or omit it when the Issue has no limit). */
+export const SCHEDULED_ISSUE_RUN_TIMEOUT_MS = issueTimeoutMs('30m')!
 
 /** A watchdog that fires this far after its own deadline did not merely time
  * out: the launcher's event loop was paused (most commonly system sleep). */
@@ -46,10 +48,11 @@ export function issueRunFailure(
     | 'signal'
     | 'killed'
     | 'error'
+    | 'timeoutMs'
   >,
-  timeoutMs = SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
 ): IssueRunFailure | undefined {
   if (task.status === 'running' || task.status === 'done') return undefined
+  const timeoutMs = task.timeoutMs ?? SCHEDULED_ISSUE_RUN_TIMEOUT_MS
 
   if (task.status === 'interrupted') {
     return {

--- a/src/workspaces/issues/run-failure.ts
+++ b/src/workspaces/issues/run-failure.ts
@@ -3,7 +3,7 @@ import { issueTimeoutMs } from './declaration.js'
 
 /** Historical scheduled Issue runs that omitted `timeoutMs` on the durable
  * record used this 30-minute budget. New fires persist the Issue's actual
- * watchdog (or omit it when the Issue has no limit). */
+ * watchdog, or `null` when the Issue has no limit. */
 export const SCHEDULED_ISSUE_RUN_TIMEOUT_MS = issueTimeoutMs('30m')!
 
 /** A watchdog that fires this far after its own deadline did not merely time
@@ -52,7 +52,9 @@ export function issueRunFailure(
   >,
 ): IssueRunFailure | undefined {
   if (task.status === 'running' || task.status === 'done') return undefined
-  const timeoutMs = task.timeoutMs ?? SCHEDULED_ISSUE_RUN_TIMEOUT_MS
+  const timeoutMs = task.timeoutMs === undefined
+    ? SCHEDULED_ISSUE_RUN_TIMEOUT_MS
+    : task.timeoutMs
 
   if (task.status === 'interrupted') {
     return {
@@ -63,7 +65,7 @@ export function issueRunFailure(
     }
   }
 
-  if (task.killed) {
+  if (task.killed && timeoutMs !== null) {
     const durationMs = task.durationMs ?? timeoutMs
     const lateByMs = durationMs - timeoutMs
     if (lateByMs >= SCHEDULED_ISSUE_WATCHDOG_LATE_GRACE_MS) {

--- a/src/workspaces/schedule/declaration.ts
+++ b/src/workspaces/schedule/declaration.ts
@@ -22,6 +22,7 @@ import {
   issueFirePrompt,
   readWorkspaceIssues,
   type IssueRecord,
+  type IssueTimeout,
 } from '../issues/declaration.js'
 
 export {
@@ -54,6 +55,7 @@ export interface ScheduleSnapshotTask {
   credentialSource?: 'native'
   model?: string
   effort?: ModelReasoningEffort
+  timeout?: IssueTimeout
   /** False once the owning issue reaches a terminal status (done/canceled). */
   enabled: boolean
   /** When the scanner last fired this issue (epoch ms), null if never. */
@@ -113,6 +115,7 @@ export function snapshotScheduledIssue(
     ...(issue.credentialSource ? { credentialSource: issue.credentialSource } : {}),
     ...(issue.model ? { model: issue.model } : {}),
     ...(issue.effort ? { effort: issue.effort } : {}),
+    ...(issue.timeout ? { timeout: issue.timeout } : {}),
     enabled: !isTerminalStatus(issue.status),
     lastFiredAtMs,
     // An overdue computed time clamps to now: a due-now task reads "due now",

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -73,6 +73,7 @@ interface IssueSpec {
   credentialSource?: 'native'
   model?: string
   effort?: string
+  timeout?: string
   assignee?: string
   body?: string
 }
@@ -88,6 +89,7 @@ function issueMd(spec: IssueSpec): string {
   if (spec.credentialSource) lines.push(`credentialSource: ${spec.credentialSource}`)
   if (spec.model) lines.push(`model: ${spec.model}`)
   if (spec.effort) lines.push(`effort: ${spec.effort}`)
+  if (spec.timeout) lines.push(`timeout: ${spec.timeout}`)
   // Scanner tests exercise dispatch policy, not declaration defaults. Keep the
   // historical fresh-every-fire fixture explicit now that omitted scheduled
   // ownership means recruit once (`@new-then-resume`).
@@ -123,7 +125,7 @@ function scannerFor(
       m: WorkspaceMeta,
       a: CliAdapter,
       p: string,
-      t: number,
+      t?: number,
       trigger?: import('../headless-task-registry.js').HeadlessTaskTrigger,
       resumeId?: string,
     ) => Promise<{ taskId: string; resumeId: string }>
@@ -171,7 +173,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'same exact prompt',
-      30 * 60_000,
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 'retry-me' },
       undefined,
       undefined,
@@ -186,6 +188,32 @@ describe('ScheduleScanner', () => {
       },
     )
     expect(markers.get('w1', 'retry-me')).toBeUndefined()
+  })
+
+  it('passes an Issue timeout as the dispatch watchdog and omits it by default', async () => {
+    const limited = await makeWs('w1', [{
+      id: 'limited',
+      title: 'Limited',
+      when: { kind: 'every', every: '30m' },
+      what: 'go',
+      timeout: '45m',
+    }])
+    const unlimited = await makeWs('w2', [{
+      id: 'open',
+      title: 'Open',
+      when: { kind: 'every', every: '30m' },
+      what: 'go',
+    }])
+    const limitedScan = scannerFor([limited])
+    const unlimitedScan = scannerFor([unlimited])
+    await limitedScan.scanner.scan()
+    await unlimitedScan.scanner.scan()
+    expect(limitedScan.dispatch.mock.calls[0]?.[3]).toBe(45 * 60_000)
+    expect(unlimitedScan.dispatch.mock.calls[0]?.[3]).toBeUndefined()
+
+    const retry = scannerFor([limited])
+    await retry.scanner.runIssueNow('w1', 'limited')
+    expect(retry.dispatch.mock.calls[0]?.[3]).toBe(45 * 60_000)
   })
 
   it('refuses manual retry for an unscheduled or terminal Issue', async () => {
@@ -208,7 +236,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'go',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 't1' },
       undefined,
       undefined,
@@ -263,7 +291,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'go',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 'tuned' },
       undefined,
       undefined,
@@ -296,7 +324,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'go',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 'native' },
       undefined,
       undefined,
@@ -329,7 +357,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'continue',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 'owned' },
       'resume-kind-owl-abc123',
     )
@@ -354,7 +382,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'own this work from now on',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 'sticky' },
       undefined,
       undefined,
@@ -410,7 +438,7 @@ describe('ScheduleScanner', () => {
       execution,
       headlessAdapter,
       'revisit your report',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'home', issueId: 'review-report' },
       'resume-peer-author',
     )
@@ -438,7 +466,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'go',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 'sched' },
       undefined,
       undefined,
@@ -465,7 +493,7 @@ describe('ScheduleScanner', () => {
       ws,
       headlessAdapter,
       'scan movers',
-      expect.any(Number),
+      undefined,
       { kind: 'issue', workspaceId: 'w1', issueId: 't1' },
       undefined,
       undefined,

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -204,16 +204,67 @@ describe('ScheduleScanner', () => {
       when: { kind: 'every', every: '30m' },
       what: 'go',
     }])
-    const limitedScan = scannerFor([limited])
-    const unlimitedScan = scannerFor([unlimited])
-    await limitedScan.scanner.scan()
-    await unlimitedScan.scanner.scan()
-    expect(limitedScan.dispatch.mock.calls[0]?.[3]).toBe(45 * 60_000)
-    expect(unlimitedScan.dispatch.mock.calls[0]?.[3]).toBeUndefined()
+    const { scanner: limitedScanner, dispatch: limitedDispatch } = scannerFor([limited])
+    const { scanner: unlimitedScanner, dispatch: unlimitedDispatch } = scannerFor([unlimited])
+    await limitedScanner.scan()
+    await unlimitedScanner.scan()
+    expect(limitedDispatch).toHaveBeenCalledWith(
+      limited,
+      headlessAdapter,
+      'go',
+      45 * 60_000,
+      { kind: 'issue', workspaceId: 'w1', issueId: 'limited' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'limited',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
+    )
+    expect(unlimitedDispatch).toHaveBeenCalledWith(
+      unlimited,
+      headlessAdapter,
+      'go',
+      undefined,
+      { kind: 'issue', workspaceId: 'w2', issueId: 'open' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w2',
+        issueId: 'open',
+        policy: 'new-each-run',
+        fire: 'schedule',
+      },
+    )
 
-    const retry = scannerFor([limited])
-    await retry.scanner.runIssueNow('w1', 'limited')
-    expect(retry.dispatch.mock.calls[0]?.[3]).toBe(45 * 60_000)
+    const { scanner: retryScanner, dispatch: retryDispatch } = scannerFor([limited])
+    await retryScanner.runIssueNow('w1', 'limited')
+    expect(retryDispatch).toHaveBeenCalledWith(
+      limited,
+      headlessAdapter,
+      'go',
+      45 * 60_000,
+      { kind: 'issue', workspaceId: 'w1', issueId: 'limited' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        kind: 'issue',
+        workspaceId: 'w1',
+        issueId: 'limited',
+        policy: 'new-each-run',
+        fire: 'retry',
+      },
+    )
   })
 
   it('refuses manual retry for an unscheduled or terminal Issue', async () => {

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -38,10 +38,10 @@ import {
   issueAssigneeClaimsFirstSession,
   issueAssigneeResumeId,
   issueFirePrompt,
+  issueTimeoutMs,
   readWorkspaceIssues,
   type IssueRecord,
 } from '../issues/declaration.js'
-import { SCHEDULED_ISSUE_RUN_TIMEOUT_MS } from '../issues/run-failure.js'
 
 import {
   fireBase,
@@ -88,7 +88,7 @@ export interface ScheduleScannerDeps {
     meta: WorkspaceMeta,
     adapter: CliAdapter,
     prompt: string,
-    timeoutMs: number,
+    timeoutMs?: number,
     /** Composite source of the dispatch. Execution may happen elsewhere. */
     trigger?: HeadlessTaskTrigger,
     /** Product Session to continue. Omitted means allocate a fresh Session. */
@@ -160,8 +160,8 @@ export class ScheduleScanner {
 
   /** Dispatch one scheduled Issue immediately without touching its firing
    * marker. This is the authoritative manual-retry path: it re-reads the live
-   * Issue and reuses the exact prompt, owner, runtime, and timeout used by the
-   * scanner, while preserving the next scheduled occurrence. */
+   * Issue and reuses the exact prompt, owner, runtime, and optional timeout used
+   * by the scanner, while preserving the next scheduled occurrence. */
   async runIssueNow(wsId: string, issueId: string): Promise<{ taskId: string }> {
     const ws = this.deps.registry.get(wsId)
     if (!ws) throw new ScheduledIssueRunNowError('not_found', 'Workspace not found.')
@@ -188,6 +188,7 @@ export class ScheduleScanner {
       issueRunOverrides(issue),
       issueAssigneeResumeId(issue.assignee) ?? undefined,
       issueAssigneeClaimsFirstSession(issue.assignee),
+      issueTimeoutMs(issue.timeout),
       true,
     )
   }
@@ -278,6 +279,7 @@ export class ScheduleScanner {
           issueRunOverrides(issue),
           issueAssigneeResumeId(issue.assignee) ?? undefined,
           issueAssigneeClaimsFirstSession(issue.assignee),
+          issueTimeoutMs(issue.timeout),
           nowMs,
         )
       }
@@ -302,6 +304,7 @@ export class ScheduleScanner {
     selection: SessionRuntimeSelection | undefined,
     resumeId: string | undefined,
     claimFreshSession: boolean,
+    timeoutMs: number | undefined,
     nowMs: number,
   ): Promise<void> {
     try {
@@ -313,6 +316,7 @@ export class ScheduleScanner {
         selection,
         resumeId,
         claimFreshSession,
+        timeoutMs,
       )
       await this.deps.markers.set(issueWorkspace.id, taskId, nowMs)
       this.deps.logger.info('schedule.fired', {
@@ -341,6 +345,7 @@ export class ScheduleScanner {
     selection?: SessionRuntimeSelection,
     resumeId?: string,
     claimFreshSession = false,
+    timeoutMs?: number,
     manual = false,
   ): Promise<{ taskId: string }> {
     const dispatchKey = `${issueWorkspace.id}:${issueId}`
@@ -386,7 +391,7 @@ export class ScheduleScanner {
               executionWorkspace,
               adapter,
               what,
-              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              timeoutMs,
               trigger,
               resumeId,
               undefined,
@@ -396,7 +401,7 @@ export class ScheduleScanner {
               executionWorkspace,
               adapter,
               what,
-              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              timeoutMs,
               trigger,
               resumeId,
             )
@@ -405,7 +410,7 @@ export class ScheduleScanner {
               executionWorkspace,
               adapter,
               what,
-              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              timeoutMs,
               trigger,
               undefined,
               undefined,
@@ -417,7 +422,7 @@ export class ScheduleScanner {
               executionWorkspace,
               adapter,
               what,
-              SCHEDULED_ISSUE_RUN_TIMEOUT_MS,
+              timeoutMs,
               trigger,
               undefined,
               undefined,

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -1653,6 +1653,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         ...(parentTaskId ? { parentTaskId } : {}),
         ...(trigger ? { trigger } : {}),
         ...(inquiry ? { inquiry } : {}),
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       });
       await resumeRegistry.ensure({
         resumeId: identity.resumeId,

--- a/ui/src/api/headless.ts
+++ b/ui/src/api/headless.ts
@@ -54,8 +54,9 @@ export interface HeadlessTaskRecord {
   signal?: string | null
   killed?: boolean
   error?: string
-  /** Watchdog budget when this dispatch armed one. */
-  timeoutMs?: number
+  /** Positive watchdog budget, `null` for an explicitly unlimited new run,
+   * absent only on historical records. */
+  timeoutMs?: number | null
   /** Backend has resolved this product identity to a native runtime session. */
   resumable: boolean
   output?: {

--- a/ui/src/api/headless.ts
+++ b/ui/src/api/headless.ts
@@ -54,6 +54,8 @@ export interface HeadlessTaskRecord {
   signal?: string | null
   killed?: boolean
   error?: string
+  /** Watchdog budget when this dispatch armed one. */
+  timeoutMs?: number
   /** Backend has resolved this product identity to a native runtime session. */
   resumable: boolean
   output?: {

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -5,6 +5,9 @@ import type { InboxEntry } from './inbox'
 import type { ScheduleWhen } from './schedule'
 import type { ModelReasoningEffort } from './types'
 
+export const ISSUE_TIMEOUTS = ['15m', '30m', '45m', '60m'] as const
+export type IssueTimeout = (typeof ISSUE_TIMEOUTS)[number]
+
 /**
  * Issue board — the canonical client shape for GET /api/issues.
  *
@@ -122,6 +125,8 @@ export interface IssueListItem {
   model?: string
   /** Native reasoning effort for the scheduled fire override, if set. */
   effort?: ModelReasoningEffort
+  /** Optional scheduled-run watchdog; omit for no limit. */
+  timeout?: IssueTimeout
   /** Present iff the issue is scheduled (shares the core Schedule union). */
   when?: ScheduleWhen
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
@@ -220,6 +225,8 @@ export interface IssueDetailIssue {
   model?: string
   /** Native reasoning effort for the scheduled fire (frontmatter `effort`), if set. */
   effort?: ModelReasoningEffort
+  /** Optional scheduled-run watchdog (frontmatter `timeout`), if set. */
+  timeout?: IssueTimeout
   /** Scanner last-fired marker (epoch ms) — scheduled issues only. */
   lastFiredAtMs?: number | null
   /** Computed next fire (epoch ms) — scheduled issues only. */
@@ -258,6 +265,7 @@ export interface IssuePatch {
   credentialSource?: 'native' | null
   model?: string | null
   effort?: ModelReasoningEffort | null
+  timeout?: IssueTimeout | null
   what?: string
 }
 
@@ -287,9 +295,10 @@ export const issuesApi = {
 
   /**
    * Human write path: patch one issue's editable fields (any subset of
-   * status / priority / assignee / agent / credential / model / effort / what).
+   * status / priority / assignee / agent / credential / model / effort / timeout / what).
    * Null runtime fields clear their one-run overrides so Workspace/native
-   * defaults apply. Returns the SAME detail shape as `getDetail` so the caller
+   * defaults apply. `timeout: null` removes the optional run watchdog.
+   * Returns the SAME detail shape as `getDetail` so the caller
    * can apply it directly (refetch-free).
    * Working-tree write on the server, no commit.
    */

--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   getWorkspaceSessionDirectory: vi.fn(),
   listAgentCredentials: vi.fn(),
   getPresets: vi.fn(),
+  updateIssue: vi.fn(),
 }))
 
 const scheduledIssue: IssueDetailData = {
@@ -83,6 +84,17 @@ vi.mock('../api/config', () => ({
   configApi: { getPresets: mocks.getPresets },
 }))
 
+vi.mock('../api/issues', async (importOriginal) => {
+  const actual = await importOriginal() as typeof import('../api/issues')
+  return {
+    ...actual,
+    issuesApi: {
+      ...actual.issuesApi,
+      update: mocks.updateIssue,
+    },
+  }
+})
+
 vi.mock('./MarkdownWhatEditor', () => ({
   MarkdownWhatEditor: ({ value }: { value: string }) => <div>{value}</div>,
 }))
@@ -93,6 +105,8 @@ beforeEach(async () => {
   delete scheduledIssue.issue.credential
   delete scheduledIssue.issue.model
   delete scheduledIssue.issue.effort
+  delete scheduledIssue.issue.timeout
+  mocks.updateIssue.mockResolvedValue(scheduledIssue)
   mocks.getWorkspaceSessionDirectory.mockResolvedValue({ sessions: [] })
   mocks.listAgentCredentials.mockResolvedValue([{
     slug: 'longcat-1',
@@ -209,6 +223,7 @@ describe('IssueDetail property controls', () => {
     expect(screen.getByRole('combobox', { name: 'Priority' })).toBeTruthy()
     expect(screen.getByRole('combobox', { name: 'Assignee' }).className).toContain('w-full')
     expect(screen.getByRole('combobox', { name: 'Runtime' })).toBeTruthy()
+    expect(screen.getByRole('combobox', { name: 'Run timeout' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Configure codex' }).className).toContain('size-10')
     expect(screen.getByRole('heading', { level: 3, name: 'Schedule' })).toBeTruthy()
     expect(screen.getByRole('heading', { level: 3, name: 'Execution' })).toBeTruthy()
@@ -227,6 +242,24 @@ describe('IssueDetail property controls', () => {
 
     fireEvent.change(model, { target: { value: 'custom' } })
     expect(screen.getByRole('textbox', { name: 'Custom run model' })).toBeTruthy()
+  })
+
+  it('patches the optional run timeout from the execution inspector', async () => {
+    mocks.updateIssue.mockResolvedValue({
+      ...scheduledIssue,
+      issue: { ...scheduledIssue.issue, timeout: '30m' },
+    })
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+    const timeout = await screen.findByRole('combobox', { name: 'Run timeout' }) as HTMLSelectElement
+    expect(timeout.value).toBe('')
+    fireEvent.change(timeout, { target: { value: '30m' } })
+    await waitFor(() => {
+      expect(mocks.updateIssue).toHaveBeenCalledWith(
+        'demo-ws-auto-quant',
+        'morning-scan',
+        { timeout: '30m' },
+      )
+    })
   })
 
   it('chooses a credential before narrowing model and effort options', async () => {

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Brain, ChevronRight, Clock, Cpu, Hash, History, Inbox, KeyRound, ListChecks, MessageSquare, RotateCcw, Settings, TrendingUp, X } from 'lucide-react'
+import { ArrowLeft, Brain, ChevronRight, Clock, Cpu, Hash, History, Inbox, KeyRound, ListChecks, MessageSquare, RotateCcw, Settings, Timer, TrendingUp, X } from 'lucide-react'
 
 import type { HeadlessTaskStatus } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
@@ -15,6 +15,8 @@ import type {
   IssueProvenanceRecord,
   IssueRunRecord,
   IssueStatus,
+  IssueTimeout,
+  ISSUE_TIMEOUTS,
   WikilinkIssueRef,
   WikilinkResolution,
 } from '../api/issues'
@@ -816,6 +818,30 @@ function PropertiesRail({
               {agentNeedsCredential && (
                 <p className="mt-2 text-xs leading-snug text-warning">{t('issues.detail.aiCredentialMissing')}</p>
               )}
+              <InspectorField
+                label={t('issues.detail.timeout')}
+                icon={<Timer size={13} aria-hidden />}
+                className="mt-3"
+              >
+                <select
+                  className={`${railControl} w-full`}
+                  aria-label={t('issues.detail.timeout')}
+                  value={issue.timeout ?? ''}
+                  disabled={saving}
+                  onChange={(event) => {
+                    const value = event.target.value
+                    onPatch({ timeout: value === '' ? null : value as IssueTimeout })
+                  }}
+                >
+                  <option value="">{t('issues.detail.timeoutNone')}</option>
+                  {ISSUE_TIMEOUTS.map((timeout) => (
+                    <option key={timeout} value={timeout}>{timeout}</option>
+                  ))}
+                </select>
+                <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
+                  {t('issues.detail.timeoutHint')}
+                </p>
+              </InspectorField>
             </InspectorSection>
 
             {issue.automationHealth && (
@@ -1127,6 +1153,7 @@ function mutationFieldLabel(field: string, t: TFunction): string {
     case 'credential': return t('issues.detail.mutationField.credential')
     case 'model': return t('issues.detail.mutationField.model')
     case 'effort': return t('issues.detail.mutationField.effort')
+    case 'timeout': return t('issues.detail.mutationField.timeout')
     case 'what': return t('issues.detail.mutationField.what')
     default: return field
   }

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -16,10 +16,10 @@ import type {
   IssueRunRecord,
   IssueStatus,
   IssueTimeout,
-  ISSUE_TIMEOUTS,
   WikilinkIssueRef,
   WikilinkResolution,
 } from '../api/issues'
+import { ISSUE_TIMEOUTS, issuesApi } from '../api/issues'
 import type { ModelReasoningEffort } from '../api/types'
 import type { Preset, PresetModel } from '../api/types'
 import { configApi } from '../api/config'
@@ -33,7 +33,6 @@ import {
   type WorkspaceRuntimeModeSettings,
   type WorkspaceSessionDirectoryEntry,
 } from './workspace/api'
-import { issuesApi } from '../api/issues'
 import { credentialAccessLabel } from './workspace/AgentLaunchControls'
 import { useIssueDetail } from '../hooks/useIssueDetail'
 import { useWorkspaces } from '../contexts/workspaces-context'

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -510,6 +510,7 @@ export function demoIssueUpdate(
       delete boardIssue.credential
       delete boardIssue.model
       delete boardIssue.effort
+      // timeout is a run budget, not Session birth — keep it.
     }
   }
   if (patch.what !== undefined) {
@@ -555,6 +556,10 @@ export function demoIssueUpdate(
   if (patch.effort !== undefined) {
     if (patch.effort === null) delete boardIssue.effort
     else boardIssue.effort = patch.effort
+  }
+  if (patch.timeout !== undefined) {
+    if (patch.timeout === null) delete boardIssue.timeout
+    else boardIssue.timeout = patch.timeout
   }
   return demoIssueDetail(wsId, id)
 }

--- a/ui/src/demo/handlers/issues.spec.ts
+++ b/ui/src/demo/handlers/issues.spec.ts
@@ -32,4 +32,22 @@ describe('demo Issue handlers', () => {
       effort: 'high',
     })
   })
+
+  it('round-trips an optional timeout patch through the detail contract', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/issues/demo-ws-auto-quant/morning-scan`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ timeout: '45m' }),
+      },
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.issue).toMatchObject({
+      id: 'morning-scan',
+      timeout: '45m',
+    })
+  })
 })

--- a/ui/src/demo/handlers/issues.ts
+++ b/ui/src/demo/handlers/issues.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import type { ModelReasoningEffort } from '../../api'
-import type { IssuePriority, IssueStatus } from '../../api/issues'
+import { ISSUE_TIMEOUTS, type IssuePriority, type IssueStatus, type IssueTimeout } from '../../api/issues'
 import {
   demoIssueAddComment,
   demoIssueDetail,
@@ -76,6 +76,7 @@ export const issuesHandlers = [
       credentialSource?: unknown
       model?: unknown
       effort?: unknown
+      timeout?: unknown
       what?: unknown
     } | null
     if (!body || typeof body !== 'object') {
@@ -91,6 +92,7 @@ export const issuesHandlers = [
       credentialSource?: 'native' | null
       model?: string | null
       effort?: ModelReasoningEffort | null
+      timeout?: IssueTimeout | null
       what?: string
     } = {}
     if (body.status !== undefined) {
@@ -160,6 +162,15 @@ export const issuesHandlers = [
         patch.effort = body.effort as ModelReasoningEffort
       }
     }
+    if (body.timeout !== undefined) {
+      if (body.timeout === null || body.timeout === '') {
+        patch.timeout = null
+      } else if (!(ISSUE_TIMEOUTS as readonly string[]).includes(String(body.timeout))) {
+        return HttpResponse.json({ error: 'invalid_timeout' }, { status: 400 })
+      } else {
+        patch.timeout = body.timeout as IssueTimeout
+      }
+    }
     if (body.what !== undefined) {
       if (typeof body.what !== 'string' || !body.what.trim()) {
         return HttpResponse.json({ error: 'invalid_what' }, { status: 400 })
@@ -175,6 +186,7 @@ export const issuesHandlers = [
       && patch.credentialSource === undefined
       && patch.model === undefined
       && patch.effort === undefined
+      && patch.timeout === undefined
       && patch.what === undefined
     ) {
       return HttpResponse.json({ error: 'no_fields' }, { status: 400 })

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -106,6 +106,9 @@ export const en = {
       credential: 'Credential',
       model: 'Model',
       effort: 'Effort',
+      timeout: 'Run timeout',
+      timeoutNone: 'No limit',
+      timeoutHint: 'Optional watchdog for this scheduled run. Leave unset so the agent can finish without a time cap.',
       health: 'Health',
       runHealth: 'Run health',
       lastRun: 'Last run',
@@ -219,6 +222,7 @@ export const en = {
         credential: 'Credential',
         model: 'Model',
         effort: 'Effort',
+        timeout: 'Run timeout',
         what: 'What',
       },
       mutationValue: {

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -95,6 +95,9 @@ export const ja: Resources = {
       credential: '認証情報',
       model: 'モデル',
       effort: '推論レベル',
+      timeout: '実行タイムアウト',
+      timeoutNone: '制限なし',
+      timeoutHint: 'このスケジュール実行の任意ウォッチドッグです。未設定ならエージェントが終わるまで待ちます。',
       health: '実行状態',
       runHealth: '実行状態',
       lastRun: '前回の実行',
@@ -208,6 +211,7 @@ export const ja: Resources = {
         credential: '認証情報',
         model: 'モデル',
         effort: '推論レベル',
+        timeout: '実行タイムアウト',
         what: '作業内容',
       },
       mutationValue: {

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -102,6 +102,9 @@ export const zhHant: Resources = {
       credential: '憑證',
       model: '模型',
       effort: '推理強度',
+      timeout: '執行時限',
+      timeoutNone: '不限制',
+      timeoutHint: '這次排程執行的可選看門狗。不設則讓 Agent 跑到自己結束。',
       health: '執行狀態',
       runHealth: '執行狀態',
       lastRun: '上次執行',
@@ -215,6 +218,7 @@ export const zhHant: Resources = {
         credential: '憑證',
         model: '模型',
         effort: '推理強度',
+        timeout: '執行時限',
         what: '任務內容',
       },
       mutationValue: {

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -94,6 +94,9 @@ export const zh: Resources = {
       credential: '凭证',
       model: '模型',
       effort: '推理强度',
+      timeout: '运行时限',
+      timeoutNone: '不限制',
+      timeoutHint: '这次计划运行的可选看门狗。不设则让 Agent 跑到自己结束。',
       health: '运行状态',
       runHealth: '运行状态',
       lastRun: '上次运行',
@@ -207,6 +210,7 @@ export const zh: Resources = {
         credential: '凭证',
         model: '模型',
         effort: '推理强度',
+        timeout: '运行时限',
         what: '任务内容',
       },
       mutationValue: {


### PR DESCRIPTION
Supersedes #1075 for integration because the fork branch does not grant maintainer write access.

Preserves both original RainMona/Cursor commits and adds one review fix: new unlimited Issue runs persist an explicit no-limit sentinel, so they cannot be confused with historical records that inherited the former 30-minute watchdog.

Verification:
- full `pnpm test` (4,139 passed; 9 skipped)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- real `/issues` route: No limit → 15m → No limit persisted correctly

Original PR: #1075