### PR TITLE
feat(ui): show Runtime brands in Session rows

### DIFF
--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -151,6 +151,34 @@ describe('SessionRow actions', () => {
     title: 'Review AAPL earnings',
   }
 
+  it('shows the Session runtime brand instead of a generic agent glyph', () => {
+    const { rerender } = render(
+      <SessionRow
+        session={{ ...session, agent: 'codex' }}
+        isActive={false}
+        onSelect={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Review AAPL earnings' }).querySelector('[data-agent-runtime-icon="codex"]')).toBeTruthy()
+
+    rerender(
+      <SessionRow
+        session={{ ...session, agent: 'claude' }}
+        isActive={false}
+        onSelect={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Review AAPL earnings' }).querySelector('[data-agent-runtime-icon="claude"]')).toBeTruthy()
+  })
+
   it('names destructive and lifecycle actions for their target session', async () => {
     const user = userEvent.setup()
     const onPause = vi.fn()

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { formatRelativeTime } from '../../lib/intl';
 import type { ReactElement } from 'react';
-import { Archive, Bot, ChevronDown, ChevronRight, Code2, Cpu, LayoutGrid, Library, LoaderCircle, Pencil, Play, Plus, RotateCcw, Settings as SettingsIcon, Sparkles, Square, Terminal, X, type LucideIcon } from 'lucide-react';
+import { Archive, ChevronDown, ChevronRight, LayoutGrid, Library, LoaderCircle, Pencil, Play, Plus, RotateCcw, Settings as SettingsIcon, Square, Terminal, X, type LucideIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { headlessApi, type HeadlessTaskRecord } from '../../api/headless';
@@ -18,6 +18,7 @@ import { sessionCoworkerLabel, workspaceDisplayName, workspaceDisplayTitle } fro
 import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order';
 import { useReorderMotion } from './useReorderMotion';
 import { SidebarActionMenu } from './SidebarActionMenu';
+import { AgentRuntimeIcon } from '../../lib/agentRuntimeIcon';
 
 /**
  * Workspace launcher sidebar.
@@ -288,24 +289,14 @@ function agentPrefix(id: string): string {
 }
 
 /**
- * Glyph for a given agent SDK. Icon-first so users don't have to learn the
- * `c1` / `x1` / `sh1` naming convention — at-a-glance they see which CLI
- * the session is running. Unknown adapter id falls back to its first
- * letter (text), keeping the badge non-empty even for future adapters
- * before they get an icon.
+ * Session identity reuses the same brand marks as the runtime picker and
+ * settings catalog. Shell is a utility rather than an Agent Runtime, so it
+ * keeps the terminal glyph; unknown extension runtimes use the shared Bot
+ * fallback.
  */
-const AGENT_ICONS: Record<string, LucideIcon> = {
-  claude: Sparkles,
-  codex: Cpu,
-  opencode: Code2,
-  pi: Bot,
-  shell: Terminal,
-};
-
 function AgentBadgeGlyph({ agentId }: { agentId: string }): ReactElement {
-  const Icon = AGENT_ICONS[agentId];
-  if (Icon) return <Icon size={11} strokeWidth={2.25} aria-hidden="true" />;
-  return <span className="text-[10px] font-mono" aria-hidden="true">{agentPrefix(agentId)}</span>;
+  if (agentId === 'shell') return <Terminal size={11} strokeWidth={2.25} aria-hidden="true" />;
+  return <AgentRuntimeIcon agentId={agentId} className="h-3 w-3" />;
 }
 
 /** Compact high-frequency action used beside a Workspace or Session row. */


### PR DESCRIPTION
## Summary
- reuse the shared Agent Runtime brand component in every Session row
- keep Shell sessions on the Terminal utility glyph and unknown extensions on the shared fallback
- cover Chat recent conversations, Workspace session trees, Manager sessions, and headless run rows through the shared primitive

## Verification
- `npx tsc --noEmit`
- `pnpm exec vitest run ui/src/components/workspace/Sidebar.spec.tsx ui/src/components/workspace/ChatWorkspaceSection.spec.tsx`
- `pnpm -F open-alice-ui build`
- `pnpm test` (4,959 passed, 9 skipped)
- live `/chat` sidebar QA with Pi, Codex, and opencode Sessions