### PR TITLE
feat(ui): share pinned runtime draft for cred/model/effort

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -254,6 +254,10 @@ tuple. Neither form ever contains a key or endpoint. Once an exact
 `@resumeId` exists, Issue frontmatter cannot replace its credential source,
 model, or effort. The Issue page and paused Session settings may still replace
 those three dimensions on the stored binding; the Agent runtime stays frozen.
+Those editors, plus Workspace interactive/headless preference rows, share one
+pinned runtime draft (`usePinnedRuntimeDraft`) and `AgentLaunchSelectors`.
+Unknown model ids are typed through the shared custom-model dialog; they are
+not limited to the preset catalog.
 Follow-up turns replay the stored binding instead of consulting newly
 changed Workspace defaults.
 

--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => ({
   listAgentCredentials: vi.fn(),
   updateResumeRuntime: vi.fn(),
   getPresets: vi.fn(),
+  getWorkspaceCredentialDefaults: vi.fn(),
+  getAgentRuntimeReadiness: vi.fn(),
   updateIssue: vi.fn(),
   runNow: vi.fn(),
   retry: vi.fn(),
@@ -65,8 +67,32 @@ vi.mock('../hooks/useIssueDetail', () => ({
 vi.mock('../contexts/workspaces-context', () => ({
   useWorkspaces: () => ({
     agents: [
-      { id: 'codex', displayName: 'Codex', kind: 'agent', installed: true },
-      { id: 'pi', displayName: 'Pi', kind: 'agent', installed: true },
+      {
+        id: 'codex',
+        displayName: 'Codex',
+        kind: 'agent',
+        installed: true,
+        capabilities: {
+          parallelPerCwd: true,
+          resumeLast: true,
+          resumeById: true,
+          transcriptDiscovery: 'subprocess',
+          aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['openai-responses'] },
+        },
+      },
+      {
+        id: 'pi',
+        displayName: 'Pi',
+        kind: 'agent',
+        installed: true,
+        capabilities: {
+          parallelPerCwd: true,
+          resumeLast: true,
+          resumeById: true,
+          transcriptDiscovery: 'none',
+          aiProvider: { credentialSource: 'runtime-or-workspace', wirePreference: ['openai-chat'] },
+        },
+      },
     ],
     defaultAgent: 'pi',
     issueDefaultAgent: null,
@@ -76,16 +102,24 @@ vi.mock('../contexts/workspaces-context', () => ({
   }),
 }))
 
-vi.mock('./workspace/api', () => ({
-  detectWorkspaceCredential: mocks.detectWorkspaceCredential,
-  getAgentReadiness: vi.fn().mockResolvedValue({ agents: {} }),
-  getWorkspaceSessionDirectory: mocks.getWorkspaceSessionDirectory,
-  listAgentCredentials: mocks.listAgentCredentials,
-  updateResumeRuntime: mocks.updateResumeRuntime,
-}))
+vi.mock('./workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./workspace/api')>()
+  return {
+    ...actual,
+    detectWorkspaceCredential: mocks.detectWorkspaceCredential,
+    getAgentReadiness: vi.fn().mockResolvedValue({ agents: {} }),
+    getAgentRuntimeReadiness: mocks.getAgentRuntimeReadiness,
+    getWorkspaceSessionDirectory: mocks.getWorkspaceSessionDirectory,
+    listAgentCredentials: mocks.listAgentCredentials,
+    updateResumeRuntime: mocks.updateResumeRuntime,
+  }
+})
 
 vi.mock('../api/config', () => ({
-  configApi: { getPresets: mocks.getPresets },
+  configApi: {
+    getPresets: mocks.getPresets,
+    getWorkspaceCredentialDefaults: mocks.getWorkspaceCredentialDefaults,
+  },
 }))
 
 vi.mock('../api/issues', async (importOriginal) => {
@@ -123,6 +157,25 @@ beforeEach(async () => {
     runtime: { credentialSource: 'vault', credentialSlug: 'longcat-1', model: 'LongCat-2.0', reasoningEffort: 'high' },
   })
   mocks.getWorkspaceSessionDirectory.mockResolvedValue({ sessions: [] })
+  mocks.getWorkspaceCredentialDefaults.mockResolvedValue({ defaults: {} })
+  mocks.getAgentRuntimeReadiness.mockResolvedValue({
+    checkedAt: '2026-08-17T00:00:00.000Z',
+    overallReady: true,
+    agents: {
+      codex: {
+        agent: 'codex',
+        displayName: 'Codex',
+        installed: true,
+        binPath: null,
+        status: 'ready',
+        ready: true,
+        source: 'global-login',
+        checkedAt: '2026-08-17T00:00:00.000Z',
+        durationMs: 1,
+        message: 'ready',
+      },
+    },
+  })
   mocks.listAgentCredentials.mockResolvedValue([{
     slug: 'longcat-1',
     vendor: 'longcat',
@@ -330,17 +383,12 @@ describe('IssueDetail property controls', () => {
     expect(screen.getByRole('button', { name: 'AI configuration' }).textContent)
       .toContain('Runtime managed')
     fireEvent.click(screen.getByRole('button', { name: 'AI configuration' }))
-    const credential = screen.getByRole('combobox', { name: 'AI access' }) as HTMLSelectElement
-    const model = screen.getByRole('combobox', { name: 'Run model' }) as HTMLSelectElement
-    const effort = screen.getByRole('combobox', { name: 'Effort' }) as HTMLSelectElement
-    await waitFor(() => {
-      expect(credential.value).toBe('inherit')
-      expect(model.selectedOptions[0]?.textContent).toBe('Default · runtime managed')
-      expect(effort.selectedOptions[0]?.textContent).toBe('Runtime managed')
-    })
-
-    fireEvent.change(model, { target: { value: 'custom' } })
-    expect(screen.getByRole('textbox', { name: 'Custom run model' })).toBeTruthy()
+    const inherit = await screen.findByRole('checkbox', { name: 'Follow Workspace headless preference' }) as HTMLInputElement
+    expect(inherit.checked).toBe(true)
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('chatLanding.selectModelAndEffort') }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Model/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: i18n.t('chatLanding.customModel') }))
+    expect(await screen.findByRole('textbox', { name: i18n.t('chatLanding.customModelId') })).toBeTruthy()
   })
 
   it('patches the optional run timeout from the execution inspector', async () => {
@@ -388,16 +436,19 @@ describe('IssueDetail property controls', () => {
     scheduledIssue.issue.credential = 'deepseek-1'
     render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
     fireEvent.click(await screen.findByRole('button', { name: 'AI configuration' }))
-    const credential = screen.getByRole('combobox', { name: 'AI access' }) as HTMLSelectElement
-    const model = screen.getByRole('combobox', { name: 'Run model' }) as HTMLSelectElement
-    const effort = screen.getByRole('combobox', { name: 'Effort' }) as HTMLSelectElement
+    expect((screen.getByRole('checkbox', { name: 'Follow Workspace headless preference' }) as HTMLInputElement).checked).toBe(false)
     await waitFor(() => {
-      expect(credential.value).toBe('vault:deepseek-1')
-      expect(Array.from(model.options).map((option) => option.value)).toContain('deepseek-v4-flash')
-      expect(Array.from(model.options).map((option) => option.value)).not.toContain('LongCat-2.0')
-      expect(Array.from(effort.options).map((option) => option.value))
-        .toEqual(['', 'low', 'high', 'max'])
+      expect(screen.getByRole('button', { name: i18n.t('chatLanding.selectCredential') }).textContent)
+        .toContain('DeepSeek')
     })
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('chatLanding.selectModelAndEffort') }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Model/ }))
+    expect(await screen.findByRole('menuitemradio', { name: /deepseek-v4-flash/i })).toBeTruthy()
+    expect(screen.queryByRole('menuitemradio', { name: /LongCat/ })).toBeNull()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Effort/ }))
+    expect(await screen.findByRole('menuitemradio', { name: /low/ })).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: /high/ })).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: /max/ })).toBeTruthy()
   })
 
   it('confirms a bound Session capability change without rewriting Issue frontmatter', async () => {
@@ -429,10 +480,10 @@ describe('IssueDetail property controls', () => {
     expect(screen.getByText('codex')).toBeTruthy()
 
     fireEvent.click(trigger)
-    const access = await screen.findByRole('combobox', { name: 'AI access' }) as HTMLSelectElement
-    expect(Array.from(access.options).map((option) => option.value)).not.toContain('inherit')
-    expect(access.value).toBe('native')
-    fireEvent.change(screen.getByRole('combobox', { name: 'Effort' }), { target: { value: 'low' } })
+    expect(screen.queryByRole('checkbox', { name: 'Follow Workspace headless preference' })).toBeNull()
+    fireEvent.click(await screen.findByRole('button', { name: i18n.t('chatLanding.selectModelAndEffort') }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Effort/ }))
+    fireEvent.click(await screen.findByRole('menuitemradio', { name: /low/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Apply configuration' }))
 
     const confirm = await screen.findByRole('alertdialog')
@@ -452,6 +503,52 @@ describe('IssueDetail property controls', () => {
     ))
     expect(mocks.updateIssue).not.toHaveBeenCalled()
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+  })
+
+  it('accepts a typed custom model id on a bound Session', async () => {
+    scheduledIssue.issue.assignee = '@resume-kind-owl-abc123'
+    delete scheduledIssue.issue.agent
+    mocks.getWorkspaceSessionDirectory.mockResolvedValue({
+      sessions: [{
+        resumeId: 'resume-kind-owl-abc123',
+        agent: 'codex',
+        createdAt: Date.now() - 86_400_000,
+        updatedAt: Date.now() - 60_000,
+        resumable: true,
+        active: false,
+        runtime: {
+          credentialSource: 'native',
+          model: 'claude-sonnet-4-5',
+          reasoningEffort: 'high',
+        },
+      }],
+    })
+
+    render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
+    const trigger = await screen.findByRole('button', { name: 'AI configuration' })
+    await waitFor(() => expect((trigger as HTMLButtonElement).disabled).toBe(false))
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('button', { name: i18n.t('chatLanding.selectModelAndEffort') }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Model/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: i18n.t('chatLanding.customModel') }))
+    fireEvent.change(await screen.findByRole('textbox', { name: i18n.t('chatLanding.customModelId') }), {
+      target: { value: 'openrouter/some-new-id' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('common.save') }))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply configuration' }))
+
+    const confirm = await screen.findByRole('alertdialog')
+    expect(confirm.textContent).toContain('openrouter/some-new-id')
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Change capabilities' }))
+    await waitFor(() => expect(mocks.updateResumeRuntime).toHaveBeenCalledWith(
+      'demo-ws-auto-quant',
+      'resume-kind-owl-abc123',
+      expect.objectContaining({
+        credentialSource: 'native',
+        model: 'openrouter/some-new-id',
+      }),
+    ))
+    expect(mocks.updateIssue).not.toHaveBeenCalled()
   })
 
   it('locks bound Session AI configuration while a turn is running', async () => {

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
-import { ArrowLeft, Brain, Check, ChevronRight, Clock, Cpu, Hash, History, Inbox, KeyRound, ListChecks, LoaderCircle, MessageSquare, Play, RotateCcw, Search, Settings, SlidersHorizontal, Timer, TrendingUp, UserRound, X } from 'lucide-react'
+import { ArrowLeft, Check, ChevronRight, Clock, Cpu, Hash, History, Inbox, KeyRound, ListChecks, LoaderCircle, MessageSquare, Play, RotateCcw, Search, Settings, SlidersHorizontal, Timer, TrendingUp, UserRound, X } from 'lucide-react'
 import { inputClass } from './form'
 
 import type { HeadlessTaskStatus, HeadlessTurnProgress } from '../api/headless'
@@ -21,9 +21,7 @@ import type {
   WikilinkResolution,
 } from '../api/issues'
 import { DEFAULT_ISSUE_COMMENT_PROMPT, ISSUE_TIMEOUTS, issuesApi } from '../api/issues'
-import type { ModelReasoningEffort } from '../api/types'
-import type { Preset, PresetModel } from '../api/types'
-import { configApi } from '../api/config'
+
 import {
   getAgentReadiness,
   getWorkspaceSessionDirectory,
@@ -31,12 +29,18 @@ import {
   updateResumeRuntime,
   type AgentCredentialReadiness,
   type AgentId,
+  type AgentInfo,
   type PausedSessionRuntimeUpdate,
   type SavedCredential,
   type WorkspaceRuntimeModeSettings,
   type WorkspaceSessionDirectoryEntry,
 } from './workspace/api'
-import { credentialAccessLabel } from './workspace/AgentLaunchControls'
+import { AgentLaunchSelectors, credentialAccessLabel } from './workspace/AgentLaunchControls'
+import {
+  formatPinnedCapability,
+  pinnedLaunchFromBinding,
+  usePinnedRuntimeDraft,
+} from '../hooks/usePinnedRuntimeDraft'
 import { useIssueDetail } from '../hooks/useIssueDetail'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { formatRelativeTime } from '../lib/intl'
@@ -63,12 +67,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import {
-  issueEffortOptions,
-  issueModelOptions,
-  issueModelSemantics,
-  resolveIssueAiSelection,
-} from './issue-runtime-options'
+import { resolveIssueAiSelection } from './issue-runtime-options'
 
 // Run-status pill tints — mirrors AutomationRunsSection's STATUS_STYLE so the
 // Issue's independent operational history stays consistent with Automation.
@@ -455,104 +454,8 @@ function AgentEditor({
   )
 }
 
-function ModelEditor({
-  value,
-  defaultModel,
-  models,
-  loadingDefault,
-  disabled,
-  onChange,
-}: {
-  value?: string
-  defaultModel: string | null
-  models: readonly PresetModel[]
-  loadingDefault: boolean
-  disabled?: boolean
-  onChange: (next: string | null) => void
-}) {
-  const { t } = useTranslation()
-  const [customMode, setCustomMode] = useState(Boolean(value))
-  const [draft, setDraft] = useState(value ?? '')
-  const inputRef = useRef<HTMLInputElement>(null)
-  useEffect(() => {
-    setCustomMode(Boolean(value))
-    setDraft(value ?? '')
-  }, [value])
-  const commit = () => {
-    const next = draft.trim()
-    if (next !== (value ?? '')) onChange(next || null)
-    if (!next) setCustomMode(false)
-  }
-  const defaultLabel = loadingDefault
-    ? t('issues.detail.defaultLoading')
-    : defaultModel
-      ? t('issues.detail.defaultValue', { value: defaultModel })
-      : t('issues.detail.defaultRuntimeDecides')
-  const knownValue = value && models.some((model) => model.id === value)
-
-  return (
-    <div className="min-w-0 flex-1">
-      <select
-        className={`${railControl} w-full`}
-        value={customMode ? (knownValue ? value : 'custom') : 'default'}
-        disabled={disabled}
-        aria-label={t('issues.detail.runModel')}
-        onChange={(event) => {
-          if (event.target.value === 'default') {
-            setCustomMode(false)
-            setDraft('')
-            if (value) onChange(null)
-            return
-          }
-          if (event.target.value !== 'custom') {
-            setCustomMode(true)
-            setDraft(event.target.value)
-            onChange(event.target.value)
-            return
-          }
-          setCustomMode(true)
-          queueMicrotask(() => inputRef.current?.focus())
-        }}
-      >
-        <option value="default">{defaultLabel}</option>
-        {models.map((model) => (
-          <option key={model.id} value={model.id}>{model.label}</option>
-        ))}
-        <option value="custom">
-          {value ? t('issues.detail.overrideValue', { value }) : t('issues.detail.customModel')}
-        </option>
-      </select>
-      {customMode && !knownValue && (
-        <input
-          ref={inputRef}
-          className={`${railControl} mt-1 w-full`}
-          value={draft}
-          disabled={disabled}
-          placeholder={t('issues.detail.nativeModelPlaceholder')}
-          aria-label={t('issues.detail.customRunModel')}
-          onChange={(event) => setDraft(event.target.value)}
-          onBlur={commit}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              commit()
-              event.currentTarget.blur()
-            } else if (event.key === 'Escape' && !value) {
-              setDraft('')
-              setCustomMode(false)
-            }
-          }}
-        />
-      )}
-    </div>
-  )
-}
-
 function credentialLabel(credential: SavedCredential | null | undefined): string {
   return credential ? credentialAccessLabel(credential) : ''
-}
-
-function formatAiCapability(parts: { access: string; model: string; effort: string }): string {
-  return `${parts.access} · ${parts.model} · ${parts.effort}`
 }
 
 function issuePatchToRuntimeUpdate(patch: IssuePatch): PausedSessionRuntimeUpdate {
@@ -565,6 +468,26 @@ function issuePatchToRuntimeUpdate(patch: IssuePatch): PausedSessionRuntimeUpdat
   }
 }
 
+function runtimeUpdateToIssuePatch(
+  update: PausedSessionRuntimeUpdate,
+  inherit: boolean,
+): IssuePatch {
+  if (inherit) {
+    return {
+      credential: null,
+      credentialSource: null,
+      model: update.model ?? null,
+      effort: update.reasoningEffort ?? null,
+    }
+  }
+  return {
+    credential: update.credentialSource === 'vault' ? update.credentialSlug ?? null : null,
+    credentialSource: update.credentialSource === 'native' ? 'native' : null,
+    model: update.model ?? null,
+    effort: update.reasoningEffort ?? null,
+  }
+}
+
 function ownerSessionBusy(session: WorkspaceSessionDirectoryEntry | undefined): boolean {
   return Boolean(
     session?.active
@@ -573,60 +496,81 @@ function ownerSessionBusy(session: WorkspaceSessionDirectoryEntry | undefined): 
   )
 }
 
+function issueLaunchSeed(
+  agent: string,
+  issue: IssueDetailIssue,
+  mode: WorkspaceRuntimeModeSettings | null,
+): ReturnType<typeof pinnedLaunchFromBinding> {
+  if (issue.credentialSource === 'native') {
+    return pinnedLaunchFromBinding(agent, {
+      credentialSource: 'native',
+      model: issue.model,
+      reasoningEffort: issue.effort,
+    })
+  }
+  if (issue.credential) {
+    return pinnedLaunchFromBinding(agent, {
+      credentialSource: 'vault',
+      credentialSlug: issue.credential,
+      model: issue.model,
+      reasoningEffort: issue.effort,
+    })
+  }
+  const inherited = resolveIssueAiSelection({ mode, agent, issue })
+  return pinnedLaunchFromBinding(agent, {
+    credentialSource: inherited.accessMode,
+    credentialSlug: inherited.credentialSlug,
+    model: issue.model ?? inherited.model,
+    reasoningEffort: issue.effort ?? inherited.reasoningEffort,
+  })
+}
+
 function IssueAiEditor({
+  wsId,
   issue,
   agent,
+  agents,
   mode,
   credentials,
-  presets,
-  loading,
   disabled,
   bound,
   boundRuntime,
   onApply,
+  onConfigureProvider,
 }: {
+  wsId: string
   issue: IssueDetailIssue
   agent: string | null
+  agents: readonly AgentInfo[]
   mode: WorkspaceRuntimeModeSettings | null
   credentials: readonly SavedCredential[]
-  presets: readonly Preset[]
-  loading: boolean
   disabled: boolean
   bound?: boolean
   boundRuntime?: WorkspaceSessionDirectoryEntry['runtime']
   onApply: (patch: IssuePatch, capability: { from: string; to: string }) => void
+  onConfigureProvider: () => void
 }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
-  const initialAccess = bound
-    ? (boundRuntime?.credentialSource === 'vault' && boundRuntime.credentialSlug
-      ? `vault:${boundRuntime.credentialSlug}`
-      : 'native')
-    : issue.credentialSource === 'native'
-      ? 'native'
-      : issue.credential
-        ? `vault:${issue.credential}`
-        : 'inherit'
-  const initialModel = bound ? boundRuntime?.model ?? null : issue.model ?? null
-  const initialEffort = bound ? boundRuntime?.reasoningEffort ?? null : issue.effort ?? null
-  const [access, setAccess] = useState(initialAccess)
-  const [model, setModel] = useState<string | null>(initialModel)
-  const [effort, setEffort] = useState<ModelReasoningEffort | null>(initialEffort)
+  const inheritsAccess = !bound && issue.credentialSource !== 'native' && !issue.credential
+  const [inherit, setInherit] = useState(inheritsAccess)
+  const agentId = agent ?? 'codex'
+  const initial = bound
+    ? pinnedLaunchFromBinding(agentId, boundRuntime)
+    : issueLaunchSeed(agentId, issue, mode)
+  const editor = usePinnedRuntimeDraft({
+    workspaceId: wsId,
+    agent: agentId,
+    agents,
+    initial,
+    active: open,
+  })
 
   useEffect(() => {
     if (!open) return
-    setAccess(initialAccess)
-    setModel(initialModel)
-    setEffort(initialEffort)
-  }, [initialAccess, initialEffort, initialModel, open])
+    setInherit(inheritsAccess)
+  }, [inheritsAccess, open])
 
