### PR TITLE
fix(ui): accept Prediction in Activity Bar layout

### DIFF
--- a/src/core/ui-layout.spec.ts
+++ b/src/core/ui-layout.spec.ts
@@ -26,6 +26,12 @@ afterEach(async () => {
 })
 
 describe('ui-layout', () => {
+  it('accepts the Auto Prediction page emitted by the Activity Bar editor', () => {
+    const layout = defaultUiLayout()
+    expect(layout.groups.find((group) => group.id === 'beta')?.items).toContain('prediction')
+    expect(() => parseUiLayoutWrite(layout)).not.toThrow()
+  })
+
   it('hides Dev by default and keeps Settings visible', () => {
     const layout = defaultUiLayout()
     expect(layout.hidden).toEqual(['dev'])
@@ -55,6 +61,7 @@ describe('ui-layout', () => {
       'office',
       'portfolio',
       'connectors',
+      'prediction',
     ])
     expect(layout.hidden).not.toContain('trading-as-git')
     expect(layout.hidden).toEqual(['dev'])

--- a/src/core/ui-layout.ts
+++ b/src/core/ui-layout.ts
@@ -15,6 +15,7 @@ import { dataPath } from './paths.js'
 export const ACTIVITY_PAGE_IDS = [
   'chat',
   'auto-quant',
+  'prediction',
   'inbox',
   'tracked',
   'workspaces',
@@ -64,7 +65,7 @@ export function defaultUiLayout(): UiLayout {
     version: 1,
     groups: [
       { id: 'primary', items: ['chat', 'inbox', 'issue', 'auto-quant', 'tracked', 'market'] },
-      { id: 'beta', items: ['office', 'portfolio', 'connectors'] },
+      { id: 'beta', items: ['prediction', 'office', 'portfolio', 'connectors'] },
       { id: 'system', items: ['workspaces', 'automation', 'settings', 'dev'] },
     ],
     hidden: ['dev'],


### PR DESCRIPTION
## Summary
- add Auto Prediction to the backend Activity Bar layout contract and default beta group
- cover the exact editor payload that previously returned `400 invalid_ui_layout` in CLI mode
- keep retired Trading-as-Git layout normalization expectations aligned with the complete page catalog

## Root cause
The UI added `prediction` to its Activity Bar catalog, but the backend Zod write schema still rejected that page id. Every Activity Bar edit therefore failed after the UI normalized `prediction` into the submitted document.

## Verification
- `pnpm exec vitest run src/core/ui-layout.spec.ts src/webui/routes/ui-layout.spec.ts ui/src/live/ui-layout.spec.ts`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (576 passed, 1 skipped; 4871 tests passed, 9 skipped)