### PR TITLE
feat(connector): stream Telegram owner chat drafts

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -62,10 +62,15 @@ categories.
   contains the literal tag `[[no-reply]]`. Ordinary chat replies treat that
   tag as text. Inbound owner comments are not echoed back to that connector.
   While a desk turn is running, Alice also
-  ships sealed mid-turn `text` blocks (a tool or error followed them) so the
-  phone chat does not wait for the final reply. Tool names, status, and
-  payloads stay off the owner chat. The trailing text still becomes today's
-  reply comment. Telegram is the first `desk` adapter; Discord and Slack do
+  projects an explicit `accepted | progress | final | failed` lifecycle.
+  Telegram turns `accepted` into a native Bot API live draft immediately,
+  refreshes that draft every 20 seconds, and replaces it with sealed mid-turn
+  `text` blocks (a tool or error followed them). If live drafts are unavailable,
+  Telegram refreshes the ordinary typing action every four seconds. Final and
+  failed replies are always persistent messages; ephemeral progress never
+  suppresses an identical final answer. Tool names, status, and payloads stay
+  off the owner chat. The trailing text still becomes today's reply comment.
+  Telegram is the first `desk` adapter; Discord and Slack do
   not advertise `desk` until they ingest private owner chat.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.

--- a/packages/connector-protocol/src/types.spec.ts
+++ b/packages/connector-protocol/src/types.spec.ts
@@ -26,25 +26,33 @@ const baseNotification = {
 }
 
 describe('owner chat messages', () => {
-  it('rejects empty or oversized owner-chat text', () => {
-    expect(() => ownerChatMessageSchema.parse({
+  it('requires lifecycle identity and text for visible phases', () => {
+    const base = {
       id: 'desk-1',
       adapterId: 'telegram',
-      text: '',
+      conversationId: 'comment-1',
+    }
+    expect(ownerChatMessageSchema.parse({
+      ...base,
+      phase: 'accepted',
+    }).phase).toBe('accepted')
+    expect(() => ownerChatMessageSchema.parse({
+      ...base,
+      phase: 'progress',
     })).toThrow()
     expect(ownerChatMessageSchema.parse({
-      id: 'desk-1',
-      adapterId: 'telegram',
+      ...base,
+      phase: 'final',
       text: 'Markets are quiet.',
     }).text).toBe('Markets are quiet.')
     expect(ownerChatMessageSchema.parse({
-      id: 'desk-1',
-      adapterId: 'telegram',
+      ...base,
+      phase: 'failed',
       text: 'x'.repeat(OWNER_CHAT_TEXT_MAX),
     }).text).toHaveLength(OWNER_CHAT_TEXT_MAX)
     expect(() => ownerChatMessageSchema.parse({
-      id: 'desk-1',
-      adapterId: 'telegram',
+      ...base,
+      phase: 'final',
       text: 'x'.repeat(OWNER_CHAT_TEXT_MAX + 1),
     })).toThrow()
   })

--- a/packages/connector-protocol/src/types.ts
+++ b/packages/connector-protocol/src/types.ts
@@ -136,10 +136,26 @@ export const TELEGRAM_PLAIN_TEXT_MAX = 4096
 /** Owner-private chat text. Not an Inbox item. Telegram `sendRichMessage` allows 32768 UTF-8 characters. */
 export const OWNER_CHAT_TEXT_MAX = 32_768
 
+export const ownerChatPhaseSchema = z.enum(['accepted', 'progress', 'final', 'failed'])
+export type OwnerChatPhase = z.infer<typeof ownerChatPhaseSchema>
+
+/** Lifecycle event for one owner-private Agent turn.
+ * `accepted` starts transport-native activity without requiring model text.
+ * `progress` is ephemeral; `final` and `failed` must remain visible. */
 export const ownerChatMessageSchema = z.object({
   id: z.string().min(1),
   adapterId: z.string().min(1),
-  text: z.string().min(1).max(OWNER_CHAT_TEXT_MAX),
+  conversationId: z.string().min(1),
+  phase: ownerChatPhaseSchema,
+  text: z.string().min(1).max(OWNER_CHAT_TEXT_MAX).optional(),
+}).superRefine((message, ctx) => {
+  if (message.phase !== 'accepted' && !message.text) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['text'],
+      message: `${message.phase} owner-chat events require text`,
+    })
+  }
 })
 export type OwnerChatMessage = z.infer<typeof ownerChatMessageSchema>
 

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -10,6 +10,9 @@ const stopMock = vi.fn()
 const getMe = vi.fn(async () => ({ id: 1, is_bot: true, first_name: 'OpenAlice', username: 'openalice_bot' }))
 const setMyCommands = vi.fn(async () => undefined)
 const sendRichMessage = vi.fn(async () => undefined)
+const sendMessageDraft = vi.fn(async () => true)
+const sendRichMessageDraft = vi.fn(async () => true)
+const sendChatAction = vi.fn(async () => true)
 const sendMessage = vi.fn(async () => undefined)
 const sendDocument = vi.fn(async () => undefined)
 
@@ -23,6 +26,9 @@ vi.mock('grammy', async (importOriginal) => {
         getMe,
         setMyCommands,
         sendRichMessage,
+        sendMessageDraft,
+        sendRichMessageDraft,
+        sendChatAction,
         sendMessage,
         sendDocument,
       }
@@ -88,6 +94,12 @@ describe('Telegram polling readiness', () => {
     setMyCommands.mockReset()
     setMyCommands.mockResolvedValue(undefined)
     sendRichMessage.mockReset()
+    sendMessageDraft.mockReset()
+    sendMessageDraft.mockResolvedValue(true)
+    sendRichMessageDraft.mockReset()
+    sendRichMessageDraft.mockResolvedValue(true)
+    sendChatAction.mockReset()
+    sendChatAction.mockResolvedValue(true)
     sendMessage.mockReset()
     sendDocument.mockReset()
     stopMock.mockResolvedValue(undefined)
@@ -234,6 +246,12 @@ describe('Telegram rich outbound text', () => {
     getMe.mockReset()
     getMe.mockResolvedValue({ id: 1, is_bot: true, first_name: 'OpenAlice', username: 'openalice_bot' })
     sendRichMessage.mockReset()
+    sendMessageDraft.mockReset()
+    sendMessageDraft.mockResolvedValue(true)
+    sendRichMessageDraft.mockReset()
+    sendRichMessageDraft.mockResolvedValue(true)
+    sendChatAction.mockReset()
+    sendChatAction.mockResolvedValue(true)
     sendMessage.mockReset()
     sendDocument.mockReset()
     startMock.mockImplementation((options: { onStart?: () => void }) => {
@@ -256,6 +274,70 @@ describe('Telegram rich outbound text', () => {
     expect(sendRichMessage).toHaveBeenCalledWith('99', { markdown })
     expect(sendMessage).not.toHaveBeenCalled()
     await adapter.stop()
+  })
+
+  it('shows a native draft before model text, updates it, then persists the final reply', async () => {
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
+
+    await adapter.sendOwnerChat({
+      id: 'accepted-1', adapterId: 'telegram', conversationId: 'comment-1', phase: 'accepted',
+    })
+    await adapter.sendOwnerChat({
+      id: 'progress-1', adapterId: 'telegram', conversationId: 'comment-1', phase: 'progress',
+      text: 'Checking the market.',
+    })
+    await adapter.sendOwnerChat({
+      id: 'final-1', adapterId: 'telegram', conversationId: 'comment-1', phase: 'final',
+      text: 'The market is quiet.',
+    })
+    await adapter.sendOwnerChat({
+      id: 'late-progress', adapterId: 'telegram', conversationId: 'comment-1', phase: 'progress',
+      text: 'Late transport update.',
+    })
+
+    const draftId = expect.any(Number)
+    expect(sendMessageDraft).toHaveBeenCalledWith(99, draftId, '')
+    expect(sendRichMessageDraft).toHaveBeenCalledWith(99, draftId, { markdown: 'Checking the market.' })
+    expect(sendRichMessageDraft).toHaveBeenCalledTimes(1)
+    expect(sendRichMessage).toHaveBeenCalledWith('99', { markdown: 'The market is quiet.' })
+    await adapter.stop()
+  })
+
+  it('falls back to Telegram typing when live drafts are unavailable', async () => {
+    sendMessageDraft.mockRejectedValueOnce(new Error('method unavailable'))
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
+
+    await adapter.sendOwnerChat({
+      id: 'accepted-1', adapterId: 'telegram', conversationId: 'comment-1', phase: 'accepted',
+    })
+
+    expect(sendChatAction).toHaveBeenCalledWith(99, 'typing')
+    await adapter.stop()
+  })
+
+  it('refreshes an active draft before its TTL and stops after the final reply', async () => {
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
+    vi.useFakeTimers()
+    try {
+      await adapter.sendOwnerChat({
+        id: 'accepted-1', adapterId: 'telegram', conversationId: 'comment-1', phase: 'accepted',
+      })
+      expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sendMessageDraft).toHaveBeenCalledTimes(2)
+
+      await adapter.sendOwnerChat({
+        id: 'final-1', adapterId: 'telegram', conversationId: 'comment-1', phase: 'final', text: 'Done.',
+      })
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(sendMessageDraft).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+      await adapter.stop()
+    }
   })
 
   it('sends Inbox notifications as rich GFM', async () => {

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { Bot, InlineKeyboard, InputFile, type Context } from 'grammy'
 import { autoRetry } from '@grammyjs/auto-retry'
 import type {
@@ -7,6 +8,7 @@ import type {
   ConnectorUtaFailure,
   ConnectorUtaPresentation,
   InboxNotification,
+  OwnerChatMessage,
 } from '@traderalice/connector-protocol'
 import { isInboxPushEnabled, TELEGRAM_CONNECTOR_DEFINITION } from '@traderalice/connector-protocol'
 import { createInboxStore, type IInboxStore } from '@/core/inbox-store.js'
@@ -50,6 +52,19 @@ import {
 } from './telegram-uta.js'
 import { sendTelegramRichText } from './telegram-rich-text.js'
 
+const TELEGRAM_DRAFT_HEARTBEAT_MS = 20_000
+const TELEGRAM_TYPING_HEARTBEAT_MS = 4_000
+const MAX_FINISHED_DRAFTS = 128
+
+interface TelegramDraftSession {
+  draftId: number
+  markdown?: string
+  typingFallback: boolean
+  stopped: boolean
+  pending: Promise<void>
+  timer?: ReturnType<typeof setTimeout>
+}
+
 export class TelegramConnectorAdapter implements ConnectorAdapter {
   readonly id = 'telegram'
   private readonly tracker = new AdapterHealthTracker(this.id)
@@ -64,6 +79,8 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   private readonly inboxSessions = new Map<string, TelegramInboxSession>()
   private readonly utaSessions = new Map<string, TelegramUtaSession>()
   private readonly utaPending = new Map<string, { chatId: number; messageId: number; session: TelegramUtaSession }>()
+  private readonly drafts = new Map<string, TelegramDraftSession>()
+  private readonly finishedDrafts = new Set<string>()
   private stopped = true
   private loop?: Promise<void>
   private abort?: AbortController
@@ -123,6 +140,8 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
 
   async stop(): Promise<void> {
     this.stopped = true
+    this.stopAllDrafts()
+    this.finishedDrafts.clear()
     this.abort?.abort()
     await this.disconnectSession()
     await this.loop?.catch(() => undefined)
@@ -178,6 +197,27 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       this.tracker.degraded(error)
       throw error
     }
+  }
+
+  async sendOwnerChat(message: OwnerChatMessage): Promise<void> {
+    if (message.phase === 'accepted' || message.phase === 'progress') {
+      this.tracker.attempt()
+      try {
+        if (message.phase === 'accepted') {
+          await this.startDraft(message.conversationId)
+        } else if (message.text) {
+          await this.updateDraft(message.conversationId, message.text)
+        }
+        this.tracker.success(this.ownerUserId)
+        return
+      } catch (error) {
+        this.tracker.degraded(error)
+        throw error
+      }
+    }
+
+    await this.finishDraft(message.conversationId)
+    if (message.text) await this.sendOwnerText(message.text)
   }
 
   health(): ConnectorAdapterHealth {
@@ -280,6 +320,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
 
   private async disconnectSession(): Promise<void> {
     this.sessionReady = false
+    this.stopAllDrafts()
     const bot = this.bot
     this.bot = undefined
     await Promise.resolve(bot?.stop()).catch(() => undefined)
@@ -627,6 +668,139 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   private isOwner(userId: string): boolean {
     return Boolean(this.ownerUserId && this.ownerUserId === userId)
   }
+
+  private async startDraft(conversationId: string): Promise<void> {
+    if (this.finishedDrafts.has(conversationId)) return
+    this.stopDraft(conversationId)
+    const session: TelegramDraftSession = {
+      draftId: telegramDraftId(conversationId),
+      typingFallback: false,
+      stopped: false,
+      pending: Promise.resolve(),
+    }
+    this.drafts.set(conversationId, session)
+    try {
+      await this.queueDraftRefresh(conversationId, session)
+    } finally {
+      this.armDraftHeartbeat(conversationId, session)
+    }
+  }
+
+  private async updateDraft(conversationId: string, markdown: string): Promise<void> {
+    if (this.finishedDrafts.has(conversationId)) return
+    let session = this.drafts.get(conversationId)
+    if (!session) {
+      session = {
+        draftId: telegramDraftId(conversationId),
+        typingFallback: false,
+        stopped: false,
+        pending: Promise.resolve(),
+      }
+      this.drafts.set(conversationId, session)
+    }
+    session.markdown = markdown
+    try {
+      await this.queueDraftRefresh(conversationId, session)
+    } finally {
+      this.armDraftHeartbeat(conversationId, session)
+    }
+  }
+
+  private queueDraftRefresh(conversationId: string, session: TelegramDraftSession): Promise<void> {
+    const next = session.pending.catch(() => undefined).then(async () => {
+      if (session.stopped || this.drafts.get(conversationId) !== session) return
+      await this.refreshDraft(session)
+    })
+    session.pending = next
+    return next
+  }
+
+  private async refreshDraft(session: TelegramDraftSession): Promise<void> {
+    if (!this.bot || !this.sessionReady) throw new Error('Telegram bot is not ready')
+    const chatId = telegramNumericChatId(this.chatId)
+    if (session.typingFallback) {
+      await this.bot.api.sendChatAction(chatId, 'typing')
+      return
+    }
+    try {
+      if (session.markdown) {
+        await this.bot.api.sendRichMessageDraft(chatId, session.draftId, { markdown: session.markdown })
+      } else {
+        await this.bot.api.sendMessageDraft(chatId, session.draftId, '')
+      }
+      return
+    } catch (error) {
+      if (session.markdown) {
+        try {
+          await this.bot.api.sendMessageDraft(
+            chatId,
+            session.draftId,
+            truncateTelegramText(session.markdown, 4096),
+          )
+          return
+        } catch {
+          // Fall through to the universally supported activity indicator.
+        }
+      }
+      console.warn('[connector] Telegram live draft fell back to typing:', formatAdapterError(error))
+      session.typingFallback = true
+      await this.bot.api.sendChatAction(chatId, 'typing')
+    }
+  }
+
+  private async finishDraft(conversationId: string): Promise<void> {
+    const session = this.drafts.get(conversationId)
+    if (session) {
+      this.stopDraft(conversationId)
+      await session.pending.catch(() => undefined)
+    }
+    this.markDraftFinished(conversationId)
+  }
+
+  private stopDraft(conversationId: string): void {
+    const session = this.drafts.get(conversationId)
+    if (!session) return
+    session.stopped = true
+    if (session.timer) clearTimeout(session.timer)
+    this.drafts.delete(conversationId)
+  }
+
+  private stopAllDrafts(): void {
+    for (const conversationId of [...this.drafts.keys()]) this.stopDraft(conversationId)
+  }
+
+  private armDraftHeartbeat(conversationId: string, session: TelegramDraftSession): void {
+    if (session.stopped || this.drafts.get(conversationId) !== session) return
+    if (session.timer) clearTimeout(session.timer)
+    const delay = session.typingFallback ? TELEGRAM_TYPING_HEARTBEAT_MS : TELEGRAM_DRAFT_HEARTBEAT_MS
+    session.timer = setTimeout(() => {
+      void this.queueDraftRefresh(conversationId, session).catch((error) => {
+        this.tracker.degraded(error)
+        console.warn('[connector] Telegram owner-chat activity refresh failed:', formatAdapterError(error))
+      }).finally(() => this.armDraftHeartbeat(conversationId, session))
+    }, delay)
+    session.timer.unref?.()
+  }
+
+  private markDraftFinished(conversationId: string): void {
+    if (this.finishedDrafts.size >= MAX_FINISHED_DRAFTS) {
+      const oldest = this.finishedDrafts.values().next().value
+      if (oldest !== undefined) this.finishedDrafts.delete(oldest)
+    }
+    this.finishedDrafts.add(conversationId)
+  }
+}
+
+export function telegramDraftId(conversationId: string): number {
+  const value = createHash('sha256').update(conversationId).digest().readUInt32BE(0) & 0x7fff_ffff
+  return value || 1
+}
+
+function telegramNumericChatId(chatId: string | undefined): number {
+  if (!chatId) throw new Error('Telegram private chat is not linked')
+  const numeric = Number(chatId)
+  if (!Number.isSafeInteger(numeric)) throw new Error('Telegram private chat id is invalid')
+  return numeric
 }
 
 export function telegramConnectorRegistration(

--- a/services/connector/src/core/adapter.ts
+++ b/services/connector/src/core/adapter.ts
@@ -6,6 +6,7 @@ import type {
   ConnectorUtaFailure,
   ConnectorUtaPresentation,
   InboxNotification,
+  OwnerChatMessage,
 } from '@traderalice/connector-protocol'
 import { randomUUID } from 'node:crypto'
 import {
@@ -52,6 +53,8 @@ export interface ConnectorAdapter {
   stop(): Promise<void>
   deliver(notification: InboxNotification): Promise<void>
   sendOwnerText(text: string): Promise<void>
+  /** Optional transport-native lifecycle projection for desk-capable adapters. */
+  sendOwnerChat?(message: OwnerChatMessage): Promise<void>
   /** Directed current-file delivery. Must not send an Inbox summary. */
   deliverArtifact?(delivery: ConnectorArtifactDelivery): Promise<void>
   /** Directed UTA review panel. Must not send an Inbox summary. */

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -350,7 +350,13 @@ describe('DeliveryManager connector registry', () => {
     })
     await manager.start()
 
-    expect(manager.enqueueOwnerChat({ id: 'desk-comment-1', adapterId: 'broken', text: 'hello' }))
+    expect(manager.enqueueOwnerChat({
+      id: 'desk-comment-1',
+      adapterId: 'broken',
+      conversationId: 'comment-1',
+      phase: 'final',
+      text: 'hello',
+    }))
       .toEqual({ accepted: true, deliveryId: 'desk-comment-1' })
     await vi.waitFor(() => expect(warn).toHaveBeenCalledWith(
       '[connector] broken owner-chat delivery failed:',

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -395,16 +395,25 @@ export class DeliveryManager {
       direction: 'outbound',
       stage: 'delivery.attempted',
       connectorId: adapter.id,
-      payload: { kind: 'owner-chat', textLength: message.text.length },
+      payload: {
+        kind: 'owner-chat',
+        phase: message.phase,
+        conversationId: message.conversationId,
+        textLength: message.text?.length ?? 0,
+      },
     })
     try {
-      await adapter.sendOwnerText(message.text)
+      if (adapter.sendOwnerChat) {
+        await adapter.sendOwnerChat(message)
+      } else if (message.phase !== 'accepted' && message.text) {
+        await adapter.sendOwnerText(message.text)
+      }
       await this.record({
         correlationId,
         direction: 'outbound',
         stage: 'delivery.succeeded',
         connectorId: adapter.id,
-        payload: { kind: 'owner-chat' },
+        payload: { kind: 'owner-chat', phase: message.phase, conversationId: message.conversationId },
       })
     } catch (error) {
       await this.record({
@@ -412,7 +421,12 @@ export class DeliveryManager {
         direction: 'outbound',
         stage: 'delivery.failed',
         connectorId: adapter.id,
-        payload: { kind: 'owner-chat', error: error instanceof Error ? error.message : String(error) },
+        payload: {
+          kind: 'owner-chat',
+          phase: message.phase,
+          conversationId: message.conversationId,
+          error: error instanceof Error ? error.message : String(error),
+        },
       })
       throw error
     }

--- a/src/workspaces/issues/comment-delivery.ts
+++ b/src/workspaces/issues/comment-delivery.ts
@@ -13,7 +13,10 @@ import {
 } from './comments.js'
 import { renderIssueCommentPrompt } from './comment-prompt.js'
 import { issueAssigneeResumeId, type IssueRecord } from './declaration.js'
-import { projectDeskComment } from './telegram-desk-project.js'
+import {
+  projectDeskComment,
+  projectWorkspaceDeskFailure,
+} from './telegram-desk-project.js'
 
 const COMMENT_REPLY_TIMEOUT_MS = 300_000
 
@@ -189,6 +192,10 @@ export async function recordIssueCommentReply(input: {
     return 'replied'
   }
 
+  const failureText = input.error
+    ?? (input.status === 'done'
+      ? 'The Issue reply Agent finished without a final reply.'
+      : `The Issue reply run ended as ${input.status}.`)
   const updated = await updateIssueCommentDelivery(
     input.issueWorkspaceDir,
     input.issueId,
@@ -197,12 +204,15 @@ export async function recordIssueCommentReply(input: {
       state: 'failed',
       targetResumeId: input.task.resumeId,
       taskId: input.task.taskId,
-      error: input.error
-        ?? (input.status === 'done'
-          ? 'The Issue reply Agent finished without a final reply.'
-          : `The Issue reply run ended as ${input.status}.`),
+      error: failureText,
     },
   )
   if (!updated.ok) throw new Error(updated.error)
+  await projectWorkspaceDeskFailure({
+    wsDir: input.issueWorkspaceDir,
+    issueId: input.issueId,
+    conversationId: input.sourceCommentId,
+    text: `The Agent could not complete this reply: ${failureText}`,
+  }).catch(() => undefined)
   return 'failed'
 }

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -48,10 +48,10 @@ function host(overrides: Partial<TelegramDeskChatHost> = {}): TelegramDeskChatHo
 }
 
 function mockClient() {
-  const sent: { id: string; text: string }[] = []
+  const sent: Array<{ id: string; conversationId: string; phase: string; text?: string }> = []
   const client = {
-    sendOwnerMessage: async (message: { id: string; text: string }) => {
-      sent.push({ id: message.id, text: message.text })
+    sendOwnerMessage: async (message: { id: string; conversationId: string; phase: string; text?: string }) => {
+      sent.push(message)
       return { accepted: true }
     },
   } as unknown as ConnectorClient
@@ -102,17 +102,44 @@ describe('telegram desk ingest and stamp', () => {
       [{ id: 'ws-a', dir: wsDir }],
     )
     expect(created.ok).toBe(true)
+    const { client } = mockClient()
     const result = await ingestTelegramOwnerMessage(host(), {
       connectorId: 'telegram',
       userId: '42',
       text: 'What is the overnight risk?',
-    })
+    }, client)
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.comment.author).toBe('human')
     expect(result.comment.via).toBe('telegram')
     expect(result.comment.markdown).toBe('What is the overnight risk?')
     expect(shouldProjectDeskComment(created.ok ? created.issue : { connectorDesk: 'telegram' }, result.comment)).toBe(false)
+  })
+
+  it('starts native owner-chat activity after the Agent turn is scheduled', async () => {
+    const created = await createTelegramConnectorDesk(
+      { id: 'ws-a', dir: wsDir },
+      [{ id: 'ws-a', dir: wsDir }],
+    )
+    expect(created.ok).toBe(true)
+    const { client, sent } = mockClient()
+    const result = await ingestTelegramOwnerMessage(host({
+      conversation: () => ({
+        ask: async () => ({ status: 'accepted', taskId: 'run-1', resumeId: 'resume-1' }),
+      } as unknown as NonNullable<ReturnType<TelegramDeskChatHost['conversation']>>),
+    }), {
+      connectorId: 'telegram',
+      userId: '42',
+      text: 'What is the overnight risk?',
+    }, client)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(sent).toEqual([expect.objectContaining({
+      id: `desk-accepted-${result.comment.id}`,
+      conversationId: result.comment.id,
+      phase: 'accepted',
+    })])
   })
 
   it('stamps a scheduled fire as a comment', async () => {
@@ -242,10 +269,11 @@ describe('telegram desk ingest and stamp', () => {
       [{ id: 'ws-a', dir: wsDir }],
     )
     expect(created.ok).toBe(true)
+    const { client } = mockClient()
     const result = await ingestTelegramOwnerMessages(host(), [
       { connectorId: 'telegram', userId: '42', text: '那个事情我想了想你再改改' },
       { connectorId: 'telegram', userId: '42', text: '算了不用改了,就这样吧' },
-    ])
+    ], client)
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.comment.markdown).toBe([

--- a/src/workspaces/issues/telegram-desk-chat.ts
+++ b/src/workspaces/issues/telegram-desk-chat.ts
@@ -29,13 +29,15 @@ import {
   findConnectorDesks,
   type ConnectorDesk,
 } from './connector-desk.js'
-import { projectDeskComment } from './telegram-desk-project.js'
+import { projectDeskComment, projectDeskLifecycle } from './telegram-desk-project.js'
 
 export {
   TELEGRAM_NO_REPLY_TAG,
   containsTelegramNoReply,
   projectDeskComment,
+  projectDeskLifecycle,
   projectDeskTurnProgress,
+  projectWorkspaceDeskFailure,
   projectWorkspaceDeskTurnProgress,
   shouldProjectDeskComment,
 } from './telegram-desk-project.js'
@@ -86,20 +88,23 @@ function quoteInboundMessage(text: string): string {
 export async function ingestTelegramOwnerMessage(
   host: ConnectorDeskChatHost,
   message: InboundOwnerMessage,
+  client?: ConnectorClient,
 ): Promise<{ ok: true; comment: IssueComment } | { ok: false; reason: string }> {
-  return ingestConnectorOwnerMessages(host, [message])
+  return ingestConnectorOwnerMessages(host, [message], client)
 }
 
 export async function ingestTelegramOwnerMessages(
   host: ConnectorDeskChatHost,
   messages: readonly InboundOwnerMessage[],
+  client?: ConnectorClient,
 ): Promise<{ ok: true; comment: IssueComment } | { ok: false; reason: string }> {
-  return ingestConnectorOwnerMessages(host, messages)
+  return ingestConnectorOwnerMessages(host, messages, client)
 }
 
 export async function ingestConnectorOwnerMessages(
   host: ConnectorDeskChatHost,
   messages: readonly InboundOwnerMessage[],
+  client: ConnectorClient = new ConnectorClient(resolveConnectorUrl()),
 ): Promise<{ ok: true; comment: IssueComment } | { ok: false; reason: string }> {
   const connectorId = messages[0]?.connectorId
   if (!connectorId) return { ok: false, reason: 'empty' }
@@ -142,6 +147,25 @@ export async function ingestConnectorOwnerMessages(
   })
   if (dispatched.status !== 'not_requested') {
     await updateIssueCommentDelivery(workspace.dir, desk.issue.id, appended.comment.id, dispatched.delivery)
+  }
+  if (dispatched.status === 'scheduled') {
+    await projectDeskLifecycle({
+      issue: appended.issue,
+      conversationId: appended.comment.id,
+      phase: 'accepted',
+      client,
+    }).catch(() => undefined)
+  } else {
+    const reason = dispatched.status === 'failed'
+      ? dispatched.delivery.error
+      : 'No Agent reply was scheduled for this message.'
+    await projectDeskLifecycle({
+      issue: appended.issue,
+      conversationId: appended.comment.id,
+      phase: 'failed',
+      text: `OpenAlice could not start the Agent: ${reason}`,
+      client,
+    }).catch(() => undefined)
   }
   return { ok: true, comment: appended.comment }
 }
@@ -223,7 +247,7 @@ export async function pullTelegramDeskInbound(
       leftover.push(...group)
       continue
     }
-    const result = await ingestConnectorOwnerMessages(host, group)
+    const result = await ingestConnectorOwnerMessages(host, group, client)
     if (!result.ok) {
       console.warn(`[connector] ${connectorId} phone-desk inbound skipped:`, result.reason)
     }

--- a/src/workspaces/issues/telegram-desk-project.spec.ts
+++ b/src/workspaces/issues/telegram-desk-project.spec.ts
@@ -12,6 +12,7 @@ import {
   deskProgressMessageId,
   deskProgressScope,
   projectDeskComment,
+  projectDeskLifecycle,
   projectDeskTurnProgress,
   projectWorkspaceDeskTurnProgress,
   resetProjectedDeskTexts,
@@ -48,10 +49,10 @@ function progress(blocks: HeadlessTurnProgress['blocks']): HeadlessTurnProgress 
 }
 
 function mockClient() {
-  const sent: { id: string; text: string }[] = []
+  const sent: Array<{ id: string; conversationId: string; phase: string; text?: string }> = []
   const client = {
-    sendOwnerMessage: async (message: { id: string; text: string }) => {
-      sent.push({ id: message.id, text: message.text })
+    sendOwnerMessage: async (message: { id: string; conversationId: string; phase: string; text?: string }) => {
+      sent.push(message)
       return { accepted: true }
     },
   } as unknown as ConnectorClient
@@ -161,10 +162,12 @@ describe('projectDeskTurnProgress', () => {
       progress: snapshot,
       client,
     })
-    expect(sent).toEqual([{
+    expect(sent).toEqual([expect.objectContaining({
       id: deskProgressMessageId('telegram-1', 'Looking at the book.'),
+      conversationId: 'telegram-1',
+      phase: 'progress',
       text: 'Looking at the book.',
-    }])
+    })])
     expect(alreadyProjectedDeskText('telegram-1', 'Looking at the book.')).toBe(true)
   })
 
@@ -210,7 +213,27 @@ describe('projectDeskTurnProgress', () => {
   })
 })
 
-describe('final comment dedup', () => {
+describe('owner-chat lifecycle', () => {
+  it('projects accepted without fake text and failed as a visible terminal event', async () => {
+    const { client, sent } = mockClient()
+    const issue = { connectorDesk: 'telegram', status: 'todo' as const }
+    await projectDeskLifecycle({ issue, conversationId: 'comment-1', phase: 'accepted', client })
+    await projectDeskLifecycle({
+      issue,
+      conversationId: 'comment-1',
+      phase: 'failed',
+      text: 'The Agent could not start.',
+      client,
+    })
+    expect(sent[0]).toMatchObject({ conversationId: 'comment-1', phase: 'accepted' })
+    expect(sent[0]).not.toHaveProperty('text')
+    expect(sent[1]).toMatchObject({
+      conversationId: 'comment-1', phase: 'failed', text: 'The Agent could not start.',
+    })
+  })
+})
+
+describe('final comment projection', () => {
   it('treats [[no-reply]] as control syntax only with connector cron metadata', async () => {
     const { client, sent } = mockClient()
     const issue = { connectorDesk: 'telegram' }
@@ -232,7 +255,7 @@ describe('final comment dedup', () => {
     })).toBe(false)
   })
 
-  it('skips a final comment whose markdown was already shipped as progress', async () => {
+  it('persists a final comment even when the same text was shown in an ephemeral draft', async () => {
     const { client, sent } = mockClient()
     const issue = { connectorDesk: 'telegram' }
     await projectDeskTurnProgress({
@@ -252,9 +275,14 @@ describe('final comment dedup', () => {
       markdown: 'Looking at the book.',
       replyTo: 'telegram-1',
     }
-    expect(shouldProjectDeskComment(issue, comment)).toBe(false)
+    expect(shouldProjectDeskComment(issue, comment)).toBe(true)
     await projectDeskComment(issue, comment, client)
-    expect(sent).toHaveLength(1)
+    expect(sent).toHaveLength(2)
+    expect(sent[1]).toMatchObject({
+      conversationId: 'telegram-1',
+      phase: 'final',
+      text: 'Looking at the book.',
+    })
     expect(alreadyProjectedDeskText('telegram-1', 'Looking at the book.')).toBe(false)
   })
 

--- a/src/workspaces/issues/telegram-desk-project.ts
+++ b/src/workspaces/issues/telegram-desk-project.ts
@@ -132,8 +132,6 @@ export function shouldProjectDeskComment(
     consumesConnectorNoReply(opts?.triggerMetadata)
     && containsTelegramNoReply(comment.markdown)
   ) return false
-  const scope = opts?.progressScopeId ?? comment.replyTo
-  if (scope && alreadyProjectedDeskText(scope, comment.markdown)) return false
   return true
 }
 
@@ -155,6 +153,8 @@ export async function projectDeskComment(
     await client.sendOwnerMessage({
       id: `desk-${comment.id}`,
       adapterId: issue.connectorDesk,
+      conversationId: scope ?? comment.id,
+      phase: 'final',
       text: normalizeDeskText(comment.markdown),
     }, AbortSignal.timeout(5_000))
   } finally {
@@ -177,12 +177,44 @@ export async function projectDeskTurnProgress(input: {
     await client.sendOwnerMessage({
       id: deskProgressMessageId(input.scopeId, text),
       adapterId: input.issue.connectorDesk,
+      conversationId: input.scopeId,
+      phase: 'progress',
       text,
     }, AbortSignal.timeout(5_000))
     markProjectedDeskText(input.scopeId, text)
     sent.push(text)
   }
   return sent
+}
+
+export async function projectDeskLifecycle(input: {
+  issue: Pick<IssueRecord, 'connectorDesk' | 'status'>
+  conversationId: string
+  phase: 'accepted' | 'failed'
+  text?: string
+  client?: ConnectorClient
+}): Promise<void> {
+  if (!isConnectorDeskIssue(input.issue) || input.issue.status === 'canceled') return
+  const client = input.client ?? new ConnectorClient(resolveConnectorUrl())
+  await client.sendOwnerMessage({
+    id: `desk-${input.phase}-${input.conversationId}`,
+    adapterId: input.issue.connectorDesk,
+    conversationId: input.conversationId,
+    phase: input.phase,
+    ...(input.text ? { text: normalizeDeskText(input.text) } : {}),
+  }, AbortSignal.timeout(5_000))
+}
+
+export async function projectWorkspaceDeskFailure(input: {
+  wsDir: string
+  issueId: string
+  conversationId: string
+  text: string
+  client?: ConnectorClient
+}): Promise<void> {
+  const issue = await readDeskIssue(input.wsDir, input.issueId)
+  if (!issue) return
+  await projectDeskLifecycle({ ...input, issue, phase: 'failed' })
 }
 
 export async function projectWorkspaceDeskTurnProgress(input: {


### PR DESCRIPTION
## Summary
- add explicit accepted/progress/final/failed lifecycle events to owner chat delivery
- use Telegram Bot API live drafts immediately after Agent dispatch, with 20-second refresh and rich progress updates
- fall back to a four-second typing heartbeat when draft APIs fail
- always persist final and failed replies, including when final text matches an ephemeral progress draft

## Verification
- npx tsc --noEmit
- pnpm -F @traderalice/connector-protocol typecheck
- pnpm test (576 passed, 1 skipped; 4870 tests passed, 9 skipped)