### PR TITLE
feat(office): add map-space depth sorting

### DIFF
--- a/plans/office-floor.md
+++ b/plans/office-floor.md
@@ -342,6 +342,26 @@ Facing-interaction increment (2026-08-29):
 - `pnpm test` passed: 594 files / 4982 tests, 1 file / 9 tests skipped
 - `pnpm --filter open-alice-ui build` passed
 
+Y-depth increment (2026-08-29):
+
+- Compared keeping fixed component layers, sorting complete Workspace pods, and sorting every map object
+  from its floor contact point. Fixed layers preserve the paper-doll look, while whole-pod sorting fails
+  when Alice walks among furniture inside a pod. Chose one shared Y-depth function because it matches the
+  painter algorithm used by classic top-down maps and keeps DOM-native controls intact.
+- Workspace signs, all four workstation slots, cabinets, personnel boards, Harness props, wall landmarks,
+  and Alice now consume the same map-space depth scale. Rugs remain on the floor, while activity bubbles
+  and labels remain local overlays inside their correctly sorted world object.
+- Removed the desk-list stacking context and the fixed Alice/sign/prop layers that previously forced Alice
+  to paint over furniture everywhere. The sign remains non-solid: Alice visibly disappears behind it when
+  walking north and reappears in front after crossing its floor line.
+- Browser-played the real Demo route across both sides of a Workspace sign: at y=264 Alice paints behind
+  the sign's y=284 floor line, then paints in front at y=312. Rechecked the six-person roster and focus
+  return, employee collision/inspection, spawn-facing cabinet prompt, and Files navigation after sorting.
+- `npx tsc --noEmit` passed
+- `cd ui && npx tsc -b` passed
+- `pnpm test` passed: 595 files / 4984 tests, 1 file / 9 tests skipped
+- `pnpm --filter open-alice-ui build` passed
+
 ## Completion
 
 计划只在 maintainer 接受真实浏览器中的 Live、All groups、employee dialog 和 pause/log

