### PR TITLE
fix(desktop): isolate existing-owner package smoke

### DIFF
--- a/apps/desktop/src/existing-owner-startup.ts
+++ b/apps/desktop/src/existing-owner-startup.ts
@@ -1,4 +1,6 @@
 import { dialog, shell } from 'electron'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
 
 import {
   decideExistingOwnerStartup,
@@ -77,6 +79,16 @@ async function takeSmokeHandoff(
     throw new Error(
       `existing-owner smoke expected browser handoff, got ${decision.kind}: ${decision.reason}`,
     )
+  }
+  const receiptPath = process.env['OPENALICE_ELECTRON_SMOKE_EXISTING_OWNER_RECEIPT']?.trim()
+  if (receiptPath) {
+    await mkdir(dirname(receiptPath), { recursive: true })
+    await writeFile(receiptPath, `${JSON.stringify({
+      schemaVersion: 1,
+      action: 'open-browser',
+      url: decision.url,
+      pid: decision.pid,
+    }, null, 2)}\n`, 'utf8')
   }
   console.log(`[guardian] existing-owner handoff → ${decision.url} pid=${decision.pid}`)
   return { action: 'quit' }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -124,6 +124,8 @@ protocol.registerSchemesAsPrivileged([
 ])
 
 if (existingOwnerSmokeMode()) {
+  const smokeUserData = process.env['OPENALICE_ELECTRON_SMOKE_USER_DATA']?.trim()
+  if (smokeUserData) app.setPath('userData', smokeUserData)
   app.commandLine.appendSwitch('no-sandbox')
   app.commandLine.appendSwitch('disable-gpu')
   app.disableHardwareAcceleration()
@@ -623,6 +625,10 @@ app.whenReady().then(async () => {
   const guardianStartedAt = currentProcessStartedAt()
   while (!takeover) {
     let existingOwner
+    desktopDiagnostics.write(
+      'existing-owner',
+      `inspect home=${userDataHome} launcherRoot=${launcherRoot}`,
+    )
     try {
       existingOwner = await resolveExistingOwnerStartup({
         userDataHome,
@@ -631,6 +637,10 @@ app.whenReady().then(async () => {
         takeoverRequested: false,
       })
     } catch (error) {
+      desktopDiagnostics.write(
+        'existing-owner',
+        `inspection failed: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
+      )
       dialog.showErrorBox(
         'OpenAlice — existing AliceProject',
         `${error instanceof Error ? error.message : String(error)}\n\nOpenAlice did not take over the running AliceProject.`,
@@ -638,6 +648,10 @@ app.whenReady().then(async () => {
       app.quit()
       return
     }
+    desktopDiagnostics.write(
+      'existing-owner',
+      `resolved action=${existingOwner.action}${existingOwner.action === 'continue' ? ` takeover=${existingOwner.takeover}` : ''}`,
+    )
     if (existingOwner.action === 'quit') {
       app.quit()
       return

--- a/scripts/desktop-existing-owner-smoke.mjs
+++ b/scripts/desktop-existing-owner-smoke.mjs
@@ -57,9 +57,17 @@ if (!skipBuild) {
 
 async function proveSurface(surface) {
   // Electron canonicalizes explicit data homes before startup. Canonicalize
-  // the fixture root too so aliases such as macOS /var -> /private/var (and
-  // Windows path casing) cannot make one AliceProject look like two identities.
-  const smokeRoot = realpathSync(mkdtempSync(join(tmpdir(), `openalice-existing-owner-${surface}-`)))
+  // the fixture root too so aliases such as macOS /var -> /private/var cannot
+  // make one AliceProject look like two identities. On Windows, tmpdir() may
+  // expose an 8.3 path (RUNNER~1) that realpathSync preserves even though the
+  // Electron data-home path later expands it. Prefer the CI runner temp root,
+  // or an ignored repo-local fallback, so both processes start with one stable
+  // long-form AliceProject identity.
+  const smokeBase = process.platform === 'win32'
+    ? (process.env.RUNNER_TEMP?.trim() || join(repoRoot, 'dist', 'smoke'))
+    : tmpdir()
+  mkdirSync(smokeBase, { recursive: true })
+  const smokeRoot = realpathSync(mkdtempSync(join(smokeBase, `openalice-existing-owner-${surface}-`)))
   const smokeHome = join(smokeRoot, 'home')
   const smokeWorkspaces = join(smokeRoot, 'workspaces')
   const electronUserData = join(smokeRoot, 'electron-user-data')

--- a/scripts/desktop-existing-owner-smoke.mjs
+++ b/scripts/desktop-existing-owner-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from 'node:child_process'
-import { mkdtempSync } from 'node:fs'
-import { rm } from 'node:fs/promises'
+import { mkdirSync, mkdtempSync, realpathSync } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
@@ -56,9 +56,15 @@ if (!skipBuild) {
 }
 
 async function proveSurface(surface) {
-  const smokeRoot = mkdtempSync(join(tmpdir(), `openalice-existing-owner-${surface}-`))
+  // Electron canonicalizes explicit data homes before startup. Canonicalize
+  // the fixture root too so aliases such as macOS /var -> /private/var (and
+  // Windows path casing) cannot make one AliceProject look like two identities.
+  const smokeRoot = realpathSync(mkdtempSync(join(tmpdir(), `openalice-existing-owner-${surface}-`)))
   const smokeHome = join(smokeRoot, 'home')
   const smokeWorkspaces = join(smokeRoot, 'workspaces')
+  const electronUserData = join(smokeRoot, 'electron-user-data')
+  const receiptPath = join(smokeRoot, 'existing-owner-handoff.json')
+  mkdirSync(electronUserData, { recursive: true })
   const fixturePath = join(repoRoot, 'scripts', 'guardian', 'runtime-handoff-fixture.ts')
   console.log(`\n[existing-owner-smoke] ${surface} home → ${smokeHome}`)
 
@@ -109,6 +115,8 @@ async function proveSurface(surface) {
       AQ_LAUNCHER_ROOT: smokeWorkspaces,
       OPENALICE_GLOBAL_DIR: join(smokeRoot, 'global'),
       OPENALICE_ELECTRON_SMOKE_EXISTING_OWNER: 'open-browser',
+      OPENALICE_ELECTRON_SMOKE_USER_DATA: electronUserData,
+      OPENALICE_ELECTRON_SMOKE_EXISTING_OWNER_RECEIPT: receiptPath,
       ELECTRON_ENABLE_LOGGING: '1',
     },
   })
@@ -130,17 +138,27 @@ async function proveSurface(surface) {
         return false
       }
     }
-    const handoffComplete = () => (
-      output.includes('[guardian] existing-owner handoff →') && output.includes(webUrl)
-    )
     const onData = (chunk) => {
       output += chunk.toString()
       process.stdout.write(chunk)
     }
     child.stdout.on('data', onData)
     child.stderr.on('data', onData)
-    child.on('exit', () => {
-      finish(!fixtureExited && ownerAlive() && handoffComplete())
+    child.on('exit', async (code) => {
+      let receipt = null
+      try {
+        receipt = JSON.parse(await readFile(receiptPath, 'utf8'))
+      } catch {
+        // The failure below includes the Electron output and exit code.
+      }
+      finish(
+        code === 0
+        && !fixtureExited
+        && ownerAlive()
+        && receipt?.action === 'open-browser'
+        && receipt?.url === webUrl
+        && receipt?.pid === fixturePid,
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

- canonicalize each temporary AliceProject root before starting the owner fixture and Electron
- isolate Electron userData so local/default profile state cannot contaminate package-smoke startup
- record the existing-owner browser handoff through a structured smoke receipt and add startup diagnostics

## Root cause

On macOS, the fixture used `/var/...` while Electron canonicalized the same temporary data home to `/private/var/...`. The lock was visible through the filesystem alias, but Runtime discovery treated the two AliceProject identities as different, so Electron reported a generic occupied-project conflict and waited behind a headless dialog.

## Verification

- `pnpm -F @traderalice/desktop build`
- `pnpm electron:smoke:existing-owner --skip-build`
- `pnpm exec vitest run apps/desktop/src/existing-owner-startup.spec.ts scripts/desktop-package-workflow.spec.ts`
- `pnpm -F @traderalice/desktop typecheck`
- `npx tsc --noEmit`
- `pnpm test` (495 files passed, 4216 tests passed)

The multi-OS package-smoke workflow remains the authoritative confirmation for Windows and Linux.