### PR TITLE
fix(connectors): default phone desk to the Ask Alice workspace

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -177,8 +177,9 @@ The surfaces deliberately have different jobs:
 
 - **Settings → Connectors** owns credentials, the setup sequence, enable/stop,
   unlink, linking instructions, and explicit test sends. The Telegram card also
-  binds the Project's one phone-desk Issue: pick a Workspace, edit What and
-  heartbeat cadence, then open the ordinary Issue detail for comments. Generic
+  binds the Project's one phone-desk Issue: the Workspace picker defaults to
+  the Ask Alice Chat workspace. The operator can edit What and heartbeat
+  cadence, then open the ordinary Issue detail for comments. Generic
   Issue create/update cannot set `telegramConnector`.
 - The phone-desk Issue is hidden from the Issue board and Tracked list. It still
   fires on `when`. Extra `telegramConnector: true` files in other Workspaces do

--- a/ui/src/components/TelegramDeskPanel.spec.tsx
+++ b/ui/src/components/TelegramDeskPanel.spec.tsx
@@ -25,12 +25,49 @@ vi.mock('../hooks/useTelegramConnectorDesk', () => ({
   useTelegramConnectorDesk: () => mocks.desk,
 }))
 
+const launchMocks = vi.hoisted(() => ({
+  recentChatWorkspaceId: 'ws-b' as string | null,
+}))
+
 vi.mock('../contexts/workspaces-context', () => ({
   useWorkspaces: () => ({
     workspaces: [
-      { id: 'ws-a', tag: 'alpha', displayName: 'Alpha desk' },
-      { id: 'ws-b', tag: 'beta', displayName: 'Beta desk' },
+      {
+        id: 'ws-a',
+        tag: 'alpha',
+        displayName: 'Alpha desk',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        template: 'auto-quant-v2',
+        sessions: [],
+      },
+      {
+        id: 'ws-b',
+        tag: 'beta',
+        displayName: 'Beta desk',
+        createdAt: '2026-06-01T00:00:00.000Z',
+        template: 'chat',
+        sessions: [],
+      },
+      {
+        id: 'ws-c',
+        tag: 'gamma',
+        displayName: 'Gamma desk',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        template: 'chat',
+        sessions: [],
+      },
     ],
+  }),
+}))
+
+vi.mock('../hooks/useAgentLaunchConfig', () => ({
+  useAgentLaunchPreferences: () => ({
+    recentChatWorkspaceId: launchMocks.recentChatWorkspaceId,
+    lastCredentialByAgent: {},
+    recentLaunch: null,
+    loaded: true,
+    rememberLaunch: vi.fn(),
+    adoptRecentChatWorkspace: vi.fn(),
   }),
 }))
 
@@ -64,6 +101,7 @@ beforeEach(async () => {
   mocks.desk.desk = null
   mocks.desk.loading = false
   mocks.desk.error = null
+  launchMocks.recentChatWorkspaceId = 'ws-b'
   vi.clearAllMocks()
 })
 
