### PR TITLE
fix(config): stop seeding ports.json as a Guardian pin

### DIFF
--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -231,7 +231,9 @@ An inherited default Web port remains automatic for the source-backed built
 Guardian: it probes upward from 47331 together with unconfigured
 MCP/local-tool, UTA, and Connector ports. Consequently multiple complete homes
 or the desktop app may occupy historical defaults without breaking a CLI
-Runtime. A machine/project setting, environment value, or explicit flag pins
+Runtime. Creating an AliceProject and the first Alice `loadConfig()` must not
+write a default into `data/config/ports.json`; a written `web` value is a pin.
+A machine/project setting, environment value, or explicit flag pins
 the Web port and fails visibly on collision, as do explicit internal
 environment or `data/config/ports.json` values. Stop and restart wait for
 Guardian plus Alice ownership evidence to clear, not merely for the control

--- a/docs/data-locations.md
+++ b/docs/data-locations.md
@@ -133,7 +133,12 @@ repair the remembered selection. An explicit environment/flag selection fails
 instead of falling back, so automation cannot accidentally target another
 Home. The missing path is never silently recreated. An inherited Web port
 remains automatic from 47331 so concurrent AliceProjects probe upward, while a
-configured port is intentionally pinned.
+configured port is intentionally pinned. First Alice boot must not write
+`data/config/ports.json` merely to materialize that default: a file `web`
+value is a pin, so a seeded `3002` (or `47331`) would refuse to move when
+another home already holds it. Existing shipped `{ "web": 3002 }` files stay
+pins; delete the key or the file to restore probing. `openalice up --port`
+and `OPENALICE_WEB_PORT` remain one-run pins and do not rewrite the file.
 
 `OPENALICE_PROJECT`, `OPENALICE_HOME`, `--project`, and `--home` remain
 higher-priority one-run/automation inputs. When they fix the selected project

