### PR TITLE
feat(autoquant): default new workspaces to v0.9.31

### DIFF
--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.4
+version: 1.1.5
 ---
 
 # AutoQuant
@@ -20,8 +20,8 @@ conversation, Inbox, market-data tools, and optional UTA access around the
 desk. It does not reproduce AutoQuant's Project, Study, Session, Run, Report,
 or Dossier lifecycle.
 
-The default supported source is AutoQuant V2 `v0.8.31` at commit
-`426d815b18450172fbcf4c6b6af77c6ae05a4967`. The exact upstream source is
+The default supported source is AutoQuant V2 `v0.9.31` at commit
+`adc6363a7af5a9105811735973d4d5cfac58cf36`. The exact upstream source is
 recorded in `.alice/harness-source.json`; the Workspace itself starts a fresh
 research branch at that commit while retaining AutoQuant's upstream history and
 `origin` remote for later Coding Agent-managed fetches and merges.

--- a/src/workspaces/templates/auto-quant-v2/template.json
+++ b/src/workspaces/templates/auto-quant-v2/template.json
@@ -8,8 +8,12 @@
   "bundledSkills": [],
   "source": {
     "repository": "https://github.com/TraderAlice/Auto-Quant-V2.git",
-    "defaultVersion": "v0.8.31",
+    "defaultVersion": "v0.9.31",
     "versions": [
+      {
+        "version": "v0.9.31",
+        "commit": "adc6363a7af5a9105811735973d4d5cfac58cf36"
+      },
       {
         "version": "v0.8.31",
         "commit": "426d815b18450172fbcf4c6b6af77c6ae05a4967"

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -95,8 +95,9 @@ describe('resolveTemplateSource', () => {
     bundledSkills: [],
     source: {
       repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-      defaultVersion: 'v0.8.31',
+      defaultVersion: 'v0.9.31',
       versions: [
+        { version: 'v0.9.31', commit: 'adc6363a7af5a9105811735973d4d5cfac58cf36' },
         { version: 'v0.8.31', commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967' },
         { version: 'v0.8.30', commit: 'cba95f8718e8396a3147a9cc5f5275cd44feae5f' },
         { version: 'v0.8.27', commit: '4bf9eb45763776ab5fc2e02829b804594fc377a3' },
@@ -106,8 +107,8 @@ describe('resolveTemplateSource', () => {
 
   it('uses the catalog default when the caller omits a version', () => {
     expect(resolveTemplateSource(template)).toEqual({
-      version: 'v0.8.31',
-      commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
+      version: 'v0.9.31',
+      commit: 'adc6363a7af5a9105811735973d4d5cfac58cf36',
     });
   });
 

--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -225,12 +225,16 @@ export const autoQuantTemplate: TemplateInfo = {
   description: 'Agent-native quantitative research desk pinned to an approved AutoQuant V2 release.',
   groupOrder: 20,
   defaultAgents: ['codex', 'claude'],
-  version: '1.0.0',
+  version: '1.1.5',
   hasReadme: true,
   source: {
     repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-    defaultVersion: 'v0.8.31',
+    defaultVersion: 'v0.9.31',
     versions: [
+      {
+        version: 'v0.9.31',
+        commit: 'adc6363a7af5a9105811735973d4d5cfac58cf36',
+      },
       {
         version: 'v0.8.31',
         commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',

--- a/ui/src/pages/AutoQuantSetupPage.spec.tsx
+++ b/ui/src/pages/AutoQuantSetupPage.spec.tsx
@@ -32,8 +32,12 @@ const template: TemplateInfo = {
   hasReadme: true,
   source: {
     repository: 'https://github.com/TraderAlice/Auto-Quant-V2.git',
-    defaultVersion: 'v0.8.31',
+    defaultVersion: 'v0.9.31',
     versions: [
+      {
+        version: 'v0.9.31',
+        commit: 'adc6363a7af5a9105811735973d4d5cfac58cf36',
+      },
       {
         version: 'v0.8.31',
         commit: '426d815b18450172fbcf4c6b6af77c6ae05a4967',
@@ -121,7 +125,7 @@ describe('AutoQuant setup', () => {
     render(<AutoQuantSetupPage />)
 
     expect(screen.queryByPlaceholderText('Describe the strategy, market, hypothesis, or iteration goal…')).toBeNull()
-    expect(screen.getByText('v0.8.31')).toBeTruthy()
+    expect(screen.getByText('v0.9.31')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Initialize AutoQuant' }))
     await waitFor(() => expect(mocks.initializeAutoQuant).toHaveBeenCalledOnce())
   })


### PR DESCRIPTION
## Summary
- pin newly initialized AutoQuant workspaces to upstream v0.9.31 at its immutable commit
- retain the older approved versions in the source catalog
- update setup/demo fixtures and default-resolution coverage

Existing AutoQuant workspaces keep the exact source recorded in `.alice/harness-source.json`; this PR does not silently rewrite or upgrade them.

## Verification
- real upstream bootstrap at tag v0.9.31 / commit `adc6363a7af5a9105811735973d4d5cfac58cf36`
- `aq --version` → 0.9.31
- `aq project list . --json`
- `aq validate .`
- `aq orient . --json`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (548 files passed, 1 skipped; 4624 tests passed, 9 skipped)