### PR TITLE
fix: hide connector desk sessions from chat rosters

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -72,6 +72,11 @@ categories.
   off the owner chat. The trailing text still becomes today's reply comment.
   Telegram is the first `desk` adapter; Discord and Slack do
   not advertise `desk` until they ingest private owner chat.
+- A connector phone-desk Session is transport-owned conversation state, not an
+  Ask Alice coworker. It remains attributable and resumable by its Issue, and
+  visible in Issue/Automation diagnostics, but is always excluded from the
+  Ask Alice Session roster even when the operator opts into ordinary
+  headless-born Sessions.
 - Each adapter serves one owner account/private chat. Group and channel
   broadcasting are out of scope.
 - Inbox `docs` that are Markdown or static HTML reports are externalized as

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -84,6 +84,12 @@ and no new turn starts. A headless turn occupying that `resumeId` locks TUI
 spawn/resume and Archive; Automation continues to list dispatch records
 (`taskId`), not this roster.
 
+Connector phone-desk Sessions are a stricter exception: their Issue owns the
+conversation and OpenAlice never offers them in the Ask Alice roster, even
+when headless-born Sessions are enabled. The Session Directory projects this
+as roster visibility from the connector-desk domain; clients must not infer it
+from an Issue filename or connector-specific Session title.
+
 ## Session birth metadata
 
 Product Sessions may carry an optional, immutable `metadata.createdBy` bag on

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -99,6 +99,7 @@ import {
 } from './issues/board.js';
 import {
   buildWorkspaceSessionDirectory,
+  connectorDeskRosterExclusions,
   type WorkspaceSessionDirectory,
 } from './session-directory.js';
 import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
@@ -2576,12 +2577,25 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     if (!ws) return null;
     await sessionRegistry.ensureLoaded(wsId);
     void refreshSessionTitles(ws);
+    const issueRead = await readWorkspaceIssues(ws.dir);
+    const rosterExclusions = issueRead.ok
+      ? connectorDeskRosterExclusions({
+          issues: issueRead.issues,
+          executionsForIssue: (issueId) => headlessTasks.list({
+            issue: { workspaceId: wsId, issueId },
+          }),
+          inquiriesForIssue: (issueId) => headlessTasks.list({
+            inquiry: { kind: 'issue', workspaceId: wsId, issueId },
+          }),
+        })
+      : new Set<string>();
     return buildWorkspaceSessionDirectory({
       workspace: { id: ws.id, tag: ws.tag },
       identities: resumeRegistry.list({ wsId, limit }),
       interactiveFor: (resumeId) => sessionRegistry.findByResumeId(wsId, resumeId),
       latestExecutionFor: (resumeId) => headlessTasks.latestForResumeId(resumeId),
       isActive: (resumeId) => activeResumeIds.has(resumeId),
+      rosterVisibilityFor: (resumeId) => rosterExclusions.has(resumeId) ? 'hidden' : undefined,
     });
   };
 

