### PR TITLE
fix(ui): keep Ask Alice recent sessions bounded

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -31,6 +31,9 @@ const directoryState = vi.hoisted(() => ({
   directories: new Map(),
 }))
 const { openOrFocus } = actions
+const focusedTabState = vi.hoisted(() => ({
+  tab: null as { spec: { kind: string; params: Record<string, string> } } | null,
+}))
 
 vi.mock('../../hooks/useWorkspaceSessionDirectory', () => ({
   useWorkspaceSessionDirectories: () => ({
@@ -47,7 +50,7 @@ vi.mock('../../tabs/store', () => ({
 }))
 
 vi.mock('../../tabs/types', () => ({
-  getFocusedTab: () => null,
+  getFocusedTab: () => focusedTabState.tab,
 }))
 
 const harnessPreference = vi.hoisted(() => ({
@@ -163,6 +166,7 @@ function renderSection(
 beforeEach(async () => {
   for (const mock of Object.values(actions)) mock.mockClear()
   directoryState.directories = new Map()
+  focusedTabState.tab = null
   harnessPreference.showHeadlessBornSessions = true
   window.localStorage.clear()
   await i18n.changeLanguage('en')
@@ -442,21 +446,33 @@ describe('ChatWorkspaceSection actions', () => {
     expect(retryTemplates).toHaveBeenCalledOnce()
   })
 
-  it('scrolls the full Workspace roster and keeps Browse in the context menu', () => {
+  it('caps focused and recent sidebars to a recent work set and keeps Browse complete', () => {
     const sessions = Array.from({ length: 9 }, (_, index) => chatSession(index + 1))
+    const workspace = { ...chatWorkspace, sessions }
     const onNavigate = vi.fn()
-    renderSection([{ ...chatWorkspace, sessions }], null, onNavigate)
 
-    expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(9)
-    expect(screen.getByRole('button', { name: 'Conversation 3' })).toBeTruthy()
+    const expectCappedSidebar = () => {
+      expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(8)
+      expect(screen.getByRole('button', { name: 'Conversation 9' })).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'Conversation 3' })).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'Conversation 2' })).toBeTruthy()
+      expect(screen.queryByRole('button', { name: 'Conversation 1' })).toBeNull()
+      expect(
+        screen.getByText('Recent conversations', { selector: 'span.uppercase' }).nextElementSibling?.textContent,
+      ).toBe('9')
+    }
+
+    const { unmount: unmountFocused } = renderSection([workspace], null, onNavigate, 'focused')
+    expectCappedSidebar()
     expect(screen.queryByRole('button', { name: 'View all 9 sessions' })).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Chat context: Workspaces' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Chat context: chat-jul11' }))
     fireEvent.click(screen.getByRole('button', { name: 'Browse all conversations' }))
 
     const dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
     const browser = within(dialog)
     expect(browser.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(9)
+    expect(browser.getByRole('button', { name: 'Conversation 1' })).toBeTruthy()
     expect(openOrFocus).not.toHaveBeenCalled()
 
     fireEvent.click(browser.getByRole('button', { name: 'Conversation 3' }))
@@ -465,6 +481,105 @@ describe('ChatWorkspaceSection actions', () => {
       params: { wsId: chatWorkspace.id, sessionId: 'chat-session-3', source: 'chat' },
     })
     expect(onNavigate).toHaveBeenCalledTimes(1)
+    unmountFocused()
+
+    const { unmount: unmountRecent } = renderSection([workspace], null, undefined, 'recent')
+    expectCappedSidebar()
+    unmountRecent()
+
+    focusedTabState.tab = {
+      spec: {
+        kind: 'workspace',
+        params: { wsId: chatWorkspace.id, sessionId: 'chat-session-1', source: 'chat' },
+      },
+    }
+    renderSection([workspace], null, undefined, 'focused')
+    expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(8)
+    expect(screen.getByRole('button', { name: 'Conversation 1' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Conversation 2' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Conversation 9' })).toBeTruthy()
+    expect(
+      screen.getByText('Recent conversations', { selector: 'span.uppercase' }).nextElementSibling?.textContent,
+    ).toBe('9')
+    expect(
+      screen.getByRole('button', { name: 'Conversation 9' }).compareDocumentPosition(
+        screen.getByRole('button', { name: 'Conversation 1' }),
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it('keeps every running headless row while still capping the recent work set', () => {
+    directoryState.directories = new Map([[chatWorkspace.id, {
+      workspace: { id: chatWorkspace.id, tag: chatWorkspace.tag },
+      sessions: [
+        {
+          resumeId: 'resume-headless-running-a',
+          agent: 'claude',
+          createdAt: Date.parse('2026-08-03T00:00:00.000Z'),
+          updatedAt: Date.parse('2026-08-03T01:00:00.000Z'),
+          lifecycle: 'active',
+          resumable: true,
+          active: true,
+          latestExecution: {
+            taskId: 'task-run-a',
+            status: 'running',
+            startedAt: Date.parse('2026-08-03T01:00:00.000Z'),
+            issueId: 'scan-open',
+          },
+        },
+        {
+          resumeId: 'resume-headless-running-b',
+          agent: 'codex',
+          createdAt: Date.parse('2026-08-03T00:30:00.000Z'),
+          updatedAt: Date.parse('2026-08-03T02:00:00.000Z'),
+          lifecycle: 'active',
+          resumable: true,
+          active: true,
+          latestExecution: {
+            taskId: 'task-run-b',
+            status: 'running',
+            startedAt: Date.parse('2026-08-03T02:00:00.000Z'),
+            issueId: 'risk-watch',
+          },
+        },
+      ],
+    }]])
+    const sessions = [
+      ...Array.from({ length: 9 }, (_, index) => chatSession(index + 1)),
+      {
+        ...chatSession(20),
+        id: 'session-headless-running-a',
+        resumeId: 'resume-headless-running-a',
+        agent: 'claude',
+        name: 'c1',
+        surface: 'headless' as const,
+        state: 'running' as const,
+        title: null,
+        lastActiveAt: '2026-08-03T01:00:00.000Z',
+      },
+      {
+        ...chatSession(21),
+        id: 'session-headless-running-b',
+        resumeId: 'resume-headless-running-b',
+        agent: 'codex',
+        name: 'x1',
+        surface: 'headless' as const,
+        state: 'running' as const,
+        title: null,
+        lastActiveAt: '2026-08-03T02:00:00.000Z',
+      },
+    ]
+    renderSection([{ ...chatWorkspace, sessions }], null, undefined, 'focused')
+
+    const runningSection = screen.getByRole('region', { name: 'Running in background' })
+    expect(within(runningSection).getByText('Scan Open')).toBeTruthy()
+    expect(within(runningSection).getByText('Risk Watch')).toBeTruthy()
+    expect(within(runningSection).getByText('2')).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(8)
+    expect(screen.queryByRole('button', { name: 'Conversation 1' })).toBeNull()
+    expect(
+      screen.getByText('Recent conversations', { selector: 'span.uppercase' }).nextElementSibling?.textContent,
+    ).toBe('9')
   })
 
   it('browses current or cross-Workspace conversations without leaving the page first', async () => {

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -51,6 +51,7 @@ import {
   joinWorkspaceHarnessSessions,
   type HarnessSession,
 } from './harness-sessions'
+import { selectRecentSidebarWorkset } from './harness-session-workset'
 import { harnessSessionRosterSubtitle } from './harness-session-presentation'
 import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order'
 import { useWorkspaceSessionDirectories } from '../../hooks/useWorkspaceSessionDirectory'
@@ -813,8 +814,9 @@ function HarnessSessionRoster(props: HarnessSessionRosterProps): ReactElement {
   const [runningExpanded, setRunningExpanded] = useState(true)
   const running = props.sessions.filter((row) => row.headlessOccupying)
   const recent = props.sessions.filter((row) => !row.headlessOccupying)
+  const visibleRecent = selectRecentSidebarWorkset(recent, props.isRowActive)
   const runningRef = useReorderMotion<HTMLDivElement>(running.map(props.keyFor))
-  const recentRef = useReorderMotion<HTMLDivElement>(recent.map(props.keyFor))
+  const recentRef = useReorderMotion<HTMLDivElement>(visibleRecent.map(props.keyFor))
   const renderRow = (row: HarnessSession) => (
     <HarnessSessionRow
       key={props.keyFor(row)}
@@ -878,7 +880,7 @@ function HarnessSessionRoster(props: HarnessSessionRosterProps): ReactElement {
           <p className="px-3 py-2 text-[11px] leading-relaxed text-muted-foreground/55">
             {t('chat.allConversationsRunning')}
           </p>
-        ) : recent.map(renderRow)}
+        ) : visibleRecent.map(renderRow)}
       </div>
     </div>
   )

--- a/ui/src/components/workspace/harness-session-workset.spec.ts
+++ b/ui/src/components/workspace/harness-session-workset.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  RECENT_SIDEBAR_WORKSET_LIMIT,
+  selectRecentSidebarWorkset,
+} from './harness-session-workset'
+
+function ids(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `row-${index + 1}`)
+}
+
+describe('selectRecentSidebarWorkset', () => {
+  it('returns the full list when it already fits the cap', () => {
+    const recent = ids(7)
+    expect(selectRecentSidebarWorkset(recent, () => false)).toEqual(recent)
+    expect(selectRecentSidebarWorkset(ids(8), (id) => id === 'row-8')).toEqual(ids(8))
+    expect(selectRecentSidebarWorkset([], () => true)).toEqual([])
+  })
+
+  it('keeps the first 8 rows when the active row is already visible or absent', () => {
+    const recent = ids(12)
+    expect(selectRecentSidebarWorkset(recent, () => false)).toEqual(ids(8))
+    expect(selectRecentSidebarWorkset(recent, (id) => id === 'row-3')).toEqual(ids(8))
+    expect(RECENT_SIDEBAR_WORKSET_LIMIT).toBe(8)
+  })
+
+  it('replaces the last visible row with an overflow active row and keeps relative order', () => {
+    const recent = ids(12)
+    expect(selectRecentSidebarWorkset(recent, (id) => id === 'row-9')).toEqual([
+      'row-1', 'row-2', 'row-3', 'row-4', 'row-5', 'row-6', 'row-7', 'row-9',
+    ])
+    expect(selectRecentSidebarWorkset(recent, (id) => id === 'row-12')).toEqual([
+      'row-1', 'row-2', 'row-3', 'row-4', 'row-5', 'row-6', 'row-7', 'row-12',
+    ])
+  })
+
+  it('keeps a single visible slot for an overflow active row when the cap is 1', () => {
+    expect(selectRecentSidebarWorkset(ids(4), (id) => id === 'row-4', 1)).toEqual(['row-4'])
+  })
+})

--- a/ui/src/components/workspace/harness-session-workset.ts
+++ b/ui/src/components/workspace/harness-session-workset.ts
@@ -1,0 +1,28 @@
+export const RECENT_SIDEBAR_WORKSET_LIMIT = 8
+
+/**
+ * Bound the Ask Alice / AutoQuant quick sidebar to the newest recent rows.
+ * `recent` must already be in roster order and must exclude running /
+ * headless-occupying rows. If the active row sits past the cap, it replaces
+ * the last visible row; retained rows keep their relative order.
+ */
+export function selectRecentSidebarWorkset<T>(
+  recent: readonly T[],
+  isActive: (row: T) => boolean,
+  limit = RECENT_SIDEBAR_WORKSET_LIMIT,
+): T[] {
+  if (limit <= 0 || recent.length === 0) return []
+  if (recent.length <= limit) return [...recent]
+
+  let overflowActiveIndex = -1
+  for (let index = limit; index < recent.length; index += 1) {
+    const row = recent[index]
+    if (row !== undefined && isActive(row)) {
+      overflowActiveIndex = index
+      break
+    }
+  }
+  if (overflowActiveIndex < 0) return recent.slice(0, limit)
+
+  return recent.filter((_, index) => index < limit - 1 || index === overflowActiveIndex)
+}


### PR DESCRIPTION
## Summary
- bound focused and cross-Workspace Ask Alice/AutoQuant recent rosters to eight non-running sessions
- keep every running/headless-occupying session in the existing dedicated section
- retain the active session when it falls outside the normal recent window
- preserve the full session count and full Browse all conversations inventory

## Design decision
Two approaches were considered:

1. Raw truncation: render only the first eight ordered rows. This is simple, but a currently open older Session can disappear from the navigation that owns it.
2. Bounded work set (chosen): keep the first eight ordered recent rows, replacing the last visible row with the active overflow row when necessary. Running work remains separately visible and the browse dialog remains the complete inventory.

The second approach keeps the sidebar a quick-navigation surface without changing durable Session membership, `resumeId`, backend ordering, or the full conversation manager.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4746 passed, 9 skipped)
- targeted workspace UI specs (24 passed)
- real `pnpm dev` route with 62 sessions: eight visible in sidebar, 62 present in Browse all conversations, bottom Workspace context remains visible
