### PR TITLE
feat(connectors): stack Telegram DMs until the desk is idle

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -25,9 +25,11 @@ categories.
   and `/test` stay the generic slash-command control plane. Discord DMs are
   still not ingested.
 - Connector Service never interprets chat. Alice owns the phone-desk Issue.
-  Connector queues owner text and Alice drains it only while a live phone-desk
-  Issue exists; Alice projects desk comments that do not contain the literal
-  tag `[[no-reply]]`. Inbound Telegram comments are not echoed back.
+  Connector queues owner text and Alice drains that stack only while a live
+  phone-desk Issue exists and no desk generation is running. Several stacked
+  DMs become one quoted comment. Alice projects desk comments that do not
+  contain the literal tag `[[no-reply]]`. Inbound Telegram comments are not
+  echoed back.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
 - Inbox `docs` that are Markdown or static HTML reports are sent as file attachments, not flattened
@@ -71,8 +73,10 @@ Workspace agent
 Telegram owner DM
   -> Telegram adapter (linked private chat only)
   -> Connector inbound queue
-  -> Alice drain (only while a live phone-desk Issue exists)
-  -> Issue comment (via: telegram)
+  -> Alice drain only while a live phone-desk Issue exists and no
+     desk generation is running; later DMs stay stacked
+  -> one Issue comment (via: telegram); several stacked DMs are
+     quoted into that one comment
   -> existing comment-reply dispatch
   -> owner-chat projection unless [[no-reply]]
 ```

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -100,9 +100,11 @@ The filename stem is the stable issue id. Frontmatter:
   Tracked list omit the row. What remains the exact scheduled Input Prompt.
   Comments are the chat transcript. The desk is created with
   `commentPrompt: '{comment}'` so inbound DMs are the Input Prompt as-is.
-  Owner Telegram DMs become comments; scheduled-fire `assistantText` is stamped
-  as a comment. Connector projects comments that do not contain `[[no-reply]]`
-  and did not arrive from Telegram.
+  Owner Telegram DMs become comments. While a desk fire or comment reply is
+  running, later DMs stay in the Connector queue; Alice flushes that stack as
+  one quoted comment when the desk is idle again. Scheduled-fire
+  `assistantText` is stamped as a comment. Connector projects comments that
+  do not contain `[[no-reply]]` and did not arrive from Telegram.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 Only the credential slug is persisted; endpoint and key material remain in the

--- a/plans/telegram-connector-issue.md
+++ b/plans/telegram-connector-issue.md
@@ -49,7 +49,10 @@ Chosen model (serial alignment, not a second chat surface):
 
 ## Occupancy
 
-Existing per-`resumeId` busy stays. Queue-on-busy is out of this plan.
+Existing per-`resumeId` busy stays. A general Issue busy-queue is still out
+of this plan. Telegram inbound is different: later owner DMs stay in the
+Connector queue while a desk generation is running, then flush as one quoted
+comment.
 
 ## Increments
 
@@ -71,7 +74,7 @@ Existing per-`resumeId` busy stays. Queue-on-busy is out of this plan.
 
 ### Not in this plan
 
-Queue when `busy`. Groups / Discord chat. Showing the stored bot token. Changing `inbox_push` for ordinary Issues.
+General Issue queue when `busy`. Groups / Discord chat. Showing the stored bot token. Changing `inbox_push` for ordinary Issues.
 
 ## Completion
 

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -142,7 +142,7 @@ export class DeliveryManager {
     if (overflow > 0) this.inbound.splice(0, overflow)
   }
 
-  drainInbound(limit = 20): InboundOwnerMessage[] {
+  drainInbound(limit = MAX_INBOUND_OWNER_MESSAGES): InboundOwnerMessage[] {
     return this.inbound.splice(0, Math.max(0, limit))
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ import { SessionStore } from './core/session.js'
 import { createInboxStore } from './core/inbox-store.js'
 import { startInboxConnectorBridge } from './services/connector-client/index.js'
 import { createWorkspaceConversationControl } from './workspaces/conversation-control.js'
-import { startTelegramDeskInboundPoll } from './workspaces/issues/telegram-desk-chat.js'
+import { startTelegramDeskInboundPoll, telegramDeskHasRunningWork } from './workspaces/issues/telegram-desk-chat.js'
 import { ToolCenter } from './core/tool-center.js'
 import { WorkspaceToolCenter } from './core/workspace-tool-center.js'
 import { inboxPushFactory } from './tool/inbox-push.js'
@@ -296,6 +296,11 @@ async function main() {
     conversation: () => {
       const service = workspaceServiceRef.current
       return service ? createWorkspaceConversationControl(service) : undefined
+    },
+    deskGenerating: (desk) => {
+      const service = workspaceServiceRef.current
+      if (!service) return false
+      return telegramDeskHasRunningWork(service.headlessTasks.list({ status: 'running' }), desk)
     },
   })
 

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -8,13 +8,17 @@ import type { ConnectorClient } from '@traderalice/connector-protocol'
 import { createTelegramConnectorDesk } from './telegram-connector.js'
 import {
   containsTelegramNoReply,
+  formatTelegramInboundStack,
   ingestTelegramOwnerMessage,
+  ingestTelegramOwnerMessages,
   pullTelegramDeskInbound,
   startTelegramDeskInboundPoll,
   shouldProjectDeskComment,
   stampTelegramDeskScheduledFire,
+  telegramDeskHasRunningWork,
   type TelegramDeskChatHost,
 } from './telegram-desk-chat.js'
+import { readIssueComments } from './comments.js'
 
 let home: string
 let wsDir: string
@@ -29,7 +33,7 @@ afterEach(async () => {
   await rm(home, { recursive: true, force: true })
 })
 
-function host(): TelegramDeskChatHost {
+function host(overrides: Partial<TelegramDeskChatHost> = {}): TelegramDeskChatHost {
   return {
     listWorkspaces: () => [{ id: 'ws-a', dir: wsDir }],
     getWorkspace: (id) => id === 'ws-a' ? { id: 'ws-a', dir: wsDir } : undefined,
@@ -39,6 +43,7 @@ function host(): TelegramDeskChatHost {
       latest: () => undefined,
     } as unknown as NonNullable<ReturnType<TelegramDeskChatHost['provenanceStore']>>),
     conversation: () => undefined,
+    ...overrides,
   }
 }
 
@@ -151,6 +156,50 @@ describe('telegram desk ingest and stamp', () => {
     expect(comment).toBeNull()
   })
 
+  it('quotes stacked inbound DMs as one comment', () => {
+    expect(formatTelegramInboundStack(['one'])).toBe('one')
+    expect(formatTelegramInboundStack([
+      '那个事情我想了想你再改改',
+      '算了不用改了,就这样吧',
+    ])).toBe([
+      '> 那个事情我想了想你再改改',
+      '> 算了不用改了,就这样吧',
+    ].join('\n'))
+    expect(telegramDeskHasRunningWork([
+      {
+        status: 'running',
+        inquiry: {
+          subject: { kind: 'issue', workspaceId: 'ws-a', issueId: 'telegram-phone-desk', relation: 'owner' },
+          question: 'hi',
+          resolution: { mode: 'exact' },
+        },
+      },
+    ], { wsId: 'ws-a', issue: { id: 'telegram-phone-desk' } })).toBe(true)
+    expect(telegramDeskHasRunningWork([
+      { status: 'done', trigger: { kind: 'issue', workspaceId: 'ws-a', issueId: 'telegram-phone-desk' } },
+    ], { wsId: 'ws-a', issue: { id: 'telegram-phone-desk' } })).toBe(false)
+  })
+
+  it('records stacked inbound DMs as one human comment', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    const result = await ingestTelegramOwnerMessages(host(), [
+      { connectorId: 'telegram', userId: '42', text: '那个事情我想了想你再改改' },
+      { connectorId: 'telegram', userId: '42', text: '算了不用改了,就这样吧' },
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.comment.markdown).toBe([
+      '> 那个事情我想了想你再改改',
+      '> 算了不用改了,就这样吧',
+    ].join('\n'))
+    const comments = await readIssueComments(wsDir, created.ok ? created.issue.id : 'telegram-phone-desk')
+    expect(comments.ok && comments.comments).toHaveLength(1)
+  })
+
   it('does not drain Connector inbound until a live desk exists', async () => {
     let drained = 0
     const client = {
@@ -169,6 +218,27 @@ describe('telegram desk ingest and stamp', () => {
     )
     expect(created.ok).toBe(true)
     await pullTelegramDeskInbound(host(), client)
+    expect(drained).toBe(1)
+  })
+
+  it('leaves Connector inbound stacked while the desk is generating', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    let drained = 0
+    const client = {
+      drainInbound: async () => {
+        drained += 1
+        return [{ connectorId: 'telegram', userId: '42', text: 'later' }]
+      },
+    } as unknown as ConnectorClient
+
+    await pullTelegramDeskInbound(host({ deskGenerating: () => true }), client)
+    expect(drained).toBe(0)
+
+    await pullTelegramDeskInbound(host({ deskGenerating: () => false }), client)
     expect(drained).toBe(1)
   })
 

--- a/src/workspaces/issues/telegram-desk-chat.ts
+++ b/src/workspaces/issues/telegram-desk-chat.ts
@@ -39,21 +39,66 @@ export interface TelegramDeskChatHost {
   getWorkspace(id: string): { id: string; dir: string } | undefined
   provenanceStore(): IProvenanceStore | undefined
   conversation(): WorkspaceConversationControl | undefined
+  /** True while a scheduled fire or comment reply for this desk is running. */
+  deskGenerating?(desk: TelegramConnectorDesk): boolean
+}
+
+export function telegramDeskHasRunningWork(
+  tasks: readonly Pick<HeadlessTaskRecord, 'status' | 'trigger' | 'inquiry'>[],
+  desk: { wsId: string; issue: { id: string } },
+): boolean {
+  return tasks.some((task) => task.status === 'running' && isDeskTask(task, desk))
+}
+
+function isDeskTask(
+  task: Pick<HeadlessTaskRecord, 'trigger' | 'inquiry'>,
+  desk: { wsId: string; issue: { id: string } },
+): boolean {
+  const trigger = task.trigger
+  if (trigger?.kind === 'issue' && trigger.workspaceId === desk.wsId && trigger.issueId === desk.issue.id) {
+    return true
+  }
+  const subject = task.inquiry?.subject
+  return subject?.kind === 'issue' && subject.workspaceId === desk.wsId && subject.issueId === desk.issue.id
+}
+
+/** One inbound stays as-is. Several become one stacked comment, each quoted. */
+export function formatTelegramInboundStack(texts: readonly string[]): string {
+  const parts = texts.map((text) => text.trim()).filter((text) => text.length > 0)
+  if (parts.length === 0) return ''
+  if (parts.length === 1) return parts[0] ?? ''
+  return parts.map(quoteInboundMessage).join('\n')
+}
+
+function quoteInboundMessage(text: string): string {
+  return text.split('\n').map((line) => (line.length > 0 ? `> ${line}` : '>')).join('\n')
 }
 
 export async function ingestTelegramOwnerMessage(
   host: TelegramDeskChatHost,
   message: InboundOwnerMessage,
 ): Promise<{ ok: true; comment: IssueComment } | { ok: false; reason: string }> {
-  if (message.connectorId !== 'telegram') {
+  return ingestTelegramOwnerMessages(host, [message])
+}
+
+export async function ingestTelegramOwnerMessages(
+  host: TelegramDeskChatHost,
+  messages: readonly InboundOwnerMessage[],
+): Promise<{ ok: true; comment: IssueComment } | { ok: false; reason: string }> {
+  const texts = messages
+    .filter((message) => message.connectorId === 'telegram')
+    .map((message) => message.text)
+  if (texts.length === 0 && messages.length > 0) {
     return { ok: false, reason: 'unsupported_connector' }
   }
+  const markdown = formatTelegramInboundStack(texts)
+  if (!markdown) return { ok: false, reason: 'empty' }
   const desk = await findLiveDesk(host)
   if (!desk) return { ok: false, reason: 'desk_disabled' }
   const workspace = host.getWorkspace(desk.wsId)
   if (!workspace) return { ok: false, reason: 'workspace_missing' }
 
-  const appended = await appendIssueComment(workspace.dir, desk.issue.id, 'human', message.text, {
+  const appended = await appendIssueComment(workspace.dir, desk.issue.id, 'human', markdown, {
     id: `telegram-${randomUUID()}`,
     via: 'telegram',
   })
@@ -131,14 +176,16 @@ export async function pullTelegramDeskInbound(
   client: ConnectorClient,
 ): Promise<void> {
   // Drain is destructive. Leave Connector's queue untouched until a live desk
-  // can accept the text as a comment.
-  if (!(await findLiveDesk(host))) return
+  // can accept the stack as one comment, and until any in-flight generation
+  // has finished so later DMs can pile up instead of racing the same Session.
+  const desk = await findLiveDesk(host)
+  if (!desk) return
+  if (host.deskGenerating?.(desk)) return
   const messages = await client.drainInbound(AbortSignal.timeout(5_000))
-  for (const message of messages) {
-    const result = await ingestTelegramOwnerMessage(host, message)
-    if (!result.ok) {
-      console.warn('[connector] Telegram phone-desk inbound skipped:', result.reason)
-    }
+  if (messages.length === 0) return
+  const result = await ingestTelegramOwnerMessages(host, messages)
+  if (!result.ok) {
+    console.warn('[connector] Telegram phone-desk inbound skipped:', result.reason)
   }
 }
 


### PR DESCRIPTION
## Summary

Telegram inbound is non-blocking. If the owner types again while the desk is generating, those DMs now stay in the Connector queue instead of becoming separate comments that hit `busy`.

When the desk is idle again, Alice drains the stack as **one** human comment:

- one message stays as-is
- several messages are quoted into one comment, e.g. `> 先改改` / `> 算了不用改了`

Connector remains a queue. Alice decides when to flush: live desk, and no running scheduled fire or comment-reply task for that Issue.

This is not a general Issue busy-queue.

## Verification

- `tsc --noEmit`
- `vitest run` (4219 passed)

## Boundary touch

- none