### PR TITLE
fix(connector): reconnect Telegram instead of dying on first handshake

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -209,11 +209,17 @@ run `/link`. Removing the token is a different action.
 `awaiting_link` means the adapter can already receive `/link`. Telegram does
 not report that until long polling has started (`onStart`); Discord waits for
 the gateway to become ready. Publishing Telegram's slash-command menu is
-best-effort: a failed `setMyCommands` must not block polling or Inbox delivery.
-The Connector HTTP health endpoint binds before those external calls so
-Guardian can probe a `starting` adapter instead of treating the whole service
-as missing. A failed adapter stays registered with its `lastError` rather than
-collapsing to "configured but not running."
+best-effort and happens only after polling is live: a hung or failed
+`setMyCommands` must not block `start()`, long polling, owner chat, or Inbox
+delivery. `start()` arms the adapter and returns; the Bot API session is a
+supervised loop. A hung handshake is abandoned after one attempt budget
+(default 30s) and the same adapter reconnects with backoff. That budget is
+not a process-level deadline and does not stop Connector Service. The
+Connector HTTP health endpoint binds before those external calls so Guardian
+can probe a `starting` adapter instead of treating the whole service as
+missing. A failed adapter stays registered with its `lastError` rather than
+collapsing to "configured but not running." Configuration errors such as a
+missing bot token still fail `start()` and do not reconnect.
 
 Both adapters reject commands from any account other than the linked owner.
 Use `/status` for adapter health and `/test` for an explicit delivery check.
@@ -282,7 +288,10 @@ Each probe also records a stable reason code, check timestamp, and latency. A
 failed optional-service probe must never change Alice or Inbox availability.
 An adapter in `starting` or `awaiting_link` is online and intentionally
 incomplete, so it does not degrade the service; external notification delivery
-becomes healthy only after the owner runs `/link`.
+becomes healthy only after the owner runs `/link`. A Telegram adapter that
+cannot reach the Bot API stays `starting` or `degraded` and reconnects
+inside the Connector process; Alice reports `degraded` only while the
+adapter is `degraded`.
 The contract matrix lives in `src/services/optional-carrier/health.spec.ts`;
 `integrations.spec.ts` applies it to the real UTA and Connector response shapes.
 Guardian/process smoke tests remain responsible for proving that an enabled

--- a/services/connector/src/adapters/shared.spec.ts
+++ b/services/connector/src/adapters/shared.spec.ts
@@ -4,8 +4,10 @@ import type { InboxNotification } from '@traderalice/connector-protocol'
 import {
   AdapterHealthTracker,
   decodeInboxAttachments,
+  formatAdapterError,
   formatInboxNotification,
   formatPlainInboxNotification,
+  superviseLongConnection,
 } from './shared.js'
 
 const notification: InboxNotification = {
@@ -84,6 +86,45 @@ describe('recorded Inbox payload formatting', () => {
         contentBase64: Buffer.from('x').toString('base64'),
       }],
     })).toThrow('digest mismatch')
+  })
+})
+
+describe('adapter error formatting', () => {
+  it('includes nested fetch causes so Settings can show the real network failure', () => {
+    const error = new Error("Network request for 'setMyCommands' failed!")
+    error.cause = new Error('connect ECONNREFUSED 198.18.0.130:443')
+    expect(formatAdapterError(error)).toBe(
+      "Network request for 'setMyCommands' failed! — connect ECONNREFUSED 198.18.0.130:443",
+    )
+    const tracker = new AdapterHealthTracker('telegram')
+    tracker.degraded(error)
+    expect(tracker.get().lastError).toContain('ECONNREFUSED')
+  })
+})
+
+describe('long-connection supervisor', () => {
+  it('reconnects after a dropped session and stops when asked', async () => {
+    let sessions = 0
+    let stopped = false
+    const disconnects: number[] = []
+    const failures: string[] = []
+    const loop = superviseLongConnection({
+      label: 'probe',
+      isStopped: () => stopped,
+      runSession: async () => {
+        sessions += 1
+        if (sessions === 1) throw new Error('Network request for \'getUpdates\' failed!')
+        stopped = true
+      },
+      disconnect: async () => { disconnects.push(sessions) },
+      onFailure: (error) => { failures.push(error instanceof Error ? error.message : String(error)) },
+      delay: async () => undefined,
+      reconnectDelayMs: 1,
+    })
+
+    await loop
+    expect(failures[0]).toContain('getUpdates')
+    expect(disconnects.length).toBeGreaterThanOrEqual(1)
   })
 })
 

--- a/services/connector/src/adapters/shared.ts
+++ b/services/connector/src/adapters/shared.ts
@@ -31,7 +31,7 @@ export class AdapterHealthTracker {
       ...this.value,
       status: 'degraded',
       detail: 'External connector is unavailable.',
-      lastError: error instanceof Error ? error.message : String(error),
+      lastError: formatAdapterError(error),
     }
   }
 
@@ -52,6 +52,14 @@ export class AdapterHealthTracker {
     }
   }
 
+  connecting(detail?: string): void {
+    this.value = {
+      ...this.value,
+      status: 'starting',
+      detail: detail ?? 'Connecting to the external platform.',
+    }
+  }
+
   stopped(): void {
     this.value = { ...this.value, status: 'stopped' }
   }
