### PR TITLE
fix(harness): restore clean cross-platform checks

### DIFF
--- a/src/workspaces/harness-source-upgrade.ts
+++ b/src/workspaces/harness-source-upgrade.ts
@@ -192,7 +192,11 @@ export class HarnessSourceUpgradeManager {
       }
       await atomicWriteJson(join(workspace.dir, JOURNAL_REL), journal)
       try {
-        await runGit(workspace.dir, ['merge', '--no-ff', '--no-commit', target.commit])
+        await runGit(workspace.dir, [
+          '-c', 'user.email=launcher@local',
+          '-c', 'user.name=OpenAlice',
+          'merge', '--no-ff', '--no-commit', target.commit,
+        ])
         await atomicWriteJson(join(workspace.dir, RECEIPT_REL), {
           ...receipt,
           version: target.version,

--- a/src/workspaces/harness-surface-manager.spec.ts
+++ b/src/workspaces/harness-surface-manager.spec.ts
@@ -69,7 +69,7 @@ describe('HarnessSurfaceManager', () => {
     const stopped = await manager.stop('ws-1', 'studio')
     expect(stopped.phase).toBe('stopped')
     expect(manager.resolveHost(ready.routeHost)).toBeNull()
-  })
+  }, 30_000)
 })
 
 async function waitFor<T>(read: () => T, done: (value: T) => boolean): Promise<T> {


### PR DESCRIPTION
## Summary
- provide the OpenAlice committer identity to the no-commit Harness source merge
- retain the full Surface lifecycle assertions while allowing Windows process-tree cleanup its cross-platform time budget

## Verification
- npx tsc --noEmit
- pnpm test (4851 passed, 9 skipped)
- targeted Harness source upgrade and Surface manager specs