### PR TITLE
feat(workspaces): publish compact headless progress on comment transport

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -29,6 +29,9 @@ the durable truth after it changes. Git history is the archive.
 
 ## Active
 
+- [[plans/comment-turn-progress.md]] — Feed headless listener blocks back to
+  the comment/inquiry transport. Increment 1 is the compact progress contract;
+  Issue, Inbox, and Telegram decide how to consume it.
 - [[plans/issue-comment-prompt.md]] — Optional per-Issue `commentPrompt`
   template for comment-reply Input Prompts. Omission keeps the historical
   wrapper; chat desks seed `{comment}`.

--- a/PLANS.md
+++ b/PLANS.md
@@ -31,7 +31,8 @@ the durable truth after it changes. Git history is the archive.
 
 - [[plans/comment-turn-progress.md]] — Feed headless listener blocks back to
   the comment/inquiry transport. Increment 1 is the compact progress contract;
-  Issue, Inbox, and Telegram decide how to consume it.
+  increment 3 ships sealed Telegram mid-turn texts. Issue and Inbox UI still
+  decide how to consume the same field.
 - [[plans/issue-comment-prompt.md]] — Optional per-Issue `commentPrompt`
   template for comment-reply Input Prompts. Omission keeps the historical
   wrapper; chat desks seed `{comment}`.

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -52,7 +52,10 @@ categories.
   phone-desk Issue exists and no desk generation is running. Several stacked
   DMs become one quoted comment. Alice projects desk comments that do not
   contain the literal tag `[[no-reply]]`. Inbound Telegram comments are not
-  echoed back.
+  echoed back. While a desk turn is running, Alice also ships sealed mid-turn
+  `text` blocks (a tool or error followed them) so the phone chat does not
+  wait for the final reply. Tool names, status, and payloads stay off Telegram.
+  The trailing text still becomes today's reply comment.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
 - Inbox `docs` that are Markdown or static HTML reports are externalized as
@@ -249,10 +252,10 @@ The surfaces deliberately have different jobs:
   `commentPrompt: '{comment}'` so those comments are the reply Input Prompt
   as-is. Scheduled-fire `assistantText` is stamped as a comment. Connector
   projects those comments unless they contain the literal tag `[[no-reply]]`
-  or arrived from Telegram. Pending comment replies may also carry compact
-  turn progress from the headless listener; Connector does not project that
-  yet. How Telegram consumes it (typing, a status edit, or shipping new
-  semantic text blocks) is a later Connector decision.
+  or arrived from Telegram. Pending comment replies also carry compact turn
+  progress. The phone desk ships sealed mid-turn `text` blocks (the last
+  consecutive text before a tool or error) and skips tool/error blocks. A
+  text already sent this way is not sent again as the final comment.
 - **Beta → Connectors** is a read-only operations view: service health, adapter
   status, linked owner, and last delivery evidence.
 - **Dev Panel** may expose logs and replay tooling, but it is not a product

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -249,7 +249,10 @@ The surfaces deliberately have different jobs:
   `commentPrompt: '{comment}'` so those comments are the reply Input Prompt
   as-is. Scheduled-fire `assistantText` is stamped as a comment. Connector
   projects those comments unless they contain the literal tag `[[no-reply]]`
-  or arrived from Telegram.
+  or arrived from Telegram. Pending comment replies may also carry compact
+  turn progress from the headless listener; Connector does not project that
+  yet. How Telegram consumes it (typing, a status edit, or shipping new
+  semantic text blocks) is a later Connector decision.
 - **Beta → Connectors** is a read-only operations view: service health, adapter
   status, linked owner, and last delivery evidence.
 - **Dev Panel** may expose logs and replay tooling, but it is not a product

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -345,6 +345,9 @@ When an Issue has a fixed `@resumeId` owner, a comment from somebody else is
 delivered to that exact Session. The Input Prompt is `commentPrompt` when set,
 otherwise the historical wrapper around the comment. The final assistant response is recorded as a
 reply comment, linked by `replyTo`; delivery state stays on the source comment.
+While that delivery is `pending`, compact turn progress (semantic text blocks
+and tool status, never tool payloads) may ride on the same record so Inbox,
+Issue, and Connector can watch the turn without each parsing headless logs.
 For a human comment without a fixed owner, OpenAlice follows the Issue creation
 provenance and uses the universal follow-up rule: continue the attributable
 creator, or recruit a reconstructed Agent in the Issue Workspace when creation

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -348,6 +348,9 @@ reply comment, linked by `replyTo`; delivery state stays on the source comment.
 While that delivery is `pending`, compact turn progress (semantic text blocks
 and tool status, never tool payloads) may ride on the same record so Inbox,
 Issue, and Connector can watch the turn without each parsing headless logs.
+The Telegram phone desk already ships sealed mid-turn `text` blocks from that
+progress; tool and error blocks stay local.
+
 For a human comment without a fixed owner, OpenAlice follows the Issue creation
 provenance and uses the universal follow-up rule: continue the attributable
 creator, or recruit a reconstructed Agent in the Issue Workspace when creation

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -348,6 +348,8 @@ reply comment, linked by `replyTo`; delivery state stays on the source comment.
 While that delivery is `pending`, compact turn progress (semantic text blocks
 and tool status, never tool payloads) may ride on the same record so Inbox,
 Issue, and Connector can watch the turn without each parsing headless logs.
+This bounded snapshot is live transport, not durable transcript history, and
+is removed from the task record at terminal state.
 The Telegram phone desk already ships sealed mid-turn `text` blocks from that
 progress; tool and error blocks stay local.
 

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -104,9 +104,12 @@ The filename stem is the stable issue id. Frontmatter:
   running, later DMs stay in the Connector queue; Alice flushes that stack as
   one quoted comment when the desk is idle again. Scheduled-fire
   `assistantText` is stamped as a comment. Connector projects comments that
-  do not contain `[[no-reply]]` and did not arrive from Telegram. Projected
-  comments use Telegram MarkdownV2; a parse failure tries `sendRichMessage`,
-  then plain text.
+  do not contain `[[no-reply]]` and did not arrive from Telegram. While a
+  desk turn is running, it also ships sealed mid-turn `text` blocks — the
+  last consecutive text before a tool or error — and never ships tool I/O.
+  The trailing text stays with the final comment. Projected comments use
+  Telegram MarkdownV2; a parse failure tries `sendRichMessage`, then plain
+  text.
 
 `agent`, `credential`/`credentialSource`, `model`, and `effort` are one Session-creation tuple.
 Only the credential slug is persisted; endpoint and key material remain in the
@@ -145,7 +148,8 @@ may carry compact **turn progress** from the headless listener: interleaved
 semantic `text` blocks, tool names/status, and errors. That projection is
 transport only — it is not the reply comment, and it never includes tool
 input/output. Inbox inquiries expose the same shape on the inquiry record.
-Issue UI, Inbox, and Connector decide how to render or project it. A human comment without a fixed owner
+Issue UI and Inbox still decide how to render it. The Telegram phone desk
+already projects sealed `text` blocks from that same field. A human comment without a fixed owner
 uses the same provenance-aware fallback as Inbox: OpenAlice asks the
 attributable creator, or recruits a reconstruction Agent in the Issue
 Workspace when no creator Session exists. The answer is recorded in Activity

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -140,7 +140,12 @@ Comments are also the Issue's normal conversation entry. When `assignee` is an
 exact `@resumeId`, a comment from somebody else is delivered asynchronously to
 that Session and its final reply is appended as another structured comment.
 The source comment records `pending`, `replied`, or `failed`, so a durable note
-never masquerades as a delivered message. A human comment without a fixed owner
+never masquerades as a delivered message. While `pending`, the same delivery
+may carry compact **turn progress** from the headless listener: interleaved
+semantic `text` blocks, tool names/status, and errors. That projection is
+transport only — it is not the reply comment, and it never includes tool
+input/output. Inbox inquiries expose the same shape on the inquiry record.
+Issue UI, Inbox, and Connector decide how to render or project it. A human comment without a fixed owner
 uses the same provenance-aware fallback as Inbox: OpenAlice asks the
 attributable creator, or recruits a reconstruction Agent in the Issue
 Workspace when no creator Session exists. The answer is recorded in Activity

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -147,7 +147,9 @@ never masquerades as a delivered message. While `pending`, the same delivery
 may carry compact **turn progress** from the headless listener: interleaved
 semantic `text` blocks, tool names/status, and errors. That projection is
 transport only — it is not the reply comment, and it never includes tool
-input/output. Inbox inquiries expose the same shape on the inquiry record.
+input/output. The snapshot has a fixed UTF-8 byte budget and is removed from
+the task record when the run finishes; terminal delivery state and the
+structured run log remain durable. Inbox inquiries expose the same shape on the inquiry record.
 Issue UI and Inbox still decide how to render it. The Telegram phone desk
 already projects sealed `text` blocks from that same field. A human comment without a fixed owner
 uses the same provenance-aware fallback as Inbox: OpenAlice asks the

--- a/plans/comment-turn-progress.md
+++ b/plans/comment-turn-progress.md
@@ -1,6 +1,6 @@
 # Plan: Headless turn progress on the comment path
 
-**Status:** active — increment 1  
+**Status:** active — increments 1 and 3  
 **Owner guides:** [[docs/workspace-issues-and-scheduling.md]], [[docs/conversation-provenance.md]], [[docs/connector-service.md]]  
 **Delivery:** serial PR to `dev` (`area:collaboration`, `area:workspace`, `review:deep`). Open PR, do not merge.
 
@@ -26,9 +26,15 @@ or projects it stays a consumer decision.
 - **Write cheaply.** First semantic snapshot publishes immediately; later
   updates debounce (~1s) and skip identical fingerprints. Comment sidecar
   writes only for Issue-comment inquiries (`subject.commentId`).
-- **Out of this increment:** Issue Activity chrome, Inbox thread chrome, and
+- **Out of increment 1:** Issue Activity chrome, Inbox thread chrome, and
   Telegram `send`/`edit` policy. Those consume the field; they do not define
   it.
+- **Telegram ships sealed text only.** A `text` block goes to the phone desk
+  only after a tool or error follows it. Consecutive texts are one narration:
+  only the last one before the non-text block is sent, so streamed chunks do
+  not each become a DM. Tool/error blocks stay off Telegram. The trailing
+  text is still today's final comment. A text already sent as progress is
+  not sent again when that comment is stamped.
 
 ## Compact shape
 
@@ -51,7 +57,7 @@ keeps `headless-tasks.json` and comment sidecars bounded.
 
 ## Increments
 
