### PR TITLE
release: 0.90.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.89.4-beta",
+  "version": "0.90.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.89.4-beta",
+  "version": "0.90.0-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump the OpenAlice product version to 0.90.0-beta
- keep the distributed CLI on the same product version

## Verification
- `npx tsc --noEmit`
- `pnpm test` (4861 passed, 9 skipped)
- verified root and CLI manifests both resolve to `0.90.0-beta`

## Boundary touch
- release metadata only