### PR TITLE
feat(ui): surface significant agent activity

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       shadcn:
         specifier: ^4.16.1
         version: 4.16.1(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.8
+        version: 2.0.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -4773,6 +4776,16 @@ packages:
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  sonner@2.0.8:
+    resolution: {integrity: sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9755,6 +9768,13 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sonner@2.0.8(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   source-map-js@1.2.1: {}
 

--- a/src/webui/routes/agent-runtime.spec.ts
+++ b/src/webui/routes/agent-runtime.spec.ts
@@ -46,4 +46,23 @@ describe('GET /api/agent-runtime', () => {
     const body = await res.json() as { lastSeq: number }
     expect(body.lastSeq).toBe(3)
   })
+
+  it('records a Sonner probe through the same runtime journal', async () => {
+    const record = vi.fn(async (type, payload) => ({ seq: 7, ts: 1, type, payload }))
+    const app = new Hono().route('/', createAgentRuntimeLogRoutes({
+      agentRuntimeLog: { record },
+    } as never))
+
+    const res = await app.request('/sonner-test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'success' }),
+    })
+
+    expect(res.status).toBe(201)
+    expect(record).toHaveBeenCalledWith('dev.sonner_test', expect.objectContaining({
+      agent: 'Dev Panel',
+      testState: 'success',
+    }))
+  })
 })

--- a/src/webui/routes/agent-runtime.ts
+++ b/src/webui/routes/agent-runtime.ts
@@ -3,6 +3,7 @@
  * Occupancy history for Automation; never a spawn or replay-control surface.
  */
 import { Hono } from 'hono'
+import { z } from 'zod'
 
 import { isAgentRuntimeEventType } from '../../workspaces/agent-runtime-log.js'
 import type { WorkspaceService } from '../../workspaces/service.js'
@@ -14,6 +15,23 @@ function positiveInteger(value: string | undefined, fallback: number): number {
 
 export function createAgentRuntimeLogRoutes(svc: WorkspaceService): Hono {
   const app = new Hono()
+
+  app.post('/sonner-test', async (c) => {
+    const parsed = z.object({
+      state: z.enum(['running', 'success', 'error']),
+    }).safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) return c.json({ error: 'state must be running, success, or error' }, 400)
+
+    const now = Date.now()
+    const entry = await svc.agentRuntimeLog.record('dev.sonner_test', {
+      workspaceId: '__dev__',
+      resumeId: `sonner-test-${now}`,
+      agent: 'Dev Panel',
+      testState: parsed.data.state,
+      message: `Sonner ${parsed.data.state} test`,
+    })
+    return c.json({ entry }, 201)
+  })
 
   app.get('/', async (c) => {
     const afterSeqRaw = c.req.query('afterSeq')

--- a/src/workspaces/agent-runtime-log.ts
+++ b/src/workspaces/agent-runtime-log.ts
@@ -22,12 +22,14 @@ export const AGENT_RUNTIME_EVENT_TYPES = [
   'runtime.turn.text',
   'runtime.turn.tool',
   'runtime.turn.error',
+  'dev.sonner_test',
 ] as const
 
 export type AgentRuntimeEventType = (typeof AGENT_RUNTIME_EVENT_TYPES)[number]
 export type AgentRuntimeSurface = 'terminal' | 'webpi' | 'headless'
 export type AgentRuntimeStopStatus = 'done' | 'failed' | 'interrupted' | 'paused'
 export type AgentRuntimeToolStatus = 'running' | 'completed' | 'failed'
+export type SonnerTestState = 'running' | 'success' | 'error'
 
 export interface AgentRuntimeTurnMetrics {
   readonly textBlocks: number
@@ -86,6 +88,10 @@ export type AgentRuntimePayload =
       readonly toolStatus: AgentRuntimeToolStatus
     })
   | (AgentRuntimeSubject & {
+      readonly message: string
+    })
+  | (AgentRuntimeSubject & {
+      readonly testState: SonnerTestState
       readonly message: string
     })
 
@@ -209,6 +215,9 @@ export class AgentRuntimeLog {
   private accept(event: AgentRuntimeEvent): void {
     this.total += 1
     if (this.first === 0 || event.seq < this.first) this.first = event.seq
+    // Dev-only notification probes belong to the append-only diagnostic stream
+    // so they exercise the real UI projection, but never represent occupancy.
+    if (event.type === 'dev.sonner_test') return
     const payload = event.payload as AgentRuntimeSubject
     if (!payload.workspaceId || !payload.resumeId) return
     const key = `${payload.workspaceId}\u0000${payload.resumeId}`

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "react-router-dom": "^7.18.2",
     "recharts": "^3.8.0",
     "shadcn": "^4.16.1",
+    "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "zustand": "^5.0.13"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { ActivityBar } from './components/ActivityBar'
+import { ActivityToasts } from './components/ActivityToasts'
 import { MobileContextBar } from './components/MobileContextBar'
 import { TabHost } from './components/TabHost'
 import { DesktopUpdatePrompt } from './components/DesktopUpdatePrompt'
@@ -131,6 +132,7 @@ function AppShellContent() {
           {mainContent}
         </div>
         <UrlAdopter />
+        <ActivityToasts />
         {showFirstRunGuide && (
           <Suspense fallback={null}>
             <FirstRunGuide />

--- a/ui/src/api/agentRuntimeLog.ts
+++ b/ui/src/api/agentRuntimeLog.ts
@@ -1,4 +1,4 @@
-import { fetchJson } from './client'
+import { fetchJson, headers } from './client'
 
 export type AgentRuntimeEventType =
   | 'session.born'
@@ -9,6 +9,7 @@ export type AgentRuntimeEventType =
   | 'runtime.turn.text'
   | 'runtime.turn.tool'
   | 'runtime.turn.error'
+  | 'dev.sonner_test'
 
 export type AgentRuntimeSurface = 'terminal' | 'webpi' | 'headless'
 
@@ -52,6 +53,7 @@ export interface AgentRuntimePayload {
     toolFailures: number
   }
   truncated?: boolean
+  testState?: 'running' | 'success' | 'error'
 }
 
 export interface AgentRuntimeEvent {
@@ -87,5 +89,12 @@ export const agentRuntimeLogApi = {
     if (opts.type) params.set('type', opts.type)
     const qs = params.toString()
     return fetchJson<AgentRuntimePage>(`/api/agent-runtime${qs ? `?${qs}` : ''}`)
+  },
+  async triggerSonnerTest(state: 'running' | 'success' | 'error'): Promise<void> {
+    await fetchJson('/api/agent-runtime/sonner-test', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ state }),
+    })
   },
 }

--- a/ui/src/components/ActivityToasts.spec.tsx
+++ b/ui/src/components/ActivityToasts.spec.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+
+import type { AgentActivitySignal, GlobalAgentActivityData } from '../hooks/useGlobalAgentActivity'
+import { ActivityToasts } from './ActivityToasts'
+
+const useActivity = vi.fn<() => GlobalAgentActivityData>()
+
+vi.mock('../hooks/useGlobalAgentActivity', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../hooks/useGlobalAgentActivity')>()
+  return { ...original, useGlobalAgentActivity: () => useActivity() }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { agent?: string }) => `${key}:${values?.agent ?? ''}`,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    loading: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}))
+
+function signal(overrides: Partial<AgentActivitySignal> = {}): AgentActivitySignal {
+  return {
+    id: 'conversation:task:task-1',
+    kind: 'conversation',
+    workspaceId: 'chat-1',
+    agent: 'pi',
+    resumeId: 'resume-1',
+    taskId: 'task-1',
+    occurredAt: 1_000,
+    revision: 1,
+    ...overrides,
+  }
+}
+
+function data(signals: AgentActivitySignal[]): GlobalAgentActivityData {
+  return {
+    signals,
+    summary: {
+      primary: signals[0] ?? null,
+      count: signals.length,
+      hasFailure: signals.some(({ kind }) => kind === 'conversation-failed'),
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useActivity.mockReturnValue(data([]))
+})
+
+describe('ActivityToasts', () => {
+  it('keeps one loading toast per Agent request and dismisses it on completion', async () => {
+    useActivity.mockReturnValue(data([signal()]))
+    const view = render(<ActivityToasts />)
+
+    await waitFor(() => expect(toast.loading).toHaveBeenCalledWith(
+      'activityToast.conversationRunning:pi',
+      expect.objectContaining({ id: 'openalice-activity:task:task-1' }),
+    ))
+
+    view.rerender(<ActivityToasts />)
+    expect(toast.loading).toHaveBeenCalledTimes(1)
+
+    useActivity.mockReturnValue(data([]))
+    view.rerender(<ActivityToasts />)
+    await waitFor(() => expect(toast.dismiss).toHaveBeenCalledWith(
+      'openalice-activity:task:task-1',
+    ))
+  })
+
+  it('updates a running Agent request in place when it fails', async () => {
+    useActivity.mockReturnValue(data([signal()]))
+    const view = render(<ActivityToasts />)
+    await waitFor(() => expect(toast.loading).toHaveBeenCalledTimes(1))
+
+    useActivity.mockReturnValue(data([signal({
+      id: 'conversation-failed:task:task-1',
+      kind: 'conversation-failed',
+      revision: 2,
+    })]))
+    view.rerender(<ActivityToasts />)
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(
+      'activityToast.conversationFailed:pi',
+      expect.objectContaining({ id: 'openalice-activity:task:task-1' }),
+    ))
+    expect(toast.dismiss).not.toHaveBeenCalled()
+  })
+
+  it('announces an Agent-originated Inbox delivery once', async () => {
+    useActivity.mockReturnValue(data([signal({
+      id: 'inbox:entry-1',
+      kind: 'inbox',
+      inboxEntryId: 'entry-1',
+    })]))
+    const view = render(<ActivityToasts />)
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(
+      'activityToast.inboxDelivered:pi',
+      expect.objectContaining({ id: 'openalice-activity:inbox:entry-1' }),
+    ))
+    view.rerender(<ActivityToasts />)
+    expect(toast.success).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a dedicated Sonner test signal through the production bridge', async () => {
+    useActivity.mockReturnValue(data([signal({
+      id: 'sonner-test:42',
+      kind: 'sonner-test-success',
+      workspaceId: '__dev__',
+      agent: 'Dev Panel',
+      taskId: undefined,
+      resumeId: undefined,
+      detail: 'Sonner success test',
+      revision: 42,
+    })]))
+    render(<ActivityToasts />)
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(
+      'Sonner success test',
+      expect.objectContaining({ id: 'openalice-activity:sonner-test:42' }),
+    ))
+  })
+})

