### PR TITLE
fix(ci): keep remote installer smoke dependency-free

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: 22.19.0
 
       - name: Exercise clean SSH host fixture
-        run: node scripts/remote-ssh-smoke.mjs
+        run: node scripts/remote-ssh-smoke.mjs --skip-tui
 
   dev-channel-install:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
         run: node scripts/install-docker-smoke.mjs
 
       - name: Exercise candidate installer through managed SSH remote
-        run: node scripts/remote-ssh-smoke.mjs
+        run: node scripts/remote-ssh-smoke.mjs --skip-tui
 
   build-headless-runtime:
     name: Build headless Runtime (${{ matrix.platform }}-${{ matrix.arch }})

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -506,7 +506,7 @@ signals a guessed PID, exposes the Guardian socket, or performs trading writes.
   terminal cleanup.
 - [x] Walk the real TUI against an isolated Docker SSH host; no user Home,
   provider account, broker, or connector may be used.
-- [ ] Open and merge the fourth serial PR to `dev`; inspect trailing CI.
+- [x] Open and merge the fourth serial PR to `dev`; inspect trailing CI.
 
 ### Increment 5 — completion and release evidence
 
@@ -574,6 +574,13 @@ retry, cancellation acknowledgement with retry, and terminal cleanup. The
 Docker SSH fixture drives the real TUI through default-No and approved
 success, proving no default-No destination, registered result, portable
 Workspace content, and no resume ledger. Publication remains.
+
+Increment 4 publication follow-up (2026-08-23): the feature PR merged as
+PR #1164. Its trailing Installer Smoke exposed that the dependency-free
+managed-remote job loaded `node-pty` before reaching its non-TUI path. The
+fixture now loads PTY support only for the local interactive journey, while CI
+and release installer jobs explicitly retain the dependency-free remote path;
+both variants pass the full disposable Docker acceptance locally.
 
 Final local gate refresh (2026-08-23): the complete CLI package passes 291
 tests and the repository passes 4,936 tests with 9 skipped, alongside root,

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { spawn, spawnSync } from 'node:child_process'
 import { Writable } from 'node:stream'
-import * as pty from 'node-pty'
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -19,6 +18,7 @@ const image = `openalice-remote-smoke:${suffix}`
 const args = process.argv.slice(2)
 const keepImage = args.includes('--keep-image')
 const keepContainer = args.includes('--keep-container')
+const skipTui = args.includes('--skip-tui')
 let imageBuilt = false
 let container = ''
 let scratch = ''
@@ -34,12 +34,17 @@ a local acceptance gate and is not wired into PR CI.
 Options:
   --keep-image      Preserve the temporary Docker image
   --keep-container  Preserve the running fixture container (also keeps image)
