### PR TITLE
feat(office): animate Alice tile movement

### DIFF
--- a/plans/office-floor.md
+++ b/plans/office-floor.md
@@ -129,8 +129,8 @@ atlas 后再替换静态 coworker，不把 mood atlas 行误当成方向行。
   终端机和植物，CSS 不再负责绘制已接入物件
 - [x] 将 desk/cabinet/terminal 从正面排队改为生成式俯视物件；档案柜成为地图内 Files
   交互，而不是铭牌图标
-- [x] Alice 独占 Codex pet v2，员工使用按 runtime 区分的生成角色；移动时 Alice 只做
-  atlas 支持的左右镜像
+- [x] Alice 独占 Codex pet v2，员工使用按 runtime 区分的生成角色；水平移动消费 atlas
+  正式左右跑步行，纵向移动不伪造缺失的背面帧
 - [x] 员工超出 pod 舒适容量时使用可进入/可展开的小组人数提示，不显示 `+58`
 - [x] 统一 tile、阴影、像素缩放和主色卡映射
 
@@ -379,6 +379,27 @@ Operations-board increment (2026-08-29):
 - `npx tsc --noEmit` passed
 - `cd ui && npx tsc -b` passed
 - `pnpm test` passed: 595 files / 4985 tests, 1 file / 9 tests skipped
+- `pnpm --filter open-alice-ui build` passed
+
+Alice-walk-cycle increment (2026-08-29):
+
+- Compared a CSS-only bob, generating a replacement four-direction Alice, and consuming the authored
+  movement rows already present in the canonical Alice v2 atlas. Chose the existing right/left run rows
+  plus a restrained vertical step bob: it improves game feel without replacing Alice or mislabeling a
+  side-running frame as a nonexistent back-facing frame.
+- Replaced the employee-mood adapter with an Alice-specific pose contract: idle, walk-right, and walk-left.
+  Horizontal steps now animate the eight authored run frames; vertical steps retain the correct frontal
+  silhouette while sharing the discrete footfall motion.
+- Added a 96ms three-step map-position transition and a 150ms walking hold so taps read as tile steps and
+  held keys maintain a continuous run cycle. Collision immediately cancels walking before the directional
+  bump, and reduced motion disables both interpolation and bobbing while preserving pose/state feedback.
+- Browser-played the real Demo route: a right step enters `walk-right` and advances to frame 1 before
+  returning to idle; a left step selects the separately authored `walk-left`; northward movement keeps
+  the frontal pose and walking state; collision at the Operations Board cancels walking and shows bump
+  without changing the y=264 logical position.
+- `npx tsc --noEmit` passed
+- `cd ui && npx tsc -b` passed
+- `pnpm test` passed: 596 files / 4987 tests, 1 file / 9 tests skipped
 - `pnpm --filter open-alice-ui build` passed
 
 ## Completion

--- a/ui/src/office/OfficeAliceSprite.spec.tsx
+++ b/ui/src/office/OfficeAliceSprite.spec.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { OfficeAliceSprite, officeAlicePose } from './OfficeAliceSprite'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('OfficeAliceSprite', () => {
+  it('uses authored side-running rows only for horizontal walking', () => {
+    expect(officeAlicePose('right', true)).toBe('walk-right')
+    expect(officeAlicePose('left', true)).toBe('walk-left')
+    expect(officeAlicePose('up', true)).toBe('idle')
+    expect(officeAlicePose('down', true)).toBe('idle')
+
+    const { container, rerender } = render(
+      <OfficeAliceSprite
+        direction="right"
+        walking
+        reducedMotion
+        label="Alice"
+        scale={0.2}
+      />,
+    )
+    expect(container.firstElementChild?.getAttribute('data-pose')).toBe('walk-right')
+    expect(container.firstElementChild?.getAttribute('data-frame')).toBe('0')
+
+    rerender(
+      <OfficeAliceSprite
+        direction="left"
+        walking
+        reducedMotion
+        label="Alice"
+        scale={0.2}
+      />,
+    )
+    expect(container.firstElementChild?.getAttribute('data-pose')).toBe('walk-left')
+  })
+
+  it('advances the authored run cycle while Alice keeps moving', () => {
+    vi.useFakeTimers()
+    const { container } = render(
+      <OfficeAliceSprite
+        direction="right"
+        walking
+        reducedMotion={false}
+        label="Alice"
+        scale={0.2}
+      />,
+    )
+
+    expect(container.firstElementChild?.getAttribute('data-frame')).toBe('0')
+    act(() => vi.advanceTimersByTime(80))
+    expect(container.firstElementChild?.getAttribute('data-frame')).toBe('1')
+    act(() => vi.advanceTimersByTime(80))
+    expect(container.firstElementChild?.getAttribute('data-frame')).toBe('2')
+  })
+})

