### PR TITLE
fix(ui): use transparent Codex runtime mark

### DIFF
--- a/ui/src/lib/agentRuntimeIcon.spec.tsx
+++ b/ui/src/lib/agentRuntimeIcon.spec.tsx
@@ -24,4 +24,13 @@ describe('AgentRuntimeIcon', () => {
 
     expect(container.querySelector('svg[data-agent-runtime-icon="future-runtime"]')).toBeTruthy()
   })
+
+  it('renders the Codex glyph without the color asset white tile', () => {
+    const { container } = render(<AgentRuntimeIcon agentId="codex" />)
+
+    const icon = container.querySelector<HTMLElement>('[data-agent-runtime-icon="codex"]')
+    expect(icon?.tagName).toBe('SPAN')
+    expect(icon?.classList.contains('bg-current')).toBe(true)
+    expect(container.querySelector('img[data-agent-runtime-icon="codex"]')).toBeNull()
+  })
 })

--- a/ui/src/lib/agentRuntimeIcon.tsx
+++ b/ui/src/lib/agentRuntimeIcon.tsx
@@ -1,6 +1,6 @@
 import antigravityIcon from '@lobehub/icons-static-svg/icons/antigravity-color.svg'
 import claudeIcon from '@lobehub/icons-static-svg/icons/claude-color.svg'
-import codexIcon from '@lobehub/icons-static-svg/icons/codex-color.svg'
+import codexIcon from '@lobehub/icons-static-svg/icons/codex.svg'
 import cursorIcon from '@lobehub/icons-static-svg/icons/cursor.svg'
 import grokIcon from '@lobehub/icons-static-svg/icons/grok.svg'
 import opencodeIcon from '@lobehub/icons-static-svg/icons/opencode.svg'
@@ -21,7 +21,7 @@ interface BrandAsset {
 
 const AGENT_RUNTIME_BRANDS: Record<string, BrandAsset> = {
   claude: { src: claudeIcon },
-  codex: { src: codexIcon },
+  codex: { src: codexIcon, monochrome: true },
   cursor: { src: cursorIcon, monochrome: true },
   agy: { src: antigravityIcon },
   grok: { src: grokIcon, monochrome: true },


### PR DESCRIPTION
## Summary
- replace the white-tile Codex color asset with the official transparent monochrome glyph
- render Codex through the shared current-color mask path so sidebar interaction states stay consistent
- cover the transparent rendering contract with a focused component test

## Verification
- npx tsc --noEmit
- pnpm -F open-alice-ui build
- pnpm exec vitest run ui/src/lib/agentRuntimeIcon.spec.tsx ui/src/components/workspace/Sidebar.spec.tsx
- pnpm test
- verified /chat in the demo browser: Codex renders as a transparent masked span with no image tile