### PR TITLE
feat(connectors): add lossless Telegram rich-text delivery

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -54,11 +54,13 @@ categories.
   remain available for self-contained human-facing reports. Markdown remains
   the default agent-readable work product, while Inbox comments carry the
   concise summary for both the user and other agents.
-- Telegram text uses Bot API 10.1 `sendRichMessage` with GFM-compatible
-  `markdown`. Phone-desk comments go out as-is. Inbox titles and provenance
-  stay escaped; Inbox bodies keep their markdown. A 400 parse/format error, or
-  a missing-method response, falls back to plain `sendMessage` (4096). This is
-  not `parse_mode` MarkdownV2. Discord still uses its own markdown.
+- Telegram text uses `sendMessage` with `parse_mode: MarkdownV2`. Connector
+  converts common GFM (`**bold**`, lists, headings, code) into MarkdownV2 and
+  escapes unmatched specials so agent text does not 400. Inbox titles and
+  provenance are escaped literals; Inbox bodies go through the same converter.
+  If MarkdownV2 is rejected, Connector tries Bot API 10.1 `sendRichMessage`
+  with the original GFM, then plain `sendMessage` (4096). Discord still uses
+  its own markdown. Do not use legacy `parse_mode: Markdown`.
 - Session provenance is rendered as a visible `@resumeId` signature. The
   runtime label may accompany it (`pi · @resume-…`) but must never replace it.
 

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -46,14 +46,19 @@ categories.
   sends the original bytes instead of guessing. A skipped or ambiguous
   eligible attachment is logged and leaves bridge health degraded so partial
   or unnormalized delivery is visible to operators.
-- HTML is a presentation asset, not a Connector message format. Adapters send
-  the `.html` file with a `text/html` media type and never inline,
-  translate, or render its contents into the external chat message. OpenAlice
-  previews static HTML in an origin-less sandbox with scripts, forms,
-  navigation, and network disabled; inline CSS, SVG, and data images remain
-  available for self-contained human-facing reports. Markdown remains the
-  default agent-readable work product, while Inbox comments carry the concise
-  summary for both the user and other agents.
+- HTML report files are a presentation asset, not a Connector message format.
+  Adapters send the `.html` file with a `text/html` media type and never
+  inline, translate, or render those file contents into the chat body.
+  OpenAlice previews static HTML in an origin-less sandbox with scripts,
+  forms, navigation, and network disabled; inline CSS, SVG, and data images
+  remain available for self-contained human-facing reports. Markdown remains
+  the default agent-readable work product, while Inbox comments carry the
+  concise summary for both the user and other agents.
+- Telegram text uses Bot API 10.1 `sendRichMessage` with GFM-compatible
+  `markdown`. Phone-desk comments go out as-is. Inbox titles and provenance
+  stay escaped; Inbox bodies keep their markdown. A 400 parse/format error, or
+  a missing-method response, falls back to plain `sendMessage` (4096). This is
+  not `parse_mode` MarkdownV2. Discord still uses its own markdown.
 - Session provenance is rendered as a visible `@resumeId` signature. The
   runtime label may accompany it (`pi · @resume-…`) but must never replace it.
 

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -105,8 +105,8 @@ The filename stem is the stable issue id. Frontmatter:
   one quoted comment when the desk is idle again. Scheduled-fire
   `assistantText` is stamped as a comment. Connector projects comments that
   do not contain `[[no-reply]]` and did not arrive from Telegram. Projected
-  comments use Telegram rich markdown (`sendRichMessage`); a parse failure
-  falls back to plain text.
+  comments use Telegram MarkdownV2; a parse failure tries `sendRichMessage`,
+  then plain text.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 Only the credential slug is persisted; endpoint and key material remain in the

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -104,7 +104,9 @@ The filename stem is the stable issue id. Frontmatter:
   running, later DMs stay in the Connector queue; Alice flushes that stack as
   one quoted comment when the desk is idle again. Scheduled-fire
   `assistantText` is stamped as a comment. Connector projects comments that
-  do not contain `[[no-reply]]` and did not arrive from Telegram.
+  do not contain `[[no-reply]]` and did not arrive from Telegram. Projected
+  comments use Telegram rich markdown (`sendRichMessage`); a parse failure
+  falls back to plain text.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 Only the credential slug is persisted; endpoint and key material remain in the

--- a/packages/connector-protocol/src/types.spec.ts
+++ b/packages/connector-protocol/src/types.spec.ts
@@ -27,6 +27,11 @@ describe('owner chat messages', () => {
       adapterId: 'telegram',
       text: 'Markets are quiet.',
     }).text).toBe('Markets are quiet.')