-  const draftIssue = {
-    ...(access === 'native' ? { credentialSource: 'native' as const } : {}),
-    ...(access.startsWith('vault:') ? { credential: access.slice(6) } : {}),
-    ...(model ? { model } : {}),
-    ...(effort ? { effort } : {}),
-  }
-  const resolved = resolveIssueAiSelection({ mode, agent, issue: draftIssue })
   const committed = bound
     ? {
         accessMode: (boundRuntime?.credentialSource === 'vault' ? 'vault' : 'native') as 'vault' | 'native',
@@ -636,25 +580,6 @@ function IssueAiEditor({
         accessOrigin: 'issue' as const,
       }
     : resolveIssueAiSelection({ mode, agent, issue })
-  const selectedCredential = resolved.credentialSlug
-    ? credentials.find((candidate) => candidate.slug === resolved.credentialSlug) ?? null
-    : null
-  const models = issueModelOptions({
-    agent,
-    credential: selectedCredential,
-    defaultModel: bound
-      ? model ?? selectedCredential?.resolvedModel ?? null
-      : resolved.model ?? selectedCredential?.resolvedModel ?? null,
-    presets,
-  })
-  const effectiveModel = model
-    ?? (bound ? null : resolved.model ?? selectedCredential?.resolvedModel ?? null)
-  const semantics = issueModelSemantics(effectiveModel, models)
-  const efforts = issueEffortOptions({ agent, semantics, modelKnown: semantics !== null })
-  const inheritedEffort = bound
-    ? null
-    : resolved.reasoningEffort ?? selectedCredential?.resolvedReasoningEffort ?? null
-
   const accessLabel = (modeValue: string, slug: string | undefined, fallbackCredential: SavedCredential | null) => (
     modeValue === 'vault' || modeValue.startsWith('vault:')
       ? credentialLabel(fallbackCredential)
@@ -666,6 +591,11 @@ function IssueAiEditor({
   const committedCredential = committed.credentialSlug
     ? credentials.find((candidate) => candidate.slug === committed.credentialSlug) ?? null
     : null
+  const fallback = {
+    access: t('issues.detail.agentLogin'),
+    model: t('issues.detail.runtimeDecides'),
+    effort: t('issues.detail.runtimeDecides'),
+  }
   const summaryAccess = accessLabel(committed.accessMode, committed.credentialSlug, committedCredential)
   const summaryModel = bound
     ? committed.model ?? t('issues.detail.runtimeDecides')
@@ -673,17 +603,13 @@ function IssueAiEditor({
   const summaryEffort = bound
     ? committed.reasoningEffort ?? t('issues.detail.runtimeDecides')
     : committed.reasoningEffort ?? committedCredential?.resolvedReasoningEffort ?? t('issues.detail.runtimeDecides')
-  const draftAccess = accessLabel(
-    resolved.accessMode,
-    resolved.credentialSlug,
-    selectedCredential,
-  )
-  const draftModel = bound
-    ? model ?? t('issues.detail.runtimeDecides')
-    : model ?? resolved.model ?? selectedCredential?.resolvedModel ?? t('issues.detail.runtimeDecides')
-  const draftEffort = bound
-    ? effort ?? t('issues.detail.runtimeDecides')
-    : effort ?? resolved.reasoningEffort ?? selectedCredential?.resolvedReasoningEffort ?? t('issues.detail.runtimeDecides')
+  const draftCapability = inherit && !bound
+    ? {
+        access: t('issues.detail.followWorkspaceHeadless'),
+        model: editor.capability(fallback).model,
+        effort: editor.capability(fallback).effort,
+      }
+    : editor.capability(fallback)
   const provenance = bound
     ? t('issues.detail.sessionBinding')
     : committed.accessOrigin === 'workspace-fixed'
@@ -721,89 +647,64 @@ function IssueAiEditor({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
-          <label className="block space-y-1.5">
-            <span className="flex items-center gap-2 text-xs font-medium text-foreground"><KeyRound size={14} />{t('issues.detail.aiAccess')}</span>
-            <select
-              className={`${railControl} w-full`}
-              aria-label={t('issues.detail.aiAccess')}
-              value={access}
-              disabled={loading}
-              onChange={(event) => {
-                setAccess(event.target.value)
-                setModel(null)
-                setEffort(null)
-              }}
-            >
-              {!bound && (
-                <option value="inherit">{t('issues.detail.followWorkspaceHeadless')}</option>
-              )}
-              <option value="native">{t('issues.detail.useAgentLogin')}</option>
-              {credentials.map((credential) => (
-                <option key={credential.slug} value={`vault:${credential.slug}`}>
-                  {credentialLabel(credential)} · {credential.vendor}
-                </option>
-              ))}
-              {issue.credential && !credentials.some((credential) => credential.slug === issue.credential) && (
-                <option value={`vault:${issue.credential}`}>{t('issues.detail.missingCredentialValue', { credential: issue.credential })}</option>
-              )}
-              {bound && boundRuntime?.credentialSlug
-                && !credentials.some((credential) => credential.slug === boundRuntime.credentialSlug)
-                && (
-                  <option value={`vault:${boundRuntime.credentialSlug}`}>
-                    {t('issues.detail.missingCredentialValue', { credential: boundRuntime.credentialSlug })}
-                  </option>
-                )}
-            </select>
-            <span className="block text-[11px] leading-relaxed text-muted-foreground">
-              {t(bound ? 'issues.detail.sessionAiAccessDescription' : 'issues.detail.aiAccessDescription')}
-            </span>
-          </label>
-          <div className="space-y-1.5">
-            <span className="flex items-center gap-2 text-xs font-medium text-foreground"><Cpu size={14} />{t('issues.detail.model')}</span>
-            <ModelEditor
-              value={model ?? undefined}
-              defaultModel={bound ? null : resolved.model ?? selectedCredential?.resolvedModel ?? null}
-              models={models}
-              loadingDefault={loading}
-              disabled={disabled}
-              onChange={setModel}
+          {!bound && (
+            <label className="flex min-h-12 items-start gap-3 rounded-lg border border-border bg-muted/20 p-3">
+              <input
+                className="mt-1"
+                type="checkbox"
+                checked={inherit}
+                disabled={disabled}
+                aria-label={t('issues.detail.followWorkspaceHeadless')}
+                onChange={(event) => {
+                  const next = event.target.checked
+                  setInherit(next)
+                  if (next) return
+                  const resolved = resolveIssueAiSelection({ mode, agent, issue })
+                  if (resolved.accessMode === 'vault' && resolved.credentialSlug) {
+                    editor.config.selectCredential(resolved.credentialSlug)
+                  } else {
+                    editor.config.selectRuntimeDefault()
+                  }
+                }}
+              />
+              <span>
+                <span className="block text-sm font-medium text-foreground">
+                  {t('issues.detail.followWorkspaceHeadless')}
+                </span>
+                <span className="mt-0.5 block text-xs leading-relaxed text-muted-foreground">
+                  {t('issues.detail.aiAccessDescription')}
+                </span>
+              </span>
+            </label>
+          )}
+          <fieldset disabled={disabled} className="min-w-0 space-y-3 disabled:opacity-60">
+            <AgentLaunchSelectors
+              config={editor.config}
+              onConfigureProvider={onConfigureProvider}
+              showRuntime={false}
+              showAccess={bound || !inherit}
+              toolbar
+              layout="settings"
+              menuPlacement="down"
+              menuPositionerClassName="z-[80]"
             />
-          </div>
-          <label className="block space-y-1.5">
-            <span className="flex items-center gap-2 text-xs font-medium text-foreground"><Brain size={14} />{t('issues.detail.effort')}</span>
-            <select
-              className={`${railControl} w-full`}
-              value={effort ?? ''}
-              disabled={disabled}
-              onChange={(event) => setEffort(event.target.value ? event.target.value as ModelReasoningEffort : null)}
-            >
-              <option value="">{inheritedEffort
-                ? t('issues.detail.workspaceValue', { value: inheritedEffort })
-                : t('issues.detail.runtimeDecides')}</option>
-              {efforts.map((candidate) => <option key={candidate} value={candidate}>{candidate}</option>)}
-            </select>
-          </label>
+          </fieldset>
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {t(bound ? 'issues.detail.sessionAiAccessDescription' : 'issues.detail.aiAccessDescription')}
+          </p>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>{t('common.cancel')}</Button>
           <Button
             onClick={() => {
-              onApply({
-                credential: access.startsWith('vault:') ? access.slice(6) : null,
-                credentialSource: access === 'native' ? 'native' : null,
-                model,
-                effort,
-              }, {
-                from: formatAiCapability({
+              const update = editor.toRuntimeUpdate()
+              onApply(runtimeUpdateToIssuePatch(update, Boolean(!bound && inherit)), {
+                from: formatPinnedCapability({
                   access: summaryAccess,
                   model: summaryModel,
                   effort: summaryEffort,
                 }),
-                to: formatAiCapability({
-                  access: draftAccess,
-                  model: draftModel,
-                  effort: draftEffort,
-                }),
+                to: formatPinnedCapability(draftCapability),
               })
               setOpen(false)
             }}
@@ -901,7 +802,7 @@ function SchedulePolicyEditor({
 function PropertiesRail({
   wsId,
   issue,
-  agentOptions,
+  agents,
   issueDefaultAgent,
   defaultAgent,
   headlessRuntime,
@@ -921,7 +822,7 @@ function PropertiesRail({
 }: {
   wsId: string
   issue: IssueDetailIssue
-  agentOptions: readonly { id: string; displayName: string; installed?: boolean }[]
+  agents: readonly AgentInfo[]
   issueDefaultAgent: string | null
   defaultAgent: string | null
   headlessRuntime: WorkspaceRuntimeModeSettings | null
@@ -948,31 +849,21 @@ function PropertiesRail({
   } | null>(null)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
   const meta = STATUS_META[issue.status]
-  const issueDefaultInOptions = issueDefaultAgent && agentOptions.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
-  const defaultInOptions = defaultAgent && agentOptions.some((a) => a.id === defaultAgent) ? defaultAgent : null
+  const issueDefaultInOptions = issueDefaultAgent && agents.some((a) => a.id === issueDefaultAgent) ? issueDefaultAgent : null
+  const defaultInOptions = defaultAgent && agents.some((a) => a.id === defaultAgent) ? defaultAgent : null
   const ownerResumeId = issue.assignee.startsWith('@resume-')
     ? issue.assignee.slice(1)
     : null
   const ownerSession = ownerResumeId
     ? sessions.find((session) => session.resumeId === ownerResumeId)
     : undefined
-  const effectiveAgent = ownerSession?.agent || issue.agent || issueDefaultInOptions || defaultInOptions || agentOptions[0]?.id || null
+  const effectiveAgent = ownerSession?.agent || issue.agent || issueDefaultInOptions || defaultInOptions || agents[0]?.id || null
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const [credentialOptions, setCredentialOptions] = useState<{
     agent: string
     loading: boolean
     credentials: SavedCredential[]
   } | null>(null)
-  const [presets, setPresets] = useState<readonly Preset[]>([])
-
-  useEffect(() => {
-    let live = true
-    void configApi.getPresets()
-      .then(({ presets: next }) => { if (live) setPresets(next) })
-      .catch(() => { if (live) setPresets([]) })
-    return () => { live = false }
-  }, [])
-
   useEffect(() => {
     if (!effectiveAgent) {
       setCredentialOptions(null)
@@ -1002,9 +893,6 @@ function PropertiesRail({
   const availableCredentials = credentialOptions?.agent === effectiveAgent
     ? credentialOptions.credentials
     : []
-  const credentialsLoading = credentialOptions?.agent === effectiveAgent
-    ? credentialOptions.loading
-    : Boolean(effectiveAgent)
   const resolvedAi = resolveIssueAiSelection({ mode: headlessRuntime, agent: effectiveAgent, issue })
   const agentNeedsCredential = selectedReadiness?.requiresCredential === true
     && !selectedReadiness.ready
@@ -1179,7 +1067,7 @@ function PropertiesRail({
                       value={issue.agent}
                       issueDefaultAgent={issueDefaultAgent}
                       defaultAgent={defaultAgent}
-                      options={agentOptions}
+                      options={agents}
                       readiness={agentReadiness}
                       disabled={saving}
                       onChange={(agent) => {
@@ -1200,15 +1088,18 @@ function PropertiesRail({
               <InspectorField label={t('issues.detail.aiConfiguration')} className="mt-3">
                 <div className="flex min-w-0">
                   <IssueAiEditor
+                    wsId={wsId}
                     issue={issue}
                     agent={effectiveAgent}
+                    agents={agents}
                     mode={headlessRuntime}
                     credentials={availableCredentials}
-                    presets={presets}
-                    loading={credentialsLoading}
                     disabled={saving || Boolean(ownerResumeId && (ownerSessionBusy(ownerSession) || (sessionsLoaded && !ownerSession)))}
                     bound={Boolean(ownerResumeId)}
                     boundRuntime={ownerSession?.runtime}
+                    onConfigureProvider={() => {
+                      if (effectiveAgent) onConfigureAgent(effectiveAgent as AgentId)
+                    }}
                     onApply={(patch, capability) => {
                       if (!ownerResumeId) {
                         void onPatch(patch)
@@ -2298,7 +2189,7 @@ export function IssueDetail({
         <PropertiesRail
           wsId={wsId}
           issue={issue}
-          agentOptions={agentOptions}
+          agents={agentOptions}
           issueDefaultAgent={workspaceIssueDefaultAgent}
           defaultAgent={workspaceLegacyDefaultAgent}
           headlessRuntime={workspace?.runtimeSettings?.runtime.headless ?? null}

--- a/ui/src/components/workspace/AgentLaunchControls.tsx
+++ b/ui/src/components/workspace/AgentLaunchControls.tsx
@@ -89,12 +89,16 @@ export interface AgentLaunchSelectorsProps {
   readonly onConfigureProvider: () => void
   readonly showRuntime?: boolean
   readonly showAi?: boolean
+  /** Hide the access menu when a surface owns inherit / native / vault itself. */
+  readonly showAccess?: boolean
   readonly menuPlacement?: 'up' | 'down'
   readonly labeled?: boolean
   /** Visually recede selectors into a composer toolbar until hover/focus. */
   readonly toolbar?: boolean
   /** Present AI controls as full-width setting rows instead of composer chips. */
   readonly layout?: 'inline' | 'settings'
+  /** Raise menus above a parent settings dialog. */
+  readonly menuPositionerClassName?: string
 }
 
 export interface AgentLaunchSelectorsHandle {
@@ -245,10 +249,12 @@ function AgentLaunchInferenceMenu({
   config,
   menuPlacement,
   settings = false,
+  menuPositionerClassName,
 }: {
   config: AgentLaunchConfigState
   menuPlacement: 'up' | 'down'
   settings?: boolean
+  menuPositionerClassName?: string
 }) {
   const { t } = useTranslation()
   const pendingCustomModelRef = useRef(false)
@@ -334,6 +340,7 @@ function AgentLaunchInferenceMenu({
           align="start"
           side={settings ? 'top' : menuPlacement === 'down' ? 'bottom' : 'top'}
           sideOffset={6}
+          positionerClassName={menuPositionerClassName}
           aria-label={t('chatLanding.selectModelAndEffort')}
           className="w-[280px] max-w-[calc(100vw-2rem)] rounded-xl border border-border/70 bg-secondary p-1.5 shadow-lg ring-0"
         >
@@ -412,7 +419,7 @@ function AgentLaunchInferenceMenu({
       </DropdownMenu>
 
       <Dialog open={customModelOpen} onOpenChange={setCustomModelOpen}>
-        <DialogContent>
+        <DialogContent overlayClassName="z-[80]" className="z-[80]">
           <DialogHeader>
             <DialogTitle>{t('chatLanding.customModelTitle')}</DialogTitle>
             <DialogDescription>{t('chatLanding.customModelDescription')}</DialogDescription>
@@ -453,10 +460,12 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
     onConfigureProvider,
     showRuntime = true,
     showAi = true,
+    showAccess = true,
     menuPlacement = 'up',
     labeled = false,
     toolbar = false,
     layout = 'inline',
+    menuPositionerClassName,
   },
   ref,
 ) {
@@ -585,7 +594,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
         )}
       </div>}
 
-      {showAi && config.needsCredential && config.noCredentials && (
+      {showAi && showAccess && config.needsCredential && config.noCredentials && (
         <button
           type="button"
           onClick={onConfigureProvider}
@@ -596,7 +605,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
         </button>
       )}
 
-      {showAi && config.canSelectCredential && !config.noCredentials && config.credentials && (
+      {showAi && showAccess && config.canSelectCredential && !config.noCredentials && config.credentials && (
         <DropdownMenu open={credentialMenuOpen} onOpenChange={setCredentialMenuOpen}>
           <DropdownMenuTrigger
             type="button"
@@ -627,6 +636,7 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
             align="start"
             side={menuPlacement === 'down' ? 'bottom' : 'top'}
             sideOffset={6}
+            positionerClassName={menuPositionerClassName}
             className="w-[min(22rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] rounded-xl border border-border/70 bg-secondary p-1.5 shadow-lg ring-0"
           >
             <DropdownMenuGroup>
@@ -695,7 +705,12 @@ export const AgentLaunchSelectors = forwardRef<AgentLaunchSelectorsHandle, Agent
           className={settingsLayout ? 'w-full min-w-0' : `contents sm:flex sm:shrink-0 sm:items-center ${toolbar ? 'sm:gap-1' : 'sm:gap-2'}`}
         >
           {toolbar ? (
-            <AgentLaunchInferenceMenu config={config} menuPlacement={menuPlacement} settings={settingsLayout} />
+            <AgentLaunchInferenceMenu
+              config={config}
+              menuPlacement={menuPlacement}
+              settings={settingsLayout}
+              menuPositionerClassName={menuPositionerClassName}
+            />
           ) : (
             <>
               <AgentLaunchModelEditor config={config} labeled={labeled} />

--- a/ui/src/components/workspace/SessionSettingsDialog.spec.tsx
+++ b/ui/src/components/workspace/SessionSettingsDialog.spec.tsx
@@ -5,11 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '../../i18n'
 import type { AgentLaunchConfigState } from '../../hooks/useAgentLaunchConfig'
+import type { PinnedRuntimeDraft } from '../../hooks/usePinnedRuntimeDraft'
 import type { SessionRecord } from './api'
 import { SessionSettingsDialog } from './SessionSettingsDialog'
 
 const launchConfig = {
   effectiveAgent: 'claude',
+  selectedAgent: { id: 'claude', displayName: 'Claude Code' },
   accessMode: 'vault',
   launchCredentialSlug: 'deepseek-1',
   launchModel: 'deepseek-v4-flash',
@@ -18,9 +20,36 @@ const launchConfig = {
   selectRuntimeDefault: vi.fn(),
 } as unknown as AgentLaunchConfigState
 
-vi.mock('../../hooks/useAgentLaunchConfig', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../hooks/useAgentLaunchConfig')>()),
-  useAgentLaunchConfig: () => launchConfig,
+const editor = {
+  config: launchConfig,
+  draft: {
+    agent: 'claude',
+    accessMode: 'vault',
+    credentialSlug: 'deepseek-1',
+    model: 'deepseek-v4-flash',
+    reasoningEffort: 'high',
+  },
+  initial: {
+    agent: 'claude',
+    accessMode: 'vault',
+    credentialSlug: 'deepseek-1',
+    model: 'deepseek-v4-flash',
+    reasoningEffort: 'high',
+  },
+  dirty: false,
+  toRuntimeUpdate: () => ({
+    credentialSource: 'vault' as const,
+    credentialSlug: 'deepseek-1',
+    model: launchConfig.launchModel ?? null,
+    reasoningEffort: launchConfig.launchReasoningEffort ?? null,
+  }),
+  capability: () => ({ access: 'DeepSeek API', model: 'deepseek-v4-flash', effort: 'high' }),
+  formatCapability: () => 'DeepSeek API · deepseek-v4-flash · high',
+} as unknown as PinnedRuntimeDraft
+
+vi.mock('../../hooks/usePinnedRuntimeDraft', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../hooks/usePinnedRuntimeDraft')>()),
+  usePinnedRuntimeDraft: () => editor,
 }))
 
 vi.mock('./AgentLaunchControls', () => ({
@@ -71,11 +100,11 @@ describe('SessionSettingsDialog', () => {
     const onOpenChange = vi.fn()
     const onSaveDisplayName = vi.fn(async () => {})
     const onSaveRuntime = vi.fn(async () => {})
-    // Force a dirty AI save by changing the mocked launch selection.
     Object.assign(launchConfig, {
       launchModel: 'deepseek-v4-pro',
       launchReasoningEffort: 'xhigh',
     })
+    Object.assign(editor, { dirty: true })
 
     render(<SessionSettingsDialog
       open
@@ -108,6 +137,7 @@ describe('SessionSettingsDialog', () => {
       launchModel: 'deepseek-v4-flash',
       launchReasoningEffort: 'high',
     })
+    Object.assign(editor, { dirty: false })
 
     render(<SessionSettingsDialog
       open
@@ -136,6 +166,7 @@ describe('SessionSettingsDialog', () => {
       launchModel: null,
       launchReasoningEffort: null,
     })
+    Object.assign(editor, { dirty: true })
 
     render(<SessionSettingsDialog
       open

--- a/ui/src/components/workspace/SessionSettingsDialog.tsx
+++ b/ui/src/components/workspace/SessionSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Info } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -11,11 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import type { QuickChatLaunchPreference } from '../../api/preferences'
-import {
-  useAgentLaunchConfig,
-  type AgentLaunchPreferencesState,
-} from '../../hooks/useAgentLaunchConfig'
+import { pinnedLaunchFromBinding, usePinnedRuntimeDraft } from '../../hooks/usePinnedRuntimeDraft'
 import { AgentLaunchSelectors } from './AgentLaunchControls'
 import { sessionCoworkerLabel } from './display'
 import type {
@@ -46,28 +42,9 @@ export interface SessionSettingsDialogProps {
   readonly onPause?: () => void
 }
 
-function runtimeLaunch(record: SessionRecord): QuickChatLaunchPreference {
-  const runtime = record.runtime
-  const vault = runtime?.credentialSource === 'vault' && Boolean(runtime.credentialSlug)
-  return {
-    agent: record.agent,
-    accessMode: vault ? 'vault' : 'native',
-    credentialSlug: vault ? runtime?.credentialSlug ?? null : null,
-    model: runtime?.model ?? null,
-    reasoningEffort: runtime?.reasoningEffort ?? null,
-  }
-}
-
 function normalizeDisplayName(value: string): string | null {
   const trimmed = value.trim()
   return trimmed ? trimmed.slice(0, DISPLAY_NAME_MAX) : null
-}
-
-function launchEquals(a: QuickChatLaunchPreference, b: QuickChatLaunchPreference): boolean {
-  return a.accessMode === b.accessMode
-    && (a.credentialSlug ?? null) === (b.credentialSlug ?? null)
-    && (a.model ?? null) === (b.model ?? null)
-    && (a.reasoningEffort ?? null) === (b.reasoningEffort ?? null)
 }
 
 /**
@@ -86,66 +63,40 @@ export function SessionSettingsDialog({
   onPause,
 }: SessionSettingsDialogProps) {
   const { t } = useTranslation()
-  const initialLaunch = useMemo(() => runtimeLaunch(record), [record])
-  const initialLaunchKey = JSON.stringify(initialLaunch)
+  const initialLaunch = useMemo(
+    () => pinnedLaunchFromBinding(record.agent, record.runtime),
+    [record.agent, record.runtime],
+  )
   const initialDisplayName = record.displayName ?? ''
   const [displayName, setDisplayName] = useState(initialDisplayName)
-  const [draft, setDraft] = useState<QuickChatLaunchPreference>(initialLaunch)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const paused = record.state === 'paused'
   const supportsAi = record.agent !== 'shell' && Boolean(onSaveRuntime)
   const aiEditable = supportsAi && paused
+  const editor = usePinnedRuntimeDraft({
+    workspaceId,
+    agent: record.agent,
+    agents,
+    initial: initialLaunch,
+    active: open,
+  })
+  const config = editor.config
 
   useEffect(() => {
     if (!open) return
     setDisplayName(initialDisplayName)
-    setDraft(initialLaunch)
     setError(null)
-    // Reset only when this dialog opens for a different persisted binding.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialDisplayName, initialLaunchKey, open])
+  }, [initialDisplayName, open])
 
-  const rememberLaunch = useCallback(async (launch: QuickChatLaunchPreference) => {
-    setDraft(launch)
-  }, [])
-  const preferences = useMemo<AgentLaunchPreferencesState>(() => ({
-    lastCredentialByAgent: draft.credentialSlug
-      ? { [record.agent]: draft.credentialSlug }
-      : {},
-    recentChatWorkspaceId: workspaceId,
-    recentLaunch: draft,
-    loaded: true,
-    rememberLaunch,
-    adoptRecentChatWorkspace: () => undefined,
-  }), [draft, record.agent, rememberLaunch, workspaceId])
-  const runtimeAgents = useMemo(
-    () => agents.filter((agent) => agent.id === record.agent),
-    [agents, record.agent],
-  )
-  const config = useAgentLaunchConfig({
-    agents: runtimeAgents,
-    defaultAgent: record.agent,
-    preferences,
-    workspaceId,
-    hasWorkspace: true,
-    managedWorkspaceLaunch: true,
-  })
-  const runtimeName = runtimeAgents[0]?.displayName ?? record.agent
+  const runtimeName = config.selectedAgent?.displayName ?? record.agent
   const coworkerLabel = sessionCoworkerLabel(record)
 
   const nextDisplayName = normalizeDisplayName(displayName)
   const currentDisplayName = normalizeDisplayName(initialDisplayName)
   const displayNameDirty = nextDisplayName !== currentDisplayName
-  const launchDirty = supportsAi && !launchEquals({
-    agent: record.agent,
-    accessMode: config.accessMode,
-    credentialSlug: config.launchCredentialSlug ?? null,
-    model: config.launchModel ?? null,
-    reasoningEffort: config.launchReasoningEffort ?? null,
-  }, initialLaunch)
-  const canSaveAi = aiEditable && launchDirty && config.credentialSelectionReady && Boolean(config.effectiveAgent)
+  const canSaveAi = aiEditable && editor.dirty && config.credentialSelectionReady && Boolean(config.effectiveAgent)
   const canSave = !saving && (displayNameDirty || canSaveAi)
 
   const submit = async () => {
@@ -157,13 +108,7 @@ export function SessionSettingsDialog({
         await onSaveDisplayName(nextDisplayName)
       }
       if (canSaveAi && onSaveRuntime) {
-        const vault = config.accessMode === 'vault' && Boolean(config.launchCredentialSlug)
-        await onSaveRuntime({
-          credentialSource: vault ? 'vault' : 'native',
-          ...(vault ? { credentialSlug: config.launchCredentialSlug } : {}),
-          model: config.launchModel ?? null,
-          reasoningEffort: config.launchReasoningEffort ?? null,
-        })
+        await onSaveRuntime(editor.toRuntimeUpdate())
       }
       onOpenChange(false)
     } catch (cause) {

--- a/ui/src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
+++ b/ui/src/components/workspace/WorkspaceAIPreferencesPanel.spec.tsx
@@ -139,14 +139,13 @@ describe('WorkspaceAIPreferencesPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '编辑交互式 Session中的 Codex 偏好' }))
     fireEvent.click(screen.getByRole('radio', { name: /固定默认值/ }))
     const access = await screen.findByRole('button', { name: 'AI 访问' })
-    expect(screen.getByRole('combobox', { name: 'AI 模型' })).toBeTruthy()
-    expect(screen.getByRole('combobox', { name: '思考强度' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '模型与推理强度' })).toBeTruthy()
 
     fireEvent.click(access)
     expect(await screen.findByText('由谁管理 Codex 的 AI 访问？')).toBeTruthy()
-    expect(screen.getByRole('menuitemradio', { name: /由 Codex 管理/ })).toBeTruthy()
-    fireEvent.click(screen.getByRole('menuitemradio', { name: /DeepSeek API/ }))
-    await waitFor(() => expect(screen.queryByRole('menuitemradio', { name: /DeepSeek API/ })).toBeNull())
+    expect(screen.getByRole('menuitem', { name: /由 Codex 管理/ })).toBeTruthy()
+    fireEvent.click(screen.getByRole('menuitem', { name: /DeepSeek API/ }))
+    await waitFor(() => expect(screen.queryByRole('menuitem', { name: /DeepSeek API/ })).toBeNull())
 
     fireEvent.click(screen.getByRole('button', { name: '保存更改' }))
     await waitFor(() => expect(mocks.updateWorkspaceRuntimeDefaults).toHaveBeenCalledOnce())

--- a/ui/src/components/workspace/WorkspaceAIPreferencesPanel.tsx
+++ b/ui/src/components/workspace/WorkspaceAIPreferencesPanel.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Bot, BrainCircuit, Check, ChevronDown, Cpu, KeyRound, Pencil, RotateCcw, Settings2 } from 'lucide-react'
+import { Bot, Check, Cpu, KeyRound, Pencil, RotateCcw } from 'lucide-react'
 
 import type { QuickChatLaunchPreference } from '@/api/preferences'
 import { Button } from '@/components/ui/button'
@@ -12,21 +12,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import {
-  useAgentLaunchConfig,
-  type AgentLaunchConfigState,
-  type AgentLaunchPreferencesState,
-} from '@/hooks/useAgentLaunchConfig'
-import { credentialAccessDetail, credentialAccessLabel } from './AgentLaunchControls'
+import { usePinnedRuntimeDraft } from '@/hooks/usePinnedRuntimeDraft'
+import { AgentLaunchSelectors, credentialAccessLabel } from './AgentLaunchControls'
 import {
   listAgentCredentials,
   updateWorkspaceRuntimeDefaults,
@@ -104,175 +91,6 @@ function preferenceSummary(
   return { access, inference }
 }
 
-function RuntimePreferenceFields({
-  config,
-  onConfigureProvider,
-}: {
-  readonly config: AgentLaunchConfigState
-  readonly onConfigureProvider: () => void
-}) {
-  const { t } = useTranslation()
-  const modelListId = useId()
-  const [accessMenuOpen, setAccessMenuOpen] = useState(false)
-  const [modelDraft, setModelDraft] = useState(config.launchModel ?? '')
-  const runtimeName = config.selectedAgent?.displayName ?? t('chatLanding.runtimeFallback')
-  const nativeAccess = config.accessMode === 'native' || config.effectiveCredential === null
-  const selectedAccessLabel = nativeAccess
-    ? t('chatLanding.runtimeAccount', { runtime: runtimeName })
-    : credentialAccessLabel(config.credential)
-  const selectedAccessDetail = nativeAccess
-    ? t('chatLanding.runtimeAccountDetail')
-    : t('chatLanding.savedAccessDetail', { credential: credentialAccessDetail(config.credential) })
-  const effortOptions = config.selectedReasoningEffort
-    && !config.effortOptions.includes(config.selectedReasoningEffort)
-    ? [config.selectedReasoningEffort, ...config.effortOptions]
-    : config.effortOptions
-  const defaultModelLabel = config.defaultModel
-    ? t('chatLanding.defaultModelValue', { model: config.defaultModel })
-    : t('chatLanding.runtimeDefaultModel')
-
-  useEffect(() => setModelDraft(config.launchModel ?? ''), [config.launchModel])
-
-  const commitModel = () => {
-    const next = modelDraft.trim()
-    if (next !== (config.launchModel ?? '')) config.selectModel(next || null)
-  }
-
-  return (
-    <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-3">
-      <div className="space-y-1.5">
-        <span className="text-[11px] font-medium text-muted-foreground">{t('chatLanding.aiAccess')}</span>
-        <DropdownMenu open={accessMenuOpen} onOpenChange={setAccessMenuOpen}>
-          <DropdownMenuTrigger
-            render={<button
-              type="button"
-              aria-label={t('chatLanding.selectCredential')}
-              className="oa-pressable flex min-h-14 w-full items-center gap-3 rounded-md border border-border bg-background px-3 py-2 text-left outline-none transition-colors hover:bg-muted/35 focus-visible:ring-2 focus-visible:ring-primary/40"
-            />}
-          >
-            <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-[13px] font-medium text-foreground">{selectedAccessLabel}</span>
-              <span className="mt-0.5 block truncate text-[10.5px] text-muted-foreground">{selectedAccessDetail}</span>
-            </span>
-            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            side="bottom"
-            align="start"
-            sideOffset={6}
-            positionerClassName="z-[80]"
-            className="z-[80] max-h-52 min-w-[min(28rem,calc(100vw-3rem))] sm:max-h-64"
-          >
-            <div className="px-1.5 py-1 text-xs font-medium text-muted-foreground">
-              {t('chatLanding.credentialMenuTitle', { runtime: runtimeName })}
-            </div>
-            <DropdownMenuSeparator />
-            <DropdownMenuRadioGroup
-              value={nativeAccess ? 'native' : `vault:${config.effectiveCredential ?? ''}`}
-              onValueChange={(value) => {
-                const selected = String(value)
-                if (selected === 'native') config.selectRuntimeDefault()
-                else if (selected.startsWith('vault:')) config.selectCredential(selected.slice('vault:'.length))
-                setAccessMenuOpen(false)
-              }}
-            >
-              <DropdownMenuRadioItem value="native" className="py-2">
-                <span className="min-w-0">
-                  <span className="block truncate text-[12px] font-medium">{t('chatLanding.runtimeAccount', { runtime: runtimeName })}</span>
-                  <span className="block truncate text-[10px] text-muted-foreground">{t('chatLanding.runtimeAccountDetail')}</span>
-                </span>
-              </DropdownMenuRadioItem>
-              {config.credentials?.map((credential) => (
-                <DropdownMenuRadioItem
-                  key={credential.slug}
-                  value={`vault:${credential.slug}`}
-                  className="py-2"
-                >
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-[12px] font-medium">{credentialAccessLabel(credential)}</span>
-                    <span className="block truncate text-[10px] text-muted-foreground">
-                      {t('chatLanding.savedAccessDetail', { credential: credentialAccessDetail(credential) })}
-                    </span>
-                  </span>
-                  {credential.resolvedModel && (
-                    <span className="max-w-32 shrink-0 truncate text-[10px] text-muted-foreground">{credential.resolvedModel}</span>
-                  )}
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-            {config.credentials !== null && config.credentials.length === 0 && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={onConfigureProvider}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-[12px] text-primary hover:bg-muted"
-                >
-                  <Settings2 className="h-4 w-4" />
-                  {t('chatLanding.configureProvider')}
-                </DropdownMenuItem>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      <div className="grid gap-3 sm:grid-cols-2">
-        <label className="space-y-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">{t('chatLanding.modelField')}</span>
-          <span className="flex min-h-11 items-center gap-2 rounded-md border border-border bg-background px-3 focus-within:ring-2 focus-within:ring-primary/40">
-            <Cpu className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <input
-              list={modelListId}
-              value={modelDraft}
-              onChange={(event) => setModelDraft(event.target.value)}
-              onBlur={commitModel}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') event.currentTarget.blur()
-                if (event.key === 'Escape') {
-                  setModelDraft(config.launchModel ?? '')
-                  event.currentTarget.blur()
-                }
-              }}
-              aria-label={t('chatLanding.selectModel')}
-              placeholder={defaultModelLabel}
-              className="min-w-0 flex-1 bg-transparent py-2 text-[12px] text-foreground outline-none placeholder:text-muted-foreground"
-            />
-            <datalist id={modelListId}>
-              {config.modelOptions.map((model) => <option key={model.id} value={model.id}>{model.label}</option>)}
-            </datalist>
-          </span>
-        </label>
-
-        <label className="space-y-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">{t('chatLanding.effortField')}</span>
-          <span className="relative flex min-h-11 items-center gap-2 rounded-md border border-border bg-background px-3 focus-within:ring-2 focus-within:ring-primary/40">
-            <BrainCircuit className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <select
-              value={config.selectedReasoningEffort ?? ''}
-              onChange={(event) => config.selectReasoningEffort(
-                event.target.value
-                  ? event.target.value as NonNullable<AgentLaunchConfigState['launchReasoningEffort']>
-                  : null,
-              )}
-              aria-label={t('chatLanding.selectEffort')}
-              className="min-w-0 flex-1 appearance-none bg-transparent py-2 pr-5 text-[12px] text-foreground outline-none"
-            >
-              <option value="">{t('chatLanding.effortNotSpecified')}</option>
-              {effortOptions.map((effort) => <option key={effort} value={effort}>{effort}</option>)}
-            </select>
-            <ChevronDown className="pointer-events-none absolute right-3 h-4 w-4 text-muted-foreground" />
-          </span>
-        </label>
-      </div>
-
-      <p className="text-[10.5px] leading-relaxed text-muted-foreground">
-        {t('workspaceSettings.preferences.nativeAccessHelp')}
-      </p>
-    </div>
-  )
-}
-
 function RuntimePreferenceDialog({
   open,
   onOpenChange,
@@ -296,36 +114,23 @@ function RuntimePreferenceDialog({
   const [useFixed, setUseFixed] = useState(fixed !== undefined)
   const [applying, setApplying] = useState(false)
   const [applyError, setApplyError] = useState<string | null>(null)
-  const [draft, setDraft] = useState<QuickChatLaunchPreference>(() => (
-    launchFromPreference(agent.id, fixed ?? recent)
-  ))
+  const initial = useMemo(
+    () => launchFromPreference(agent.id, fixed ?? recent),
+    [agent.id, fixed, recent],
+  )
+  const editor = usePinnedRuntimeDraft({
+    workspaceId,
+    agent: agent.id,
+    agents: [agent],
+    initial,
+    active: open,
+  })
 
   useEffect(() => {
     if (!open) return
     setUseFixed(fixed !== undefined)
-    setDraft(launchFromPreference(agent.id, fixed ?? recent))
     setApplyError(null)
   }, [agent.id, fixed, open, recent])
-
-  const rememberLaunch = useCallback(async (launch: QuickChatLaunchPreference) => {
-    setDraft(launch)
-  }, [])
-  const preferences = useMemo<AgentLaunchPreferencesState>(() => ({
-    lastCredentialByAgent: draft.credentialSlug ? { [agent.id]: draft.credentialSlug } : {},
-    recentChatWorkspaceId: workspaceId,
-    recentLaunch: draft,
-    loaded: true,
-    rememberLaunch,
-    adoptRecentChatWorkspace: () => undefined,
-  }), [agent.id, draft, rememberLaunch, workspaceId])
-  const config = useAgentLaunchConfig({
-    agents: [agent],
-    defaultAgent: agent.id,
-    preferences,
-    workspaceId,
-    hasWorkspace: true,
-    managedWorkspaceLaunch: true,
-  })
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => { if (!applying) onOpenChange(nextOpen) }}>
@@ -374,7 +179,20 @@ function RuntimePreferenceDialog({
         </div>
 
         {useFixed && (
-          <RuntimePreferenceFields config={config} onConfigureProvider={onConfigureProvider} />
+          <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-3">
+            <AgentLaunchSelectors
+              config={editor.config}
+              onConfigureProvider={onConfigureProvider}
+              showRuntime={false}
+              toolbar
+              layout="settings"
+              menuPlacement="down"
+              menuPositionerClassName="z-[80]"
+            />
+            <p className="text-[10.5px] leading-relaxed text-muted-foreground">
+              {t('workspaceSettings.preferences.nativeAccessHelp')}
+            </p>
+          </div>
         )}
 
         {applyError && <p role="alert" className="text-xs text-destructive">{applyError}</p>}
@@ -384,7 +202,7 @@ function RuntimePreferenceDialog({
           <Button disabled={applying} onClick={() => {
             setApplying(true)
             setApplyError(null)
-            void onApply(useFixed ? preferenceFromLaunch(draft) : null)
+            void onApply(useFixed ? preferenceFromLaunch(editor.draft) : null)
               .then((message) => {
                 if (message) setApplyError(message)
                 else onOpenChange(false)

--- a/ui/src/hooks/usePinnedRuntimeDraft.spec.ts
+++ b/ui/src/hooks/usePinnedRuntimeDraft.spec.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentInfo } from '../components/workspace/api'
+import {
+  formatPinnedCapability,
+  pinnedLaunchEquals,
+  pinnedLaunchFromBinding,
+  pinnedLaunchToRuntimeUpdate,
+  usePinnedRuntimeDraft,
+} from './usePinnedRuntimeDraft'
+
+const mocks = vi.hoisted(() => ({
+  listAgentCredentials: vi.fn(),
+  getAgentRuntimeReadiness: vi.fn(),
+  getPresets: vi.fn(),
+  getWorkspaceCredentialDefaults: vi.fn(),
+  rememberQuickChatLaunch: vi.fn(),
+}))
+
+vi.mock('../components/workspace/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../components/workspace/api')>()
+  return {
+    ...actual,
+    listAgentCredentials: mocks.listAgentCredentials,
+    getAgentRuntimeReadiness: mocks.getAgentRuntimeReadiness,
+    detectWorkspaceCredential: vi.fn(),
+    getAgentReadiness: vi.fn(),
+  }
+})
+
+vi.mock('../api/config', () => ({
+  configApi: {
+    getPresets: mocks.getPresets,
+    getWorkspaceCredentialDefaults: mocks.getWorkspaceCredentialDefaults,
+  },
+}))
+
+vi.mock('../api/preferences', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/preferences')>()
+  return {
+    ...actual,
+    preferencesApi: {
+      ...actual.preferencesApi,
+      rememberQuickChatLaunch: mocks.rememberQuickChatLaunch,
+      getQuickChat: vi.fn(),
+    },
+  }
+})
+
+const codex: AgentInfo = {
+  id: 'codex',
+  displayName: 'Codex',
+  kind: 'agent',
+  installed: true,
+  capabilities: {
+    parallelPerCwd: true,
+    resumeLast: true,
+    resumeById: true,
+    transcriptDiscovery: 'subprocess',
+    aiProvider: {
+      credentialSource: 'runtime-or-workspace',
+      wirePreference: ['openai-responses'],
+    },
+  },
+}
+
+const initial = pinnedLaunchFromBinding('codex', {
+  credentialSource: 'native',
+  model: 'gpt-5.6-sol',
+  reasoningEffort: 'high',
+})
+
+beforeEach(() => {
+  mocks.listAgentCredentials.mockResolvedValue([{
+    slug: 'openrouter-1',
+    vendor: 'openrouter',
+    label: 'OpenRouter',
+    authType: 'api-key',
+    resolvedModel: 'openai/gpt-5.4',
+  }])
+  mocks.getAgentRuntimeReadiness.mockResolvedValue({
+    checkedAt: '2026-08-17T00:00:00.000Z',
+    overallReady: true,
+    agents: {
+      codex: {
+        agent: 'codex',
+        displayName: 'Codex',
+        installed: true,
+        binPath: null,
+        status: 'ready',
+        ready: true,
+        source: 'global-login',
+        checkedAt: '2026-08-17T00:00:00.000Z',
+        durationMs: 1,
+        message: 'ready',
+      },
+    },
+  })
+  mocks.getPresets.mockResolvedValue({ presets: [] })
+  mocks.getWorkspaceCredentialDefaults.mockResolvedValue({ defaults: {} })
+  mocks.rememberQuickChatLaunch.mockReset()
+})
+
+describe('pinned launch helpers', () => {
+  it('maps a vault binding to a native-or-vault launch and back', () => {
+    const launch = pinnedLaunchFromBinding('codex', {
+      credentialSource: 'vault',
+      credentialSlug: 'openrouter-1',
+      model: 'openrouter/new-model',
+      reasoningEffort: 'low',
+    })
+    expect(launch).toEqual({
+      agent: 'codex',
+      accessMode: 'vault',
+      credentialSlug: 'openrouter-1',
+      model: 'openrouter/new-model',
+      reasoningEffort: 'low',
+    })
+    expect(pinnedLaunchToRuntimeUpdate(launch)).toEqual({
+      credentialSource: 'vault',
+      credentialSlug: 'openrouter-1',
+      model: 'openrouter/new-model',
+      reasoningEffort: 'low',
+    })
+    expect(pinnedLaunchEquals(launch, { ...launch })).toBe(true)
+    expect(formatPinnedCapability({
+      access: 'OpenRouter',
+      model: 'openrouter/new-model',
+      effort: 'low',
+    })).toBe('OpenRouter · openrouter/new-model · low')
+  })
+
+  it('treats a missing vault slug as native', () => {
+    expect(pinnedLaunchFromBinding('pi', { credentialSource: 'vault' })).toEqual({
+      agent: 'pi',
+      accessMode: 'native',
+      credentialSlug: null,
+      model: null,
+      reasoningEffort: null,
+    })
+  })
+})
+
+describe('usePinnedRuntimeDraft', () => {
+  it('keeps custom model ids in the local draft and never remembers launch recents', async () => {
+    const { result } = renderHook(() => usePinnedRuntimeDraft({
+      workspaceId: 'ws-1',
+      agent: 'codex',
+      agents: [codex],
+      initial,
+    }))
+
+    await waitFor(() => expect(result.current.config.credentialSelectionReady).toBe(true))
+    expect(result.current.dirty).toBe(false)
+    expect(result.current.toRuntimeUpdate()).toEqual({
+      credentialSource: 'native',
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'high',
+    })
+
+    act(() => {
+      result.current.config.selectModel('openrouter/some-new-id')
+    })
+
+    await waitFor(() => expect(result.current.dirty).toBe(true))
+    expect(result.current.toRuntimeUpdate()).toEqual({
+      credentialSource: 'native',
+      model: 'openrouter/some-new-id',
+      reasoningEffort: null,
+    })
+    expect(result.current.formatCapability({
+      access: 'Runtime managed',
+      model: 'runtime',
+      effort: 'runtime',
+    })).toContain('openrouter/some-new-id')
+    expect(mocks.rememberQuickChatLaunch).not.toHaveBeenCalled()
+  })
+
+  it('resets to the persisted binding when the editor becomes active again', async () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => usePinnedRuntimeDraft({
+        workspaceId: 'ws-1',
+        agent: 'codex',
+        agents: [codex],
+        initial,
+        active,
+      }),
+      { initialProps: { active: true } },
+    )
+
+    await waitFor(() => expect(result.current.config.credentialSelectionReady).toBe(true))
+    act(() => {
+      result.current.config.selectReasoningEffort('low')
+    })
+    await waitFor(() => expect(result.current.dirty).toBe(true))
+
+    rerender({ active: false })
+    rerender({ active: true })
+    await waitFor(() => expect(result.current.dirty).toBe(false))
+    expect(result.current.toRuntimeUpdate().reasoningEffort).toBe('high')
+  })
+})

--- a/ui/src/hooks/usePinnedRuntimeDraft.ts
+++ b/ui/src/hooks/usePinnedRuntimeDraft.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import type { QuickChatLaunchPreference } from '../api/preferences'
+import { credentialAccessLabel } from '../components/workspace/AgentLaunchControls'
+import type {
+  AgentInfo,
+  PausedSessionRuntimeUpdate,
+} from '../components/workspace/api'
+import {
+  useAgentLaunchConfig,
+  type AgentLaunchConfigState,
+  type AgentLaunchPreferencesState,
+} from './useAgentLaunchConfig'
+
+const PINNED_PROVIDER = {
+  credentialSource: 'runtime-or-workspace' as const,
+  wirePreference: [] as const,
+}
+
+export interface PinnedRuntimeBinding {
+  readonly credentialSource?: 'native' | 'vault' | 'workspace'
+  readonly credentialSlug?: string | null
+  readonly model?: string | null
+  readonly reasoningEffort?: QuickChatLaunchPreference['reasoningEffort']
+}
+
+export interface UsePinnedRuntimeDraftOptions {
+  readonly workspaceId: string
+  readonly agent: string
+  readonly agents: readonly AgentInfo[]
+  readonly initial: QuickChatLaunchPreference
+  /** Reset the local draft when the editor becomes active or the persisted binding changes. */
+  readonly active?: boolean
+}
+
+export interface PinnedRuntimeCapability {
+  readonly access: string
+  readonly model: string
+  readonly effort: string
+}
+
+export interface PinnedRuntimeDraft {
+  readonly config: AgentLaunchConfigState
+  readonly draft: QuickChatLaunchPreference
+  readonly initial: QuickChatLaunchPreference
+  readonly dirty: boolean
+  toRuntimeUpdate(): PausedSessionRuntimeUpdate
+  capability(fallback: { access: string; model: string; effort: string }): PinnedRuntimeCapability
+  formatCapability(fallback: { access: string; model: string; effort: string }): string
+}
+
+export function pinnedLaunchEquals(
+  a: QuickChatLaunchPreference,
+  b: QuickChatLaunchPreference,
+): boolean {
+  return (a.accessMode ?? 'native') === (b.accessMode ?? 'native')
+    && (a.credentialSlug ?? null) === (b.credentialSlug ?? null)
+    && (a.model ?? null) === (b.model ?? null)
+    && (a.reasoningEffort ?? null) === (b.reasoningEffort ?? null)
+}
+
+export function pinnedLaunchFromBinding(
+  agent: string,
+  binding: PinnedRuntimeBinding | null | undefined,
+): QuickChatLaunchPreference {
+  const vault = binding?.credentialSource === 'vault' && Boolean(binding.credentialSlug)
+  return {
+    agent,
+    accessMode: vault ? 'vault' : 'native',
+    credentialSlug: vault ? binding?.credentialSlug ?? null : null,
+    model: binding?.model ?? null,
+    reasoningEffort: binding?.reasoningEffort ?? null,
+  }
+}
+
+export function pinnedLaunchToRuntimeUpdate(
+  launch: QuickChatLaunchPreference,
+): PausedSessionRuntimeUpdate {
+  const vault = launch.accessMode === 'vault' && Boolean(launch.credentialSlug)
+  return {
+    credentialSource: vault ? 'vault' : 'native',
+    ...(vault ? { credentialSlug: launch.credentialSlug } : {}),
+    model: launch.model ?? null,
+    reasoningEffort: launch.reasoningEffort ?? null,
+  }
+}
+
+export function formatPinnedCapability(parts: PinnedRuntimeCapability): string {
+  return `${parts.access} · ${parts.model} · ${parts.effort}`
+}
+
+function pinAgent(agents: readonly AgentInfo[], agentId: string): AgentInfo[] {
+  const found = agents.filter((agent) => agent.id === agentId)
+  if (found.length > 0) {
+    return found.map((agent) => (
+      agent.capabilities.aiProvider
+        ? agent
+        : {
+            ...agent,
+            capabilities: {
+              ...agent.capabilities,
+              aiProvider: PINNED_PROVIDER,
+            },
+          }
+    ))
+  }
+  return [{
+    id: agentId,
+    displayName: agentId,
+    kind: 'agent',
+    capabilities: {
+      parallelPerCwd: true,
+      resumeLast: true,
+      resumeById: true,
+      transcriptDiscovery: 'none',
+      aiProvider: PINNED_PROVIDER,
+    },
+  }]
+}
+
+function capabilityFromConfig(
+  config: AgentLaunchConfigState,
+  fallback: PinnedRuntimeCapability,
+): PinnedRuntimeCapability {
+  const vault = config.accessMode === 'vault' && Boolean(config.launchCredentialSlug)
+  return {
+    access: vault
+      ? credentialAccessLabel(config.credential)
+        || config.launchCredentialSlug
+        || fallback.access
+      : fallback.access,
+    model: config.launchModel ?? config.defaultModel ?? fallback.model,
+    effort: config.launchReasoningEffort ?? fallback.effort,
+  }
+}
+
+/**
+ * Local cred/model/effort draft for an already-chosen Agent runtime.
+ * Used by Session Settings, the Issue AI editor, and Workspace preference
+ * editors. Never writes installation or Workspace launch recents.
+ */
+export function usePinnedRuntimeDraft({
+  workspaceId,
+  agent,
+  agents,
+  initial,
+  active = true,
+}: UsePinnedRuntimeDraftOptions): PinnedRuntimeDraft {
+  const initialKey = JSON.stringify(initial)
+  const [draft, setDraft] = useState(initial)
+
+  useEffect(() => {
+    if (!active) return
+    setDraft(initial)
+    // Persist identity is the serialized launch, not object identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, initialKey])
+
+  const rememberLaunch = useCallback(async (launch: QuickChatLaunchPreference) => {
+    setDraft({
+      ...launch,
+      accessMode: launch.accessMode === 'vault' ? 'vault' : 'native',
+    })
+  }, [])
+
+  const preferences = useMemo<AgentLaunchPreferencesState>(() => ({
+    lastCredentialByAgent: draft.credentialSlug ? { [agent]: draft.credentialSlug } : {},
+    recentChatWorkspaceId: workspaceId,
+    recentLaunch: draft,
+    loaded: true,
+    rememberLaunch,
+    adoptRecentChatWorkspace: () => undefined,
+  }), [agent, draft, rememberLaunch, workspaceId])
+
+  const pinnedAgents = useMemo(() => pinAgent(agents, agent), [agent, agents])
+  const config = useAgentLaunchConfig({
+    agents: pinnedAgents,
+    defaultAgent: agent,
+    preferences,
+    workspaceId,
+    hasWorkspace: true,
+    managedWorkspaceLaunch: true,
+  })
+
+  const toRuntimeUpdate = useCallback(
+    () => pinnedLaunchToRuntimeUpdate(draft),
+    [draft],
+  )
+
+  const capability = useCallback((fallback: PinnedRuntimeCapability) => (
+    capabilityFromConfig(config, fallback)
+  ), [config])
+
+  const formatCapability = useCallback((fallback: PinnedRuntimeCapability) => (
+    formatPinnedCapability(capabilityFromConfig(config, fallback))
+  ), [config])
+
+  return {
+    config,
+    draft,
+    initial,
+    dirty: !pinnedLaunchEquals(draft, initial),
+    toRuntimeUpdate,
+    capability,
+    formatCapability,
+  }
+}


### PR DESCRIPTION
## Summary

Issue AI configuration after a Session bind (and the same cred/model/effort editors elsewhere) no longer keep a second frontend. A typed custom model id works again, including OpenRouter models that are not in the preset catalog.

- Add `usePinnedRuntimeDraft` for a frozen-agent native|vault draft. It never writes install/Workspace launch recents.
- Issue AI dialog, Session Settings, and Workspace preference rows all render `AgentLaunchSelectors` (settings + toolbar), including the existing **Custom model…** dialog.
- Bound Issue apply still confirms “from XX to XX” and `PUT /resumes/:resumeId/runtime`. Agent stays frozen. Unbound inherit stays Issue-owned chrome, not launch `auto`.
- Persist APIs are unchanged.

## Design

Rejected a one-off repair of Issue `ModelEditor` (custom input was buried and broken when the current value was already a catalog id) and rejected growing `useAgentLaunchConfig` with a binding mode. The launch hook stays the resolver; the new hook names the local-draft pattern Session Settings and Workspace preferences already copied.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 548 files, 4621 tests
- Demo browser: bound `thesis-watch` typed `openrouter/some-new-id`, confirmed from/to, summary updated. Unbound `weekly-digest` still has inherit; unchecking it shows the access picker. Mobile 390×844 dialog stacks the shared rows.

## Delivery

Serial increment to `dev`. Please do not merge until you have looked at it.