### PR TITLE
Clarify Connector chat Session visibility

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -594,7 +594,7 @@ export const en = {
       showHeadlessBorn: 'Show headless-born Sessions',
       showHeadlessBornDescription: 'Off by default. Sessions that started from an Issue or API turn and have never opened a TUI or WebPi stay on the Issue page instead of the desk roster.',
       showIssueAttached: 'Show Issue-attached Sessions',
-      showIssueAttachedDescription: 'Off by default. Sessions currently owned or occupied by an Issue stay on the Issue and Automation surfaces instead of the shared desk roster.',
+      showIssueAttachedDescription: 'Off by default. Enable this to add Sessions currently owned or occupied by ordinary Issues to the shared desk roster. Connector chat Sessions always stay hidden.',
       showUnverifiedReleases: 'Show unverified Harness releases',
       showUnverifiedReleasesDescription: 'Off by default. When enabled, OpenAlice also checks the upstream repository for its newest stable release. Those releases are clearly marked and still require a reviewed upgrade.',
       askAlice: 'Ask Alice',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -583,7 +583,7 @@ export const ja: Resources = {
       showHeadlessBorn: 'ヘッドレス生まれの Session を表示',
       showHeadlessBornDescription: '既定はオフです。Issue や API から始まり、TUI / WebPi を一度も開いていない Session は Issue ページに残り、デスク名簿には出しません。',
       showIssueAttached: 'Issue に紐づく Session を表示',
-      showIssueAttachedDescription: '既定はオフです。現在 Issue が所有または使用している Session は Issue と Automation に残り、共有デスク名簿には表示しません。',
+      showIssueAttachedDescription: '既定はオフです。有効にすると、通常の Issue が現在所有または使用している Session を共有デスク名簿に追加します。Connector チャットの Session は常に非表示です。',
       showUnverifiedReleases: '未検証の Harness リリースを表示',
       showUnverifiedReleasesDescription: '既定はオフです。有効にすると、上流リポジトリの最新安定版も確認します。未検証であることを明示し、適用前のレビューも必要です。',
       askAlice: 'Ask Alice',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -590,7 +590,7 @@ export const zhHant: Resources = {
       showHeadlessBorn: '顯示無頭出身的 Session',
       showHeadlessBornDescription: '預設關閉。從 Issue 或 API 跑起來、從未開過 TUI / WebPi 的 Session 留在 Issue 頁，不進桌子名冊。',
       showIssueAttached: '顯示掛靠 Issue 的 Session',
-      showIssueAttachedDescription: '預設關閉。目前由 Issue 持有或佔用的 Session 留在 Issue 與 Automation 頁面，不進入共享桌子名冊。',
+      showIssueAttachedDescription: '預設關閉。開啟後，普通 Issue 目前持有或佔用的 Session 會進入共享桌子名冊；Connector 聊天 Session 一律隱藏。',
       showUnverifiedReleases: '顯示未經認證的 Harness 版本',
       showUnverifiedReleasesDescription: '預設關閉。開啟後 OpenAlice 也會檢查上游倉庫最新的穩定版本；這些版本會明確標記，且仍需審閱後升級。',
       askAlice: 'Ask Alice',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -582,7 +582,7 @@ export const zh: Resources = {
       showHeadlessBorn: '显示无头出身的 Session',
       showHeadlessBornDescription: '默认关闭。从 Issue 或 API 跑起来、从未打开过 TUI / WebPi 的 Session 留在 Issue 页，不进桌子名册。',
       showIssueAttached: '显示挂靠 Issue 的 Session',
-      showIssueAttachedDescription: '默认关闭。当前由 Issue 持有或占用的 Session 留在 Issue 与 Automation 页面，不进入共享桌子名册。',
+      showIssueAttachedDescription: '默认关闭。开启后，普通 Issue 当前持有或占用的 Session 会进入共享桌子名册；Connector 聊天 Session 始终隐藏。',
       showUnverifiedReleases: '显示未经认证的 Harness 版本',
       showUnverifiedReleasesDescription: '默认关闭。开启后 OpenAlice 也会检查上游仓库最新的稳定版本；这些版本会明确标记，且仍需审阅后升级。',
       askAlice: 'Ask Alice',

--- a/ui/src/pages/HarnessSettingsPage.spec.tsx
+++ b/ui/src/pages/HarnessSettingsPage.spec.tsx
@@ -61,6 +61,7 @@ describe('HarnessSettingsPage', () => {
 
     const toggle = screen.getByRole('switch', { name: 'Show Issue-attached Sessions' })
     expect(toggle.getAttribute('aria-checked')).toBe('false')
+    expect(screen.getByText(/Connector chat Sessions always stay hidden/)).toBeTruthy()
     fireEvent.click(toggle)
     await waitFor(() => expect(mocks.save).toHaveBeenCalledWith({
       showHeadlessBornSessions: false,


### PR DESCRIPTION
## Summary
- clarify that the Issue-attached Session preference applies to ordinary Issues
- state explicitly that Connector chat Sessions always remain hidden
- keep English, Simplified Chinese, Traditional Chinese, and Japanese copy aligned
- add a focused settings-page assertion for the visibility contract

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui exec vitest run src/pages/HarnessSettingsPage.spec.tsx`
- `pnpm test` (587 passed, 1 skipped; 4965 tests passed, 9 skipped)
- verified the real Project `/settings/harness` route with the updated copy