### PR TITLE
Show exact Trading as Git order terms

### DIFF
--- a/default/skills/alice-uta/SKILL.md
+++ b/default/skills/alice-uta/SKILL.md
@@ -103,6 +103,18 @@ alice-uta git reject --help            # reject a staged change
 alice-uta git sync --help              # reconcile against the venue
 ```
 
+Shells expand `$` inside double-quoted values. For any trading thesis that
+contains currency, either use single quotes or the generated file-backed flag:
+
+```bash
+alice-uta order place ... --commit-message 'Buy below $971 after support confirmation'
+alice-uta order place ... --commit-message-file /path/to/thesis.txt
+```
+
+Never put a dollar-denominated thesis in a double-quoted `--commit-message`;
+`"$971"` can reach OpenAlice as `"71"`. File-backed string flags accept `-` to
+read stdin when the exact value is already available as a stream.
+
 ## Market clock & simulator
 
 ```bash

--- a/packages/uta-protocol/src/types/git.ts
+++ b/packages/uta-protocol/src/types/git.ts
@@ -143,6 +143,18 @@ export interface OperationSummary {
   action: OperationAction
   change: string
   status: OperationStatus
+  /** Structured order terms for review surfaces. Kept alongside `change` so
+   * text-only CLI consumers remain useful while UI clients can render exact
+   * price, size, and time-in-force without fetching the full commit. */
+  order?: {
+    side?: string
+    orderType?: string
+    totalQuantity?: string
+    cashQuantity?: string
+    limitPrice?: string
+    auxPrice?: string
+    timeInForce?: string
+  }
 }
 
 export interface CommitLogEntry {

--- a/services/uta/src/domain/trading/git/TradingGit.spec.ts
+++ b/services/uta/src/domain/trading/git/TradingGit.spec.ts
@@ -382,6 +382,29 @@ describe('TradingGit', () => {
       expect(entries[0].operations[0].symbol).toBe('AAPL')
       expect(entries[0].operations[0].action).toBe('placeOrder')
     })
+
+    it('keeps limit-order review terms in structured and text summaries', async () => {
+      const operation = buyOp('MU')
+      if (operation.action !== 'placeOrder') throw new Error('expected placeOrder')
+      operation.order.orderType = 'LMT'
+      operation.order.lmtPrice = new Decimal('971')
+      operation.order.tif = 'GTC'
+      git.add(operation)
+      git.commit('MU entry')
+      await git.push()
+
+      const [entry] = git.log()
+      expect(entry.operations[0].change).toBe('BUY 10 LMT @971 GTC (submitted)')
+      expect(entry.operations[0].order).toEqual({
+        side: 'BUY',
+        orderType: 'LMT',
+        totalQuantity: '10',
+        cashQuantity: undefined,
+        limitPrice: '971',
+        auxPrice: undefined,
+        timeInForce: 'GTC',
+      })
+    })
   })
 
   // ==================== show ====================

--- a/services/uta/src/domain/trading/git/TradingGit.ts
+++ b/services/uta/src/domain/trading/git/TradingGit.ts
@@ -368,6 +368,17 @@ export class TradingGit implements ITradingGit {
         action: op.action,
         change: this.formatOperationChange(op, result),
         status: result?.status || 'rejected',
+        ...(op.action === 'placeOrder' ? {
+          order: {
+            side: op.order?.action,
+            orderType: op.order?.orderType,
+            totalQuantity: this.formatOptionalDecimal(op.order?.totalQuantity),
+            cashQuantity: this.formatOptionalDecimal(op.order?.cashQty),
+            limitPrice: this.formatOptionalDecimal(op.order?.lmtPrice),
+            auxPrice: this.formatOptionalDecimal(op.order?.auxPrice),
+            timeInForce: op.order?.tif,
+          },
+        } : {}),
       })
     }
 
@@ -383,15 +394,22 @@ export class TradingGit implements ITradingGit {
         const hasQty = qty && !qty.equals(UNSET_DECIMAL)
         const hasCash = cashQty && !cashQty.equals(UNSET_DECIMAL) && cashQty.gt(0)
         const sizeStr = hasCash ? `$${cashQty.toFixed()}` : hasQty ? `${qty.toFixed()}` : '?'
+        const terms = [
+          op.order?.orderType,
+          this.formatOptionalDecimal(op.order?.lmtPrice, '@'),
+          this.formatOptionalDecimal(op.order?.auxPrice, 'stop @'),
+          op.order?.tif,
+        ].filter(Boolean).join(' ')
+        const orderSummary = `${side} ${sizeStr}${terms ? ` ${terms}` : ''}`
 
         if (result?.status === 'user-rejected') {
-          return `${side} ${sizeStr} (user-rejected)`
+          return `${orderSummary} (user-rejected)`
         }
         if (result?.status === 'filled') {
-          const price = result.execution?.price ? ` @${result.execution.price}` : ''
-          return `${side} ${sizeStr}${price}`
+          const price = result.execution?.price ? ` → filled @${result.execution.price}` : ' (filled)'
+          return `${orderSummary}${price}`
         }
-        return `${side} ${sizeStr} (${result?.status || 'unknown'})`
+        return `${orderSummary} (${result?.status || 'unknown'})`
       }
 
       case 'closePosition': {
@@ -436,6 +454,11 @@ export class TradingGit implements ITradingGit {
         return `${direction} ${delta.abs().toFixed()} @${op.markPrice}`
       }
     }
