### PR TITLE
feat(ui): hide Issue-attached Sessions by default

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -222,6 +222,14 @@ accepted and later failed; that occurrence stays one attempt and uses
 
 ## Agent and Human Surfaces
 
+Ask Alice, Auto Quant, and Auto Prediction share one Session roster policy.
+Sessions currently owned by an exact Issue assignee, plus Sessions actively
+executing an Issue, stay on Issue and Automation surfaces by default. Settings
+→ Harness may opt them into the shared roster independently from the separate
+headless-born Session preference. Connector-desk Sessions remain hidden
+regardless of either preference because they are transport-owned rather than
+ordinary coworkers.
+
 Agents normally use:
 
 ```bash

--- a/src/core/preferences.spec.ts
+++ b/src/core/preferences.spec.ts
@@ -43,6 +43,7 @@ describe('preferences', () => {
       autoPrediction: { defaultWorkspaceId: null },
       harness: {
         showHeadlessBornSessions: false,
+        showIssueAttachedSessions: false,
         showUnverifiedHarnessReleases: false,
       },
       agentRuntimes: { quickAccessIds: [], recentAgentIds: [] },
@@ -178,15 +179,18 @@ describe('preferences', () => {
     const path = await preferenceFile()
     expect(await readHarnessPreferences(path)).toEqual({
       showHeadlessBornSessions: false,
+      showIssueAttachedSessions: false,
       showUnverifiedHarnessReleases: false,
     })
 
     await saveHarnessPreferences({
       showHeadlessBornSessions: true,
+      showIssueAttachedSessions: true,
       showUnverifiedHarnessReleases: false,
     }, path)
     expect(await readHarnessPreferences(path)).toEqual({
       showHeadlessBornSessions: true,
+      showIssueAttachedSessions: true,
       showUnverifiedHarnessReleases: false,
     })
     expect(await readQuickChatPreferences(path)).toEqual({

--- a/src/core/preferences.ts
+++ b/src/core/preferences.ts
@@ -59,6 +59,8 @@ const harnessPreferencesSchema = z.object({
    * have never opened a TUI/WebPi stay off that roster unless this is true.
    */
   showHeadlessBornSessions: z.boolean().default(false),
+  /** Keep Sessions currently owned or occupied by an Issue off shared Harness rosters. */
+  showIssueAttachedSessions: z.boolean().default(false),
   /** Also discover stable upstream tags outside OpenAlice's verified catalog. */
   showUnverifiedHarnessReleases: z.boolean().default(false),
 })
@@ -102,6 +104,7 @@ const preferencesSchema = z.object({
   }),
   harness: harnessPreferencesSchema.default({
     showHeadlessBornSessions: false,
+    showIssueAttachedSessions: false,
     showUnverifiedHarnessReleases: false,
   }),
   agentRuntimes: agentRuntimesPreferencesSchema.default({
@@ -168,6 +171,7 @@ export async function readHarnessPreferences(path = preferencesPath()): Promise<
   const preferences = await readPreferences(path)
   return {
     showHeadlessBornSessions: preferences.harness.showHeadlessBornSessions,
+    showIssueAttachedSessions: preferences.harness.showIssueAttachedSessions,
     showUnverifiedHarnessReleases: preferences.harness.showUnverifiedHarnessReleases,
   }
 }
@@ -329,6 +333,7 @@ export async function saveHarnessPreferences(
     await writePreferences(updated, path)
     return {
       showHeadlessBornSessions: updated.harness.showHeadlessBornSessions,
+      showIssueAttachedSessions: updated.harness.showIssueAttachedSessions,
       showUnverifiedHarnessReleases: updated.harness.showUnverifiedHarnessReleases,
     }
   })

--- a/src/webui/routes/preferences.spec.ts
+++ b/src/webui/routes/preferences.spec.ts
@@ -242,10 +242,12 @@ describe('preferences routes', () => {
   it('reads and persists harness roster visibility', async () => {
     const read = vi.fn(async () => ({
       showHeadlessBornSessions: false,
+      showIssueAttachedSessions: false,
       showUnverifiedHarnessReleases: false,
     }))
     const save = vi.fn(async (next: {
       showHeadlessBornSessions: boolean
+      showIssueAttachedSessions: boolean
       showUnverifiedHarnessReleases: boolean
     }) => next)
     const app = createPreferencesRoutes({
@@ -260,6 +262,7 @@ describe('preferences routes', () => {
 
     expect(await (await app.request('/harness')).json()).toEqual({
       showHeadlessBornSessions: false,
+      showIssueAttachedSessions: false,
       showUnverifiedHarnessReleases: false,
     })
     const response = await app.request('/harness', {
@@ -267,16 +270,19 @@ describe('preferences routes', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         showHeadlessBornSessions: true,
+        showIssueAttachedSessions: true,
         showUnverifiedHarnessReleases: false,
       }),
     })
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       showHeadlessBornSessions: true,
+      showIssueAttachedSessions: true,
       showUnverifiedHarnessReleases: false,
     })
     expect(save).toHaveBeenCalledWith({
       showHeadlessBornSessions: true,
+      showIssueAttachedSessions: true,
       showUnverifiedHarnessReleases: false,
     })
   })

--- a/src/webui/routes/preferences.ts
+++ b/src/webui/routes/preferences.ts
@@ -56,6 +56,7 @@ const recentQuickChatLaunchUpdateSchema = z.object({
 
 const harnessPreferenceUpdateSchema = z.object({
   showHeadlessBornSessions: z.boolean(),
+  showIssueAttachedSessions: z.boolean(),
   showUnverifiedHarnessReleases: z.boolean(),
 })
 

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -242,6 +242,7 @@ function build(
       rememberRecentChatWorkspace: async (workspaceId) => ({ lastCredentialByAgent: {}, recentChatWorkspaceId: workspaceId }),
       readHarnessPreferences: async () => ({
         showHeadlessBornSessions: false,
+        showIssueAttachedSessions: false,
         showUnverifiedHarnessReleases: false,
       }),
     }),

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -100,6 +100,7 @@ import {
 import {
   buildWorkspaceSessionDirectory,
   connectorDeskRosterExclusions,
+  issueRosterAttachments,
   type WorkspaceSessionDirectory,
 } from './session-directory.js';
 import { completeOneShotIssueAfterRun } from './issues/auto-complete.js';
@@ -2589,6 +2590,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           }),
         })
       : new Set<string>();
+    const issueAttachments = issueRead.ok
+      ? issueRosterAttachments({
+          issues: issueRead.issues,
+          runningExecutions: headlessTasks.list({
+            wsId,
+            status: 'running',
+          }),
+        })
+      : new Set<string>();
     return buildWorkspaceSessionDirectory({
       workspace: { id: ws.id, tag: ws.tag },
       identities: resumeRegistry.list({ wsId, limit }),
@@ -2596,6 +2606,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       latestExecutionFor: (resumeId) => headlessTasks.latestForResumeId(resumeId),
       isActive: (resumeId) => activeResumeIds.has(resumeId),
       rosterVisibilityFor: (resumeId) => rosterExclusions.has(resumeId) ? 'hidden' : undefined,
+      issueAttachedFor: (resumeId) => issueAttachments.has(resumeId) ? true : undefined,
     });
   };
 

--- a/src/workspaces/session-directory.spec.ts
+++ b/src/workspaces/session-directory.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildWorkspaceSessionDirectory,
   connectorDeskRosterExclusions,
+  issueRosterAttachments,
 } from './session-directory.js'
 
 describe('buildWorkspaceSessionDirectory', () => {
@@ -100,6 +101,35 @@ describe('buildWorkspaceSessionDirectory', () => {
     expect(result.sessions[0]?.rosterVisibility).toBe('hidden')
   })
 
+  it('does not describe a headless Session record as an interactive opening', () => {
+    const result = buildWorkspaceSessionDirectory({
+      workspace: { id: 'ws-1', tag: 'research' },
+      identities: [{
+        resumeId: 'resume-headless',
+        wsId: 'ws-1',
+        agent: 'pi',
+        createdAt: 1,
+        updatedAt: 2,
+        lifecycle: 'active',
+      }],
+      interactiveFor: () => ({
+        id: 'session-headless',
+        resumeId: 'resume-headless',
+        wsId: 'ws-1',
+        agent: 'pi',
+        name: 'p1',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        lastActiveAt: '2026-08-01T00:01:00.000Z',
+        state: 'paused',
+        surface: 'headless',
+      }),
+      latestExecutionFor: () => null,
+      isActive: () => false,
+    })
+
+    expect(result.sessions[0]?.interactive).toBeUndefined()
+  })
+
   it('projects archived presence and keeps a deleted Session non-resumable', () => {
     const archived = buildWorkspaceSessionDirectory({
       workspace: { id: 'ws-1', tag: 'research' },
@@ -167,5 +197,25 @@ describe('connectorDeskRosterExclusions', () => {
       'resume-inbound',
       'resume-scheduled',
     ])
+  })
+})
+
+describe('issueRosterAttachments', () => {
+  it('finds exact Issue owners and Sessions currently executing an Issue', () => {
+    const attached = issueRosterAttachments({
+      issues: [
+        { id: 'owned', assignee: '@resume-owner' },
+        { id: 'fresh', assignee: '@new-each-run' },
+      ],
+      runningExecutions: [{
+        resumeId: 'resume-running',
+        trigger: { kind: 'issue', workspaceId: 'ws-1', issueId: 'fresh' },
+      }, {
+        resumeId: 'resume-unrelated',
+        trigger: { kind: 'issue', workspaceId: 'ws-1', issueId: 'other' },
+      }],
+    })
+
+    expect([...attached].sort()).toEqual(['resume-owner', 'resume-running'])
   })
 })

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -33,6 +33,8 @@ export interface WorkspaceSessionDirectoryEntry {
   createdBy?: SessionCreatedBy
   /** Product rosters must not offer transport-owned Sessions as coworkers. */
   rosterVisibility?: 'hidden'
+  /** Live Issue ownership/occupancy. Presentation preferences decide whether to show it. */
+  issueAttached?: true
   runtime?: PublicSessionRuntime
   latestExecution?: {
     taskId: string
@@ -72,6 +74,25 @@ export function connectorDeskRosterExclusions(input: {
   return hidden
 }
 
+export function issueRosterAttachments(input: {
+  issues: readonly Pick<IssueRecord, 'id' | 'assignee'>[]
+  runningExecutions: readonly Pick<HeadlessTaskRecord, 'resumeId' | 'trigger'>[]
+}): Set<string> {
+  const attached = new Set<string>()
+  const issueIds = new Set<string>()
+  for (const issue of input.issues) {
+    issueIds.add(issue.id)
+    const assignee = issueAssigneeResumeId(issue.assignee)
+    if (assignee) attached.add(assignee)
+  }
+  for (const task of input.runningExecutions) {
+    if (task.trigger?.kind === 'issue' && issueIds.has(task.trigger.issueId)) {
+      attached.add(task.resumeId)
+    }
+  }
+  return attached
+}
+
 /** Build the public Session directory by joining backend registries while
  * deliberately whitelisting fields. Native runtime ids and launcher record ids
  * never cross this boundary; resumeId is the sole conversation handle. */
@@ -82,6 +103,7 @@ export function buildWorkspaceSessionDirectory(input: {
   latestExecutionFor(resumeId: string): HeadlessTaskRecord | null
   isActive(resumeId: string): boolean
   rosterVisibilityFor?(resumeId: string): 'hidden' | undefined
+  issueAttachedFor?(resumeId: string): true | undefined
 }): WorkspaceSessionDirectory {
   return {
     workspace: input.workspace,
@@ -106,6 +128,7 @@ export function buildWorkspaceSessionDirectory(input: {
         ...(input.rosterVisibilityFor?.(identity.resumeId) === 'hidden'
           ? { rosterVisibility: 'hidden' as const }
           : {}),
+        ...(input.issueAttachedFor?.(identity.resumeId) ? { issueAttached: true as const } : {}),
         ...(identity.runtimeBinding
           ? { runtime: projectPublicSessionRuntime(identity.runtimeBinding) }
           : {}),
@@ -124,7 +147,7 @@ export function buildWorkspaceSessionDirectory(input: {
               },
             }
           : {}),
-        ...(interactive
+        ...(interactive && interactive.surface !== 'headless'
           ? {
               interactive: {
                 name: interactive.name,

--- a/ui/src/api/preferences.ts
+++ b/ui/src/api/preferences.ts
@@ -18,11 +18,13 @@ export interface QuickChatPreferences {
 
 export interface HarnessPreferences {
   readonly showHeadlessBornSessions: boolean
+  readonly showIssueAttachedSessions: boolean
   readonly showUnverifiedHarnessReleases: boolean
 }
 
 export const DEFAULT_HARNESS_PREFERENCES: HarnessPreferences = {
   showHeadlessBornSessions: false,
+  showIssueAttachedSessions: false,
   showUnverifiedHarnessReleases: false,
 }
 

--- a/ui/src/components/workspace/ChatWorkspaceSection.auto-quant.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.auto-quant.spec.tsx
@@ -36,7 +36,7 @@ vi.mock('../../tabs/types', () => ({
 
 vi.mock('../../hooks/useHarnessPreferences', () => ({
   useHarnessPreferences: () => ({
-    preferences: { showHeadlessBornSessions: true },
+    preferences: { showHeadlessBornSessions: true, showIssueAttachedSessions: true },
     loading: false,
     error: null,
     save: vi.fn(),

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -55,6 +55,7 @@ vi.mock('../../tabs/types', () => ({
 
 const harnessPreference = vi.hoisted(() => ({
   showHeadlessBornSessions: true,
+  showIssueAttachedSessions: true,
 }))
 
 vi.mock('../../hooks/useHarnessPreferences', () => ({
@@ -168,6 +169,7 @@ beforeEach(async () => {
   directoryState.directories = new Map()
   focusedTabState.tab = null
   harnessPreference.showHeadlessBornSessions = true
+  harnessPreference.showIssueAttachedSessions = true
   window.localStorage.clear()
   await i18n.changeLanguage('en')
 })

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -132,7 +132,11 @@ export function ChatWorkspaceSection({
   const { preferences: harnessPreferences } = useHarnessPreferences()
   const rosterJoin = useMemo(() => ({
     includeHeadlessBornSessions: harnessPreferences.showHeadlessBornSessions,
-  }), [harnessPreferences.showHeadlessBornSessions])
+    includeIssueAttachedSessions: harnessPreferences.showIssueAttachedSessions,
+  }), [
+    harnessPreferences.showHeadlessBornSessions,
+    harnessPreferences.showIssueAttachedSessions,
+  ])
   const sessionDirectories = useWorkspaceSessionDirectories(chatWorkspaceIds)
   const rosterByWorkspace = useMemo(() => {
     const next = new Map<string, HarnessSession[]>()
@@ -543,6 +547,7 @@ export function ChatWorkspaceSection({
         workspaces={chatWorkspaces}
         directories={sessionDirectories.directories}
         includeHeadlessBornSessions={harnessPreferences.showHeadlessBornSessions}
+        includeIssueAttachedSessions={harnessPreferences.showIssueAttachedSessions}
         currentWorkspaceId={conversationWorkspaceId}
         isRowActive={isRosterRowActive}
         restoreFocusRef={dialogRestoreFocusRef}

--- a/ui/src/components/workspace/WorkspaceNavigationDialogs.tsx
+++ b/ui/src/components/workspace/WorkspaceNavigationDialogs.tsx
@@ -165,6 +165,7 @@ export interface ConversationBrowserDialogProps extends DialogFocusProps {
   workspaces: readonly Workspace[]
   directories?: ReadonlyMap<string, WorkspaceSessionDirectory>
   includeHeadlessBornSessions?: boolean
+  includeIssueAttachedSessions?: boolean
   currentWorkspaceId: string | null
   isRowActive?: (row: HarnessSession) => boolean
   activeSessionId?: string | null
@@ -198,6 +199,7 @@ export function ConversationBrowserDialog(props: ConversationBrowserDialogProps)
         {
           presence: stateFilter === 'archived' ? 'archived' : 'active',
           includeHeadlessBornSessions: props.includeHeadlessBornSessions,
+          includeIssueAttachedSessions: props.includeIssueAttachedSessions,
         },
       )
       return rows.map((row) => ({ workspace, row }))
@@ -208,7 +210,7 @@ export function ConversationBrowserDialog(props: ConversationBrowserDialogProps)
       const occupancy = right.row.occupancyAt - left.row.occupancyAt
       if (occupancy !== 0) return occupancy
       return left.row.resumeId.localeCompare(right.row.resumeId)
-    }), [props.currentWorkspaceId, props.directories, props.includeHeadlessBornSessions, props.workspaces, scope, stateFilter])
+    }), [props.currentWorkspaceId, props.directories, props.includeHeadlessBornSessions, props.includeIssueAttachedSessions, props.workspaces, scope, stateFilter])
 
   const visibleSessions = useMemo(() => {
     const normalized = query.trim().toLocaleLowerCase()

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -869,6 +869,8 @@ export interface WorkspaceSessionDirectoryEntry {
   readonly createdBy?: SessionCreatedBy;
   /** Hidden Sessions remain available to their owning Issue and diagnostics. */
   readonly rosterVisibility?: 'hidden';
+  /** Current Issue ownership/occupancy; shared roster preferences may hide it. */
+  readonly issueAttached?: true;
   readonly runtime?: {
     readonly credentialSource: 'native' | 'vault' | 'workspace';
     readonly credentialSlug?: string;

--- a/ui/src/components/workspace/harness-sessions.spec.ts
+++ b/ui/src/components/workspace/harness-sessions.spec.ts
@@ -106,6 +106,27 @@ describe('harness session titles', () => {
 })
 
 describe('joinWorkspaceHarnessSessions', () => {
+  it('keeps Issue-attached Sessions off the shared roster unless explicitly enabled', () => {
+    const issueOwner = session({ resumeId: 'resume-issue-owner' })
+    const directory = {
+      workspace: { id: 'ws-1', tag: 'chat-aug1' },
+      sessions: [entry({
+        resumeId: 'resume-issue-owner',
+        issueAttached: true,
+        interactive: {
+          name: 'p1',
+          state: 'paused' as const,
+          lastActiveAt: '2026-08-03T00:00:00.000Z',
+        },
+      })],
+    }
+
+    expect(joinWorkspaceHarnessSessions(workspace([issueOwner]), directory)).toEqual([])
+    expect(joinWorkspaceHarnessSessions(workspace([issueOwner]), directory, {
+      includeIssueAttachedSessions: true,
+    }).map((row) => row.resumeId)).toEqual(['resume-issue-owner'])
+  })
+
   it('uses the persistent Session roster until Directory arrives', () => {
     const rows = joinWorkspaceHarnessSessions(workspace(), null)
     expect(rows.map((row) => row.resumeId)).toEqual(['resume-interactive'])
@@ -307,6 +328,22 @@ describe('joinWorkspaceHarnessSessions', () => {
       'resume-opened',
       'resume-interactive',
     ])
+  })
+
+  it('does not treat a Directory projection of a headless record as an interactive opening', () => {
+    const bornHeadless = headlessSession({ sourceRunId: 'run-1' })
+    const projected = entry({
+      interactive: undefined,
+      createdBy: {
+        kind: 'issue',
+        workspaceId: 'ws-1',
+        issueId: 'daily-scan',
+        policy: 'new-then-resume',
+        fire: 'schedule',
+      },
+    })
+
+    expect(isHeadlessBornWithoutInteractive(bornHeadless, projected)).toBe(true)
   })
 })
 

--- a/ui/src/components/workspace/harness-sessions.ts
+++ b/ui/src/components/workspace/harness-sessions.ts
@@ -123,6 +123,8 @@ export interface HarnessSessionJoinOptions {
   readonly presence?: SessionPresence
   /** When false (Ask Alice / Auto Quant default), hide headless-born never-TUI rows. */
   readonly includeHeadlessBornSessions?: boolean
+  /** When false (shared Harness default), keep current Issue owners/workers on Issue surfaces. */
+  readonly includeIssueAttachedSessions?: boolean
 }
 
 /** Running occupancy first (TUI or headless), then latest occupancy. */
@@ -152,6 +154,7 @@ export function joinWorkspaceHarnessSessions(
 ): HarnessSession[] {
   const wanted = opts.presence ?? 'active'
   const includeHeadlessBorn = opts.includeHeadlessBornSessions === true
+  const includeIssueAttached = opts.includeIssueAttachedSessions === true
   if (!directory) {
     if (wanted !== 'active') return []
     return orderHarnessSessions(
@@ -170,6 +173,7 @@ export function joinWorkspaceHarnessSessions(
   const rows = workspace.sessions.flatMap((session) => {
     const entry = directoryByResume.get(session.resumeId) ?? null
     if (entry?.rosterVisibility === 'hidden') return []
+    if (!includeIssueAttached && entry?.issueAttached) return []
     const presence = entryPresence(entry, session.presence ?? 'active')
     if (presence !== wanted) return []
     if (!includeHeadlessBorn && isHeadlessBornWithoutInteractive(session, entry)) return []

--- a/ui/src/demo/handlers/preferences.ts
+++ b/ui/src/demo/handlers/preferences.ts
@@ -9,6 +9,7 @@ let recentLaunch = {
   reasoningEffort: null as string | null,
 }
 let showHeadlessBornSessions = false
+let showIssueAttachedSessions = false
 let showUnverifiedHarnessReleases = false
 let agentRuntimeQuickAccessIds: string[] = []
 let recentAgentRuntimeIds: string[] = []
@@ -73,23 +74,26 @@ export const preferencesHandlers = [
     HttpResponse.json({ supported: false }),
   ),
   http.get('/api/preferences/harness', () =>
-    HttpResponse.json({ showHeadlessBornSessions, showUnverifiedHarnessReleases }),
+    HttpResponse.json({ showHeadlessBornSessions, showIssueAttachedSessions, showUnverifiedHarnessReleases }),
   ),
   http.put('/api/preferences/harness', async ({ request }) => {
     const body = (await request.json().catch(() => null)) as {
       showHeadlessBornSessions?: unknown
+      showIssueAttachedSessions?: unknown
       showUnverifiedHarnessReleases?: unknown
     } | null
     if (
       !body
       || typeof body.showHeadlessBornSessions !== 'boolean'
+      || typeof body.showIssueAttachedSessions !== 'boolean'
       || typeof body.showUnverifiedHarnessReleases !== 'boolean'
     ) {
       return HttpResponse.json({ error: 'invalid_harness_preference' }, { status: 400 })
     }
     showHeadlessBornSessions = body.showHeadlessBornSessions
+    showIssueAttachedSessions = body.showIssueAttachedSessions
     showUnverifiedHarnessReleases = body.showUnverifiedHarnessReleases
-    return HttpResponse.json({ showHeadlessBornSessions, showUnverifiedHarnessReleases })
+    return HttpResponse.json({ showHeadlessBornSessions, showIssueAttachedSessions, showUnverifiedHarnessReleases })
   }),
   http.get('/api/preferences/agent-runtimes', () =>
     HttpResponse.json({

--- a/ui/src/hooks/useHarnessPreferences.spec.ts
+++ b/ui/src/hooks/useHarnessPreferences.spec.ts
@@ -9,6 +9,7 @@ import { useHarnessPreferences } from './useHarnessPreferences'
 vi.mock('../api/preferences', () => ({
   DEFAULT_HARNESS_PREFERENCES: {
     showHeadlessBornSessions: false,
+    showIssueAttachedSessions: false,
     showUnverifiedHarnessReleases: false,
   },
   preferencesApi: {
@@ -21,7 +22,7 @@ describe('useHarnessPreferences', () => {
   beforeEach(() => {
     vi.mocked(preferencesApi.getHarness).mockReset()
     vi.mocked(preferencesApi.saveHarness).mockReset()
-    vi.mocked(preferencesApi.getHarness).mockResolvedValue({ showHeadlessBornSessions: false, showUnverifiedHarnessReleases: false })
+    vi.mocked(preferencesApi.getHarness).mockResolvedValue({ showHeadlessBornSessions: false, showIssueAttachedSessions: false, showUnverifiedHarnessReleases: false })
     vi.mocked(preferencesApi.saveHarness).mockImplementation(async (next) => next)
   })
 
@@ -34,15 +35,15 @@ describe('useHarnessPreferences', () => {
   })
 
   it('loads and saves roster visibility without leaving a stale error', async () => {
-    vi.mocked(preferencesApi.getHarness).mockResolvedValue({ showHeadlessBornSessions: true, showUnverifiedHarnessReleases: false })
+    vi.mocked(preferencesApi.getHarness).mockResolvedValue({ showHeadlessBornSessions: true, showIssueAttachedSessions: true, showUnverifiedHarnessReleases: false })
     const { result } = renderHook(() => useHarnessPreferences())
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.preferences.showHeadlessBornSessions).toBe(true)
 
     await act(async () => {
-      await result.current.save({ showHeadlessBornSessions: false, showUnverifiedHarnessReleases: false })
+      await result.current.save({ showHeadlessBornSessions: false, showIssueAttachedSessions: false, showUnverifiedHarnessReleases: false })
     })
-    expect(preferencesApi.saveHarness).toHaveBeenCalledWith({ showHeadlessBornSessions: false, showUnverifiedHarnessReleases: false })
+    expect(preferencesApi.saveHarness).toHaveBeenCalledWith({ showHeadlessBornSessions: false, showIssueAttachedSessions: false, showUnverifiedHarnessReleases: false })
     expect(result.current.preferences.showHeadlessBornSessions).toBe(false)
     expect(result.current.error).toBeNull()
   })

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -593,6 +593,8 @@ export const en = {
       sharedDescription: 'These installation-level options apply across Harness Workspaces.',
       showHeadlessBorn: 'Show headless-born Sessions',
       showHeadlessBornDescription: 'Off by default. Sessions that started from an Issue or API turn and have never opened a TUI or WebPi stay on the Issue page instead of the desk roster.',
+      showIssueAttached: 'Show Issue-attached Sessions',
+      showIssueAttachedDescription: 'Off by default. Sessions currently owned or occupied by an Issue stay on the Issue and Automation surfaces instead of the shared desk roster.',
       showUnverifiedReleases: 'Show unverified Harness releases',
       showUnverifiedReleasesDescription: 'Off by default. When enabled, OpenAlice also checks the upstream repository for its newest stable release. Those releases are clearly marked and still require a reviewed upgrade.',
       askAlice: 'Ask Alice',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -582,6 +582,8 @@ export const ja: Resources = {
       sharedDescription: 'これらのインストール単位の設定は Harness Workspace 全体に適用されます。',
       showHeadlessBorn: 'ヘッドレス生まれの Session を表示',
       showHeadlessBornDescription: '既定はオフです。Issue や API から始まり、TUI / WebPi を一度も開いていない Session は Issue ページに残り、デスク名簿には出しません。',
+      showIssueAttached: 'Issue に紐づく Session を表示',
+      showIssueAttachedDescription: '既定はオフです。現在 Issue が所有または使用している Session は Issue と Automation に残り、共有デスク名簿には表示しません。',
       showUnverifiedReleases: '未検証の Harness リリースを表示',
       showUnverifiedReleasesDescription: '既定はオフです。有効にすると、上流リポジトリの最新安定版も確認します。未検証であることを明示し、適用前のレビューも必要です。',
       askAlice: 'Ask Alice',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -589,6 +589,8 @@ export const zhHant: Resources = {
       sharedDescription: '這些安裝層級選項作用於所有 Harness Workspace。',
       showHeadlessBorn: '顯示無頭出身的 Session',
       showHeadlessBornDescription: '預設關閉。從 Issue 或 API 跑起來、從未開過 TUI / WebPi 的 Session 留在 Issue 頁，不進桌子名冊。',
+      showIssueAttached: '顯示掛靠 Issue 的 Session',
+      showIssueAttachedDescription: '預設關閉。目前由 Issue 持有或佔用的 Session 留在 Issue 與 Automation 頁面，不進入共享桌子名冊。',
       showUnverifiedReleases: '顯示未經認證的 Harness 版本',
       showUnverifiedReleasesDescription: '預設關閉。開啟後 OpenAlice 也會檢查上游倉庫最新的穩定版本；這些版本會明確標記，且仍需審閱後升級。',
       askAlice: 'Ask Alice',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -581,6 +581,8 @@ export const zh: Resources = {
       sharedDescription: '这些安装级选项作用于所有 Harness Workspace。',
       showHeadlessBorn: '显示无头出身的 Session',
       showHeadlessBornDescription: '默认关闭。从 Issue 或 API 跑起来、从未打开过 TUI / WebPi 的 Session 留在 Issue 页，不进桌子名册。',
+      showIssueAttached: '显示挂靠 Issue 的 Session',
+      showIssueAttachedDescription: '默认关闭。当前由 Issue 持有或占用的 Session 留在 Issue 与 Automation 页面，不进入共享桌子名册。',
       showUnverifiedReleases: '显示未经认证的 Harness 版本',
       showUnverifiedReleasesDescription: '默认关闭。开启后 OpenAlice 也会检查上游仓库最新的稳定版本；这些版本会明确标记，且仍需审阅后升级。',
       askAlice: 'Ask Alice',

--- a/ui/src/pages/HarnessSettingsPage.spec.tsx
+++ b/ui/src/pages/HarnessSettingsPage.spec.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   save: vi.fn(),
   preferences: {
     showHeadlessBornSessions: false,
+    showIssueAttachedSessions: false,
     showUnverifiedHarnessReleases: false,
   },
 }))
@@ -27,6 +28,7 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   mocks.preferences.showHeadlessBornSessions = false
+  mocks.preferences.showIssueAttachedSessions = false
   mocks.preferences.showUnverifiedHarnessReleases = false
 })
 
@@ -49,6 +51,20 @@ describe('HarnessSettingsPage', () => {
     fireEvent.click(toggle)
     await waitFor(() => expect(mocks.save).toHaveBeenCalledWith({
       showHeadlessBornSessions: true,
+      showIssueAttachedSessions: false,
+      showUnverifiedHarnessReleases: false,
+    }))
+  })
+
+  it('opts into showing Sessions attached to Issues independently', async () => {
+    render(<HarnessSettingsPage />)
+
+    const toggle = screen.getByRole('switch', { name: 'Show Issue-attached Sessions' })
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    fireEvent.click(toggle)
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledWith({
+      showHeadlessBornSessions: false,
+      showIssueAttachedSessions: true,
       showUnverifiedHarnessReleases: false,
     }))
   })
@@ -60,6 +76,7 @@ describe('HarnessSettingsPage', () => {
     fireEvent.click(toggle)
     await waitFor(() => expect(mocks.save).toHaveBeenCalledWith({
       showHeadlessBornSessions: false,
+      showIssueAttachedSessions: false,
       showUnverifiedHarnessReleases: true,
     }))
   })

--- a/ui/src/pages/HarnessSettingsPage.tsx
+++ b/ui/src/pages/HarnessSettingsPage.tsx
@@ -14,6 +14,8 @@ export function HarnessSettingsPage() {
   const [status, setStatus] = useState<SaveStatus>('idle')
   const rosterToggleId = useId()
   const rosterDescriptionId = `${rosterToggleId}-description`
+  const issueRosterToggleId = useId()
+  const issueRosterDescriptionId = `${issueRosterToggleId}-description`
   const releasesToggleId = useId()
   const releasesDescriptionId = `${releasesToggleId}-description`
 
@@ -57,6 +59,24 @@ export function HarnessSettingsPage() {
                   onChange={(next) => void persist({ ...preferences, showHeadlessBornSessions: next })}
                 />
                 <SaveIndicator status={status === 'idle' && error ? 'error' : status} />
+              </div>
+            </div>
+            <div className="mt-5 flex items-start justify-between gap-4 border-t border-border pt-5">
+              <div className="min-w-0">
+                <label htmlFor={issueRosterToggleId} className="block text-sm font-medium text-foreground">
+                  {t('settings.harness.showIssueAttached')}
+                </label>
+                <p id={issueRosterDescriptionId} className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+                  {t('settings.harness.showIssueAttachedDescription')}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <Toggle
+                  ariaLabel={t('settings.harness.showIssueAttached')}
+                  checked={preferences.showIssueAttachedSessions}
+                  disabled={status === 'saving'}
+                  onChange={(next) => void persist({ ...preferences, showIssueAttachedSessions: next })}
+                />
               </div>
             </div>
             <div className="mt-5 flex items-start justify-between gap-4 border-t border-border pt-5">


### PR DESCRIPTION
## Summary
- add an independent Project preference for showing Issue-attached Sessions in shared Harness rosters, default off
- derive live Issue attachment from exact assignees and currently running Issue executions in Session Directory
- keep connector desks unconditionally hidden and preserve Issue, Automation, provenance, and resume behavior
- stop projecting headless Session records as interactive openings, restoring the existing headless-born preference semantics
- add Settings UI, Demo API support, translations, docs, and regression coverage

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm -F open-alice-ui build
- pnpm test (587 files passed, 1 skipped; 4965 tests passed, 9 skipped)
- real Default AliceProject: preference persisted independently and restored to false
- real /chat: Recent conversations dropped from 69 to 42 and japan-boj-watch no longer appeared