@@ -76,11 +114,28 @@ describe('TelegramDeskPanel', () => {
     expect((screen.getByRole('button', { name: 'Enable phone desk' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
-  it('enables the desk in the selected workspace once linked', async () => {
+  it('defaults the unbound picker to the Ask Alice Chat workspace', () => {
     render(<TelegramDeskPanel linked />)
-    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'ws-b' } })
+    expect((screen.getByLabelText('Workspace') as HTMLSelectElement).value).toBe('ws-b')
+  })
+
+  it('falls back to the active Chat workspace when Ask Alice has no remembered target', () => {
+    launchMocks.recentChatWorkspaceId = null
+    render(<TelegramDeskPanel linked />)
+    expect((screen.getByLabelText('Workspace') as HTMLSelectElement).value).toBe('ws-c')
+  })
+
+  it('enables the desk in the Ask Alice workspace without a manual pick', async () => {
+    render(<TelegramDeskPanel linked />)
     fireEvent.click(screen.getByRole('button', { name: 'Enable phone desk' }))
     await waitFor(() => expect(mocks.desk.enable).toHaveBeenCalledWith('ws-b'))
+  })
+
+  it('enables the desk in the selected workspace once linked', async () => {
+    render(<TelegramDeskPanel linked />)
+    fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'ws-c' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Enable phone desk' }))
+    await waitFor(() => expect(mocks.desk.enable).toHaveBeenCalledWith('ws-c'))
   })
 
   it('opens the bound Issue detail and confirms disable', async () => {

--- a/ui/src/components/TelegramDeskPanel.tsx
+++ b/ui/src/components/TelegramDeskPanel.tsx
@@ -5,7 +5,9 @@ import { TELEGRAM_DESK_CADENCES } from '../api/connectors'
 import { ConfirmDialog } from './ConfirmDialog'
 import { Field, inputClass } from './form'
 import { MarkdownWhatEditor } from './MarkdownWhatEditor'
+import { useAgentLaunchPreferences } from '../hooks/useAgentLaunchConfig'
 import { useTelegramConnectorDesk } from '../hooks/useTelegramConnectorDesk'
+import { resolveChatWorkspaceTarget } from '../lib/chat-workspace-target'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { workspaceDisplayName } from './workspace/display'
 import { useWorkspace } from '../tabs/store'
@@ -13,6 +15,7 @@ import { useWorkspace } from '../tabs/store'
 export function TelegramDeskPanel({ linked }: { linked: boolean }) {
   const { t } = useTranslation()
   const { workspaces } = useWorkspaces()
+  const { recentChatWorkspaceId, loaded: launchPreferencesLoaded } = useAgentLaunchPreferences()
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
   const { desk, loading, error, enable, disable, saveWhat, saveCadence } = useTelegramConnectorDesk()
   const [wsId, setWsId] = useState('')
@@ -21,11 +24,21 @@ export function TelegramDeskPanel({ linked }: { linked: boolean }) {
   const workspaceSelectId = useId()
   const cadenceSelectId = useId()
 
-  const choices = useMemo(
-    () => [...workspaces].sort((left, right) => workspaceDisplayName(left).localeCompare(workspaceDisplayName(right))),
-    [workspaces],
+  const preferredWsId = useMemo(
+    () => launchPreferencesLoaded
+      ? resolveChatWorkspaceTarget(workspaces, null, recentChatWorkspaceId)?.id ?? ''
+      : '',
+    [launchPreferencesLoaded, workspaces, recentChatWorkspaceId],
   )
-  const selectedWsId = wsId || choices[0]?.id || ''
+  const choices = useMemo(
+    () => [...workspaces].sort((left, right) => {
+      if (left.id === preferredWsId) return -1
+      if (right.id === preferredWsId) return 1
+      return workspaceDisplayName(left).localeCompare(workspaceDisplayName(right))
+    }),
+    [workspaces, preferredWsId],
+  )
+  const selectedWsId = wsId || preferredWsId || (launchPreferencesLoaded ? choices[0]?.id || '' : '')
   const boundWorkspace = desk ? workspaces.find((workspace) => workspace.id === desk.wsId) : undefined
   const currentEvery = desk?.issue.when?.kind === 'every' ? desk.issue.when.every : null
   const cadenceOptions = useMemo(() => {
@@ -127,7 +140,7 @@ export function TelegramDeskPanel({ linked }: { linked: boolean }) {
                 id={workspaceSelectId}
                 className={inputClass}
                 value={selectedWsId}
-                disabled={!linked || working}
+                disabled={!linked || working || !launchPreferencesLoaded}
                 onChange={(event) => setWsId(event.target.value)}
               >
                 {choices.map((workspace) => (
@@ -141,7 +154,7 @@ export function TelegramDeskPanel({ linked }: { linked: boolean }) {
           <button
             type="button"
             className="oa-pressable inline-flex min-h-11 items-center rounded-lg bg-primary px-3 py-2 text-[12px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            disabled={!linked || !selectedWsId || working}
+            disabled={!linked || !selectedWsId || working || !launchPreferencesLoaded}
             onClick={async () => {
               setWorking(true)
               await enable(selectedWsId)

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1759,7 +1759,7 @@ export const en = {
       loading: 'Loading phone desk…',
       needLink: 'Finish linking the bot before enabling the phone desk.',
       workspace: 'Workspace',
-      workspaceDescription: 'The phone desk lives in one Workspace. Change later by disabling and enabling again.',
+      workspaceDescription: 'Defaults to the Ask Alice Chat workspace. Change later by disabling and enabling again.',
       enable: 'Enable phone desk',
       enabling: 'Enabling…',
       disable: 'Disable phone desk',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1748,7 +1748,7 @@ export const ja: Resources = {
       loading: '電話デスクを読み込み中…',
       needLink: '電話デスクを有効にする前に、Bot のリンクを完了してください。',
       workspace: 'ワークスペース',
-      workspaceDescription: '電話デスクは1つのワークスペースに属します。後から移す場合は無効化してから再有効化します。',
+      workspaceDescription: '既定は Ask Alice の Chat ワークスペースです。後から移す場合は無効化してから再有効化します。',
       enable: '電話デスクを有効化',
       enabling: '有効化しています…',
       disable: '電話デスクを無効化',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1755,7 +1755,7 @@ export const zhHant: Resources = {
       loading: '正在載入電話台…',
       needLink: '請先完成機器人連結，再啟用電話台。',
       workspace: '工作區',
-      workspaceDescription: '電話台只屬於一個工作區。之後若要換地方，先停用再重新啟用。',
+      workspaceDescription: '預設使用 Ask Alice 的 Chat 工作區。之後若要換地方，先停用再重新啟用。',
       enable: '啟用電話台',
       enabling: '正在啟用…',
       disable: '停用電話台',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1747,7 +1747,7 @@ export const zh: Resources = {
       loading: '正在加载电话台…',
       needLink: '请先完成机器人关联，再启用电话台。',
       workspace: '工作区',
-      workspaceDescription: '电话台只属于一个工作区。之后若要换地方，先停用再重新启用。',
+      workspaceDescription: '默认用 Ask Alice 的 Chat 工作区。之后若要换地方，先停用再重新启用。',
       enable: '启用电话台',
       enabling: '正在启用…',
       disable: '停用电话台',

--- a/ui/src/lib/chat-workspace-target.ts
+++ b/ui/src/lib/chat-workspace-target.ts
@@ -1,0 +1,31 @@
+import type { Workspace } from '../components/workspace/api'
+
+export function workspaceActivityMs(workspace: Pick<Workspace, 'createdAt' | 'sessions'>): number {
+  const sessionActivity = workspace.sessions
+    .map((session) => Date.parse(session.lastActiveAt))
+    .filter(Number.isFinite)
+  if (sessionActivity.length > 0) return Math.max(...sessionActivity)
+  const created = Date.parse(workspace.createdAt)
+  return Number.isFinite(created) ? created : 0
+}
+
+/** Resolve Ask Alice's current Chat workspace. Explicit selection wins, then
+ *  the persisted recent Chat workspace, then latest activity when that pointer
+ *  is missing or stale. */
+export function resolveChatWorkspaceTarget(
+  workspaces: readonly Workspace[],
+  explicitWorkspaceId: string | null,
+  recentWorkspaceId: string | null,
+  templateName = 'chat',
+): Workspace | null {
+  const chats = workspaces.filter((workspace) => workspace.template === templateName)
+  const explicit = explicitWorkspaceId
+    ? chats.find((workspace) => workspace.id === explicitWorkspaceId)
+    : undefined
+  if (explicit) return explicit
+  const recent = recentWorkspaceId
+    ? chats.find((workspace) => workspace.id === recentWorkspaceId)
+    : undefined
+  if (recent) return recent
+  return [...chats].sort((a, b) => workspaceActivityMs(b) - workspaceActivityMs(a))[0] ?? null
+}

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -16,10 +16,7 @@ import {
 
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { installHintFor } from '../components/workspace/agentInstall'
-import {
-  QuickChatError,
-  type Workspace,
-} from '../components/workspace/api'
+import { QuickChatError } from '../components/workspace/api'
 import {
   AgentLaunchDetails,
   AgentLaunchSelectors,
@@ -33,6 +30,7 @@ import {
   useAgentLaunchPreferences,
   useWorkspaceAgentLaunchPreferences,
 } from '../hooks/useAgentLaunchConfig'
+import { resolveChatWorkspaceTarget, workspaceActivityMs } from '../lib/chat-workspace-target'
 import { AutoQuantSetupPage } from './AutoQuantSetupPage'
 
 export { resolveAgentRuntime as resolveChatAgent } from '../lib/agentRuntime'
@@ -42,35 +40,7 @@ export {
   resolveAgentLaunchAiDetails as resolveQuickChatAiDetails,
   resolveAgentLaunchCredentialSlug as resolveQuickChatCredentialSlug,
 } from '../hooks/useAgentLaunchConfig'
-
-function workspaceActivityMs(workspace: Pick<Workspace, 'createdAt' | 'sessions'>): number {
-  const sessionActivity = workspace.sessions
-    .map((session) => Date.parse(session.lastActiveAt))
-    .filter(Number.isFinite)
-  if (sessionActivity.length > 0) return Math.max(...sessionActivity)
-  const created = Date.parse(workspace.createdAt)
-  return Number.isFinite(created) ? created : 0
-}
-
-/** Resolve the visible global-composer target. Explicit selection wins, then
- *  the persisted recent Chat workspace, then latest activity for upgrades. */
-export function resolveChatWorkspaceTarget(
-  workspaces: readonly Workspace[],
-  explicitWorkspaceId: string | null,
-  recentWorkspaceId: string | null,
-  templateName = 'chat',
-): Workspace | null {
-  const chats = workspaces.filter((workspace) => workspace.template === templateName)
-  const explicit = explicitWorkspaceId
-    ? chats.find((workspace) => workspace.id === explicitWorkspaceId)
-    : undefined
-  if (explicit) return explicit
-  const recent = recentWorkspaceId
-    ? chats.find((workspace) => workspace.id === recentWorkspaceId)
-    : undefined
-  if (recent) return recent
-  return [...chats].sort((a, b) => workspaceActivityMs(b) - workspaceActivityMs(a))[0] ?? null
-}
+export { resolveChatWorkspaceTarget } from '../lib/chat-workspace-target'
 
 /**
  * Quick-chat landing — the "type a message → you're in" front door for the


### PR DESCRIPTION
## Summary

The Telegram phone-desk Workspace picker was defaulting to the first name-sorted row. Enable now preselects the same Chat workspace Ask Alice already uses (`quickChat.recentChatWorkspaceId`, then the active Chat workspace). Other Workspaces stay available.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4195 passed)
- Demo Settings → Connectors: picker selected `Semis and supply chain` (`demo-chat-ws`), not Auto Quant / name order

## Boundary touch

- none