--- a/ui/src/components/ActivityToasts.tsx
+++ b/ui/src/components/ActivityToasts.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
+
+import type { AgentActivitySignal } from '../hooks/useGlobalAgentActivity'
+import { useGlobalAgentActivity } from '../hooks/useGlobalAgentActivity'
+
+const MAX_ANNOUNCED_SIGNALS = 200
+
+function toastId(signal: AgentActivitySignal): string {
+  if (signal.kind === 'inbox' || signal.kind.startsWith('sonner-test-')) {
+    return `openalice-activity:${signal.id}`
+  }
+  const operation = signal.taskId
+    ? `task:${signal.taskId}`
+    : `session:${signal.workspaceId}:${signal.resumeId ?? 'unknown'}`
+  return `openalice-activity:${operation}`
+}
+
+/**
+ * Projects significant Agent orchestration onto the shared notification layer.
+ * This owns no history or navigation surface: Inbox, Sessions, Automation, and
+ * Office remain the authoritative places for detail.
+ */
+export function ActivityToasts() {
+  const { t } = useTranslation()
+  const { signals, loading } = useGlobalAgentActivity()
+  const announced = useRef(new Map<string, number>())
+  const persistentSignals = useRef(new Set<string>())
+
+  useEffect(() => {
+    if (loading) return
+
+    const nextActive = new Set(
+      signals
+        .filter((signal) => signal.kind === 'conversation' || signal.kind === 'sonner-test-running')
+        .map(toastId),
+    )
+    const currentChannels = new Set(signals.map(toastId))
+    for (const id of persistentSignals.current) {
+      if (!currentChannels.has(id)) toast.dismiss(id)
+    }
+
+    for (const signal of signals) {
+      const id = toastId(signal)
+      if ((announced.current.get(id) ?? -1) >= signal.revision) continue
+      announced.current.set(id, signal.revision)
+
+      const agent = signal.agent ?? t('activityToast.agent')
+      if (signal.kind === 'conversation') {
+        toast.loading(t('activityToast.conversationRunning', { agent }), {
+          id,
+          duration: Number.POSITIVE_INFINITY,
+        })
+      } else if (signal.kind === 'conversation-failed') {
+        toast.error(t('activityToast.conversationFailed', { agent }), {
+          id,
+          duration: 8_000,
+        })
+      } else if (signal.kind === 'inbox') {
+        toast.success(t('activityToast.inboxDelivered', { agent }), {
+          id,
+          duration: 4_000,
+        })
+      } else if (signal.kind === 'sonner-test-running') {
+        toast.loading(signal.detail ?? 'Sonner running test', {
+          id,
+          duration: Number.POSITIVE_INFINITY,
+        })
+      } else if (signal.kind === 'sonner-test-success') {
+        toast.success(signal.detail ?? 'Sonner success test', { id, duration: 4_000 })
+      } else {
+        toast.error(signal.detail ?? 'Sonner error test', { id, duration: 8_000 })
+      }
+    }
+
+    persistentSignals.current = nextActive
+    while (announced.current.size > MAX_ANNOUNCED_SIGNALS) {
+      const oldest = announced.current.keys().next().value as string | undefined
+      if (!oldest) break
+      announced.current.delete(oldest)
+    }
+  }, [loading, signals, t])
+
+  return null
+}

