### PR TITLE
fix(connector): silently gate Feishu owner chat

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -284,6 +284,9 @@ collapsing to "configured but not running." Configuration errors such as a
 missing bot token still fail `start()` and do not reconnect.
 
 Both adapters reject commands from any account other than the linked owner.
+When Feishu starts with a preconfigured owner, its inbound gate silently drops
+every private-chat event from any other account before command parsing, including
+`/link` and `/status`; unauthorized chats receive no acknowledgement.
 Use `/status` for adapter health and `/test` for an explicit delivery check.
 `/test` still sends when Inbox push is off. `/inbox`, `/settings`, and `/uta` are
 capability commands: the catalog only declares them; Telegram renders

--- a/services/connector/src/adapters/feishu.spec.ts
+++ b/services/connector/src/adapters/feishu.spec.ts
@@ -220,16 +220,21 @@ describe('Feishu owner chat', () => {
     expect(messageCreate).toHaveBeenCalled()
   })
 
-  it('ignores group chats and non-owner text after link', async () => {
+  it('silently ignores group chats and every non-owner message after link', async () => {
     const forwardOwnerText = vi.fn(async () => undefined)
+    const updateSettings = vi.fn(async () => undefined)
     const adapter = new FeishuConnectorAdapter({ startupTimeoutMs: 200 })
     await adapter.start({
       enabled: true,
       settings: { appId: APP_ID, appSecret: APP_SECRET, ownerUserId: 'ou_owner', chatId: 'oc_chat' },
-    }, context({ forwardOwnerText }))
+    }, context({ forwardOwnerText, updateSettings }))
     await receiveHandler?.(p2pEvent('hello group', { chatType: 'group' }))
     await receiveHandler?.(p2pEvent('hello stranger', { openId: 'ou_other' }))
+    await receiveHandler?.(p2pEvent('/status', { openId: 'ou_other' }))
+    await receiveHandler?.(p2pEvent('/link', { openId: 'ou_other' }))
     expect(forwardOwnerText).not.toHaveBeenCalled()
+    expect(updateSettings).not.toHaveBeenCalled()
+    expect(messageCreate).not.toHaveBeenCalled()
     await receiveHandler?.(p2pEvent('desk please'))
     expect(forwardOwnerText).toHaveBeenCalledWith({
       text: 'desk please',

--- a/services/connector/src/adapters/feishu.ts
+++ b/services/connector/src/adapters/feishu.ts
@@ -314,6 +314,9 @@ export class FeishuConnectorAdapter implements ConnectorAdapter {
     const userId = sender?.sender_id?.open_id?.trim()
     const chatId = message?.chat_id?.trim()
     if (!userId || !chatId) return
+    // A preconfigured owner is a hard ingress allowlist. Keep every message,
+    // including control commands, silent for all other Feishu accounts.
+    if (this.ownerUserId && !this.isOwner(userId)) return
     const text = parseFeishuMessageText(message?.content, message?.message_type).trim()
     if (!text) return
     const command = parseFeishuCommand(text)


### PR DESCRIPTION
## Summary
- apply the preconfigured Feishu owner allowlist before command parsing
- silently drop all private-chat events from other accounts, including `/link` and `/status`
- document and test the silent ingress contract

## Verification
- `pnpm vitest run services/connector/src src/services/connector-client src/webui/routes/connectors.spec.ts` (152 passed)
- `pnpm build:server`