-### 1. Central transport + API projection (this PR)
+### 1. Central transport + API projection
 
 - [x] `projectTurnProgress` + fingerprint + debounced publisher
 - [x] Runner `onProgress` from the structured snapshot writer
@@ -60,7 +66,7 @@ keeps `headless-tasks.json` and comment sidecars bounded.
 - [x] Inquiry API includes `progress`; Issue comments already travel with
       `delivery`
 - [x] Owner-guide note; typecheck + focused tests
-- [ ] Review-only PR to `dev`
+- [x] Review-only PR to `dev`
 
 ### 2. Issue and Inbox consume
 
@@ -69,10 +75,15 @@ Do not invent a second fetch of `/output`.
 
 ### 3. Connector / Telegram consume
 
-Phone-desk projection decides typing, a status edit, or shipping new `text`
-blocks. Final reply stays today's comment. Do not spam tool I/O to Telegram.
+- [x] Phone-desk consumer reads the compact progress feed
+- [x] Ship sealed mid-turn `text` blocks only (last consecutive text before
+      a tool or error); skip tool/error blocks and `[[no-reply]]`
+- [x] Dedup: a text already sent as progress is not resent as the final
+      comment (`replyTo` / scheduled `taskId` scope)
+- [x] Wire comment replies and scheduled desk fires from the existing
+      progress publisher; owner-guide note
 
 ## Completion
 
-Delete this file and its [[PLANS.md]] bullet when increment 3 is accepted, or
+Delete this file and its [[PLANS.md]] bullet when increment 2 is accepted, or
 when a later change supersedes the remaining consumer work.

--- a/plans/comment-turn-progress.md
+++ b/plans/comment-turn-progress.md
@@ -1,8 +1,8 @@
 # Plan: Headless turn progress on the comment path
 
-**Status:** active — increments 1 and 3  
-**Owner guides:** [[docs/workspace-issues-and-scheduling.md]], [[docs/conversation-provenance.md]], [[docs/connector-service.md]]  
-**Delivery:** serial PR to `dev` (`area:collaboration`, `area:workspace`, `review:deep`). Open PR, do not merge.
+**Status:** active — increments 1 and 3
+**Owner guides:** [[docs/workspace-issues-and-scheduling.md]], [[docs/conversation-provenance.md]], [[docs/connector-service.md]]
+**Delivery:** serial PR to `dev` (`area:collaboration`, `area:workspace`, `review:deep`).
 
 ## Goal
 
@@ -23,9 +23,14 @@ or projects it stays a consumer decision.
 - **Source of truth is the headless task.** `HeadlessTaskRecord.progress` is
   updated while the child runs. Comment sidecars and inquiry APIs are
   projections of that record.
-- **Write cheaply.** First semantic snapshot publishes immediately; later
-  updates debounce (~1s) and skip identical fingerprints. Comment sidecar
-  writes only for Issue-comment inquiries (`subject.commentId`).
+- **Write cheaply and serially.** First semantic snapshot publishes without a
+  debounce; later updates debounce (~1s) and skip identical fingerprints. The
+  publisher invokes async consumers in one chain, and each Issue sidecar
+  serializes its complete read-modify-write cycle.
+- **Live progress stays bounded and ephemeral.** Every projected string and the
+  complete JSON snapshot have explicit UTF-8 byte limits. Terminal task records
+  discard progress because durable output already lives in the structured log;
+  terminal Issue delivery likewise replaces the pending snapshot.
 - **Out of increment 1:** Issue Activity chrome, Inbox thread chrome, and
   Telegram `send`/`edit` policy. Those consume the field; they do not define
   it.