--- a/ui/src/components/DevCategoryList.tsx
+++ b/ui/src/components/DevCategoryList.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from 'react-i18next'
-import { Wrench, Camera, ScrollText, FlaskConical, Compass } from 'lucide-react'
+import { Wrench, Camera, ScrollText, FlaskConical, Compass, PanelsTopLeft } from 'lucide-react'
 import { useWorkspace } from '../tabs/store'
 import { getFocusedTab } from '../tabs/types'
 import { SidebarRow } from './SidebarRow'
 
 const CATEGORIES = [
+  { labelKey: 'dev.frontend', tab: 'frontend', Icon: PanelsTopLeft },
   { labelKey: 'common.tools', tab: 'tools', Icon: Wrench },
   { labelKey: 'dev.onboarding', tab: 'onboarding', Icon: Compass },
   { labelKey: 'dev.snapshots', tab: 'snapshots', Icon: Camera },

--- a/ui/src/components/Toast.tsx
+++ b/ui/src/components/Toast.tsx
@@ -1,13 +1,7 @@
-import { createContext, useContext, useCallback, useState, useEffect, useRef, type ReactNode } from 'react'
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { toast } from 'sonner'
 
-// ==================== Types ====================
-
-interface ToastItem {
-  id: number
-  message: string
-  type: 'success' | 'error'
-  removing?: boolean
-}
+import { Toaster } from './ui/sonner'
 
 interface ToastContextValue {
   success: (message: string) => void
@@ -24,104 +18,20 @@ export function useToast(): ToastContextValue {
   return ctx
 }
 
-// ==================== Provider ====================
-
-const MAX_TOASTS = 3
-const DISMISS_MS = 3000
-const FADE_MS = 200
-
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<ToastItem[]>([])
-  const nextId = useRef(0)
-
-  const remove = useCallback((id: number) => {
-    // Start fade-out
-    setToasts((prev) => prev.map((t) => (t.id === id ? { ...t, removing: true } : t)))
-    // Actually remove after animation
-    setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id))
-    }, FADE_MS)
-  }, [])
-
-  const add = useCallback((message: string, type: 'success' | 'error') => {
-    const id = nextId.current++
-    setToasts((prev) => {
-      const next = [...prev, { id, message, type }]
-      // Trim excess toasts (remove oldest)
-      return next.length > MAX_TOASTS ? next.slice(-MAX_TOASTS) : next
-    })
-    // Auto-dismiss
-    setTimeout(() => remove(id), DISMISS_MS)
-  }, [remove])
-
-  const success = useCallback((message: string) => add(message, 'success'), [add])
-  const error = useCallback((message: string) => add(message, 'error'), [add])
+  const value = useMemo<ToastContextValue>(() => ({
+    success: (message) => { toast.success(message) },
+    error: (message) => { toast.error(message) },
+  }), [])
 
   return (
-    <ToastContext.Provider value={{ success, error }}>
+    <ToastContext.Provider value={value}>
       {children}
-      <ToastContainer toasts={toasts} onDismiss={remove} />
+      <Toaster
+        position="top-right"
+        visibleToasts={3}
+        closeButton
+      />
     </ToastContext.Provider>
-  )
-}
-
-// ==================== Container ====================
-
-function ToastContainer({ toasts, onDismiss }: { toasts: ToastItem[]; onDismiss: (id: number) => void }) {
-  if (toasts.length === 0) return null
-
-  return (
-    <div className="fixed bottom-4 right-4 z-[70] flex flex-col gap-2 pointer-events-none">
-      {toasts.map((toast) => (
-        <ToastNotification key={toast.id} toast={toast} onDismiss={() => onDismiss(toast.id)} />
-      ))}
-    </div>
-  )
-}
-
-// ==================== Single Toast ====================
-
-function ToastNotification({ toast, onDismiss }: { toast: ToastItem; onDismiss: () => void }) {
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    // Trigger enter animation on next frame
-    requestAnimationFrame(() => setMounted(true))
-  }, [])
-
-  const isSuccess = toast.type === 'success'
-
-  return (
-    <div
-      className={`
-        pointer-events-auto flex items-center gap-2 px-4 py-2.5 rounded-lg shadow-lg border text-sm
-        transition-[opacity,transform] duration-[var(--motion-standard)] [transition-timing-function:var(--motion-ease-out)] motion-reduce:transform-none motion-reduce:transition-none
-        ${isSuccess ? 'bg-success/10 border-success/30 text-success' : 'bg-destructive/10 border-destructive/30 text-destructive'}
-        ${mounted && !toast.removing ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-4'}
-      `}
-      role="alert"
-    >
-      {/* Icon */}
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
-        {isSuccess ? (
-          <><path d="M20 6L9 17l-5-5" /></>
-        ) : (
-          <><circle cx="12" cy="12" r="10" /><path d="M15 9l-6 6M9 9l6 6" /></>
-        )}
-      </svg>
-
-      <span className="flex-1 min-w-0 truncate">{toast.message}</span>
-
-      {/* Dismiss */}
-      <button
-        onClick={onDismiss}
-        className="shrink-0 opacity-60 hover:opacity-100 transition-opacity"
-        aria-label="Dismiss"
-      >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-          <path d="M18 6L6 18M6 6l12 12" />
-        </svg>
-      </button>
-    </div>
   )
 }

--- a/ui/src/components/ui/sonner.tsx
+++ b/ui/src/components/ui/sonner.tsx
@@ -1,0 +1,50 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from 'lucide-react'
+import type { CSSProperties } from 'react'
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
+
+import { useEffectiveTheme } from '../../theme/useEffectiveTheme'
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const theme = useEffectiveTheme()
+
+  return (
+    <Sonner
+      theme={theme}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+          '--border-radius': 'var(--radius)',
+        } as CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/ui/src/demo/handlers/agentRuntime.ts
+++ b/ui/src/demo/handlers/agentRuntime.ts
@@ -1,15 +1,18 @@
 import { http, HttpResponse } from 'msw'
 
 const now = Date.now()
