### PR TITLE
fix(connector): scope no-reply to cron metadata

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -57,9 +57,11 @@ categories.
   per `desk`-capable connector. Connector queues owner text keyed by
   `connectorId`; Alice drains that stack only while that connector's live
   desk exists and no generation is running on it. Several stacked DMs become
-  one quoted comment on that Issue. Alice projects desk comments that do not
-  contain the literal tag `[[no-reply]]`. Inbound owner comments are not
-  echoed back to that connector. While a desk turn is running, Alice also
+  one quoted comment on that Issue. Alice suppresses a desk comment only when
+  its run carries the `connector-cron-issue` trigger metadata and its text
+  contains the literal tag `[[no-reply]]`. Ordinary chat replies treat that
+  tag as text. Inbound owner comments are not echoed back to that connector.
+  While a desk turn is running, Alice also
   ships sealed mid-turn `text` blocks (a tool or error followed them) so the
   phone chat does not wait for the final reply. Tool names, status, and
   payloads stay off the owner chat. The trailing text still becomes today's

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -118,8 +118,11 @@ The filename stem is the stable issue id. Frontmatter:
   Owner DMs for that connector become comments on that Issue. While that desk
   is generating, later DMs for the same connector stay in the Connector
   queue; other connectors flush independently. Scheduled-fire