--- a/scripts/guardian/shared.ts
+++ b/scripts/guardian/shared.ts
@@ -60,6 +60,10 @@ export interface GuardianPorts {
 // An EXPLICITLY configured port that is already taken fails loud — silently
 // drifting off a value the user pinned would be worse than aborting. Only
 // unconfigured ports keep the probe-upward-from-default behavior.
+//
+// Missing ports.json is the unconfigured state. Alice must not seed a default
+// `web` value into this file: a written number is a pin, including the
+// historical `{ "web": 3002 }` first-boot seed.
 
 const PORT_DEFAULTS = { web: 47331, mcp: 47332, uta: 47333, connector: 47334, ui: 5173 } as const
 

--- a/src/core/config-ports.spec.ts
+++ b/src/core/config-ports.spec.ts
@@ -1,0 +1,66 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * ports.json is a pin, not a seedable default. config.ts resolves CONFIG_DIR
+ * at import, so each test re-imports under a fresh temp OPENALICE_HOME.
+ */
+let home: string
+let configDir: string
+let savedHome: string | undefined
+let savedWebPort: string | undefined
+
+async function loadConfigModule() {
+  vi.resetModules()
+  process.env['OPENALICE_HOME'] = home
+  return import('./config.js')
+}
+
+beforeEach(async () => {
+  savedHome = process.env['OPENALICE_HOME']
+  savedWebPort = process.env['OPENALICE_WEB_PORT']
+  delete process.env['OPENALICE_WEB_PORT']
+  home = await mkdtemp(join(tmpdir(), 'oa-ports-'))
+  configDir = join(home, 'data', 'config')
+})
+
+afterEach(async () => {
+  if (savedHome === undefined) delete process.env['OPENALICE_HOME']
+  else process.env['OPENALICE_HOME'] = savedHome
+  if (savedWebPort === undefined) delete process.env['OPENALICE_WEB_PORT']
+  else process.env['OPENALICE_WEB_PORT'] = savedWebPort
+  vi.resetModules()
+  await rm(home, { recursive: true, force: true })
+})
+
+describe('ports.json first-boot pin contract', () => {
+  it('does not seed ports.json and keeps the Guardian default in memory', async () => {
+    const { loadConfig, DEFAULT_WEB_PORT } = await loadConfigModule()
+    const config = await loadConfig()
+    expect(DEFAULT_WEB_PORT).toBe(47331)
+    expect(config.ports.web).toBe(47331)
+    expect(existsSync(join(configDir, 'ports.json'))).toBe(false)
+  })
+
+  it('does not persist OPENALICE_WEB_PORT into ports.json', async () => {
+    process.env['OPENALICE_WEB_PORT'] = '41000'
+    const { loadConfig } = await loadConfigModule()
+    const config = await loadConfig()
+    expect(config.ports.web).toBe(41000)
+    expect(existsSync(join(configDir, 'ports.json'))).toBe(false)
+  })
+
+  it('honors a shipped { "web": 3002 } pin without rewriting it', async () => {
+    await mkdir(configDir, { recursive: true })
+    const path = join(configDir, 'ports.json')
+    await writeFile(path, '{\n  "web": 3002\n}\n')
+    const { loadConfig } = await loadConfigModule()
+    const config = await loadConfig()
+    expect(config.ports.web).toBe(3002)
+    expect(await readFile(path, 'utf8')).toBe('{\n  "web": 3002\n}\n')
+  })
+})

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -352,9 +352,17 @@ const mcpSchema = z.object({
   port: z.number().int().positive().default(3001),
 }).default({ enabled: false, port: 3001 })
 
+/**
+ * In-memory fallback when `ports.json` is absent and Guardian did not inject
+ * `OPENALICE_WEB_PORT`. Must match `PORT_DEFAULTS.web` in
+ * `scripts/guardian/shared.ts`. Never persist this value as a pin: Guardian
+ * treats any `ports.json` `web` field as an explicit bind and will not probe.
+ */
+export const DEFAULT_WEB_PORT = 47331
+
 /** Local listeners are transport configuration, not external connectors. */
 const portsSchema = z.object({
-  web: z.number().int().positive().default(3002),
+  web: z.number().int().positive().default(DEFAULT_WEB_PORT),
 })
 
 const snapshotSchema = z.object({
@@ -510,9 +518,14 @@ async function removeJsonFile(filename: string): Promise<void> {
 }
 
 /** Parse with Zod; if the file was missing, seed it to disk with defaults. */
-async function parseAndSeed<T>(filename: string, schema: z.ZodType<T>, raw: unknown | undefined): Promise<T> {
+async function parseAndSeed<T>(
+  filename: string,
+  schema: z.ZodType<T>,
+  raw: unknown | undefined,
+  options?: { persistDefaults?: boolean },
+): Promise<T> {
   const parsed = schema.parse(raw ?? {})
-  if (raw === undefined) {
+  if (raw === undefined && options?.persistDefaults !== false) {
     await mkdir(CONFIG_DIR, { recursive: true })
     await writeFile(resolve(CONFIG_DIR, filename), JSON.stringify(parsed, null, 2) + '\n')
   }
@@ -541,18 +554,19 @@ async function loadConfigUnlocked(): Promise<Config> {
     aiProvider:    await parseAndSeed(files[5], aiProviderSchema, raws[5]),
     snapshot:      await parseAndSeed(files[6], snapshotSchema, raws[6]),
     mcp:           await parseAndSeed(files[7], mcpSchema, raws[7]),
-    ports:         await parseAndSeed(files[8], portsSchema, raws[8]),
+    // Missing ports.json is unconfigured, not "use 47331 forever". Seeding a
+    // default here would make Guardian treat the next boot as an explicit pin
+    // and refuse to probe when that port is already taken.
+    ports:         await parseAndSeed(files[8], portsSchema, raws[8], { persistDefaults: false }),
     news:          await parseAndSeed(files[9], newsCollectorSchema, raws[9]),
     tools:         await parseAndSeed(files[10], toolsSchema, raws[10]),
     trading:       await parseAndSeed(files[11], tradingSchema, raws[11]),
   }
 
-  // Spawn-time-fixed channel: when guardian (Electron main) spawns the
-  // backend, it injects the chosen ports as env. Env wins over the file
-  // value because the file is user preference but the actual bound port
-  // is decided by guardian at boot (may differ if the preferred port was
-  // taken). In dev mode (no guardian) both env vars are unset and the
-  // file value flows through unchanged.
+  // Guardian injects the ports it claimed as env. Env wins over the file.
+  // Explicit file/env pins fail loud when occupied; only an absent file is
+  // allowed to probe. Standalone Alice (no Guardian env) uses the in-memory
+  // default or the file as written by the user / Settings.
   const envWebPort = parseEnvPort(process.env['OPENALICE_WEB_PORT'])
   if (envWebPort !== null) config.ports.web = envWebPort
   const envMcpPort = parseEnvPort(process.env['OPENALICE_MCP_PORT'])

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,8 +16,10 @@ import { resolve } from 'node:path'
  *      the user manually started backend on a different port than
  *      configured, in which case the standalone workflow is on them.
  *
- * Default 3002 if both sources unusable, with a clear warning.
+ * Default 47331 if both sources unusable, matching Guardian PORT_DEFAULTS.web.
  */
+const DEFAULT_BACKEND_PORT = 47331
+
 function readBackendPort(): number {
   // Env wins — set by the dev orchestrator. No drift with backend.
   const envPort = Number.parseInt(process.env['OPENALICE_BACKEND_PORT'] ?? '', 10)
@@ -30,12 +32,12 @@ function readBackendPort(): number {
     const parsed = JSON.parse(raw) as { web?: number }
     const port = parsed.web
     if (typeof port === 'number' && port > 0 && port <= 65535) return port
-    console.warn(`[vite] ${configPath}: web.port missing or invalid, falling back to 3002`)
+    console.warn(`[vite] ${configPath}: web.port missing or invalid, falling back to ${DEFAULT_BACKEND_PORT}`)
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
-    console.warn(`[vite] could not read ${configPath} (${msg}), falling back to 3002`)
+    console.warn(`[vite] could not read ${configPath} (${msg}), falling back to ${DEFAULT_BACKEND_PORT}`)
   }
-  return 3002
+  return DEFAULT_BACKEND_PORT
 }
 
 const backendPort = readBackendPort()


### PR DESCRIPTION
## Summary
- First Alice `loadConfig()` on a new complete home seeded `data/config/ports.json` as `{ "web": 3002 }`.
- Guardian treats any file `web` value as an explicit pin and refuses to probe. A second AliceProject (or `pnpm dev -- --home`) then dies on the occupied 3002 instead of moving to 47331+.
- `openalice create` does not write the file; the first Runtime start does. `--port` / `OPENALICE_WEB_PORT` were already one-run and still do not persist.

## Alternatives
- Reinterpret existing `{ "web": 3002 }` as unconfigured and probe from 47331. Rejected: that shipped pin is how `~/.openalice` stays on 3002; migrating it would move the default home URL.
- Persist `--port` into `ports.json`. Rejected for this PR: that is a CLI semantics change, not the seed-as-pin bug.
- Let Guardian probe even for file pins. Rejected: silent drift off a real pin is worse than failing loud.

## Included increments
- [x] Do not persist `ports.json` defaults; align the in-memory / Vite fallback with Guardian `47331`; leave shipped `{ "web": 3002 }` pins untouched

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 4329 passed, 9 skipped

## Boundary touch
- Persisted configuration (`ports.json` first-boot write). No migration: existing `{ "web": 3002 }` remains a pin. Delete the key or the file to restore probing.

## Non-goals
- Persisting `openalice up --port`
- Rewriting already-seeded isolated homes
- Changing Guardian pin-vs-probe rules