### PR TITLE
feat(ui): hide trading chrome on NanoAlice

### DIFF
--- a/docs/alice-project.md
+++ b/docs/alice-project.md
@@ -60,7 +60,11 @@ first-writer-wins and registration must agree with that recorded product.
 TraderAlice is the trading product (Lite/Pro remain intensity inside it).
 NanoAlice is an experimental general-purpose product: Guardian never starts
 UTA for that complete home. Product is not a Settings switch; create another
-AliceProject to use a different product.
+AliceProject to use a different product. The Nano chrome hides Market, News,
+Trading as Git, and Portfolio, plus the matching Settings categories
+(Trading, Market Data, News Sources). Bookmarks to those routes return to
+Ask Alice or Settings. AutoQuant and Tracked stay visible until that
+boundary is reviewed separately.
 
 Create a named project from the CLI:
 

--- a/ui/src/components/ActivityBar.spec.ts
+++ b/ui/src/components/ActivityBar.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { NAV_SECTIONS } from './activity-navigation'
+import { NAV_SECTIONS, navSectionsForProduct } from './activity-navigation'
 
 describe('ActivityBar navigation hierarchy', () => {
   it('keeps the primary workflow ordered with Quant below Issues', () => {
@@ -17,5 +17,25 @@ describe('ActivityBar navigation hierarchy', () => {
       'news',
     ])
     expect(system?.items.map((item) => item.page)).toContain('workspaces')
+  })
+
+  it('hides trading and market-data pages on NanoAlice', () => {
+    const pages = navSectionsForProduct('nano').flatMap((section) => section.items.map((item) => item.page))
+    expect(pages).toEqual([
+      'chat',
+      'inbox',
+      'issue',
+      'auto-quant',
+      'tracked',
+      'connectors',
+      'workspaces',
+      'automation',
+      'settings',
+      'dev',
+    ])
+    expect(pages).not.toContain('market')
+    expect(pages).not.toContain('news')
+    expect(pages).not.toContain('trading-as-git')
+    expect(pages).not.toContain('portfolio')
   })
 })

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -8,7 +8,8 @@ import { usePendingPushCount } from '../live/trading-push'
 import { useActivityBarCollapse } from '../live/activity-bar-collapse'
 import { useTranslation } from 'react-i18next'
 import { ThemeToggle } from './ThemeToggle'
-import { NAV_SECTIONS } from './activity-navigation'
+import { useAliceProject } from '../hooks/useAliceProject'
+import { navSectionsForProduct } from './activity-navigation'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 
 /**
@@ -86,6 +87,8 @@ export function ActivityBar({
   returnFocusRef,
 }: ActivityBarProps) {
   const { t } = useTranslation()
+  const { project } = useAliceProject()
+  const navSections = navSectionsForProduct(project?.product)
   const selectedSidebar = useWorkspace((state) => state.selectedSidebar)
   const setSidebar = useWorkspace((state) => state.setSidebar)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
@@ -121,7 +124,7 @@ export function ActivityBar({
 
         {/* Navigation */}
         <nav className={`flex-1 flex flex-col overflow-x-hidden overflow-y-auto ${denseRail ? 'pb-3 md:pb-0.5' : 'pb-3'} ${compactRail ? 'px-2 md:items-center' : narrowRail ? 'px-2.5' : 'px-3'}`}>