--- a/ui/src/office/OfficeBuilding.tsx
+++ b/ui/src/office/OfficeBuilding.tsx
@@ -18,6 +18,7 @@ import {
 import { officeCoworkerLabel } from './label'
 import { moveAliceOnOfficeMap, officeCollisionRects } from './map-collision'
 import { layoutOfficeMap } from './map-layout'
+import { officeDepthAt } from './scene-depth'
 import { useReducedMotion } from './use-reduced-motion'
 
 export function OfficeBuilding({
@@ -357,12 +358,23 @@ export function OfficeBuilding({
             <div
               className="oa-office-map-wall"
               aria-hidden
-              style={{ backgroundImage: `url(${OFFICE_FURNITURE.generated.wallWindow})` }}
+              style={{
+                backgroundImage: `url(${OFFICE_FURNITURE.generated.wallWindow})`,
+                zIndex: officeDepthAt(112),
+              }}
             />
-            <div className="oa-office-map-landmark oa-office-map-landmark--plant" aria-hidden>
+            <div
+              className="oa-office-map-landmark oa-office-map-landmark--plant"
+              aria-hidden
+              style={{ zIndex: officeDepthAt(178) }}
+            >
               <img src={OFFICE_FURNITURE.generated.plant} alt="" style={officePixelImg} />
             </div>
-            <div className="oa-office-map-landmark oa-office-map-landmark--terminal" aria-hidden>
+            <div
+              className="oa-office-map-landmark oa-office-map-landmark--terminal"
+              aria-hidden
+              style={{ zIndex: officeDepthAt(183) }}
+            >
               <img src={OFFICE_FURNITURE.generated.terminal} alt="" style={officePixelImg} />
             </div>
             <div
@@ -371,7 +383,7 @@ export function OfficeBuilding({
               aria-label={t('office.aliceAvatar')}
               data-direction={aliceDirection}
               data-bumped={aliceBumped}
-              style={{ left: alice.x, top: alice.y }}
+              style={{ left: alice.x, top: alice.y, zIndex: officeDepthAt(alice.y) }}
             >
               <span className="oa-office-alice__sprite" aria-hidden>
                 <OfficeEmployeeSprite

--- a/ui/src/office/OfficeDesk.spec.tsx
+++ b/ui/src/office/OfficeDesk.spec.tsx
@@ -32,11 +32,13 @@ describe('OfficeDesk', () => {
       roomName: 'Chat',
       selected: false,
       nearby: false,
+      depth: 107,
       reducedMotion: true,
       onSelect: () => undefined,
     }
     const { container, rerender } = render(<OfficeDesk {...props} />)
 
+    expect(screen.getByRole('button').style.zIndex).toBe('107')
     expect(screen.queryByText('research')).toBeNull()
     expect(container.querySelector('.oa-office-coworker')?.getAttribute('data-agent')).toBe('claude')
     expect(container.querySelector('.oa-office-coworker')?.getAttribute('data-reduced-motion')).toBe('true')

--- a/ui/src/office/OfficeDesk.tsx
+++ b/ui/src/office/OfficeDesk.tsx
@@ -12,6 +12,7 @@ export function OfficeDesk({
   roomName,
   selected,
   nearby,
+  depth,
   reducedMotion,
   spriteScale,
   onSelect,
@@ -21,6 +22,7 @@ export function OfficeDesk({
   roomName: string
   selected: boolean
   nearby?: boolean
+  depth: number
   reducedMotion: boolean
   spriteScale?: number
   onSelect: () => void
@@ -52,7 +54,7 @@ export function OfficeDesk({
         data-nearby={nearby}
         data-occupied={Boolean(employee)}
         data-mood={employee?.mood}
-        style={{ width: station.widthPx, height: station.heightPx }}
+        style={{ width: station.widthPx, height: station.heightPx, zIndex: depth }}
       >
         <span className="oa-office-topdown-station" aria-hidden>
           <img

--- a/ui/src/office/OfficeMapPod.tsx
+++ b/ui/src/office/OfficeMapPod.tsx
@@ -4,6 +4,8 @@ import type { OfficeFloorEmployee, OfficeRoomSnapshot } from '../api/office'
 import { OfficeDesk } from './OfficeDesk'
 import { deskSlotsForOffice, visibleEmployeesForOffice } from './desk-slots'
 import { OFFICE_FURNITURE, officePixelImg } from './furniture'
+import { OFFICE_CABINET_CENTER, OFFICE_DESK_CENTERS, OFFICE_ROSTER_CENTER } from './pod-geometry'
+import { officeDepthAt } from './scene-depth'
 
 export function OfficeMapPod({
   group,
@@ -56,7 +58,10 @@ export function OfficeMapPod({
       data-active={active}
       data-sleeping={group.sleeping}
     >
-      <header className="oa-office-pod__sign">
+      <header
+        className="oa-office-pod__sign"
+        style={{ zIndex: officeDepthAt(layout.y + 44) }}
+      >
         <div>
           <span>{harnessTitle}</span>
           <h3>{title}</h3>
@@ -79,7 +84,10 @@ export function OfficeMapPod({
           alt=""
           aria-hidden
           className="oa-office-pod__harness-prop"
-          style={officePixelImg}
+          style={{
+            ...officePixelImg,
+            zIndex: officeDepthAt(layout.y + layout.height - 6),
+          }}
         />
         <ul className="oa-office-pod__desks">
           {slots.map((employee, index) => (
@@ -96,6 +104,7 @@ export function OfficeMapPod({
                 employee
                 && nearbyTargetId === `employee:${group.workspace.id}:${employee.resumeId}`
               )}
+              depth={officeDepthAt(layout.y + OFFICE_DESK_CENTERS[index].y)}
               reducedMotion={reducedMotion}
               spriteScale={0.23}
               onSelect={() => employee && onSelectEmployee(group.workspace.id, employee)}
@@ -106,6 +115,7 @@ export function OfficeMapPod({
         <button
           type="button"
           className="oa-office-pod__cabinet"
+          style={{ zIndex: officeDepthAt(layout.y + OFFICE_CABINET_CENTER.y + 24) }}
           data-nearby={nearbyTargetId === `cabinet:${group.workspace.id}`}
           onClick={() => onOpenFiles(group.workspace.id)}
           aria-label={`${t('office.cabinet')} · ${title}`}
@@ -118,6 +128,7 @@ export function OfficeMapPod({
             id={`office-roster-${group.workspace.id}`}
             type="button"
             className="oa-office-pod__roster"
+            style={{ zIndex: officeDepthAt(layout.y + OFFICE_ROSTER_CENTER.y + 25) }}
             data-nearby={nearbyTargetId === `roster:${group.workspace.id}`}
             onClick={() => onOpenRoster(group.workspace.id)}
             aria-label={`${t('office.roster')} · ${title}`}

--- a/ui/src/office/office.css
+++ b/ui/src/office/office.css
@@ -2733,7 +2733,6 @@
   --oa-office-bump-x: 0px;
   --oa-office-bump-y: 2px;
   position: absolute;
-  z-index: 12;
   display: grid;
   width: 34px;
   height: 42px;
@@ -2969,7 +2968,6 @@
 
 .oa-office-pod__sign {
   position: relative;
-  z-index: 13;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
@@ -3049,7 +3047,6 @@
   position: absolute;
   bottom: 3px;
   left: -3px;
-  z-index: 5;
   width: 58px;
   height: 68px;
   object-fit: contain;
@@ -3094,14 +3091,13 @@
   margin: 0;
   padding: 0;
   list-style: none;
-  z-index: 2;
+  z-index: auto;
 }
 
 .oa-office-pod__cabinet {
   position: absolute;
   right: -2px;
   bottom: 2px;
-  z-index: 7;
   width: 40px;
   height: 54px;
   padding: 0;
@@ -3140,7 +3136,6 @@
   position: absolute;
   top: 5px;
   right: -4px;
-  z-index: 7;
   width: 42px;
   height: 58px;
   padding: 0;
@@ -3504,7 +3499,6 @@
   top: 0;
   right: 0;
   left: 0;
-  z-index: 1;
   height: 102px;
   border-bottom: 4px solid var(--gba-ink);
   background-repeat: repeat-x;
@@ -3516,7 +3510,6 @@
 
 .oa-office-map-landmark {
   position: absolute;
-  z-index: 2;
   pointer-events: none;
 }
 

--- a/ui/src/office/scene-depth.spec.ts
+++ b/ui/src/office/scene-depth.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { officeDepthAt, OFFICE_DEPTH_BASE } from './scene-depth'
+
+describe('officeDepthAt', () => {
+  it('paints lower floor contacts in front of higher contacts', () => {
+    expect(officeDepthAt(360)).toBeGreaterThan(officeDepthAt(240))
+  })
+
+  it('rounds map coordinates and keeps depth above the floor layer', () => {
+    expect(officeDepthAt(12.6)).toBe(OFFICE_DEPTH_BASE + 13)
+    expect(officeDepthAt(-20)).toBe(OFFICE_DEPTH_BASE)
+  })
+})

--- a/ui/src/office/scene-depth.ts
+++ b/ui/src/office/scene-depth.ts
@@ -1,0 +1,9 @@
+/**
+ * Paint map objects from their floor contact point, like a tile-based
+ * top-down game's painter algorithm: lower feet cover higher feet.
+ */
+export const OFFICE_DEPTH_BASE = 10
+
+export function officeDepthAt(floorY: number): number {
+  return OFFICE_DEPTH_BASE + Math.max(0, Math.round(floorY))
+}


### PR DESCRIPTION
## Summary

- sort Alice and every solid/interactive Office world object from a shared map-space floor-contact Y coordinate
- remove fixed component layers and the desk-list stacking context that made the scene paint like flat stickers
- preserve local labels, bubbles, collision, proximity interaction, focus behavior, and DOM-native controls

## Design decision

Compared fixed component layers, whole-Workspace pod sorting, and object-level floor-contact sorting. Object-level Y depth is the only option that lets Alice move naturally among signs and furniture inside a pod while preserving the existing accessible DOM scene graph.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 595 files / 4984 tests passed; 1 file / 9 tests skipped
- `pnpm --filter open-alice-ui build`
- real Demo `/office`: Alice walks behind and then in front of a Workspace sign across its floor line
- real Demo `/office`: six-person roster opens and returns focus; employee inspection and cabinet-to-Files navigation still work
