### PR TITLE
feat(ui): surface all conversations from chat sidebar

### DIFF
--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -446,10 +446,11 @@ describe('ChatWorkspaceSection actions', () => {
     expect(retryTemplates).toHaveBeenCalledOnce()
   })
 
-  it('caps focused and recent sidebars to a recent work set and keeps Browse complete', () => {
+  it('caps focused and recent sidebars to a recent work set and keeps Browse complete', async () => {
     const sessions = Array.from({ length: 9 }, (_, index) => chatSession(index + 1))
     const workspace = { ...chatWorkspace, sessions }
     const onNavigate = vi.fn()
+    const user = userEvent.setup()
 
     const expectCappedSidebar = () => {
       expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(8)
@@ -464,18 +465,26 @@ describe('ChatWorkspaceSection actions', () => {
 
     const { unmount: unmountFocused } = renderSection([workspace], null, onNavigate, 'focused')
     expectCappedSidebar()
-    expect(screen.queryByRole('button', { name: 'View all 9 sessions' })).toBeNull()
+    const inlineBrowse = screen.getByRole('button', { name: 'View all 9 conversations' })
+    inlineBrowse.focus()
+    await user.click(inlineBrowse)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Chat context: chat-jul11' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Browse all conversations' }))
-
-    const dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
-    const browser = within(dialog)
+    let dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
+    let browser = within(dialog)
     expect(browser.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(9)
     expect(browser.getByRole('button', { name: 'Conversation 1' })).toBeTruthy()
+    expect(browser.getByRole('button', { name: 'Current Workspace' }).getAttribute('aria-pressed')).toBe('true')
     expect(openOrFocus).not.toHaveBeenCalled()
 
-    fireEvent.click(browser.getByRole('button', { name: 'Conversation 3' }))
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog', { name: 'Browse all conversations' })).toBeNull()
+    expect(document.activeElement).toBe(inlineBrowse)
+
+    await user.click(inlineBrowse)
+    dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
+    browser = within(dialog)
+
+    await user.click(browser.getByRole('button', { name: 'Conversation 3' }))
     expect(openOrFocus).toHaveBeenCalledWith({
       kind: 'workspace',
       params: { wsId: chatWorkspace.id, sessionId: 'chat-session-3', source: 'chat' },
@@ -485,6 +494,9 @@ describe('ChatWorkspaceSection actions', () => {
 
     const { unmount: unmountRecent } = renderSection([workspace], null, undefined, 'recent')
     expectCappedSidebar()
+    await user.click(screen.getByRole('button', { name: 'View all 9 conversations' }))
+    dialog = screen.getByRole('dialog', { name: 'Browse all conversations' })
+    expect(within(dialog).getByRole('button', { name: 'All Workspaces' }).getAttribute('aria-pressed')).toBe('true')
     unmountRecent()
 
     focusedTabState.tab = {
@@ -506,6 +518,19 @@ describe('ChatWorkspaceSection actions', () => {
         screen.getByRole('button', { name: 'Conversation 1' }),
       ) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'View all 9 conversations' })).toBeTruthy()
+  })
+
+  it('does not show an inline Browse action when every recent conversation fits', () => {
+    const workspace = {
+      ...chatWorkspace,
+      sessions: Array.from({ length: 8 }, (_, index) => chatSession(index + 1)),
+    }
+
+    renderSection([workspace], null, undefined, 'focused')
+
+    expect(screen.getAllByRole('button', { name: /^Conversation \d+$/ })).toHaveLength(8)
+    expect(screen.queryByRole('button', { name: /View all \d+ conversations/ })).toBeNull()
   })
 
   it('keeps every running headless row while still capping the recent work set', () => {

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -364,6 +364,7 @@ export function ChatWorkspaceSection({
           onDeleteSession={deleteRosterSession}
           onArchiveSession={archiveRosterSession}
           onSettingsSession={openSessionSettings}
+          onBrowseSessions={(restoreFocus) => openConversationBrowser(focusedWorkspace.id, restoreFocus)}
           onCreateWorkspace={() => setShowCreate(true)}
         />
       ) : displayMode === 'recent' ? (
@@ -380,6 +381,7 @@ export function ChatWorkspaceSection({
           onDeleteSession={deleteRosterSession}
           onArchiveSession={archiveRosterSession}
           onSettingsSession={openSessionSettings}
+          onBrowseSessions={(restoreFocus) => openConversationBrowser(null, restoreFocus)}
           onCreateWorkspace={() => setShowCreate(true)}
         />
       ) : (
@@ -775,6 +777,7 @@ interface FocusedChatWorkspaceProps {
   onDeleteSession: (row: HarnessSession) => void
   onArchiveSession: (row: HarnessSession) => void
   onSettingsSession: (row: HarnessSession) => void
+  onBrowseSessions: (restoreFocus: HTMLElement) => void
   onCreateWorkspace: () => void
 }
 
@@ -791,6 +794,7 @@ interface AllWorkspaceRecentSessionsProps {
   onDeleteSession: (row: HarnessSession) => void
   onArchiveSession: (row: HarnessSession) => void
   onSettingsSession: (row: HarnessSession) => void
+  onBrowseSessions: (restoreFocus: HTMLElement) => void
   onCreateWorkspace: () => void
 }
 
@@ -807,6 +811,7 @@ interface HarnessSessionRosterProps {
   onDeleteSession: (row: HarnessSession) => void
   onArchiveSession: (row: HarnessSession) => void
   onSettingsSession: (row: HarnessSession) => void
+  onBrowseSessions: (restoreFocus: HTMLElement) => void
 }
 
 function HarnessSessionRoster(props: HarnessSessionRosterProps): ReactElement {
@@ -882,6 +887,26 @@ function HarnessSessionRoster(props: HarnessSessionRosterProps): ReactElement {
           </p>
         ) : visibleRecent.map(renderRow)}
       </div>
+
+      {recent.length > visibleRecent.length && (
+        <button
+          type="button"
+          className="oa-nav-row group flex min-h-9 w-full items-center gap-2 px-3 py-1.5 text-left text-xs font-medium text-primary hover:bg-primary/5"
+          onClick={(event) => props.onBrowseSessions(event.currentTarget)}
+        >
+          <span className="min-w-0 flex-1 truncate">
+            {props.harness === 'auto-quant'
+              ? t('autoQuant.viewAllResearch', { count: recent.length })
+              : t('chat.viewAllConversations', { count: recent.length })}
+          </span>
+          <ChevronRight
+            size={13}
+            strokeWidth={2.2}
+            className="shrink-0 text-primary/65 transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none"
+            aria-hidden
+          />
+        </button>
+      )}
     </div>
   )
 }
@@ -928,6 +953,7 @@ function AllWorkspaceRecentSessions(props: AllWorkspaceRecentSessionsProps): Rea
         onDeleteSession={props.onDeleteSession}
         onArchiveSession={props.onArchiveSession}
         onSettingsSession={props.onSettingsSession}
+        onBrowseSessions={props.onBrowseSessions}
       />
 
       {props.workspaces.length === 0 && (
@@ -998,6 +1024,7 @@ function FocusedChatWorkspace(props: FocusedChatWorkspaceProps): ReactElement {
         onDeleteSession={props.onDeleteSession}
         onArchiveSession={props.onArchiveSession}
         onSettingsSession={props.onSettingsSession}
+        onBrowseSessions={props.onBrowseSessions}
       />
     </div>
   )

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1066,6 +1066,7 @@ export const en = {
       offboard: 'Offboard {{workspace}}',
     },
     viewAllSessions: 'View all {{count}} sessions',
+    viewAllConversations: 'View all {{count}} conversations',
     deleteWorkspace: 'Offboard workspace',
     deleteWorkspaceTitle: 'Offboard chat workspace',
     deleteWorkspaceMessage: 'Offboard chat workspace {{tag}}? Its desk moves out of the active directory, Sessions retire, and a handoff record is kept for later restore.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1055,6 +1055,7 @@ export const ja: Resources = {
       offboard: '{{workspace}} を退役',
     },
     viewAllSessions: '{{count}} 件のセッションをすべて表示',
+    viewAllConversations: '{{count}} 件の会話をすべて表示',
     deleteWorkspace: 'ワークスペースを退役',
     deleteWorkspaceTitle: 'チャットワークスペースを退役',
     deleteWorkspaceMessage: 'チャットワークスペース {{tag}} を退役させますか？作業台はアクティブディレクトリから移動し、Session は退役します。復元用の引き継ぎ記録は保持されます。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1062,6 +1062,7 @@ export const zhHant: Resources = {
       offboard: '辦理 {{workspace}} 離職',
     },
     viewAllSessions: '查看全部 {{count}} 個工作階段',
+    viewAllConversations: '查看全部 {{count}} 個對話',
     deleteWorkspace: '辦理工作區離職',
     deleteWorkspaceTitle: '辦理對話工作區離職',
     deleteWorkspaceMessage: '讓對話工作區 {{tag}} 離職？它的工作台會移出活動目錄，Session 會退休，並保留交接記錄以便日後恢復。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1054,6 +1054,7 @@ export const zh: Resources = {
       offboard: '办理 {{workspace}} 离职',
     },
     viewAllSessions: '查看全部 {{count}} 个会话',
+    viewAllConversations: '查看全部 {{count}} 个对话',
     deleteWorkspace: '办理工作区离职',
     deleteWorkspaceTitle: '办理对话工作区离职',
     deleteWorkspaceMessage: '让对话工作区 {{tag}} 离职？它的工作台会移出活动目录，Session 会退休，并保留交接记录以便日后恢复。',


### PR DESCRIPTION
## Summary
- add a lightweight inline “View all” entry after the capped recent conversation roster
- reuse the existing conversation browser with the correct current/all Workspace scope
- preserve focus when the dialog closes and localize the new conversation wording

## Design
We compared a header-level action with an inline footer action. The inline footer was selected because it preserves the recent-list hierarchy, appears exactly where truncation happens, and reuses the existing full browser without adding another navigation surface.

## Verification
- `npx tsc --noEmit`
- `pnpm test` (559 files passed, 4,747 tests passed)
- `cd ui && npx tsc -b`
- targeted `ChatWorkspaceSection` tests (20 passed)
- real `pnpm dev` browser route: 8 visible of 62, dialog shows 62, current Workspace scope, close returns focus