-          {NAV_SECTIONS.map((section, si) => {
+          {navSections.map((section, si) => {
             const labeled = section.sectionLabel.length > 0
             // User toggle wins over default. The collapse store stores
             // user's explicit preference (true/false); absence means

--- a/ui/src/components/SettingsCategoryList.spec.tsx
+++ b/ui/src/components/SettingsCategoryList.spec.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SettingsCategoryList } from './SettingsCategoryList'
+
+const mocks = vi.hoisted(() => ({
+  product: 'trader' as 'trader' | 'nano' | undefined,
+}))
+
+vi.mock('../hooks/useAliceProject', () => ({
+  useAliceProject: () => ({
+    project: mocks.product ? { product: mocks.product } : null,
+    loading: false,
+    error: null,
+    refresh: async () => undefined,
+  }),
+}))
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: Record<string, unknown>) => unknown) => selector({
+    openOrFocus: vi.fn(),
+  }),
+}))
+
+vi.mock('../tabs/types', () => ({
+  getFocusedTab: () => null,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('./SidebarRow', () => ({
+  SidebarRow: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}))
+
+afterEach(() => {
+  cleanup()
+  mocks.product = 'trader'
+})
+
+describe('SettingsCategoryList', () => {
+  it('hides trading and market-data categories on NanoAlice', () => {
+    mocks.product = 'nano'
+    render(<SettingsCategoryList />)
+    expect(screen.queryByText('settings.category.trading')).toBeNull()
+    expect(screen.queryByText('settings.category.marketData')).toBeNull()
+    expect(screen.queryByText('settings.category.newsSources')).toBeNull()
+    expect(screen.getByText('settings.category.aiProvider')).toBeTruthy()
+  })
+})

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -11,6 +11,8 @@ import {
   SlidersHorizontal,
   Wrench,
 } from 'lucide-react'
+import { useAliceProject } from '../hooks/useAliceProject'
+import { isNanoHiddenSettingsCategory, isNanoProduct } from '../lib/product-surfaces'
 import { useWorkspace } from '../tabs/store'
 import { getFocusedTab } from '../tabs/types'
 import { SidebarRow } from './SidebarRow'
@@ -36,12 +38,16 @@ const CATEGORIES = [
  */
 export function SettingsCategoryList({ onSelect }: { onSelect?: () => void }) {
   const { t } = useTranslation()
+  const { project } = useAliceProject()
   const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
+  const categories = isNanoProduct(project?.product)
+    ? CATEGORIES.filter((item) => !isNanoHiddenSettingsCategory(item.category))
+    : CATEGORIES
 
   return (
     <div className="py-1">
-      {CATEGORIES.map((item) => {
+      {categories.map((item) => {
         const active =
           focused?.kind === 'settings' && focused.params.category === item.category
         return (

--- a/ui/src/components/activity-navigation.ts
+++ b/ui/src/components/activity-navigation.ts
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react'
 
 import type { Page } from '../App'
+import { isNanoHiddenActivityPage, isNanoProduct } from '../lib/product-surfaces'
 import type { ViewSpec } from '../tabs/types'
 
 type NavItemKey =
@@ -79,3 +80,13 @@ export const NAV_SECTIONS: NavSection[] = [
     ],
   },
 ]
+
+export function navSectionsForProduct(product?: string | null): NavSection[] {
+  if (!isNanoProduct(product)) return NAV_SECTIONS
+  return NAV_SECTIONS
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => !isNanoHiddenActivityPage(item.page)),
+    }))
+    .filter((section) => section.items.length > 0)
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1102,6 +1102,12 @@ export const en = {
     quantDeskLabel: 'Quant desk',
     quantDeskTitle: 'Delegate a reproducible study',
     quantDeskPrompt: 'Ask the AutoQuant desk to test whether short-term sector rotation predicts one-week relative returns after costs. Require reproducible evidence, immutable run or report references, limitations, and no trading authority.',
+    codeReviewLabel: 'Code review',
+    codeReviewTitle: 'Review the current Workspace',
+    codeReviewPrompt: 'Read this Workspace and review the current code or notes. List the highest-risk issues, what is unfinished, and the next three concrete edits. Stay inside this folder; do not start market or trading work.',
+    inboxTriageLabel: 'Inbox',
+    inboxTriageTitle: 'Triage what landed today',
+    inboxTriagePrompt: 'Read Inbox and Issues in this Workspace. Summarize what needs a reply, what can wait, and the first action I should take. Do not invent market or trading tasks.',
   },
   autoQuantLanding: {
     heading: 'What should the quant desk investigate?',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1091,6 +1091,12 @@ export const ja: Resources = {
     quantDeskLabel: 'クオンツデスク',
     quantDeskTitle: '再現可能な研究を委任する',
     quantDeskPrompt: '短期のセクターローテーションがコスト控除後の1週間相対リターンを予測するか、AutoQuant デスクに検証を依頼してください。再現可能な証拠、不変の Run または Report 参照、限界を求め、取引権限は与えないでください。',
+    codeReviewLabel: 'コードレビュー',
+    codeReviewTitle: 'この Workspace を確認する',
+    codeReviewPrompt: 'この Workspace のコードやメモを読み、最もリスクの高い問題、未完了の作業、次に直すべき3点を挙げてください。このフォルダの外に出ず、市場や取引の作業は始めないでください。',
+    inboxTriageLabel: 'Inbox',
+    inboxTriageTitle: '今日届いたものを仕分ける',
+    inboxTriagePrompt: 'この Workspace の Inbox と Issue を読み、返信が必要なもの、後回しにできるもの、最初に取るべき行動をまとめてください。市場や取引のタスクは作らないでください。',
   },
   autoQuantLanding: {
     heading: 'クオンツデスクで何を調査しますか？',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1098,6 +1098,12 @@ export const zhHant: Resources = {
     quantDeskLabel: '量化組',
     quantDeskTitle: '委派一項可重現研究',
     quantDeskPrompt: '讓 AutoQuant 研究短期板塊輪動在計入成本後能否預測未來一週的相對報酬。要求回傳可重現證據、不可變的 Run 或 Report 參照、研究限制，並且不授予交易權限。',
+    codeReviewLabel: '程式碼審閱',
+    codeReviewTitle: '審閱目前 Workspace',
+    codeReviewPrompt: '閱讀此 Workspace 裡的程式碼或筆記，列出風險最高的問題、尚未完成的部分，以及接下來三處具體修改。只停留在這個目錄，不要開始市場或交易工作。',
+    inboxTriageLabel: '收件匣',
+    inboxTriageTitle: '整理今天進來的事項',
+    inboxTriagePrompt: '閱讀此 Workspace 的 Inbox 與 Issue，總結哪些需要回覆、哪些可以稍後處理，以及我該先做的第一件事。不要編造市場或交易任務。',
   },
   autoQuantLanding: {
     heading: '量化組接下來研究什麼？',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1090,6 +1090,12 @@ export const zh: Resources = {
     quantDeskLabel: '量化组',
     quantDeskTitle: '委派一项可复现研究',
     quantDeskPrompt: '让 AutoQuant 研究短期板块轮动在计入成本后能否预测未来一周的相对收益。要求返回可复现证据、不可变的 Run 或 Report 引用、研究局限，并且不授予交易权限。',
+    codeReviewLabel: '代码审阅',
+    codeReviewTitle: '审阅当前 Workspace',
+    codeReviewPrompt: '阅读此 Workspace 里的代码或笔记，列出风险最高的问题、尚未完成的部分，以及接下来三处具体修改。只停留在这个目录，不要开始市场或交易工作。',
+    inboxTriageLabel: '收件箱',
+    inboxTriageTitle: '整理今天进来的事项',
+    inboxTriagePrompt: '阅读此 Workspace 的 Inbox 和 Issue，总结哪些需要回复、哪些可以稍后处理，以及我该先做的第一件事。不要编造市场或交易任务。',
   },
   autoQuantLanding: {
     heading: '量化组接下来研究什么？',

--- a/ui/src/lib/chat-landing-examples.spec.ts
+++ b/ui/src/lib/chat-landing-examples.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { chatLandingExampleGroups } from './chat-landing-examples'
+
+describe('chatLandingExampleGroups', () => {
+  const t = (key: string) => key
+
+  it('keeps market and portfolio ideas on TraderAlice', () => {
+    const ids = chatLandingExampleGroups(t, 'trader').flat().map((example) => example.id)
+    expect(ids).toContain('market')
+    expect(ids).toContain('portfolio')
+    expect(ids).toContain('quant')
+  })
+
+  it('replaces trading ideas on NanoAlice', () => {
+    const groups = chatLandingExampleGroups(t, 'nano')
+    const ids = groups.flat().map((example) => example.id)
+    expect(groups).toHaveLength(1)
+    expect(ids).toEqual(['workspace', 'code-review', 'inbox'])
+    expect(ids).not.toContain('market')
+    expect(ids).not.toContain('portfolio')
+    expect(ids).not.toContain('quant')
+  })
+})

--- a/ui/src/lib/chat-landing-examples.ts
+++ b/ui/src/lib/chat-landing-examples.ts
@@ -1,0 +1,77 @@
+export interface ChatLandingExample {
+  id: string
+  label: string | null
+  title: string
+  prompt: string
+}
+
+export function chatLandingExampleGroups(
+  t: (key: string) => string,
+  product?: string | null,
+): ChatLandingExample[][] {
+  if (product === 'nano') {
+    return [[
+      {
+        id: 'workspace',
+        label: t('chatLanding.workspaceAuditLabel'),
+        title: t('chatLanding.workspaceAuditTitle'),
+        prompt: t('chatLanding.workspaceAuditPrompt'),
+      },
+      {
+        id: 'code-review',
+        label: t('chatLanding.codeReviewLabel'),
+        title: t('chatLanding.codeReviewTitle'),
+        prompt: t('chatLanding.codeReviewPrompt'),
+      },
+      {
+        id: 'inbox',
+        label: t('chatLanding.inboxTriageLabel'),
+        title: t('chatLanding.inboxTriageTitle'),
+        prompt: t('chatLanding.inboxTriagePrompt'),
+      },
+    ]]
+  }
+
+  return [
+    [
+      {
+        id: 'market',
+        label: t('chatLanding.marketBriefLabel'),
+        title: t('chatLanding.marketBriefTitle'),
+        prompt: t('chatLanding.marketBriefPrompt'),
+      },
+      {
+        id: 'portfolio',
+        label: t('chatLanding.portfolioReviewLabel'),
+        title: t('chatLanding.portfolioReviewTitle'),
+        prompt: t('chatLanding.portfolioReviewPrompt'),
+      },
+      {
+        id: 'thesis',
+        label: t('chatLanding.researchMemoLabel'),
+        title: t('chatLanding.researchMemoTitle'),
+        prompt: t('chatLanding.researchMemoPrompt'),
+      },
+    ],
+    [
+      {
+        id: 'workspace',
+        label: t('chatLanding.workspaceAuditLabel'),
+        title: t('chatLanding.workspaceAuditTitle'),
+        prompt: t('chatLanding.workspaceAuditPrompt'),
+      },
+      {
+        id: 'automation',
+        label: t('chatLanding.automationLabel'),
+        title: t('chatLanding.automationTitle'),
+        prompt: t('chatLanding.automationPrompt'),
+      },
+      {
+        id: 'quant',
+        label: t('chatLanding.quantDeskLabel'),
+        title: t('chatLanding.quantDeskTitle'),
+        prompt: t('chatLanding.quantDeskPrompt'),
+      },
+    ],
+  ]
+}

--- a/ui/src/lib/product-surfaces.spec.ts
+++ b/ui/src/lib/product-surfaces.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isNanoHiddenActivityPage,
+  isNanoHiddenSettingsCategory,
+  isNanoHiddenViewSpec,
+  isNanoProduct,
+} from './product-surfaces'
+
+describe('Nano product surfaces', () => {
+  it('treats only an explicit nano stamp as NanoAlice', () => {
+    expect(isNanoProduct('nano')).toBe(true)
+    expect(isNanoProduct('trader')).toBe(false)
+    expect(isNanoProduct(undefined)).toBe(false)
+  })
+
+  it('hides trading and market-data activity pages', () => {
+    expect(isNanoHiddenActivityPage('trading-as-git')).toBe(true)
+    expect(isNanoHiddenActivityPage('portfolio')).toBe(true)
+    expect(isNanoHiddenActivityPage('market')).toBe(true)
+    expect(isNanoHiddenActivityPage('news')).toBe(true)
+    expect(isNanoHiddenActivityPage('chat')).toBe(false)
+    expect(isNanoHiddenActivityPage('auto-quant')).toBe(false)
+    expect(isNanoHiddenActivityPage('tracked')).toBe(false)
+  })
+
+  it('hides the matching Settings categories and view specs', () => {
+    expect(isNanoHiddenSettingsCategory('trading')).toBe(true)
+    expect(isNanoHiddenSettingsCategory('market-data')).toBe(true)
+    expect(isNanoHiddenSettingsCategory('news-collector')).toBe(true)
+    expect(isNanoHiddenSettingsCategory('ai-provider')).toBe(false)
+    expect(isNanoHiddenViewSpec({ kind: 'portfolio', params: {} })).toBe(true)
+    expect(isNanoHiddenViewSpec({ kind: 'settings', params: { category: 'trading' } })).toBe(true)
+    expect(isNanoHiddenViewSpec({ kind: 'settings', params: { category: 'general' } })).toBe(false)
+    expect(isNanoHiddenViewSpec({ kind: 'chat-landing', params: {} })).toBe(false)
+  })
+})

--- a/ui/src/lib/product-surfaces.ts
+++ b/ui/src/lib/product-surfaces.ts
@@ -1,0 +1,49 @@
+import type { Page } from '../App'
+import type { ViewSpec } from '../tabs/types'
+
+export const NANO_HIDDEN_ACTIVITY_PAGES = [
+  'market',
+  'news',
+  'trading-as-git',
+  'portfolio',
+] as const satisfies readonly Page[]
+
+export const NANO_HIDDEN_SETTINGS_CATEGORIES = [
+  'trading',
+  'market-data',
+  'news-collector',
+] as const
+
+export type NanoHiddenSettingsCategory = (typeof NANO_HIDDEN_SETTINGS_CATEGORIES)[number]
+
+export function isNanoProduct(product?: string | null): boolean {
+  return product === 'nano'
+}
+
+export function isNanoHiddenActivityPage(page: Page): boolean {
+  return (NANO_HIDDEN_ACTIVITY_PAGES as readonly Page[]).includes(page)
+}
+
+export function isNanoHiddenSettingsCategory(
+  category: string,
+): category is NanoHiddenSettingsCategory {
+  return (NANO_HIDDEN_SETTINGS_CATEGORIES as readonly string[]).includes(category)
+}
+
+export function isNanoHiddenViewSpec(spec: ViewSpec): boolean {
+  switch (spec.kind) {
+    case 'market-list':
+    case 'market-rotation':
+    case 'market-board':
+    case 'market-detail':
+    case 'news':
+    case 'trading-as-git':
+    case 'portfolio':
+    case 'uta-detail':
+      return true
+    case 'settings':
+      return isNanoHiddenSettingsCategory(spec.params.category)
+    default:
+      return false
+  }
+}

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -25,11 +25,13 @@ import {
 import { RecoverySurface, RefreshNotice } from '../components/StateViews'
 import { workspaceDisplayTitle } from '../components/workspace/display'
 import { useWorkspace } from '../tabs/store'
+import { useAliceProject } from '../hooks/useAliceProject'
 import {
   useAgentLaunchConfig,
   useAgentLaunchPreferences,
   useWorkspaceAgentLaunchPreferences,
 } from '../hooks/useAgentLaunchConfig'
+import { chatLandingExampleGroups } from '../lib/chat-landing-examples'
 import { resolveChatWorkspaceTarget, workspaceActivityMs } from '../lib/chat-workspace-target'
 import { AutoQuantSetupPage } from './AutoQuantSetupPage'
 
@@ -61,6 +63,7 @@ function HarnessLandingPage({
   mode: HarnessLandingMode
 }) {
   const { t } = useTranslation()
+  const { project } = useAliceProject()
   const {
     quickChat,
     agents,
@@ -131,48 +134,7 @@ function HarnessLandingPage({
   const selectedInfo = launchConfig.selectedAgent
   const installHint = selectedInfo ? installHintFor(selectedInfo.id) : undefined
   const exampleGroups = mode === 'chat'
-    ? [
-        [
-          {
-            id: 'market',
-            label: t('chatLanding.marketBriefLabel'),
-            title: t('chatLanding.marketBriefTitle'),
-            prompt: t('chatLanding.marketBriefPrompt'),
-          },
-          {
-            id: 'portfolio',
-            label: t('chatLanding.portfolioReviewLabel'),
-            title: t('chatLanding.portfolioReviewTitle'),
-            prompt: t('chatLanding.portfolioReviewPrompt'),
-          },
-          {
-            id: 'thesis',
-            label: t('chatLanding.researchMemoLabel'),
-            title: t('chatLanding.researchMemoTitle'),
-            prompt: t('chatLanding.researchMemoPrompt'),
-          },
-        ],
-        [
-          {
-            id: 'workspace',
-            label: t('chatLanding.workspaceAuditLabel'),
-            title: t('chatLanding.workspaceAuditTitle'),
-            prompt: t('chatLanding.workspaceAuditPrompt'),
-          },
-          {
-            id: 'automation',
-            label: t('chatLanding.automationLabel'),
-            title: t('chatLanding.automationTitle'),
-            prompt: t('chatLanding.automationPrompt'),
-          },
-          {
-            id: 'quant',
-            label: t('chatLanding.quantDeskLabel'),
-            title: t('chatLanding.quantDeskTitle'),
-            prompt: t('chatLanding.quantDeskPrompt'),
-          },
-        ],
-      ]
+    ? chatLandingExampleGroups((key) => t(key as never), project?.product)
     : [[
         { id: 'quant-1', label: null, title: t('autoQuantLanding.ex1'), prompt: t('autoQuantLanding.ex1') },
         { id: 'quant-2', label: null, title: t('autoQuantLanding.ex2'), prompt: t('autoQuantLanding.ex2') },
@@ -528,7 +490,7 @@ function HarnessLandingPage({
               {t(`${copyKey}.examplesLabel`)}
             </span>
             <span aria-hidden className="h-px min-w-4 flex-1 bg-border/45" />
-            {mode === 'chat' && (
+            {mode === 'chat' && exampleGroups.length > 1 && (
               <button
                 type="button"
                 onClick={() => setExamplePage((page) => (page + 1) % exampleGroups.length)}

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -1,5 +1,7 @@
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { Navigate, Route, Routes, useParams, useSearchParams } from 'react-router-dom'
+import { useAliceProject } from '../hooks/useAliceProject'
+import { isNanoProduct } from '../lib/product-surfaces'
 import { useWorkspace } from './store'
 import { isDevTab, specEquals, type ActivitySection, type ViewSpec } from './types'
 import { getView } from './registry'
@@ -48,20 +50,20 @@ export function UrlAdopter() {
         <Route path="/auto-quant/workspaces/:wsId/view/:path" element={<AdoptAutoQuantFileViewer />} />
         <Route path="/auto-quant/workspaces/:wsId" element={<AdoptAutoQuantWorkspace />} />
         <Route path="/auto-quant/workspaces/:wsId/s/:sessionId" element={<AdoptAutoQuantWorkspace />} />
-        <Route path="/portfolio" element={<AdoptStatic spec={{ kind: 'portfolio', params: {} }} />} />
+        <Route path="/portfolio" element={<AdoptTraderStatic spec={{ kind: 'portfolio', params: {} }} />} />
         <Route path="/issues" element={<AdoptStatic spec={{ kind: 'issue', params: {} }} />} />
         <Route path="/issues/:wsId/:id" element={<AdoptIssueDetail />} />
         <Route path="/automation" element={<Navigate to="/automation/runs" replace />} />
         <Route path="/automation/:section" element={<AdoptAutomation />} />
-        <Route path="/news" element={<AdoptStatic spec={{ kind: 'news', params: {} }} />} />
-        <Route path="/market" element={<AdoptStatic spec={{ kind: 'market-list', params: {} }} />} />
-        <Route path="/market/rotation" element={<AdoptStatic spec={{ kind: 'market-rotation', params: {} }} />} />
+        <Route path="/news" element={<AdoptTraderStatic spec={{ kind: 'news', params: {} }} />} />
+        <Route path="/market" element={<AdoptTraderStatic spec={{ kind: 'market-list', params: {} }} />} />
+        <Route path="/market/rotation" element={<AdoptTraderStatic spec={{ kind: 'market-rotation', params: {} }} />} />
         {/* Static `boards` segment outranks /market/:assetClass/:symbol in
             react-router's specificity scoring, so order here doesn't matter —
             but keep it above the dynamic route for readability. */}
-        <Route path="/market/boards/:board" element={<AdoptMarketBoard />} />
-        <Route path="/market/:assetClass/:symbol" element={<AdoptMarketDetail />} />
-        <Route path="/trading-as-git" element={<AdoptStatic spec={{ kind: 'trading-as-git', params: {} }} />} />
+        <Route path="/market/boards/:board" element={<TraderOnly fallback="/chat"><AdoptMarketBoard /></TraderOnly>} />
+        <Route path="/market/:assetClass/:symbol" element={<TraderOnly fallback="/chat"><AdoptMarketDetail /></TraderOnly>} />
+        <Route path="/trading-as-git" element={<AdoptTraderStatic spec={{ kind: 'trading-as-git', params: {} }} />} />
         <Route path="/connectors" element={<AdoptStatic spec={{ kind: 'connectors', params: {} }} />} />
 
         {/* Settings — one entry per category */}
@@ -70,13 +72,13 @@ export function UrlAdopter() {
         <Route path="/settings/ai-provider" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'ai-provider' } }} />} />
         <Route path="/settings/agent-permissions" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'agent-permissions' } }} />} />
         <Route path="/settings/tools" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'tools' } }} />} />
-        <Route path="/settings/trading" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'trading' } }} />} />
+        <Route path="/settings/trading" element={<AdoptTraderSettings category="trading" />} />
         <Route path="/settings/issues" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'issues' } }} />} />
         <Route path="/settings/mcp" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'mcp' } }} />} />
-        <Route path="/settings/market-data" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'market-data' } }} />} />
-        <Route path="/settings/news-collector" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'news-collector' } }} />} />
+        <Route path="/settings/market-data" element={<AdoptTraderSettings category="market-data" />} />
+        <Route path="/settings/news-collector" element={<AdoptTraderSettings category="news-collector" />} />
         <Route path="/settings/connectors" element={<AdoptStatic spec={{ kind: 'settings', params: { category: 'connectors' } }} />} />
