### PR TITLE
feat(ui): merge Portfolio and Trading as Git into Broker

### DIFF
--- a/src/core/ui-layout.spec.ts
+++ b/src/core/ui-layout.spec.ts
@@ -45,6 +45,21 @@ describe('ui-layout', () => {
     expect(layout.hidden).toEqual(['dev'])
   })
 
+  it('drops a retired trading-as-git rail entry from persisted layouts', () => {
+    const layout = normalizeUiLayout({
+      version: 1,
+      groups: [{ id: 'beta', items: ['office', 'trading-as-git', 'portfolio', 'connectors'] }],
+      hidden: ['trading-as-git', 'dev'],
+    })
+    expect(layout.groups.find((group) => group.id === 'beta')?.items).toEqual([
+      'office',
+      'portfolio',
+      'connectors',
+    ])
+    expect(layout.hidden).not.toContain('trading-as-git')
+    expect(layout.hidden).toEqual(['dev'])
+  })
+
   it('treats a missing or malformed file as the default document', async () => {
     const path = await layoutFile()
     expect(await readUiLayout(path)).toEqual(defaultUiLayout())

--- a/src/core/ui-layout.ts
+++ b/src/core/ui-layout.ts
@@ -23,7 +23,6 @@ export const ACTIVITY_PAGE_IDS = [
   'automation',
   'market',
   'issue',
-  'trading-as-git',
   'connectors',
   'settings',
   'dev',
@@ -65,7 +64,7 @@ export function defaultUiLayout(): UiLayout {
     version: 1,
     groups: [
       { id: 'primary', items: ['chat', 'inbox', 'issue', 'auto-quant', 'tracked', 'market'] },
-      { id: 'beta', items: ['office', 'trading-as-git', 'portfolio', 'connectors'] },
+      { id: 'beta', items: ['office', 'portfolio', 'connectors'] },
       { id: 'system', items: ['workspaces', 'automation', 'settings', 'dev'] },
     ],
     hidden: ['dev'],

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,7 +23,6 @@ import { useLocale } from './i18n/useLocale'
 export type Page =
   | 'chat' | 'auto-quant' | 'inbox' | 'tracked' | 'workspaces' | 'portfolio' | 'office' | 'automation' | 'market'
   | 'issue'
-  | 'trading-as-git'
   | 'connectors'
   | 'settings' | 'dev'
 

--- a/ui/src/components/ActivityBar.spec.ts
+++ b/ui/src/components/ActivityBar.spec.ts
@@ -17,7 +17,12 @@ describe('ActivityBar navigation hierarchy', () => {
       'tracked',
       'market',
     ])
-    expect(beta?.items.map((item) => item.page)).toContain('office')
+    expect(beta?.items.map((item) => item.page)).toEqual([
+      'office',
+      'portfolio',
+      'connectors',
+    ])
+    expect(beta?.items.find((item) => item.page === 'portfolio')?.labelKey).toBe('nav.item.broker')
     expect(system?.items.map((item) => item.page)).toContain('workspaces')
   })
 
@@ -37,7 +42,6 @@ describe('ActivityBar navigation hierarchy', () => {
       'dev',
     ])
     expect(pages).not.toContain('market')
-    expect(pages).not.toContain('trading-as-git')
     expect(pages).not.toContain('portfolio')
   })
 

