### PR TITLE
feat(connectors): add Telegram Inbox browsing

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -22,8 +22,9 @@ categories.
 - Guardian may start, stop, or restart it without restarting Alice or UTA.
 - Inbox delivery remains outbound by default. Each adapter may advertise
   `inbox` and `settings` capabilities and implement those slash commands
-  itself. Telegram uses an inline-button form: `/inbox` pages unread items
-  and `/settings` toggles Inbox push. Discord and Slack register the same
+  itself. Telegram uses an inline-button form: `/inbox` defaults to unread
+  items, can switch to the full Inbox history, and `/settings` toggles Inbox
+  push. Discord and Slack register the same
   commands and currently reply with a placeholder. `inboxPush: false` skips Inbox
   `deliver` for that adapter and does not affect phone-desk owner chat.
   `/link`, `/status`, and `/test` stay the generic control plane. Discord
@@ -32,7 +33,8 @@ categories.
   view is a bounded summary: title, Workspace, time, a short body prefix,
   and an attachment count. It never expands raw Workspace paths. Telegram
   keeps five items per page and hard-caps the whole page below the 4096
-  plain-text limit. Entries with files offer a short “view files” control.
+  plain-text limit. Each row opens a bounded detail view; entries with files
+  then offer a short “view files” control.
   Callback data carries only page-local indexes or a server-validated
   Inbox entry id plus doc index, never a trusted raw path.
 - On-demand file pull is not phone-desk inbound and is not an ordinary
@@ -53,8 +55,12 @@ categories.
   echoed back.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
-- Inbox `docs` that are Markdown or static HTML reports are sent as file attachments, not flattened
-  into the message body. Alice reads the live Workspace file before crossing
+- Inbox `docs` that are Markdown or static HTML reports are externalized as
+  file attachments, not flattened into the message body. Telegram sends them
+  only after the owner requests a file from `/inbox`; its proactive push lists
+  the available files without attaching all of them. Other adapters retain
+  their existing push-time attachment behavior until they implement the same
+  pull controls. Alice reads the live Workspace file before crossing
   the process boundary; Connector Service never reaches into a Workspace
   itself. The Workspace artifact is never rewritten or given an agent-facing
   encoding requirement. At the externalization boundary Alice detects the
@@ -109,7 +115,7 @@ Telegram owner DM
   -> existing comment-reply dispatch
   -> owner-chat projection unless [[no-reply]]
 
-Telegram /inbox "view files" confirm
+Telegram /inbox detail -> "view files" confirm
   -> Connector action queue (requestId, connectorId, entryId, docIndex)
   -> Alice connector action bridge drain (not the phone-desk inbound drain)
   -> Alice re-reads Inbox entry and materializes one Workspace file

