### PR TITLE
release: 0.90.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.90.0-beta",
+  "version": "0.90.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "main": "dist/electron/main.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.90.0-beta",
+  "version": "0.90.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- advance the OpenAlice product version from `0.90.0-beta` to `0.90.1`
- keep the root and distributed CLI manifests aligned
- publish this patch as a non-prerelease version

## Local release acceptance
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (587 passed, 1 skipped; 4965 tests passed, 9 skipped)
- `pnpm build`
- `pnpm exec vitest run scripts/release-workflow.spec.ts`
- `pnpm test:install:docker`
- `node scripts/remote-ssh-smoke.mjs --skip-tui`
- `pnpm electron:smoke:workspace` (unsigned packaged macOS arm64, isolated data; all acceptance checks passed)

## Residual release gate
- master promotion remains blocked on the complete GitHub CI/package matrix
- the release workflow will build signed/notarized macOS artifacts, the Windows installer, N-1 upgrades, headless runtimes, Broker Packs, CLI candidate, and CDN aliases before publication
- no manual Windows GUI journey is claimed