--- a/ui/src/office/OfficeAliceSprite.tsx
+++ b/ui/src/office/OfficeAliceSprite.tsx
@@ -1,20 +1,33 @@
 import { useEffect, useState } from 'react'
 
-import { defaultOfficeSpritePack, type OfficeEmployeeMood } from './sprite-pack'
+import { defaultOfficeSpritePack, type OfficeAlicePose } from './sprite-pack'
 
-export function OfficeEmployeeSprite({
-  mood,
+export type OfficeAliceDirection = 'up' | 'right' | 'down' | 'left'
+
+export function officeAlicePose(
+  direction: OfficeAliceDirection,
+  walking: boolean,
+): OfficeAlicePose {
+  if (!walking || direction === 'up' || direction === 'down') return 'idle'
+  return direction === 'left' ? 'walk-left' : 'walk-right'
+}
+
+export function OfficeAliceSprite({
+  direction,
+  walking,
   reducedMotion,
   label,
   scale = 0.5,
 }: {
-  mood: OfficeEmployeeMood
+  direction: OfficeAliceDirection
+  walking: boolean
   reducedMotion: boolean
   label: string
   scale?: number
 }) {
   const pack = defaultOfficeSpritePack
-  const pose = pack.pose(mood)
+  const action = officeAlicePose(direction, walking)
+  const pose = pack.pose(action)
   const [frame, setFrame] = useState(0)
 
   useEffect(() => {
@@ -32,7 +45,7 @@ export function OfficeEmployeeSprite({
     }
     tick()
     return () => window.clearTimeout(timer)
-  }, [mood, pose.frames, pose.durationsMs, reducedMotion])
+  }, [action, pose.durationsMs, pose.frames, reducedMotion])
 
   const displayWidth = pack.cell.width * scale
   const displayHeight = pack.cell.height * scale
@@ -41,6 +54,8 @@ export function OfficeEmployeeSprite({
       aria-hidden
       title={label}
       className="shrink-0"
+      data-pose={action}
+      data-frame={frame}
       style={{
         width: displayWidth,
         height: displayHeight,

--- a/ui/src/office/OfficeBuilding.spec.tsx
+++ b/ui/src/office/OfficeBuilding.spec.tsx
@@ -99,6 +99,8 @@ describe('OfficeBuilding', () => {
     await userEvent.keyboard('d')
     expect(alice.style.left).toBe('504px')
     expect(alice.dataset.direction).toBe('right')
+    expect(alice.dataset.walking).toBe('true')
+    expect(alice.querySelector('[data-pose="walk-right"]')).toBeTruthy()
     fireEvent.pointerDown(map, { pointerId: 1, clientX: 400, clientY: 300 })
     fireEvent.pointerMove(map, { pointerId: 1, clientX: 300, clientY: 250 })
     expect(map.querySelector<HTMLElement>('.oa-office-map')?.style.transform)

--- a/ui/src/office/OfficeBuilding.tsx
+++ b/ui/src/office/OfficeBuilding.tsx
@@ -8,7 +8,7 @@ import type {
 } from '../api/office'
 import { Popover, PopoverContent, PopoverTrigger } from '../components/ui/popover'
 import { OFFICE_FURNITURE, officePixelImg } from './furniture'
-import { OfficeEmployeeSprite } from './OfficeEmployeeSprite'
+import { OfficeAliceSprite, type OfficeAliceDirection } from './OfficeAliceSprite'
 import { OfficeMapPod } from './OfficeMapPod'
 import {
   nearestOfficeInteractionTarget,
@@ -48,7 +48,8 @@ export function OfficeBuilding({
   const [camera, setCamera] = useState({ x: 0, y: 0 })
   const [alice, setAlice] = useState({ x: 480, y: 336 })
   const aliceRef = useRef(alice)
-  const [aliceDirection, setAliceDirection] = useState<'up' | 'right' | 'down' | 'left'>('down')
+  const [aliceDirection, setAliceDirection] = useState<OfficeAliceDirection>('down')
+  const [aliceWalking, setAliceWalking] = useState(false)
   const [aliceBumped, setAliceBumped] = useState(false)
   const [panning, setPanning] = useState(false)
   const viewportRef = useRef<HTMLDivElement>(null)
@@ -62,6 +63,7 @@ export function OfficeBuilding({
   } | null>(null)
   const bumpTimerRef = useRef<number | null>(null)
   const bumpFrameRef = useRef<number | null>(null)
+  const walkTimerRef = useRef<number | null>(null)
   const awakeGroups = useMemo(
     () => building.offices.filter((office) => !office.sleeping),
     [building.offices],
@@ -150,8 +152,11 @@ export function OfficeBuilding({
     aliceRef.current = mapLayout.alice
     setAlice(mapLayout.alice)
     setAliceDirection('down')
+    setAliceWalking(false)
   }
   const showCollisionBump = () => {
+    if (walkTimerRef.current != null) window.clearTimeout(walkTimerRef.current)
+    setAliceWalking(false)
     if (bumpFrameRef.current != null) window.cancelAnimationFrame(bumpFrameRef.current)
     if (bumpTimerRef.current != null) window.clearTimeout(bumpTimerRef.current)
     setAliceBumped(false)
@@ -160,14 +165,21 @@ export function OfficeBuilding({
       bumpTimerRef.current = window.setTimeout(() => setAliceBumped(false), 140)
     })
   }
+  const showAliceWalking = () => {
+    if (walkTimerRef.current != null) window.clearTimeout(walkTimerRef.current)
+    setAliceWalking(true)
+    walkTimerRef.current = window.setTimeout(() => setAliceWalking(false), 150)
+  }
   useEffect(() => () => {
     if (bumpFrameRef.current != null) window.cancelAnimationFrame(bumpFrameRef.current)
     if (bumpTimerRef.current != null) window.clearTimeout(bumpTimerRef.current)
+    if (walkTimerRef.current != null) window.clearTimeout(walkTimerRef.current)
   }, [])
   useLayoutEffect(() => {
     aliceRef.current = mapLayout.alice
     setAlice(mapLayout.alice)
     setAliceDirection('down')
+    setAliceWalking(false)
     setCamera(centeredCamera())
   // Reframe only when the visible map geometry changes, not on every live poll.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -310,6 +322,7 @@ export function OfficeBuilding({
           const next = move.position
           aliceRef.current = next
           setAlice(next)
+          showAliceWalking()
           const viewport = viewportRef.current?.getBoundingClientRect()
           if (viewport) {
             setCamera((currentCamera) => officeCameraFollowingAlice(
@@ -411,12 +424,14 @@ export function OfficeBuilding({
               role="img"
               aria-label={t('office.aliceAvatar')}
               data-direction={aliceDirection}
+              data-walking={aliceWalking}
               data-bumped={aliceBumped}
               style={{ left: alice.x, top: alice.y, zIndex: officeDepthAt(alice.y) }}
             >
               <span className="oa-office-alice__sprite" aria-hidden>
-                <OfficeEmployeeSprite
-                  mood="idle"
+                <OfficeAliceSprite
+                  direction={aliceDirection}
+                  walking={aliceWalking}
                   reducedMotion={reducedMotion}
                   label={t('office.aliceAvatar')}
                   scale={0.2}

--- a/ui/src/office/office.css
+++ b/ui/src/office/office.css
@@ -2738,6 +2738,7 @@
   height: 42px;
   place-items: center;
   transform: translate(-50%, -50%);
+  transition: left 96ms steps(3, end), top 96ms steps(3, end);
   pointer-events: none;
 }
 
@@ -2781,8 +2782,13 @@
   transform-origin: center bottom;
 }
 
-.oa-office-alice[data-direction="left"] > .oa-office-alice__sprite {
-  transform: scaleX(-1);
+.oa-office-alice[data-walking="true"][data-direction="up"] > .oa-office-alice__sprite,
+.oa-office-alice[data-walking="true"][data-direction="down"] > .oa-office-alice__sprite {
+  animation: oa-office-alice-step 160ms steps(2, end) infinite;
+}
+
+@keyframes oa-office-alice-step {
+  50% { transform: translateY(-2px); }
 }
 
 .oa-office-alice small {
@@ -3672,6 +3678,15 @@
   }
 
   .oa-office-alice[data-bumped="true"] {
+    animation: none;
+  }
+
+  .oa-office-alice {
+    transition: none;
+  }
+
+  .oa-office-alice[data-walking="true"][data-direction="up"] > .oa-office-alice__sprite,
+  .oa-office-alice[data-walking="true"][data-direction="down"] > .oa-office-alice__sprite {
     animation: none;
   }
 }

--- a/ui/src/office/sprite-pack.spec.ts
+++ b/ui/src/office/sprite-pack.spec.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { defaultOfficeSpritePack, type OfficeEmployeeMood } from './sprite-pack'
+import { defaultOfficeSpritePack, type OfficeAlicePose } from './sprite-pack'
 
 describe('defaultOfficeSpritePack (Codex v2 adapter)', () => {
-  it('maps product moods to v2 rows without leaking atlas names into the model', () => {
-    const moods: OfficeEmployeeMood[] = ['idle', 'working', 'talking', 'waiting', 'review', 'failed']
-    expect(moods.map((mood) => defaultOfficeSpritePack.pose(mood).row)).toEqual([0, 7, 3, 6, 8, 5])
+  it('maps Alice movement actions to the authored v2 idle and run rows', () => {
+    const actions: OfficeAlicePose[] = ['idle', 'walk-right', 'walk-left']
+    expect(actions.map((action) => defaultOfficeSpritePack.pose(action).row)).toEqual([0, 1, 2])
+    expect(defaultOfficeSpritePack.pose('walk-right').frames).toBe(8)
     expect(defaultOfficeSpritePack.cell).toEqual({ width: 192, height: 208 })
     expect(defaultOfficeSpritePack.sheetUrl).toContain('/office/packs/')
   })

--- a/ui/src/office/sprite-pack.ts
+++ b/ui/src/office/sprite-pack.ts
@@ -1,15 +1,9 @@
 /**
  * Office only depends on this pack interface. Codex pet v2 is the first
- * adapter — not part of the employee / desk / office model. It now belongs
+ * adapter — not part of the employee / desk / office model. It belongs
  * exclusively to Alice; runtime coworkers use generated static overworld art.
  */
-export type OfficeEmployeeMood =
-  | 'idle'
-  | 'working'
-  | 'talking'
-  | 'waiting'
-  | 'review'
-  | 'failed'
+export type OfficeAlicePose = 'idle' | 'walk-right' | 'walk-left'
 
 export interface OfficeSpritePose {
   readonly row: number
@@ -23,19 +17,16 @@ export interface OfficeSpritePack {
   readonly sheetUrl: string
   readonly cell: { readonly width: number; readonly height: number }
   readonly atlas: { readonly columns: number; readonly rows: number }
-  pose(mood: OfficeEmployeeMood): OfficeSpritePose
+  pose(action: OfficeAlicePose): OfficeSpritePose
 }
 
-/** Codex v2 atlas: 1536×2288, 8×11, 192×208 cells. Rows 0–8 are moods. */
+/** Codex v2 atlas: 1536×2288, 8×11, 192×208 cells. Rows 0–2 are idle/right-run/left-run. */
 const V2_CELL = { width: 192, height: 208 } as const
 
-const V2_POSES: Record<OfficeEmployeeMood, OfficeSpritePose> = {
+const V2_POSES: Record<OfficeAlicePose, OfficeSpritePose> = {
   idle: { row: 0, frames: 6, durationsMs: [280, 110, 110, 140, 140, 320] },
-  working: { row: 7, frames: 6, durationsMs: [120, 120, 120, 120, 120, 220] },
-  talking: { row: 3, frames: 4, durationsMs: [140, 140, 140, 280] },
-  waiting: { row: 6, frames: 6, durationsMs: [150, 150, 150, 150, 150, 260] },
-  review: { row: 8, frames: 6, durationsMs: [150, 150, 150, 150, 150, 280] },
-  failed: { row: 5, frames: 8, durationsMs: [140, 140, 140, 140, 140, 140, 140, 240] },
+  'walk-right': { row: 1, frames: 8, durationsMs: [80, 80, 80, 80, 80, 80, 80, 80] },
+  'walk-left': { row: 2, frames: 8, durationsMs: [80, 80, 80, 80, 80, 80, 80, 80] },
 }
 
 export const defaultOfficeSpritePack: OfficeSpritePack = {
@@ -44,7 +35,7 @@ export const defaultOfficeSpritePack: OfficeSpritePack = {
   sheetUrl: '/office/packs/alice-maid/spritesheet.webp',
   cell: V2_CELL,
   atlas: { columns: 8, rows: 11 },
-  pose(mood) {
-    return V2_POSES[mood]
+  pose(action) {
+    return V2_POSES[action]
   },
 }


### PR DESCRIPTION
## Summary

- replace the former employee-mood sprite adapter with an Alice-specific idle/right-run/left-run contract
- consume the canonical Alice v2 atlas's authored eight-frame horizontal run rows
- add short stepped tile interpolation, a walking hold, vertical-only footfall bob, collision stop, and reduced-motion fallback
- preserve discrete collision and facing interaction coordinates while improving the rendered travel between tiles

## Design decision

Compared CSS-only bobbing, generating a replacement four-direction Alice, and using the authored v2 movement rows. The canonical run rows were selected for horizontal motion; vertical travel deliberately keeps Alice's frontal pose with a small step bob because the pack has no truthful back-facing row.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 596 files / 4987 tests passed; 1 file / 9 tests skipped
- `pnpm --filter open-alice-ui build`
- focused Alice sprite/building specs — 3 files / 5 tests passed
- real Demo `/office`: right and left select their authored run rows; stop returns to idle; north travel keeps the frontal pose; Operations Board collision cancels walking and triggers bump without moving the logical position