@@ -52,8 +57,8 @@ interface HeadlessTurnProgress {
 }
 ```
 
-Blocks keep interleaved semantic text. Tool payloads are dropped. A block cap
-keeps `headless-tasks.json` and comment sidecars bounded.
+Blocks keep interleaved semantic text. Tool payloads are dropped. Block and
+UTF-8 payload caps keep `headless-tasks.json` and comment sidecars bounded.
 
 ## Increments
 

--- a/plans/comment-turn-progress.md
+++ b/plans/comment-turn-progress.md
@@ -1,0 +1,78 @@
+# Plan: Headless turn progress on the comment path
+
+**Status:** active — increment 1  
+**Owner guides:** [[docs/workspace-issues-and-scheduling.md]], [[docs/conversation-provenance.md]], [[docs/connector-service.md]]  
+**Delivery:** serial PR to `dev` (`area:collaboration`, `area:workspace`, `review:deep`). Open PR, do not merge.
+
+## Goal
+
+Headless already hears interleaved `text` / tool / error blocks while a turn
+runs. Comment-shaped conversations (Issue replies, Inbox inquiries, Telegram
+desk) only learn the final `assistantText`. Centralize that live timeline as
+**turn progress** on the comment/inquiry transport. How each surface renders
+or projects it stays a consumer decision.
+
+## Decisions
+
+- **One projector, many readers.** `projectTurnProgress` is the only compact
+  shape. Issue comments, Inbox inquiries, and later Connector all read it.
+  Consumers do not each parse vendor JSONL or `/output`.
+- **Progress is not a reply.** Source comments stay `pending` until
+  `complete()`. The reply comment is still the final `assistantText`. Progress
+  never becomes What, and tool input/output never enter the compact shape.
+- **Source of truth is the headless task.** `HeadlessTaskRecord.progress` is
+  updated while the child runs. Comment sidecars and inquiry APIs are
+  projections of that record.
+- **Write cheaply.** First semantic snapshot publishes immediately; later
+  updates debounce (~1s) and skip identical fingerprints. Comment sidecar
+  writes only for Issue-comment inquiries (`subject.commentId`).
+- **Out of this increment:** Issue Activity chrome, Inbox thread chrome, and
+  Telegram `send`/`edit` policy. Those consume the field; they do not define
+  it.
+
+## Compact shape
+
+```ts
+type HeadlessProgressBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool'; id: string; name: string; status: 'running' | 'completed' | 'failed' }
+  | { type: 'error'; message: string }
+
+interface HeadlessTurnProgress {
+  updatedAt: number
+  assistantText: string | null
+  blocks: HeadlessProgressBlock[]
+  metrics: { textBlocks: number; toolCalls: number; toolFailures: number }
+}
+```
+
+Blocks keep interleaved semantic text. Tool payloads are dropped. A block cap
+keeps `headless-tasks.json` and comment sidecars bounded.
+
+## Increments
+
+### 1. Central transport + API projection (this PR)
+
+- [x] `projectTurnProgress` + fingerprint + debounced publisher
+- [x] Runner `onProgress` from the structured snapshot writer
+- [x] Persist `HeadlessTaskRecord.progress`; fan out to pending Issue
+      `delivery.progress` when the task is a comment reply
+- [x] Inquiry API includes `progress`; Issue comments already travel with
+      `delivery`
+- [x] Owner-guide note; typecheck + focused tests
+- [ ] Review-only PR to `dev`
+
+### 2. Issue and Inbox consume
+
+Read `delivery.progress` / inquiry `progress` instead of a spinner-only wait.
+Do not invent a second fetch of `/output`.
+
+### 3. Connector / Telegram consume
+
+Phone-desk projection decides typing, a status edit, or shipping new `text`
+blocks. Final reply stays today's comment. Do not spam tool I/O to Telegram.
+
+## Completion
+
+Delete this file and its [[PLANS.md]] bullet when increment 3 is accepted, or
+when a later change supersedes the remaining consumer work.

--- a/src/webui/routes/inquiries.spec.ts
+++ b/src/webui/routes/inquiries.spec.ts
@@ -159,6 +159,37 @@ describe('business inquiry routes', () => {
     expect(dispatchHeadlessTask.mock.calls[1]?.[6]?.subject).toMatchObject({ relation: 'run', runId: 'run-old' })
   })
 
+  it('projects compact turn progress on inquiry history', async () => {
+    const { app, list } = build()
+    const progress = {
+      updatedAt: 2,
+      assistantText: null,
+      blocks: [{ type: 'tool' as const, id: 't1', name: 'Read', status: 'running' as const }],
+      metrics: { textBlocks: 0, toolCalls: 1, toolFailures: 0 },
+    }
+    list.mockReturnValue([{
+      taskId: 'run-ask',
+      resumeId: 'resume-author',
+      wsId: 'ws-1',
+      agent: 'pi',
+      prompt: 'Why?',
+      status: 'running',
+      startedAt: 1,
+      inquiry: {
+        subject: { kind: 'inbox', entryId: 'entry-1' },
+        question: 'Why?',
+        resolution: { mode: 'exact' },
+      },
+      progress,
+    }])
+    const body = await json(await app.request('/inbox/entry-1'))
+    expect(body.inquiries).toEqual([expect.objectContaining({
+      taskId: 'run-ask',
+      assistantText: null,
+      progress,
+    })])
+  })
+
   it('lists inquiry history by business object', async () => {
     const { app, list } = build()
     expect((await app.request('/inbox/entry-1')).status).toBe(200)

--- a/src/webui/routes/inquiries.ts
+++ b/src/webui/routes/inquiries.ts
@@ -12,6 +12,7 @@ import { Hono } from 'hono'
 import type { IInboxStore } from '../../core/inbox-store.js'
 import { makeInboxEntryOriginResolver } from '../../core/workspace-tool-center.js'
 import { createWorkspaceConversationControl } from '../../workspaces/conversation-control.js'
+import { projectTurnProgress } from '../../workspaces/headless-progress.js'
 import type { HeadlessInquiryScope, HeadlessInquirySubject, HeadlessTaskRecord } from '../../workspaces/headless-task-registry.js'
 import { issueAssigneeResumeId } from '../../workspaces/issues/declaration.js'
 import { HeadlessCapacityError, HeadlessResumeError, type WorkspaceService } from '../../workspaces/service.js'
@@ -58,6 +59,8 @@ async function inquiryProjection(
   task: HeadlessTaskRecord,
 ) {
   const current = await conversation.read(task.taskId)
+  const progress = task.progress
+    ?? (current?.structured ? projectTurnProgress(current.structured) : null)
   return {
     taskId: task.taskId,
     resumeId: task.resumeId,
@@ -69,7 +72,8 @@ async function inquiryProjection(
     ...(task.durationMs !== undefined ? { durationMs: task.durationMs } : {}),
     ...(task.error ? { error: task.error } : {}),
     inquiry: task.inquiry!,
-    assistantText: current?.structured?.assistantText ?? null,
+    assistantText: current?.structured?.assistantText ?? task.progress?.assistantText ?? null,
+    ...(progress ? { progress } : {}),
   }
 }
 

--- a/src/workspaces/headless-progress.spec.ts
+++ b/src/workspaces/headless-progress.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { HeadlessStructuredOutput } from './headless-output.js'
+import {
+  createProgressPublisher,
+  MAX_PROGRESS_BLOCKS,
+  progressChanged,
+  progressFingerprint,
+  projectTurnProgress,
+} from './headless-progress.js'
+
+function structured(
+  overrides: Partial<HeadlessStructuredOutput> = {},
+): HeadlessStructuredOutput {
+  return {
+    schemaVersion: 1,
+    assistantText: 'Done.',
+    blocks: [
+      { type: 'text', text: 'I will check.' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'completed', input: { path: '/secret' }, output: 'ok' },
+      { type: 'text', text: 'Done.' },
+    ],
+    metrics: { textBlocks: 2, toolCalls: 1, toolFailures: 0 },
+    truncated: false,
+    ...overrides,
+  }
+}
+
+describe('projectTurnProgress', () => {
+  it('keeps interleaved text and drops tool payloads', () => {
+    const progress = projectTurnProgress(structured(), 42)
+    expect(progress.updatedAt).toBe(42)
+    expect(progress.assistantText).toBe('Done.')
+    expect(progress.blocks).toEqual([
+      { type: 'text', text: 'I will check.' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'completed' },
+      { type: 'text', text: 'Done.' },
+    ])
+    expect(progress.metrics).toEqual({ textBlocks: 2, toolCalls: 1, toolFailures: 0 })
+  })
+
+  it('keeps the newest blocks when the compact cap is exceeded', () => {
+    const blocks = Array.from({ length: MAX_PROGRESS_BLOCKS + 5 }, (_, index) => ({
+      type: 'text' as const,
+      text: `line-${index}`,
+    }))
+    const progress = projectTurnProgress(structured({
+      blocks,
+      assistantText: 'line-44',
+      metrics: { textBlocks: blocks.length, toolCalls: 0, toolFailures: 0 },
+    }))
+    expect(progress.blocks).toHaveLength(MAX_PROGRESS_BLOCKS)
+    expect(progress.blocks[0]).toEqual({ type: 'text', text: 'line-5' })
+    expect(progress.blocks.at(-1)).toEqual({ type: 'text', text: 'line-44' })
+  })
+})
+
+describe('progress fingerprint', () => {
+  it('ignores updatedAt so identical snapshots do not republish', () => {
+    const first = projectTurnProgress(structured(), 1)
+    const second = projectTurnProgress(structured(), 99)
+    expect(progressFingerprint(first)).toBe(progressFingerprint(second))
+    expect(progressChanged(first, second)).toBe(false)
+    expect(progressChanged(null, first)).toBe(true)
+  })
+})
+
+describe('createProgressPublisher', () => {
+  it('publishes the first snapshot immediately and debounces later ones', async () => {
+    vi.useFakeTimers()
+    const publish = vi.fn()
+    const publisher = createProgressPublisher({ debounceMs: 1_000, publish })
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'one' }), 1))
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'two' }), 2))
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'three' }), 3))
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish.mock.calls[0]?.[0].assistantText).toBe('one')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(publish).toHaveBeenCalledTimes(2)
+    expect(publish.mock.calls[1]?.[0].assistantText).toBe('three')
+    vi.useRealTimers()
+  })
+
+  it('flush publishes the latest pending snapshot', async () => {
+    vi.useFakeTimers()
+    const publish = vi.fn()
+    const publisher = createProgressPublisher({ debounceMs: 1_000, publish })
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'one' }), 1))
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'two' }), 2))
+    await publisher.flush()
+    expect(publish.mock.calls.map((call) => call[0].assistantText)).toEqual(['one', 'two'])
+    vi.useRealTimers()
+  })
+})

--- a/src/workspaces/headless-progress.spec.ts
+++ b/src/workspaces/headless-progress.spec.ts
@@ -4,6 +4,7 @@ import type { HeadlessStructuredOutput } from './headless-output.js'
 import {
   createProgressPublisher,
   MAX_PROGRESS_BLOCKS,
+  MAX_PROGRESS_PAYLOAD_BYTES,
   progressChanged,
   progressFingerprint,
   projectTurnProgress,
@@ -53,6 +54,22 @@ describe('projectTurnProgress', () => {
     expect(progress.blocks[0]).toEqual({ type: 'text', text: 'line-5' })
     expect(progress.blocks.at(-1)).toEqual({ type: 'text', text: 'line-44' })
   })
+
+  it('bounds the complete persisted snapshot by UTF-8 bytes', () => {
+    const blocks = Array.from({ length: MAX_PROGRESS_BLOCKS }, (_, index) => ({
+      type: 'text' as const,
+      text: `line-${index}-${'猫'.repeat(8_000)}`,
+    }))
+    const progress = projectTurnProgress(structured({
+      blocks,
+      assistantText: '猫'.repeat(8_000),
+      metrics: { textBlocks: blocks.length, toolCalls: 0, toolFailures: 0 },
+    }))
+    expect(Buffer.byteLength(JSON.stringify(progress), 'utf8')).toBeLessThanOrEqual(MAX_PROGRESS_PAYLOAD_BYTES)
+    expect(progress.blocks.length).toBeGreaterThan(0)
+    expect(progress.blocks.at(-1)).toMatchObject({ type: 'text' })
+    expect(JSON.stringify(progress)).not.toContain('�')
+  })
 })
 
 describe('progress fingerprint', () => {
@@ -73,11 +90,30 @@ describe('createProgressPublisher', () => {
     publisher.offer(projectTurnProgress(structured({ assistantText: 'one' }), 1))
     publisher.offer(projectTurnProgress(structured({ assistantText: 'two' }), 2))
     publisher.offer(projectTurnProgress(structured({ assistantText: 'three' }), 3))
+    await vi.advanceTimersByTimeAsync(0)
     expect(publish).toHaveBeenCalledTimes(1)
     expect(publish.mock.calls[0]?.[0].assistantText).toBe('one')
     await vi.advanceTimersByTimeAsync(1_000)
     expect(publish).toHaveBeenCalledTimes(2)
     expect(publish.mock.calls[1]?.[0].assistantText).toBe('three')
+    vi.useRealTimers()
+  })
+
+  it('does not overlap asynchronous publishers', async () => {
+    vi.useFakeTimers()
+    const releases: Array<() => void> = []
+    const publish = vi.fn(async () => new Promise<void>((resolve) => releases.push(resolve)))
+    const publisher = createProgressPublisher({ debounceMs: 1_000, publish })
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'one' }), 1))
+    await vi.advanceTimersByTimeAsync(0)
+    publisher.offer(projectTurnProgress(structured({ assistantText: 'two' }), 2))
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(publish).toHaveBeenCalledTimes(1)
+    releases.shift()?.()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(publish).toHaveBeenCalledTimes(2)
+    releases.shift()?.()
+    await publisher.flush()
     vi.useRealTimers()
   })
 

--- a/src/workspaces/headless-progress.ts
+++ b/src/workspaces/headless-progress.ts
@@ -10,6 +10,12 @@ import type { HeadlessStructuredOutput } from './headless-output.js'
 
 export const HEADLESS_PROGRESS_DEBOUNCE_MS = 1_000
 export const MAX_PROGRESS_BLOCKS = 40
+export const MAX_PROGRESS_PAYLOAD_BYTES = 32 * 1_024
+const MAX_PROGRESS_ASSISTANT_BYTES = 4 * 1_024
+const MAX_PROGRESS_TEXT_BYTES = 4 * 1_024
+const MAX_PROGRESS_ERROR_BYTES = 1 * 1_024
+const MAX_PROGRESS_LABEL_BYTES = 256
+const CLIPPED_SUFFIX = '…'
 
 export type HeadlessProgressToolStatus = 'running' | 'completed' | 'failed'
 
@@ -29,24 +35,52 @@ export interface HeadlessTurnProgress {
   }
 }
 
+function clipUtf8(value: string, maxBytes: number): string {
+  const encoded = Buffer.from(value, 'utf8')
+  if (encoded.byteLength <= maxBytes) return value
+  const suffix = Buffer.from(CLIPPED_SUFFIX, 'utf8')
+  const budget = Math.max(0, maxBytes - suffix.byteLength)
+  let end = budget
+  while (end > 0 && (encoded[end] & 0xc0) === 0x80) end -= 1
+  return `${encoded.subarray(0, end).toString('utf8')}${CLIPPED_SUFFIX}`
+}
+
 export function projectTurnProgress(
   structured: HeadlessStructuredOutput,
   now = Date.now(),
 ): HeadlessTurnProgress {
   const blocks = structured.blocks.flatMap((block): HeadlessProgressBlock[] => {
-    if (block.type === 'text') return [{ type: 'text', text: block.text }]
-    if (block.type === 'error') return [{ type: 'error', message: block.message }]
-    return [{ type: 'tool', id: block.id, name: block.name, status: block.status }]
+    if (block.type === 'text') return [{ type: 'text', text: clipUtf8(block.text, MAX_PROGRESS_TEXT_BYTES) }]
+    if (block.type === 'error') return [{ type: 'error', message: clipUtf8(block.message, MAX_PROGRESS_ERROR_BYTES) }]
+    return [{
+      type: 'tool',
+      id: clipUtf8(block.id, MAX_PROGRESS_LABEL_BYTES),
+      name: clipUtf8(block.name, MAX_PROGRESS_LABEL_BYTES),
+      status: block.status,
+    }]
   })
-  const trimmed = blocks.length <= MAX_PROGRESS_BLOCKS
+  const blockLimited = blocks.length <= MAX_PROGRESS_BLOCKS
     ? blocks
     : blocks.slice(blocks.length - MAX_PROGRESS_BLOCKS)
-  return {
+  let payloadBlocks = blockLimited
+  const buildProgress = (): HeadlessTurnProgress => ({
     updatedAt: now,
-    assistantText: structured.assistantText,
-    blocks: trimmed,
+    assistantText: structured.assistantText === null
+      ? null
+      : clipUtf8(structured.assistantText, MAX_PROGRESS_ASSISTANT_BYTES),
+    blocks: payloadBlocks,
     metrics: structured.metrics,
+  })
+  // The block count alone is not a storage bound: normalized text blocks can
+  // each be large. Prefer the newest activity and keep the exact persisted
+  // snapshot below one explicit UTF-8 budget.
+  while (
+    payloadBlocks.length > 0
+    && Buffer.byteLength(JSON.stringify(buildProgress()), 'utf8') > MAX_PROGRESS_PAYLOAD_BYTES
+  ) {
+    payloadBlocks = payloadBlocks.slice(1)
   }
+  return buildProgress()
 }
 
 /** Equality key that ignores the wall-clock stamp. */
@@ -74,25 +108,33 @@ export function createProgressPublisher(opts: {
 } {
   const debounceMs = opts.debounceMs ?? HEADLESS_PROGRESS_DEBOUNCE_MS
   let latest: HeadlessTurnProgress | null = null
-  let published: HeadlessTurnProgress | null = null
+  let started = false
+  let queuedFingerprint: string | null = null
   let timer: NodeJS.Timeout | null = null
   let chain = Promise.resolve()
 
   const enqueue = (progress: HeadlessTurnProgress) => {
-    if (!progressChanged(published, progress)) return
-    published = progress
-    try {
-      const result = opts.publish(progress)
-      chain = chain.then(() => Promise.resolve(result)).catch(() => undefined)
-    } catch {
-      /* publisher errors must not break the runner */
-    }
+    const fingerprint = progressFingerprint(progress)
+    if (fingerprint === queuedFingerprint) return
+    queuedFingerprint = fingerprint
+    // Invoke the publisher inside the chain. Calling it before `then()` makes
+    // asynchronous registry/comment writes overlap even though their returned
+    // promises are nominally chained.
+    chain = chain.then(async () => {
+      try {
+        await opts.publish(progress)
+      } catch {
+        if (queuedFingerprint === fingerprint) queuedFingerprint = null
+        /* publisher errors must not break the runner */
+      }
+    })
   }
 
   return {
     offer(progress) {
       latest = progress
-      if (!published) {
+      if (!started) {
+        started = true
         enqueue(progress)
         return
       }

--- a/src/workspaces/headless-progress.ts
+++ b/src/workspaces/headless-progress.ts
@@ -1,0 +1,115 @@
+/**
+ * Compact live progress for one headless turn.
+ *
+ * The runner already accumulates vendor-neutral structured blocks. This module
+ * is the only projection those blocks take before they reach comment-shaped
+ * conversations (Issue replies, Inbox inquiries, later Connector). Tool
+ * input/output stay out of the shape: they are noisy and can carry paths.
+ */
+import type { HeadlessStructuredOutput } from './headless-output.js'
+
+export const HEADLESS_PROGRESS_DEBOUNCE_MS = 1_000
+export const MAX_PROGRESS_BLOCKS = 40
+
+export type HeadlessProgressToolStatus = 'running' | 'completed' | 'failed'
+
+export type HeadlessProgressBlock =
+  | { readonly type: 'text'; readonly text: string }
+  | { readonly type: 'tool'; readonly id: string; readonly name: string; readonly status: HeadlessProgressToolStatus }
+  | { readonly type: 'error'; readonly message: string }
+
+export interface HeadlessTurnProgress {
+  readonly updatedAt: number
+  readonly assistantText: string | null
+  readonly blocks: readonly HeadlessProgressBlock[]
+  readonly metrics: {
+    readonly textBlocks: number
+    readonly toolCalls: number
+    readonly toolFailures: number
+  }
+}
+
+export function projectTurnProgress(
+  structured: HeadlessStructuredOutput,
+  now = Date.now(),
+): HeadlessTurnProgress {
+  const blocks = structured.blocks.flatMap((block): HeadlessProgressBlock[] => {
+    if (block.type === 'text') return [{ type: 'text', text: block.text }]
+    if (block.type === 'error') return [{ type: 'error', message: block.message }]
+    return [{ type: 'tool', id: block.id, name: block.name, status: block.status }]
+  })
+  const trimmed = blocks.length <= MAX_PROGRESS_BLOCKS
+    ? blocks
+    : blocks.slice(blocks.length - MAX_PROGRESS_BLOCKS)
+  return {
+    updatedAt: now,
+    assistantText: structured.assistantText,
+    blocks: trimmed,
+    metrics: structured.metrics,
+  }
+}
+
+/** Equality key that ignores the wall-clock stamp. */
+export function progressFingerprint(progress: HeadlessTurnProgress): string {
+  return JSON.stringify({
+    assistantText: progress.assistantText,
+    blocks: progress.blocks,
+    metrics: progress.metrics,
+  })
+}
+
+export function progressChanged(
+  previous: HeadlessTurnProgress | null | undefined,
+  next: HeadlessTurnProgress,
+): boolean {
+  return !previous || progressFingerprint(previous) !== progressFingerprint(next)
+}
+
+export function createProgressPublisher(opts: {
+  readonly debounceMs?: number
+  readonly publish: (progress: HeadlessTurnProgress) => void | Promise<void>
+}): {
+  offer(progress: HeadlessTurnProgress): void
+  flush(): Promise<void>
+} {
+  const debounceMs = opts.debounceMs ?? HEADLESS_PROGRESS_DEBOUNCE_MS
+  let latest: HeadlessTurnProgress | null = null
+  let published: HeadlessTurnProgress | null = null
+  let timer: NodeJS.Timeout | null = null
+  let chain = Promise.resolve()
+
+  const enqueue = (progress: HeadlessTurnProgress) => {
+    if (!progressChanged(published, progress)) return
+    published = progress
+    try {
+      const result = opts.publish(progress)
+      chain = chain.then(() => Promise.resolve(result)).catch(() => undefined)
+    } catch {
+      /* publisher errors must not break the runner */
+    }
+  }
+
+  return {
+    offer(progress) {
+      latest = progress
+      if (!published) {
+        enqueue(progress)
+        return
+      }
+      if (timer) return
+      timer = setTimeout(() => {
+        timer = null
+        if (latest) enqueue(latest)
+      }, debounceMs)
+      timer.unref()
+    },
+    async flush() {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      if (latest) enqueue(latest)
+      await chain
+    },
+  }
+}

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -57,9 +57,16 @@ describe('HeadlessTaskRegistry', () => {
   it('complete updates status; get returns it; runningCount drops', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
     const a = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1 })
+    await reg.setProgress(a.taskId, {
+      updatedAt: 1,
+      assistantText: 'working',
+      blocks: [{ type: 'text', text: 'working' }],
+      metrics: { textBlocks: 1, toolCalls: 0, toolFailures: 0 },
+    })
     await reg.complete(a.taskId, { status: 'done', exitCode: 0, durationMs: 5, finishedAt: 2 })
     expect(reg.get(a.taskId)?.status).toBe('done')
     expect(reg.get(a.taskId)?.exitCode).toBe(0)
+    expect(reg.get(a.taskId)?.progress).toBeUndefined()
     expect(reg.runningCount()).toBe(0)
   })
 

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -129,7 +129,7 @@ export interface HeadlessTaskRecord {
   agentSessionId?: string
   /** Compact list-view projection; full normalized blocks stay in the log API. */
   output?: HeadlessTaskOutputSummary
-  /** Live compact timeline. Written while the child runs; last snapshot remains. */
+  /** Live compact timeline. Present only while the child is running. */
   progress?: HeadlessTurnProgress
 }
 
@@ -183,6 +183,7 @@ export class HeadlessTaskRegistry {
       if (t.status === 'running') {
         t.status = 'interrupted'
         t.finishedAt = t.finishedAt ?? t.startedAt
+        delete t.progress
         changed = true
       }
     }
@@ -249,13 +250,13 @@ export class HeadlessTaskRegistry {
         | 'killed'
         | 'error'
         | 'output'
-        | 'progress'
       >
     >,
   ): Promise<void> {
     const rec = this.tasks.find((t) => t.taskId === taskId)
     if (!rec) return
     Object.assign(rec, patch)
+    if (rec.status !== 'running') delete rec.progress
     await this.flush()
   }
 

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -19,6 +19,7 @@ import { dirname, join } from 'node:path'
 
 import type { ModelReasoningEffort } from '../ai-providers/model-semantics.js'
 import type { HeadlessLaunchErrorCode } from './headless-task.js'
+import { progressChanged, type HeadlessTurnProgress } from './headless-progress.js'
 import type { Logger } from './logger.js'
 
 export type HeadlessTaskStatus = 'running' | 'done' | 'failed' | 'interrupted'
@@ -128,6 +129,8 @@ export interface HeadlessTaskRecord {
   agentSessionId?: string
   /** Compact list-view projection; full normalized blocks stay in the log API. */
   output?: HeadlessTaskOutputSummary
+  /** Live compact timeline. Written while the child runs; last snapshot remains. */
+  progress?: HeadlessTurnProgress
 }
 
 /** Task-log file paths — shared by the writer (service) and reader (route). */
@@ -246,12 +249,21 @@ export class HeadlessTaskRegistry {
         | 'killed'
         | 'error'
         | 'output'
+        | 'progress'
       >
     >,
   ): Promise<void> {
     const rec = this.tasks.find((t) => t.taskId === taskId)
     if (!rec) return
     Object.assign(rec, patch)
+    await this.flush()
+  }
+
+  /** Compact live timeline for comment/inquiry consumers. */
+  async setProgress(taskId: string, progress: HeadlessTurnProgress): Promise<void> {
+    const rec = this.tasks.find((t) => t.taskId === taskId)
+    if (!rec || !progressChanged(rec.progress, progress)) return
+    rec.progress = progress
     await this.flush()
   }
 

--- a/src/workspaces/headless-task.spec.ts
+++ b/src/workspaces/headless-task.spec.ts
@@ -157,6 +157,7 @@ describe('runHeadlessTask', () => {
     const script =
       `process.stdout.write(${JSON.stringify(first + '\n')});` +
       `process.stdout.write(${JSON.stringify(second)});`;
+    const snapshots: string[] = [];
     const r = await runHeadlessTask({
       command: ['node', '-e', script],
       cwd: process.cwd(),
@@ -176,10 +177,15 @@ describe('runHeadlessTask', () => {
           return [];
         }
       },
+      onProgress: (snapshot) => {
+        snapshots.push(snapshot.assistantText ?? '');
+      },
     });
     expect(r.assistantText).toBe('Hello 👋');
     expect(r.structured.assistantText).toBe('Hello 👋');
     expect(r.structured.blocks).toHaveLength(2);
+    expect(snapshots).toContain('Hello');
+    expect(snapshots.at(-1)).toBe('Hello 👋');
   });
 
   it('streams stdout/stderr diagnostics beyond the 16KB in-memory tails', async () => {

--- a/src/workspaces/headless-task.ts
+++ b/src/workspaces/headless-task.ts
@@ -72,6 +72,8 @@ export interface HeadlessTaskArgs {
   readonly extractAssistantText?: (line: string) => string | null;
   /** Adapter-owned JSONL translator for response and tool blocks. */
   readonly extractOutputEvents?: (line: string) => readonly HeadlessOutputEvent[];
+  /** Live structured snapshot for comment/inquiry progress. */
+  readonly onProgress?: (snapshot: HeadlessStructuredOutput) => void;
   /** Adapter-owned compaction filter for persisted stdout diagnostics. */
   readonly keepDiagnosticLine?: (line: string) => boolean;
   /**
@@ -346,7 +348,9 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
         onAssistantText: (text) => {
           assistantText = text.slice(-ASSISTANT_TEXT_MAX_CHARS);
           structuredOutput.setAssistantText(assistantText);
-          structuredWriter?.schedule(structuredOutput.snapshot(true));
+          const snapshot = structuredOutput.snapshot(true);
+          structuredWriter?.schedule(snapshot);
+          args.onProgress?.(snapshot);
         },
         onOutputEvents: (events) => {
           structuredOutput.add(events);
@@ -354,6 +358,7 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
             const snapshot = structuredOutput.snapshot(true);
             assistantText = snapshot.assistantText;
             structuredWriter?.schedule(snapshot);
+            args.onProgress?.(snapshot);
           }
         },
         ...(args.keepDiagnosticLine
@@ -398,6 +403,7 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
       ...(details.systemCode ? { systemCode: details.systemCode } : {}),
     });
     const structured = structuredOutput.snapshot(false);
+    args.onProgress?.(structured);
     await structuredWriter?.finish(structured);
     await Promise.all([outFile?.end(), errFile?.end()]);
     return {
@@ -525,6 +531,7 @@ export async function runHeadlessTask(args: HeadlessTaskArgs): Promise<HeadlessT
   scanner?.finish();
   const structured = structuredOutput.snapshot(false);
   assistantText = structured.assistantText;
+  args.onProgress?.(structured);
   await structuredWriter?.finish(structured);
   await Promise.all([outFile?.end(), errFile?.end()]);
   const durationMs = Date.now() - start;

--- a/src/workspaces/issues/comments-progress.spec.ts
+++ b/src/workspaces/issues/comments-progress.spec.ts
@@ -53,6 +53,23 @@ describe('updateIssueCommentProgress', () => {
     })
   })
 
+  it('serializes concurrent sidecar mutations without losing comments', async () => {
+    await createIssue(dir, { id: 'desk', title: 'Desk' })
+    const writes = Array.from({ length: 20 }, (_, index) => appendIssueComment(
+      dir,
+      'desk',
+      'human',
+      `comment ${index}`,
+      { id: `comment-${index}` },
+    ))
+    const results = await Promise.all(writes)
+    expect(results.every((result) => result.ok)).toBe(true)
+    const comments = await readIssueComments(dir, 'desk')
+    expect(comments.ok && comments.comments.map((comment) => comment.id).sort()).toEqual(
+      Array.from({ length: 20 }, (_, index) => `comment-${index}`).sort(),
+    )
+  })
+
   it('refuses progress once the comment is no longer pending', async () => {
     await createIssue(dir, { id: 'desk', title: 'Desk' })
     await appendIssueComment(dir, 'desk', 'human', 'hello', {

--- a/src/workspaces/issues/comments-progress.spec.ts
+++ b/src/workspaces/issues/comments-progress.spec.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { HeadlessTurnProgress } from '../headless-progress.js'
+import {
+  appendIssueComment,
+  readIssueComments,
+  updateIssueCommentDelivery,
+  updateIssueCommentProgress,
+} from './comments.js'
+import { createIssue } from './mutate.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'issue-comment-progress-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+const progress: HeadlessTurnProgress = {
+  updatedAt: 10,
+  assistantText: null,
+  blocks: [{ type: 'tool', id: 't1', name: 'Read', status: 'running' }],
+  metrics: { textBlocks: 0, toolCalls: 1, toolFailures: 0 },
+}
+
+describe('updateIssueCommentProgress', () => {
+  it('attaches compact progress to a pending comment and skips identical snapshots', async () => {
+    await createIssue(dir, { id: 'desk', title: 'Desk' })
+    await appendIssueComment(dir, 'desk', 'human', 'hello', {
+      id: 'comment-1',
+      delivery: { state: 'pending', targetResumeId: 'resume-owner', taskId: 'run-1' },
+    })
+    const first = await updateIssueCommentProgress(dir, 'desk', 'comment-1', progress)
+    expect(first.ok && first.changed).toBe(true)
+    const repeat = await updateIssueCommentProgress(dir, 'desk', 'comment-1', {
+      ...progress,
+      updatedAt: 99,
+    })
+    expect(repeat.ok && repeat.changed).toBe(false)
+    const comments = await readIssueComments(dir, 'desk')
+    expect(comments.ok && comments.comments[0]?.delivery).toEqual({
+      state: 'pending',
+      targetResumeId: 'resume-owner',
+      taskId: 'run-1',
+      progress,
+    })
+  })
+
+  it('refuses progress once the comment is no longer pending', async () => {
+    await createIssue(dir, { id: 'desk', title: 'Desk' })
+    await appendIssueComment(dir, 'desk', 'human', 'hello', {
+      id: 'comment-1',
+      delivery: { state: 'pending', targetResumeId: 'resume-owner', taskId: 'run-1' },
+    })
+    await updateIssueCommentDelivery(dir, 'desk', 'comment-1', {
+      state: 'replied',
+      targetResumeId: 'resume-owner',
+      taskId: 'run-1',
+      replyCommentId: 'comment-reply-run-1',
+    })
+    const updated = await updateIssueCommentProgress(dir, 'desk', 'comment-1', progress)
+    expect(updated.ok).toBe(false)
+  })
+})

--- a/src/workspaces/issues/comments.ts
+++ b/src/workspaces/issues/comments.ts
@@ -14,6 +14,10 @@ import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 
 import { readWorkspaceFile, writeWorkspaceFile } from '../file-service.js'
+import {
+  progressChanged,
+  type HeadlessTurnProgress,
+} from '../headless-progress.js'
 import { ISSUES_DIR_REL, parseIssueContent, type IssueRecord } from './declaration.js'
 
 export interface IssueComment {
@@ -29,11 +33,33 @@ export interface IssueComment {
   via?: 'telegram'
 }
 
+const headlessTurnProgressSchema = z.object({
+  updatedAt: z.number(),
+  assistantText: z.string().nullable(),
+  blocks: z.array(z.union([
+    z.object({ type: z.literal('text'), text: z.string() }),
+    z.object({
+      type: z.literal('tool'),
+      id: z.string().min(1),
+      name: z.string().min(1),
+      status: z.enum(['running', 'completed', 'failed']),
+    }),
+    z.object({ type: z.literal('error'), message: z.string() }),
+  ])),
+  metrics: z.object({
+    textBlocks: z.number().int().nonnegative(),
+    toolCalls: z.number().int().nonnegative(),
+    toolFailures: z.number().int().nonnegative(),
+  }),
+})
+
 export type IssueCommentDelivery =
   | {
       state: 'pending'
       targetResumeId: string
       taskId: string
+      /** Compact live timeline. Absent until the first structured snapshot. */
+      progress?: HeadlessTurnProgress
     }
   | {
       state: 'replied'
@@ -53,6 +79,7 @@ const issueCommentDeliverySchema = z.discriminatedUnion('state', [
     state: z.literal('pending'),
     targetResumeId: z.string().min(1),
     taskId: z.string().min(1),
+    progress: headlessTurnProgressSchema.optional(),
   }),
   z.object({
     state: z.literal('replied'),
@@ -180,4 +207,34 @@ export async function updateIssueCommentDelivery(
   comments[index] = comment
   await writeIssueComments(wsDir, id, comments)
   return { ok: true, comment }
+}
+
+/** Attach live turn progress to a pending comment. No-ops when the comment
+ * is missing, no longer pending, or the compact snapshot did not change. */
+export async function updateIssueCommentProgress(
+  wsDir: string,
+  id: string,
+  commentId: string,
+  progress: HeadlessTurnProgress,
+): Promise<{ ok: true; comment: IssueComment; changed: boolean } | { ok: false; error: string }> {
+  const existing = await readIssueComments(wsDir, id)
+  if (!existing.ok) return existing
+  const index = existing.comments.findIndex((comment) => comment.id === commentId)
+  if (index < 0) return { ok: false, error: `comment not found: ${commentId}` }
+  const current = existing.comments[index]
+  const delivery = current?.delivery
+  if (!current || delivery?.state !== 'pending') {
+    return { ok: false, error: `comment is not awaiting a reply: ${commentId}` }
+  }
+  if (!progressChanged(delivery.progress, progress)) {
+    return { ok: true, comment: current, changed: false }
+  }
+  const comment = {
+    ...current,
+    delivery: { ...delivery, progress },
+  }
+  const comments = [...existing.comments]
+  comments[index] = comment
+  await writeIssueComments(wsDir, id, comments)
+  return { ok: true, comment, changed: true }
 }

--- a/src/workspaces/issues/comments.ts
+++ b/src/workspaces/issues/comments.ts
@@ -154,6 +154,31 @@ async function writeIssueComments(wsDir: string, id: string, comments: IssueComm
   await writeWorkspaceFile(wsDir, issueCommentsRel(id), content)
 }
 
+const issueCommentMutationChains = new Map<string, Promise<void>>()
+
+/** Serialize the full read-modify-write cycle for one Issue sidecar. Different
+ * Issues remain independent, while progress, delivery, and human comments on
+ * the same Issue cannot overwrite one another. */
+async function mutateIssueComments<T>(
+  wsDir: string,
+  id: string,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  const key = `${wsDir}\0${id}`
+  const predecessor = issueCommentMutationChains.get(key) ?? Promise.resolve()
+  let release!: () => void
+  const turn = new Promise<void>((resolve) => { release = resolve })
+  const tail = predecessor.then(() => turn)
+  issueCommentMutationChains.set(key, tail)
+  await predecessor
+  try {
+    return await mutation()
+  } finally {
+    release()
+    if (issueCommentMutationChains.get(key) === tail) issueCommentMutationChains.delete(key)
+  }
+}
+
 export async function appendIssueComment(
   wsDir: string,
   id: string,
@@ -171,25 +196,27 @@ export async function appendIssueComment(
   if (!author.trim() || !markdown) {
     return { ok: false, reason: 'invalid', error: 'author and comment markdown must be non-empty' }
   }
-  const existing = await readIssueComments(wsDir, id)
-  if (!existing.ok) return { ok: false, reason: 'invalid', error: existing.error }
+  return mutateIssueComments(wsDir, id, async (): Promise<AppendIssueCommentResult> => {
+    const existing = await readIssueComments(wsDir, id)
+    if (!existing.ok) return { ok: false, reason: 'invalid', error: existing.error }
 
-  if (options.id) {
-    const duplicate = existing.comments.find((comment) => comment.id === options.id)
-    if (duplicate) return { ok: true, issue: issue.issue, comment: duplicate }
-  }
+    if (options.id) {
+      const duplicate = existing.comments.find((comment) => comment.id === options.id)
+      if (duplicate) return { ok: true, issue: issue.issue, comment: duplicate }
+    }
 
-  const comment: IssueComment = {
-    id: options.id ?? `comment-${randomUUID()}`,
-    author: author.trim(),
-    at: options.at ?? new Date().toISOString(),
-    markdown,
-    ...(options.replyTo ? { replyTo: options.replyTo } : {}),
-    ...(options.delivery ? { delivery: options.delivery } : {}),
-    ...(options.via ? { via: options.via } : {}),
-  }
-  await writeIssueComments(wsDir, id, [...existing.comments, comment])
-  return { ok: true, issue: issue.issue, comment }
+    const comment: IssueComment = {
+      id: options.id ?? `comment-${randomUUID()}`,
+      author: author.trim(),
+      at: options.at ?? new Date().toISOString(),
+      markdown,
+      ...(options.replyTo ? { replyTo: options.replyTo } : {}),
+      ...(options.delivery ? { delivery: options.delivery } : {}),
+      ...(options.via ? { via: options.via } : {}),
+    }
+    await writeIssueComments(wsDir, id, [...existing.comments, comment])
+    return { ok: true, issue: issue.issue, comment }
+  })
 }
 
 export async function updateIssueCommentDelivery(
@@ -198,15 +225,17 @@ export async function updateIssueCommentDelivery(
   commentId: string,
   delivery: IssueCommentDelivery,
 ): Promise<{ ok: true; comment: IssueComment } | { ok: false; error: string }> {
-  const existing = await readIssueComments(wsDir, id)
-  if (!existing.ok) return existing
-  const index = existing.comments.findIndex((comment) => comment.id === commentId)
-  if (index < 0) return { ok: false, error: `comment not found: ${commentId}` }
-  const comment = { ...existing.comments[index], delivery }
-  const comments = [...existing.comments]
-  comments[index] = comment
-  await writeIssueComments(wsDir, id, comments)
-  return { ok: true, comment }
+  return mutateIssueComments(wsDir, id, async () => {
+    const existing = await readIssueComments(wsDir, id)
+    if (!existing.ok) return existing
+    const index = existing.comments.findIndex((comment) => comment.id === commentId)
+    if (index < 0) return { ok: false as const, error: `comment not found: ${commentId}` }
+    const comment = { ...existing.comments[index], delivery }
+    const comments = [...existing.comments]
+    comments[index] = comment
+    await writeIssueComments(wsDir, id, comments)
+    return { ok: true as const, comment }
+  })
 }
 
 /** Attach live turn progress to a pending comment. No-ops when the comment
@@ -217,24 +246,26 @@ export async function updateIssueCommentProgress(
   commentId: string,
   progress: HeadlessTurnProgress,
 ): Promise<{ ok: true; comment: IssueComment; changed: boolean } | { ok: false; error: string }> {
-  const existing = await readIssueComments(wsDir, id)
-  if (!existing.ok) return existing
-  const index = existing.comments.findIndex((comment) => comment.id === commentId)
-  if (index < 0) return { ok: false, error: `comment not found: ${commentId}` }
-  const current = existing.comments[index]
-  const delivery = current?.delivery
-  if (!current || delivery?.state !== 'pending') {
-    return { ok: false, error: `comment is not awaiting a reply: ${commentId}` }
-  }
-  if (!progressChanged(delivery.progress, progress)) {
-    return { ok: true, comment: current, changed: false }
-  }
-  const comment = {
-    ...current,
-    delivery: { ...delivery, progress },
-  }
-  const comments = [...existing.comments]
-  comments[index] = comment
-  await writeIssueComments(wsDir, id, comments)
-  return { ok: true, comment, changed: true }
+  return mutateIssueComments(wsDir, id, async () => {
+    const existing = await readIssueComments(wsDir, id)
+    if (!existing.ok) return existing
+    const index = existing.comments.findIndex((comment) => comment.id === commentId)
+    if (index < 0) return { ok: false as const, error: `comment not found: ${commentId}` }
+    const current = existing.comments[index]
+    const delivery = current?.delivery
+    if (!current || delivery?.state !== 'pending') {
+      return { ok: false as const, error: `comment is not awaiting a reply: ${commentId}` }
+    }
+    if (!progressChanged(delivery.progress, progress)) {
+      return { ok: true as const, comment: current, changed: false }
+    }
+    const comment = {
+      ...current,
+      delivery: { ...delivery, progress },
+    }
+    const comments = [...existing.comments]
+    comments[index] = comment
+    await writeIssueComments(wsDir, id, comments)
+    return { ok: true as const, comment, changed: true }
+  })
 }

--- a/src/workspaces/issues/telegram-desk-chat.ts
+++ b/src/workspaces/issues/telegram-desk-chat.ts
@@ -3,6 +3,8 @@
  *
  * Connector only transports. Issue comments are the transcript. The literal
  * tag [[no-reply]] is filtered here so silent heartbeat comments stay local.
+ * Sealed mid-turn text blocks (a tool or error followed them) also project so
+ * the phone chat does not wait for the final reply.
  */
 import { randomUUID } from 'node:crypto'
 import {
@@ -31,6 +33,8 @@ export {
   TELEGRAM_NO_REPLY_TAG,
   containsTelegramNoReply,
   projectDeskComment,
+  projectDeskTurnProgress,
+  projectWorkspaceDeskTurnProgress,
   shouldProjectDeskComment,
 } from './telegram-desk-project.js'
 
@@ -167,7 +171,9 @@ export async function stampTelegramDeskScheduledFire(input: {
     at: input.task.finishedAt ?? Date.now(),
     fingerprint: `telegram-desk-fire:${input.task.taskId}`,
   })
-  await projectDeskComment(appended.issue, appended.comment).catch(() => undefined)
+  await projectDeskComment(appended.issue, appended.comment, undefined, {
+    progressScopeId: input.task.taskId,
+  }).catch(() => undefined)
   return appended.comment
 }
 

--- a/src/workspaces/issues/telegram-desk-project.spec.ts
+++ b/src/workspaces/issues/telegram-desk-project.spec.ts
@@ -1,0 +1,256 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { ConnectorClient } from '@traderalice/connector-protocol'
+
+import type { HeadlessTurnProgress } from '../headless-progress.js'
+import { createTelegramConnectorDesk } from './telegram-connector.js'
+import {
+  alreadyProjectedDeskText,
+  deskProgressMessageId,
+  deskProgressScope,
+  projectDeskComment,
+  projectDeskTurnProgress,
+  projectWorkspaceDeskTurnProgress,
+  resetProjectedDeskTexts,
+  sealedProgressTexts,
+  shouldProjectDeskComment,
+} from './telegram-desk-project.js'
+
+let home: string
+let wsDir: string
+
+beforeEach(async () => {
+  resetProjectedDeskTexts()
+  home = await mkdtemp(join(tmpdir(), 'tg-desk-progress-'))
+  wsDir = join(home, 'ws')
+  await mkdir(join(wsDir, '.alice', 'issues'), { recursive: true })
+})
+
+afterEach(async () => {
+  resetProjectedDeskTexts()
+  await rm(home, { recursive: true, force: true })
+})
+
+function progress(blocks: HeadlessTurnProgress['blocks']): HeadlessTurnProgress {
+  return {
+    updatedAt: 1,
+    assistantText: [...blocks].reverse().find((block) => block.type === 'text')?.text ?? null,
+    blocks,
+    metrics: {
+      textBlocks: blocks.filter((block) => block.type === 'text').length,
+      toolCalls: blocks.filter((block) => block.type === 'tool').length,
+      toolFailures: 0,
+    },
+  }
+}
+
+function mockClient() {
+  const sent: { id: string; text: string }[] = []
+  const client = {
+    sendOwnerMessage: async (message: { id: string; text: string }) => {
+      sent.push({ id: message.id, text: message.text })
+      return { accepted: true }
+    },
+  } as unknown as ConnectorClient
+  return { client, sent }
+}
+
+describe('sealedProgressTexts', () => {
+  it('sends only the last consecutive text before a tool or error', () => {
+    expect(sealedProgressTexts(progress([
+      { type: 'text', text: "I'll" },
+      { type: 'text', text: "I'll check the book." },
+      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
+      { type: 'text', text: 'The overnight risk is low.' },
+    ]))).toEqual(["I'll check the book."])
+  })
+
+  it('ships each sealed narration and keeps the trailing reply local', () => {
+    expect(sealedProgressTexts(progress([
+      { type: 'text', text: 'Looking at the book.' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'completed' },
+      { type: 'text', text: 'Checking another file.' },
+      { type: 'tool', id: 't2', name: 'Read', status: 'running' },
+      { type: 'text', text: 'Here is the answer.' },
+    ]))).toEqual(['Looking at the book.', 'Checking another file.'])
+  })
+
+  it('does not ship a lone trailing text, tools, errors, or [[no-reply]]', () => {
+    expect(sealedProgressTexts(progress([
+      { type: 'text', text: 'Final answer only.' },
+    ]))).toEqual([])
+    expect(sealedProgressTexts(progress([
+      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
+      { type: 'text', text: 'After the tool.' },
+    ]))).toEqual([])
+    expect(sealedProgressTexts(progress([
+      { type: 'text', text: '[[no-reply]] quiet' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
+    ]))).toEqual([])
+    expect(sealedProgressTexts(progress([
+      { type: 'error', message: 'boom' },
+    ]))).toEqual([])
+  })
+})
+
+describe('deskProgressScope', () => {
+  it('prefers the comment id for an Issue reply and the task id for a fire', () => {
+    expect(deskProgressScope({
+      taskId: 'run-reply',
+      inquiry: {
+        subject: {
+          kind: 'issue',
+          workspaceId: 'ws-a',
+          issueId: 'telegram-phone-desk',
+          relation: 'owner',
+          commentId: 'telegram-1',
+        },
+      },
+    })).toEqual({
+      workspaceId: 'ws-a',
+      issueId: 'telegram-phone-desk',
+      scopeId: 'telegram-1',
+    })
+    expect(deskProgressScope({
+      taskId: 'run-fire',
+      trigger: { kind: 'issue', workspaceId: 'ws-a', issueId: 'telegram-phone-desk' },
+    })).toEqual({
+      workspaceId: 'ws-a',
+      issueId: 'telegram-phone-desk',
+      scopeId: 'run-fire',
+    })
+    expect(deskProgressScope({
+      taskId: 'run-inbox',
+      inquiry: {
+        subject: { kind: 'inbox', entryId: 'in-1' },
+      },
+    })).toBeNull()
+  })
+})
+
+describe('projectDeskTurnProgress', () => {
+  const desk = { telegramConnector: true as const, status: 'todo' as const }
+
+  it('sends sealed texts once and skips tools', async () => {
+    const { client, sent } = mockClient()
+    const snapshot = progress([
+      { type: 'text', text: 'Looking at the book.' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
+      { type: 'text', text: 'Still thinking.' },
+    ])
+    await projectDeskTurnProgress({
+      issue: desk,
+      scopeId: 'telegram-1',
+      progress: snapshot,
+      client,
+    })
+    await projectDeskTurnProgress({
+      issue: desk,
+      scopeId: 'telegram-1',
+      progress: snapshot,
+      client,
+    })
+    expect(sent).toEqual([{
+      id: deskProgressMessageId('telegram-1', 'Looking at the book.'),
+      text: 'Looking at the book.',
+    }])
+    expect(alreadyProjectedDeskText('telegram-1', 'Looking at the book.')).toBe(true)
+  })
+
+  it('does not project ordinary Issues or a canceled desk', async () => {
+    const { client, sent } = mockClient()
+    const snapshot = progress([
+      { type: 'text', text: 'Looking.' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
+    ])
+    await projectDeskTurnProgress({
+      issue: { status: 'todo' },
+      scopeId: 'c1',
+      progress: snapshot,
+      client,
+    })
+    await projectDeskTurnProgress({
+      issue: { telegramConnector: true, status: 'canceled' },
+      scopeId: 'c1',
+      progress: snapshot,
+      client,
+    })
+    expect(sent).toEqual([])
+  })
+
+  it('loads the live desk Issue from the Workspace', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    const { client, sent } = mockClient()
+    await projectWorkspaceDeskTurnProgress({
+      wsDir,
+      issueId: created.ok ? created.issue.id : 'telegram-phone-desk',
+      scopeId: 'run-1',
+      progress: progress([
+        { type: 'text', text: 'Heartbeat check.' },
+        { type: 'error', message: 'later' },
+      ]),
+      client,
+    })
+    expect(sent.map((item) => item.text)).toEqual(['Heartbeat check.'])
+  })
+})
+
+describe('final comment dedup', () => {
+  it('skips a final comment whose markdown was already shipped as progress', async () => {
+    const { client, sent } = mockClient()
+    const issue = { telegramConnector: true as const }
+    await projectDeskTurnProgress({
+      issue: { ...issue, status: 'todo' },
+      scopeId: 'telegram-1',
+      progress: progress([
+        { type: 'text', text: 'Looking at the book.' },
+        { type: 'tool', id: 't1', name: 'Read', status: 'completed' },
+        { type: 'text', text: 'Looking at the book.' },
+      ]),
+      client,
+    })
+    const comment = {
+      id: 'comment-reply-run-1',
+      author: '@resume-a',
+      at: 'now',
+      markdown: 'Looking at the book.',
+      replyTo: 'telegram-1',
+    }
+    expect(shouldProjectDeskComment(issue, comment)).toBe(false)
+    await projectDeskComment(issue, comment, client)
+    expect(sent).toHaveLength(1)
+    expect(alreadyProjectedDeskText('telegram-1', 'Looking at the book.')).toBe(false)
+  })
+
+  it('still ships a different final reply', async () => {
+    const { client, sent } = mockClient()
+    const issue = { telegramConnector: true as const }
+    await projectDeskTurnProgress({
+      issue: { ...issue, status: 'todo' },
+      scopeId: 'run-1',
+      progress: progress([
+        { type: 'text', text: 'Looking at the book.' },
+        { type: 'tool', id: 't1', name: 'Read', status: 'completed' },
+        { type: 'text', text: 'Here is the answer.' },
+      ]),
+      client,
+    })
+    await projectDeskComment(issue, {
+      id: 'comment-fire-run-1',
+      author: '@resume-a',
+      at: 'now',
+      markdown: 'Here is the answer.',
+    }, client, { progressScopeId: 'run-1' })
+    expect(sent.map((item) => item.text)).toEqual([
+      'Looking at the book.',
+      'Here is the answer.',
+    ])
+  })
+})

--- a/src/workspaces/issues/telegram-desk-project.ts
+++ b/src/workspaces/issues/telegram-desk-project.ts
@@ -1,33 +1,182 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
 import { ConnectorClient, OWNER_CHAT_TEXT_MAX } from '@traderalice/connector-protocol'
 
 import { resolveConnectorUrl } from '../../services/connector-client/index.js'
+import type { HeadlessTaskTrigger, HeadlessTaskInquiry } from '../headless-task-registry.js'
+import type { HeadlessTurnProgress } from '../headless-progress.js'
 import type { IssueComment } from './comments.js'
-import { isTelegramConnectorIssue } from './declaration.js'
+import {
+  ISSUES_DIR_REL,
+  isTelegramConnectorIssue,
+  parseIssueContent,
+  type IssueRecord,
+} from './declaration.js'
 
 export const TELEGRAM_NO_REPLY_TAG = '[[no-reply]]'
+
+const MAX_PROGRESS_SCOPES = 64
+const sentByScope = new Map<string, Set<string>>()
 
 export function containsTelegramNoReply(text: string): boolean {
   return text.includes(TELEGRAM_NO_REPLY_TAG)
 }
 
+export function normalizeDeskText(text: string): string {
+  return text.trim().slice(0, OWNER_CHAT_TEXT_MAX)
+}
+
+/**
+ * Texts that are safe to ship before the turn finishes.
+ *
+ * A text block is sealed only when a tool or error follows it. Consecutive
+ * text blocks are treated as one growing narration: only the last one before
+ * the non-text block is sent, so streamed chunks do not each become a DM.
+ * The trailing text stays with today's final comment / `assistantText`.
+ */
+export function sealedProgressTexts(progress: HeadlessTurnProgress): string[] {
+  const sealed: string[] = []
+  const { blocks } = progress
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]
+    if (block?.type !== 'text') continue
+    const next = blocks[i + 1]
+    if (!next || next.type === 'text') continue
+    const text = normalizeDeskText(block.text)
+    if (!text || containsTelegramNoReply(text)) continue
+    sealed.push(text)
+  }
+  return sealed
+}
+
+export function deskProgressMessageId(scopeId: string, text: string): string {
+  const digest = createHash('sha256').update(text).digest('base64url').slice(0, 12)
+  return `desk-progress-${scopeId}-${digest}`
+}
+
+export function deskProgressScope(task: {
+  readonly taskId: string
+  readonly inquiry?: Pick<HeadlessTaskInquiry, 'subject'>
+  readonly trigger?: HeadlessTaskTrigger
+}): { workspaceId: string; issueId: string; scopeId: string } | null {
+  const subject = task.inquiry?.subject
+  if (subject?.kind === 'issue') {
+    return {
+      workspaceId: subject.workspaceId,
+      issueId: subject.issueId,
+      scopeId: subject.commentId ?? task.taskId,
+    }
+  }
+  const trigger = task.trigger
+  if (trigger?.kind === 'issue') {
+    return {
+      workspaceId: trigger.workspaceId,
+      issueId: trigger.issueId,
+      scopeId: task.taskId,
+    }
+  }
+  return null
+}
+
+export function alreadyProjectedDeskText(scopeId: string, text: string): boolean {
+  return sentByScope.get(scopeId)?.has(normalizeDeskText(text)) === true
+}
+
+export function forgetProjectedDeskTexts(scopeId: string): void {
+  sentByScope.delete(scopeId)
+}
+
+/** Test-only: drop in-memory desk-progress dedup. */
+export function resetProjectedDeskTexts(): void {
+  sentByScope.clear()
+}
+
+function markProjectedDeskText(scopeId: string, text: string): void {
+  let seen = sentByScope.get(scopeId)
+  if (!seen) {
+    if (sentByScope.size >= MAX_PROGRESS_SCOPES) {
+      const oldest = sentByScope.keys().next().value
+      if (oldest !== undefined) sentByScope.delete(oldest)
+    }
+    seen = new Set()
+    sentByScope.set(scopeId, seen)
+  }
+  seen.add(text)
+}
+
 export function shouldProjectDeskComment(
   issue: { telegramConnector?: true },
   comment: IssueComment,
+  opts?: { progressScopeId?: string },
 ): boolean {
-  return isTelegramConnectorIssue(issue)
-    && comment.via !== 'telegram'
-    && !containsTelegramNoReply(comment.markdown)
+  if (!isTelegramConnectorIssue(issue) || comment.via === 'telegram') return false
+  if (containsTelegramNoReply(comment.markdown)) return false
+  const scope = opts?.progressScopeId ?? comment.replyTo
+  if (scope && alreadyProjectedDeskText(scope, comment.markdown)) return false
+  return true
 }
 
 export async function projectDeskComment(
   issue: { telegramConnector?: true },
   comment: IssueComment,
   client: ConnectorClient = new ConnectorClient(resolveConnectorUrl()),
+  opts?: { progressScopeId?: string },
 ): Promise<void> {
-  if (!shouldProjectDeskComment(issue, comment)) return
-  await client.sendOwnerMessage({
-    id: `desk-${comment.id}`,
-    adapterId: 'telegram',
-    text: comment.markdown.slice(0, OWNER_CHAT_TEXT_MAX),
-  }, AbortSignal.timeout(5_000))
+  const scope = opts?.progressScopeId ?? comment.replyTo
+  try {
+    if (!shouldProjectDeskComment(issue, comment, { progressScopeId: scope })) return
+    await client.sendOwnerMessage({
+      id: `desk-${comment.id}`,
+      adapterId: 'telegram',
+      text: normalizeDeskText(comment.markdown),
+    }, AbortSignal.timeout(5_000))
+  } finally {
+    if (scope) forgetProjectedDeskTexts(scope)
+  }
+}
+
+export async function projectDeskTurnProgress(input: {
+  issue: Pick<IssueRecord, 'telegramConnector' | 'status'>
+  scopeId: string
+  progress: HeadlessTurnProgress
+  client?: ConnectorClient
+}): Promise<string[]> {
+  if (!isTelegramConnectorIssue(input.issue) || input.issue.status === 'canceled') return []
+  const client = input.client ?? new ConnectorClient(resolveConnectorUrl())
+  const sent: string[] = []
+  for (const text of sealedProgressTexts(input.progress)) {
+    if (alreadyProjectedDeskText(input.scopeId, text)) continue
+    await client.sendOwnerMessage({
+      id: deskProgressMessageId(input.scopeId, text),
+      adapterId: 'telegram',
+      text,
+    }, AbortSignal.timeout(5_000))
+    markProjectedDeskText(input.scopeId, text)
+    sent.push(text)
+  }
+  return sent
+}
+
+export async function projectWorkspaceDeskTurnProgress(input: {
+  wsDir: string
+  issueId: string
+  scopeId: string
+  progress: HeadlessTurnProgress
+  client?: ConnectorClient
+}): Promise<string[]> {
+  const issue = await readDeskIssue(input.wsDir, input.issueId)
+  if (!issue) return []
+  return projectDeskTurnProgress({ ...input, issue })
+}
+
+async function readDeskIssue(wsDir: string, issueId: string): Promise<IssueRecord | null> {
+  try {
+    const raw = await readFile(join(wsDir, ISSUES_DIR_REL, `${issueId}.md`), 'utf8')
+    const parsed = parseIssueContent(issueId, raw)
+    return parsed.ok ? parsed.issue : null
+  } catch {
+    return null
+  }
 }

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -109,6 +109,10 @@ import {
 } from './headless-progress.js';
 import { stampTelegramDeskScheduledFire } from './issues/telegram-desk-chat.js';
 import {
+  deskProgressScope,
+  projectWorkspaceDeskTurnProgress,
+} from './issues/telegram-desk-project.js';
+import {
   IssueChangeTracker,
   issueMutation,
   issueMutationFingerprint,
@@ -1803,24 +1807,42 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       publish: async (progress) => {
         await headlessTasks.setProgress(rec.taskId, progress);
         const subject = rec.inquiry?.subject;
-        if (subject?.kind !== 'issue' || !subject.commentId) return;
-        const issueWorkspace = registry.get(subject.workspaceId);
-        if (!issueWorkspace) return;
-        const updated = await updateIssueCommentProgress(
-          issueWorkspace.dir,
-          subject.issueId,
-          subject.commentId,
-          progress,
-        );
-        if (!updated.ok) {
-          launcherLogger.warn('issue.comment_progress_failed', {
-            taskId: rec.taskId,
-            wsId: subject.workspaceId,
-            issueId: subject.issueId,
-            commentId: subject.commentId,
-            error: updated.error,
-          });
+        if (subject?.kind === 'issue' && subject.commentId) {
+          const issueWorkspace = registry.get(subject.workspaceId);
+          if (issueWorkspace) {
+            const updated = await updateIssueCommentProgress(
+              issueWorkspace.dir,
+              subject.issueId,
+              subject.commentId,
+              progress,
+            );
+            if (!updated.ok) {
+              launcherLogger.warn('issue.comment_progress_failed', {
+                taskId: rec.taskId,
+                wsId: subject.workspaceId,
+                issueId: subject.issueId,
+                commentId: subject.commentId,
+                error: updated.error,
+              });
+            }
+          }
         }
+        const desk = deskProgressScope(rec);
+        if (!desk) return;
+        const deskWorkspace = registry.get(desk.workspaceId);
+        if (!deskWorkspace) return;
+        await projectWorkspaceDeskTurnProgress({
+          wsDir: deskWorkspace.dir,
+          issueId: desk.issueId,
+          scopeId: desk.scopeId,
+          progress,
+        }).catch((err) => launcherLogger.warn('telegram.desk_progress_failed', {
+          taskId: rec.taskId,
+          wsId: desk.workspaceId,
+          issueId: desk.issueId,
+          scopeId: desk.scopeId,
+          err,
+        }));
       },
     });
     // Fire-and-forget: run to natural exit, then fill the record. Process

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -53,6 +53,7 @@ import {
 import { logger as launcherLogger } from './logger.js';
 import { runHeadlessProbe, type HeadlessProbeResult } from './probe.js';
 import { headlessTaskStatus, runHeadlessTask, type HeadlessTaskResult } from './headless-task.js';
+import type { HeadlessStructuredOutput } from './headless-output.js';
 import {
   checkingRuntimeReadinessRow,
   failedRuntimeReadinessRow,
@@ -100,8 +101,12 @@ import {
   type WorkspaceSessionDirectory,
 } from './session-directory.js';
 import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
-import { readIssueComments } from './issues/comments.js';
+import { readIssueComments, updateIssueCommentProgress } from './issues/comments.js';
 import { recordIssueCommentReply } from './issues/comment-delivery.js';
+import {
+  createProgressPublisher,
+  projectTurnProgress,
+} from './headless-progress.js';
 import { stampTelegramDeskScheduledFire } from './issues/telegram-desk-chat.js';
 import {
   IssueChangeTracker,
@@ -1493,6 +1498,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       sessionRuntime?: ResolvedSessionRuntimeBinding;
       /** Record this supplied binding only after a fresh child actually spawns. */
       rememberRuntime?: boolean;
+      onProgress?: (snapshot: HeadlessStructuredOutput) => void;
     } = {},
   ): Promise<HeadlessTaskResult> => {
     const operationLease = workspaceOperationGuard.acquire(ws.id, 'headless-run');
@@ -1601,6 +1607,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
             ? { keepDiagnosticLine: adapter.keepHeadlessDiagnosticLine.bind(adapter) }
             : {}),
           ...(opts.onSessionId ? { onSessionId: opts.onSessionId } : {}),
+          ...(opts.onProgress ? { onProgress: opts.onProgress } : {}),
           onChildSpawned: (child) => {
             activityLease.attach(child);
             if (rememberRuntime && existsSync(ws.dir)) {
@@ -1792,6 +1799,30 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       throw err;
     }
     if (!resumeId) activeResumeIds.add(rec.resumeId);
+    const progressPublisher = createProgressPublisher({
+      publish: async (progress) => {
+        await headlessTasks.setProgress(rec.taskId, progress);
+        const subject = rec.inquiry?.subject;
+        if (subject?.kind !== 'issue' || !subject.commentId) return;
+        const issueWorkspace = registry.get(subject.workspaceId);
+        if (!issueWorkspace) return;
+        const updated = await updateIssueCommentProgress(
+          issueWorkspace.dir,
+          subject.issueId,
+          subject.commentId,
+          progress,
+        );
+        if (!updated.ok) {
+          launcherLogger.warn('issue.comment_progress_failed', {
+            taskId: rec.taskId,
+            wsId: subject.workspaceId,
+            issueId: subject.issueId,
+            commentId: subject.commentId,
+            error: updated.error,
+          });
+        }
+      },
+    });
     // Fire-and-forget: run to natural exit, then fill the record. Process
     // failures and terminal in-band runtime errors fail the task; retryable
     // errors followed by a later assistant reply remain visible in Activity
@@ -1802,6 +1833,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       ...(nativeResume ? { resume: nativeResume } : {}),
       sessionRuntime,
       ...(!resumeId ? { rememberRuntime: true } : {}),
+      onProgress: (snapshot) => progressPublisher.offer(projectTurnProgress(snapshot)),
       onSessionId: (id) => {
         void Promise.all([
           headlessTasks.setAgentSessionId(rec.taskId, id),
@@ -1814,6 +1846,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       },
     })
       .then(async (r) => {
+        progressPublisher.offer(projectTurnProgress(r.structured));
+        await progressPublisher.flush();
         const status = headlessTaskStatus(r);
         await headlessTasks.complete(rec.taskId, {
           status,
@@ -1900,6 +1934,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         );
       })
       .catch(async (err) => {
+        await progressPublisher.flush();
         const message = err instanceof Error ? err.message : String(err);
         await headlessTasks.complete(rec.taskId, {
           status: 'failed',

--- a/ui/src/api/headless.ts
+++ b/ui/src/api/headless.ts
@@ -66,6 +66,22 @@ export interface HeadlessTaskRecord {
     toolCalls: number
     toolFailures: number
   }
+  /** Compact live timeline for comment/inquiry consumers. */
+  progress?: HeadlessTurnProgress
+}
+
+export type HeadlessProgressToolStatus = 'running' | 'completed' | 'failed'
+
+export type HeadlessProgressBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool'; id: string; name: string; status: HeadlessProgressToolStatus }
+  | { type: 'error'; message: string }
+
+export interface HeadlessTurnProgress {
+  updatedAt: number
+  assistantText: string | null
+  blocks: HeadlessProgressBlock[]
+  metrics: { textBlocks: number; toolCalls: number; toolFailures: number }
 }
 
 export type HeadlessToolStatus = 'running' | 'completed' | 'failed'

--- a/ui/src/api/inquiries.ts
+++ b/ui/src/api/inquiries.ts
@@ -1,5 +1,5 @@
 import { fetchJson, headers } from './client'
-import type { HeadlessTaskStatus } from './headless'
+import type { HeadlessTaskStatus, HeadlessTurnProgress } from './headless'
 
 export type InquirySubject =
   | { kind: 'inbox'; entryId: string }
@@ -22,6 +22,7 @@ export interface InquiryRecord {
   durationMs?: number
   error?: string
   assistantText: string | null
+  progress?: HeadlessTurnProgress
   inquiry: {
     subject: InquirySubject
     question: string

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -1,6 +1,6 @@
 import { fetchJson, headers } from './client'
 import type { Entity } from './entities'
-import type { HeadlessTaskRecord } from './headless'
+import type { HeadlessTaskRecord, HeadlessTurnProgress } from './headless'
 import type { InboxEntry } from './inbox'
 import type { ScheduleWhen } from './schedule'
 import type { ModelReasoningEffort } from './types'
@@ -82,7 +82,7 @@ export type IssueActivityRecord =
   | { kind: 'comment'; id: string; at: number; comment: IssueComment }
 
 export type IssueCommentDelivery =
-  | { state: 'pending'; targetResumeId: string; taskId: string }
+  | { state: 'pending'; targetResumeId: string; taskId: string; progress?: HeadlessTurnProgress }
   | { state: 'replied'; targetResumeId: string; taskId: string; replyCommentId: string }
   | { state: 'failed'; targetResumeId?: string; taskId?: string; error: string }
 


### PR DESCRIPTION
## Summary
- Project vendor-neutral headless `text` / tool / error events into a compact live turn-progress contract for Issue replies and Inbox inquiries; tool input/output never enter the projection.
- Send only sealed mid-turn narration from Telegram phone-desk runs, deduplicating text that later becomes the final Issue comment.
- Bound persisted snapshots to 32 KiB UTF-8, remove live progress at terminal state, serialize async publishers, and serialize same-Issue comment sidecar mutations.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `cd ui && npx tsc -b`
- [x] `pnpm test` — 4320 passed, 9 skipped
- [x] Focused progress, comment concurrency, registry lifecycle, inquiry API, and Telegram projection specs

## Remaining increment
- Issue and Inbox visual rendering of the shared progress field stays in the active execution plan; this PR establishes the transport and first Telegram consumer.