### PR TITLE
chore(release): prepare 0.89.4-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.89.3-beta",
+  "version": "0.89.4-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.89.3-beta",
+  "version": "0.89.4-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the OpenAlice product version to `0.89.4-beta`
- keep the distributed `@traderalice/openalice-cli` version aligned
- leave feature scope unchanged; this is the isolated release-version commit

## Local verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 550 files / 4636 tests passed
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` — packaged Workspace acceptance passed

After this lands on `dev`, the release is promoted through a separate `dev → master` PR. The `master` release workflow owns tag and GitHub Release creation.