### PR TITLE
fix(skills): safe shell quoting for alice-workspace prose flags

### DIFF
--- a/default/skills/alice-workspace/SKILL.md
+++ b/default/skills/alice-workspace/SKILL.md
@@ -206,6 +206,27 @@ alice-workspace track search --query uranium
 alice-workspace track add --name uranium-ccj --description 'Cameco — uranium miner'
 ```
 
+Prose flags (`--description`, `--prompt`, `--text`, `--what`, …) go through the
+shell. **Never** write `\'` inside single quotes — bash ends the quote at the
+first `'`, so `McDonald\'s …布林50…` becomes a syntax error before the CLI
+runs. Prefer:
+
+```bash
+# Double quotes for short prose that may contain apostrophes.
+alice-workspace track add --name stock-mcd \
+  --description "McDonald's — low-vol blue chip; Bollinger|MA entry"
+
+# Heredoc for longer Chinese/English prose (safest).
+DESC=$(cat <<'EOF'
+McDonald's — 用户超喜欢的低波动蓝筹。低位低轨买入：布林|MA(布林50<2% 或 MA200<-8%)
+EOF
+)
+alice-workspace track add --name stock-mcd --description "$DESC"
+```
+
+If the runtime exposes `entity_upsert`, prefer that tool for tracking — the
+description never passes through `bash -c`.
+
 ## Upgrade managed Workspace guidance
 
 Preview first; apply only after reviewing the plan:

--- a/src/tool/entity-upsert.ts
+++ b/src/tool/entity-upsert.ts
@@ -38,6 +38,8 @@ export const entityUpsertFactory: WorkspaceToolFactory = {
         '  in prose, so keep it terse and reuse it exactly.',
         '- description: one line — the full identity the terse name leaves out (e.g. name "stock-vst" ->',
         '  "Vistra, Texas independent power producer driven by AI datacenter electricity demand").',
+        '  Prefer this tool over `alice-workspace track add` when the description contains',
+        '  apostrophes or other shell-sensitive characters — the tool path never goes through bash -c.',
         '- type: "asset" (a tradable instrument — has a ticker) or "topic" (a theme grouping assets).',
         '',
         'Before creating, prefer reusing an existing name: call entity_search first so you write',

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.4
+version: 1.1.5
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.8.5
+version: 1.8.6
 ---
 
 # Chat


### PR DESCRIPTION
## Summary

Community report (Docker + Pi): every `bash` call first failed with a syntax error, then succeeded on retry.

## Root cause

Not an Alice double-invoke. Pi’s bash tool runs `spawn('/bin/bash', ['-c', command])` with the model’s string unchanged. The model emitted:

```bash
--description 'McDonald\'s — …布林|MA(布林50…)…'
```

In bash **single quotes**, `\'` does not escape `'`. The quote ends early; the parser dies near `布林50` (`$ '\345\270\203…'` in some locales). “Fail then succeed” is the normal agent retry after the tool error.

Reproduced locally with the same `-c` argv shape.

## Fix

Guidance only (spawn path is correct):

- `default/skills/alice-workspace/SKILL.md` — warn against `\'` in `'…'`; show double quotes + heredoc for prose flags
- tip `entity_upsert` as the non-shell track path
- bump Chat `1.8.5 → 1.8.6` and AutoQuant `1.1.4 → 1.1.5` so existing desks can upgrade managed guidance

## Test plan

- [x] Reproduced bad quoting → same `line 3` / `布林50` syntax error
- [x] Heredoc / double-quote patterns parse
- [x] `tsc --noEmit`
- [ ] Existing Workspace: template upgrade picks up skill (optional smoke)