--- a/src/workspaces/session-directory.spec.ts
+++ b/src/workspaces/session-directory.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildWorkspaceSessionDirectory } from './session-directory.js'
+import {
+  buildWorkspaceSessionDirectory,
+  connectorDeskRosterExclusions,
+} from './session-directory.js'
 
 describe('buildWorkspaceSessionDirectory', () => {
   it('joins useful state while hiding native and launcher ids', () => {
@@ -77,6 +80,26 @@ describe('buildWorkspaceSessionDirectory', () => {
     expect(JSON.stringify(result)).not.toContain('private repeated prompt')
   })
 
+  it('projects connector-owned Sessions as hidden roster state', () => {
+    const result = buildWorkspaceSessionDirectory({
+      workspace: { id: 'ws-1', tag: 'research' },
+      identities: [{
+        resumeId: 'resume-phone-desk',
+        wsId: 'ws-1',
+        agent: 'pi',
+        createdAt: 1,
+        updatedAt: 2,
+        lifecycle: 'active',
+      }],
+      interactiveFor: () => undefined,
+      latestExecutionFor: () => null,
+      isActive: () => false,
+      rosterVisibilityFor: () => 'hidden',
+    })
+
+    expect(result.sessions[0]?.rosterVisibility).toBe('hidden')
+  })
+
   it('projects archived presence and keeps a deleted Session non-resumable', () => {
     const archived = buildWorkspaceSessionDirectory({
       workspace: { id: 'ws-1', tag: 'research' },
@@ -121,5 +144,28 @@ describe('buildWorkspaceSessionDirectory', () => {
       presence: 'deleted',
       resumable: false,
     })
+  })
+})
+
+describe('connectorDeskRosterExclusions', () => {
+  it('finds the fixed owner plus scheduled and inbound connector conversations', () => {
+    const hidden = connectorDeskRosterExclusions({
+      issues: [
+        { id: 'telegram-phone-desk', assignee: '@resume-current', connectorDesk: 'telegram' },
+        { id: 'ordinary-issue', assignee: '@resume-visible' },
+      ],
+      executionsForIssue: (issueId) => issueId === 'telegram-phone-desk'
+        ? [{ resumeId: 'resume-scheduled' }]
+        : [{ resumeId: 'resume-visible-run' }],
+      inquiriesForIssue: (issueId) => issueId === 'telegram-phone-desk'
+        ? [{ resumeId: 'resume-inbound' }]
+        : [{ resumeId: 'resume-visible-inquiry' }],
+    })
+
+    expect([...hidden].sort()).toEqual([
+      'resume-current',
+      'resume-inbound',
+      'resume-scheduled',
+    ])
   })
 })

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -1,5 +1,10 @@
 import type { HeadlessTaskRecord, HeadlessTaskStatus } from './headless-task-registry.js'
 import {
+  issueAssigneeResumeId,
+  isConnectorDeskIssue,
+  type IssueRecord,
+} from './issues/declaration.js'
+import {
   sessionPresence,
   type ResumeIdentityRecord,
   type SessionPresence,
@@ -26,6 +31,8 @@ export interface WorkspaceSessionDirectoryEntry {
   active: boolean
   /** Secret-free birth stamp when this product Session was first allocated. */
   createdBy?: SessionCreatedBy
+  /** Product rosters must not offer transport-owned Sessions as coworkers. */
+  rosterVisibility?: 'hidden'
   runtime?: PublicSessionRuntime
   latestExecution?: {
     taskId: string
@@ -49,6 +56,22 @@ export interface WorkspaceSessionDirectory {
   sessions: WorkspaceSessionDirectoryEntry[]
 }
 
+export function connectorDeskRosterExclusions(input: {
+  issues: readonly Pick<IssueRecord, 'id' | 'assignee' | 'connectorDesk'>[]
+  executionsForIssue(issueId: string): readonly Pick<HeadlessTaskRecord, 'resumeId'>[]
+  inquiriesForIssue(issueId: string): readonly Pick<HeadlessTaskRecord, 'resumeId'>[]
+}): Set<string> {
+  const hidden = new Set<string>()
+  for (const issue of input.issues) {
+    if (!isConnectorDeskIssue(issue)) continue
+    const assignee = issueAssigneeResumeId(issue.assignee)
+    if (assignee) hidden.add(assignee)
+    for (const task of input.executionsForIssue(issue.id)) hidden.add(task.resumeId)
+    for (const task of input.inquiriesForIssue(issue.id)) hidden.add(task.resumeId)
+  }
+  return hidden
+}
+
 /** Build the public Session directory by joining backend registries while
  * deliberately whitelisting fields. Native runtime ids and launcher record ids
  * never cross this boundary; resumeId is the sole conversation handle. */
@@ -58,6 +81,7 @@ export function buildWorkspaceSessionDirectory(input: {
   interactiveFor(resumeId: string): SessionRecord | undefined
   latestExecutionFor(resumeId: string): HeadlessTaskRecord | null
   isActive(resumeId: string): boolean
+  rosterVisibilityFor?(resumeId: string): 'hidden' | undefined
 }): WorkspaceSessionDirectory {
   return {
     workspace: input.workspace,
@@ -79,6 +103,9 @@ export function buildWorkspaceSessionDirectory(input: {
           && Boolean(identity.agentSessionId),
         active: identity.lifecycle !== 'retired' && input.isActive(identity.resumeId),
         ...(identity.metadata?.createdBy ? { createdBy: identity.metadata.createdBy } : {}),
+        ...(input.rosterVisibilityFor?.(identity.resumeId) === 'hidden'
+          ? { rosterVisibility: 'hidden' as const }
+          : {}),
         ...(identity.runtimeBinding
           ? { runtime: projectPublicSessionRuntime(identity.runtimeBinding) }
           : {}),

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -867,6 +867,8 @@ export interface WorkspaceSessionDirectoryEntry {
   readonly active: boolean;
   /** Present when this product Session was allocated after birth metadata shipped. */
   readonly createdBy?: SessionCreatedBy;
+  /** Hidden Sessions remain available to their owning Issue and diagnostics. */
+  readonly rosterVisibility?: 'hidden';
   readonly runtime?: {
     readonly credentialSource: 'native' | 'vault' | 'workspace';
     readonly credentialSlug?: string;

--- a/ui/src/components/workspace/harness-sessions.spec.ts
+++ b/ui/src/components/workspace/harness-sessions.spec.ts
@@ -148,6 +148,27 @@ describe('joinWorkspaceHarnessSessions', () => {
     expect(rows.some((row) => row.resumeId === 'resume-directory-only')).toBe(false)
   })
 
+  it('always hides connector-owned Sessions even when ordinary headless rows are enabled', () => {
+    const connector = headlessSession({
+      id: 'session-connector',
+      resumeId: 'resume-connector',
+    })
+    const ordinary = headlessSession()
+    const rows = joinWorkspaceHarnessSessions(workspace([session(), connector, ordinary]), {
+      workspace: { id: 'ws-1', tag: 'chat-aug1' },
+      sessions: [
+        entry({ resumeId: 'resume-interactive' }),
+        entry({ resumeId: 'resume-connector', rosterVisibility: 'hidden' }),
+        entry(),
+      ],
+    }, { includeHeadlessBornSessions: true })
+
+    expect(rows.map((row) => row.resumeId)).toEqual([
+      'resume-headless-only',
+      'resume-interactive',
+    ])
+  })
+
   it('locks TUI while headless occupies and sorts running occupancy first', () => {
     const paused = session({ lastActiveAt: '2026-08-03T00:00:00.000Z' })
     const runningHeadless = entry({

--- a/ui/src/components/workspace/harness-sessions.ts
+++ b/ui/src/components/workspace/harness-sessions.ts
@@ -169,6 +169,7 @@ export function joinWorkspaceHarnessSessions(
   )
   const rows = workspace.sessions.flatMap((session) => {
     const entry = directoryByResume.get(session.resumeId) ?? null
+    if (entry?.rosterVisibility === 'hidden') return []
     const presence = entryPresence(entry, session.presence ?? 'active')
     if (presence !== wanted) return []
     if (!includeHeadlessBorn && isHeadlessBornWithoutInteractive(session, entry)) return []


### PR DESCRIPTION
## Summary
- classify every Session owned by a connector phone-desk Issue as hidden from product rosters
- hide fixed assignees, scheduled executions, and inbound reconstruction/reply Sessions without relying on Telegram-specific names
- keep connector Sessions available to their Issue, Automation, provenance, and diagnostics
- make roster exclusion unconditional even when ordinary headless-born Sessions are enabled

## Live acceptance
- the current Telegram owner Session `resume-still-canvas-tide-rgbj3r` is projected as `rosterVisibility: hidden`
- its earlier reconstructed Session is also projected as hidden
- a real Ask Alice page connected to the current backend shows neither the Telegram phone-desk row nor its prompt

## Verification
- `pnpm exec vitest run src/workspaces/session-directory.spec.ts ui/src/components/workspace/harness-sessions.spec.ts ui/src/components/workspace/ChatWorkspaceSection.spec.tsx`
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (4956 passed, 9 skipped)