### PR TITLE
fix(office): clarify first-touch interactions

### DIFF
--- a/plans/office-floor.md
+++ b/plans/office-floor.md
@@ -596,6 +596,27 @@ North-facing Alice increment (2026-08-29):
 - `pnpm test` passed: 599 files / 4994 tests, 1 file / 9 tests skipped
 - `pnpm --filter open-alice-ui build` passed
 
+First-touch interaction increment (2026-08-29):
+
+- Replayed the current reset path and found that Alice spawned 79px from the nearest filing cabinet while
+  the 84px interaction radius immediately painted a large Files prompt. That made opening a Workspace look
+  like the intended first action instead of letting the movement tutorial lead exploration.
+- Compared moving the spawn point, delaying the prompt, and tightening the facing cone. Chose a 72px radius:
+  it clears the neutral spawn while every employee, cabinet, roster board, and Operations Board remains
+  reachable from outside its collision footprint. The existing directional side/back gates remain unchanged.
+- Browser movement also found that the roster and Occupancy log left the map prompt/highlight visible behind
+  their modal windows. `OfficePage` now explicitly suspends world interaction for every Office overlay;
+  `OfficeBuilding` clears its nearby target, prompt, and highlight for the complete suspended state.
+- Browser-played reset, two-step roster approach, Enter activation, roster close, and Operations log. Reset
+  has no target or prompt, the roster prompt appears only after approaching, and both windows leave the
+  underlying scene inert with no nearby highlight or prompt.
+- Rechecked the neutral reset state at 760×900 in the dark Office surface: no horizontal overflow, no
+  premature target, and no visible text below the 12px Office minimum.
+- Focused interaction, OfficeBuilding, and OfficePage specs passed: 3 files / 9 tests.
+- `npx tsc --noEmit` and `cd ui && npx tsc -b` passed
+- `pnpm test` passed: 599 files / 4995 tests, 1 file / 9 tests skipped
+- `pnpm --filter open-alice-ui build` passed
+
 ## Completion
 
 计划只在 maintainer 接受真实浏览器中的 Live、All groups、employee dialog 和 pause/log

