### PR TITLE
Keep Session runtime icons independent of lifecycle state

### DIFF
--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -151,7 +151,7 @@ describe('SessionRow actions', () => {
     title: 'Review AAPL earnings',
   }
 
-  it('shows the Session runtime brand instead of a generic agent glyph', () => {
+  it('keeps the Session runtime brand visible independently of lifecycle state', () => {
     const { rerender } = render(
       <SessionRow
         session={{ ...session, agent: 'codex' }}
@@ -163,7 +163,23 @@ describe('SessionRow actions', () => {
       />,
     )
 
-    expect(screen.getByRole('button', { name: 'Review AAPL earnings' }).querySelector('[data-agent-runtime-icon="codex"]')).toBeTruthy()
+    const runningCodex = screen.getByRole('button', { name: 'Review AAPL earnings' }).querySelector('[data-agent-runtime-icon="codex"]')
+    expect(runningCodex).toBeTruthy()
+    expect(runningCodex?.parentElement?.className).toContain('text-foreground/80')
+
+    rerender(
+      <SessionRow
+        session={{ ...session, agent: 'codex', state: 'paused', pid: null, startedAt: null }}
+        isActive={false}
+        onSelect={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    const pausedCodex = screen.getByRole('button', { name: 'Review AAPL earnings' }).querySelector('[data-agent-runtime-icon="codex"]')
+    expect(pausedCodex?.parentElement?.className).toContain('text-foreground/80')
 
     rerender(
       <SessionRow

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -715,7 +715,9 @@ export function SessionRow(props: SessionRowProps): ReactElement {
         aria-label={selectLabel}
         aria-current={props.isActive ? 'page' : undefined}
       >
-        <span className={`shrink-0 flex items-center justify-center w-3.5 ${isPaused && !headlessOccupying ? 'text-muted-foreground/40' : 'text-muted-foreground/70'}`}>
+        {/* Runtime identity stays stable across Session state. The action at the
+            right and the row treatment carry paused/running/selected state. */}
+        <span className="shrink-0 flex items-center justify-center w-3.5 text-foreground/80">
           <AgentBadgeGlyph agentId={s.agent} />
         </span>
         <span className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- keep Agent Runtime identity at a stable high-contrast treatment in Session rows
- preserve official full-color assets such as Claude while keeping transparent monochrome marks legible
- leave paused/running state to the trailing action and selected state to the row treatment

## Design review
- Removes conflicting state semantics between full-color image assets and current-color masks.
- Clarifies the information hierarchy: the leading mark identifies the Runtime; the trailing action communicates lifecycle state.
- Reuses the existing semantic foreground token and existing row/action state primitives; no new visual dialect.
- The compact row behavior is unchanged across narrow, medium, and wide widths.
- Accessibility semantics remain on `aria-current`, `aria-busy`, and labelled lifecycle actions.

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui exec vitest run src/components/workspace/Sidebar.spec.tsx src/lib/agentRuntimeIcon.spec.tsx`
- `pnpm test` (587 passed, 1 skipped; 4965 tests passed, 9 skipped)
- Real Project `/chat`: verified Codex and Claude Session icons retain stable identity with the 42-conversation roster