### PR TITLE
refactor(connector): standardize lifecycle failure ownership

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -175,6 +175,16 @@ Core dispatch must not branch on platform IDs. Adding a connector means:
 3. register its factory at service composition;
 4. add adapter-specific tests and packaging dependencies.
 
+`ConnectorAdapter` is also the lifecycle boundary. `start()` validates durable
+configuration and arms the adapter; `stop()` is idempotent and releases every
+SDK resource. A long-lived adapter must recover transient disconnects either
+through its SDK or the shared connection supervisor. If a legacy synchronous
+`start()` still lets a transport failure escape, the adapter classifies that
+failure as `retry` or `fatal`; DeliveryManager schedules retries but never
+parses third-party or platform-specific error text itself. Health must move
+through `starting`, `awaiting_link`, `healthy`, `degraded`, and `stopped` as the
+external session changes rather than treating process startup as connectivity.
+
 The Settings renderer consumes definitions as data. The DeliveryManager test
 registers a fake third adapter to prevent a future Discord/Telegram union or
 `if (id === ...)` dispatch from becoming the architecture.

--- a/services/connector/src/adapters/discord.ts
+++ b/services/connector/src/adapters/discord.ts
@@ -12,6 +12,7 @@ import type {
 } from '../core/adapter.js'
 import {
   AdapterHealthTracker,
+  classifyNetworkStartFailure,
   decodeInboxAttachments,
   formatInboxNotification,
 } from './shared.js'
@@ -21,6 +22,8 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
   private readonly tracker = new AdapterHealthTracker(this.id)
   private client?: Client
   private ownerUserId?: string
+
+  classifyStartFailure = classifyNetworkStartFailure
 
   async start(config: ConnectorAdapterConfig, context: ConnectorAdapterContext): Promise<void> {
     try {

--- a/services/connector/src/adapters/shared.spec.ts
+++ b/services/connector/src/adapters/shared.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { InboxNotification } from '@traderalice/connector-protocol'
 import {
   AdapterHealthTracker,
+  classifyNetworkStartFailure,
   decodeInboxAttachments,
   formatAdapterError,
   formatInboxNotification,
@@ -99,6 +100,13 @@ describe('adapter error formatting', () => {
     const tracker = new AdapterHealthTracker('telegram')
     tracker.degraded(error)
     expect(tracker.get().lastError).toContain('ECONNREFUSED')
+  })
+})
+
+describe('adapter-owned start failure classification', () => {
+  it('retries transport failures without teaching core platform error strings', () => {
+    expect(classifyNetworkStartFailure(new Error('connect ECONNREFUSED 198.18.0.130:443'))).toBe('retry')
+    expect(classifyNetworkStartFailure(new Error('Slack setting botToken is required'))).toBe('fatal')
   })
 })
 

--- a/services/connector/src/adapters/shared.ts
+++ b/services/connector/src/adapters/shared.ts
@@ -4,6 +4,19 @@ import type {
   ConnectorAttachment,
   InboxNotification,
 } from '@traderalice/connector-protocol'
+import type { ConnectorStartFailureDisposition } from '../core/adapter.js'
+
+/**
+ * Shared default for adapters whose SDK exposes transport failures only as
+ * errors. Keep this at the adapter boundary: DeliveryManager must never infer
+ * platform lifecycle semantics from third-party error text.
+ */
+export function classifyNetworkStartFailure(error: unknown): ConnectorStartFailureDisposition {
+  const message = formatAdapterError(error)
+  return /did not become ready|did not answer getme|api is unreachable|network request|fetch failed|econn|etimedout|enotfound|enetunreach|ehostunreach|socket disconnected|aborted delay|certificate|eai_again|socket hang up|tls connection/i.test(message)
+    ? 'retry'
+    : 'fatal'
+}
 
 export class AdapterHealthTracker {
   private value: ConnectorAdapterHealth

--- a/services/connector/src/adapters/slack.ts
+++ b/services/connector/src/adapters/slack.ts
@@ -13,6 +13,7 @@ import type {
 } from '../core/adapter.js'
 import {
   AdapterHealthTracker,
+  classifyNetworkStartFailure,
   decodeInboxAttachments,
   formatInboxNotification,
 } from './shared.js'
@@ -24,6 +25,8 @@ export class SlackConnectorAdapter implements ConnectorAdapter {
   private web?: WebClient
   private socket?: SocketModeClient
   private ownerUserId?: string
+
+  classifyStartFailure = classifyNetworkStartFailure
 
   constructor(options: { startupTimeoutMs?: number } = {}) {
     this.startupTimeoutMs = options.startupTimeoutMs ?? 15_000

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -220,7 +220,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
     } finally {
       if (attemptTimer) clearTimeout(attemptTimer)
     }
-    await Promise.race([polling, this.whenAborted()])
+    await this.awaitPollingOrAbort(polling)
   }
 
   private async disconnectSession(): Promise<void> {
@@ -289,25 +289,36 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
     })
   }
 