+let demoSonnerSeq = 6
+const demoSonnerEvents: Array<Record<string, unknown>> = []
 
 export const agentRuntimeHandlers = [
   http.get('/api/agent-runtime', () => HttpResponse.json({
-    lastSeq: 6,
+    lastSeq: demoSonnerSeq,
     page: 1,
     pageSize: 50,
-    total: 6,
+    total: 6 + demoSonnerEvents.length,
     totalPages: 1,
     entries: [
+      ...demoSonnerEvents,
       {
         seq: 6,
         ts: now - 12_000,
@@ -99,4 +102,26 @@ export const agentRuntimeHandlers = [
       },
     ],
   })),
+  http.post('/api/agent-runtime/sonner-test', async ({ request }) => {
+    const body = await request.json() as { state?: 'running' | 'success' | 'error' }
+    const state = body.state
+    if (!state || !['running', 'success', 'error'].includes(state)) {
+      return HttpResponse.json({ error: 'invalid state' }, { status: 400 })
+    }
+    demoSonnerSeq += 1
+    const entry = {
+      seq: demoSonnerSeq,
+      ts: Date.now(),
+      type: 'dev.sonner_test',
+      payload: {
+        workspaceId: '__dev__',
+        resumeId: `sonner-test-${demoSonnerSeq}`,
+        agent: 'Dev Panel',
+        testState: state,
+        message: `Sonner ${state} test`,
+      },
+    }
+    demoSonnerEvents.unshift(entry)
+    return HttpResponse.json({ entry }, { status: 201 })
+  }),
 ]

--- a/ui/src/hooks/useGlobalAgentActivity.spec.ts
+++ b/ui/src/hooks/useGlobalAgentActivity.spec.ts
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentRuntimeEvent } from '../api/agentRuntimeLog'
+import type { InboxEntry } from '../api/inbox'
+import {
+  conversationActivityFilter,
+  inboxActivityFilter,
+  projectGlobalActivity,
+  sonnerTestActivityFilter,
+  summarizeAgentActivity,
+  useGlobalAgentActivity,
+  type GlobalActivityFilter,
+} from './useGlobalAgentActivity'
+
+const queryRuntime = vi.fn()
+const queryInbox = vi.fn()
+
+vi.mock('../api', () => ({
+  api: {
+    agentRuntime: { query: (...args: unknown[]) => queryRuntime(...args) },
+    inbox: { history: (...args: unknown[]) => queryInbox(...args) },
+  },
+}))
+
+function event(
+  seq: number,
+  type: AgentRuntimeEvent['type'],
+  payload: Partial<AgentRuntimeEvent['payload']> = {},
+  ts = seq * 1_000,
+): AgentRuntimeEvent {
+  return {
+    seq,
+    ts,
+    type,
+    payload: {
+      workspaceId: 'chat-1',
+      resumeId: 'resume-1',
+      agent: 'pi',
+      taskId: 'task-1',
+      ...payload,
+    },
+  }
+}
+
+function conversationCause() {
+  return {
+    kind: 'conversation' as const,
+    from: {
+      kind: 'session' as const,
+      workspaceId: 'chat-parent',
+      resumeId: 'resume-parent',
+      agent: 'codex',
+    },
+    resolution: 'exact' as const,
+  }
+}
+
+function inboxEntry(overrides: Partial<InboxEntry> = {}): InboxEntry {
+  return {
+    id: 'inbox-1',
+    ts: 10_000,
+    workspaceId: 'chat-1',
+    comments: 'Done',
+    origin: {
+      kind: 'headless',
+      agent: 'pi',
+      runId: 'task-1',
+      resumeId: 'resume-1',
+    },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  queryRuntime.mockReset()
+  queryInbox.mockReset()
+})
+
+describe('global activity filters', () => {
+  it('surfaces Agent-to-Agent scheduling without exposing ordinary UI, Issue, or tool work', () => {
+    const sources = {
+      runtimeEvents: [
+        event(1, 'runtime.started', { taskId: 'ui', cause: { kind: 'ui' } }),
+        event(2, 'runtime.started', {
+          taskId: 'issue',
+          cause: { kind: 'issue', workspaceId: 'chat-1', issueId: 'daily-close' },
+        }),
+        event(3, 'runtime.turn.tool', { taskId: 'tool', toolName: 'bash', toolStatus: 'running' }),
+        event(6, 'runtime.started', {
+          taskId: 'human-follow-up',
+          cause: { kind: 'conversation', from: { kind: 'human' } },
+        }),
+        event(4, 'runtime.started', { taskId: 'conversation', cause: conversationCause() }),
+        event(5, 'runtime.turn.tool', {
+          taskId: 'conversation',
+          toolName: 'bash',
+          toolStatus: 'running',
+        }),
+      ],
+      inboxEntries: [],
+    }
+
+    expect(conversationActivityFilter.project(sources, 5_000)).toEqual([
+      expect.objectContaining({
+        id: 'conversation:task:conversation',
+        kind: 'conversation',
+        taskId: 'conversation',
+        revision: 4,
+      }),
+    ])
+  })
+
+  it('removes completed or paused scheduling and retains recent failures as the same signal family', () => {
+    const started = event(1, 'runtime.started', { cause: conversationCause() })
+    expect(conversationActivityFilter.project({
+      runtimeEvents: [started, event(2, 'runtime.stopped', { status: 'paused' })],
+      inboxEntries: [],
+    }, 2_000)).toEqual([])
+
+    expect(conversationActivityFilter.project({
+      runtimeEvents: [started, event(2, 'runtime.stopped', { status: 'failed', error: 'no auth' })],
+      inboxEntries: [],
+    }, 2_000)).toEqual([
+      expect.objectContaining({
+        id: 'conversation-failed:task:task-1',
+        kind: 'conversation-failed',
+        detail: 'no auth',
+      }),
+    ])
+  })
+
+  it('surfaces only recent Agent-originated Inbox deliveries', () => {
+    expect(inboxActivityFilter.project({
+      runtimeEvents: [],
+      inboxEntries: [
+        inboxEntry(),
+        inboxEntry({ id: 'manual', origin: { kind: 'manual', agent: 'human' } }),
+        inboxEntry({ id: 'old', ts: 1_000 }),
+        inboxEntry({ id: 'anonymous', origin: undefined }),
+      ],
+    }, 15_000)).toEqual([
+      expect.objectContaining({
+        id: 'inbox:inbox-1',
+        kind: 'inbox',
+        inboxEntryId: 'inbox-1',
+      }),
+    ])
+  })
+
+  it('supports new signal families through filter registration without changing the activity bridge', () => {
+    const customFilter: GlobalActivityFilter = {
+      id: 'custom',
+      project: () => [{
+        id: 'custom:1',
+        kind: 'inbox',
+        workspaceId: 'chat-custom',
+        occurredAt: 9_000,
+        revision: 1,
+      }],
+    }
+    const signals = projectGlobalActivity(
+      { runtimeEvents: [], inboxEntries: [] },
+      10_000,
+      [customFilter],
+    )
+
+    expect(signals.map((signal) => signal.id)).toEqual(['custom:1'])
+    expect(summarizeAgentActivity(signals)).toEqual({
+      primary: signals[0],
+      count: 1,
+      hasFailure: false,
+    })
+  })
+
+  it('projects dedicated Sonner probes without treating ordinary runtime events as UI tests', () => {
+    const sources = {
+      runtimeEvents: [
+        event(1, 'runtime.started', { cause: { kind: 'ui' } }, 9_000),
+        event(2, 'dev.sonner_test', {
+          workspaceId: '__dev__',
+          resumeId: 'sonner-test-2',
+          agent: 'Dev Panel',
+          testState: 'success',
+          message: 'Sonner success test',
+        }, 10_000),
+      ],
+      inboxEntries: [],
+    }
+
+    expect(sonnerTestActivityFilter.project(sources, 11_000)).toEqual([
+      expect.objectContaining({
+        id: 'sonner-test:2',
+        kind: 'sonner-test-success',
+        detail: 'Sonner success test',
+      }),
+    ])
+  })
+})
+
+describe('useGlobalAgentActivity', () => {
+  it('combines incremental runtime events with Inbox deliveries and preserves data on partial failure', async () => {
+    const now = Date.now()
+    queryRuntime
+      .mockResolvedValueOnce({
+        entries: [event(2, 'runtime.started', { cause: conversationCause() }, now)],
+        lastSeq: 2,
+      })
+      .mockResolvedValueOnce({
+        entries: [event(3, 'runtime.turn.tool', { toolName: 'bash', toolStatus: 'running' }, now + 1_000)],
+        lastSeq: 3,
+      })
+      .mockRejectedValueOnce(new Error('runtime offline'))
+    queryInbox
+      .mockResolvedValueOnce({ entries: [inboxEntry({ ts: now })], hasMore: false })
+      .mockResolvedValueOnce({ entries: [inboxEntry({ ts: now })], hasMore: false })
+      .mockResolvedValueOnce({ entries: [inboxEntry({ ts: now })], hasMore: false })
+
+    const { result, unmount } = renderHook(() => useGlobalAgentActivity())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(queryRuntime).toHaveBeenCalledWith({ page: 1, pageSize: 100 })
+    expect(queryInbox).toHaveBeenCalledWith({ limit: 25 })
+    expect(result.current.signals.map((signal) => signal.kind).sort()).toEqual(['conversation', 'inbox'])
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(queryRuntime).toHaveBeenLastCalledWith({ afterSeq: 2, limit: 100 })
+    expect(result.current.signals.find((signal) => signal.kind === 'conversation')?.revision).toBe(2)
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.error).toBe('runtime offline')
+    expect(result.current.signals).toHaveLength(2)
+    unmount()
+  })
+})

