### PR TITLE
refactor(ui): rename Broker navigation to Trading

### DIFF
--- a/ui/src/components/ActivityBar.spec.ts
+++ b/ui/src/components/ActivityBar.spec.ts
@@ -23,7 +23,7 @@ describe('ActivityBar navigation hierarchy', () => {
       'portfolio',
       'connectors',
     ])
-    expect(beta?.items.find((item) => item.page === 'portfolio')?.labelKey).toBe('nav.item.broker')
+    expect(beta?.items.find((item) => item.page === 'portfolio')?.labelKey).toBe('nav.item.trading')
     expect(system?.items.map((item) => item.page)).toContain('workspaces')
   })
 

--- a/ui/src/components/PortfolioSidebar.tsx
+++ b/ui/src/components/PortfolioSidebar.tsx
@@ -10,7 +10,7 @@ import { usePendingPushCount } from '../live/trading-push'
 import { useEffect } from 'react'
 
 /**
- * Broker sidebar — Trading as Git, then Overview + per-UTA accounts.
+ * Trading sidebar — Trading as Git, then Overview + per-UTA accounts.
  *
  * - "Trading as Git" opens the staged-write review tab (`kind: 'trading-as-git'`).
  * - "All Accounts" opens the aggregate portfolio tab (`kind: 'portfolio'`).

--- a/ui/src/components/activity-navigation.ts
+++ b/ui/src/components/activity-navigation.ts
@@ -30,7 +30,7 @@ import {
 type NavItemKey =
   | 'nav.item.inbox' | 'nav.item.tracked' | 'nav.item.chat' | 'nav.item.autoQuant' | 'nav.item.autoPrediction' | 'nav.item.workspaces'
   | 'nav.item.market' | 'nav.item.office' | 'nav.item.issue'
-  | 'nav.item.broker' | 'nav.item.connectors' | 'nav.item.automation' | 'nav.item.settings' | 'nav.item.dev'
+  | 'nav.item.trading' | 'nav.item.connectors' | 'nav.item.automation' | 'nav.item.settings' | 'nav.item.dev'
 
 interface NavLeaf {
   page: Page
@@ -100,8 +100,8 @@ export const NAV_SECTIONS: NavSection[] = [
     items: [
       { page: 'prediction', labelKey: 'nav.item.autoPrediction', icon: Binary, defaultTab: { kind: 'auto-prediction-landing', params: {} } },
       { page: 'office',     labelKey: 'nav.item.office',     icon: Building2, defaultTab: { kind: 'office', params: {} } },
-      // Trading as Git is a Broker navigator leaf, not a rail item.
-      { page: 'portfolio',  labelKey: 'nav.item.broker',     icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
+      // Trading as Git and broker accounts are Trading navigator leaves, not rail items.
+      { page: 'portfolio',  labelKey: 'nav.item.trading',    icon: LineChart, defaultTab: { kind: 'portfolio', params: {} } },
       { page: 'connectors', labelKey: 'nav.item.connectors', icon: Plug, defaultTab: { kind: 'connectors', params: {} } },
     ],
   },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -25,7 +25,7 @@ export const en = {
       news: 'News',
       office: 'Office',
       tradingAsGit: 'Trading as Git',
-      broker: 'Broker',
+      trading: 'Trading',
       portfolio: 'Portfolio',
       connectors: 'Connectors',
       issue: 'Issues',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -14,7 +14,7 @@ export const ja: Resources = {
       news: 'ニュース',
       office: 'オフィス',
       tradingAsGit: 'Trading as Git',
-      broker: 'ブローカー',
+      trading: '取引',
       portfolio: 'ポートフォリオ',
       connectors: 'コネクター',
       issue: 'イシュー',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -22,7 +22,7 @@ export const zhHant: Resources = {
       news: '新聞',
       office: '辦公室',
       tradingAsGit: '交易即 Git',
-      broker: '券商',
+      trading: '交易',
       portfolio: '投資組合',
       connectors: '連接器',
       issue: '議題',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -14,7 +14,7 @@ export const zh: Resources = {
       news: '新闻',
       office: '办公室',
       tradingAsGit: '交易即 Git',
-      broker: '券商',
+      trading: '交易',
       portfolio: '投资组合',
       connectors: '连接器',
       issue: '议题',

--- a/ui/src/pages/PageSidebarShell.tsx
+++ b/ui/src/pages/PageSidebarShell.tsx
@@ -8,7 +8,7 @@ type NavTitleKey =
   | 'nav.item.settings'
   | 'nav.item.dev'
   | 'nav.item.market'
-  | 'nav.item.broker'
+  | 'nav.item.trading'
   | 'nav.item.automation'
 
 interface PageSidebarShellProps {

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -450,9 +450,9 @@ function RedirectUtaDetail() {
  * Page-owned sidebars keep the highlight in sync while the app shell stays
  * unaware of each surface's local navigation.
  *
- * `uta-detail` and `trading-as-git` are Broker navigator leaves. Account
+ * `uta-detail` and `trading-as-git` are Trading navigator leaves. Account
  * detail still lives under /settings/uta/:id for historical reasons;
- * Trading as Git keeps /trading-as-git. Both highlight the Broker rail item.
+ * Trading as Git keeps /trading-as-git. Both highlight the Trading rail item.
  */
 function specToSection(spec: ViewSpec): ActivitySection {
   switch (spec.kind) {

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -105,11 +105,11 @@ export interface ViewModule<K extends ViewKind> {
 
 // ==================== Per-kind modules ====================
 
-function BrokerArea({ children }: { children: ReactNode }) {
+function TradingArea({ children }: { children: ReactNode }) {
   return (
     <PageSidebarShell
       storageKey="portfolio"
-      titleKey="nav.item.broker"
+      titleKey="nav.item.trading"
       defaultWidth={220}
       sidebar={<PortfolioSidebar />}
     >
@@ -123,9 +123,9 @@ const portfolioModule: ViewModule<'portfolio'> = {
   title: () => 'Portfolio',
   toUrl: () => '/portfolio',
   Component: () => (
-    <BrokerArea>
+    <TradingArea>
       <PortfolioPage />
-    </BrokerArea>
+    </TradingArea>
   ),
 }
 
@@ -134,9 +134,9 @@ const tradingAsGitModule: ViewModule<'trading-as-git'> = {
   title: () => 'Trading as Git',
   toUrl: () => '/trading-as-git',
   Component: () => (
-    <BrokerArea>
+    <TradingArea>
       <TradingAsGitPage />
-    </BrokerArea>
+    </TradingArea>
   ),
 }
 
@@ -346,9 +346,9 @@ const utaDetailModule: ViewModule<'uta-detail'> = {
   title: (spec) => `Account ${spec.params.id}`,
   toUrl: (spec) => `/settings/uta/${encodeURIComponent(spec.params.id)}`,
   Component: (props) => (
-    <BrokerArea>
+    <TradingArea>
       <UTADetailPage {...props} />
-    </BrokerArea>
+    </TradingArea>
   ),
 }
 


### PR DESCRIPTION
## Summary
- rename the Beta rail entry and shared portfolio/account sidebar from Broker to Trading
- keep broker-specific account and connection terminology inside the Trading area
- update all four UI locales and navigation ownership names

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (4858 passed, 9 skipped)
- demo /portfolio: Beta rail, sidebar heading, collapse control, and resize separator all read Trading