### PR TITLE
feat(connectors): carry Telegram phone-desk chat over comments

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -31,8 +31,8 @@ the durable truth after it changes. Git history is the archive.
 
 - [[plans/telegram-connector-issue.md]] — One Issue per Alice Project is the
   Telegram phone desk: What is the heartbeat prompt, comments are the chat,
-  Connector only transports. Increment 1 is schema, uniqueness, board hide,
-  and Settings bind.
+  Connector only transports. Increment 1 bound the desk in Settings.
+  Increment 2 projects comments unless `[[no-reply]]`.
 - [[plans/session-presence.md]] — Give product Sessions an in-desk presence
   (`active` / `archived` / `deleted`) separate from workspace `retired`, uncap
   the Ask Alice roster, and make Archive the floor action instead of deleting

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -20,8 +20,14 @@ categories.
   Inbox item read.
 - The service is optional in every trading mode, including lite.
 - Guardian may start, stop, or restart it without restarting Alice or UTA.
-- Version 1 is outbound-only. `/link`, `/status`, and `/test` reserve a generic
-  slash-command control plane; ordinary DM text is not ingested.
+- Inbox delivery remains outbound. Telegram owner private-chat text is ingested
+  only as comments on the Alice Project's phone-desk Issue. `/link`, `/status`,
+  and `/test` stay the generic slash-command control plane. Discord DMs are
+  still not ingested.
+- Connector Service never interprets chat. Alice owns the phone-desk Issue.
+  Connector queues owner text and Alice drains it only while a live phone-desk
+  Issue exists; Alice projects desk comments that do not contain the literal
+  tag `[[no-reply]]`. Inbound Telegram comments are not echoed back.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
 - Inbox `docs` that are Markdown or static HTML reports are sent as file attachments, not flattened
@@ -61,6 +67,14 @@ Workspace agent
           -> Discord Connector
           -> Telegram Connector
           -> future adapter