+    expect(ownerChatMessageSchema.parse({
+      id: 'desk-1',
+      adapterId: 'telegram',
+      text: 'x'.repeat(OWNER_CHAT_TEXT_MAX),
+    }).text).toHaveLength(OWNER_CHAT_TEXT_MAX)
     expect(() => ownerChatMessageSchema.parse({
       id: 'desk-1',
       adapterId: 'telegram',

--- a/packages/connector-protocol/src/types.ts
+++ b/packages/connector-protocol/src/types.ts
@@ -120,8 +120,11 @@ export const connectorDeliveryReceiptSchema = z.object({
   deliveryId: z.string().min(1),
 })
 
-/** Owner-private chat text. Not an Inbox item. Telegram's sendMessage cap is 4096. */
-export const OWNER_CHAT_TEXT_MAX = 4096
+/** Telegram `sendMessage` cap. Used when rich-message send falls back to plain text. */
+export const TELEGRAM_PLAIN_TEXT_MAX = 4096
+
+/** Owner-private chat text. Not an Inbox item. Telegram `sendRichMessage` allows 32768 UTF-8 characters. */
+export const OWNER_CHAT_TEXT_MAX = 32_768
 
 export const ownerChatMessageSchema = z.object({
   id: z.string().min(1),

--- a/plans/telegram-connector-issue.md
+++ b/plans/telegram-connector-issue.md
@@ -75,10 +75,11 @@ comment.
 ### 3. Telegram rich-message rendering
 
 - [x] Connector Grammy ≥ 1.44 so `sendRichMessage` exists
-- [x] Phone-desk owner chat and Inbox text use `sendRichMessage({ markdown })`
-- [x] Parse/missing-method 400/404 falls back to plain `sendMessage`
+- [x] Phone-desk owner chat and Inbox text use `sendMessage` MarkdownV2
+- [x] GFM is converted; unmatched specials are escaped
+- [x] MarkdownV2 parse 400 falls back to `sendRichMessage`, then plain text
 - [x] Owner-chat cap follows the rich-message 32768 limit
-- [x] HTML report attachments stay files; no MarkdownV2 `parse_mode`
+- [x] HTML report attachments stay files; no legacy `parse_mode: Markdown`
 
 ### Not in this plan
 

--- a/plans/telegram-connector-issue.md
+++ b/plans/telegram-connector-issue.md
@@ -1,6 +1,6 @@
 # Plan: Telegram phone-desk Issue
 
-**Status:** active — increment 2  
+**Status:** active — increment 3 
 **Owner guides:** [[docs/workspace-issues-and-scheduling.md]], [[docs/connector-service.md]], [[docs/conversation-provenance.md]]  
 **Delivery:** serial PRs to `dev` (`area:collaboration`, `area:settings`). Increment 2 is `review:deep`. Open PR, do not merge.
 
@@ -71,6 +71,14 @@ comment.
 - [x] Inbound owner DM → comment → existing reply dispatch → project unless `[[no-reply]]`
 - [x] Scheduled fire of this Issue stamps `assistantText` as a comment, then same filter
 - [x] Literal tag only; send nothing when present
+
+### 3. Telegram rich-message rendering
+
+- [x] Connector Grammy ≥ 1.44 so `sendRichMessage` exists
+- [x] Phone-desk owner chat and Inbox text use `sendRichMessage({ markdown })`
+- [x] Parse/missing-method 400/404 falls back to plain `sendMessage`
+- [x] Owner-chat cap follows the rich-message 32768 limit
+- [x] HTML report attachments stay files; no MarkdownV2 `parse_mode`
 
 ### Not in this plan
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,7 +437,7 @@ importers:
     dependencies:
       '@grammyjs/auto-retry':
         specifier: ^2.0.2
-        version: 2.0.2(grammy@1.40.0(encoding@0.1.13))
+        version: 2.0.2(grammy@1.45.1(encoding@0.1.13))
       '@hono/node-server':
         specifier: ^2.0.12
         version: 2.0.12(hono@4.12.32)
@@ -448,8 +448,8 @@ importers:
         specifier: 14.26.5
         version: 14.26.5
       grammy:
-        specifier: ^1.40.0
-        version: 1.40.0(encoding@0.1.13)
+        specifier: ^1.45.1
+        version: 1.45.1(encoding@0.1.13)
       hono:
         specifier: ^4.12.32
         version: 4.12.32
@@ -1196,8 +1196,8 @@ packages:
     peerDependencies:
       grammy: ^1.10.0
 
-  '@grammyjs/types@3.24.0':
-    resolution: {integrity: sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==}
+  '@grammyjs/types@4.0.0':
+    resolution: {integrity: sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==}
 
   '@hono/node-server@2.0.12':
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
@@ -3204,8 +3204,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.40.0:
-    resolution: {integrity: sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==}
+  grammy@1.45.1:
+    resolution: {integrity: sha512-Y4VL/hqJMZZxwlUr5ZgM68CFu2iIeEkNLR1cY3+Ww68CIvWARDsoXFix7+31rmyC0+7L85ZI+Pq3E5JSG5+nLQ==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   graphql@16.14.0:
@@ -6062,14 +6062,14 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@grammyjs/auto-retry@2.0.2(grammy@1.40.0(encoding@0.1.13))':
+  '@grammyjs/auto-retry@2.0.2(grammy@1.45.1(encoding@0.1.13))':
     dependencies:
       debug: 4.4.3
-      grammy: 1.40.0(encoding@0.1.13)
+      grammy: 1.45.1(encoding@0.1.13)
     transitivePeerDependencies:
       - supports-color
 
-  '@grammyjs/types@3.24.0': {}
+  '@grammyjs/types@4.0.0': {}
 
   '@hono/node-server@2.0.12(hono@4.12.32)':
     dependencies:
@@ -8170,9 +8170,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.40.0(encoding@0.1.13):
+  grammy@1.45.1(encoding@0.1.13):
     dependencies:
-      '@grammyjs/types': 3.24.0
+      '@grammyjs/types': 4.0.0
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0(encoding@0.1.13)

--- a/services/connector/package.json
+++ b/services/connector/package.json
@@ -16,7 +16,7 @@
     "@hono/node-server": "^2.0.12",
     "@traderalice/connector-protocol": "workspace:*",
     "discord.js": "14.26.5",
-    "grammy": "^1.40.0",
+    "grammy": "^1.45.1",
     "hono": "^4.12.32",
     "zod": "^4.3.6"
   },

--- a/services/connector/src/adapters/shared.ts
+++ b/services/connector/src/adapters/shared.ts
@@ -62,7 +62,7 @@ export class AdapterHealthTracker {
 
 export function formatInboxNotification(notification: InboxNotification): string {
   const workspace = notification.workspaceLabel ?? notification.workspaceId
-  const provenance = formatProvenance(notification)
+  const provenance = formatInboxProvenance(notification)
   const parts = [
     `**${escapeMarkdown(notification.title)}**`,
     `Workspace: ${escapeMarkdown(workspace)}`,
@@ -75,7 +75,7 @@ export function formatInboxNotification(notification: InboxNotification): string
 
 export function formatPlainInboxNotification(notification: InboxNotification): string {
   const workspace = notification.workspaceLabel ?? notification.workspaceId
-  const provenance = formatProvenance(notification)
+  const provenance = formatInboxProvenance(notification)
   const parts = [notification.title, `Workspace: ${workspace}`]
   if (provenance) parts.push(`From: ${provenance}`)
   if (notification.body.trim()) parts.push('', truncate(notification.body.trim(), 1_600))
@@ -113,7 +113,7 @@ export function decodeInboxAttachments(notification: InboxNotification): Decoded
   })
 }
 
-function formatProvenance(notification: InboxNotification): string | undefined {
+export function formatInboxProvenance(notification: InboxNotification): string | undefined {
   const actor = notification.provenance?.actorLabel?.trim()
   const resumeId = notification.provenance?.resumeId?.trim()
   const signature = resumeId ? `@${resumeId}` : undefined

--- a/services/connector/src/adapters/telegram-markdown-v2.spec.ts
+++ b/services/connector/src/adapters/telegram-markdown-v2.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import type { InboxNotification } from '@traderalice/connector-protocol'
+import {
+  escapeTelegramMarkdownV2,
+  formatTelegramInboxMarkdownV2,
+  toTelegramMarkdownV2,
+} from './telegram-markdown-v2.js'
+
+describe('Telegram MarkdownV2 conversion', () => {
+  it('escapes sendMessage specials in literal text', () => {
+    expect(escapeTelegramMarkdownV2('Hello, world! @resume-calm.')).toBe(
+      'Hello, world\\! @resume\\-calm\\.',
+    )
+  })
+
+  it('maps common GFM markers onto MarkdownV2', () => {
+    expect(toTelegramMarkdownV2('**bold** and *italic* and ~~old~~')).toBe(
+      '*bold* and _italic_ and ~old~',
+    )
+    expect(toTelegramMarkdownV2('`code.dot` and [docs](https://t.me/foo)')).toBe(
+      '`code.dot` and [docs](https://t.me/foo)',
+    )
+  })
+
+  it('turns headings and lists into MarkdownV2-safe lines', () => {
+    expect(toTelegramMarkdownV2([
+      '# Overnight risk',
+      '',
+      '- one',
+      '1. two',
+      '> quoted',
+    ].join('\n'))).toBe([
+      '*Overnight risk*',
+      '',
+      '• one',
+      '1\\. two',
+      '>quoted',
+    ].join('\n'))
+  })
+
+  it('keeps unmatched markers literal instead of emitting broken entities', () => {
+    expect(toTelegramMarkdownV2('price is 3*2=6.')).toBe('price is 3\\*2\\=6\\.')
+  })
+
+  it('preserves fenced code without treating inner specials as markup', () => {
+    expect(toTelegramMarkdownV2('see\n```ts\nconst n = 1.0\n```\n')).toBe(
+      'see\n```ts\nconst n = 1.0\n```\n',
+    )
+  })
+
+  it('formats Inbox titles as escaped MarkdownV2 instead of GFM', () => {
+    const notification: InboxNotification = {
+      id: 'inbox-1',
+      createdAt: '2026-07-13T00:00:00.000Z',
+      workspaceId: 'ws-1',
+      workspaceLabel: 'Research *desk*',
+      title: 'Close [scan]',
+      body: 'Three **findings**.',
+      provenance: { resumeId: 'resume-calm-river-12ab' },
+      href: 'https://openalice.example/inbox',
+    }
+    expect(formatTelegramInboxMarkdownV2(notification)).toBe([
+      '*Close \\[scan\\]*',
+      'Workspace: Research \\*desk\\*',
+      'From: @resume\\-calm\\-river\\-12ab',
+      '',
+      'Three *findings*\\.',
+      '',
+      'https://openalice\\.example/inbox',
+    ].join('\n'))
+  })
+})

--- a/services/connector/src/adapters/telegram-markdown-v2.ts
+++ b/services/connector/src/adapters/telegram-markdown-v2.ts
@@ -1,0 +1,164 @@
+import type { InboxNotification } from '@traderalice/connector-protocol'
+import { formatInboxProvenance } from './shared.js'
+
+const MARKDOWN_V2_SPECIALS = new Set([
+  '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\',
+])
+
+/** Escape a literal Telegram MarkdownV2 string. */
+export function escapeTelegramMarkdownV2(text: string): string {
+  return [...text].map((character) => (
+    MARKDOWN_V2_SPECIALS.has(character) ? `\\${character}` : character
+  )).join('')
+}
+
+function escapeTelegramMarkdownV2Code(text: string): string {
+  return text.replace(/([`\\])/g, '\\$1')
+}
+
+function escapeTelegramMarkdownV2Url(url: string): string {
+  return url.replace(/([)\\])/g, '\\$1')
+}
+
+/**
+ * Convert common GFM/agent markdown into Telegram `parse_mode: MarkdownV2`.
+ * Unmatched markers stay literal and are escaped so the Bot API does not 400.
+ */
+export function toTelegramMarkdownV2(source: string): string {
+  const parts: string[] = []
+  const fence = /```([^\n`]*)\n?([\s\S]*?)```/g
+  let last = 0
+  for (const match of source.matchAll(fence)) {
+    const index = match.index ?? 0
+    parts.push(convertMarkdownSection(source.slice(last, index)))
+    const language = match[1].trim()
+    const code = escapeTelegramMarkdownV2Code(match[2].replace(/\n$/, ''))
+    parts.push(language ? `\`\`\`${language}\n${code}\n\`\`\`` : `\`\`\`\n${code}\n\`\`\``)
+    last = index + match[0].length
+  }
+  parts.push(convertMarkdownSection(source.slice(last)))
+  return parts.join('')
+}
+
+function convertMarkdownSection(section: string): string {
+  if (!section) return section
+  return section.split('\n').map(convertMarkdownLine).join('\n')
+}
+
+function convertMarkdownLine(line: string): string {
+  const heading = /^(#{1,6})\s+(.+)$/.exec(line)
+  if (heading) return `*${escapeTelegramMarkdownV2(heading[2].trim())}*`
+  const quote = /^>\s?(.*)$/.exec(line)
+  if (quote) return `>${convertInline(quote[1])}`
+  const unordered = /^(\s*)[-*+]\s+(.+)$/.exec(line)
+  if (unordered) return `${unordered[1]}• ${convertInline(unordered[2])}`
+  const ordered = /^(\s*)(\d+)\.\s+(.+)$/.exec(line)
+  if (ordered) return `${ordered[1]}${escapeTelegramMarkdownV2(ordered[2])}\\. ${convertInline(ordered[3])}`
+  return convertInline(line)
+}
+
+function convertInline(input: string): string {
+  let index = 0
+  let output = ''
+  while (index < input.length) {
+    if (input.startsWith('***', index)) {
+      const end = input.indexOf('***', index + 3)
+      if (end !== -1) {
+        output += `*_${escapeTelegramMarkdownV2(input.slice(index + 3, end))}_*`
+        index = end + 3
+        continue
+      }
+    }
+    if (input.startsWith('**', index)) {
+      const end = input.indexOf('**', index + 2)
+      if (end !== -1) {
+        output += `*${escapeTelegramMarkdownV2(input.slice(index + 2, end))}*`
+        index = end + 2
+        continue
+      }
+    }
+    if (input.startsWith('__', index)) {
+      const end = input.indexOf('__', index + 2)
+      if (end !== -1) {
+        output += `*${escapeTelegramMarkdownV2(input.slice(index + 2, end))}*`
+        index = end + 2
+        continue
+      }
+    }
+    if (input.startsWith('~~', index)) {
+      const end = input.indexOf('~~', index + 2)
+      if (end !== -1) {
+        output += `~${escapeTelegramMarkdownV2(input.slice(index + 2, end))}~`
+        index = end + 2
+        continue
+      }
+    }
+    if (input[index] === '`') {
+      const end = input.indexOf('`', index + 1)
+      if (end !== -1) {
+        output += `\`${escapeTelegramMarkdownV2Code(input.slice(index + 1, end))}\``
+        index = end + 1
+        continue
+      }
+    }
+    if (input[index] === '[') {
+      const close = input.indexOf(']', index + 1)
+      if (close !== -1 && input[close + 1] === '(') {
+        const urlEnd = input.indexOf(')', close + 2)
+        if (urlEnd !== -1) {
+          output += `[${escapeTelegramMarkdownV2(input.slice(index + 1, close))}](${escapeTelegramMarkdownV2Url(input.slice(close + 2, urlEnd))})`
+          index = urlEnd + 1
+          continue
+        }
+      }
+    }
+    if (input[index] === '*' && input[index + 1] !== '*') {
+      const end = findSingleMarker(input, '*', index + 1)
+      if (end !== -1) {
+        output += `_${escapeTelegramMarkdownV2(input.slice(index + 1, end))}_`
+        index = end + 1
+        continue
+      }
+    }
+    if (input[index] === '_' && input[index + 1] !== '_') {
+      const end = findSingleMarker(input, '_', index + 1)
+      if (end !== -1) {
+        output += `_${escapeTelegramMarkdownV2(input.slice(index + 1, end))}_`
+        index = end + 1
+        continue
+      }
+    }
+    output += escapeTelegramMarkdownV2(input[index] ?? '')
+    index += 1
+  }
+  return output
+}
+
+export function formatTelegramInboxMarkdownV2(notification: InboxNotification): string {
+  const workspace = notification.workspaceLabel ?? notification.workspaceId
+  const provenance = formatInboxProvenance(notification)
+  const parts = [
+    `*${escapeTelegramMarkdownV2(notification.title)}*`,
+    `Workspace: ${escapeTelegramMarkdownV2(workspace)}`,
+  ]
+  if (provenance) parts.push(`From: ${escapeTelegramMarkdownV2(provenance)}`)
+  const body = notification.body.trim()
+  if (body) {
+    const clipped = body.length <= 1_600 ? body : `${body.slice(0, 1_599)}…`
+    parts.push('', toTelegramMarkdownV2(clipped))
+  }
+  if (notification.href) parts.push('', escapeTelegramMarkdownV2(notification.href))
+  return parts.join('\n')
+}
+
+function findSingleMarker(input: string, marker: '*' | '_', from: number): number {
+  for (let index = from; index < input.length; index += 1) {
+    if (input[index] !== marker) continue
+    if (input[index + 1] === marker) {
+      index += 1
+      continue
+    }
+    return index
+  }
+  return -1
+}

--- a/services/connector/src/adapters/telegram-rich-message-api.spec.ts
+++ b/services/connector/src/adapters/telegram-rich-message-api.spec.ts
@@ -1,0 +1,16 @@
+import { Api } from 'grammy'
+import { describe, expect, it } from 'vitest'
+
+describe('grammy Bot API 10.1 rich-message surface', () => {
+  it('exposes sendRichMessage and sendRichMessageDraft on Api', () => {
+    expect(typeof Api.prototype.sendRichMessage).toBe('function')
+    expect(typeof Api.prototype.sendRichMessageDraft).toBe('function')
+  })
+
+  it('types html and markdown payloads as sendRichMessage input', () => {
+    const html: Parameters<Api['sendRichMessage']>[1] = { html: '<b>hello</b>' }
+    const markdown: Parameters<Api['sendRichMessage']>[1] = { markdown: '*hello*' }
+    expect(html).toEqual({ html: '<b>hello</b>' })
+    expect(markdown).toEqual({ markdown: '*hello*' })
+  })
+})

--- a/services/connector/src/adapters/telegram-rich-text.spec.ts
+++ b/services/connector/src/adapters/telegram-rich-text.spec.ts
@@ -1,0 +1,76 @@
+import { TELEGRAM_PLAIN_TEXT_MAX } from '@traderalice/connector-protocol'
+import { GrammyError } from 'grammy'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  clipTelegramPlainText,
+  isRecoverableRichMessageError,
+  sendTelegramRichText,
+} from './telegram-rich-text.js'
+
+function grammyError(description: string, errorCode = 400, method = 'sendRichMessage') {
+  return new GrammyError(`Call to '${method}' failed!`, {
+    ok: false,
+    error_code: errorCode,
+    description,
+  }, method, {})
+}
+
+describe('Telegram rich-text send', () => {
+  it('sends markdown through sendRichMessage', async () => {
+    const api = {
+      sendRichMessage: vi.fn(async () => undefined),
+      sendMessage: vi.fn(async () => undefined),
+    }
+
+    await sendTelegramRichText(api, '42', '**hello**')
+
+    expect(api.sendRichMessage).toHaveBeenCalledWith('42', { markdown: '**hello**' })
+    expect(api.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('falls back to plain text when Telegram cannot parse the rich markdown', async () => {
+    const api = {
+      sendRichMessage: vi.fn(async () => {
+        throw grammyError("Bad Request: can't parse rich message markdown")
+      }),
+      sendMessage: vi.fn(async () => undefined),
+    }
+
+    await sendTelegramRichText(api, '42', '# broken <', 'plain fallback')
+
+    expect(api.sendMessage).toHaveBeenCalledWith('42', 'plain fallback')
+  })
+
+  it('falls back when sendRichMessage is not available', async () => {
+    const api = {
+      sendRichMessage: vi.fn(async () => {
+        throw grammyError('Not Found: method not found', 404)
+      }),
+      sendMessage: vi.fn(async () => undefined),
+    }
+
+    await sendTelegramRichText(api, '42', '*still readable*')
+
+    expect(api.sendMessage).toHaveBeenCalledWith('42', '*still readable*')
+  })
+
+  it('does not swallow a transport or authorization failure', async () => {
+    const api = {
+      sendRichMessage: vi.fn(async () => {
+        throw grammyError('Unauthorized', 401)
+      }),
+      sendMessage: vi.fn(async () => undefined),
+    }
+
+    await expect(sendTelegramRichText(api, '42', 'hello')).rejects.toThrow('401')
+    expect(api.sendMessage).not.toHaveBeenCalled()
+    expect(isRecoverableRichMessageError(new Error('offline'))).toBe(false)
+  })
+
+  it('clips a long fallback to the sendMessage cap', () => {
+    const text = `${'a'.repeat(TELEGRAM_PLAIN_TEXT_MAX)}!`
+    const clipped = clipTelegramPlainText(text)
+    expect(clipped).toHaveLength(TELEGRAM_PLAIN_TEXT_MAX)
+    expect(clipped.endsWith('…')).toBe(true)
+  })
+})

--- a/services/connector/src/adapters/telegram-rich-text.spec.ts
+++ b/services/connector/src/adapters/telegram-rich-text.spec.ts
@@ -3,9 +3,9 @@ import { GrammyError } from 'grammy'
 import { describe, expect, it, vi } from 'vitest'
 import { toTelegramMarkdownV2 } from './telegram-markdown-v2.js'
 import {
-  clipTelegramPlainText,
   isRecoverableRichMessageError,
   sendTelegramRichText,
+  splitTelegramPlainText,
 } from './telegram-rich-text.js'
 
 function grammyError(description: string, errorCode = 400, method = 'sendMessage') {
@@ -17,7 +17,7 @@ function grammyError(description: string, errorCode = 400, method = 'sendMessage
 }
 
 describe('Telegram rich-text send', () => {
-  it('sends converted MarkdownV2 through sendMessage', async () => {
+  it('sends original GFM through sendRichMessage', async () => {
     const api = {
       sendRichMessage: vi.fn(async () => undefined),
       sendMessage: vi.fn(async () => undefined),
@@ -25,21 +25,21 @@ describe('Telegram rich-text send', () => {
 
     await sendTelegramRichText(api, '42', '**hello**')
 
-    expect(api.sendMessage).toHaveBeenCalledWith('42', '*hello*', { parse_mode: 'MarkdownV2' })
-    expect(api.sendRichMessage).not.toHaveBeenCalled()
+    expect(api.sendRichMessage).toHaveBeenCalledWith('42', { markdown: '**hello**' })
+    expect(api.sendMessage).not.toHaveBeenCalled()
   })
 
-  it('falls back to sendRichMessage when MarkdownV2 is rejected', async () => {
+  it('falls back to MarkdownV2 when sendRichMessage is unavailable', async () => {
     const api = {
-      sendRichMessage: vi.fn(async () => undefined),
-      sendMessage: vi.fn(async () => {
-        throw grammyError("Bad Request: can't parse entities")
+      sendRichMessage: vi.fn(async () => {
+        throw grammyError('Not Found', 404, 'sendRichMessage')
       }),
+      sendMessage: vi.fn(async () => undefined),
     }
 
     await sendTelegramRichText(api, '42', '**hello**')
 
-    expect(api.sendRichMessage).toHaveBeenCalledWith('42', { markdown: '**hello**' })
+    expect(api.sendMessage).toHaveBeenCalledWith('42', '*hello*', { parse_mode: 'MarkdownV2' })
   })
 
   it('falls back to plain text when both formatted sends fail', async () => {
@@ -61,22 +61,59 @@ describe('Telegram rich-text send', () => {
 
   it('does not swallow a transport or authorization failure', async () => {
     const api = {
-      sendRichMessage: vi.fn(async () => undefined),
-      sendMessage: vi.fn(async () => {
+      sendRichMessage: vi.fn(async () => {
         throw grammyError('Unauthorized', 401)
       }),
+      sendMessage: vi.fn(async () => undefined),
     }
 
     await expect(sendTelegramRichText(api, '42', 'hello')).rejects.toThrow('401')
-    expect(api.sendRichMessage).not.toHaveBeenCalled()
+    expect(api.sendMessage).not.toHaveBeenCalled()
     expect(isRecoverableRichMessageError(new Error('offline'))).toBe(false)
   })
 
-  it('clips a long fallback to the sendMessage cap', () => {
-    const text = `${'a'.repeat(TELEGRAM_PLAIN_TEXT_MAX)}!`
-    const clipped = clipTelegramPlainText(text)
-    expect(clipped).toHaveLength(TELEGRAM_PLAIN_TEXT_MAX)
-    expect(clipped.endsWith('…')).toBe(true)
+  it('sends a long owner message intact through sendRichMessage', async () => {
+    const markdown = 'a'.repeat(5_000)
+    const api = {
+      sendRichMessage: vi.fn(async () => undefined),
+      sendMessage: vi.fn(async () => undefined),
+    }
+
+    await sendTelegramRichText(api, '42', markdown)
+
+    expect(api.sendRichMessage).toHaveBeenCalledWith('42', { markdown })
+    expect(api.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('preserves a long plain fallback across multiple messages', async () => {
+    const plain = `${'a'.repeat(4_000)}\n\n${'🙂'.repeat(600)}`
+    const api = {
+      sendRichMessage: vi.fn(async () => {
+        throw grammyError('Not Found', 404, 'sendRichMessage')
+      }),
+      sendMessage: vi.fn(async (_chatId, _text, other?: { parse_mode?: 'MarkdownV2' }) => {
+        if (other?.parse_mode === 'MarkdownV2') {
+          throw grammyError('Bad Request: message is too long')
+        }
+      }),
+    }
+
+    await sendTelegramRichText(api, '42', plain)
+
+    const plainCalls = api.sendMessage.mock.calls.filter((call) => call[2] === undefined)
+    const chunks = plainCalls.map((call) => call[1])
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.join('')).toBe(plain)
+    expect(chunks.every((chunk) => chunk.length <= TELEGRAM_PLAIN_TEXT_MAX)).toBe(true)
+    expect(chunks.every((chunk) => !chunk.endsWith('\ud83d'))).toBe(true)
+  })
+
+  it('splits plain text at readable boundaries without losing content', () => {
+    const text = `${'a'.repeat(TELEGRAM_PLAIN_TEXT_MAX - 20)}\n\n${'b'.repeat(40)}`
+    const chunks = splitTelegramPlainText(text)
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0].endsWith('\n\n')).toBe(true)
+    expect(chunks.join('')).toBe(text)
     expect(toTelegramMarkdownV2('a.b')).toBe('a\\.b')
   })
 })

--- a/services/connector/src/adapters/telegram-rich-text.spec.ts
+++ b/services/connector/src/adapters/telegram-rich-text.spec.ts
@@ -1,13 +1,14 @@
 import { TELEGRAM_PLAIN_TEXT_MAX } from '@traderalice/connector-protocol'
 import { GrammyError } from 'grammy'
 import { describe, expect, it, vi } from 'vitest'
+import { toTelegramMarkdownV2 } from './telegram-markdown-v2.js'
 import {
   clipTelegramPlainText,
   isRecoverableRichMessageError,
   sendTelegramRichText,
 } from './telegram-rich-text.js'
 
-function grammyError(description: string, errorCode = 400, method = 'sendRichMessage') {
+function grammyError(description: string, errorCode = 400, method = 'sendMessage') {
   return new GrammyError(`Call to '${method}' failed!`, {
     ok: false,
     error_code: errorCode,
@@ -16,7 +17,7 @@ function grammyError(description: string, errorCode = 400, method = 'sendRichMes
 }
 
 describe('Telegram rich-text send', () => {
-  it('sends markdown through sendRichMessage', async () => {
+  it('sends converted MarkdownV2 through sendMessage', async () => {
     const api = {
       sendRichMessage: vi.fn(async () => undefined),
       sendMessage: vi.fn(async () => undefined),
@@ -24,46 +25,50 @@ describe('Telegram rich-text send', () => {
 
     await sendTelegramRichText(api, '42', '**hello**')
 
-    expect(api.sendRichMessage).toHaveBeenCalledWith('42', { markdown: '**hello**' })
-    expect(api.sendMessage).not.toHaveBeenCalled()
+    expect(api.sendMessage).toHaveBeenCalledWith('42', '*hello*', { parse_mode: 'MarkdownV2' })
+    expect(api.sendRichMessage).not.toHaveBeenCalled()
   })
 
-  it('falls back to plain text when Telegram cannot parse the rich markdown', async () => {
+  it('falls back to sendRichMessage when MarkdownV2 is rejected', async () => {
+    const api = {
+      sendRichMessage: vi.fn(async () => undefined),
+      sendMessage: vi.fn(async () => {
+        throw grammyError("Bad Request: can't parse entities")
+      }),
+    }
+
+    await sendTelegramRichText(api, '42', '**hello**')
+
+    expect(api.sendRichMessage).toHaveBeenCalledWith('42', { markdown: '**hello**' })
+  })
+
+  it('falls back to plain text when both formatted sends fail', async () => {
     const api = {
       sendRichMessage: vi.fn(async () => {
-        throw grammyError("Bad Request: can't parse rich message markdown")
+        throw grammyError("Bad Request: can't parse rich message markdown", 400, 'sendRichMessage')
       }),
-      sendMessage: vi.fn(async () => undefined),
+      sendMessage: vi.fn(async (_chatId, _text, other?: { parse_mode?: 'MarkdownV2' }) => {
+        if (other?.parse_mode === 'MarkdownV2') {
+          throw grammyError("Bad Request: can't parse entities")
+        }
+      }),
     }
 
     await sendTelegramRichText(api, '42', '# broken <', 'plain fallback')
 
-    expect(api.sendMessage).toHaveBeenCalledWith('42', 'plain fallback')
-  })
-
-  it('falls back when sendRichMessage is not available', async () => {
-    const api = {
-      sendRichMessage: vi.fn(async () => {
-        throw grammyError('Not Found: method not found', 404)
-      }),
-      sendMessage: vi.fn(async () => undefined),
-    }
-
-    await sendTelegramRichText(api, '42', '*still readable*')
-
-    expect(api.sendMessage).toHaveBeenCalledWith('42', '*still readable*')
+    expect(api.sendMessage).toHaveBeenLastCalledWith('42', 'plain fallback')
   })
 
   it('does not swallow a transport or authorization failure', async () => {
     const api = {
-      sendRichMessage: vi.fn(async () => {
+      sendRichMessage: vi.fn(async () => undefined),
+      sendMessage: vi.fn(async () => {
         throw grammyError('Unauthorized', 401)
       }),
-      sendMessage: vi.fn(async () => undefined),
     }
 
     await expect(sendTelegramRichText(api, '42', 'hello')).rejects.toThrow('401')
-    expect(api.sendMessage).not.toHaveBeenCalled()
+    expect(api.sendRichMessage).not.toHaveBeenCalled()
     expect(isRecoverableRichMessageError(new Error('offline'))).toBe(false)
   })
 
@@ -72,5 +77,6 @@ describe('Telegram rich-text send', () => {
     const clipped = clipTelegramPlainText(text)
     expect(clipped).toHaveLength(TELEGRAM_PLAIN_TEXT_MAX)
     expect(clipped.endsWith('…')).toBe(true)
+    expect(toTelegramMarkdownV2('a.b')).toBe('a\\.b')
   })
 })

--- a/services/connector/src/adapters/telegram-rich-text.ts
+++ b/services/connector/src/adapters/telegram-rich-text.ts
@@ -11,9 +11,9 @@ export interface TelegramRichTextApi {
   ): Promise<unknown>
 }
 
-/** Send formatted Telegram text. MarkdownV2 is the `sendMessage` parse_mode.
- * Raw agent markdown is converted first. If Telegram rejects that payload,
- * try Bot API 10.1 `sendRichMessage` with the original GFM, then plain text. */
+/** Send formatted Telegram text without silently discarding message content.
+ * Bot API 10.1 rich messages accept the complete owner-chat payload. Older or
+ * incompatible endpoints fall back to MarkdownV2, then lossless plain chunks. */
 export async function sendTelegramRichText(
   api: TelegramRichTextApi,
   chatId: string,
@@ -22,30 +22,48 @@ export async function sendTelegramRichText(
   markdownV2 = toTelegramMarkdownV2(markdown),
 ): Promise<void> {
   try {
-    await api.sendMessage(chatId, clipTelegramPlainText(markdownV2), { parse_mode: 'MarkdownV2' })
+    await api.sendRichMessage(chatId, { markdown })
     return
   } catch (error) {
     if (!isRecoverableRichMessageError(error)) throw error
     console.warn(
-      '[connector] Telegram MarkdownV2 fell back:',
+      '[connector] Telegram rich message fell back:',
       error instanceof Error ? error.message : error,
     )
   }
   try {
-    await api.sendRichMessage(chatId, { markdown })
+    await api.sendMessage(chatId, markdownV2, { parse_mode: 'MarkdownV2' })
+    return
   } catch (error) {
     if (!isRecoverableRichMessageError(error)) throw error
     console.warn(
-      '[connector] Telegram rich message fell back to plain text:',
+      '[connector] Telegram MarkdownV2 fell back to plain text:',
       error instanceof Error ? error.message : error,
     )
-    await api.sendMessage(chatId, clipTelegramPlainText(plainFallback))
+  }
+
+  for (const chunk of splitTelegramPlainText(plainFallback)) {
+    await api.sendMessage(chatId, chunk)
   }
 }
 
-export function clipTelegramPlainText(text: string): string {
-  if (text.length <= TELEGRAM_PLAIN_TEXT_MAX) return text
-  return `${text.slice(0, TELEGRAM_PLAIN_TEXT_MAX - 1)}…`
+/** Split plain Telegram text at readable boundaries while preserving every
+ * code unit and never cutting through a Unicode grapheme cluster. */
+export function splitTelegramPlainText(text: string): string[] {
+  if (text.length <= TELEGRAM_PLAIN_TEXT_MAX) return [text]
+
+  const chunks: string[] = []
+  let remaining = text
+  while (remaining.length > TELEGRAM_PLAIN_TEXT_MAX) {
+    const safeEnd = telegramChunkEnd(remaining)
+    const candidate = remaining.slice(0, safeEnd)
+    const preferredEnd = preferredTelegramBreak(candidate)
+    const chunkEnd = preferredEnd > 0 ? preferredEnd : safeEnd
+    chunks.push(remaining.slice(0, chunkEnd))
+    remaining = remaining.slice(chunkEnd)
+  }
+  if (remaining) chunks.push(remaining)
+  return chunks
 }
 
 export function isRecoverableRichMessageError(error: unknown): boolean {
@@ -56,6 +74,32 @@ export function isRecoverableRichMessageError(error: unknown): boolean {
   return description.includes('parse')
     || description.includes('markdown')
     || description.includes('rich message')
+    || description.includes('too long')
     || description.includes('method not found')
     || description.includes('unknown method')
+}
+
+function telegramChunkEnd(text: string): number {
+  const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+  let end = 0
+  for (const { segment } of segmenter.segment(text)) {
+    if (end + segment.length > TELEGRAM_PLAIN_TEXT_MAX) break
+    end += segment.length
+  }
+
+  // An artificially huge grapheme cannot satisfy both constraints. Keep the
+  // loop progressing at a Unicode code-point boundary in that pathological case.
+  if (end === 0) return [...text][0]?.length ?? text.length
+  return end
+}
+
+function preferredTelegramBreak(candidate: string): number {
+  const minimumReadableChunk = Math.floor(candidate.length / 2)
+  const breaks = [
+    candidate.lastIndexOf('\n\n') + 2,
+    candidate.lastIndexOf('\n') + 1,
+    candidate.lastIndexOf(' ') + 1,
+    candidate.lastIndexOf('\t') + 1,
+  ]
+  return breaks.find((index) => index >= minimumReadableChunk) ?? 0
 }

--- a/services/connector/src/adapters/telegram-rich-text.ts
+++ b/services/connector/src/adapters/telegram-rich-text.ts
@@ -1,20 +1,36 @@
 import { TELEGRAM_PLAIN_TEXT_MAX } from '@traderalice/connector-protocol'
 import { GrammyError } from 'grammy'
+import { toTelegramMarkdownV2 } from './telegram-markdown-v2.js'
 
 export interface TelegramRichTextApi {
   sendRichMessage(chatId: string | number, richMessage: { markdown: string }): Promise<unknown>
-  sendMessage(chatId: string | number, text: string): Promise<unknown>
+  sendMessage(
+    chatId: string | number,
+    text: string,
+    other?: { parse_mode?: 'MarkdownV2' },
+  ): Promise<unknown>
 }
 
-/** Send GFM-compatible markdown through Bot API 10.1. A parse/format 400
- * (or a missing-method response) falls back to plain `sendMessage` so the
- * owner still receives the text. */
+/** Send formatted Telegram text. MarkdownV2 is the `sendMessage` parse_mode.
+ * Raw agent markdown is converted first. If Telegram rejects that payload,
+ * try Bot API 10.1 `sendRichMessage` with the original GFM, then plain text. */
 export async function sendTelegramRichText(
   api: TelegramRichTextApi,
   chatId: string,
   markdown: string,
   plainFallback = markdown,
+  markdownV2 = toTelegramMarkdownV2(markdown),
 ): Promise<void> {
+  try {
+    await api.sendMessage(chatId, clipTelegramPlainText(markdownV2), { parse_mode: 'MarkdownV2' })
+    return
+  } catch (error) {
+    if (!isRecoverableRichMessageError(error)) throw error
+    console.warn(
+      '[connector] Telegram MarkdownV2 fell back:',
+      error instanceof Error ? error.message : error,
+    )
+  }
   try {
     await api.sendRichMessage(chatId, { markdown })
   } catch (error) {

--- a/services/connector/src/adapters/telegram-rich-text.ts
+++ b/services/connector/src/adapters/telegram-rich-text.ts
@@ -1,0 +1,45 @@
+import { TELEGRAM_PLAIN_TEXT_MAX } from '@traderalice/connector-protocol'
+import { GrammyError } from 'grammy'
+
+export interface TelegramRichTextApi {
+  sendRichMessage(chatId: string | number, richMessage: { markdown: string }): Promise<unknown>
+  sendMessage(chatId: string | number, text: string): Promise<unknown>
+}
+
+/** Send GFM-compatible markdown through Bot API 10.1. A parse/format 400
+ * (or a missing-method response) falls back to plain `sendMessage` so the
+ * owner still receives the text. */
+export async function sendTelegramRichText(
+  api: TelegramRichTextApi,
+  chatId: string,
+  markdown: string,
+  plainFallback = markdown,
+): Promise<void> {
+  try {
+    await api.sendRichMessage(chatId, { markdown })
+  } catch (error) {
+    if (!isRecoverableRichMessageError(error)) throw error
+    console.warn(
+      '[connector] Telegram rich message fell back to plain text:',
+      error instanceof Error ? error.message : error,
+    )
+    await api.sendMessage(chatId, clipTelegramPlainText(plainFallback))
+  }
+}
+
+export function clipTelegramPlainText(text: string): string {
+  if (text.length <= TELEGRAM_PLAIN_TEXT_MAX) return text
+  return `${text.slice(0, TELEGRAM_PLAIN_TEXT_MAX - 1)}…`
+}
+
+export function isRecoverableRichMessageError(error: unknown): boolean {
+  if (!(error instanceof GrammyError)) return false
+  if (error.error_code === 404) return true
+  if (error.error_code !== 400) return false
+  const description = error.description.toLowerCase()
+  return description.includes('parse')
+    || description.includes('markdown')
+    || description.includes('rich message')
+    || description.includes('method not found')
+    || description.includes('unknown method')
+}

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { InboxNotification } from '@traderalice/connector-protocol'
 import { CommandRegistry } from '../core/adapter.js'
-import { formatTelegramInboxMarkdownV2, toTelegramMarkdownV2 } from './telegram-markdown-v2.js'
+import { formatInboxNotification } from './shared.js'
 import { TelegramConnectorAdapter, withTimeout } from './telegram.js'
 
 const startMock = vi.fn()
@@ -162,7 +162,7 @@ describe('Telegram rich outbound text', () => {
     sendMessage.mockResolvedValue(undefined)
   })
 
-  it('projects owner comments as MarkdownV2', async () => {
+  it('projects owner comments as rich GFM', async () => {
     const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
     await adapter.start({
       enabled: true,
@@ -172,13 +172,11 @@ describe('Telegram rich outbound text', () => {
 
     await adapter.sendOwnerText(markdown)
 
-    expect(sendMessage).toHaveBeenCalledWith('99', toTelegramMarkdownV2(markdown), {
-      parse_mode: 'MarkdownV2',
-    })
-    expect(sendRichMessage).not.toHaveBeenCalled()
+    expect(sendRichMessage).toHaveBeenCalledWith('99', { markdown })
+    expect(sendMessage).not.toHaveBeenCalled()
   })
 
-  it('sends Inbox notifications as MarkdownV2', async () => {
+  it('sends Inbox notifications as rich GFM', async () => {
     const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
     await adapter.start({
       enabled: true,
@@ -197,9 +195,9 @@ describe('Telegram rich outbound text', () => {
 
     await adapter.deliver(notification)
 
-    expect(sendMessage).toHaveBeenCalledWith('99', formatTelegramInboxMarkdownV2(notification), {
-      parse_mode: 'MarkdownV2',
+    expect(sendRichMessage).toHaveBeenCalledWith('99', {
+      markdown: formatInboxNotification(notification),
     })
-    expect(sendRichMessage).not.toHaveBeenCalled()
+    expect(sendMessage).not.toHaveBeenCalled()
   })
 })

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { InboxNotification } from '@traderalice/connector-protocol'
 import { CommandRegistry } from '../core/adapter.js'
-import { formatInboxNotification } from './shared.js'
+import { formatTelegramInboxMarkdownV2, toTelegramMarkdownV2 } from './telegram-markdown-v2.js'
 import { TelegramConnectorAdapter, withTimeout } from './telegram.js'
 
 const startMock = vi.fn()
@@ -162,22 +162,23 @@ describe('Telegram rich outbound text', () => {
     sendMessage.mockResolvedValue(undefined)
   })
 
-  it('projects owner comments through sendRichMessage markdown', async () => {
+  it('projects owner comments as MarkdownV2', async () => {
     const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
     await adapter.start({
       enabled: true,
       settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
     }, context())
+    const markdown = '**hello**\n\n- one\n- two'
 
-    await adapter.sendOwnerText('**hello**\n\n- one\n- two')
+    await adapter.sendOwnerText(markdown)
 
-    expect(sendRichMessage).toHaveBeenCalledWith('99', {
-      markdown: '**hello**\n\n- one\n- two',
+    expect(sendMessage).toHaveBeenCalledWith('99', toTelegramMarkdownV2(markdown), {
+      parse_mode: 'MarkdownV2',
     })
-    expect(sendMessage).not.toHaveBeenCalled()
+    expect(sendRichMessage).not.toHaveBeenCalled()
   })
 
-  it('sends Inbox notifications as escaped rich markdown', async () => {
+  it('sends Inbox notifications as MarkdownV2', async () => {
     const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
     await adapter.start({
       enabled: true,
@@ -196,9 +197,9 @@ describe('Telegram rich outbound text', () => {
 
     await adapter.deliver(notification)
 
-    expect(sendRichMessage).toHaveBeenCalledWith('99', {
-      markdown: formatInboxNotification(notification),
+    expect(sendMessage).toHaveBeenCalledWith('99', formatTelegramInboxMarkdownV2(notification), {
+      parse_mode: 'MarkdownV2',
     })
-    expect(sendMessage).not.toHaveBeenCalled()
+    expect(sendRichMessage).not.toHaveBeenCalled()
   })
 })

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -1,28 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { InboxNotification } from '@traderalice/connector-protocol'
 import { CommandRegistry } from '../core/adapter.js'
+import { formatInboxNotification } from './shared.js'
 import { TelegramConnectorAdapter, withTimeout } from './telegram.js'
 
 const startMock = vi.fn()
 const stopMock = vi.fn()
 const setMyCommands = vi.fn(async () => undefined)
+const sendRichMessage = vi.fn(async () => undefined)
+const sendMessage = vi.fn(async () => undefined)
+const sendDocument = vi.fn(async () => undefined)
 
-vi.mock('grammy', () => ({
-  Bot: class {
-    api = {
-      config: { use() {} },
-      setMyCommands,
-    }
-    command() {}
-    on() {}
-    start(options: { onStart?: () => void }) {
-      return startMock(options)
-    }
-    stop() {
-      return stopMock()
-    }
-  },
-  InputFile: class {},
-}))
+vi.mock('grammy', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('grammy')>()
+  return {
+    ...actual,
+    Bot: class {
+      api = {
+        config: { use() {} },
+        setMyCommands,
+        sendRichMessage,
+        sendMessage,
+        sendDocument,
+      }
+      command() {}
+      on() {}
+      start(options: { onStart?: () => void }) {
+        return startMock(options)
+      }
+      stop() {
+        return stopMock()
+      }
+    },
+    InputFile: class {},
+  }
+})
 
 vi.mock('@grammyjs/auto-retry', () => ({
   autoRetry: () => () => undefined,
@@ -57,7 +69,13 @@ describe('Telegram polling readiness', () => {
     startMock.mockReset()
     stopMock.mockReset()
     setMyCommands.mockClear()
+    sendRichMessage.mockReset()
+    sendMessage.mockReset()
+    sendDocument.mockReset()
     stopMock.mockResolvedValue(undefined)
+    sendRichMessage.mockResolvedValue(undefined)
+    sendMessage.mockResolvedValue(undefined)
+    sendDocument.mockResolvedValue(undefined)
   })
 
   it('does not claim awaiting_link until long polling has started', async () => {
@@ -127,5 +145,60 @@ describe('Telegram polling readiness', () => {
       status: 'degraded',
       lastError: 'Telegram setting botToken is required',
     })
+  })
+})
+
+describe('Telegram rich outbound text', () => {
+  beforeEach(() => {
+    startMock.mockReset()
+    stopMock.mockReset()
+    sendRichMessage.mockReset()
+    sendMessage.mockReset()
+    startMock.mockImplementation((options: { onStart?: () => void }) => {
+      queueMicrotask(() => options.onStart?.())
+      return new Promise(() => undefined)
+    })
+    sendRichMessage.mockResolvedValue(undefined)
+    sendMessage.mockResolvedValue(undefined)
+  })
+
+  it('projects owner comments through sendRichMessage markdown', async () => {
+    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
+    await adapter.start({
+      enabled: true,
+      settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
+    }, context())
+
+    await adapter.sendOwnerText('**hello**\n\n- one\n- two')
+
+    expect(sendRichMessage).toHaveBeenCalledWith('99', {
+      markdown: '**hello**\n\n- one\n- two',
+    })
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('sends Inbox notifications as escaped rich markdown', async () => {
+    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
+    await adapter.start({
+      enabled: true,
+      settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
+    }, context())
+    const notification: InboxNotification = {
+      id: 'inbox-1',
+      createdAt: '2026-07-13T00:00:00.000Z',
+      workspaceId: 'ws-1',
+      workspaceLabel: 'Research *desk*',
+      title: 'Close [scan]',
+      body: 'Three **findings**.',
+      provenance: { resumeId: 'resume-calm-river-12ab' },
+      href: 'https://openalice.example/inbox',
+    }
+
+    await adapter.deliver(notification)
+
+    expect(sendRichMessage).toHaveBeenCalledWith('99', {
+      markdown: formatInboxNotification(notification),
+    })
+    expect(sendMessage).not.toHaveBeenCalled()
   })
 })

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -17,6 +17,7 @@ import {
   formatInboxNotification,
   formatPlainInboxNotification,
 } from './shared.js'
+import { formatTelegramInboxMarkdownV2 } from './telegram-markdown-v2.js'
 import { sendTelegramRichText } from './telegram-rich-text.js'
 
 export class TelegramConnectorAdapter implements ConnectorAdapter {
@@ -114,6 +115,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
         this.chatId,
         formatInboxNotification(notification),
         formatPlainInboxNotification(notification),
+        formatTelegramInboxMarkdownV2(notification),
       )
       for (const attachment of decodeInboxAttachments(notification)) {
         await this.bot.api.sendDocument(

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -14,8 +14,10 @@ import type {
 import {
   AdapterHealthTracker,
   decodeInboxAttachments,
+  formatInboxNotification,
   formatPlainInboxNotification,
 } from './shared.js'
+import { sendTelegramRichText } from './telegram-rich-text.js'
 
 export class TelegramConnectorAdapter implements ConnectorAdapter {
   readonly id = 'telegram'
@@ -107,7 +109,12 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
     if (!this.chatId) throw new Error('Telegram private chat is not linked')
     this.tracker.attempt()
     try {
-      await this.bot.api.sendMessage(this.chatId, formatPlainInboxNotification(notification))
+      await sendTelegramRichText(
+        this.bot.api,
+        this.chatId,
+        formatInboxNotification(notification),
+        formatPlainInboxNotification(notification),
+      )
       for (const attachment of decodeInboxAttachments(notification)) {
         await this.bot.api.sendDocument(
           this.chatId,
@@ -126,7 +133,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
     if (!this.chatId) throw new Error('Telegram private chat is not linked')
     this.tracker.attempt()
     try {
-      await this.bot.api.sendMessage(this.chatId, text)
+      await sendTelegramRichText(this.bot.api, this.chatId, text)
       this.tracker.success(this.ownerUserId)
     } catch (error) {
       this.tracker.degraded(error)

--- a/src/workspaces/issues/telegram-desk-project.ts
+++ b/src/workspaces/issues/telegram-desk-project.ts
@@ -1,4 +1,4 @@
-import { ConnectorClient } from '@traderalice/connector-protocol'
+import { ConnectorClient, OWNER_CHAT_TEXT_MAX } from '@traderalice/connector-protocol'
 
 import { resolveConnectorUrl } from '../../services/connector-client/index.js'
 import type { IssueComment } from './comments.js'
@@ -28,6 +28,6 @@ export async function projectDeskComment(
   await client.sendOwnerMessage({
     id: `desk-${comment.id}`,
     adapterId: 'telegram',
-    text: comment.markdown.slice(0, 4096),
+    text: comment.markdown.slice(0, OWNER_CHAT_TEXT_MAX),
   }, AbortSignal.timeout(5_000))
 }


### PR DESCRIPTION
## Summary

- upgrade Grammy to `^1.45.1` for Telegram Bot API 10.1 rich-message support
- send complete GFM through `sendRichMessage` first, supporting rich text up to Telegram's 32K limit
- fall back to complete MarkdownV2 for older or incompatible Bot API endpoints
- fall back again to lossless 4096-character plain-text chunks when formatted delivery is rejected
- preserve the entire message across every fallback instead of silently truncating the tail
- keep Inbox reports and owner-chat replies on the same shared delivery path; HTML report attachments and Discord behavior remain unchanged

## Root cause

The original implementation clipped the MarkdownV2 payload to 4096 characters before sending it and returned on success. Messages between 4K and 32K therefore never reached the new rich-message path and lost content without reporting an error. Escaping could also consume the limit before Telegram parsed the visible text.

## Verification

- `pnpm exec vitest run services/connector/src/adapters/telegram-markdown-v2.spec.ts services/connector/src/adapters/telegram-rich-text.spec.ts services/connector/src/adapters/telegram.spec.ts packages/connector-protocol/src/types.spec.ts`
  - 4 files, 25 tests passed
- `npx tsc --noEmit`
- `pnpm test`
  - 498 passed / 1 skipped files
  - 4236 passed / 9 skipped tests
- `git diff --check`

## Boundary touch

None. Telegram transport behavior only; no persisted state, credentials, trading writes, or cross-service ownership changes.