### PR TITLE
feat(harness): guide Studio setup through Agent

### DIFF
--- a/docs/harness-web-surfaces.md
+++ b/docs/harness-web-surfaces.md
@@ -127,7 +127,12 @@ AutoQuant and Prediction expose Studio beside New research after a default
 Workspace exists. Opening Studio starts idempotently and presents an announced
 starting state until readiness. Failure preserves bounded logs and offers
 retry; ready state embeds the Harness and offers Refresh, Restart, Logs, and
-Open separately.
+Open separately. A failed launch presents the bounded, redacted child output
+inline. When the output indicates an unprepared source checkout, the recovery
+action opens that Harness's Quick Start with a setup task prefilled. The user
+reviews the Agent, credential, model, and effort before sending it to inspect
+repository instructions, install declared dependencies, and verify Studio.
+OpenAlice does not guess or run a package-manager install itself.
 
 The iframe fills the Harness content pane. Its toolbar wraps instead of causing
 horizontal overflow, uses shared Button primitives and visible focus, announces

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1090,6 +1090,13 @@ export const en = {
     startingTitle: 'Starting Studio',
     startingBody: 'OpenAlice is assigning its private ports and waiting for the Harness readiness check.',
     failedTitle: 'Studio could not start',
+    diagnosis: {
+      'missing-dependencies': 'This Workspace does not appear to have its Studio dependencies installed yet.',
+      generic: 'The Harness process exited before its Studio passed the readiness check.',
+    },
+    studioOutput: 'Studio output',
+    setupBody: 'OpenAlice does not install a Harness silently. Open a prefilled Quick Start, review the Agent and AI configuration, then ask it to inspect the repository, install declared dependencies, and verify Studio.',
+    setupWithAgent: 'Set up with Agent',
     tryAgain: 'Try again',
     phase: { stopped: 'Stopped', starting: 'Starting…', ready: 'Ready', failed: 'Failed', stopping: 'Stopping…' },
   },

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1079,6 +1079,13 @@ export const ja: Resources = {
     startingTitle: 'Studio を起動しています',
     startingBody: 'OpenAlice が内部ポートを割り当て、Harness の準備完了を待っています。',
     failedTitle: 'Studio を起動できませんでした',
+    diagnosis: {
+      'missing-dependencies': 'このワークスペースには Studio に必要な依存関係がまだインストールされていないようです。',
+      generic: 'Studio が準備完了になる前に Harness プロセスが終了しました。',
+    },
+    studioOutput: 'Studio の出力',
+    setupBody: 'OpenAlice は Harness を自動ではインストールしません。タスク入力済みの Quick Start を開き、Agent と AI の設定を確認してから、リポジトリの確認、依存関係のインストール、Studio の検証を依頼してください。',
+    setupWithAgent: 'Agent でセットアップ',
     tryAgain: '再試行',
     phase: { stopped: '停止', starting: '起動中…', ready: '準備完了', failed: '失敗', stopping: '停止中…' },
   },

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1086,6 +1086,13 @@ export const zhHant: Resources = {
     startingTitle: '正在啟動 Studio',
     startingBody: 'OpenAlice 正在分配內部連接埠，並等待 Harness 通過就緒檢查。',
     failedTitle: 'Studio 啟動失敗',
+    diagnosis: {
+      'missing-dependencies': '這個工作區似乎尚未安裝 Studio 所需的相依套件。',
+      generic: 'Harness 程序在 Studio 通過就緒檢查前退出了。',
+    },
+    studioOutput: 'Studio 輸出',
+    setupBody: 'OpenAlice 不會在背景安裝 Harness。請開啟已預填任務的 Quick Start，檢查 Agent 與 AI 設定後，再讓它檢查儲存庫、安裝宣告的相依套件並驗證 Studio。',
+    setupWithAgent: '使用 Agent 完成設定',
     tryAgain: '重試',
     phase: { stopped: '已停止', starting: '正在啟動…', ready: '已就緒', failed: '失敗', stopping: '正在停止…' },
   },

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1078,6 +1078,13 @@ export const zh: Resources = {
     startingTitle: '正在启动 Studio',
     startingBody: 'OpenAlice 正在分配内部端口，并等待 Harness 通过就绪检查。',
     failedTitle: 'Studio 启动失败',
+    diagnosis: {
+      'missing-dependencies': '这个工作区似乎还没有安装 Studio 所需的依赖。',
+      generic: 'Harness 进程在 Studio 通过就绪检查前退出了。',
+    },
+    studioOutput: 'Studio 输出',
+    setupBody: 'OpenAlice 不会静默安装 Harness。请打开已预填任务的 Quick Start，检查 Agent 和 AI 配置后，再让它检查仓库、安装声明的依赖并验证 Studio。',
+    setupWithAgent: '使用 Agent 完成设置',
     tryAgain: '重试',
     phase: { stopped: '已停止', starting: '正在启动…', ready: '已就绪', failed: '失败', stopping: '正在停止…' },
   },