@@ -59,6 +67,60 @@ export class AdapterHealthTracker {
   get(): ConnectorAdapterHealth {
     return { ...this.value }
   }
+}
+
+export const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT_MS = 30_000
+export const DEFAULT_CONNECTION_RETRY_DELAY_MS = 5_000
+export const MAX_CONNECTION_RETRY_DELAY_MS = 60_000
+
+export async function superviseLongConnection(options: {
+  isStopped: () => boolean
+  runSession: () => Promise<void>
+  disconnect: () => Promise<void>
+  onFailure: (error: unknown) => void
+  delay: (ms: number) => Promise<void>
+  reconnectDelayMs?: number
+  label: string
+}): Promise<void> {
+  let failures = 0
+  const baseDelay = options.reconnectDelayMs ?? DEFAULT_CONNECTION_RETRY_DELAY_MS
+  while (!options.isStopped()) {
+    try {
+      await options.runSession()
+      if (options.isStopped()) return
+      failures = 0
+      options.onFailure(new Error(`${options.label} session ended`))
+    } catch (error) {
+      if (options.isStopped()) return
+      failures += 1
+      options.onFailure(error)
+    }
+    await options.disconnect().catch(() => undefined)
+    if (options.isStopped()) return
+    const delayMs = Math.min(baseDelay * 2 ** Math.max(0, failures - 1), MAX_CONNECTION_RETRY_DELAY_MS)
+    console.warn(`[connector] ${options.label} reconnect in ${delayMs}ms`)
+    await options.delay(delayMs)
+  }
+}
+
+export function formatAdapterError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error)
+  const parts = [error.message]
+  const nested = 'error' in error ? (error as { error?: unknown }).error : undefined
+  let current: unknown = error.cause ?? nested
+  const seen = new Set<unknown>([error])
+  while (current && !seen.has(current) && parts.length < 4) {
+    seen.add(current)
+    if (current instanceof Error) {
+      if (current.message && !parts.includes(current.message)) parts.push(current.message)
+      current = current.cause
+      continue
+    }
+    const text = String(current)
+    if (text && !parts.includes(text)) parts.push(text)
+    break
+  }
+  return parts.join(' — ')
 }
 
 export function formatInboxNotification(notification: InboxNotification): string {

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -7,6 +7,7 @@ import { TelegramConnectorAdapter, withTimeout } from './telegram.js'
 
 const startMock = vi.fn()
 const stopMock = vi.fn()
+const getMe = vi.fn(async () => ({ id: 1, is_bot: true, first_name: 'OpenAlice', username: 'openalice_bot' }))
 const setMyCommands = vi.fn(async () => undefined)
 const sendRichMessage = vi.fn(async () => undefined)
 const sendMessage = vi.fn(async () => undefined)
@@ -19,6 +20,7 @@ vi.mock('grammy', async (importOriginal) => {
     Bot: class {
       api = {
         config: { use() {} },
+        getMe,
         setMyCommands,
         sendRichMessage,
         sendMessage,
@@ -52,6 +54,16 @@ function context() {
   }
 }
 
+async function startUntilReady(
+  adapter: TelegramConnectorAdapter,
+  settings: Record<string, string>,
+): Promise<void> {
+  await adapter.start({ enabled: true, settings }, context())
+  await vi.waitFor(() => {
+    expect(['healthy', 'awaiting_link']).toContain(adapter.health().status)
+  })
+}
+
 describe('Telegram startup timeout', () => {
   it('rejects an external startup operation that does not settle in time', async () => {
     await expect(withTimeout(
@@ -70,7 +82,10 @@ describe('Telegram polling readiness', () => {
   beforeEach(() => {
     startMock.mockReset()
     stopMock.mockReset()
-    setMyCommands.mockClear()
+    getMe.mockReset()
+    getMe.mockResolvedValue({ id: 1, is_bot: true, first_name: 'OpenAlice', username: 'openalice_bot' })
+    setMyCommands.mockReset()
+    setMyCommands.mockResolvedValue(undefined)
     sendRichMessage.mockReset()
     sendMessage.mockReset()
     sendDocument.mockReset()
@@ -80,33 +95,52 @@ describe('Telegram polling readiness', () => {
     sendDocument.mockResolvedValue(undefined)
   })
 
-  it('does not claim awaiting_link until long polling has started', async () => {
+  it('returns from start while still connecting, then becomes awaiting_link', async () => {
     startMock.mockImplementation((options: { onStart?: () => void }) => {
       queueMicrotask(() => options.onStart?.())
       return new Promise(() => undefined)
     })
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
 
     const started = adapter.start({ enabled: true, settings: { botToken: 'token' } }, context())
     expect(adapter.health().status).toBe('starting')
     await started
-
-    expect(adapter.health().status).toBe('awaiting_link')
-    expect(setMyCommands).toHaveBeenCalledOnce()
+    await vi.waitFor(() => {
+      expect(adapter.health().status).toBe('awaiting_link')
+    })
+    await adapter.stop()
   })
 
-  it('still starts polling when the command menu cannot be published', async () => {
-    setMyCommands.mockRejectedValueOnce(new Error("Call to 'setMyCommands' failed! (404: Not Found)"))
+  it('does not let a hung command menu block polling or start()', async () => {
+    setMyCommands.mockImplementation(() => new Promise(() => undefined))
     startMock.mockImplementation((options: { onStart?: () => void }) => {
       queueMicrotask(() => options.onStart?.())
       return new Promise(() => undefined)
     })
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
 
     await adapter.start({ enabled: true, settings: { botToken: 'token' } }, context())
-
-    expect(adapter.health().status).toBe('awaiting_link')
+    await vi.waitFor(() => {
+      expect(adapter.health().status).toBe('awaiting_link')
+    })
     expect(startMock).toHaveBeenCalledOnce()
+    await adapter.stop()
+  })
+
+  it('still starts polling when the command menu cannot be published', async () => {
+    setMyCommands.mockRejectedValue(new Error("Call to 'setMyCommands' failed! (404: Not Found)"))
+    startMock.mockImplementation((options: { onStart?: () => void }) => {
+      queueMicrotask(() => options.onStart?.())
+      return new Promise(() => undefined)
+    })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+
+    await adapter.start({ enabled: true, settings: { botToken: 'token' } }, context())
+    await vi.waitFor(() => {
+      expect(adapter.health().status).toBe('awaiting_link')
+    })
+    expect(startMock).toHaveBeenCalledOnce()
+    await adapter.stop()
   })
 
   it('marks a linked bot healthy only after polling is ready', async () => {
@@ -114,30 +148,71 @@ describe('Telegram polling readiness', () => {
       queueMicrotask(() => options.onStart?.())
       return new Promise(() => undefined)
     })
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
 
     await adapter.start({
       enabled: true,
       settings: { botToken: 'token', ownerUserId: '42', chatId: '42' },
     }, context())
-
-    expect(adapter.health()).toMatchObject({ status: 'healthy', owner: '42' })
+    await vi.waitFor(() => {
+      expect(adapter.health()).toMatchObject({ status: 'healthy', owner: '42' })
+    })
+    await adapter.stop()
   })
 
-  it('stays degraded when polling never becomes ready', async () => {
-    startMock.mockImplementation(() => new Promise(() => undefined))
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 20 })
+  it('abandons a hung session and reconnects without failing start()', async () => {
+    let attempts = 0
+    startMock.mockImplementation((options: { onStart?: () => void }) => {
+      attempts += 1
+      if (attempts >= 2) queueMicrotask(() => options.onStart?.())
+      return new Promise(() => undefined)
+    })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 20, reconnectDelayMs: 5 })
 
-    await expect(adapter.start(
-      { enabled: true, settings: { botToken: 'token' } },
-      context(),
-    )).rejects.toThrow('Telegram polling did not become ready within 20ms')
-    expect(adapter.health().status).toBe('degraded')
-    expect(stopMock).toHaveBeenCalled()
+    await adapter.start({ enabled: true, settings: { botToken: 'token' } }, context())
+    expect(adapter.health().status).toBe('starting')
+    await vi.waitFor(() => {
+      expect(adapter.health().status).toBe('awaiting_link')
+      expect(attempts).toBeGreaterThanOrEqual(2)
+    })
+    await adapter.stop()
+  })
+
+  it('reconnects after polling drops', async () => {
+    let attempts = 0
+    startMock.mockImplementation((options: { onStart?: () => void }) => {
+      attempts += 1
+      queueMicrotask(() => options.onStart?.())
+      if (attempts === 1) return Promise.reject(new Error('Network request for \'getUpdates\' failed!'))
+      return new Promise(() => undefined)
+    })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 5 })
+
+    await adapter.start({ enabled: true, settings: { botToken: 'token' } }, context())
+    await vi.waitFor(() => {
+      expect(attempts).toBeGreaterThanOrEqual(2)
+      expect(adapter.health().status).toBe('awaiting_link')
+    })
+    await adapter.stop()
+  })
+
+  it('stops a pending reconnect', async () => {
+    startMock.mockImplementation(() => new Promise(() => undefined))
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 20, reconnectDelayMs: 50 })
+
+    await adapter.start({ enabled: true, settings: { botToken: 'token' } }, context())
+    await vi.waitFor(() => {
+      expect(startMock).toHaveBeenCalled()
+    })
+    await adapter.stop()
+    const afterStop = startMock.mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(startMock.mock.calls.length).toBe(afterStop)
+    expect(adapter.health().status).toBe('stopped')
   })
 
   it('reports validation failures instead of remaining stuck in starting', async () => {
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 20 })
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 20 })
 
     await expect(adapter.start(
       { enabled: true, settings: {} },
@@ -147,6 +222,7 @@ describe('Telegram polling readiness', () => {
       status: 'degraded',
       lastError: 'Telegram setting botToken is required',
     })
+    expect(startMock).not.toHaveBeenCalled()
   })
 })
 
@@ -154,6 +230,8 @@ describe('Telegram rich outbound text', () => {
   beforeEach(() => {
     startMock.mockReset()
     stopMock.mockReset()
+    getMe.mockReset()
+    getMe.mockResolvedValue({ id: 1, is_bot: true, first_name: 'OpenAlice', username: 'openalice_bot' })
     sendRichMessage.mockReset()
     sendMessage.mockReset()
     sendDocument.mockReset()
@@ -161,31 +239,27 @@ describe('Telegram rich outbound text', () => {
       queueMicrotask(() => options.onStart?.())
       return new Promise(() => undefined)
     })
+    stopMock.mockResolvedValue(undefined)
     sendRichMessage.mockResolvedValue(undefined)
     sendMessage.mockResolvedValue(undefined)
     sendDocument.mockResolvedValue(undefined)
   })
 
   it('projects owner comments as rich GFM', async () => {
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
-    await adapter.start({
-      enabled: true,
-      settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
-    }, context())
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
     const markdown = '**hello**\n\n- one\n- two'
 
     await adapter.sendOwnerText(markdown)
 
     expect(sendRichMessage).toHaveBeenCalledWith('99', { markdown })
     expect(sendMessage).not.toHaveBeenCalled()
+    await adapter.stop()
   })
 
   it('sends Inbox notifications as rich GFM', async () => {
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
-    await adapter.start({
-      enabled: true,
-      settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
-    }, context())
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
     const attachment = Buffer.from('# Close scan\n')
     const notification: InboxNotification = {
       id: 'inbox-1',
@@ -212,14 +286,12 @@ describe('Telegram rich outbound text', () => {
     })
     expect(sendMessage).not.toHaveBeenCalled()
     expect(sendDocument).not.toHaveBeenCalled()
+    await adapter.stop()
   })
 
   it('sends a requested file without repeating the Inbox summary', async () => {
-    const adapter = new TelegramConnectorAdapter({ startupTimeoutMs: 200 })
-    await adapter.start({
-      enabled: true,
-      settings: { botToken: 'token', ownerUserId: '42', chatId: '99' },
-    }, context())
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
     const content = Buffer.from('# Close scan\n')
 
     await adapter.deliverArtifact({
@@ -244,5 +316,6 @@ describe('Telegram rich outbound text', () => {
     )
     expect(sendRichMessage).not.toHaveBeenCalled()
     expect(sendMessage).not.toHaveBeenCalled()
+    await adapter.stop()
   })
 })

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -15,9 +15,13 @@ import type {
 } from '../core/adapter.js'
 import {
   AdapterHealthTracker,
+  DEFAULT_CONNECTION_ATTEMPT_TIMEOUT_MS,
+  DEFAULT_CONNECTION_RETRY_DELAY_MS,
   decodeConnectorAttachment,
+  formatAdapterError,
   formatInboxNotification,
   formatPlainInboxNotification,
+  superviseLongConnection,
 } from './shared.js'
 import { formatTelegramInboxMarkdownV2 } from './telegram-markdown-v2.js'
 import {
@@ -35,117 +39,80 @@ import { sendTelegramRichText } from './telegram-rich-text.js'
 export class TelegramConnectorAdapter implements ConnectorAdapter {
   readonly id = 'telegram'
   private readonly tracker = new AdapterHealthTracker(this.id)
-  private readonly startupTimeoutMs: number
+  private readonly attemptTimeoutMs: number
+  private readonly reconnectDelayMs: number
   private bot?: Bot
+  private sessionReady = false
   private ownerUserId?: string
   private chatId?: string
   private inboxPush = true
   private inboxStore?: IInboxStore
   private readonly inboxSessions = new Map<string, TelegramInboxSession>()
+  private stopped = true
+  private loop?: Promise<void>
+  private abort?: AbortController
+  private token?: string
+  private adapterContext?: ConnectorAdapterContext
 
-  constructor(options: { startupTimeoutMs?: number; inboxStore?: IInboxStore } = {}) {
-    this.startupTimeoutMs = options.startupTimeoutMs ?? 15_000
+  constructor(options: {
+    attemptTimeoutMs?: number
+    reconnectDelayMs?: number
+    startupTimeoutMs?: number
+    inboxStore?: IInboxStore
+  } = {}) {
+    this.attemptTimeoutMs = options.attemptTimeoutMs ?? options.startupTimeoutMs ?? DEFAULT_CONNECTION_ATTEMPT_TIMEOUT_MS
+    this.reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_CONNECTION_RETRY_DELAY_MS
     this.inboxStore = options.inboxStore
   }
 
   async start(config: ConnectorAdapterConfig, context: ConnectorAdapterContext): Promise<void> {
+    let token: string
     try {
-      const token = requiredString(config, 'botToken')
-      this.ownerUserId = optionalString(config, 'ownerUserId')
-      this.chatId = optionalString(config, 'chatId')
-      this.inboxPush = isInboxPushEnabled(config.settings)
-      const bot = new Bot(token)
-      this.bot = bot
-
-      bot.command('inbox', async (ctx) => {
-        if (ctx.chat.type !== 'private' || !ctx.from) return
-        await this.presentInbox(ctx, context, { stack: [], scope: 'unread' }).catch(async (error) => {
-          this.tracker.degraded(error)
-          await ctx.reply('Could not load Inbox. Check OpenAlice logs.').catch(() => undefined)
-        })
-      })
-      bot.command('settings', async (ctx) => {
-        if (ctx.chat.type !== 'private' || !ctx.from) return
-        await this.presentSettings(ctx, context).catch(async (error) => {
-          this.tracker.degraded(error)
-          await ctx.reply('Could not open settings. Check OpenAlice logs.').catch(() => undefined)
-        })
-      })
-      bot.on('callback_query:data', async (ctx) => {
-        await this.handleControl(ctx, context).catch(async (error) => {
-          this.tracker.degraded(error)
-          await ctx.answerCallbackQuery({ text: 'That control failed.' }).catch(() => undefined)
-        })
-      })
-
-      for (const command of TELEGRAM_CONNECTOR_DEFINITION.commands) {
-        if (command.name === 'inbox' || command.name === 'settings') continue
-        bot.command(command.name, async (ctx) => {
-          if (ctx.chat.type !== 'private' || !ctx.from) return
-          const handled = await context.commands.execute({
-            connectorId: this.id,
-            command: command.name,
-            userId: String(ctx.from.id),
-            chatId: String(ctx.chat.id),
-            reply: async (message) => { await ctx.reply(message) },
-          }).catch(async (error) => {
-            this.tracker.degraded(error)
-            await ctx.reply('Connector command failed. Check OpenAlice logs.').catch(() => undefined)
-            return true
-          })
-          if (!handled) await ctx.reply('Unknown connector command.')
-        })
-      }
-      this.registerCommands(context)
-      bot.on('message:text', async (ctx) => {
-        if (ctx.chat.type !== 'private' || !ctx.from) return
-        const text = ctx.message.text.trim()
-        if (!text || text.startsWith('/')) return
-        if (!this.isOwner(String(ctx.from.id))) return
-        try {
-          await context.forwardOwnerText({
-            text,
-            userId: String(ctx.from.id),
-            chatId: String(ctx.chat.id),
-          })
-        } catch (error) {
-          this.tracker.degraded(error)
-          await ctx.reply('OpenAlice could not accept this message. Check Connector Settings and logs.')
-            .catch(() => undefined)
-        }
-      })
-      // The slash-command menu is convenience. A 404/transformer failure here
-      // must not block long polling, owner chat, or Inbox delivery — users can
-      // still type the commands directly.
-      await publishTelegramCommands(bot).catch((error) => {
-        console.warn('[connector] Telegram command menu was not published:', error instanceof Error ? error.message : error)
-      })
-      await withTimeout(
-        () => waitForTelegramPolling(bot, (error) => this.tracker.degraded(error)),
-        this.startupTimeoutMs,
-        `Telegram polling did not become ready within ${this.startupTimeoutMs}ms`,
-      )
-      // Keep the optional startup menu call untransformed; install retries only
-      // after polling is live for subsequent Telegram API traffic.
-      bot.api.config.use(autoRetry())
-      if (this.ownerUserId && this.chatId) this.tracker.healthy(this.ownerUserId)
-      else this.tracker.awaitingLink()
+      token = requiredString(config, 'botToken')
     } catch (error) {
       this.tracker.degraded(error)
-      await this.bot?.stop().catch(() => undefined)
-      this.bot = undefined
       throw error
     }
+    this.ownerUserId = optionalString(config, 'ownerUserId')
+    this.chatId = optionalString(config, 'chatId')
+    this.inboxPush = isInboxPushEnabled(config.settings)
+    this.token = token
+    this.adapterContext = context
+    this.registerCommands(context)
+    this.stopped = false
+    this.abort = new AbortController()
+    this.tracker.connecting('Connecting to Telegram.')
+    this.loop = superviseLongConnection({
+      label: 'telegram',
+      isStopped: () => this.stopped,
+      runSession: () => this.runSession(),
+      disconnect: () => this.disconnectSession(),
+      onFailure: (error) => {
+        this.sessionReady = false
+        this.tracker.degraded(error)
+        console.warn('[connector] Telegram session failed:', formatAdapterError(error))
+      },
+      delay: (ms) => this.delay(ms),
+      reconnectDelayMs: this.reconnectDelayMs,
+    }).catch((error) => {
+      if (!this.stopped) {
+        this.tracker.degraded(error)
+        console.warn('[connector] Telegram supervisor stopped:', formatAdapterError(error))
+      }
+    })
   }
 
   async stop(): Promise<void> {
-    await this.bot?.stop().catch(() => undefined)
-    this.bot = undefined
+    this.stopped = true
+    this.abort?.abort()
+    await this.disconnectSession()
+    await this.loop?.catch(() => undefined)
+    this.loop = undefined
     this.tracker.stopped()
   }
 
   async deliver(notification: InboxNotification): Promise<void> {
-    if (!this.bot) throw new Error('Telegram bot is not ready')
+    if (!this.bot || !this.sessionReady) throw new Error('Telegram bot is not ready')
     if (!this.chatId) throw new Error('Telegram private chat is not linked')
     this.tracker.attempt()
     try {
@@ -164,7 +131,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   }
 
   async deliverArtifact(delivery: ConnectorArtifactDelivery): Promise<void> {
-    if (!this.bot) throw new Error('Telegram bot is not ready')
+    if (!this.bot || !this.sessionReady) throw new Error('Telegram bot is not ready')
     if (!this.chatId) throw new Error('Telegram private chat is not linked')
     this.tracker.attempt()
     try {
@@ -182,7 +149,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   }
 
   async sendOwnerText(text: string): Promise<void> {
-    if (!this.bot) throw new Error('Telegram bot is not ready')
+    if (!this.bot || !this.sessionReady) throw new Error('Telegram bot is not ready')
     if (!this.chatId) throw new Error('Telegram private chat is not linked')
     this.tracker.attempt()
     try {
@@ -196,6 +163,152 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
 
   health(): ConnectorAdapterHealth {
     return this.tracker.get()
+  }
+
+  private async runSession(): Promise<void> {
+    const token = this.token
+    const context = this.adapterContext
+    if (!token || !context) throw new Error('Telegram adapter is not armed')
+    if (this.tracker.get().status === 'degraded') this.tracker.connecting('Reconnecting to Telegram.')
+    const bot = new Bot(token)
+    this.bot = bot
+    this.sessionReady = false
+    this.attachBot(bot, context)
+
+    let ready = false
+    let resolveReady!: () => void
+    const becameReady = new Promise<void>((resolve) => { resolveReady = resolve })
+    const polling = bot.start({
+      drop_pending_updates: true,
+      onStart: () => {
+        ready = true
+        resolveReady()
+        this.sessionReady = true
+        if (this.ownerUserId && this.chatId) this.tracker.healthy(this.ownerUserId)
+        else this.tracker.awaitingLink()
+        // Menu publish is convenience only. Never put it on the session
+        // critical path: a hang or 400 must not delay getUpdates.
+        void withTimeout(
+          () => publishTelegramCommands(bot),
+          this.attemptTimeoutMs,
+          `Telegram command menu publish exceeded ${this.attemptTimeoutMs}ms`,
+        ).catch((error) => {
+          console.warn('[connector] Telegram command menu was not published:', formatAdapterError(error))
+        })
+        bot.api.config.use(autoRetry())
+      },
+    })
+
+    let attemptTimer: ReturnType<typeof setTimeout> | undefined
+    const attemptExpired = new Promise<never>((_resolve, reject) => {
+      attemptTimer = setTimeout(() => {
+        reject(new Error(`Telegram polling session did not become ready within ${this.attemptTimeoutMs}ms`))
+      }, this.attemptTimeoutMs)
+      attemptTimer.unref?.()
+    })
+    try {
+      await Promise.race([
+        becameReady,
+        polling.then(() => {
+          if (!ready) throw new Error('Telegram polling ended before it became ready')
+        }),
+        attemptExpired,
+      ])
+    } catch (error) {
+      await Promise.resolve(bot.stop()).catch(() => undefined)
+      throw error
+    } finally {
+      if (attemptTimer) clearTimeout(attemptTimer)
+    }
+    await Promise.race([polling, this.whenAborted()])
+  }
+
+  private async disconnectSession(): Promise<void> {
+    this.sessionReady = false
+    const bot = this.bot
+    this.bot = undefined
+    await Promise.resolve(bot?.stop()).catch(() => undefined)
+  }
+
+  private attachBot(bot: Bot, context: ConnectorAdapterContext): void {
+    bot.command('inbox', async (ctx) => {
+      if (ctx.chat.type !== 'private' || !ctx.from) return
+      await this.presentInbox(ctx, context, { stack: [], scope: 'unread' }).catch(async (error) => {
+        this.tracker.degraded(error)
+        await ctx.reply('Could not load Inbox. Check OpenAlice logs.').catch(() => undefined)
+      })
+    })
+    bot.command('settings', async (ctx) => {
+      if (ctx.chat.type !== 'private' || !ctx.from) return
+      await this.presentSettings(ctx, context).catch(async (error) => {
+        this.tracker.degraded(error)
+        await ctx.reply('Could not open settings. Check OpenAlice logs.').catch(() => undefined)
+      })
+    })
+    bot.on('callback_query:data', async (ctx) => {
+      await this.handleControl(ctx, context).catch(async (error) => {
+        this.tracker.degraded(error)
+        await ctx.answerCallbackQuery({ text: 'That control failed.' }).catch(() => undefined)
+      })
+    })
+
+    for (const command of TELEGRAM_CONNECTOR_DEFINITION.commands) {
+      if (command.name === 'inbox' || command.name === 'settings') continue
+      bot.command(command.name, async (ctx) => {
+        if (ctx.chat.type !== 'private' || !ctx.from) return
+        const handled = await context.commands.execute({
+          connectorId: this.id,
+          command: command.name,
+          userId: String(ctx.from.id),
+          chatId: String(ctx.chat.id),
+          reply: async (message) => { await ctx.reply(message) },
+        }).catch(async (error) => {
+          this.tracker.degraded(error)
+          await ctx.reply('Connector command failed. Check OpenAlice logs.').catch(() => undefined)
+          return true
+        })
+        if (!handled) await ctx.reply('Unknown connector command.')
+      })
+    }
+    bot.on('message:text', async (ctx) => {
+      if (ctx.chat.type !== 'private' || !ctx.from) return
+      const text = ctx.message.text.trim()
+      if (!text || text.startsWith('/')) return
+      if (!this.isOwner(String(ctx.from.id))) return
+      try {
+        await context.forwardOwnerText({
+          text,
+          userId: String(ctx.from.id),
+          chatId: String(ctx.chat.id),
+        })
+      } catch (error) {
+        this.tracker.degraded(error)
+        await ctx.reply('OpenAlice could not accept this message. Check Connector Settings and logs.')
+          .catch(() => undefined)
+      }
+    })
+  }
+
+  private whenAborted(): Promise<void> {
+    const signal = this.abort?.signal
+    if (!signal || signal.aborted) return Promise.resolve()
+    return new Promise((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    })
+  }
+
+  private async delay(ms: number): Promise<void> {
+    const signal = this.abort?.signal
+    if (signal?.aborted) return
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, ms)
+      timer.unref?.()
+      const onAbort = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      signal?.addEventListener('abort', onAbort, { once: true })
+    })
   }
 
   private registerCommands(context: ConnectorAdapterContext): void {
@@ -366,23 +479,6 @@ async function publishTelegramCommands(bot: Bot): Promise<void> {
     command: name,
     description,
   })))
-}
-
-function waitForTelegramPolling(bot: Bot, onFailure: (error: unknown) => void): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let ready = false
-    void bot.start({
-      drop_pending_updates: true,
-      onStart: () => {
-        ready = true
-        resolve()
-      },
-    }).catch((error) => {
-      console.warn('[connector] Telegram polling stopped:', error instanceof Error ? error.message : error)
-      onFailure(error)
-      if (!ready) reject(error)
-    })
-  })
 }
 
 export async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -7,7 +7,11 @@ import type {
 } from '@traderalice/connector-protocol'
 import type { ConnectorAdapter, ConnectorAdapterContext } from './adapter.js'
 import { ConnectorRegistry } from './adapter.js'
-import { DeliveryManager, MAX_INBOUND_OWNER_MESSAGES } from './delivery-manager.js'
+import {
+  DeliveryManager,
+  isTransientConnectorStartError,
+  MAX_INBOUND_OWNER_MESSAGES,
+} from './delivery-manager.js'
 import { createConnectorIOEvent, type ConnectorIOEvent, type ConnectorIORecorder } from './io-events.js'
 
 class MemoryRecorder implements ConnectorIORecorder {
@@ -146,6 +150,7 @@ describe('DeliveryManager connector registry', () => {
       registry,
       config: { version: 1, adapters: { broken: { enabled: true, settings: {} } } },
       updateAdapterSettings: async () => undefined,
+      adapterStartRetryDelayMs: 60_000,
     })
 
     await manager.start()
@@ -155,6 +160,119 @@ describe('DeliveryManager connector registry', () => {
       adapters: [{ id: 'broken', status: 'degraded', lastError: 'Telegram API did not become ready' }],
     })
     await manager.stop()
+  })
+
+  it('retries a transient adapter start failure without dropping the registration', async () => {
+    let attempts = 0
+    let status: ConnectorAdapterHealth['status'] = 'degraded'
+    const adapter: ConnectorAdapter = {
+      id: 'flaky',
+      start: async () => {
+        attempts += 1
+        if (attempts === 1) throw new Error('Telegram polling did not become ready within 15000ms')
+        status = 'healthy'
+      },
+      stop: async () => { status = 'stopped' },
+      deliver: async () => undefined,
+      sendOwnerText: async () => undefined,
+      health: () => ({ id: 'flaky', enabled: true, status }),
+    }
+    const registry = new ConnectorRegistry()
+    registry.register({
+      definition: { id: 'flaky', label: 'Flaky', description: 'Flaky adapter.', fields: [], commands: [] },
+      create: () => adapter,
+    })
+    const manager = new DeliveryManager({
+      registry,
+      config: { version: 1, adapters: { flaky: { enabled: true, settings: {} } } },
+      updateAdapterSettings: async () => undefined,
+      adapterStartRetryDelayMs: 5,
+    })
+
+    await manager.start()
+    expect(attempts).toBe(1)
+    expect(manager.health().adapters[0]?.status).toBe('degraded')
+
+    await vi.waitFor(() => {
+      expect(attempts).toBe(2)
+      expect(manager.health().adapters[0]?.status).toBe('healthy')
+    })
+    await manager.stop()
+  })
+
+  it('does not retry a configuration error', async () => {
+    let attempts = 0
+    const adapter: ConnectorAdapter = {
+      id: 'invalid',
+      start: async () => {
+        attempts += 1
+        throw new Error('Telegram setting botToken is required')
+      },
+      stop: async () => undefined,
+      deliver: async () => undefined,
+      sendOwnerText: async () => undefined,
+      health: () => ({
+        id: 'invalid',
+        enabled: true,
+        status: 'degraded',
+        lastError: 'Telegram setting botToken is required',
+      }),
+    }
+    const registry = new ConnectorRegistry()
+    registry.register({
+      definition: { id: 'invalid', label: 'Invalid', description: 'Invalid adapter.', fields: [], commands: [] },
+      create: () => adapter,
+    })
+    const manager = new DeliveryManager({
+      registry,
+      config: { version: 1, adapters: { invalid: { enabled: true, settings: {} } } },
+      updateAdapterSettings: async () => undefined,
+      adapterStartRetryDelayMs: 5,
+    })
+
+    await manager.start()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(attempts).toBe(1)
+    await manager.stop()
+  })
+
+  it('cancels a pending start retry on stop', async () => {
+    let attempts = 0
+    const adapter: ConnectorAdapter = {
+      id: 'slow-fail',
+      start: async () => {
+        attempts += 1
+        throw new Error('Network request for \'getMe\' failed!')
+      },
+      stop: async () => undefined,
+      deliver: async () => undefined,
+      sendOwnerText: async () => undefined,
+      health: () => ({ id: 'slow-fail', enabled: true, status: 'degraded' }),
+    }
+    const registry = new ConnectorRegistry()
+    registry.register({
+      definition: { id: 'slow-fail', label: 'Slow fail', description: 'Fails.', fields: [], commands: [] },
+      create: () => adapter,
+    })
+    const manager = new DeliveryManager({
+      registry,
+      config: { version: 1, adapters: { 'slow-fail': { enabled: true, settings: {} } } },
+      updateAdapterSettings: async () => undefined,
+      adapterStartRetryDelayMs: 50,
+    })
+
+    await manager.start()
+    expect(attempts).toBe(1)
+    await manager.stop()
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(attempts).toBe(1)
+  })
+
+  it('classifies Telegram polling timeouts as transient', () => {
+    expect(isTransientConnectorStartError(new Error('Telegram polling did not become ready within 15000ms'))).toBe(true)
+    expect(isTransientConnectorStartError(new Error("Network request for 'setMyCommands' failed!"))).toBe(true)
+    expect(isTransientConnectorStartError(new Error('Telegram Bot API is unreachable: Telegram Bot API did not answer getMe within 15000ms'))).toBe(true)
+    expect(isTransientConnectorStartError(new Error('Telegram setting botToken is required'))).toBe(false)
   })
 
   it('contains adapter delivery failures', async () => {

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -39,6 +39,8 @@ export interface DeliveryManagerOptions {
   updateAdapterSettings(id: string, patch: Record<string, string | number | boolean>): Promise<void>
   startedAt?: string
   recorder?: ConnectorIORecorder
+  /** First retry delay after a transient adapter start failure. Doubles each attempt up to 60s. */
+  adapterStartRetryDelayMs?: number
 }
 
 /**
@@ -47,12 +49,20 @@ export interface DeliveryManagerOptions {
  * durable notification and performs external delivery after returning.
  */
 export const MAX_INBOUND_OWNER_MESSAGES = 100
+export const DEFAULT_ADAPTER_START_RETRY_DELAY_MS = 5_000
+const MAX_ADAPTER_START_RETRY_DELAY_MS = 60_000
+
+export function isTransientConnectorStartError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /did not become ready|did not answer getme|bot api is unreachable|network request|fetch failed|econn|etimedout|enotfound|enetunreach|ehostunreach|socket disconnected|aborted delay|certificate|eai_again|socket hang up|tls connection/i.test(message)
+}
 
 export class DeliveryManager {
   private readonly adapters = new Map<string, ConnectorAdapter>()
   private readonly commands = new Map<string, CommandRegistry>()
   private readonly inbound: InboundOwnerMessage[] = []
   private readonly actions: ConnectorArtifactRequest[] = []
+  private readonly bootRetries = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly startedAt: string
   private stopped = false
 
@@ -77,7 +87,7 @@ export class DeliveryManager {
     for (const [id, config] of Object.entries(this.options.config.adapters)) {
       if (!config.enabled || !this.adapters.has(id)) continue
       await this.bootAdapter(id, config).catch((error) => {
-        console.warn(`[connector] ${id} failed to start:`, error instanceof Error ? error.message : error)
+        this.handleAdapterStartFailure(id, config, error, 0)
       })
     }
   }
@@ -304,6 +314,7 @@ export class DeliveryManager {
 
   async stop(): Promise<void> {
     this.stopped = true
+    for (const id of [...this.bootRetries.keys()]) this.clearAdapterStartRetry(id)
     await Promise.allSettled([...this.adapters.values()].map((adapter) => adapter.stop()))
     this.adapters.clear()
     this.commands.clear()
@@ -344,6 +355,42 @@ export class DeliveryManager {
     // Keep a failed adapter registered. start() may record a useful degraded
     // reason; dropping it here reduced Settings to "configured but not running".
     await adapter.start(config, context)
+  }
+
+  private handleAdapterStartFailure(
+    id: string,
+    config: ConnectorAdapterConfig,
+    error: unknown,
+    attempt: number,
+  ): void {
+    console.warn(`[connector] ${id} failed to start:`, error instanceof Error ? error.message : error)
+    if (!isTransientConnectorStartError(error)) return
+    this.scheduleAdapterStartRetry(id, config, attempt)
+  }
+
+  private scheduleAdapterStartRetry(id: string, config: ConnectorAdapterConfig, attempt: number): void {
+    if (this.stopped) return
+    this.clearAdapterStartRetry(id)
+    const base = this.options.adapterStartRetryDelayMs ?? DEFAULT_ADAPTER_START_RETRY_DELAY_MS
+    const delayMs = Math.min(base * 2 ** attempt, MAX_ADAPTER_START_RETRY_DELAY_MS)
+    console.warn(`[connector] ${id} will retry start in ${delayMs}ms`)
+    const timer = setTimeout(() => {
+      this.bootRetries.delete(id)
+      if (this.stopped) return
+      const current = this.options.config.adapters[id]
+      if (!current?.enabled) return
+      void this.bootAdapter(id, current).catch((error) => {
+        this.handleAdapterStartFailure(id, current, error, attempt + 1)
+      })
+    }, delayMs)
+    timer.unref?.()
+    this.bootRetries.set(id, timer)
+  }
+
+  private clearAdapterStartRetry(id: string): void {
+    const timer = this.bootRetries.get(id)
+    if (timer) clearTimeout(timer)
+    this.bootRetries.delete(id)
   }
 
   private get recorder(): ConnectorIORecorder {


### PR DESCRIPTION
## Summary

Telegram Connector treated the Bot API long poll as a one-shot startup ritual. `setMyCommands` ran on the critical path, the first handshake had a fatal 15s deadline, and a dropped session left the adapter dead until Guardian restarted the process.

This change:

- returns from `start()` as soon as the adapter is armed, so Connector HTTP health is not blocked by Telegram
- publishes the slash-command menu only after polling is live, and never lets a hung `setMyCommands` block getUpdates
- supervises the polling session: one attempt may be abandoned after 30s, then the same adapter reconnects with backoff
- retries transient DeliveryManager boot failures so Discord/Slack keep the same outer recovery until they get the same session loop
- keeps missing-token and other config errors as hard `start()` failures

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 550 passed, 1 skipped; 4653 passed, 9 skipped
- `pnpm -F @traderalice/connector-service test` — 81 passed

No live Telegram send and no credential changes.

## Residual risk

- Discord and Slack still use their original 15s fatal start; DeliveryManager retries those from the outside
- The installed 0.89.4-beta Runtime does not include this until the next `dev` payload or a source-backed run