### PR TITLE
feat(office): make interactions facing-aware

### DIFF
--- a/plans/office-floor.md
+++ b/plans/office-floor.md
@@ -64,8 +64,9 @@ Session、Files 或 provenance。
 
 - 单击员工：选中并在底部打开游戏对话框；再次操作进入 Session。
 - 单击 Workspace 铭牌/档案柜：打开该 Workspace Files。
-- Alice 靠近员工或档案柜时，只高亮距离最近的对象并显示单一游戏按键提示；Enter/Space
-  执行与鼠标点击相同的动作，不用键盘用户在地图对象之间 Tab 巡航。
+- Alice 靠近员工、档案柜或名册板时，只高亮面向锥形范围内的最佳对象并显示单一游戏
+  按键提示；正侧方和背后对象不抢提示。Enter/Space 执行与鼠标点击相同的动作，不用
+  键盘用户在地图对象之间 Tab 巡航。
 - 拖动空地：平移镜头；不得触发员工点击。
 - WASD/方向键：移动 Alice；靠近视口安全边缘时镜头跟随，地图保持可键盘聚焦并提供
   可读 label。
@@ -323,6 +324,22 @@ Runtime-coworker increment (2026-08-29):
 - `npx tsc --noEmit` passed
 - `cd ui && npx tsc -b` passed
 - `pnpm test` passed: 594 files / 4981 tests, 1 file / 9 tests skipped
+- `pnpm --filter open-alice-ui build` passed
+
+Facing-interaction increment (2026-08-29):
+
+- Replaced pure nearest-distance selection with a facing-aware interaction cone. The cone keeps a small
+  foot-level tolerance, widens in front of Alice, and rejects objects directly to the side or behind her.
+- Movement updates facing before collision resolution, so pressing toward a solid desk, cabinet, or roster
+  board turns Alice in place and immediately exposes that object without allowing her to walk through it.
+- Preserved mouse behavior and the single Enter/Space prompt; only keyboard/game interaction targeting
+  changed. Existing collision, camera, cabinet, employee, and roster routes remain DOM-native.
+- Browser-played the real Demo route: spawn faces the cabinet rather than the roster behind Alice; moving up
+  then bump-turning left selects the roster without changing position; navigating around the rug and bumping
+  down into a desk selects the Pi employee; Enter opens the correct roster, Agent file, and Workspace Files.
+- `npx tsc --noEmit` passed
+- `cd ui && npx tsc -b` passed
+- `pnpm test` passed: 594 files / 4982 tests, 1 file / 9 tests skipped
 - `pnpm --filter open-alice-ui build` passed
 
 ## Completion