--- a/ui/src/components/ActivityBar.tsx
+++ b/ui/src/components/ActivityBar.tsx
@@ -25,7 +25,6 @@ function activitySectionFor(page: Page): ActivitySection {
     case 'inbox':                return 'inbox'
     case 'tracked':              return 'tracked'
     case 'workspaces':           return 'workspaces'
-    case 'trading-as-git':       return 'trading-as-git'
     case 'connectors':           return 'connectors'
     case 'settings':             return 'settings'
     case 'dev':                  return 'dev'
@@ -222,7 +221,7 @@ export function ActivityBar({
                               {unreadInbox > 99 ? '99+' : unreadInbox}
                             </span>
                           )}
-                          {item.page === 'trading-as-git' && pendingPush > 0 && (
+                          {item.page === 'portfolio' && pendingPush > 0 && (
                             <span
                               aria-label={t('nav.pendingPush', { count: pendingPush })}
                               className={`shrink-0 min-w-[18px] h-[18px] px-1.5 rounded-full bg-destructive text-[10px] font-semibold text-destructive-foreground tabular-nums flex items-center justify-center ${

--- a/ui/src/components/PortfolioSidebar.spec.tsx
+++ b/ui/src/components/PortfolioSidebar.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { useWorkspace } from '../tabs/store'
+import { getFocusedTab } from '../tabs/types'
+import { PortfolioSidebar } from './PortfolioSidebar'
+
+const mocks = vi.hoisted(() => ({
+  pendingPush: 0,
+}))
+
+vi.mock('../hooks/useTradingConfig', () => ({
+  useTradingConfig: () => ({
+    utas: [
+      {
+        id: 'uta-1',
+        label: 'Paper',
+        presetId: 'alpaca-paper',
+        enabled: true,
+        guards: [],
+        presetConfig: {},
+        readOnly: false,
+        asVendor: false,
+      },
+    ],
+    loading: false,
+  }),
+}))
+
+vi.mock('../live/trading-mode', () => ({
+  ensureTradingModePolling: vi.fn(),
+  useTradingMode: (selector: (state: {
+    status: { mode: 'live' }
+    loading: boolean
+  }) => unknown) => selector({
+    status: { mode: 'live' },
+    loading: false,
+  }),
+}))
+
+vi.mock('../live/trading-push', () => ({
+  usePendingPushCount: () => mocks.pendingPush,
+}))
+
+beforeEach(async () => {
+  mocks.pendingPush = 0
+  window.localStorage.clear()
+  await i18n.changeLanguage('en')
+  useWorkspace.setState({
+    tabs: {},
+    tree: { kind: 'leaf', group: { id: 'g1', tabIds: [], activeTabId: null } },
+    focusedGroupId: 'g1',
+    selectedSidebar: null,
+  })
+})
+
+afterEach(cleanup)
+
+describe('PortfolioSidebar', () => {
+  it('puts Trading as Git above the portfolio account list', () => {
+    render(<PortfolioSidebar />)
+    const rows = screen.getAllByRole('button')
+    expect(rows[0]?.textContent).toContain('Trading as Git')
+    expect(screen.getByRole('button', { name: 'All Accounts' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Paper' })).toBeTruthy()
+  })
+
+  it('opens Trading as Git from the first navigator row', () => {
+    render(<PortfolioSidebar />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trading as Git' }))
+    expect(getFocusedTab(useWorkspace.getState())?.spec).toEqual({
+      kind: 'trading-as-git',
+      params: {},
+    })
+  })
+
+  it('shows a pending-push count on the Trading as Git row', () => {
+    mocks.pendingPush = 3
+    render(<PortfolioSidebar />)
+    expect(screen.getByLabelText('3 pending to push')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Trading as Git/ }).textContent).toContain('3')
+  })
+})

--- a/ui/src/components/PortfolioSidebar.tsx
+++ b/ui/src/components/PortfolioSidebar.tsx
@@ -6,11 +6,13 @@ import { SidebarRow } from './SidebarRow'
 import { SidebarSectionHeader } from './SidebarSectionHeader'
 import { SidebarRowsSkeleton } from './StateViews'
 import { ensureTradingModePolling, useTradingMode } from '../live/trading-mode'
+import { usePendingPushCount } from '../live/trading-push'
 import { useEffect } from 'react'
 
 /**
- * Portfolio sidebar — Overview + per-UTA accounts.
+ * Broker sidebar — Trading as Git, then Overview + per-UTA accounts.
  *
+ * - "Trading as Git" opens the staged-write review tab (`kind: 'trading-as-git'`).
  * - "All Accounts" opens the aggregate portfolio tab (`kind: 'portfolio'`).
  * - Each UTA row opens that account's detail tab (`kind: 'uta-detail'`).
  *
@@ -22,11 +24,13 @@ export function PortfolioSidebar() {
   const { utas, loading } = useTradingConfig()
   const tradingMode = useTradingMode((s) => s.status.mode)
   const tradingModeLoading = useTradingMode((s) => s.loading)
+  const pendingPush = usePendingPushCount()
   const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
 
   useEffect(() => { ensureTradingModePolling() }, [])
 
+  const tradingAsGitActive = focused?.kind === 'trading-as-git'
   const overviewActive = focused?.kind === 'portfolio'
   const focusedUtaId =
     focused?.kind === 'uta-detail' ? focused.params.id : null
@@ -35,6 +39,22 @@ export function PortfolioSidebar() {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="flex-1 overflow-y-auto min-h-0 py-1">
+        <SidebarRow
+          label={t('nav.item.tradingAsGit')}
+          active={tradingAsGitActive}
+          onClick={() => openOrFocus({ kind: 'trading-as-git', params: {} })}
+          trail={
+            pendingPush > 0 ? (
+              <span
+                aria-label={t('nav.pendingPush', { count: pendingPush })}
+                className="min-w-[18px] h-[18px] px-1.5 rounded-full bg-destructive text-[10px] font-semibold text-destructive-foreground tabular-nums flex items-center justify-center"
+              >
+                {pendingPush > 99 ? '99+' : pendingPush}
+              </span>
+            ) : undefined
+          }
+        />
+
         <SidebarSectionHeader>{t('portfolio.overview')}</SidebarSectionHeader>
         <SidebarRow
           label={t('portfolio.allAccounts')}

--- a/ui/src/components/activity-navigation.ts
+++ b/ui/src/components/activity-navigation.ts
@@ -2,7 +2,6 @@ import {
   BarChart3,
   Building2,
   Code2,
-  GitBranch,
   Inbox,
   LineChart,
   ListChecks,
@@ -29,8 +28,8 @@ import {
 
 type NavItemKey =
   | 'nav.item.inbox' | 'nav.item.tracked' | 'nav.item.chat' | 'nav.item.autoQuant' | 'nav.item.workspaces'
-  | 'nav.item.market' | 'nav.item.office' | 'nav.item.tradingAsGit' | 'nav.item.issue'
-  | 'nav.item.portfolio' | 'nav.item.connectors' | 'nav.item.automation' | 'nav.item.settings' | 'nav.item.dev'
+  | 'nav.item.market' | 'nav.item.office' | 'nav.item.issue'
+  | 'nav.item.broker' | 'nav.item.connectors' | 'nav.item.automation' | 'nav.item.settings' | 'nav.item.dev'
 
 interface NavLeaf {
   page: Page
@@ -98,10 +97,10 @@ export const NAV_SECTIONS: NavSection[] = [
     labelKey: 'nav.section.beta',
     descriptionKey: 'nav.betaDescription',
     items: [
-      { page: 'office',         labelKey: 'nav.item.office',       icon: Building2, defaultTab: { kind: 'office', params: {} } },
-      { page: 'trading-as-git', labelKey: 'nav.item.tradingAsGit', icon: GitBranch, defaultTab: { kind: 'trading-as-git', params: {} } },
-      { page: 'portfolio',      labelKey: 'nav.item.portfolio',    icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
-      { page: 'connectors',     labelKey: 'nav.item.connectors',   icon: Plug, defaultTab: { kind: 'connectors', params: {} } },
+      { page: 'office',     labelKey: 'nav.item.office',     icon: Building2, defaultTab: { kind: 'office', params: {} } },
+      // Trading as Git is a Broker navigator leaf, not a rail item.
+      { page: 'portfolio',  labelKey: 'nav.item.broker',     icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
+      { page: 'connectors', labelKey: 'nav.item.connectors', icon: Plug, defaultTab: { kind: 'connectors', params: {} } },
     ],
   },
   {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -24,6 +24,7 @@ export const en = {
       news: 'News',
       office: 'Office',
       tradingAsGit: 'Trading as Git',
+      broker: 'Broker',
       portfolio: 'Portfolio',
       connectors: 'Connectors',
       issue: 'Issues',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -13,6 +13,7 @@ export const ja: Resources = {
       news: 'ニュース',
       office: 'オフィス',
       tradingAsGit: 'Trading as Git',
+      broker: 'ブローカー',
       portfolio: 'ポートフォリオ',
       connectors: 'コネクター',
       issue: 'イシュー',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -21,6 +21,7 @@ export const zhHant: Resources = {
       news: '新聞',
       office: '辦公室',
       tradingAsGit: '交易即 Git',
+      broker: '券商',
       portfolio: '投資組合',
       connectors: '連接器',
       issue: '議題',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -13,6 +13,7 @@ export const zh: Resources = {
       news: '新闻',
       office: '办公室',
       tradingAsGit: '交易即 Git',
+      broker: '券商',
       portfolio: '投资组合',
       connectors: '连接器',
       issue: '议题',

--- a/ui/src/lib/product-surfaces.spec.ts
+++ b/ui/src/lib/product-surfaces.spec.ts
@@ -15,7 +15,6 @@ describe('Nano product surfaces', () => {
   })
 
   it('hides trading and market-data activity pages', () => {
-    expect(isNanoHiddenActivityPage('trading-as-git')).toBe(true)
     expect(isNanoHiddenActivityPage('portfolio')).toBe(true)
     expect(isNanoHiddenActivityPage('market')).toBe(true)
     expect(isNanoHiddenActivityPage('chat')).toBe(false)
@@ -31,6 +30,8 @@ describe('Nano product surfaces', () => {
     expect(isNanoHiddenSettingsCategory('ai-provider')).toBe(false)
     expect(isNanoHiddenSettingsCategory('beta')).toBe(false)
     expect(isNanoHiddenViewSpec({ kind: 'portfolio', params: {} })).toBe(true)
+    expect(isNanoHiddenViewSpec({ kind: 'trading-as-git', params: {} })).toBe(true)
+    expect(isNanoHiddenViewSpec({ kind: 'uta-detail', params: { id: 'uta-1' } })).toBe(true)
     expect(isNanoHiddenViewSpec({ kind: 'news', params: {} })).toBe(true)
     expect(isNanoHiddenViewSpec({ kind: 'settings', params: { category: 'trading' } })).toBe(true)
     expect(isNanoHiddenViewSpec({ kind: 'settings', params: { category: 'general' } })).toBe(false)

--- a/ui/src/lib/product-surfaces.ts
+++ b/ui/src/lib/product-surfaces.ts
@@ -3,7 +3,6 @@ import type { ViewSpec } from '../tabs/types'
 
 export const NANO_HIDDEN_ACTIVITY_PAGES = [
   'market',
-  'trading-as-git',
   'portfolio',
 ] as const satisfies readonly Page[]
 

--- a/ui/src/live/trading-push.ts
+++ b/ui/src/live/trading-push.ts
@@ -6,11 +6,11 @@ import { filterAccountTierUTAs } from '../lib/uta-account-filter'
 reloadOnHotUpdate('live/trading-push')
 
 /**
- * Live count of staged-but-unpushed trading operations, for the
- * Trading-as-Git activity-bar badge. Mirrors the Inbox unread badge:
- * pending pushes are an attention state the user must be reminded of,
- * otherwise a staged order sits forgotten because nothing surfaces it
- * outside the Trading-as-Git panel.
+ * Live count of staged-but-unpushed trading operations, for the Broker
+ * activity-bar badge and Trading-as-Git navigator row. Mirrors the Inbox
+ * unread badge: pending pushes are an attention state the user must be
+ * reminded of, otherwise a staged order sits forgotten because nothing
+ * surfaces it outside the Trading-as-Git panel.
  *
  * Polls `listUTAs` + per-account `walletStatus` (the same data the
  * PushApprovalPanel reads, summed). 15s cadence: this is a passive

--- a/ui/src/live/ui-layout.spec.ts
+++ b/ui/src/live/ui-layout.spec.ts
@@ -60,4 +60,19 @@ describe('ui-layout document', () => {
     expect(layout.hidden).not.toContain('news')
     expect(layout.hidden).toEqual(['dev'])
   })
+
+  it('drops a retired trading-as-git rail entry from persisted layouts', () => {
+    const layout = normalizeUiLayout({
+      version: 1,
+      groups: [{ id: 'beta', items: ['office', 'trading-as-git', 'portfolio', 'connectors'] }],
+      hidden: ['trading-as-git', 'dev'],
+    })
+    expect(layout.groups.find((group) => group.id === 'beta')?.items).toEqual([
+      'office',
+      'portfolio',
+      'connectors',
+    ])
+    expect(layout.hidden).not.toContain('trading-as-git')
+    expect(layout.hidden).toEqual(['dev'])
+  })
 })

--- a/ui/src/live/ui-layout.ts
+++ b/ui/src/live/ui-layout.ts
@@ -11,7 +11,6 @@ export const ACTIVITY_PAGE_IDS = [
   'automation',
   'market',
   'issue',
-  'trading-as-git',
   'connectors',
   'settings',
   'dev',
@@ -46,7 +45,7 @@ export function defaultUiLayout(): UiLayout {
     version: 1,
     groups: [
       { id: 'primary', items: ['chat', 'inbox', 'issue', 'auto-quant', 'tracked', 'market'] },
-      { id: 'beta', items: ['office', 'trading-as-git', 'portfolio', 'connectors'] },
+      { id: 'beta', items: ['office', 'portfolio', 'connectors'] },
       { id: 'system', items: ['workspaces', 'automation', 'settings', 'dev'] },
     ],
     hidden: ['dev'],

--- a/ui/src/pages/PageSidebarShell.tsx
+++ b/ui/src/pages/PageSidebarShell.tsx
@@ -5,11 +5,10 @@ import { PageSidebarLayout, type PageSidebarControls } from '../components/PageS
 type NavTitleKey =
   | 'nav.item.tracked'
   | 'nav.item.workspaces'
-  | 'nav.item.tradingAsGit'
   | 'nav.item.settings'
   | 'nav.item.dev'
   | 'nav.item.market'
-  | 'nav.item.portfolio'
+  | 'nav.item.broker'
   | 'nav.item.automation'
 
 interface PageSidebarShellProps {

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -417,9 +417,9 @@ function RedirectUtaDetail() {
  * Page-owned sidebars keep the highlight in sync while the app shell stays
  * unaware of each surface's local navigation.
  *
- * `uta-detail` is intentionally Portfolio's sidebar: the URL lives
- * under /settings/uta/:id for historical reasons but the page is a
- * Portfolio drill-in (positions / equity for one account).
+ * `uta-detail` and `trading-as-git` are Broker navigator leaves. Account
+ * detail still lives under /settings/uta/:id for historical reasons;
+ * Trading as Git keeps /trading-as-git. Both highlight the Broker rail item.
  */
 function specToSection(spec: ViewSpec): ActivitySection {
   switch (spec.kind) {
@@ -444,8 +444,8 @@ function specToSection(spec: ViewSpec): ActivitySection {
     case 'workspace-list':
     case 'template-catalog':
     case 'template-detail':    return 'workspaces'
-    case 'trading-as-git':     return 'trading-as-git'
     case 'connectors':         return 'connectors'
+    case 'trading-as-git':
     case 'portfolio':
     case 'uta-detail':         return 'portfolio'
     case 'issue':

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -104,19 +104,27 @@ export interface ViewModule<K extends ViewKind> {
 
 // ==================== Per-kind modules ====================
 
+function BrokerArea({ children }: { children: ReactNode }) {
+  return (
+    <PageSidebarShell
+      storageKey="portfolio"
+      titleKey="nav.item.broker"
+      defaultWidth={220}
+      sidebar={<PortfolioSidebar />}
+    >
+      {children}
+    </PageSidebarShell>
+  )
+}
+
 const portfolioModule: ViewModule<'portfolio'> = {
   kind: 'portfolio',
   title: () => 'Portfolio',
   toUrl: () => '/portfolio',
   Component: () => (
-    <PageSidebarShell
-      storageKey="portfolio"
-      titleKey="nav.item.portfolio"
-      defaultWidth={220}
-      sidebar={<PortfolioSidebar />}
-    >
+    <BrokerArea>
       <PortfolioPage />
-    </PageSidebarShell>
+    </BrokerArea>
   ),
 }
 
@@ -124,7 +132,11 @@ const tradingAsGitModule: ViewModule<'trading-as-git'> = {
   kind: 'trading-as-git',
   title: () => 'Trading as Git',
   toUrl: () => '/trading-as-git',
-  Component: () => <TradingAsGitPage />,
+  Component: () => (
+    <BrokerArea>
+      <TradingAsGitPage />
+    </BrokerArea>
+  ),
 }
 
 const connectorsModule: ViewModule<'connectors'> = {
@@ -333,14 +345,9 @@ const utaDetailModule: ViewModule<'uta-detail'> = {
   title: (spec) => `Account ${spec.params.id}`,
   toUrl: (spec) => `/settings/uta/${encodeURIComponent(spec.params.id)}`,
   Component: (props) => (
-    <PageSidebarShell
-      storageKey="portfolio"
-      titleKey="nav.item.portfolio"
-      defaultWidth={220}
-      sidebar={<PortfolioSidebar />}
-    >
+    <BrokerArea>
       <UTADetailPage {...props} />
-    </PageSidebarShell>
+    </BrokerArea>
   ),
 }
 

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -88,7 +88,6 @@ export type ActivitySection =
   | 'inbox'
   | 'tracked'
   | 'workspaces'
-  | 'trading-as-git'
   | 'connectors'
   | 'settings'
   | 'dev'


### PR DESCRIPTION
## Summary
- Merge the two UTA Beta rail items (Portfolio and Trading as Git) into one **Broker** Activity Bar entry. Both surfaces are the same domain and both are still beta; two adjacent buttons were the wrong grain.
- Keep the persisted rail id as `portfolio` so existing `data/ui-layout.json` placements and hide-flags stay put. Only the label changes.
- Trading as Git becomes a Broker navigator leaf (same pattern as News under Market): first row in the page sidebar, still reachable at `/trading-as-git`. Account detail continues to live in that same navigator.
- Pending-push badge moves from the old Trading as Git rail icon onto Broker, and also appears on the Trading as Git sidebar row.

### Alternatives considered
1. **Single Broker rail item + page-owned navigator** (chosen). Matches the existing Market/News hierarchy, removes duplicate Beta chrome, and keeps deep links.
2. Keep both rail items. Status quo: two UTA beta buttons that belong together.
3. A Broker landing page with internal tabs. Extra hop, and it would restyle a page navigator as a second shell.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 4817 passed, 9 skipped
- Demo UI in the browser (`pnpm -F open-alice-ui dev:demo`):
  - Activity rail shows Broker, not Portfolio + Trading as Git
  - Broker opens Portfolio; sidebar order is Trading as Git, All Accounts, then accounts
  - Trading as Git and account drill-in keep Broker highlighted
  - Settings → Activity bar lists Broker only
  - Mobile: Open Broker drawer reaches Trading as Git; rail current-page stays Broker
  - Market → News still highlights Market (no regression)

## Residual risk
- Users who hid Portfolio but left Trading as Git visible now only have Broker, and it stays hidden until they unhide it in Settings → Activity bar.
- Persisted `selectedSidebar: 'trading-as-git'` no longer matches a rail item until the next navigation; the next click/URL adopt sets Broker.