-  private whenAborted(): Promise<void> {
+  private async awaitPollingOrAbort(polling: Promise<void>): Promise<void> {
     const signal = this.abort?.signal
-    if (!signal || signal.aborted) return Promise.resolve()
-    return new Promise((resolve) => {
-      signal.addEventListener('abort', () => resolve(), { once: true })
+    if (!signal || signal.aborted) return
+    let onAbort: (() => void) | undefined
+    const aborted = new Promise<void>((resolve) => {
+      onAbort = resolve
+      signal.addEventListener('abort', onAbort, { once: true })
     })
+    try {
+      await Promise.race([polling, aborted])
+    } finally {
+      if (onAbort) signal.removeEventListener('abort', onAbort)
+    }
   }
 
   private async delay(ms: number): Promise<void> {
     const signal = this.abort?.signal
     if (signal?.aborted) return
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, ms)
-      timer.unref?.()
-      const onAbort = () => {
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
         clearTimeout(timer)
+        signal?.removeEventListener('abort', finish)
         resolve()
       }
-      signal?.addEventListener('abort', onAbort, { once: true })
+      const timer = setTimeout(finish, ms)
+      timer.unref?.()
+      signal?.addEventListener('abort', finish, { once: true })
     })
   }
 

--- a/services/connector/src/core/adapter.ts
+++ b/services/connector/src/core/adapter.ts
@@ -23,6 +23,8 @@ export interface ConnectorCommandContext {
 
 export type ConnectorCommandHandler = (context: ConnectorCommandContext) => Promise<void>
 
+export type ConnectorStartFailureDisposition = 'fatal' | 'retry'
+
 export interface ConnectorAdapterContext {
   commands: CommandRegistry
   updateSettings(patch: Record<string, string | number | boolean>): Promise<void>
@@ -35,6 +37,11 @@ export interface ConnectorAdapterContext {
 export interface ConnectorAdapter {
   readonly id: string
   start(config: ConnectorAdapterConfig, context: ConnectorAdapterContext): Promise<void>
+  /**
+   * Classify failures that escape start(). Core owns retry scheduling, while
+   * each adapter owns the meaning of its SDK errors. The default is fatal.
+   */
+  classifyStartFailure?(error: unknown): ConnectorStartFailureDisposition
   stop(): Promise<void>
   deliver(notification: InboxNotification): Promise<void>
   sendOwnerText(text: string): Promise<void>

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -9,7 +9,6 @@ import type { ConnectorAdapter, ConnectorAdapterContext } from './adapter.js'
 import { ConnectorRegistry } from './adapter.js'
 import {
   DeliveryManager,
-  isTransientConnectorStartError,
   MAX_INBOUND_OWNER_MESSAGES,
 } from './delivery-manager.js'
 import { createConnectorIOEvent, type ConnectorIOEvent, type ConnectorIORecorder } from './io-events.js'
@@ -167,6 +166,7 @@ describe('DeliveryManager connector registry', () => {
     let status: ConnectorAdapterHealth['status'] = 'degraded'
     const adapter: ConnectorAdapter = {
       id: 'flaky',
+      classifyStartFailure: () => 'retry',
       start: async () => {
         attempts += 1
         if (attempts === 1) throw new Error('Telegram polling did not become ready within 15000ms')
@@ -240,6 +240,7 @@ describe('DeliveryManager connector registry', () => {
     let attempts = 0
     const adapter: ConnectorAdapter = {
       id: 'slow-fail',
+      classifyStartFailure: () => 'retry',
       start: async () => {
         attempts += 1
         throw new Error('Network request for \'getMe\' failed!')
@@ -266,13 +267,6 @@ describe('DeliveryManager connector registry', () => {
     await manager.stop()
     await new Promise((resolve) => setTimeout(resolve, 80))
     expect(attempts).toBe(1)
-  })
-
-  it('classifies Telegram polling timeouts as transient', () => {
-    expect(isTransientConnectorStartError(new Error('Telegram polling did not become ready within 15000ms'))).toBe(true)
-    expect(isTransientConnectorStartError(new Error("Network request for 'setMyCommands' failed!"))).toBe(true)
-    expect(isTransientConnectorStartError(new Error('Telegram Bot API is unreachable: Telegram Bot API did not answer getMe within 15000ms'))).toBe(true)
-    expect(isTransientConnectorStartError(new Error('Telegram setting botToken is required'))).toBe(false)
   })
 
   it('contains adapter delivery failures', async () => {

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -52,11 +52,6 @@ export const MAX_INBOUND_OWNER_MESSAGES = 100
 export const DEFAULT_ADAPTER_START_RETRY_DELAY_MS = 5_000
 const MAX_ADAPTER_START_RETRY_DELAY_MS = 60_000
 
-export function isTransientConnectorStartError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return /did not become ready|did not answer getme|bot api is unreachable|network request|fetch failed|econn|etimedout|enotfound|enetunreach|ehostunreach|socket disconnected|aborted delay|certificate|eai_again|socket hang up|tls connection/i.test(message)
-}
-
 export class DeliveryManager {
   private readonly adapters = new Map<string, ConnectorAdapter>()
   private readonly commands = new Map<string, CommandRegistry>()
@@ -364,7 +359,8 @@ export class DeliveryManager {
     attempt: number,
   ): void {
     console.warn(`[connector] ${id} failed to start:`, error instanceof Error ? error.message : error)
-    if (!isTransientConnectorStartError(error)) return
+    const adapter = this.adapters.get(id)
+    if (adapter?.classifyStartFailure?.(error) !== 'retry') return
     this.scheduleAdapterStartRetry(id, config, attempt)
   }
 


### PR DESCRIPTION
## Summary
- keep Connector Service retry scheduling generic while adapters classify their own SDK start failures
- document ConnectorAdapter as the lifecycle boundary for future platforms
- remove Telegram reconnect abort listeners after each attempt so repeated outages do not accumulate handlers

Follow-up to #1128.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (550 files passed, 4,653 tests passed)
- `pnpm -F @traderalice/connector-service test` (11 files, 81 tests)