--- a/ui/src/office/OfficeBuilding.spec.tsx
+++ b/ui/src/office/OfficeBuilding.spec.tsx
@@ -230,32 +230,33 @@ describe('OfficeBuilding', () => {
 
   it('renders an interactive personnel board for groups larger than the four-desk map', async () => {
     const onOpenRoster = vi.fn()
-    render(
-      <OfficeBuilding
-        building={{
-          config: {
-            workspaceSleepAfterMs: 1,
-            harnessMinimumVisibleGroups: { chat: 1, 'auto-quant': 0, prediction: 0, other: 0 },
-          },
+    const building = {
+      config: {
+        workspaceSleepAfterMs: 1,
+        harnessMinimumVisibleGroups: { chat: 1, 'auto-quant': 0, prediction: 0, other: 0 },
+      },
+      lastSeq: 1,
+      firstSeq: 1,
+      offices: [{
+        workspace: { id: 'chat-full', tag: 'chat', harness: 'chat' as const },
+        lastInteractionAt: 1,
+        sleeping: false,
+        employees: Array.from({ length: 6 }, (_, index) => ({
+          resumeId: `resume-${index}`,
+          agent: 'codex',
+          name: `x${index + 1}`,
+          title: `Session ${index + 1}`,
+          mood: index < 2 ? 'working' as const : 'idle' as const,
+          bubble: null,
           lastSeq: 1,
-          firstSeq: 1,
-          offices: [{
-            workspace: { id: 'chat-full', tag: 'chat', harness: 'chat' },
-            lastInteractionAt: 1,
-            sleeping: false,
-            employees: Array.from({ length: 6 }, (_, index) => ({
-              resumeId: `resume-${index}`,
-              agent: 'codex',
-              name: `x${index + 1}`,
-              title: `Session ${index + 1}`,
-              mood: index < 2 ? 'working' as const : 'idle' as const,
-              bubble: null,
-              lastSeq: 1,
-              lastInteractionAt: 1,
-              drawers: [],
-            })),
-          }],
-        }}
+          lastInteractionAt: 1,
+          drawers: [],
+        })),
+      }],
+    }
+    const view = render(
+      <OfficeBuilding
+        building={building}
         onSelectEmployee={vi.fn()}
         onOpenEmployee={vi.fn()}
         onOpenFiles={vi.fn()}
@@ -267,6 +268,26 @@ describe('OfficeBuilding', () => {
     expect(screen.getAllByTestId(/^office-desk-/)).toHaveLength(4)
     const board = screen.getByRole('button', { name: 'Team roster · chat' })
     expect(board.querySelector('img')?.getAttribute('src')).toBe('/office/furniture/personnel-board-v1.png')
+    const map = screen.getByLabelText('Office map. Drag to pan; use arrows or WASD to move Alice; press Enter or Space to interact nearby.')
+    map.focus()
+    await userEvent.keyboard('aw')
+    expect(screen.getByText('View chat roster')).toBeTruthy()
+    expect(board.dataset.nearby).toBe('true')
+
+    view.rerender(
+      <OfficeBuilding
+        building={building}
+        interactionSuspended
+        onSelectEmployee={vi.fn()}
+        onOpenEmployee={vi.fn()}
+        onOpenFiles={vi.fn()}
+        onOpenRoster={onOpenRoster}
+        onOpenLog={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(board.dataset.nearby).toBe('false')
+
     await userEvent.click(board)
     expect(onOpenRoster).toHaveBeenCalledWith('chat-full')
   })

--- a/ui/src/office/OfficeBuilding.tsx
+++ b/ui/src/office/OfficeBuilding.tsx
@@ -35,6 +35,7 @@ export function OfficeBuilding({
   building,
   groupTitle,
   selected,
+  interactionSuspended = false,
   onSelectEmployee,
   onOpenEmployee,
   onOpenFiles,
@@ -44,6 +45,7 @@ export function OfficeBuilding({
   building: OfficeBuildingSnapshot
   groupTitle?: (workspaceId: string, tag: string) => string
   selected?: { workspaceId: string; resumeId: string } | null
+  interactionSuspended?: boolean
   onSelectEmployee: (workspaceId: string, employee: OfficeFloorEmployee) => void
   onOpenEmployee: (workspaceId: string, employee: OfficeFloorEmployee) => void
   onOpenFiles: (workspaceId: string) => void
@@ -134,8 +136,10 @@ export function OfficeBuilding({
     [mapLayout.width],
   )
   const nearbyTarget = useMemo(
-    () => nearestOfficeInteractionTarget(alice, aliceDirection, interactionTargets),
-    [alice, aliceDirection, interactionTargets],
+    () => interactionSuspended || selected
+      ? null
+      : nearestOfficeInteractionTarget(alice, aliceDirection, interactionTargets),
+    [alice, aliceDirection, interactionSuspended, interactionTargets, selected],
   )
   const promptPlacement = useMemo(
     () => nearbyTarget
@@ -525,7 +529,7 @@ export function OfficeBuilding({
               />
             )
           })}
-          {nearbyTarget && promptPlacement && !selected && (
+          {nearbyTarget && promptPlacement && (
             <div
               className="oa-office-interact-prompt"
               role="status"

--- a/ui/src/office/interaction-targets.spec.ts
+++ b/ui/src/office/interaction-targets.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { OfficeRoomSnapshot } from '../api/office'
 import {
+  OFFICE_INTERACTION_RADIUS,
   nearestOfficeInteractionTarget,
   officeCameraFollowingAlice,
   officeInteractionTargets,
@@ -91,6 +92,72 @@ describe('Office interaction targets', () => {
     expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'right', targets)?.id)
       .toBe('cabinet:side')
     expect(nearestOfficeInteractionTarget({ x: 0, y: 0 }, 'left', targets)).toBeNull()
+  })
+
+  it('starts outside interaction range but keeps every object reachable from a safe approach', () => {
+    const twoGroupLayout = layoutOfficeMap([
+      { id: 'chat-1', harness: 'chat' },
+      { id: 'quant-1', harness: 'auto-quant' },
+    ])
+    const quantGroup: OfficeRoomSnapshot = {
+      ...group,
+      workspace: { id: 'quant-1', tag: 'quant', harness: 'auto-quant' },
+      employees: [],
+    }
+    const projected = officeInteractionTargets(
+      [group, quantGroup],
+      twoGroupLayout,
+      (_id, tag) => tag,
+    )
+
+    expect(OFFICE_INTERACTION_RADIUS).toBe(72)
+    expect(nearestOfficeInteractionTarget(twoGroupLayout.alice, 'down', projected)).toBeNull()
+
+    const safeApproaches = [
+      {
+        id: 'employee',
+        target: {
+          id: 'employee:test',
+          kind: 'employee' as const,
+          x: 0,
+          y: 0,
+          workspaceId: 'test',
+          roomName: 'Test',
+          employee: group.employees[0]!,
+        },
+      },
+      {
+        id: 'cabinet',
+        target: {
+          id: 'cabinet:test',
+          kind: 'cabinet' as const,
+          x: 0,
+          y: 0,
+          workspaceId: 'test',
+          roomName: 'Test',
+        },
+      },
+      {
+        id: 'roster',
+        target: {
+          id: 'roster:test',
+          kind: 'roster' as const,
+          x: 0,
+          y: 0,
+          workspaceId: 'test',
+          roomName: 'Test',
+        },
+      },
+      {
+        id: 'operations',
+        target: { id: 'operations' as const, kind: 'operations' as const, x: 0, y: 0 },
+      },
+    ]
+
+    for (const { id, target } of safeApproaches) {
+      expect(nearestOfficeInteractionTarget({ x: 0, y: 64 }, 'up', [target])?.kind)
+        .toBe(id)
+    }
   })
 
   it('keeps Alice inside the camera safe area without escaping map bounds', () => {

--- a/ui/src/office/interaction-targets.ts
+++ b/ui/src/office/interaction-targets.ts
@@ -4,7 +4,7 @@ import { visibleEmployeesForOffice } from './desk-slots'
 import { officeOperationsBoardPosition } from './map-landmarks'
 import { OFFICE_CABINET_CENTER, OFFICE_DESK_CENTERS, OFFICE_ROSTER_CENTER } from './pod-geometry'
 
-export const OFFICE_INTERACTION_RADIUS = 84
+export const OFFICE_INTERACTION_RADIUS = 72
 export const OFFICE_INTERACTION_SIDE_REACH = 52
 export const OFFICE_INTERACTION_MIN_SIDE_REACH = 18
 export const OFFICE_INTERACTION_BACK_REACH = 8

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -168,6 +168,7 @@ export function OfficePage() {
                   return workspace ? workspaceDisplayName(workspace) : tag
                 }}
                 selected={selected}
+                interactionSuspended={logOpen || Boolean(selectedSeat) || Boolean(rosterOffice)}
                 onSelectEmployee={(workspaceId, employee) => {
                   setSelected({ workspaceId, resumeId: employee.resumeId })
                   setLogOpen(false)


### PR DESCRIPTION
## Summary
- keep the neutral Office spawn outside interaction range so movement is the first clear action
- preserve reachable approaches for every world object within collision boundaries
- suspend nearby prompts and highlights while any Office window owns interaction

## Verification
- real `/office` reset, roster approach/Enter, roster close, and Operations log playthrough
- 760x900 dark-surface reset with no overflow or premature prompt
- focused Office specs (3 files / 9 tests)
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` (599 files / 4995 tests passed)
- `pnpm --filter open-alice-ui build`