-  `assistantText` is stamped as a comment. Connector projects comments that
-  do not contain `[[no-reply]]` and did not arrive from that connector.
+  `assistantText` is stamped as a comment. Scheduler and Run now / Retry now
+  executions of this Issue carry `trigger.metadata.kind: connector-cron-issue`.
+  Only comments and progress from a run with that metadata consume
+  `[[no-reply]]`; ordinary chat mentions of the syntax are delivered as text.
+  Connector does not echo comments that arrived from that connector.
   While a desk turn is running, it also ships sealed mid-turn `text` blocks —
   the last consecutive text before a tool or error — and never ships tool I/O.
   The trailing text stays with the final comment. Shipped

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -106,14 +106,30 @@ describe('HeadlessTaskRegistry', () => {
 
   it('records a composite Issue trigger when an issue fired the run', async () => {
     const reg = await HeadlessTaskRegistry.load(path, noopLogger)
-    const fired = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'x', startedAt: 1, trigger: { kind: 'issue', workspaceId: 'home', issueId: 'daily-scan' } })
+    const fired = await createTask(reg, {
+      wsId: 'w1',
+      agent: 'codex',
+      prompt: 'x',
+      startedAt: 1,
+      trigger: {
+        kind: 'issue',
+        workspaceId: 'home',
+        issueId: 'daily-scan',
+        metadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
+      },
+    })
     const manual = await createTask(reg, { wsId: 'w1', agent: 'codex', prompt: 'y', startedAt: 2 })
-    expect(fired.trigger).toEqual({ kind: 'issue', workspaceId: 'home', issueId: 'daily-scan' })
+    expect(fired.trigger).toEqual({
+      kind: 'issue',
+      workspaceId: 'home',
+      issueId: 'daily-scan',
+      metadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
+    })
     // Manual runs leave the field absent (not undefined-valued) so the JSON stays clean.
     expect('trigger' in manual).toBe(false)
     // Persists across reload.
     const reg2 = await HeadlessTaskRegistry.load(path, noopLogger)
-    expect(reg2.get(fired.taskId)?.trigger?.issueId).toBe('daily-scan')
+    expect(reg2.get(fired.taskId)?.trigger).toEqual(fired.trigger)
   })
 
   it('persists an explicit unlimited watchdog separately from historical absence', async () => {

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -41,10 +41,18 @@ export interface HeadlessTaskOutputSummary {
 /** The business object that caused an execution. This is intentionally
  * independent from `wsId`: an exact signed Session may execute in Workspace B
  * while answering a scheduled Issue whose source of truth remains Workspace A. */
+export type HeadlessTaskTriggerMetadata = {
+  readonly kind: 'connector-cron-issue'
+  readonly connectorId: string
+}
+
 export type HeadlessTaskTrigger = {
   readonly kind: 'issue'
   readonly workspaceId: string
   readonly issueId: string
+  /** Optional execution profile stamped by the dispatcher. Consumers must
+   * ignore control syntax unless the matching profile is present. */
+  readonly metadata?: HeadlessTaskTriggerMetadata
 }
 
 /** Business object that requested a headless follow-up. Product provenance

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -47,8 +47,19 @@ function host(overrides: Partial<TelegramDeskChatHost> = {}): TelegramDeskChatHo
   }
 }
 
+function mockClient() {
+  const sent: { id: string; text: string }[] = []
+  const client = {
+    sendOwnerMessage: async (message: { id: string; text: string }) => {
+      sent.push({ id: message.id, text: message.text })
+      return { accepted: true }
+    },
+  } as unknown as ConnectorClient
+  return { client, sent }
+}
+
 describe('telegram desk chat filter', () => {
-  it('projects agent comments and skips inbound telegram or [[no-reply]]', () => {
+  it('projects agent comments, including syntax discussions, and skips inbound telegram', () => {
     const issue = { connectorDesk: 'telegram' }
     expect(shouldProjectDeskComment(issue, {
       id: 'c1', author: '@resume-a', at: 'now', markdown: 'Hello from the desk.',
@@ -58,6 +69,11 @@ describe('telegram desk chat filter', () => {
     })).toBe(false)
     expect(shouldProjectDeskComment(issue, {
       id: 'c3', author: '@resume-a', at: 'now', markdown: '[[no-reply]] nothing to say',
+    })).toBe(true)
+    expect(shouldProjectDeskComment(issue, {
+      id: 'c3', author: '@resume-a', at: 'now', markdown: '[[no-reply]] nothing to say',
+    }, {
+      triggerMetadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
     })).toBe(false)
     expect(shouldProjectDeskComment({}, {
       id: 'c4', author: '@resume-a', at: 'now', markdown: 'ordinary issue',
@@ -106,8 +122,10 @@ describe('telegram desk ingest and stamp', () => {
     )
     expect(created.ok).toBe(true)
     if (!created.ok) return
+    const { client, sent } = mockClient()
     const comment = await stampTelegramDeskScheduledFire({
       host: host(),
+      client,
       workspaceId: 'ws-a',
       issueId: created.issue.id,
       task: {
@@ -119,13 +137,22 @@ describe('telegram desk ingest and stamp', () => {
         startedAt: 1,
         status: 'done',
         finishedAt: 2,
+        trigger: {
+          kind: 'issue',
+          workspaceId: 'ws-a',
+          issueId: created.issue.id,
+          metadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
+        },
       },
       assistantText: 'Markets are quiet. [[no-reply]] no send.',
     })
     expect(comment?.markdown).toContain('[[no-reply]]')
     expect(comment?.id).toBe('comment-fire-run-1')
+    expect(sent).toEqual([])
     if (!comment) return
-    expect(shouldProjectDeskComment(created.issue, comment)).toBe(false)
+    expect(shouldProjectDeskComment(created.issue, comment, {
+      triggerMetadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
+    })).toBe(false)
   })
 
   it('does not publish partial assistant text from a failed scheduled fire', async () => {
@@ -151,6 +178,35 @@ describe('telegram desk ingest and stamp', () => {
         finishedAt: 2,
       },
       assistantText: 'Partial answer before the runtime failed.',
+    })
+
+    expect(comment).toBeNull()
+  })
+
+  it('does not consume connector control syntax without trigger metadata', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+
+    const comment = await stampTelegramDeskScheduledFire({
+      host: host(),
+      workspaceId: 'ws-a',
+      issueId: created.issue.id,
+      task: {
+        taskId: 'run-unmarked',
+        resumeId: 'resume-desk-owner',
+        wsId: 'ws-a',
+        agent: 'pi',
+        prompt: 'wake',
+        startedAt: 1,
+        status: 'done',
+        finishedAt: 2,
+        trigger: { kind: 'issue', workspaceId: 'ws-a', issueId: created.issue.id },
+      },
+      assistantText: 'We discussed [[no-reply]] syntax.',
     })
 
     expect(comment).toBeNull()

--- a/src/workspaces/issues/telegram-desk-chat.ts
+++ b/src/workspaces/issues/telegram-desk-chat.ts
@@ -2,7 +2,8 @@
  * Connector phone-desk chat hop.
  *
  * Connector only transports. Each adapter's Issue comments are that
- * specialist's transcript. The literal tag [[no-reply]] stays local.
+ * specialist's transcript. The literal tag [[no-reply]] stays local only for
+ * runs explicitly stamped with the connector-cron-issue execution profile.
  * Sealed mid-turn text blocks also project so the phone chat does not
  * wait for the final reply.
  */
@@ -151,6 +152,7 @@ export async function stampTelegramDeskScheduledFire(input: {
   issueId: string
   task: HeadlessTaskRecord
   assistantText?: string | null
+  client?: ConnectorClient
 }): Promise<IssueComment | null> {
   // A native CLI can emit partial assistant text before exiting with an error
   // or interruption. Keep that diagnostic in the run record, but do not turn
@@ -158,11 +160,17 @@ export async function stampTelegramDeskScheduledFire(input: {
   if (input.task.status !== 'done') return null
   const text = input.assistantText?.trim()
   if (!text) return null
+  const triggerMetadata = input.task.trigger?.metadata
+  if (triggerMetadata?.kind !== 'connector-cron-issue') return null
   const workspace = input.host.getWorkspace(input.workspaceId)
   if (!workspace) return null
   const desks = await findConnectorDesks(input.host.listWorkspaces())
   const desk = desks.find((item) => item.wsId === input.workspaceId && item.issue.id === input.issueId)
-  if (!desk || desk.issue.status === 'canceled') return null
+  if (
+    !desk
+    || desk.issue.status === 'canceled'
+    || desk.connectorId !== triggerMetadata.connectorId
+  ) return null
 
   const appended = await appendIssueComment(
     workspace.dir,
@@ -185,8 +193,9 @@ export async function stampTelegramDeskScheduledFire(input: {
     at: input.task.finishedAt ?? Date.now(),
     fingerprint: `telegram-desk-fire:${input.task.taskId}`,
   })
-  await projectDeskComment(appended.issue, appended.comment, undefined, {
+  await projectDeskComment(appended.issue, appended.comment, input.client, {
     progressScopeId: input.task.taskId,
+    triggerMetadata,
   }).catch(() => undefined)
   return appended.comment
 }

--- a/src/workspaces/issues/telegram-desk-project.spec.ts
+++ b/src/workspaces/issues/telegram-desk-project.spec.ts
@@ -78,7 +78,7 @@ describe('sealedProgressTexts', () => {
     ]))).toEqual(['Looking at the book.', 'Checking another file.'])
   })
 
-  it('does not ship a lone trailing text, tools, errors, or [[no-reply]]', () => {
+  it('does not ship a lone trailing text, tools, or errors', () => {
     expect(sealedProgressTexts(progress([
       { type: 'text', text: 'Final answer only.' },
     ]))).toEqual([])
@@ -87,12 +87,20 @@ describe('sealedProgressTexts', () => {
       { type: 'text', text: 'After the tool.' },
     ]))).toEqual([])
     expect(sealedProgressTexts(progress([
-      { type: 'text', text: '[[no-reply]] quiet' },
-      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
-    ]))).toEqual([])
-    expect(sealedProgressTexts(progress([
       { type: 'error', message: 'boom' },
     ]))).toEqual([])
+  })
+
+  it('consumes [[no-reply]] only for connector cron Issue progress', () => {
+    const snapshot = progress([
+      { type: 'text', text: 'We discussed [[no-reply]] syntax.' },
+      { type: 'tool', id: 't1', name: 'Read', status: 'running' },
+    ])
+    expect(sealedProgressTexts(snapshot)).toEqual(['We discussed [[no-reply]] syntax.'])
+    expect(sealedProgressTexts(snapshot, {
+      kind: 'connector-cron-issue',
+      connectorId: 'telegram',
+    })).toEqual([])
   })
 })
 
@@ -203,6 +211,27 @@ describe('projectDeskTurnProgress', () => {
 })
 
 describe('final comment dedup', () => {
+  it('treats [[no-reply]] as control syntax only with connector cron metadata', async () => {
+    const { client, sent } = mockClient()
+    const issue = { connectorDesk: 'telegram' }
+    const comment = {
+      id: 'comment-reply-run-quoted',
+      author: '@resume-a',
+      at: 'now',
+      markdown: 'Here is how `[[no-reply]]` works.',
+    }
+    expect(shouldProjectDeskComment(issue, comment)).toBe(true)
+    await projectDeskComment(issue, comment, client)
+    expect(sent.map((item) => item.text)).toEqual(['Here is how `[[no-reply]]` works.'])
+
+    expect(shouldProjectDeskComment(issue, comment, {
+      triggerMetadata: {
+        kind: 'connector-cron-issue',
+        connectorId: 'telegram',
+      },
+    })).toBe(false)
+  })
+
   it('skips a final comment whose markdown was already shipped as progress', async () => {
     const { client, sent } = mockClient()
     const issue = { connectorDesk: 'telegram' }

--- a/src/workspaces/issues/telegram-desk-project.ts
+++ b/src/workspaces/issues/telegram-desk-project.ts
@@ -5,7 +5,11 @@ import { join } from 'node:path'
 import { ConnectorClient, OWNER_CHAT_TEXT_MAX } from '@traderalice/connector-protocol'
 
 import { resolveConnectorUrl } from '../../services/connector-client/index.js'
-import type { HeadlessTaskTrigger, HeadlessTaskInquiry } from '../headless-task-registry.js'
+import type {
+  HeadlessTaskInquiry,
+  HeadlessTaskTrigger,
+  HeadlessTaskTriggerMetadata,
+} from '../headless-task-registry.js'
 import type { HeadlessTurnProgress } from '../headless-progress.js'
 import type { IssueComment } from './comments.js'
 import {
@@ -24,6 +28,12 @@ export function containsTelegramNoReply(text: string): boolean {
   return text.includes(TELEGRAM_NO_REPLY_TAG)
 }
 
+export function consumesConnectorNoReply(
+  metadata: HeadlessTaskTriggerMetadata | undefined,
+): boolean {
+  return metadata?.kind === 'connector-cron-issue'
+}
+
 export function normalizeDeskText(text: string): string {
   return text.trim().slice(0, OWNER_CHAT_TEXT_MAX)
 }
@@ -36,7 +46,10 @@ export function normalizeDeskText(text: string): string {
  * the non-text block is sent, so streamed chunks do not each become a DM.
  * The trailing text stays with today's final comment / `assistantText`.
  */
-export function sealedProgressTexts(progress: HeadlessTurnProgress): string[] {
+export function sealedProgressTexts(
+  progress: HeadlessTurnProgress,
+  metadata?: HeadlessTaskTriggerMetadata,
+): string[] {
   const sealed: string[] = []
   const { blocks } = progress
   for (let i = 0; i < blocks.length; i++) {
@@ -45,7 +58,7 @@ export function sealedProgressTexts(progress: HeadlessTurnProgress): string[] {
     const next = blocks[i + 1]
     if (!next || next.type === 'text') continue
     const text = normalizeDeskText(block.text)
-    if (!text || containsTelegramNoReply(text)) continue
+    if (!text || (consumesConnectorNoReply(metadata) && containsTelegramNoReply(text))) continue
     sealed.push(text)
   }
   return sealed
@@ -109,10 +122,16 @@ function markProjectedDeskText(scopeId: string, text: string): void {
 export function shouldProjectDeskComment(
   issue: { connectorDesk?: string },
   comment: IssueComment,
-  opts?: { progressScopeId?: string },
+  opts?: {
+    progressScopeId?: string
+    triggerMetadata?: HeadlessTaskTriggerMetadata
+  },
 ): boolean {
   if (!isConnectorDeskIssue(issue) || comment.via) return false
-  if (containsTelegramNoReply(comment.markdown)) return false
+  if (
+    consumesConnectorNoReply(opts?.triggerMetadata)
+    && containsTelegramNoReply(comment.markdown)
+  ) return false
   const scope = opts?.progressScopeId ?? comment.replyTo
   if (scope && alreadyProjectedDeskText(scope, comment.markdown)) return false
   return true
@@ -122,11 +141,17 @@ export async function projectDeskComment(
   issue: { connectorDesk?: string },
   comment: IssueComment,
   client: ConnectorClient = new ConnectorClient(resolveConnectorUrl()),
-  opts?: { progressScopeId?: string },
+  opts?: {
+    progressScopeId?: string
+    triggerMetadata?: HeadlessTaskTriggerMetadata
+  },
 ): Promise<void> {
   const scope = opts?.progressScopeId ?? comment.replyTo
   try {
-    if (!shouldProjectDeskComment(issue, comment, { progressScopeId: scope }) || !issue.connectorDesk) return
+    if (!shouldProjectDeskComment(issue, comment, {
+      progressScopeId: scope,
+      triggerMetadata: opts?.triggerMetadata,
+    }) || !issue.connectorDesk) return
     await client.sendOwnerMessage({
       id: `desk-${comment.id}`,
       adapterId: issue.connectorDesk,
@@ -141,12 +166,13 @@ export async function projectDeskTurnProgress(input: {
   issue: Pick<IssueRecord, 'connectorDesk' | 'status'>
   scopeId: string
   progress: HeadlessTurnProgress
+  triggerMetadata?: HeadlessTaskTriggerMetadata
   client?: ConnectorClient
 }): Promise<string[]> {
   if (!isConnectorDeskIssue(input.issue) || input.issue.status === 'canceled') return []
   const client = input.client ?? new ConnectorClient(resolveConnectorUrl())
   const sent: string[] = []
-  for (const text of sealedProgressTexts(input.progress)) {
+  for (const text of sealedProgressTexts(input.progress, input.triggerMetadata)) {
     if (alreadyProjectedDeskText(input.scopeId, text)) continue
     await client.sendOwnerMessage({
       id: deskProgressMessageId(input.scopeId, text),
@@ -164,6 +190,7 @@ export async function projectWorkspaceDeskTurnProgress(input: {
   issueId: string
   scopeId: string
   progress: HeadlessTurnProgress
+  triggerMetadata?: HeadlessTaskTriggerMetadata
   client?: ConnectorClient
 }): Promise<string[]> {
   const issue = await readDeskIssue(input.wsDir, input.issueId)

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -84,6 +84,7 @@ interface IssueSpec {
   effort?: string
   timeout?: string
   assignee?: string
+  connectorDesk?: string
   body?: string
 }
 
@@ -99,6 +100,7 @@ function issueMd(spec: IssueSpec): string {
   if (spec.model) lines.push(`model: ${spec.model}`)
   if (spec.effort) lines.push(`effort: ${spec.effort}`)
   if (spec.timeout) lines.push(`timeout: ${spec.timeout}`)
+  if (spec.connectorDesk) lines.push(`connectorDesk: ${spec.connectorDesk}`)
   // Scanner tests exercise dispatch policy, not declaration defaults. Keep the
   // historical fresh-every-fire fixture explicit now that omitted scheduled
   // ownership means recruit once (`@new-then-resume`).
@@ -167,6 +169,39 @@ function scannerFor(
 }
 
 describe('ScheduleScanner', () => {
+  it('stamps connector cron metadata on scheduled and run-now phone-desk runs', async () => {
+    const ws = await makeWs('w1', [{
+      id: 'telegram-phone-desk',
+      title: 'Telegram phone desk',
+      when: { kind: 'every', every: '30m' },
+      what: 'wake',
+      connectorDesk: 'telegram',
+    }])
+    const { scanner, dispatch } = scannerFor([ws])
+
+    await scanner.scan()
+    expect(vi.mocked(dispatch).mock.calls[0]?.[4]).toEqual({
+      kind: 'issue',
+      workspaceId: 'w1',
+      issueId: 'telegram-phone-desk',
+      metadata: {
+        kind: 'connector-cron-issue',
+        connectorId: 'telegram',
+      },
+    })
+
+    await scanner.runIssueNow('w1', 'telegram-phone-desk')
+    expect(vi.mocked(dispatch).mock.calls[1]?.[4]).toEqual({
+      kind: 'issue',
+      workspaceId: 'w1',
+      issueId: 'telegram-phone-desk',
+      metadata: {
+        kind: 'connector-cron-issue',
+        connectorId: 'telegram',
+      },
+    })
+  })
+
   it('manually retries with live Issue semantics without moving the schedule marker', async () => {
     const ws = await makeWs('w1', [{
       id: 'retry-me',

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -209,6 +209,7 @@ export class ScheduleScanner {
       issueAssigneeResumeId(issue.assignee) ?? undefined,
       issueAssigneeClaimsFirstSession(issue.assignee),
       issueTimeoutMs(issue.timeout),
+      issue.connectorDesk,
       true,
     )
   }
@@ -308,6 +309,7 @@ export class ScheduleScanner {
           issueAssigneeResumeId(issue.assignee) ?? undefined,
           issueAssigneeClaimsFirstSession(issue.assignee),
           issueTimeoutMs(issue.timeout),
+          issue.connectorDesk,
           nowMs,
         )
       }
@@ -336,6 +338,7 @@ export class ScheduleScanner {
     resumeId: string | undefined,
     claimFreshSession: boolean,
     timeoutMs: number | undefined,
+    connectorDesk: string | undefined,
     nowMs: number,
   ): Promise<void> {
     try {
@@ -348,6 +351,7 @@ export class ScheduleScanner {
         resumeId,
         claimFreshSession,
         timeoutMs,
+        connectorDesk,
       )
       await this.deps.markers.set(issueWorkspace.id, taskId, nowMs)
       this.deps.logger.info('schedule.fired', {
@@ -400,6 +404,7 @@ export class ScheduleScanner {
     resumeId?: string,
     claimFreshSession = false,
     timeoutMs?: number,
+    connectorDesk?: string,
     manual = false,
   ): Promise<{ taskId: string }> {
     const dispatchKey = `${issueWorkspace.id}:${issueId}`
@@ -428,6 +433,14 @@ export class ScheduleScanner {
         kind: 'issue',
         workspaceId: issueWorkspace.id,
         issueId,
+        ...(connectorDesk
+          ? {
+              metadata: {
+                kind: 'connector-cron-issue' as const,
+                connectorId: connectorDesk,
+              },
+            }
+          : {}),
       }
       // Fresh recruits only: exact @resumeId continues an existing Session.
       const createdBy: SessionCreatedBy | undefined = resumeId

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -1964,6 +1964,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           issueId: desk.issueId,
           scopeId: desk.scopeId,
           progress,
+          triggerMetadata: rec.trigger?.metadata,
         }).catch((err) => launcherLogger.warn('telegram.desk_progress_failed', {
           taskId: rec.taskId,
           wsId: desk.workspaceId,


### PR DESCRIPTION
## Summary
- persist a closed `connector-cron-issue` metadata profile on scheduled Connector Desk runs
- consume `[[no-reply]]` only when that execution metadata is present, including mid-turn progress
- treat the tag as ordinary text in human chat and unmarked Issue replies
- inject a mock Connector client in delivery tests so unit tests cannot reach a live Telegram bot
- document the execution-profile contract

## Verification
- `npx tsc --noEmit`
- targeted scheduler / phone-desk / registry tests (78 passed)
- `pnpm test` (4865 passed, 9 skipped)