-        <Route path="/settings/uta/:id" element={<AdoptUtaDetail />} />
+        <Route path="/settings/uta/:id" element={<TraderOnly fallback="/settings"><AdoptUtaDetail /></TraderOnly>} />
 
         {/* Dev */}
         <Route path="/dev" element={<Navigate to="/dev/tools" replace />} />
@@ -138,6 +140,39 @@ export function UrlAdopter() {
 function AdoptStatic({ spec }: { spec: ViewSpec }) {
   useAdopt(spec)
   return null
+}
+
+function TraderOnly({
+  children,
+  fallback,
+}: {
+  children: ReactNode
+  fallback: string
+}) {
+  const { project, loading } = useAliceProject()
+  if (loading) return null
+  if (isNanoProduct(project?.product)) return <Navigate to={fallback} replace />
+  return children
+}
+
+function AdoptTraderStatic({ spec }: { spec: ViewSpec }) {
+  return (
+    <TraderOnly fallback="/chat">
+      <AdoptStatic spec={spec} />
+    </TraderOnly>
+  )
+}
+
+function AdoptTraderSettings({
+  category,
+}: {
+  category: 'trading' | 'market-data' | 'news-collector'
+}) {
+  return (
+    <TraderOnly fallback="/settings">
+      <AdoptStatic spec={{ kind: 'settings', params: { category } }} />
+    </TraderOnly>
+  )
 }
 
 function AdoptMarketDetail() {


### PR DESCRIPTION
## Summary
- NanoAlice hides Market, News, Trading as Git, and Portfolio from the Activity Bar. Those routes redirect to Ask Alice.
- Settings also hides Trading, Market Data, and News Sources; those deep links go back to Settings.
- Ask Alice suggestions on Nano drop market/portfolio/quant prompts for workspace, code review, and Inbox triage.

AutoQuant and Tracked stay visible. Onboarding still mentions trading capabilities.

## Test plan
- [x] `npx tsc --noEmit` and `cd ui && npx tsc -b`
- [x] Focused nav/settings/example specs
- [x] `pnpm test` (one unrelated telegram drain flake passed on rerun)
- [ ] Open a NanoAlice project and confirm the four tabs are gone
- [ ] Hit `/portfolio`, `/market`, `/news`, `/trading-as-git` and confirm redirect to `/chat`
- [ ] Confirm TraderAlice still shows the full rail


Made with [Cursor](https://cursor.com)