--- a/ui/src/hooks/useGlobalAgentActivity.ts
+++ b/ui/src/hooks/useGlobalAgentActivity.ts
@@ -1,0 +1,319 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { api } from '../api'
+import type { AgentRuntimeCause, AgentRuntimeEvent } from '../api/agentRuntimeLog'
+import type { InboxEntry } from '../api/inbox'
+
+const POLL_MS = 4_000
+const INITIAL_EVENT_LIMIT = 100
+const EVENT_CACHE_LIMIT = 500
+const INBOX_LIMIT = 25
+const RECENT_SIGNAL_MS = 12_000
+const FAILURE_SIGNAL_MS = 12_000
+// Runtime logs are append-only, but a hard process exit can omit the matching
+// stopped event. Do not let that historical gap leave the global affordance
+// claiming that a delegated request is still active forever.
+const ACTIVE_STALE_MS = 24 * 60 * 60 * 1_000
+export const GLOBAL_ACTIVITY_REFRESH_EVENT = 'openalice:activity-refresh'
+
+/**
+ * A signal is a deliberately small, user-facing fact selected from a larger
+ * log stream. It is not a second runtime state machine. Each filter owns the
+ * semantics needed to decide whether its source event is globally notable.
+ */
+export type AgentActivityKind =
+  | 'conversation'
+  | 'conversation-failed'
+  | 'inbox'
+  | 'sonner-test-running'
+  | 'sonner-test-success'
+  | 'sonner-test-error'
+
+export interface AgentActivitySignal {
+  readonly id: string
+  readonly kind: AgentActivityKind
+  readonly workspaceId: string
+  readonly agent?: string
+  readonly resumeId?: string
+  readonly sessionRecordId?: string
+  readonly taskId?: string
+  readonly inboxEntryId?: string
+  readonly cause?: AgentRuntimeCause
+  readonly detail?: string
+  readonly occurredAt: number
+  /** Monotonic revision within a source, used to animate a newly notable fact once. */
+  readonly revision: number
+}
+
+export interface GlobalActivitySources {
+  readonly runtimeEvents: readonly AgentRuntimeEvent[]
+  readonly inboxEntries: readonly InboxEntry[]
+}
+
+/** Extend global activity projection by registering another narrow source filter here. */
+export interface GlobalActivityFilter {
+  readonly id: string
+  project(sources: GlobalActivitySources, now: number): readonly AgentActivitySignal[]
+}
+
+export interface AgentActivitySummary {
+  readonly primary: AgentActivitySignal | null
+  readonly count: number
+  readonly hasFailure: boolean
+}
+
+export interface GlobalAgentActivityData {
+  readonly signals: readonly AgentActivitySignal[]
+  readonly summary: AgentActivitySummary
+  readonly loading: boolean
+  readonly error: string | null
+  refresh(): Promise<void>
+}
+
+function runtimeOperationId(event: AgentRuntimeEvent): string {
+  if (event.payload.taskId) return `task:${event.payload.taskId}`
+  return `session:${event.payload.workspaceId}:${event.payload.resumeId}`
+}
+
+interface ConversationProjection {
+  readonly id: string
+  readonly workspaceId: string
+  readonly resumeId: string
+  readonly agent: string
+  readonly sessionRecordId?: string
+  readonly taskId?: string
+  readonly cause: Extract<AgentRuntimeCause, { kind: 'conversation' }>
+  readonly startedAt: number
+  readonly updatedAt: number
+  readonly revision: number
+  readonly failed?: string
+  readonly closed: boolean
+}
+
+function conversationFailure(event: AgentRuntimeEvent): string | undefined {
+  if (event.type === 'runtime.spawn_failed') {
+    return event.payload.error ?? event.payload.launchErrorCode ?? 'Agent request could not start'
+  }
+  if (event.type === 'runtime.rejected') return event.payload.reason ?? 'Agent request was rejected'
+  if (event.type === 'runtime.stopped' && event.payload.status === 'failed') {
+    return event.payload.error ?? 'Agent request failed'
+  }
+  return undefined
+}
+
+export const conversationActivityFilter: GlobalActivityFilter = {
+  id: 'agent-conversation',
+  project({ runtimeEvents }, now) {
+    const projected = new Map<string, ConversationProjection>()
+    for (const event of [...runtimeEvents].sort((a, b) => a.seq - b.seq)) {
+      const id = runtimeOperationId(event)
+      const previous = projected.get(id)
+      const cause = event.payload.cause?.kind === 'conversation'
+        ? event.payload.cause
+        : previous?.cause
+      if (!cause || cause.from?.kind === 'human') continue
+
+      const failure = conversationFailure(event)
+      const closed = event.type === 'runtime.stopped' && event.payload.status !== 'failed'
+      projected.set(id, {
+        id,
+        workspaceId: event.payload.workspaceId || previous?.workspaceId || '',
+        resumeId: event.payload.resumeId || previous?.resumeId || '',
+        agent: event.payload.agent || previous?.agent || '',
+        ...(event.payload.sessionRecordId || previous?.sessionRecordId
+          ? { sessionRecordId: event.payload.sessionRecordId ?? previous?.sessionRecordId }
+          : {}),
+        ...(event.payload.taskId || previous?.taskId
+          ? { taskId: event.payload.taskId ?? previous?.taskId }
+          : {}),
+        cause,
+        startedAt: previous?.startedAt ?? event.ts,
+        updatedAt: event.ts,
+        // Tool-level progress can update the underlying conversation without
+        // becoming a new global announcement. Only the conversation boundary
+        // (start, failure, or close) advances the projected revision.
+        revision: failure || closed ? event.seq : previous?.revision ?? event.seq,
+        ...(failure ? { failed: failure } : previous?.failed ? { failed: previous.failed } : {}),
+        closed: failure ? false : closed || previous?.closed === true,
+      })
+    }
+
+    return [...projected.values()].flatMap((item): AgentActivitySignal[] => {
+      const age = Math.max(0, now - item.updatedAt)
+      if (item.failed) {
+        if (age > FAILURE_SIGNAL_MS) return []
+        return [{
+          id: `conversation-failed:${item.id}`,
+          kind: 'conversation-failed',
+          workspaceId: item.workspaceId,
+          agent: item.agent,
+          resumeId: item.resumeId,
+          ...(item.sessionRecordId ? { sessionRecordId: item.sessionRecordId } : {}),
+          ...(item.taskId ? { taskId: item.taskId } : {}),
+          cause: item.cause,
+          detail: item.failed,
+          occurredAt: item.updatedAt,
+          revision: item.revision,
+        }]
+      }
+      if (item.closed || now - item.startedAt > ACTIVE_STALE_MS) return []
+      return [{
+        id: `conversation:${item.id}`,
+        kind: 'conversation',
+        workspaceId: item.workspaceId,
+        agent: item.agent,
+        resumeId: item.resumeId,
+        ...(item.sessionRecordId ? { sessionRecordId: item.sessionRecordId } : {}),
+        ...(item.taskId ? { taskId: item.taskId } : {}),
+        cause: item.cause,
+        occurredAt: item.startedAt,
+        revision: item.revision,
+      }]
+    })
+  },
+}
+
+export const inboxActivityFilter: GlobalActivityFilter = {
+  id: 'agent-inbox',
+  project({ inboxEntries }, now) {
+    return inboxEntries.flatMap((entry): AgentActivitySignal[] => {
+      if (!entry.origin?.agent || entry.origin.kind === 'manual') return []
+      if (Math.max(0, now - entry.ts) > RECENT_SIGNAL_MS) return []
+      return [{
+        id: `inbox:${entry.id}`,
+        kind: 'inbox',
+        workspaceId: entry.workspaceId,
+        agent: entry.origin.agent,
+        ...(entry.origin.resumeId ? { resumeId: entry.origin.resumeId } : {}),
+        ...(entry.origin.sessionId ? { sessionRecordId: entry.origin.sessionId } : {}),
+        ...(entry.origin.runId ? { taskId: entry.origin.runId } : {}),
+        inboxEntryId: entry.id,
+        occurredAt: entry.ts,
+        revision: entry.ts,
+      }]
+    })
+  },
+}
+
+export const sonnerTestActivityFilter: GlobalActivityFilter = {
+  id: 'dev-sonner-test',
+  project({ runtimeEvents }, now) {
+    return runtimeEvents.flatMap((event): AgentActivitySignal[] => {
+      if (event.type !== 'dev.sonner_test' || !event.payload.testState) return []
+      if (Math.max(0, now - event.ts) > RECENT_SIGNAL_MS) return []
+      return [{
+        id: `sonner-test:${event.seq}`,
+        kind: `sonner-test-${event.payload.testState}` as AgentActivityKind,
+        workspaceId: event.payload.workspaceId,
+        agent: event.payload.agent,
+        detail: event.payload.message,
+        occurredAt: event.ts,
+        revision: event.seq,
+      }]
+    })
+  },
+}
+
+export const globalActivityFilters: readonly GlobalActivityFilter[] = [
+  conversationActivityFilter,
+  inboxActivityFilter,
+  sonnerTestActivityFilter,
+]
+
+export function projectGlobalActivity(
+  sources: GlobalActivitySources,
+  now = Date.now(),
+  filters: readonly GlobalActivityFilter[] = globalActivityFilters,
+): AgentActivitySignal[] {
+  return filters
+    .flatMap((filter) => filter.project(sources, now))
+    .sort((a, b) => Number(b.kind === 'conversation-failed') - Number(a.kind === 'conversation-failed')
+      || b.occurredAt - a.occurredAt)
+}
+
+export function summarizeAgentActivity(
+  signals: readonly AgentActivitySignal[],
+): AgentActivitySummary {
+  return {
+    primary: signals[0] ?? null,
+    count: signals.length,
+    hasFailure: signals.some((signal) => signal.kind === 'conversation-failed'),
+  }
+}
+
+/**
+ * Global projection of significant cross-Agent scheduling and delivery facts.
+ * Office owns the complete runtime state machine; this hook intentionally
+ * exposes only signals selected by the registered high-level filters.
+ */
+export function useGlobalAgentActivity(): GlobalAgentActivityData {
+  const [runtimeEvents, setRuntimeEvents] = useState<AgentRuntimeEvent[]>([])
+  const [inboxEntries, setInboxEntries] = useState<InboxEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [now, setNow] = useState(Date.now())
+  const cursorRef = useRef(0)
+  const initializedRef = useRef(false)
+
+  const refresh = useCallback(async () => {
+    const runtimeRequest = initializedRef.current
+      ? api.agentRuntime.query({ afterSeq: cursorRef.current, limit: INITIAL_EVENT_LIMIT })
+      : api.agentRuntime.query({ page: 1, pageSize: INITIAL_EVENT_LIMIT })
+    const [runtimeResult, inboxResult] = await Promise.allSettled([
+      runtimeRequest,
+      api.inbox.history({ limit: INBOX_LIMIT }),
+    ])
+
+    const errors: string[] = []
+    if (runtimeResult.status === 'fulfilled') {
+      const incoming = [...runtimeResult.value.entries].sort((a, b) => a.seq - b.seq)
+      setRuntimeEvents((current) => {
+        const bySeq = new Map(current.map((event) => [event.seq, event]))
+        for (const event of incoming) bySeq.set(event.seq, event)
+        return [...bySeq.values()].sort((a, b) => a.seq - b.seq).slice(-EVENT_CACHE_LIMIT)
+      })
+      cursorRef.current = Math.max(
+        cursorRef.current,
+        runtimeResult.value.lastSeq,
+        ...incoming.map((event) => event.seq),
+      )
+      initializedRef.current = true
+    } else {
+      errors.push(runtimeResult.reason instanceof Error
+        ? runtimeResult.reason.message
+        : String(runtimeResult.reason))
+    }
+
+    if (inboxResult.status === 'fulfilled') {
+      setInboxEntries(inboxResult.value.entries)
+    } else {
+      errors.push(inboxResult.reason instanceof Error
+        ? inboxResult.reason.message
+        : String(inboxResult.reason))
+    }
+
+    setNow(Date.now())
+    setError(errors.length > 0 ? errors.join('; ') : null)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const id = window.setInterval(() => void refresh(), POLL_MS)
+    const refreshFromActivity = () => void refresh()
+    window.addEventListener(GLOBAL_ACTIVITY_REFRESH_EVENT, refreshFromActivity)
+    return () => {
+      window.clearInterval(id)
+      window.removeEventListener(GLOBAL_ACTIVITY_REFRESH_EVENT, refreshFromActivity)
+    }
+  }, [refresh])
+
+  const signals = useMemo(() => projectGlobalActivity(
+    { runtimeEvents, inboxEntries },
+    now,
+    globalActivityFilters,
+  ), [inboxEntries, now, runtimeEvents])
+  const summary = useMemo(() => summarizeAgentActivity(signals), [signals])
+
+  return { signals, summary, loading, error, refresh }
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1597,6 +1597,7 @@ export const en = {
   dev: {
     onboarding: 'Onboarding',
     snapshots: 'Snapshots',
+    frontend: 'Frontend',
     filterTools: 'Filter tools…',
     selectTool: 'Select a tool from the left panel.',
     toolDetailsLoadError: 'Failed to load tool details.',
@@ -1747,6 +1748,12 @@ export const en = {
     runsDescription: 'Headless agent runs across workspaces — what the workers are doing.',
     api: 'API',
     apiDescription: 'Trigger workspace automation from outside, and review the schedule-file format.',
+  },
+  activityToast: {
+    agent: 'Agent',
+    conversationRunning: '{{agent}} is handling another Agent request',
+    conversationFailed: '{{agent}} could not complete an Agent request',
+    inboxDelivered: '{{agent}} sent an Inbox update',
   },
   office: {
     description: 'Harness offices share one floor. Each Workspace forms a group; every Session has its own desk.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1586,6 +1586,7 @@ export const ja: Resources = {
   dev: {
     onboarding: 'オンボーディング',
     snapshots: 'スナップショット',
+    frontend: 'フロントエンド',
     filterTools: 'ツールを絞り込む…',
     selectTool: '左側のパネルからツールを選択してください。',
     toolDetailsLoadError: 'ツールの詳細を読み込めませんでした。',
@@ -1736,6 +1737,12 @@ export const ja: Resources = {
     runsDescription: 'ワークスペースをまたぐヘッドレス Agent の実行状況を確認します。',
     api: 'API',
     apiDescription: '外部からワークスペース自動化を起動し、スケジュールファイル形式を確認します。',
+  },
+  activityToast: {
+    agent: 'Agent',
+    conversationRunning: '{{agent}} が別の Agent からの依頼を処理中です',
+    conversationFailed: '{{agent}} が Agent からの依頼を完了できませんでした',
+    inboxDelivered: '{{agent}} が Inbox にメッセージを送信しました',
   },
   office: {
     description: '複数の Harness オフィスが同じフロアを共有する。Workspace はグループとなり、Session が各自の机に座る。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1593,6 +1593,7 @@ export const zhHant: Resources = {
   dev: {
     onboarding: '新手引導',
     snapshots: '快照',
+    frontend: '前端',
     filterTools: '篩選工具…',
     selectTool: '請從左側面板選擇一個工具。',
     toolDetailsLoadError: '工具詳細資料載入失敗。',
@@ -1743,6 +1744,12 @@ export const zhHant: Resources = {
     runsDescription: '查看跨工作區的無頭 Agent 運行與工作進度。',
     api: 'API',
     apiDescription: '從外部觸發工作區自動化，並查看排程檔案格式。',
+  },
+  activityToast: {
+    agent: 'Agent',
+    conversationRunning: '{{agent}} 正在處理另一個 Agent 的請求',
+    conversationFailed: '{{agent}} 未能完成 Agent 請求',
+    inboxDelivered: '{{agent}} 已傳送一則 Inbox 訊息',
   },
   office: {
     description: '多個 Harness 辦公室共處一個平層。Workspace 是小組，每個 Session 都有自己的工位。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1585,6 +1585,7 @@ export const zh: Resources = {
   dev: {
     onboarding: '新手引导',
     snapshots: '快照',
+    frontend: '前端',
     filterTools: '筛选工具…',
     selectTool: '请从左侧面板选择一个工具。',
     toolDetailsLoadError: '工具详情加载失败。',
@@ -1735,6 +1736,12 @@ export const zh: Resources = {
     runsDescription: '查看跨工作区的无头 Agent 运行及工作进度。',
     api: 'API',
     apiDescription: '从外部触发工作区自动化，并查看调度文件格式。',
+  },
+  activityToast: {
+    agent: 'Agent',
+    conversationRunning: '{{agent}} 正在处理另一个 Agent 的请求',
+    conversationFailed: '{{agent}} 未能完成 Agent 请求',
+    inboxDelivered: '{{agent}} 已发送一条 Inbox 消息',
   },
   office: {
     description: '多个 Harness 办公室共处一个平层。Workspace 是小组，每个 Session 都有自己的工位。',

--- a/ui/src/pages/DevPage.spec.tsx
+++ b/ui/src/pages/DevPage.spec.tsx
@@ -30,4 +30,13 @@ describe('DevPage', () => {
     )
     expect(screen.getByText('请从左侧面板选择一个工具。')).toBeTruthy()
   })
+
+  it('exposes the frontend feedback lab as a first-class Dev Panel surface', () => {
+    render(<DevPage spec={{ kind: 'dev', params: { tab: 'frontend' } }} />)
+
+    expect(screen.getByRole('heading', { name: 'Frontend lab' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Show running' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Show success' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Show error' })).toBeTruthy()
+  })
 })

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -6,6 +6,7 @@ import { getIntlLocale } from '../lib/intl'
 import { useToast } from '../components/Toast'
 import { LogsPage } from './LogsPage'
 import { SimulatorPage } from './SimulatorPage'
+import { FrontendLabPage } from './FrontendLabPage'
 import { OnboardingDesignPage } from './OnboardingDesignPage'
 import {
   toolsApi,
@@ -22,6 +23,7 @@ import { filterAccountTierUTAs } from '../lib/uta-account-filter'
 type Tab = Extract<ViewSpec, { kind: 'dev' }>['params']['tab']
 
 const TAB_TITLE_KEYS = {
+  frontend: 'dev.frontend',
   tools: 'common.tools',
   onboarding: 'dev.onboarding',
   snapshots: 'dev.snapshots',
@@ -47,6 +49,7 @@ export function DevPage({ spec }: DevPageProps) {
       <PageHeader title={t(TAB_TITLE_KEYS[tab])} />
       <div className={`flex-1 min-h-0 ${SELF_SCROLLING_TABS.has(tab) ? 'flex flex-col' : 'overflow-y-auto'}`}>
         {tab === 'tools' && <ToolsTab />}
+        {tab === 'frontend' && <FrontendLabPage />}
         {tab === 'onboarding' && <OnboardingDesignPage />}
         {tab === 'snapshots' && <SnapshotsTab />}
         {tab === 'logs' && <LogsPage />}

--- a/ui/src/pages/FrontendLabPage.tsx
+++ b/ui/src/pages/FrontendLabPage.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { CheckCircle2, CircleAlert, LoaderCircle } from 'lucide-react'
+
+import { agentRuntimeLogApi } from '../api/agentRuntimeLog'
+import { Button } from '../components/ui/button'
+import { GLOBAL_ACTIVITY_REFRESH_EVENT } from '../hooks/useGlobalAgentActivity'
+
+type TestState = 'running' | 'success' | 'error'
+
+const TESTS: ReadonlyArray<{
+  state: TestState
+  label: string
+  description: string
+  icon: typeof LoaderCircle
+  variant: 'outline' | 'default' | 'destructive'
+}> = [
+  {
+    state: 'running',
+    label: 'Show running',
+    description: 'Persistent work in progress; it expires automatically after the test window.',
+    icon: LoaderCircle,
+    variant: 'outline',
+  },
+  {
+    state: 'success',
+    label: 'Show success',
+    description: 'A completed significant activity using the normal success duration.',
+    icon: CheckCircle2,
+    variant: 'default',
+  },
+  {
+    state: 'error',
+    label: 'Show error',
+    description: 'A failed significant activity that remains visible longer.',
+    icon: CircleAlert,
+    variant: 'destructive',
+  },
+]
+
+export function FrontendLabPage() {
+  const [pending, setPending] = useState<TestState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const trigger = async (state: TestState) => {
+    setPending(state)
+    setError(null)
+    try {
+      await agentRuntimeLogApi.triggerSonnerTest(state)
+      window.dispatchEvent(new Event(GLOBAL_ACTIVITY_REFRESH_EVENT))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPending(null)
+    }
+  }
+
+  return (
+    <div className="px-4 py-5 md:px-6">
+      <div className="max-w-[760px] space-y-5">
+        <div>
+          <h2 className="text-[18px] font-semibold text-foreground">Frontend lab</h2>
+          <p className="mt-1 max-w-[620px] text-[13px] leading-relaxed text-muted-foreground">
+            Exercise shared UI feedback through the real application event pipeline.
+          </p>
+        </div>
+
+        <section className="overflow-hidden rounded-xl border border-border bg-secondary/35">
+          <div className="border-b border-border px-4 py-3">
+            <h3 className="text-[14px] font-semibold text-foreground">Activity Sonner</h3>
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+              Each button appends a dedicated test activity to the runtime journal. The global
+              activity filter then projects it into the same Sonner bridge used by real work.
+            </p>
+          </div>
+          <div className="divide-y divide-border">
+            {TESTS.map((test) => (
+              <div key={test.state} className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <div className="text-[13px] font-medium text-foreground">{test.label}</div>
+                  <div className="mt-0.5 text-[12px] text-muted-foreground">{test.description}</div>
+                </div>
+                <Button
+                  type="button"
+                  variant={test.variant}
+                  disabled={pending !== null}
+                  onClick={() => void trigger(test.state)}
+                >
+                  <test.icon className={pending === test.state ? 'animate-spin' : ''} />
+                  {pending === test.state ? 'Triggering…' : test.label}
+                </Button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {error ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
+            {error}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/pages/OfficeRuntimeSection.tsx
+++ b/ui/src/pages/OfficeRuntimeSection.tsx
@@ -15,12 +15,14 @@ const STATUS_STYLE: Record<AgentRuntimeEventType, string> = {
   'runtime.turn.text': 'bg-primary/10 text-foreground',
   'runtime.turn.tool': 'bg-info/10 text-info',
   'runtime.turn.error': 'bg-destructive/15 text-destructive',
+  'dev.sonner_test': 'bg-secondary text-muted-foreground',
 }
 
 function eventLabel(type: AgentRuntimeEventType): string {
   if (type === 'runtime.turn.text') return 'text'
   if (type === 'runtime.turn.tool') return 'tool'
   if (type === 'runtime.turn.error') return 'error'
+  if (type === 'dev.sonner_test') return 'Sonner test'
   return type.replace('runtime.', '').replace('session.', '')
 }
 
@@ -31,6 +33,7 @@ function eventDetail(event: AgentRuntimeEvent): string | null {
     return [payload.toolName, payload.toolStatus].filter(Boolean).join(' · ') || null
   }
   if (event.type === 'runtime.turn.error') return payload.message ?? payload.error ?? null
+  if (event.type === 'dev.sonner_test') return payload.message ?? null
   if (event.type === 'runtime.stopped' && payload.assistantText) return payload.assistantText
   return null
 }

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -359,6 +359,7 @@ const designProjectModule: ViewModule<'design-project'> = {
 }
 
 const devTabTitle: Record<Extract<ViewSpec, { kind: 'dev' }>['params']['tab'], string> = {
+  frontend: 'Frontend',
   tools: 'Tools',
   onboarding: 'Onboarding',
   snapshots: 'Snapshots',

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -17,7 +17,7 @@ export type WorkspaceSource = 'chat' | 'auto-quant'
 export type FileViewerSource = WorkspaceSource | 'tracked'
 
 /** One source of truth for the Dev sidebar and `/dev/:tab` URL contract. */
-export const DEV_TABS = ['tools', 'onboarding', 'snapshots', 'logs', 'simulator'] as const
+export const DEV_TABS = ['frontend', 'tools', 'onboarding', 'snapshots', 'logs', 'simulator'] as const
 export type DevTab = typeof DEV_TABS[number]
 
 export function isDevTab(value: string): value is DevTab {


### PR DESCRIPTION
## Summary
- replace the activity orb with filtered Sonner notifications
- surface only significant agent dispatch and Inbox activity
- add a Dev Panel simulator event for manual verification

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test
- verified the real Dev Panel and Chat routes in browser