+  }
+
+  private formatOptionalDecimal(value: Decimal | undefined, prefix = ''): string | undefined {
+    if (!value || value.equals(UNSET_DECIMAL)) return undefined
+    return `${prefix}${value.toFixed()}`
   }
 
   show(hash: CommitHash): GitCommit | null {

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -91,7 +91,7 @@ async function main() {
   if (wantsHelp) return printVerbHelp(group, verb, cmd)
 
   // Run it.
-  const args = parseFlags(argv.slice(argv.indexOf(verb) + 1), cmd.schema, { group, verb })
+  const args = await parseFlags(argv.slice(argv.indexOf(verb) + 1), cmd.schema, { group, verb })
   const res = await invoke(base, cmd.tool, args)
   process.stdout.write(res.endsWith('\n') ? res : res + '\n')
 }
@@ -200,7 +200,7 @@ async function fetchSocketJson(socketPath, path, opts) {
 
 // ---- flag parsing ---------------------------------------------------------
 
-function parseFlags(tokens, schema, command) {
+async function parseFlags(tokens, schema, command) {
   const args = {}
   const meta = {}
   const docs = []
@@ -239,11 +239,21 @@ function parseFlags(tokens, schema, command) {
     // Preserve an exact schema key first (some data tools intentionally use
     // hyphenated keys), then normalize only when the camelCase key exists.
     const camelKey = key.replace(/-([a-zA-Z0-9])/g, (_, ch) => ch.toUpperCase())
-    const schemaKey = Object.prototype.hasOwnProperty.call(properties, key)
+    const directSchemaKey = Object.prototype.hasOwnProperty.call(properties, key)
       ? key
       : Object.prototype.hasOwnProperty.call(properties, camelKey)
         ? camelKey
         : key
+    // A file-backed string flag avoids the caller shell interpreting values
+    // such as "$971" before this process receives them. Every string option
+    // automatically gains `--<name>-file <path>`; `-` reads stdin.
+    const fileBaseKey = key.endsWith('-file') ? key.slice(0, -5) : ''
+    const fileBaseCamelKey = fileBaseKey.replace(/-([a-zA-Z0-9])/g, (_, ch) => ch.toUpperCase())
+    const fileSchemaKey = !Object.prototype.hasOwnProperty.call(properties, directSchemaKey) &&
+      fileBaseKey && properties[fileBaseCamelKey]?.type === 'string'
+      ? fileBaseCamelKey
+      : null
+    const schemaKey = fileSchemaKey || directSchemaKey
     const propertySchema = properties[schemaKey]
     const supportedAlias =
       (schemaKey === 'meta' && Object.prototype.hasOwnProperty.call(properties, 'metadataFilter')) ||
@@ -260,7 +270,14 @@ function parseFlags(tokens, schema, command) {
           `Run \`${BIN} ${command.group} ${command.verb} --help\` before retrying.`,
       )
     }
-    if (propertySchema && propertySchema.type === 'boolean' && typeof val === 'string') {
+    if (fileSchemaKey) {
+      const { readFileSync } = await import('node:fs')
+      try {
+        val = readFileSync(val === '-' ? 0 : String(val), 'utf8').replace(/\r?\n$/, '')
+      } catch (error) {
+        fail(`cannot read --${key} value from "${val}": ${error && error.message ? error.message : String(error)}`)
+      }
+    } else if (propertySchema && propertySchema.type === 'boolean' && typeof val === 'string') {
       if (val === 'true') val = true
       else if (val === 'false') val = false
     }
@@ -339,6 +356,9 @@ function printVerbHelp(group, verb, cmd) {
         : ''
     const repeatable = type === 'array' ? ' (repeatable)' : ''
     out(`  --${flag}${valueHint}${req}${repeatable}   ${firstLine(p.description || '')}`)
+    if (type === 'string') {
+      out(`  --${flag}-file <path>   Read the exact value from a file (use - for stdin; avoids shell interpolation).`)
+    }
   }
 }
 

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -360,6 +360,67 @@ describe('CLI launchers and payload', () => {
         stderr: expect.stringContaining('unexpected positional argument "alpaca-paper"'),
       })
       expect(invocations).toBe(0)
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads string values from files without shell interpolation', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'openalice-cli-shim-string-file-'))
+    const socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\openalice-cli-shim-string-file-${process.pid}-${Date.now()}`
+      : join(dir, 'tools.sock')
+    const messagePath = join(dir, 'message.txt')
+    await writeFile(messagePath, 'Buy MU below $971 after support confirmation\n')
+    let invocation: { tool?: string; args?: Record<string, unknown> } | null = null
+    const server = createServer((req, res) => {
+      if (req.method === 'POST') {
+        const chunks: Buffer[] = []
+        req.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+        req.on('end', () => {
+          invocation = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ content: [{ type: 'text', text: '{"ok":true}' }] }))
+        })
+        return
+      }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        description: 'UTA test manifest',
+        groups: {
+          order: {
+            place: {
+              tool: 'placeOrder',
+              description: 'Place an order',
+              schema: {
+                type: 'object',
+                properties: { commitMessage: { type: 'string', description: 'Trading thesis' } },
+              },
+            },
+          },
+        },
+      }))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, resolve)
+    })
+    const env = {
+      ...process.env,
+      AQ_WS_ID: 'ws1',
+      OPENALICE_TOOL_SOCKET: socketPath,
+      OPENALICE_TOOL_URL: '/cli',
+    }
+    try {
+      const help = await runCli('alice-uta', ['order', 'place', '--help'], env)
+      expect(help.stdout).toContain('--commit-message-file <path>')
+
+      await runCli('alice-uta', ['order', 'place', '--commit-message-file', messagePath], env)
+      expect(invocation).toEqual({
+        tool: 'placeOrder',
+        args: { commitMessage: 'Buy MU below $971 after support confirmation' },
+      })
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()))
       await rm(dir, { recursive: true, force: true })

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -368,7 +368,21 @@ export interface Position {
 export interface WalletCommitLog {
   hash: string
   message: string
-  operations: Array<{ symbol: string; action: string; change: string; status: string }>
+  operations: Array<{
+    symbol: string
+    action: string
+    change: string
+    status: string
+    order?: {
+      side?: string
+      orderType?: string
+      totalQuantity?: string
+      cashQuantity?: string
+      limitPrice?: string
+      auxPrice?: string
+      timeInForce?: string
+    }
+  }>
   timestamp: string
   round?: number
 }

--- a/ui/src/components/PushApprovalPanel.spec.tsx
+++ b/ui/src/components/PushApprovalPanel.spec.tsx
@@ -184,6 +184,37 @@ describe('PushApprovalPanel localization', () => {
     expect(mocks.walletPush).not.toHaveBeenCalled()
   })
 
+  it('shows exact order terms for pushed Trading as Git commits', async () => {
+    mocks.walletLog.mockResolvedValue({
+      commits: [{
+        hash: '8ecf74c612345678',
+        message: 'MU tactical swing long',
+        timestamp: '2026-08-17T08:00:00.000Z',
+        operations: [{
+          symbol: 'MU',
+          action: 'placeOrder',
+          change: 'BUY 10 LMT @971 GTC (submitted)',
+          status: 'submitted',
+          order: {
+            side: 'BUY',
+            orderType: 'LMT',
+            totalQuantity: '10',
+            limitPrice: '971',
+            timeInForce: 'GTC',
+          },
+        }],
+      }],
+    })
+
+    render(<PushApprovalPanel />)
+
+    fireEvent.click(await screen.findByText('买入 MU · 10 · @ 971'))
+    expect(await screen.findByText('MU tactical swing long')).toBeTruthy()
+    expect(await screen.findByText('买入 MU')).toBeTruthy()
+    expect(screen.getByText('LMT · 数量 10 · 限价 971 · GTC')).toBeTruthy()
+    expect(screen.getByText('已提交')).toBeTruthy()
+  })
+
   it('uses a queue-to-detail drill-in on narrow layouts while preserving the desktop split view', async () => {
     mocks.walletStatus.mockResolvedValue({
       staged: [{

--- a/ui/src/components/PushApprovalPanel.tsx
+++ b/ui/src/components/PushApprovalPanel.tsx
@@ -170,7 +170,7 @@ function operationDisplay(op: WalletOperation, t: TFunction): OperationDisplay {
   }
 }
 
-function historyOperationDisplay(op: WalletCommitLog['operations'][number]): OperationDisplay {
+function historyOperationDisplay(op: WalletCommitLog['operations'][number], t: TFunction): OperationDisplay {
   const action = op.action.toUpperCase()
   const marker: OperationDisplay['marker'] =
     action.includes('BUY') || action.includes('PLACE') ? '+'
@@ -181,6 +181,33 @@ function historyOperationDisplay(op: WalletCommitLog['operations'][number]): Ope
       : marker === '+' ? 'buy'
         : marker === '-' ? 'sell'
           : 'modify'
+  if (op.order) {
+    const sideRaw = (op.order.side || '').toUpperCase()
+    const side = sideRaw === 'BUY'
+      ? t('tradingReview.operation.buy')
+      : sideRaw === 'SELL'
+        ? t('tradingReview.operation.sell')
+        : sideRaw || t('tradingReview.operation.order')
+    const quantity = op.order.totalQuantity || op.order.cashQuantity
+    const detailParts = [
+      orderTypeLabel(op.order.orderType, t),
+      quantity ? t('tradingReview.operation.quantityShort', { value: quantity }) : null,
+      op.order.limitPrice ? t('tradingReview.operation.limitPrice', { value: op.order.limitPrice }) : null,
+      op.order.auxPrice ? t('tradingReview.operation.auxPrice', { value: op.order.auxPrice }) : null,
+      op.order.timeInForce,
+    ].filter(Boolean)
+    return {
+      marker,
+      tone,
+      title: t('tradingReview.operation.placeTitle', {
+        side,
+        symbol: op.symbol !== 'unknown' ? op.symbol : t('tradingReview.operation.unknown'),
+      }),
+      detail: detailParts.join(' · '),
+      symbol: op.symbol,
+      status: op.status,
+    }
+  }
   return {
     marker,
     tone,
@@ -230,6 +257,14 @@ function itemTimestamp(item: ReviewItem): string | null {
 function itemTitle(item: ReviewItem, t: TFunction): string {
   if (item.kind === 'pending') return item.status.pendingMessage || t('tradingReview.pendingPush')
   if (item.kind === 'staged') return t('tradingReview.stagedOperations')
+  const primaryOrder = item.commit.operations.find((operation) => operation.order)
+  if (primaryOrder?.order) {
+    const operation = historyOperationDisplay(primaryOrder, t)
+    const quantity = primaryOrder.order.totalQuantity
+      || (primaryOrder.order.cashQuantity ? `$${primaryOrder.order.cashQuantity}` : '')
+    const price = primaryOrder.order.limitPrice ? `@ ${primaryOrder.order.limitPrice}` : ''
+    return [operation.title, quantity, price].filter(Boolean).join(' · ')
+  }
   return item.commit.message
 }
 
@@ -239,7 +274,7 @@ function itemAccountLabel(item: ReviewItem): string {
 }
 
 function itemOperations(item: ReviewItem, t: TFunction): OperationDisplay[] {
-  if (item.kind === 'history') return item.commit.operations.map(historyOperationDisplay)
+  if (item.kind === 'history') return item.commit.operations.map((operation) => historyOperationDisplay(operation, t))
   return item.status.staged.map((operation) => operationDisplay(operation, t))
 }
 
@@ -860,6 +895,11 @@ function ReviewDetail({
                   )}
                 </div>
                 <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+                {item.kind === 'history' && title !== item.commit.message && (
+                  <p className="mt-1.5 max-w-3xl text-[12px] leading-relaxed text-muted-foreground">
+                    {item.commit.message}
+                  </p>
+                )}
                 <div className="mt-1 text-[12px] text-muted-foreground">
                   {item.kind === 'history'
                     ? t('tradingReview.pushedAgo', { time: formatRelativeTime(item.commit.timestamp) })


### PR DESCRIPTION
## What changed

- preserve structured order side, type, quantity, prices, and time-in-force in Trading as Git history summaries
- render exact order terms as the primary review title and operation detail while retaining the original commit message as a secondary note
- add generic `--<string-flag>-file` CLI inputs so values such as `$971` can bypass shell interpolation
- document the safe Trading as Git commit-message path and cover it with regression tests

## Root cause

The order itself was a submitted MU limit buy at 971. The shell expanded `$9` in a double-quoted commit message before `alice-uta` received it, leaving `71.00`. Trading as Git then rendered only that lossy free-form message and omitted the structured order terms that still existed in the operation.

## Impact

Trading review now shows the broker-relevant facts directly (`BUY MU · 10 · @ 971`, `LMT`, `GTC`, status). Agents can pass exact free-form CLI strings from a file or stdin when shell expansion would be unsafe. Historical commit messages remain unchanged.

## Verification

- `npx tsc --noEmit`
- `pnpm -C ui exec tsc -b`
- `pnpm test` (4619 passed, 9 skipped)
- real `/trading-as-git` route verified against the existing MU paper order
- no broker write was performed