### PR TITLE
chore: approve Auto Prediction v0.1.2

### DIFF
--- a/src/workspaces/templates/auto-prediction/README.md
+++ b/src/workspaces/templates/auto-prediction/README.md
@@ -1,5 +1,5 @@
 ---
-version: 0.1.1
+version: 0.1.2
 ---
 
 # Auto Prediction
@@ -19,14 +19,16 @@ tools, Workspace lifecycle, and the managed Studio route around the desk.
 OpenAlice supervises only the command declared by `harness.json`; Auto
 Prediction retains its complete Studio and control-plane ownership.
 
-The exact upstream source is recorded in `.alice/harness-source.json`. Until
-Auto Prediction publishes releases, OpenAlice labels the approved commit as an
-experimental snapshot rather than inventing release semantics.
+The exact upstream source is recorded in `.alice/harness-source.json`.
+OpenAlice pins each approved release tag to its verified commit while retaining
+earlier qualified versions for explicit selection and rollback.
 
-The current approved release is `v0.1.1` at commit
-`db49d9dde1386fe3f0f8e7b7c78aa3810b7438b9`. It retains the Node.js 22
-qualification and implements the generic v1 managed Studio capability. The
-earlier qualified snapshots remain selectable for source-history work.
+The current approved release is `v0.1.2` at commit
+`d6c9447cab29898a6eb5fa06be3598b8474cc02f`. It retains the Node.js 22
+qualification and implements the generic v1 managed Studio capability with a
+bounded startup path while the initial catalog refresh continues in the
+background. Release `v0.1.1` and the earlier qualified snapshots remain
+selectable for rollback and source-history work.
 
 ## Starting work
 

--- a/src/workspaces/templates/auto-prediction/template.json
+++ b/src/workspaces/templates/auto-prediction/template.json
@@ -8,8 +8,12 @@
   "bundledSkills": [],
   "source": {
     "repository": "https://github.com/TraderAlice/Auto-Prediction.git",
-    "defaultVersion": "v0.1.1",
+    "defaultVersion": "v0.1.2",
     "versions": [
+      {
+        "version": "v0.1.2",
+        "commit": "d6c9447cab29898a6eb5fa06be3598b8474cc02f"
+      },
       {
         "version": "v0.1.1",
         "commit": "db49d9dde1386fe3f0f8e7b7c78aa3810b7438b9"

--- a/ui/src/demo/fixtures/workspaces.ts
+++ b/ui/src/demo/fixtures/workspaces.ts
@@ -200,8 +200,8 @@ const demoIssueWorkspaces: Workspace[] = [
       schemaVersion: 1,
       template: 'auto-prediction',
       repository: 'https://github.com/TraderAlice/Auto-Prediction.git',
-      version: 'v0.1.1',
-      commit: 'db49d9dde1386fe3f0f8e7b7c78aa3810b7438b9',
+      version: 'v0.1.2',
+      commit: 'd6c9447cab29898a6eb5fa06be3598b8474cc02f',
     },
     sessions: [],
     agentOverride: { claude: false, codex: false, opencode: false, pi: false },
@@ -283,12 +283,16 @@ export const autoPredictionTemplate: TemplateInfo = {
   description: 'Agent-native prediction-market research desk pinned to an approved Auto Prediction source snapshot.',
   groupOrder: 30,
   defaultAgents: ['codex', 'claude'],
-  version: '0.1.1',
+  version: '0.1.2',
   hasReadme: true,
   source: {
     repository: 'https://github.com/TraderAlice/Auto-Prediction.git',
-    defaultVersion: 'v0.1.1',
+    defaultVersion: 'v0.1.2',
     versions: [
+      {
+        version: 'v0.1.2',
+        commit: 'd6c9447cab29898a6eb5fa06be3598b8474cc02f',
+      },
       {
         version: 'v0.1.1',
         commit: 'db49d9dde1386fe3f0f8e7b7c78aa3810b7438b9',


### PR DESCRIPTION
## Summary
- approve Auto Prediction v0.1.2 as the default Harness source
- pin the annotated release tag to d6c9447cab29898a6eb5fa06be3598b8474cc02f
- retain v0.1.1 and earlier snapshots for explicit rollback
- keep the UI demo catalog and source receipt aligned with the production template

## Acceptance
- verified the remote v0.1.2 tag resolves to the pinned commit
- AP v0.1.2 managed Studio starts within the bounded readiness window while catalog refresh continues in the background
- real demo Workspace overview renders `Harness source v0.1.2 · d6c9447cab29`

## Verification
- `pnpm exec vitest run src/workspaces/template-registry.spec.ts src/workspaces/workspace-creation.e2e.spec.ts ui/src/pages/AutoPredictionSetupPage.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4953 passed, 9 skipped)