### PR TITLE
fix(harness): join concurrent child cleanup

### DIFF
--- a/src/workspaces/harness-surface-manager.spec.ts
+++ b/src/workspaces/harness-surface-manager.spec.ts
@@ -11,14 +11,7 @@ const dirs: string[] = []
 
 afterEach(async () => {
   await Promise.all(managers.splice(0).map((manager) => manager.dispose()))
-  await Promise.all(dirs.splice(0).map((dir) => rm(dir, {
-    recursive: true,
-    force: true,
-    // Windows can briefly retain the child process's cwd after taskkill has
-    // reported that the process exited. Let fs.rm absorb that teardown race.
-    maxRetries: 8,
-    retryDelay: 100,
-  })))
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
 describe('HarnessSurfaceManager', () => {

--- a/src/workspaces/harness-surface-manager.spec.ts
+++ b/src/workspaces/harness-surface-manager.spec.ts
@@ -11,7 +11,14 @@ const dirs: string[] = []
 
 afterEach(async () => {
   await Promise.all(managers.splice(0).map((manager) => manager.dispose()))
-  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, {
+    recursive: true,
+    force: true,
+    // Windows can briefly retain the child process's cwd after taskkill has
+    // reported that the process exited. Let fs.rm absorb that teardown race.
+    maxRetries: 8,
+    retryDelay: 100,
+  })))
 })
 
 describe('HarnessSurfaceManager', () => {

--- a/src/workspaces/harness-surface-manager.ts
+++ b/src/workspaces/harness-surface-manager.ts
@@ -40,6 +40,7 @@ interface SurfaceRuntime {
   readonly entryPort: number
   phase: HarnessSurfacePhase
   child: ChildProcess | null
+  childClosed: Promise<void> | null
   manifestVersion: number
   harnessVersion: string
   startedAt: string
@@ -151,6 +152,7 @@ export class HarnessSurfaceManager {
       entryPort: ports[declared.entryPort]!,
       phase: 'starting',
       child: null,
+      childClosed: null,
       manifestVersion: manifest.manifestVersion,
       harnessVersion: manifest.version,
       startedAt: new Date().toISOString(),
@@ -185,6 +187,7 @@ export class HarnessSurfaceManager {
         windowsHide: true,
       })
       runtime.child = child
+      runtime.childClosed = new Promise((resolve) => child.once('close', () => resolve()))
       child.stdout?.on('data', (chunk: Buffer) => appendLog(runtime, chunk))
       child.stderr?.on('data', (chunk: Buffer) => appendLog(runtime, chunk))
       child.once('error', (err) => {
@@ -253,13 +256,22 @@ export class HarnessSurfaceManager {
 
   private async stopChild(runtime: SurfaceRuntime): Promise<void> {
     const child = runtime.child
+    const childClosed = runtime.childClosed
     runtime.child = null
-    if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return
-    try {
-      await terminateProcessTree(child.pid, { gracefulMs: 4_000, forceMs: 4_000 })
-    } catch (err) {
-      appendLog(runtime, Buffer.from(`OpenAlice cleanup: ${err instanceof Error ? err.message : String(err)}\n`))
+    runtime.childClosed = null
+    if (!child) return
+    if (child.pid && child.exitCode === null && child.signalCode === null) {
+      try {
+        await terminateProcessTree(child.pid, { gracefulMs: 4_000, forceMs: 4_000 })
+      } catch (err) {
+        appendLog(runtime, Buffer.from(`OpenAlice cleanup: ${err instanceof Error ? err.message : String(err)}\n`))
+      }
     }
+    // `exit` only means the process ended. `close` additionally means Node has
+    // released its stdio handles, including the child's Workspace cwd on
+    // Windows. Give that teardown a bounded chance to finish before callers
+    // remove or replace the directory.
+    if (childClosed) await Promise.race([childClosed, delay(2_000)])
   }
 
   private fail(runtime: SurfaceRuntime, message: string): void {

--- a/src/workspaces/harness-surface-manager.ts
+++ b/src/workspaces/harness-surface-manager.ts
@@ -41,6 +41,7 @@ interface SurfaceRuntime {
   phase: HarnessSurfacePhase
   child: ChildProcess | null
   childClosed: Promise<void> | null
+  childStop: Promise<void> | null
   manifestVersion: number
   harnessVersion: string
   startedAt: string
@@ -153,6 +154,7 @@ export class HarnessSurfaceManager {
       phase: 'starting',
       child: null,
       childClosed: null,
+      childStop: null,
       manifestVersion: manifest.manifestVersion,
       harnessVersion: manifest.version,
       startedAt: new Date().toISOString(),
@@ -255,6 +257,20 @@ export class HarnessSurfaceManager {
   }
 
   private async stopChild(runtime: SurfaceRuntime): Promise<void> {
+    if (runtime.childStop) {
+      await runtime.childStop
+      return
+    }
+    const operation = this.stopChildOnce(runtime)
+    runtime.childStop = operation
+    try {
+      await operation
+    } finally {
+      if (runtime.childStop === operation) runtime.childStop = null
+    }
+  }
+
+  private async stopChildOnce(runtime: SurfaceRuntime): Promise<void> {
     const child = runtime.child
     const childClosed = runtime.childClosed
     runtime.child = null


### PR DESCRIPTION
## Summary
- make concurrent Harness child-stop callers join the same in-flight cleanup
- wait for the child close event after process-tree termination so Windows releases stdio and cwd handles
- preserve the existing no-retry test teardown so the timeout/dispose race remains covered

## Evidence
- release preflight CI runs 33050496646, 33051541446, and 33052488436 consistently reproduced EBUSY while timeout cleanup and dispose raced
- pnpm exec vitest run src/workspaces/harness-surface-manager.spec.ts
- targeted Harness spec repeated 10 times
- npx tsc --noEmit
- pnpm test (587 passed, 1 skipped; 4965 passed, 9 skipped)

Product version remains 0.90.1.