--- a/ui/src/lib/harness-surface-failure.ts
+++ b/ui/src/lib/harness-surface-failure.ts
@@ -1,0 +1,5 @@
+export function harnessSurfaceFailureKind(logs: string): 'missing-dependencies' | 'generic' {
+  return /node_modules\s+missing|command not found|spawn\s+ENOENT/i.test(logs)
+    ? 'missing-dependencies'
+    : 'generic'
+}

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -350,6 +350,29 @@ describe('ChatLandingPage compact-height layout', () => {
     expect(screen.getByPlaceholderText('Describe the market relationship, settlement question, or evidence gap…').className)
       .toContain('min-h-[72px]')
   })
+
+  it('prefills an Auto Prediction Quick Start without launching it', () => {
+    const predictionWorkspace: Workspace = {
+      ...chatWorkspace(),
+      id: 'prediction-1',
+      tag: 'prediction',
+      template: 'auto-prediction',
+    }
+    workspaces = [predictionWorkspace]
+    mocks.useWorkspaces.mockImplementation(() => context(workspaces, null, predictionWorkspace.id))
+
+    render(<AutoPredictionLandingPage spec={{
+      params: {
+        targetWsId: predictionWorkspace.id,
+        initialPrompt: 'Install the declared dependencies, then verify Studio.',
+      },
+    }} />)
+
+    expect((screen.getByPlaceholderText(
+      'Describe the market relationship, settlement question, or evidence gap…',
+    ) as HTMLTextAreaElement).value).toBe('Install the declared dependencies, then verify Studio.')
+    expect(mocks.quickChat).not.toHaveBeenCalled()
+  })
 })
 
 describe('ChatLandingPage Workspace inventory states', () => {

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -61,7 +61,7 @@ function HarnessLandingPage({
   spec,
   mode,
 }: {
-  spec: { params: { targetWsId?: string } }
+  spec: { params: { targetWsId?: string; initialPrompt?: string } }
   mode: HarnessLandingMode
 }) {
   const { t } = useTranslation()
@@ -124,7 +124,7 @@ function HarnessLandingPage({
   // loop, so it can't be seeded with a first message).
   const cliAgents = agents.filter((a) => a.kind !== 'utility')
 
-  const [value, setValue] = useState('')
+  const [value, setValue] = useState(spec.params.initialPrompt ?? '')
   const [launching, setLaunching] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [examplePage, setExamplePage] = useState(0)
@@ -548,27 +548,27 @@ function HarnessLandingPage({
   )
 }
 
-export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: string } } }) {
+export function ChatLandingPage({ spec }: { spec: { params: { targetWsId?: string; initialPrompt?: string } } }) {
   const ctx = useWorkspaces()
   const hasChatWorkspace = ctx.workspaces.some((workspace) => workspace.template === 'chat')
   if (!hasChatWorkspace) return <ChatSetupPage />
   return <HarnessLandingPage spec={spec} mode="chat" />
 }
 
-export function AutoQuantLandingPage({ spec }: { spec: { params: { targetWsId?: string } } }) {
+export function AutoQuantLandingPage({ spec }: { spec: { params: { targetWsId?: string; initialPrompt?: string } } }) {
   const ctx = useWorkspaces()
   const workspace = ctx.workspaces.find((candidate) =>
     candidate.id === ctx.autoQuantDefaultWorkspaceId
     && candidate.template === 'auto-quant-v2')
   if (!workspace) return <AutoQuantSetupPage />
-  return <HarnessLandingPage spec={{ params: { targetWsId: workspace.id } }} mode="auto-quant" />
+  return <HarnessLandingPage spec={{ params: { targetWsId: workspace.id, initialPrompt: spec.params.initialPrompt } }} mode="auto-quant" />
 }
 
-export function AutoPredictionLandingPage({ spec }: { spec: { params: { targetWsId?: string } } }) {
+export function AutoPredictionLandingPage({ spec }: { spec: { params: { targetWsId?: string; initialPrompt?: string } } }) {
   const ctx = useWorkspaces()
   const workspace = ctx.workspaces.find((candidate) =>
     candidate.id === ctx.autoPredictionDefaultWorkspaceId
     && candidate.template === 'auto-prediction')
   if (!workspace) return <AutoPredictionSetupPage />
-  return <HarnessLandingPage spec={{ params: { targetWsId: workspace.id } }} mode="prediction" />
+  return <HarnessLandingPage spec={{ params: { targetWsId: workspace.id, initialPrompt: spec.params.initialPrompt } }} mode="prediction" />
 }

--- a/ui/src/pages/HarnessSurfacePage.spec.tsx
+++ b/ui/src/pages/HarnessSurfacePage.spec.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { i18n } from '../i18n'
+import { harnessSurfaceFailureKind } from '../lib/harness-surface-failure'
+import { HarnessSurfacePage } from './HarnessSurfacePage'
+
+const mocks = vi.hoisted(() => ({
+  getHarnessSurface: vi.fn(),
+  startHarnessSurface: vi.fn(),
+  restartHarnessSurface: vi.fn(),
+  openOrFocus: vi.fn(),
+}))
+
+vi.mock('../api/harness-surfaces', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/harness-surfaces')>()
+  return {
+    ...actual,
+    getHarnessSurface: mocks.getHarnessSurface,
+    startHarnessSurface: mocks.startHarnessSurface,
+    restartHarnessSurface: mocks.restartHarnessSurface,
+  }
+})
+
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) => (
+    selector({ openOrFocus: mocks.openOrFocus })
+  ),
+}))
+
+const failedSurface = {
+  surface: {
+    workspaceId: 'prediction-1',
+    capability: 'studio' as const,
+    manifestVersion: 1,
+    harnessVersion: '0.1.1',
+    phase: 'failed' as const,
+    generation: 1,
+    error: 'Studio stopped before it was closed (exit 1)',
+    logs: 'sh: vite: command not found\nLocal package.json exists, but node_modules missing\n',
+  },
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+  mocks.getHarnessSurface.mockResolvedValue(failedSurface)
+})
+
+afterEach(cleanup)
+
+describe('HarnessSurfacePage failure recovery', () => {
+  it('shows a dependency diagnosis and opens a prefilled Agent Quick Start', async () => {
+    render(<HarnessSurfacePage workspaceId="prediction-1" source="prediction" />)
+
+    expect(await screen.findByRole('heading', { name: 'Studio could not start' })).toBeTruthy()
+    expect(screen.getByText(/does not appear to have its Studio dependencies installed/)).toBeTruthy()
+    expect(screen.getByText(/vite: command not found/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set up with Agent' }))
+
+    await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({
+      kind: 'auto-prediction-landing',
+      params: {
+        targetWsId: 'prediction-1',
+        initialPrompt: expect.stringContaining('Inspect harness.json'),
+      },
+    }))
+  })
+
+  it('keeps unrelated process failures on the generic diagnosis path', () => {
+    expect(harnessSurfaceFailureKind('worker exited after an internal assertion')).toBe('generic')
+  })
+})

--- a/ui/src/pages/HarnessSurfacePage.tsx
+++ b/ui/src/pages/HarnessSurfacePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ExternalLink, Loader2, RefreshCw, RotateCcw, ScrollText } from 'lucide-react'
+import { Bot, ExternalLink, Loader2, RefreshCw, RotateCcw, ScrollText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -10,9 +10,23 @@ import {
   type HarnessSurfaceResponse,
 } from '../api/harness-surfaces'
 import { Button } from '../components/ui/button'
+import { harnessSurfaceFailureKind } from '../lib/harness-surface-failure'
+import { useWorkspace } from '../tabs/store'
+import type { WorkspaceSource } from '../tabs/types'
 
-export function HarnessSurfacePage({ workspaceId }: { workspaceId: string }) {
+const HARNESS_SETUP_PROMPT = `Set up this Harness Workspace so its Studio capability can run.
+
+Inspect harness.json, the repository documentation, lockfiles, and package scripts before changing anything. Install the required dependencies with the repository's declared package manager and normal locked-install workflow. Do not guess a global tool or replace the lockfile. Then run the smallest relevant Studio/readiness smoke, stop any processes you started, and report exactly what you installed and verified. Do not change product code unless setup genuinely requires a repository fix.`
+
+export function HarnessSurfacePage({
+  workspaceId,
+  source,
+}: {
+  workspaceId: string
+  source: Exclude<WorkspaceSource, 'chat'>
+}) {
   const { t } = useTranslation()
+  const openOrFocus = useWorkspace((state) => state.openOrFocus)
   const [response, setResponse] = useState<HarnessSurfaceResponse | null>(null)
   const [requestError, setRequestError] = useState<string | null>(null)
   const [frameGeneration, setFrameGeneration] = useState(0)
@@ -57,6 +71,15 @@ export function HarnessSurfacePage({ workspaceId }: { workspaceId: string }) {
 
   const phase = response?.surface.phase
   const error = requestError ?? response?.surface.error ?? null
+  const logs = response?.surface.logs ?? ''
+  const failureKind = harnessSurfaceFailureKind(logs)
+
+  const openSetupQuickStart = () => {
+    openOrFocus({
+      kind: source === 'auto-quant' ? 'auto-quant-landing' : 'auto-prediction-landing',
+      params: { targetWsId: workspaceId, initialPrompt: HARNESS_SETUP_PROMPT },
+    })
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
@@ -73,15 +96,17 @@ export function HarnessSurfacePage({ workspaceId }: { workspaceId: string }) {
         <Button variant="ghost" size="sm" onClick={() => void restart()}>
           <RotateCcw aria-hidden />{t('harnessSurface.restart')}
         </Button>
-        <Button variant="ghost" size="sm" onClick={() => setShowLogs((value) => !value)} aria-expanded={showLogs}>
-          <ScrollText aria-hidden />{t('harnessSurface.logs')}
-        </Button>
+        {!error && (
+          <Button variant="ghost" size="sm" onClick={() => setShowLogs((value) => !value)} aria-expanded={showLogs}>
+            <ScrollText aria-hidden />{t('harnessSurface.logs')}
+          </Button>
+        )}
         <Button variant="outline" size="sm" disabled={!surfaceUrl} onClick={() => surfaceUrl && window.open(surfaceUrl, '_blank', 'noopener,noreferrer')}>
           <ExternalLink aria-hidden />{t('harnessSurface.openSeparate')}
         </Button>
       </div>
 
-      {showLogs && (
+      {showLogs && !error && (
         <pre className="max-h-48 shrink-0 overflow-auto border-b border-border bg-muted/40 p-3 text-xs text-muted-foreground" aria-label={t('harnessSurface.logs')}>
           {response?.surface.logs || t('harnessSurface.noLogs')}
         </pre>
@@ -97,19 +122,45 @@ export function HarnessSurfacePage({ workspaceId }: { workspaceId: string }) {
             allow="clipboard-read; clipboard-write"
           />
         ) : (
-          <div className="flex h-full items-center justify-center p-6">
-            <div className="max-w-md text-center">
+          <div className="flex h-full items-center justify-center overflow-auto p-4 sm:p-6">
+            <div className="w-full max-w-2xl text-center">
               {phase !== 'failed' && !error && <Loader2 className="mx-auto mb-3 size-6 animate-spin text-primary motion-reduce:animate-none" aria-hidden />}
               <h2 className="text-base font-semibold text-foreground">
                 {error ? t('harnessSurface.failedTitle') : t('harnessSurface.startingTitle')}
               </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {error ?? t('harnessSurface.startingBody')}
-              </p>
-              {error && (
-                <Button className="mt-4" onClick={() => void restart()}>
-                  <RotateCcw aria-hidden />{t('harnessSurface.tryAgain')}
-                </Button>
+              {error ? (
+                <div className="mt-3 text-left">
+                  <p className="text-sm text-muted-foreground">
+                    {t(`harnessSurface.diagnosis.${failureKind}`)}
+                  </p>
+                  <div className="mt-3 rounded-lg border border-border bg-muted/30 p-3">
+                    <p className="break-words font-mono text-xs text-foreground">{error}</p>
+                    <details className="mt-2" open>
+                      <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+                        {t('harnessSurface.studioOutput')}
+                      </summary>
+                      <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background p-3 text-xs text-muted-foreground">
+                        {logs || t('harnessSurface.noLogs')}
+                      </pre>
+                    </details>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {t('harnessSurface.setupBody')}
+                  </p>
+                  <div className="mt-4 flex flex-wrap justify-center gap-2">
+                    <Button onClick={openSetupQuickStart}>
+                      <Bot aria-hidden />
+                      {t('harnessSurface.setupWithAgent')}
+                    </Button>
+                    <Button variant="outline" onClick={() => void restart()}>
+                      <RotateCcw aria-hidden />{t('harnessSurface.tryAgain')}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {t('harnessSurface.startingBody')}
+                </p>
               )}
             </div>
           </div>

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -473,7 +473,7 @@ const harnessSurfaceModule: ViewModule<'harness-surface'> = {
     return `${tag ?? spec.params.wsId.slice(0, 8)} · Studio`
   },
   toUrl: (spec) => `/${spec.params.source}/workspaces/${encodeURIComponent(spec.params.wsId)}/studio`,
-  Component: ({ spec }) => <HarnessSurfacePage workspaceId={spec.params.wsId} />,
+  Component: ({ spec }) => <HarnessSurfacePage workspaceId={spec.params.wsId} source={spec.params.source} />,
 }
 
 const workspaceManagerModule: ViewModule<'workspace-manager'> = {

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -58,9 +58,9 @@ export type ViewSpec =
         issue?: string
       }
     }
-  | { kind: 'chat-landing';        params: { targetWsId?: string } }
-  | { kind: 'auto-quant-landing';  params: { targetWsId?: string } }
-  | { kind: 'auto-prediction-landing'; params: { targetWsId?: string } }
+  | { kind: 'chat-landing';        params: { targetWsId?: string; initialPrompt?: string } }
+  | { kind: 'auto-quant-landing';  params: { targetWsId?: string; initialPrompt?: string } }
+  | { kind: 'auto-prediction-landing'; params: { targetWsId?: string; initialPrompt?: string } }
   | { kind: 'harness-surface'; params: { wsId: string; capability: 'studio'; source: 'auto-quant' | 'prediction' } }
   | { kind: 'workspace-manager';   params: { sessionId?: string } }
   | {


### PR DESCRIPTION
## Summary
- surface bounded, redacted Studio output and dependency-focused diagnosis when a Harness web capability fails
- route setup recovery to a prefilled Harness Quick Start so users can review Agent, credential, model, and effort before sending
- document the recovery contract and cover the navigation/prefill behavior with tests

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4861 passed, 9 skipped)
- manually verified Prediction Studio failure -> Set up with Agent -> prefilled Quick Start in the demo UI; no task was sent