--- a/services/connector/src/adapters/telegram-controls.spec.ts
+++ b/services/connector/src/adapters/telegram-controls.spec.ts
@@ -9,6 +9,7 @@ import {
   advanceInboxSession,
   assertTelegramFormBounds,
   formatTelegramInboxConfirmPage,
+  formatTelegramInboxDetailPage,
   formatTelegramInboxFilesPage,
   formatTelegramInboxPage,
   formatTelegramSettingsPage,
@@ -37,7 +38,11 @@ describe('Telegram interactive controls', () => {
   it('parses button payloads without command params or raw paths', () => {
     expect(parseTelegramControl('i:o')).toEqual({ kind: 'inbox', direction: 'older' })
     expect(parseTelegramControl('i:n')).toEqual({ kind: 'inbox', direction: 'newer' })
+    expect(parseTelegramControl('i:s:u')).toEqual({ kind: 'inbox-scope', scope: 'unread' })
+    expect(parseTelegramControl('i:s:a')).toEqual({ kind: 'inbox-scope', scope: 'all' })
+    expect(parseTelegramControl('i:e:2')).toEqual({ kind: 'inbox-entry', entryIndex: 2 })
     expect(parseTelegramControl('i:b')).toEqual({ kind: 'inbox-back' })
+    expect(parseTelegramControl('i:v')).toEqual({ kind: 'inbox-open-files' })
     expect(parseTelegramControl('i:f:0')).toEqual({ kind: 'inbox-files', entryIndex: 0 })
     expect(parseTelegramControl('i:f:4')).toEqual({ kind: 'inbox-files', entryIndex: 4 })
     expect(parseTelegramControl('i:fp:2')).toEqual({ kind: 'inbox-files-page', page: 2 })
@@ -60,14 +65,19 @@ describe('Telegram interactive controls', () => {
       entries: [entry()],
       hasMore: true,
       canGoNewer: false,
+      scope: 'unread',
     })
     expect(page.text).toContain('Inbox · unread')
     expect(page.text).toContain('1. Overnight risk')
     expect(page.text).toContain('Three findings.')
-    expect(page.actions).toEqual([[{ text: 'Older', data: 'i:o' }]])
+    expect(page.actions).toEqual([
+      [{ text: '✓ Unread', data: 'i:s:u' }, { text: 'All', data: 'i:s:a' }],
+      [{ text: '1 · Overnight risk', data: 'i:e:0' }],
+      [{ text: 'Older', data: 'i:o' }],
+    ])
   })
 
-  it('summarizes attachments by count and offers a bounded view-files button', () => {
+  it('summarizes attachments by count and opens the entry detail', () => {
     const page = formatTelegramInboxPage({
       entries: [entry({
         docs: [
@@ -77,10 +87,11 @@ describe('Telegram interactive controls', () => {
       })],
       hasMore: false,
       canGoNewer: false,
+      scope: 'unread',
     })
     expect(page.text).toContain('Files: 2')
     expect(page.text).not.toContain('research/deep/nested')
-    expect(collectActions(page)).toEqual([{ text: 'Files 1', data: 'i:f:0' }])
+    expect(collectActions(page).map((action) => action.data)).toEqual(['i:s:u', 'i:s:a', 'i:e:0'])
     assertTelegramFormBounds(page)
   })
 
@@ -97,11 +108,13 @@ describe('Telegram interactive controls', () => {
       entries,
       hasMore: true,
       canGoNewer: true,
+      scope: 'unread',
     })
     const again = formatTelegramInboxPage({
       entries,
       hasMore: true,
       canGoNewer: true,
+      scope: 'unread',
     })
     expect(page.text).toBe(again.text)
     expect(page.text.length).toBeLessThan(TELEGRAM_PLAIN_TEXT_MAX)
@@ -116,7 +129,11 @@ describe('Telegram interactive controls', () => {
       'Files: 2',
     ])
     const actions = collectActions(page)
-    expect(actions.map((action) => action.data)).toEqual(['i:f:0', 'i:f:1', 'i:f:2', 'i:f:3', 'i:f:4', 'i:n', 'i:o'])
+    expect(actions.map((action) => action.data)).toEqual([
+      'i:s:u', 'i:s:a',
+      'i:e:0', 'i:e:1', 'i:e:2', 'i:e:3', 'i:e:4',
+      'i:n', 'i:o',
+    ])
     for (const action of actions) {
       expect(action.text.length).toBeLessThanOrEqual(TELEGRAM_BUTTON_TEXT_MAX)
       expect(Buffer.byteLength(action.data, 'utf8')).toBeLessThanOrEqual(TELEGRAM_CALLBACK_DATA_MAX)
@@ -129,11 +146,26 @@ describe('Telegram interactive controls', () => {
     expect(inboxFileDisplayName('research/deep/报告 😀.md')).toBe('报告 😀.md')
   })
 
+  it('renders a bounded detail view before exposing its files', () => {
+    const detail = formatTelegramInboxDetailPage(entry({
+      comments: `Overnight risk\n\n${'Finding. '.repeat(400)}`,
+      docs: [{ path: 'research/close.md' }],
+    }))
+    expect(detail.text).toContain('Overnight risk')
+    expect(detail.text).toContain('Files: 1')
+    expect(detail.text.length).toBeLessThanOrEqual(TELEGRAM_INBOX_PAGE_HARD_MAX)
+    expect(detail.actions).toEqual([
+      [{ text: 'View 1 file', data: 'i:v' }],
+      [{ text: 'Back to Inbox', data: 'i:b' }],
+    ])
+    assertTelegramFormBounds(detail)
+  })
+
   it('keeps Inbox paging on the same form via a cursor stack', () => {
-    const first = { stack: [] as string[] }
+    const first = { stack: [] as string[], scope: 'all' as const }
     const older = advanceInboxSession(first, 'older', 'entry-5')
-    expect(older).toEqual({ stack: [''], before: 'entry-5' })
-    expect(advanceInboxSession(older, 'newer')).toEqual({ stack: [], before: undefined })
+    expect(older).toEqual({ stack: [''], scope: 'all', before: 'entry-5' })
+    expect(advanceInboxSession(older, 'newer')).toEqual({ stack: [], scope: 'all', before: undefined })
   })
 
   it('renders Settings as a single toggle button', () => {
@@ -203,6 +235,47 @@ describe('Telegram inbox control transitions', () => {
       { kind: 'inbox-send' },
       { isOwner: false, getEntry },
     )).resolves.toEqual({ kind: 'forbidden' })
+  })
+
+  it('switches between unread and full history while resetting pagination', async () => {
+    await expect(transitionTelegramInbox(
+      { stack: ['', 'older'], scope: 'unread', before: 'entry-5', entryIds: ['entry-1'] },
+      { kind: 'inbox-scope', scope: 'all' },
+      { isOwner: true, getEntry: async () => listed },
+    )).resolves.toEqual({
+      kind: 'reload-inbox',
+      session: { stack: [], scope: 'all', entryIds: [], view: undefined },
+    })
+  })
+
+  it('opens an entry detail before its file list and returns through the same layers', async () => {
+    const detail = await transitionTelegramInbox(
+      { stack: [], scope: 'all', entryIds: ['entry-1'] },
+      { kind: 'inbox-entry', entryIndex: 0 },
+      { isOwner: true, getEntry: async () => listed },
+    )
+    expect(detail.kind).toBe('show')
+    if (detail.kind !== 'show') return
+    expect(detail.session.view).toEqual({ kind: 'detail', entryId: 'entry-1' })
+    expect(detail.form.text).toContain('Overnight risk')
+
+    const files = await transitionTelegramInbox(
+      detail.session,
+      { kind: 'inbox-open-files' },
+      { isOwner: true, getEntry: async () => listed },
+    )
+    expect(files.kind).toBe('show')
+    if (files.kind !== 'show') return
+    expect(files.session.view).toEqual({ kind: 'files', entryId: 'entry-1', page: 0 })
+
+    const back = await transitionTelegramInbox(
+      files.session,
+      { kind: 'inbox-back' },
+      { isOwner: true, getEntry: async () => listed },
+    )
+    expect(back.kind).toBe('show')
+    if (back.kind !== 'show') return
+    expect(back.session.view).toEqual({ kind: 'detail', entryId: 'entry-1' })
   })
 
   it('opens a file list from a page-local entry index', async () => {

--- a/services/connector/src/adapters/telegram-controls.ts
+++ b/services/connector/src/adapters/telegram-controls.ts
@@ -9,13 +9,19 @@ export const TELEGRAM_BUTTON_TEXT_MAX = 64
 export const TELEGRAM_INBOX_TITLE_MAX = 48
 export const TELEGRAM_INBOX_WORKSPACE_MAX = 28
 export const TELEGRAM_INBOX_BODY_MAX = 72
+export const TELEGRAM_INBOX_DETAIL_BODY_MAX = 1800
 export const TELEGRAM_INBOX_FILENAME_MAX = 40
+
+export type TelegramInboxScope = 'unread' | 'all'
 
 export type TelegramControl =
   | { kind: 'inbox'; direction: 'older' | 'newer' }
+  | { kind: 'inbox-scope'; scope: TelegramInboxScope }
+  | { kind: 'inbox-entry'; entryIndex: number }
   | { kind: 'inbox-back' }
   | { kind: 'settings'; inboxPush: boolean }
   | { kind: 'inbox-files'; entryIndex: number }
+  | { kind: 'inbox-open-files' }
   | { kind: 'inbox-files-page'; page: number }
   | { kind: 'inbox-doc'; docIndex: number }
   | { kind: 'inbox-send' }
@@ -33,9 +39,11 @@ export interface TelegramForm {
 
 export interface TelegramInboxSession {
   stack: string[]
+  scope?: TelegramInboxScope
   before?: string
   entryIds?: string[]
   view?:
+    | { kind: 'detail'; entryId: string }
     | { kind: 'files'; entryId: string; page: number }
     | { kind: 'confirm'; entryId: string; docIndex: number; filePage: number }
     | { kind: 'requesting'; entryId: string; docIndex: number }
@@ -59,6 +67,7 @@ export type TelegramInboxResolution =
   | { kind: 'error'; text: string; session?: TelegramInboxSession }
 
 const FILES_CONTROL = /^i:f:([0-4])$/
+const ENTRY_CONTROL = /^i:e:([0-4])$/
 const FILE_PAGE_CONTROL = /^i:fp:(\d{1,3})$/
 const DOC_CONTROL = /^i:d:(\d{1,3})$/
 
@@ -66,11 +75,16 @@ export function parseTelegramControl(data: string): TelegramControl | undefined 
   if (data.length === 0 || data.length > TELEGRAM_CALLBACK_DATA_MAX) return undefined
   if (data === 'i:o') return { kind: 'inbox', direction: 'older' }
   if (data === 'i:n') return { kind: 'inbox', direction: 'newer' }
+  if (data === 'i:s:u') return { kind: 'inbox-scope', scope: 'unread' }
+  if (data === 'i:s:a') return { kind: 'inbox-scope', scope: 'all' }
   if (data === 'i:b') return { kind: 'inbox-back' }
+  if (data === 'i:v') return { kind: 'inbox-open-files' }
   if (data === 'i:y') return { kind: 'inbox-send' }
   if (data === 'i:x') return { kind: 'inbox-cancel' }
   if (data === 's:p:0') return { kind: 'settings', inboxPush: false }
   if (data === 's:p:1') return { kind: 'settings', inboxPush: true }
+  const entry = ENTRY_CONTROL.exec(data)
+  if (entry) return { kind: 'inbox-entry', entryIndex: Number(entry[1]) }
   const files = FILES_CONTROL.exec(data)
   if (files) return { kind: 'inbox-files', entryIndex: Number(files[1]) }
   const filePage = FILE_PAGE_CONTROL.exec(data)
@@ -110,18 +124,25 @@ export function formatTelegramInboxPage(input: {
   entries: InboxEntry[]
   hasMore: boolean
   canGoNewer: boolean
+  scope: TelegramInboxScope
 }): TelegramForm {
+  const scopeActions = [
+    button(input.scope === 'unread' ? '✓ Unread' : 'Unread', 'i:s:u'),
+    button(input.scope === 'all' ? '✓ All' : 'All', 'i:s:a'),
+  ]
   if (input.entries.length === 0) {
     return {
       text: input.canGoNewer
-        ? 'No older unread Inbox items.'
-        : 'No unread Inbox items. Open Inbox in OpenAlice for the full history.',
-      actions: input.canGoNewer ? [[button('Newer', 'i:n')]] : [],
+        ? `No older ${input.scope === 'unread' ? 'unread ' : ''}Inbox items.`
+        : input.scope === 'unread'
+          ? 'No unread Inbox items. Switch to All for the full history.'
+          : 'Inbox is empty.',
+      actions: [scopeActions, ...(input.canGoNewer ? [[button('Newer', 'i:n')]] : [])],
     }
   }
 
-  const lines = ['Inbox · unread', '']
-  const fileButtons: TelegramFormAction[] = []
+  const lines = [`Inbox · ${input.scope}`, '']
+  const entryButtons: TelegramFormAction[][] = []
   for (const [index, entry] of input.entries.entries()) {
     const workspace = truncateTelegramText(
       entry.workspaceLabel ?? entry.workspaceId,
@@ -133,15 +154,12 @@ export function formatTelegramInboxPage(input: {
     lines.push(`${index + 1}. ${inboxEntryTitle(entry)}`)
     lines.push(`${workspace} · ${when}`)
     if (body) lines.push(truncateTelegramText(body, TELEGRAM_INBOX_BODY_MAX))
-    if (docCount > 0) {
-      lines.push(`Files: ${docCount}`)
-      fileButtons.push(button(`Files ${index + 1}`, `i:f:${index}`))
-    }
+    if (docCount > 0) lines.push(`Files: ${docCount}`)
     lines.push('')
+    entryButtons.push([button(`${index + 1} · ${inboxEntryTitle(entry)}`, `i:e:${index}`)])
   }
 
-  const actions: TelegramFormAction[][] = []
-  if (fileButtons.length > 0) actions.push(...chunk(fileButtons, 3))
+  const actions: TelegramFormAction[][] = [scopeActions, ...entryButtons]
   const nav: TelegramFormAction[] = []
   if (input.canGoNewer) nav.push(button('Newer', 'i:n'))
   if (input.hasMore) nav.push(button('Older', 'i:o'))
@@ -150,6 +168,26 @@ export function formatTelegramInboxPage(input: {
     text: fitPageText(lines.join('\n')),
     actions,
   }
+}
+
+export function formatTelegramInboxDetailPage(entry: InboxEntry): TelegramForm {
+  const workspace = truncateTelegramText(
+    entry.workspaceLabel ?? entry.workspaceId,
+    TELEGRAM_INBOX_WORKSPACE_MAX,
+  )
+  const body = entry.comments?.trim()
+  const docCount = entry.docs?.length ?? 0
+  const lines = [
+    inboxEntryTitle(entry),
+    `${workspace} · ${formatInboxWhen(entry.ts)}`,
+    '',
+    body ? truncateTelegramText(body, TELEGRAM_INBOX_DETAIL_BODY_MAX) : 'No message body.',
+    ...(docCount > 0 ? ['', `Files: ${docCount}`] : []),
+  ]
+  const actions: TelegramFormAction[][] = []
+  if (docCount > 0) actions.push([button(`View ${docCount} file${docCount === 1 ? '' : 's'}`, 'i:v')])
+  actions.push([button('Back to Inbox', 'i:b')])
+  return { text: fitPageText(lines.join('\n')), actions }
 }
 
 export function formatTelegramInboxFilesPage(entry: InboxEntry, page: number): TelegramForm {
@@ -229,14 +267,14 @@ export function advanceInboxSession(
   if (direction === 'older') {
     if (!oldestId) return session
     return {
+      ...session,
       stack: [...session.stack, session.before ?? ''],
       before: oldestId,
-      entryIds: session.entryIds,
     }
   }
   const stack = [...session.stack]
   const before = stack.pop()
-  return { stack, before: before || undefined, entryIds: session.entryIds }
+  return { ...session, stack, before: before || undefined }
 }
 
 export async function transitionTelegramInbox(
@@ -249,6 +287,13 @@ export async function transitionTelegramInbox(
 ): Promise<TelegramInboxResolution> {
   if (!deps.isOwner) return { kind: 'forbidden' }
   if (control.kind === 'settings') return { kind: 'settings', inboxPush: control.inboxPush }
+  if (control.kind === 'inbox-scope') {
+    if (!session) return { kind: 'expired' }
+    return {
+      kind: 'reload-inbox',
+      session: { stack: [], scope: control.scope, entryIds: [], view: undefined },
+    }
+  }
   if (control.kind === 'inbox') {
     if (!session) return { kind: 'expired' }
     return { kind: 'page', direction: control.direction, session }
@@ -256,7 +301,33 @@ export async function transitionTelegramInbox(
   if (!session) return { kind: 'expired' }
 
   if (control.kind === 'inbox-back') {
+    if (session.view?.kind === 'files' || session.view?.kind === 'confirm') {
+      const entry = await deps.getEntry(session.view.entryId)
+      if (!entry) return missingEntry(session)
+      const next = { ...session, view: { kind: 'detail' as const, entryId: entry.id } }
+      return { kind: 'show', form: formatTelegramInboxDetailPage(entry), session: next }
+    }
     return { kind: 'reload-inbox', session: { ...session, view: undefined } }
+  }
+
+  if (control.kind === 'inbox-entry') {
+    const entryId = session.entryIds?.[control.entryIndex]
+    if (!entryId) return { kind: 'expired' }
+    const entry = await deps.getEntry(entryId)
+    if (!entry) return missingEntry(session)
+    const next = { ...session, view: { kind: 'detail' as const, entryId } }
+    return { kind: 'show', form: formatTelegramInboxDetailPage(entry), session: next }
+  }
+
+  if (control.kind === 'inbox-open-files') {
+    if (session.view?.kind !== 'detail') return { kind: 'expired' }
+    const entry = await deps.getEntry(session.view.entryId)
+    if (!entry) return missingEntry(session)
+    const next: TelegramInboxSession = {
+      ...session,
+      view: { kind: 'files', entryId: entry.id, page: 0 },
+    }
+    return { kind: 'show', form: formatTelegramInboxFilesPage(entry, 0), session: next }
   }
 
   if (control.kind === 'inbox-files') {

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -186,6 +186,7 @@ describe('Telegram rich outbound text', () => {
       enabled: true,
       settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
     }, context())
+    const attachment = Buffer.from('# Close scan\n')
     const notification: InboxNotification = {
       id: 'inbox-1',
       createdAt: '2026-07-13T00:00:00.000Z',
@@ -195,6 +196,13 @@ describe('Telegram rich outbound text', () => {
       body: 'Three **findings**.',
       provenance: { resumeId: 'resume-calm-river-12ab' },
       href: 'https://openalice.example/inbox',
+      attachments: [{
+        filename: 'close.md',
+        mediaType: 'text/markdown; charset=utf-8',
+        sizeBytes: attachment.byteLength,
+        contentSha256: createHash('sha256').update(attachment).digest('hex'),
+        contentBase64: attachment.toString('base64'),
+      }],
     }
 
     await adapter.deliver(notification)
@@ -203,6 +211,7 @@ describe('Telegram rich outbound text', () => {
       markdown: formatInboxNotification(notification),
     })
     expect(sendMessage).not.toHaveBeenCalled()
+    expect(sendDocument).not.toHaveBeenCalled()
   })
 
   it('sends a requested file without repeating the Inbox summary', async () => {

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -16,7 +16,6 @@ import type {
 import {
   AdapterHealthTracker,
   decodeConnectorAttachment,
-  decodeInboxAttachments,
   formatInboxNotification,
   formatPlainInboxNotification,
 } from './shared.js'
@@ -60,7 +59,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
 
       bot.command('inbox', async (ctx) => {
         if (ctx.chat.type !== 'private' || !ctx.from) return
-        await this.presentInbox(ctx, context, { stack: [] }).catch(async (error) => {
+        await this.presentInbox(ctx, context, { stack: [], scope: 'unread' }).catch(async (error) => {
           this.tracker.degraded(error)
           await ctx.reply('Could not load Inbox. Check OpenAlice logs.').catch(() => undefined)
         })
@@ -157,12 +156,6 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
         formatPlainInboxNotification(notification),
         formatTelegramInboxMarkdownV2(notification),
       )
-      for (const attachment of decodeInboxAttachments(notification)) {
-        await this.bot.api.sendDocument(
-          this.chatId,
-          new InputFile(attachment.content, attachment.filename),
-        )
-      }
       this.tracker.success(this.ownerUserId)
     } catch (error) {
       this.tracker.degraded(error)
@@ -240,13 +233,15 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       else await ctx.reply('This command is only available to the linked owner.')
       return
     }
+    const scope = session.scope ?? 'unread'
     const page = await this.resolveInboxStore().read({
-      unread: true,
+      ...(scope === 'unread' ? { unread: true } : {}),
       limit: TELEGRAM_INBOX_PAGE_SIZE,
       ...(session.before ? { before: session.before } : {}),
     })
     const nextSession: TelegramInboxSession = {
       stack: session.stack,
+      scope,
       ...(session.before ? { before: session.before } : {}),
       entryIds: page.entries.map((entry) => entry.id),
     }
@@ -254,6 +249,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       entries: page.entries,
       hasMore: page.hasMore,
       canGoNewer: session.stack.length > 0,
+      scope,
     })
     const sent = await this.presentForm(ctx, form, mode)
     if (sent && ctx.chat) this.inboxSessions.set(sessionKey(ctx.chat.id, sent), nextSession)
@@ -304,8 +300,9 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       return
     }
     if (resolution.kind === 'page') {
+      const scope = resolution.session.scope ?? 'unread'
       const page = await this.resolveInboxStore().read({
-        unread: true,
+        ...(scope === 'unread' ? { unread: true } : {}),
         limit: TELEGRAM_INBOX_PAGE_SIZE,
         ...(resolution.session.before ? { before: resolution.session.before } : {}),
       })


### PR DESCRIPTION
## Summary
- let Telegram `/inbox` switch between unread and complete Inbox history
- keep pages to five entries with detail-first navigation and newer/older paging
- deliver Inbox files only after explicit owner confirmation instead of attaching every file to proactive pushes

## Verification
- `pnpm -F @traderalice/connector-service typecheck`
- `pnpm -F @traderalice/connector-service test` (72 tests)
- `npx tsc --noEmit`
- `pnpm test` (4284 passed, 9 skipped)