--- a/ui/src/office/OfficeBuilding.tsx
+++ b/ui/src/office/OfficeBuilding.tsx
@@ -114,8 +114,8 @@ export function OfficeBuilding({
     [groups, mapLayout, resolveGroupTitle],
   )
   const nearbyTarget = useMemo(
-    () => nearestOfficeInteractionTarget(alice, interactionTargets),
-    [alice, interactionTargets],
+    () => nearestOfficeInteractionTarget(alice, aliceDirection, interactionTargets),
+    [alice, aliceDirection, interactionTargets],
   )
   const sleepAfterDays = Math.max(
     1,

--- a/ui/src/office/interaction-targets.spec.ts
+++ b/ui/src/office/interaction-targets.spec.ts
@@ -43,9 +43,47 @@ describe('Office interaction targets', () => {
     })
     expect(nearestOfficeInteractionTarget(
       { x: employee!.x + 24, y: employee!.y },
+      'left',
       targets,
     )?.id).toBe(employee?.id)
-    expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, targets)).toBeNull()
+    expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'down', targets)).toBeNull()
+  })
+
+  it('selects only an object in Alice’s facing cone', () => {
+    const targets = [
+      {
+        id: 'cabinet:up',
+        kind: 'cabinet' as const,
+        x: 0,
+        y: -48,
+        workspaceId: 'up',
+        roomName: 'Up',
+      },
+      {
+        id: 'cabinet:down',
+        kind: 'cabinet' as const,
+        x: 0,
+        y: 48,
+        workspaceId: 'down',
+        roomName: 'Down',
+      },
+      {
+        id: 'cabinet:side',
+        kind: 'cabinet' as const,
+        x: 58,
+        y: 10,
+        workspaceId: 'side',
+        roomName: 'Side',
+      },
+    ]
+
+    expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'up', targets)?.id)
+      .toBe('cabinet:up')
+    expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'down', targets)?.id)
+      .toBe('cabinet:down')
+    expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'right', targets)?.id)
+      .toBe('cabinet:side')
+    expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'left', targets)).toBeNull()
   })
 
   it('keeps Alice inside the camera safe area without escaping map bounds', () => {

--- a/ui/src/office/interaction-targets.ts
+++ b/ui/src/office/interaction-targets.ts
@@ -4,6 +4,11 @@ import { visibleEmployeesForOffice } from './desk-slots'
 import { OFFICE_CABINET_CENTER, OFFICE_DESK_CENTERS, OFFICE_ROSTER_CENTER } from './pod-geometry'
 
 export const OFFICE_INTERACTION_RADIUS = 84
+export const OFFICE_INTERACTION_SIDE_REACH = 52
+export const OFFICE_INTERACTION_MIN_SIDE_REACH = 18
+export const OFFICE_INTERACTION_BACK_REACH = 8
+
+export type OfficeFacingDirection = 'up' | 'right' | 'down' | 'left'
 
 export type OfficeInteractionTarget =
   | {
@@ -82,17 +87,37 @@ export function officeInteractionTargets(
 
 export function nearestOfficeInteractionTarget(
   alice: { x: number; y: number },
+  facing: OfficeFacingDirection,
   targets: readonly OfficeInteractionTarget[],
   radius = OFFICE_INTERACTION_RADIUS,
 ): OfficeInteractionTarget | null {
   let nearest: OfficeInteractionTarget | null = null
-  let nearestDistanceSquared = radius * radius
+  let nearestScore = Number.POSITIVE_INFINITY
+  const vector = {
+    up: { x: 0, y: -1 },
+    right: { x: 1, y: 0 },
+    down: { x: 0, y: 1 },
+    left: { x: -1, y: 0 },
+  }[facing]
 
   for (const target of targets) {
-    const distanceSquared = (target.x - alice.x) ** 2 + (target.y - alice.y) ** 2
-    if (distanceSquared > nearestDistanceSquared) continue
+    const dx = target.x - alice.x
+    const dy = target.y - alice.y
+    const distanceSquared = dx ** 2 + dy ** 2
+    if (distanceSquared > radius * radius) continue
+    const forward = dx * vector.x + dy * vector.y
+    const sideways = Math.abs(dx * vector.y - dy * vector.x)
+    const sideReach = Math.min(
+      OFFICE_INTERACTION_SIDE_REACH,
+      Math.max(OFFICE_INTERACTION_MIN_SIDE_REACH, forward + OFFICE_INTERACTION_MIN_SIDE_REACH),
+    )
+    if (forward < -OFFICE_INTERACTION_BACK_REACH || sideways > sideReach) {
+      continue
+    }
+    const score = distanceSquared + sideways ** 2
+    if (score > nearestScore) continue
     nearest = target
-    nearestDistanceSquared = distanceSquared
+    nearestScore = score
   }
 
   return nearest

--- a/ui/src/office/map-collision.spec.ts
+++ b/ui/src/office/map-collision.spec.ts
@@ -31,7 +31,7 @@ describe('Office map collision', () => {
     const move = moveAliceOnOfficeMap(current, { x: -24, y: 0 }, layout)
 
     expect(move).toMatchObject({ position: current, bumped: true, obstacleId: 'desk:chat-1:0' })
-    expect(nearestOfficeInteractionTarget(current, [{
+    expect(nearestOfficeInteractionTarget(current, 'left', [{
       id: 'employee:chat-1:resume-1',
       kind: 'employee',
       ...desk,


### PR DESCRIPTION
## Summary
- replace nearest-distance prompts with a GBA-style facing cone
- let collision attempts turn Alice in place so solid furniture remains immediately interactable
- preserve mouse actions while making keyboard target selection predictable around crowded pods

## Design
The interaction cone keeps a small foot-level tolerance, widens forward, and rejects objects directly beside or behind Alice. This keeps the single Enter/Space action while removing proximity prompt jumps.

## Verification
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (594 files / 4982 tests passed; 1 file / 9 skipped)
- pnpm --filter open-alice-ui build
- real Demo /office browser play: spawn-facing cabinet, collision turn into roster, collision turn into employee, roster/Agent-file/Files dispatch