+
+Telegram owner DM
+  -> Telegram adapter (linked private chat only)
+  -> Connector inbound queue
+  -> Alice drain (only while a live phone-desk Issue exists)
+  -> Issue comment (via: telegram)
+  -> existing comment-reply dispatch
+  -> owner-chat projection unless [[no-reply]]
 ```
 
 Load-bearing paths:
@@ -73,6 +87,10 @@ Load-bearing paths:
 - `src/core/connector-config.ts` — sealed config and Guardian enable/restart
   control.
 - `src/services/connector-client/` — Inbox projection and Alice-side health.
+- `src/workspaces/issues/telegram-desk-chat.ts` — phone-desk inbound drain
+  and scheduled-fire comment stamp.
+- `src/workspaces/issues/telegram-desk-project.ts` — `[[no-reply]]` filter
+  and owner-chat projection.
 - `src/webui/routes/connectors.ts` + `ui/src/pages/ConnectorsPage.tsx` — generic
   Settings surface.
 
@@ -164,8 +182,9 @@ The surfaces deliberately have different jobs:
   Issue create/update cannot set `telegramConnector`.
 - The phone-desk Issue is hidden from the Issue board and Tracked list. It still
   fires on `when`. Extra `telegramConnector: true` files in other Workspaces do
-  not fire. Version 2 will project comments to Telegram unless they contain the
-  literal tag `[[no-reply]]`.
+  not fire. Owner DMs become comments; scheduled-fire `assistantText` is stamped
+  as a comment. Connector projects those comments unless they contain the
+  literal tag `[[no-reply]]` or arrived from Telegram.
 - **Beta → Connectors** is a read-only operations view: service health, adapter
   status, linked owner, and last delivery evidence.
 - **Dev Panel** may expose logs and replay tooling, but it is not a product

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -331,8 +331,10 @@ to a Session only when exactly one Session could have made them; concurrent
 edits remain explicitly unknown rather than crediting the wrong coworker.
 
 The Alice Project's Telegram phone-desk Issue uses this same comment sidecar as
-its chat transcript. Settings binds the desk; inbound Telegram projection is a
-later Connector increment and does not create a second conversation object.
+its chat transcript. Owner private-chat text arrives as a human comment with
+`via: telegram` and `origin.kind: external`. Scheduled-fire replies and Alice
+comments are projected back unless they contain `[[no-reply]]`. Connector does
+not create a second conversation object.
 
 When an Issue has a fixed `@resumeId` owner, a comment from somebody else is
 delivered to that exact Session. The final assistant response is recorded as a

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -90,8 +90,9 @@ The filename stem is the stable issue id. Frontmatter:
   most one live desk exists in the Project. Settings → Connectors is the only
   writer of this flag; generic create/CLI/MCP cannot set it. The board and
   Tracked list omit the row. What remains the exact scheduled Input Prompt.
-  Comments are the chat transcript. Connector delivery of those comments is a
-  later increment.
+  Comments are the chat transcript. Owner Telegram DMs become comments;
+  scheduled-fire `assistantText` is stamped as a comment. Connector projects
+  comments that do not contain `[[no-reply]]` and did not arrive from Telegram.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 Only the credential slug is persisted; endpoint and key material remain in the

--- a/packages/connector-protocol/src/client.ts
+++ b/packages/connector-protocol/src/client.ts
@@ -2,9 +2,13 @@ import {
   connectorDeliveryReceiptSchema,
   connectorServiceHealthSchema,
   inboxNotificationSchema,
+  inboundOwnerMessageSchema,
+  ownerChatMessageSchema,
   type ConnectorDeliveryReceipt,
   type ConnectorServiceHealth,
   type InboxNotification,
+  type InboundOwnerMessage,
+  type OwnerChatMessage,
 } from './types.js'
 
 export class ConnectorClient {
@@ -27,6 +31,31 @@ export class ConnectorClient {
       signal,
     })
     if (!response.ok) throw new Error(`Connector Service delivery failed: ${response.status}`)
+    return connectorDeliveryReceiptSchema.parse(await response.json())
+  }
+
+  async drainInbound(signal?: AbortSignal): Promise<InboundOwnerMessage[]> {
+    const response = await this.fetchImpl(new URL('/v1/inbound/drain', this.baseUrl), {
+      method: 'POST',
+      signal,
+    })
+    if (!response.ok) throw new Error(`Connector Service inbound drain failed: ${response.status}`)
+    const body = await response.json() as { messages?: unknown }
+    if (!Array.isArray(body.messages)) return []
+    return body.messages.flatMap((message) => {
+      const parsed = inboundOwnerMessageSchema.safeParse(message)
+      return parsed.success ? [parsed.data] : []
+    })
+  }
+
+  async sendOwnerMessage(message: OwnerChatMessage, signal?: AbortSignal): Promise<ConnectorDeliveryReceipt> {
+    const response = await this.fetchImpl(new URL('/v1/notifications/owner-chat', this.baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ownerChatMessageSchema.parse(message)),
+      signal,
+    })
+    if (!response.ok) throw new Error(`Connector Service owner-chat delivery failed: ${response.status}`)
     return connectorDeliveryReceiptSchema.parse(await response.json())
   }
 }

--- a/packages/connector-protocol/src/types.spec.ts
+++ b/packages/connector-protocol/src/types.spec.ts
@@ -2,7 +2,9 @@ import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
 import {
   MAX_CONNECTOR_ATTACHMENT_BYTES,
+  OWNER_CHAT_TEXT_MAX,
   inboxNotificationSchema,
+  ownerChatMessageSchema,
 } from './types.js'
 
 const baseNotification = {
@@ -12,6 +14,26 @@ const baseNotification = {
   title: 'Report ready',
   body: '',
 }
+
+describe('owner chat messages', () => {
+  it('rejects empty or oversized owner-chat text', () => {
+    expect(() => ownerChatMessageSchema.parse({
+      id: 'desk-1',
+      adapterId: 'telegram',
+      text: '',
+    })).toThrow()
+    expect(ownerChatMessageSchema.parse({
+      id: 'desk-1',
+      adapterId: 'telegram',
+      text: 'Markets are quiet.',
+    }).text).toBe('Markets are quiet.')
+    expect(() => ownerChatMessageSchema.parse({
+      id: 'desk-1',
+      adapterId: 'telegram',
+      text: 'x'.repeat(OWNER_CHAT_TEXT_MAX + 1),
+    })).toThrow()
+  })
+})
 
 describe('Inbox notification attachments', () => {
   it('accepts a bounded Markdown file payload', () => {

--- a/packages/connector-protocol/src/types.ts
+++ b/packages/connector-protocol/src/types.ts
@@ -119,4 +119,22 @@ export const connectorDeliveryReceiptSchema = z.object({
   accepted: z.literal(true),
   deliveryId: z.string().min(1),
 })
+
+/** Owner-private chat text. Not an Inbox item. Telegram's sendMessage cap is 4096. */
+export const OWNER_CHAT_TEXT_MAX = 4096
+
+export const ownerChatMessageSchema = z.object({
+  id: z.string().min(1),
+  adapterId: z.string().min(1),
+  text: z.string().min(1).max(OWNER_CHAT_TEXT_MAX),
+})
+export type OwnerChatMessage = z.infer<typeof ownerChatMessageSchema>
+
+export const inboundOwnerMessageSchema = z.object({
+  connectorId: z.string().min(1),
+  userId: z.string().min(1),
+  chatId: z.string().min(1).optional(),
+  text: z.string().min(1).max(OWNER_CHAT_TEXT_MAX),
+})
+export type InboundOwnerMessage = z.infer<typeof inboundOwnerMessageSchema>
 export type ConnectorDeliveryReceipt = z.infer<typeof connectorDeliveryReceiptSchema>

--- a/plans/telegram-connector-issue.md
+++ b/plans/telegram-connector-issue.md
@@ -1,6 +1,6 @@
 # Plan: Telegram phone-desk Issue
 
-**Status:** active — increment 1  
+**Status:** active — increment 2  
 **Owner guides:** [[docs/workspace-issues-and-scheduling.md]], [[docs/connector-service.md]], [[docs/conversation-provenance.md]]  
 **Delivery:** serial PRs to `dev` (`area:collaboration`, `area:settings`). Increment 2 is `review:deep`. Open PR, do not merge.
 
@@ -65,9 +65,9 @@ Existing per-`resumeId` busy stays. Queue-on-busy is out of this plan.
 
 ### 2. Comments in, comments out, `[[no-reply]]` (`review:deep`)
 
-- [ ] Inbound owner DM → comment → existing reply dispatch → project unless `[[no-reply]]`
-- [ ] Scheduled fire of this Issue stamps `assistantText` as a comment, then same filter
-- [ ] Literal tag only; send nothing when present
+- [x] Inbound owner DM → comment → existing reply dispatch → project unless `[[no-reply]]`
+- [x] Scheduled fire of this Issue stamps `assistantText` as a comment, then same filter
+- [x] Literal tag only; send nothing when present
 
 ### Not in this plan
 

--- a/services/connector/src/adapters/discord.ts
+++ b/services/connector/src/adapters/discord.ts
@@ -112,6 +112,20 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
     }
   }
 
+  async sendOwnerText(text: string): Promise<void> {
+    if (!this.client?.isReady()) throw new Error('Discord client is not ready')
+    if (!this.ownerUserId) throw new Error('Discord owner is not linked')
+    this.tracker.attempt()
+    try {
+      const user = await this.client.users.fetch(this.ownerUserId)
+      await user.send({ content: text })
+      this.tracker.success(this.ownerUserId)
+    } catch (error) {
+      this.tracker.degraded(error)
+      throw error
+    }
+  }
+
   health(): ConnectorAdapterHealth {
     return this.tracker.get()
   }

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -13,6 +13,7 @@ vi.mock('grammy', () => ({
       setMyCommands,
     }
     command() {}
+    on() {}
     start(options: { onStart?: () => void }) {
       return startMock(options)
     }
@@ -33,6 +34,7 @@ function context() {
     updateSettings: async () => undefined,
     getServiceStatus: () => 'healthy',
     sendTest: async () => 'probe',
+    forwardOwnerText: async () => undefined,
   }
 }
 

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -56,6 +56,23 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
         })
       }
       this.registerCommands(context)
+      bot.on('message:text', async (ctx) => {
+        if (ctx.chat.type !== 'private' || !ctx.from) return
+        const text = ctx.message.text.trim()
+        if (!text || text.startsWith('/')) return
+        if (!this.isOwner(String(ctx.from.id))) return
+        try {
+          await context.forwardOwnerText({
+            text,
+            userId: String(ctx.from.id),
+            chatId: String(ctx.chat.id),
+          })
+        } catch (error) {
+          this.tracker.degraded(error)
+          await ctx.reply('OpenAlice could not accept this message. Check Connector Settings and logs.')
+            .catch(() => undefined)
+        }
+      })
       await withTimeout(async () => {
         await bot.api.setMyCommands(TELEGRAM_CONNECTOR_DEFINITION.commands.map(({ name, description }) => ({
           command: name,
@@ -91,6 +108,19 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
           new InputFile(attachment.content, attachment.filename),
         )
       }
+      this.tracker.success(this.ownerUserId)
+    } catch (error) {
+      this.tracker.degraded(error)
+      throw error
+    }
+  }
+
+  async sendOwnerText(text: string): Promise<void> {
+    if (!this.bot) throw new Error('Telegram bot is not ready')
+    if (!this.chatId) throw new Error('Telegram private chat is not linked')
+    this.tracker.attempt()
+    try {
+      await this.bot.api.sendMessage(this.chatId, text)
       this.tracker.success(this.ownerUserId)
     } catch (error) {
       this.tracker.degraded(error)

--- a/services/connector/src/core/adapter.ts
+++ b/services/connector/src/core/adapter.ts
@@ -27,6 +27,7 @@ export interface ConnectorAdapterContext {
   updateSettings(patch: Record<string, string | number | boolean>): Promise<void>
   getServiceStatus(): string
   sendTest(connectorId: string): Promise<string>
+  forwardOwnerText(input: { text: string; userId: string; chatId?: string }): Promise<void>
 }
 
 export interface ConnectorAdapter {
@@ -34,6 +35,7 @@ export interface ConnectorAdapter {
   start(config: ConnectorAdapterConfig, context: ConnectorAdapterContext): Promise<void>
   stop(): Promise<void>
   deliver(notification: InboxNotification): Promise<void>
+  sendOwnerText(text: string): Promise<void>
   health(): ConnectorAdapterHealth
 }
 

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -7,7 +7,7 @@ import type {
 } from '@traderalice/connector-protocol'
 import type { ConnectorAdapter, ConnectorAdapterContext } from './adapter.js'
 import { ConnectorRegistry } from './adapter.js'
-import { DeliveryManager } from './delivery-manager.js'
+import { DeliveryManager, MAX_INBOUND_OWNER_MESSAGES } from './delivery-manager.js'
 import { createConnectorIOEvent, type ConnectorIOEvent, type ConnectorIORecorder } from './io-events.js'
 
 class MemoryRecorder implements ConnectorIORecorder {
@@ -33,6 +33,8 @@ class FakeThirdPartyAdapter implements ConnectorAdapter {
   async deliver(notification: InboxNotification): Promise<void> {
     this.delivered.push(notification)
   }
+
+  async sendOwnerText(): Promise<void> {}
 
   health(): ConnectorAdapterHealth {
     return { id: this.id, enabled: true, status: this.status }
@@ -70,6 +72,20 @@ describe('DeliveryManager connector registry', () => {
 
     expect(adapter.delivered).toHaveLength(1)
     expect(manager.health()).toMatchObject({ status: 'healthy' })
+    manager.acceptInbound({ connectorId: 'carrier-pigeon', userId: '1', text: 'hello' })
+    expect(manager.drainInbound()).toEqual([
+      { connectorId: 'carrier-pigeon', userId: '1', text: 'hello' },
+    ])
+    expect(manager.drainInbound()).toEqual([])
+    manager.acceptInbound({ connectorId: 'carrier-pigeon', userId: '1', text: '' })
+    expect(manager.drainInbound()).toEqual([])
+    for (let i = 0; i < MAX_INBOUND_OWNER_MESSAGES + 1; i += 1) {
+      manager.acceptInbound({ connectorId: 'carrier-pigeon', userId: '1', text: `m${i}` })
+    }
+    const kept = manager.drainInbound(MAX_INBOUND_OWNER_MESSAGES)
+    expect(kept).toHaveLength(MAX_INBOUND_OWNER_MESSAGES)
+    expect(kept[0]?.text).toBe('m1')
+    expect(kept.at(-1)?.text).toBe(`m${MAX_INBOUND_OWNER_MESSAGES}`)
     await manager.stop()
   })
 
@@ -81,6 +97,7 @@ describe('DeliveryManager connector registry', () => {
       start: async () => { await gate },
       stop: async () => undefined,
       deliver: async () => undefined,
+      sendOwnerText: async () => undefined,
       health: () => ({ id: 'slow', enabled: true, status: 'starting' }),
     }
     const registry = new ConnectorRegistry()
@@ -112,6 +129,7 @@ describe('DeliveryManager connector registry', () => {
       start: async () => { throw new Error('Telegram API did not become ready') },
       stop: async () => undefined,
       deliver: async () => { throw new Error('Telegram is not ready') },
+      sendOwnerText: async () => undefined,
       health: () => ({
         id: 'broken',
         enabled: true,
@@ -148,6 +166,7 @@ describe('DeliveryManager connector registry', () => {
         start: async () => undefined,
         stop: async () => undefined,
         deliver: async () => { throw new Error('external outage') },
+        sendOwnerText: async () => undefined,
         health: () => ({ id: 'broken', enabled: true, status: 'degraded' as const, lastError: 'external outage' }),
       }),
     })
@@ -176,6 +195,7 @@ describe('DeliveryManager connector registry', () => {
         start: async () => undefined,
         stop: async () => undefined,
         deliver: async () => { throw new Error('owner not linked') },
+        sendOwnerText: async () => undefined,
         health: () => ({ id: 'unlinked', enabled: true, status: 'awaiting_link' as const }),
       }),
     })

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -186,6 +186,36 @@ describe('DeliveryManager connector registry', () => {
     })).resolves.toBeUndefined()
   })
 
+  it('contains asynchronous owner-chat failures after accepting the projection', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const registry = new ConnectorRegistry()
+    registry.register({
+      definition: { id: 'broken', label: 'Broken', description: 'Broken adapter.', fields: [], commands: [] },
+      create: () => ({
+        id: 'broken',
+        start: async () => undefined,
+        stop: async () => undefined,
+        deliver: async () => undefined,
+        sendOwnerText: async () => { throw new Error('owner chat offline') },
+        health: () => ({ id: 'broken', enabled: true, status: 'degraded' as const }),
+      }),
+    })
+    const manager = new DeliveryManager({
+      registry,
+      config: { version: 1, adapters: { broken: { enabled: true, settings: {} } } },
+      updateAdapterSettings: vi.fn(),
+    })
+    await manager.start()
+
+    expect(manager.enqueueOwnerChat({ id: 'desk-comment-1', adapterId: 'broken', text: 'hello' }))
+      .toEqual({ accepted: true, deliveryId: 'desk-comment-1' })
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledWith(
+      '[connector] broken owner-chat delivery failed:',
+      'owner chat offline',
+    ))
+    warn.mockRestore()
+  })
+
   it('treats an online bot waiting for /link as an intentional setup phase', async () => {
     const registry = new ConnectorRegistry()
     registry.register({

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from 'node:crypto'
-import type {
-  ConnectorAdapterConfig,
-  ConnectorAdapterHealth,
-  ConnectorConfig,
-  ConnectorDeliveryReceipt,
-  ConnectorServiceHealth,
-  InboxNotification,
+import {
+  inboundOwnerMessageSchema,
+  type ConnectorAdapterConfig,
+  type ConnectorAdapterHealth,
+  type ConnectorConfig,
+  type ConnectorDeliveryReceipt,
+  type ConnectorServiceHealth,
+  type InboxNotification,
+  type InboundOwnerMessage,
+  type OwnerChatMessage,
 } from '@traderalice/connector-protocol'
 import {
   CommandRegistry,
@@ -32,9 +35,12 @@ export interface DeliveryManagerOptions {
  * from the caller that originally wrote the Inbox item. Enqueue accepts the
  * durable notification and performs external delivery after returning.
  */
+export const MAX_INBOUND_OWNER_MESSAGES = 100
+
 export class DeliveryManager {
   private readonly adapters = new Map<string, ConnectorAdapter>()
   private readonly commands = new Map<string, CommandRegistry>()
+  private readonly inbound: InboundOwnerMessage[] = []
   private readonly startedAt: string
   private stopped = false
 
@@ -128,6 +134,58 @@ export class DeliveryManager {
     return probeId
   }
 
+  acceptInbound(input: InboundOwnerMessage): void {
+    const parsed = inboundOwnerMessageSchema.safeParse(input)
+    if (!parsed.success) return
+    this.inbound.push(parsed.data)
+    const overflow = this.inbound.length - MAX_INBOUND_OWNER_MESSAGES
+    if (overflow > 0) this.inbound.splice(0, overflow)
+  }
+
+  drainInbound(limit = 20): InboundOwnerMessage[] {
+    return this.inbound.splice(0, Math.max(0, limit))
+  }
+
+  enqueueOwnerChat(message: OwnerChatMessage): ConnectorDeliveryReceipt {
+    const deliveryId = message.id
+    queueMicrotask(() => {
+      if (this.stopped) return
+      void this.sendOwnerChat(message, deliveryId)
+    })
+    return { accepted: true, deliveryId }
+  }
+
+  async sendOwnerChat(message: OwnerChatMessage, correlationId = message.id): Promise<void> {
+    const adapter = this.adapters.get(message.adapterId)
+    if (!adapter) throw new Error(`Connector is not running: ${message.adapterId}`)
+    await this.record({
+      correlationId,
+      direction: 'outbound',
+      stage: 'delivery.attempted',
+      connectorId: adapter.id,
+      payload: { kind: 'owner-chat', textLength: message.text.length },
+    })
+    try {
+      await adapter.sendOwnerText(message.text)
+      await this.record({
+        correlationId,
+        direction: 'outbound',
+        stage: 'delivery.succeeded',
+        connectorId: adapter.id,
+        payload: { kind: 'owner-chat' },
+      })
+    } catch (error) {
+      await this.record({
+        correlationId,
+        direction: 'outbound',
+        stage: 'delivery.failed',
+        connectorId: adapter.id,
+        payload: { kind: 'owner-chat', error: error instanceof Error ? error.message : String(error) },
+      })
+      throw error
+    }
+  }
+
   health(): ConnectorServiceHealth {
     const adapters: ConnectorAdapterHealth[] = []
     for (const [id, config] of Object.entries(this.options.config.adapters)) {
@@ -168,6 +226,14 @@ export class DeliveryManager {
       updateSettings: (patch) => this.options.updateAdapterSettings(id, patch),
       getServiceStatus: () => this.health().status,
       sendTest: (connectorId) => this.sendTest(connectorId),
+      forwardOwnerText: async (input) => {
+        this.acceptInbound({
+          connectorId: id,
+          userId: input.userId,
+          text: input.text,
+          ...(input.chatId ? { chatId: input.chatId } : {}),
+        })
+      },
     }
     // Keep a failed adapter registered. start() may record a useful degraded
     // reason; dropping it here reduced Settings to "configured but not running".

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -150,7 +150,16 @@ export class DeliveryManager {
     const deliveryId = message.id
     queueMicrotask(() => {
       if (this.stopped) return
-      void this.sendOwnerChat(message, deliveryId)
+      void this.sendOwnerChat(message, deliveryId).catch((error) => {
+        // The Issue comment is already durable before Alice projects it here.
+        // Keep owner-chat delivery best-effort like ordinary Inbox projection:
+        // a stopped/unlinked adapter or external outage must not become an
+        // unhandled rejection that can terminate Connector Service.
+        console.warn(
+          `[connector] ${message.adapterId} owner-chat delivery failed:`,
+          error instanceof Error ? error.message : error,
+        )
+      })
     })
     return { accepted: true, deliveryId }
   }

--- a/services/connector/src/main.ts
+++ b/services/connector/src/main.ts
@@ -10,6 +10,7 @@ import { serve } from '@hono/node-server'
 import {
   connectorDeliveryReceiptSchema,
   inboxNotificationSchema,
+  ownerChatMessageSchema,
 } from '@traderalice/connector-protocol'
 import { ConnectorRegistry } from './core/adapter.js'
 import { DeliveryManager } from './core/delivery-manager.js'
@@ -53,6 +54,13 @@ async function main(): Promise<void> {
   app.post('/v1/notifications/inbox', async (c) => {
     const notification = inboxNotificationSchema.parse(await c.req.json())
     return c.json(connectorDeliveryReceiptSchema.parse(manager.enqueue(notification)), 202)
+  })
+  app.post('/v1/notifications/owner-chat', async (c) => {
+    const message = ownerChatMessageSchema.parse(await c.req.json())
+    return c.json(connectorDeliveryReceiptSchema.parse(manager.enqueueOwnerChat(message)), 202)
+  })
+  app.post('/v1/inbound/drain', async (c) => {
+    return c.json({ messages: manager.drainInbound() })
   })
   app.post('/v1/connectors/:id/test', async (c) => {
     const probeId = await manager.sendTest(c.req.param('id'))

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,8 @@ import { createEconomyTools } from './tool/economy.js'
 import { SessionStore } from './core/session.js'
 import { createInboxStore } from './core/inbox-store.js'
 import { startInboxConnectorBridge } from './services/connector-client/index.js'
+import { createWorkspaceConversationControl } from './workspaces/conversation-control.js'
+import { startTelegramDeskInboundPoll } from './workspaces/issues/telegram-desk-chat.js'
 import { ToolCenter } from './core/tool-center.js'
 import { WorkspaceToolCenter } from './core/workspace-tool-center.js'
 import { inboxPushFactory } from './tool/inbox-push.js'
@@ -287,6 +289,15 @@ async function main() {
   // skip (see cron listener). Created here so cron dispatch can hold it.
   const workspaceServiceRef = createWorkspaceServiceRef()
   startInboxConnectorBridge(inboxStore, () => workspaceServiceRef.current)
+  startTelegramDeskInboundPoll({
+    listWorkspaces: () => workspaceServiceRef.current?.registry.list() ?? [],
+    getWorkspace: (id) => workspaceServiceRef.current?.registry.get(id),
+    provenanceStore: () => workspaceServiceRef.current?.provenanceStore,
+    conversation: () => {
+      const service = workspaceServiceRef.current
+      return service ? createWorkspaceConversationControl(service) : undefined
+    },
+  })
 
   // Snapshot scheduler lives in UTA after Step 6 — Alice no longer
   // drives the periodic equity-curve writes. The UTA service starts

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -57,6 +57,7 @@ import {
   type IssueComment,
 } from '../workspaces/issues/comments.js'
 import { dispatchIssueCommentReply } from '../workspaces/issues/comment-delivery.js'
+import { projectDeskComment } from '../workspaces/issues/telegram-desk-project.js'
 import { issueMutation, issueMutationFingerprint } from '../workspaces/issues/change-tracker.js'
 import {
   NEW_THEN_RESUME_ASSIGNEE,
@@ -426,6 +427,7 @@ export const issueCommentFactory: WorkspaceToolFactory = {
             ...(origin ? { authorResumeId: origin.resumeId } : {}),
             source: origin ?? { kind: 'workspace', workspaceId: ctx.workspaceId },
           })
+          await projectDeskComment(res.issue, res.comment).catch(() => undefined)
           if (dispatched.status !== 'not_requested') {
             const updated = await updateIssueCommentDelivery(
               dir.dir,

--- a/src/webui/routes/issues.ts
+++ b/src/webui/routes/issues.ts
@@ -51,6 +51,7 @@ import {
   type IssueTimeout,
 } from '../../workspaces/issues/declaration.js'
 import { appendIssueComment, updateIssueFields } from '../../workspaces/issues/mutate.js'
+import { projectDeskComment } from '../../workspaces/issues/telegram-desk-project.js'
 import { deprecatedIssueAssigneeReplacement } from '../../workspaces/session-signature.js'
 import { isAgentRuntime } from '../../workspaces/cli-adapter.js'
 import { logger as launcherLogger } from '../../workspaces/logger.js'
@@ -405,6 +406,9 @@ export function createIssuesRoutes(svc: WorkspaceService, deps: IssueRoutesDeps 
           })
         }
       }
+      await projectDeskComment(res.issue, res.comment).catch((err) => {
+        launcherLogger.warn('telegram_desk.comment_project_failed', { wsId, id, err })
+      })
       launcherLogger.info('issue.comment_added', { wsId, id, author: 'human' })
       const detail = await svc.issueDetail(wsId, id)
       return c.json(detail ?? { issue: res.issue, comments: [res.comment], runs: [], inboxReports: [], provenance: [], activity: [] })

--- a/src/workspaces/issues/comment-delivery.ts
+++ b/src/workspaces/issues/comment-delivery.ts
@@ -12,6 +12,7 @@ import {
   type IssueCommentDelivery,
 } from './comments.js'
 import { issueAssigneeResumeId, type IssueRecord } from './declaration.js'
+import { projectDeskComment } from './telegram-desk-project.js'
 
 const COMMENT_REPLY_TIMEOUT_MS = 300_000
 
@@ -183,6 +184,7 @@ export async function recordIssueCommentReply(input: {
       },
     )
     if (!updated.ok) throw new Error(updated.error)
+    await projectDeskComment(appended.issue, appended.comment).catch(() => undefined)
     return 'replied'
   }
 

--- a/src/workspaces/issues/comments.ts
+++ b/src/workspaces/issues/comments.ts
@@ -25,6 +25,8 @@ export interface IssueComment {
   replyTo?: string
   /** Delivery is optional for agent-authored notes and owner self-comments. */
   delivery?: IssueCommentDelivery
+  /** Present when the comment arrived through a Connector owner chat. */
+  via?: 'telegram'
 }
 
 export type IssueCommentDelivery =
@@ -73,6 +75,7 @@ const issueCommentSchema = z.object({
   markdown: z.string().min(1),
   replyTo: z.string().min(1).optional(),
   delivery: issueCommentDeliverySchema.optional(),
+  via: z.literal('telegram').optional(),
 })
 
 const issueCommentsFileSchema = z.object({
@@ -116,6 +119,7 @@ export interface AppendIssueCommentOptions {
   at?: string
   replyTo?: string
   delivery?: IssueCommentDelivery
+  via?: 'telegram'
 }
 
 async function writeIssueComments(wsDir: string, id: string, comments: IssueComment[]): Promise<void> {
@@ -155,6 +159,7 @@ export async function appendIssueComment(
     markdown,
     ...(options.replyTo ? { replyTo: options.replyTo } : {}),
     ...(options.delivery ? { delivery: options.delivery } : {}),
+    ...(options.via ? { via: options.via } : {}),
   }
   await writeIssueComments(wsDir, id, [...existing.comments, comment])
   return { ok: true, issue: issue.issue, comment }

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -1,0 +1,145 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { ConnectorClient } from '@traderalice/connector-protocol'
+
+import { createTelegramConnectorDesk } from './telegram-connector.js'
+import {
+  containsTelegramNoReply,
+  ingestTelegramOwnerMessage,
+  pullTelegramDeskInbound,
+  shouldProjectDeskComment,
+  stampTelegramDeskScheduledFire,
+  type TelegramDeskChatHost,
+} from './telegram-desk-chat.js'
+
+let home: string
+let wsDir: string
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), 'tg-desk-chat-'))
+  wsDir = join(home, 'ws')
+  await mkdir(join(wsDir, '.alice', 'issues'), { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true })
+})
+
+function host(): TelegramDeskChatHost {
+  return {
+    listWorkspaces: () => [{ id: 'ws-a', dir: wsDir }],
+    getWorkspace: (id) => id === 'ws-a' ? { id: 'ws-a', dir: wsDir } : undefined,
+    provenanceStore: () => ({
+      append: async () => undefined,
+      list: () => [],
+      latest: () => undefined,
+    } as unknown as NonNullable<ReturnType<TelegramDeskChatHost['provenanceStore']>>),
+    conversation: () => undefined,
+  }
+}
+
+describe('telegram desk chat filter', () => {
+  it('projects agent comments and skips inbound telegram or [[no-reply]]', () => {
+    const issue = { telegramConnector: true as const }
+    expect(shouldProjectDeskComment(issue, {
+      id: 'c1', author: '@resume-a', at: 'now', markdown: 'Hello from the desk.',
+    })).toBe(true)
+    expect(shouldProjectDeskComment(issue, {
+      id: 'c2', author: 'human', at: 'now', markdown: 'From Telegram', via: 'telegram',
+    })).toBe(false)
+    expect(shouldProjectDeskComment(issue, {
+      id: 'c3', author: '@resume-a', at: 'now', markdown: '[[no-reply]] nothing to say',
+    })).toBe(false)
+    expect(shouldProjectDeskComment({}, {
+      id: 'c4', author: '@resume-a', at: 'now', markdown: 'ordinary issue',
+    })).toBe(false)
+  })
+
+  it('matches the no-reply tag as a literal substring', () => {
+    expect(containsTelegramNoReply('[[no-reply]] quiet')).toBe(true)
+    expect(containsTelegramNoReply('no reply')).toBe(false)
+  })
+})
+
+describe('telegram desk ingest and stamp', () => {
+  it('refuses inbound when the phone desk is disabled', async () => {
+    const result = await ingestTelegramOwnerMessage(host(), {
+      connectorId: 'telegram',
+      userId: '42',
+      text: 'Anybody home?',
+    })
+    expect(result).toEqual({ ok: false, reason: 'desk_disabled' })
+  })
+
+  it('records an inbound owner DM as a human comment that does not echo', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    const result = await ingestTelegramOwnerMessage(host(), {
+      connectorId: 'telegram',
+      userId: '42',
+      text: 'What is the overnight risk?',
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.comment.author).toBe('human')
+    expect(result.comment.via).toBe('telegram')
+    expect(result.comment.markdown).toBe('What is the overnight risk?')
+    expect(shouldProjectDeskComment(created.ok ? created.issue : { telegramConnector: true }, result.comment)).toBe(false)
+  })
+
+  it('stamps a scheduled fire as a comment', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+    const comment = await stampTelegramDeskScheduledFire({
+      host: host(),
+      workspaceId: 'ws-a',
+      issueId: created.issue.id,
+      task: {
+        taskId: 'run-1',
+        resumeId: 'resume-desk-owner',
+        wsId: 'ws-a',
+        agent: 'pi',
+        prompt: 'wake',
+        startedAt: 1,
+        status: 'done',
+        finishedAt: 2,
+      },
+      assistantText: 'Markets are quiet. [[no-reply]] no send.',
+    })
+    expect(comment?.markdown).toContain('[[no-reply]]')
+    expect(comment?.id).toBe('comment-fire-run-1')
+    if (!comment) return
+    expect(shouldProjectDeskComment(created.issue, comment)).toBe(false)
+  })
+
+  it('does not drain Connector inbound until a live desk exists', async () => {
+    let drained = 0
+    const client = {
+      drainInbound: async () => {
+        drained += 1
+        return [{ connectorId: 'telegram', userId: '42', text: 'queued' }]
+      },
+    } as unknown as ConnectorClient
+
+    await pullTelegramDeskInbound(host(), client)
+    expect(drained).toBe(0)
+
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    await pullTelegramDeskInbound(host(), client)
+    expect(drained).toBe(1)
+  })
+})

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -10,6 +10,7 @@ import {
   containsTelegramNoReply,
   ingestTelegramOwnerMessage,
   pullTelegramDeskInbound,
+  startTelegramDeskInboundPoll,
   shouldProjectDeskComment,
   stampTelegramDeskScheduledFire,
   type TelegramDeskChatHost,
@@ -122,6 +123,34 @@ describe('telegram desk ingest and stamp', () => {
     expect(shouldProjectDeskComment(created.issue, comment)).toBe(false)
   })
 
+  it('does not publish partial assistant text from a failed scheduled fire', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+
+    const comment = await stampTelegramDeskScheduledFire({
+      host: host(),
+      workspaceId: 'ws-a',
+      issueId: created.issue.id,
+      task: {
+        taskId: 'run-failed',
+        resumeId: 'resume-desk-owner',
+        wsId: 'ws-a',
+        agent: 'pi',
+        prompt: 'wake',
+        startedAt: 1,
+        status: 'failed',
+        finishedAt: 2,
+      },
+      assistantText: 'Partial answer before the runtime failed.',
+    })
+
+    expect(comment).toBeNull()
+  })
+
   it('does not drain Connector inbound until a live desk exists', async () => {
     let drained = 0
     const client = {
@@ -141,5 +170,34 @@ describe('telegram desk ingest and stamp', () => {
     expect(created.ok).toBe(true)
     await pullTelegramDeskInbound(host(), client)
     expect(drained).toBe(1)
+  })
+
+  it('does not overlap inbound drains when one poll is still running', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+
+    let active = 0
+    let maxActive = 0
+    let drains = 0
+    const client = {
+      drainInbound: async () => {
+        drains += 1
+        active += 1
+        maxActive = Math.max(maxActive, active)
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        active -= 1
+        return []
+      },
+    } as unknown as ConnectorClient
+
+    const stop = startTelegramDeskInboundPoll(host(), { intervalMs: 2, client })
+    await new Promise((resolve) => setTimeout(resolve, 55))
+    stop()
+
+    expect(drains).toBeGreaterThan(1)
+    expect(maxActive).toBe(1)
   })
 })

--- a/src/workspaces/issues/telegram-desk-chat.ts
+++ b/src/workspaces/issues/telegram-desk-chat.ts
@@ -1,0 +1,170 @@
+/**
+ * Telegram phone-desk chat hop.
+ *
+ * Connector only transports. Issue comments are the transcript. The literal
+ * tag [[no-reply]] is filtered here so silent heartbeat comments stay local.
+ */
+import { randomUUID } from 'node:crypto'
+import {
+  ConnectorClient,
+  type InboundOwnerMessage,
+} from '@traderalice/connector-protocol'
+
+import type { WorkspaceConversationControl } from '../../core/workspace-tool-center.js'
+import type { IProvenanceStore } from '../../core/provenance-store.js'
+import { resolveConnectorUrl } from '../../services/connector-client/index.js'
+import type { HeadlessTaskRecord } from '../headless-task-registry.js'
+import { sessionSignature } from '../session-signature.js'
+import {
+  appendIssueComment,
+  updateIssueCommentDelivery,
+  type IssueComment,
+} from './comments.js'
+import { dispatchIssueCommentReply } from './comment-delivery.js'
+import {
+  findTelegramConnectorDesks,
+  type TelegramConnectorDesk,
+} from './telegram-connector.js'
+import { projectDeskComment } from './telegram-desk-project.js'
+
+export {
+  TELEGRAM_NO_REPLY_TAG,
+  containsTelegramNoReply,
+  projectDeskComment,
+  shouldProjectDeskComment,
+} from './telegram-desk-project.js'
+
+export interface TelegramDeskChatHost {
+  listWorkspaces(): readonly { id: string; dir: string }[]
+  getWorkspace(id: string): { id: string; dir: string } | undefined
+  provenanceStore(): IProvenanceStore | undefined
+  conversation(): WorkspaceConversationControl | undefined
+}
+
+export async function ingestTelegramOwnerMessage(
+  host: TelegramDeskChatHost,
+  message: InboundOwnerMessage,
+): Promise<{ ok: true; comment: IssueComment } | { ok: false; reason: string }> {
+  if (message.connectorId !== 'telegram') {
+    return { ok: false, reason: 'unsupported_connector' }
+  }
+  const desk = await findLiveDesk(host)
+  if (!desk) return { ok: false, reason: 'desk_disabled' }
+  const workspace = host.getWorkspace(desk.wsId)
+  if (!workspace) return { ok: false, reason: 'workspace_missing' }
+
+  const appended = await appendIssueComment(workspace.dir, desk.issue.id, 'human', message.text, {
+    id: `telegram-${randomUUID()}`,
+    via: 'telegram',
+  })
+  if (!appended.ok) {
+    return { ok: false, reason: appended.reason === 'invalid' ? appended.error : 'issue_missing' }
+  }
+
+  await host.provenanceStore()?.append({
+    artifact: { kind: 'issue', workspaceId: desk.wsId, issueId: desk.issue.id },
+    action: 'commented',
+    origin: { kind: 'external', system: 'telegram' },
+    at: Date.now(),
+  })
+
+  const conversation = host.conversation()
+  const dispatched = await dispatchIssueCommentReply({
+    conversation,
+    issueWorkspaceId: desk.wsId,
+    issue: appended.issue,
+    comment: appended.comment,
+    source: { kind: 'human' },
+  })
+  if (dispatched.status !== 'not_requested') {
+    await updateIssueCommentDelivery(workspace.dir, desk.issue.id, appended.comment.id, dispatched.delivery)
+  }
+  return { ok: true, comment: appended.comment }
+}
+
+export async function stampTelegramDeskScheduledFire(input: {
+  host: TelegramDeskChatHost
+  workspaceId: string
+  issueId: string
+  task: HeadlessTaskRecord
+  assistantText?: string | null
+}): Promise<IssueComment | null> {
+  const text = input.assistantText?.trim()
+  if (!text) return null
+  const workspace = input.host.getWorkspace(input.workspaceId)
+  if (!workspace) return null
+  const desks = await findTelegramConnectorDesks(input.host.listWorkspaces())
+  const desk = desks.find((item) => item.wsId === input.workspaceId && item.issue.id === input.issueId)
+  if (!desk || desk.issue.status === 'canceled') return null
+
+  const appended = await appendIssueComment(
+    workspace.dir,
+    desk.issue.id,
+    sessionSignature(input.task.resumeId),
+    text,
+    { id: `comment-fire-${input.task.taskId}` },
+  )
+  if (!appended.ok) return null
+  await input.host.provenanceStore()?.append({
+    artifact: { kind: 'issue', workspaceId: desk.wsId, issueId: desk.issue.id },
+    action: 'commented',
+    origin: {
+      kind: 'session',
+      workspaceId: input.task.wsId,
+      resumeId: input.task.resumeId,
+      agent: input.task.agent,
+      execution: { kind: 'headless', taskId: input.task.taskId },
+    },
+    at: input.task.finishedAt ?? Date.now(),
+    fingerprint: `telegram-desk-fire:${input.task.taskId}`,
+  })
+  await projectDeskComment(appended.issue, appended.comment).catch(() => undefined)
+  return appended.comment
+}
+
+export async function pullTelegramDeskInbound(
+  host: TelegramDeskChatHost,
+  client: ConnectorClient,
+): Promise<void> {
+  // Drain is destructive. Leave Connector's queue untouched until a live desk
+  // can accept the text as a comment.
+  if (!(await findLiveDesk(host))) return
+  const messages = await client.drainInbound(AbortSignal.timeout(5_000))
+  for (const message of messages) {
+    const result = await ingestTelegramOwnerMessage(host, message)
+    if (!result.ok) {
+      console.warn('[connector] Telegram phone-desk inbound skipped:', result.reason)
+    }
+  }
+}
+
+export function startTelegramDeskInboundPoll(
+  host: TelegramDeskChatHost,
+  options: { intervalMs?: number; client?: ConnectorClient } = {},
+): () => void {
+  const client = options.client ?? new ConnectorClient(resolveConnectorUrl())
+  const intervalMs = options.intervalMs ?? 1_500
+  let stopped = false
+  const tick = async () => {
+    if (stopped) return
+    try {
+      await pullTelegramDeskInbound(host, client)
+    } catch {
+      // Connector is optional.
+    }
+  }
+  const timer = setInterval(() => { void tick() }, intervalMs)
+  timer.unref?.()
+  void tick()
+  return () => {
+    stopped = true
+    clearInterval(timer)
+  }
+}
+
+async function findLiveDesk(host: TelegramDeskChatHost): Promise<TelegramConnectorDesk | null> {
+  const desks = await findTelegramConnectorDesks(host.listWorkspaces())
+  const desk = desks[0]
+  if (!desk || desk.issue.status === 'canceled') return null
+  return desk
+}

--- a/src/workspaces/issues/telegram-desk-chat.ts
+++ b/src/workspaces/issues/telegram-desk-chat.ts
@@ -89,6 +89,10 @@ export async function stampTelegramDeskScheduledFire(input: {
   task: HeadlessTaskRecord
   assistantText?: string | null
 }): Promise<IssueComment | null> {
+  // A native CLI can emit partial assistant text before exiting with an error
+  // or interruption. Keep that diagnostic in the run record, but do not turn
+  // it into a durable phone-desk reply or project it to Telegram.
+  if (input.task.status !== 'done') return null
   const text = input.assistantText?.trim()
   if (!text) return null
   const workspace = input.host.getWorkspace(input.workspaceId)
@@ -145,12 +149,16 @@ export function startTelegramDeskInboundPoll(
   const client = options.client ?? new ConnectorClient(resolveConnectorUrl())
   const intervalMs = options.intervalMs ?? 1_500
   let stopped = false
+  let running = false
   const tick = async () => {
-    if (stopped) return
+    if (stopped || running) return
+    running = true
     try {
       await pullTelegramDeskInbound(host, client)
     } catch {
       // Connector is optional.
+    } finally {
+      running = false
     }
   }
   const timer = setInterval(() => { void tick() }, intervalMs)

--- a/src/workspaces/issues/telegram-desk-project.ts
+++ b/src/workspaces/issues/telegram-desk-project.ts
@@ -1,0 +1,33 @@
+import { ConnectorClient } from '@traderalice/connector-protocol'
+
+import { resolveConnectorUrl } from '../../services/connector-client/index.js'
+import type { IssueComment } from './comments.js'
+import { isTelegramConnectorIssue } from './declaration.js'
+
+export const TELEGRAM_NO_REPLY_TAG = '[[no-reply]]'
+
+export function containsTelegramNoReply(text: string): boolean {
+  return text.includes(TELEGRAM_NO_REPLY_TAG)
+}
+
+export function shouldProjectDeskComment(
+  issue: { telegramConnector?: true },
+  comment: IssueComment,
+): boolean {
+  return isTelegramConnectorIssue(issue)
+    && comment.via !== 'telegram'
+    && !containsTelegramNoReply(comment.markdown)
+}
+
+export async function projectDeskComment(
+  issue: { telegramConnector?: true },
+  comment: IssueComment,
+  client: ConnectorClient = new ConnectorClient(resolveConnectorUrl()),
+): Promise<void> {
+  if (!shouldProjectDeskComment(issue, comment)) return
+  await client.sendOwnerMessage({
+    id: `desk-${comment.id}`,
+    adapterId: 'telegram',
+    text: comment.markdown.slice(0, 4096),
+  }, AbortSignal.timeout(5_000))
+}

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -102,6 +102,7 @@ import {
 import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
 import { readIssueComments } from './issues/comments.js';
 import { recordIssueCommentReply } from './issues/comment-delivery.js';
+import { stampTelegramDeskScheduledFire } from './issues/telegram-desk-chat.js';
 import {
   IssueChangeTracker,
   issueMutation,
@@ -793,6 +794,40 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         wsId: subject.workspaceId,
         issueId: subject.issueId,
         commentId: subject.commentId,
+        err,
+      });
+    }
+  };
+
+  const telegramDeskChatHost = {
+    listWorkspaces: () => registry.list().map((workspace) => ({ id: workspace.id, dir: workspace.dir })),
+    getWorkspace: (id: string) => {
+      const workspace = registry.get(id);
+      return workspace ? { id: workspace.id, dir: workspace.dir } : undefined;
+    },
+    provenanceStore: () => provenanceStore,
+    conversation: () => undefined,
+  };
+
+  const stampTelegramDeskFire = async (
+    task: HeadlessTaskRecord,
+    assistantText?: string | null,
+  ): Promise<void> => {
+    if (task.trigger?.kind !== 'issue') return;
+    if (task.inquiry?.subject.kind === 'issue' && task.inquiry.subject.commentId) return;
+    try {
+      await stampTelegramDeskScheduledFire({
+        host: telegramDeskChatHost,
+        workspaceId: task.trigger.workspaceId,
+        issueId: task.trigger.issueId,
+        task,
+        ...(assistantText !== undefined ? { assistantText } : {}),
+      });
+    } catch (err) {
+      launcherLogger.warn('telegram_desk.fire_stamp_failed', {
+        taskId: task.taskId,
+        wsId: task.trigger.workspaceId,
+        issueId: task.trigger.issueId,
         err,
       });
     }
@@ -1764,6 +1799,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           assistantText: r.structured.assistantText,
           ...(status !== 'done' && r.stderrTail ? { error: r.stderrTail.slice(-1000) } : {}),
         });
+        await stampTelegramDeskFire(rec, r.structured.assistantText);
         // Scheduled one-shot issues are the only board items whose lifecycle can
         // be closed mechanically from a run exit. Repeating schedules keep their
         // issue open; failed one-shots stay open so the operator can inspect and

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -84,6 +84,7 @@ export interface IssueComment {
   markdown: string
   replyTo?: string
   delivery?: IssueCommentDelivery
+  via?: 'telegram'
 }
 
 export type IssueRunFailureKind =


### PR DESCRIPTION
## Summary

Increment 2 of the Telegram phone-desk plan. Connector remains transport only. The Project's one phone-desk Issue is the chat transcript.

- Owner private-chat text is queued in Connector and drained by Alice only while a live `telegramConnector` desk exists. The comment is stored with `via: telegram` so it is not echoed back.
- That inbound comment uses the existing Issue comment-reply dispatch. The agent's final reply is recorded as a comment and projected to Telegram unless it contains the literal tag `[[no-reply]]`.
- A scheduled desk fire stamps `assistantText` as a comment, then applies the same filter. Silent heartbeats stay on the Issue and are not sent.
- Connector exposes `/v1/notifications/owner-chat` and `/v1/inbound/drain`. The inbound queue is capped at 100 messages.

Busy-queue, groups, and Discord chat stay out of this plan.

## Plan

`plans/telegram-connector-issue.md`

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/connector-protocol typecheck`
- `pnpm test` (4189 passed)

Please leave this unmerged for review.

## Residual risk

- A crash between a successful drain and comment append can still drop that one message. The poll no longer drains when the desk is missing, which covers the common Alice-startup window.
- If a scheduled desk run also writes an Issue comment via the tool, both that comment and the stamped `assistantText` can project.
- Occupancy remains exclusive per `resumeId`. Comments that hit busy fail without a queue.
- #1082's post-merge desktop package smoke had macos/windows package-job failures while CI test/build were green. Those jobs are packaging, not this chat hop.