### PR TITLE
fix(settings): FMP Test key uses EquitySearch, matching Intrinio

### DIFF
--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -444,7 +444,7 @@ export function createMarketDataRoutes(ctx: EngineContext) {
     bls:              { credField: 'bls_api_key',              provider: 'bls',              model: 'BlsSearch',               params: { query: 'unemployment' } },
     eia:              { credField: 'eia_api_key',              provider: 'eia',              model: 'ShortTermEnergyOutlook',  params: {} },
     econdb:           { credField: 'econdb_api_key',           provider: 'econdb',           model: 'AvailableIndicators',     params: {} },
-    fmp:              { credField: 'fmp_api_key',              provider: 'fmp',              model: 'EquityScreener',          params: { limit: 1 } },
+    fmp:              { credField: 'fmp_api_key',              provider: 'fmp',              model: 'EquitySearch',            params: { query: 'AAPL', limit: 1 } },
     intrinio:         { credField: 'intrinio_api_key',         provider: 'intrinio',         model: 'EquitySearch',            params: { query: 'AAPL', limit: 1 } },
   }
 


### PR DESCRIPTION
## FMP Test-key endpoint: use EquitySearch (matches Intrinio)

Settings → Market Data → Advanced: the "Test FMP key" button probes a key via the Test-key endpoint. FMP was using `EquityScreener {limit:1}` while Intrinio already uses `EquitySearch {query:'AAPL', limit:1}`. This makes FMP consistent (and the screener endpoint is a heavier call for a key probe).

- `src/webui/routes/config.ts` — one-line change in `TEST_ENDPOINTS`; `EquitySearch` is a registered FMP fetcher (`packages/opentypebb/src/providers/fmp/index.ts:135`)
- Verified: root `npx tsc --noEmit` clean
- Suggested labels: `area:settings`, `area:market-data`