+  --skip-tui        Skip the dependency-backed interactive TUI journey
   -h, --help        Show this help
 `)
   process.exit(0)
 }
 
-const unknownArgs = args.filter((arg) => !['--keep-image', '--keep-container'].includes(arg))
+const unknownArgs = args.filter((arg) => ![
+  '--keep-image',
+  '--keep-container',
+  '--skip-tui',
+].includes(arg))
 if (unknownArgs.length > 0) {
   console.error(`remote docker smoke: unknown option: ${unknownArgs[0]}`)
   process.exit(1)
@@ -228,30 +233,34 @@ try {
     'test -f /home/smoke/.openalice-interrupted/workspaces/workspaces/ws-transfer/research.txt',
     'test ! -e /home/smoke/.openalice-transfer-remote-smoke-interrupted.staging',
   ].join('; ')], { env: smokeEnv })
-  console.log('[remote-ssh-smoke] walking the real TUI transfer wizard (default No, then success)')
-  await driveTransferTui(smokeEnv, {
-    projectKey: 'tui-migrated',
-    destinationHome: '/home/smoke/.openalice-tui-migrated',
-    approve: false,
-  })
-  console.log('[remote-ssh-smoke] TUI default-No journey completed')
-  run('ssh', [remoteTarget, 'test ! -e /home/smoke/.openalice-tui-migrated'], { env: smokeEnv })
-  await driveTransferTui(smokeEnv, {
-    projectKey: 'tui-migrated',
-    destinationHome: '/home/smoke/.openalice-tui-migrated',
-    approve: true,
-  })
-  console.log('[remote-ssh-smoke] TUI approved journey completed')
-  const tuiRegistry = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" project list --json')
-  const tuiProject = tuiRegistry.projects?.find((project) => project.key === 'tui-migrated')
-  if (tuiProject?.home !== '/home/smoke/.openalice-tui-migrated') {
-    throw new Error(`TUI registered the wrong destination: ${JSON.stringify(tuiRegistry)}`)
+  if (skipTui) {
+    console.log('[remote-ssh-smoke] skipping dependency-backed TUI journey')
+  } else {
+    console.log('[remote-ssh-smoke] walking the real TUI transfer wizard (default No, then success)')
+    await driveTransferTui(smokeEnv, {
+      projectKey: 'tui-migrated',
+      destinationHome: '/home/smoke/.openalice-tui-migrated',
+      approve: false,
+    })
+    console.log('[remote-ssh-smoke] TUI default-No journey completed')
+    run('ssh', [remoteTarget, 'test ! -e /home/smoke/.openalice-tui-migrated'], { env: smokeEnv })
+    await driveTransferTui(smokeEnv, {
+      projectKey: 'tui-migrated',
+      destinationHome: '/home/smoke/.openalice-tui-migrated',
+      approve: true,
+    })
+    console.log('[remote-ssh-smoke] TUI approved journey completed')
+    const tuiRegistry = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" project list --json')
+    const tuiProject = tuiRegistry.projects?.find((project) => project.key === 'tui-migrated')
+    if (tuiProject?.home !== '/home/smoke/.openalice-tui-migrated') {
+      throw new Error(`TUI registered the wrong destination: ${JSON.stringify(tuiRegistry)}`)
+    }
+    run('ssh', [remoteTarget, [
+      'set -eu',
+      'test -f /home/smoke/.openalice-tui-migrated/workspaces/workspaces/ws-transfer/research.txt',
+      'test ! -e /home/smoke/.openalice-tui-migrated/workspaces/state/resume-identities.json',
+    ].join('; ')], { env: smokeEnv })
   }
-  run('ssh', [remoteTarget, [
-    'set -eu',
-    'test -f /home/smoke/.openalice-tui-migrated/workspaces/workspaces/ws-transfer/research.txt',
-    'test ! -e /home/smoke/.openalice-tui-migrated/workspaces/state/resume-identities.json',
-  ].join('; ')], { env: smokeEnv })
   const transferArgs = [
     cliEntry, 'project', 'transfer',
     '--from', 'default',
@@ -487,6 +496,7 @@ function sshWithInput(target, env, command, input) {
 }
 
 async function driveTransferTui(env, options) {
+  const pty = await import('node-pty')
   const child = pty.spawn(process.execPath, [cliEntry], {
     cols: 110,
     rows: 32,


### PR DESCRIPTION
## Summary

- stop importing `node-pty` at module load time in the clean managed-remote smoke
- dynamically load PTY support only for the local interactive migration journey
- make dependency-free CI/release installer jobs explicitly use `--skip-tui`
- retain the default local `pnpm test:remote:docker` behavior with real TUI default-No and success journeys

## Root cause

PR #1164 added the real TUI journey to `scripts/remote-ssh-smoke.mjs`, but the Installer Smoke intentionally runs from a clean checkout without installing repository dependencies. Its top-level `node-pty` import therefore failed before the managed-remote fixture started.

## Verification

- `node scripts/remote-ssh-smoke.mjs --skip-tui` — passed and cleaned resources
- `node scripts/remote-ssh-smoke.mjs` — passed both real TUI journeys and cleaned resources
- `npx tsc --noEmit`
- `pnpm test` — 4,936 passed, 9 skipped