### PR TITLE
feat(office): keep quiet floors in game world

### DIFF
--- a/plans/office-floor.md
+++ b/plans/office-floor.md
@@ -636,6 +636,27 @@ Spawn-compass environment increment (2026-08-29):
 - `pnpm test` passed: 599 files / 4995 tests, 1 file / 9 tests skipped
 - `pnpm --filter open-alice-ui build` passed
 
+Quiet-floor scene increment (2026-08-29):
+
+- Audited the true zero-Workspace route and the filtered all-sleeping route. The former abandoned Office
+  completely for a page-level paragraph; the latter covered the whole map with a Dashboard-like empty card.
+- Compared keeping the page copy, retaining the full-map overlay, and preserving the floor with a compact
+  in-world system notice. Chose the in-world notice so the map, Alice, spawn compass, landmarks, Operations
+  Board, movement controls, and day/night atmosphere remain the product even when there are no desks.
+- Empty map layout now has an explicit 960×672 zero-pod scene with Alice centered at (480, 336), rather than
+  inheriting a phantom one-pod calculation. OfficePage always renders the game surface when floor data exists.
+- The generated signal receiver now anchors a single physical 16-bit notice below Alice. A truly empty Office
+  explains where active Sessions will appear without offering a meaningless filter action; an all-sleeping
+  Office offers All groups and restores its hidden pods in place.
+- Added layout, building, and page coverage for the centered zero state, generated receiver, map retention,
+  absence of the All groups action when nothing exists, and the sleeping-to-all-groups transition.
+- Browser-played the standard two-group floor, true zero-Workspace floor, and all-sleeping floor. At
+  1280×720 and 760×900 the notice stays inside the camera without covering Alice, the Operations Board,
+  or movement controls; All groups restores both hidden pods and no scenario adds horizontal overflow.
+- `npx tsc --noEmit` and `cd ui && npx tsc -b` passed
+- `pnpm test` passed: 599 files / 4998 tests, 1 file / 9 tests skipped
+- `pnpm --filter open-alice-ui build` passed
+
 ## Completion
 
 计划只在 maintainer 接受真实浏览器中的 Live、All groups、employee dialog 和 pause/log

--- a/ui/src/office/OfficeBuilding.spec.tsx
+++ b/ui/src/office/OfficeBuilding.spec.tsx
@@ -19,7 +19,7 @@ beforeEach(async () => {
 })
 
 describe('OfficeBuilding', () => {
-  it('uses the generated signal receiver for a quiet floor', () => {
+  it('keeps an empty Office inside the game world with Alice centered', () => {
     render(
       <OfficeBuilding
         building={{
@@ -40,9 +40,55 @@ describe('OfficeBuilding', () => {
     )
 
     const building = screen.getByTestId('office-building')
+    const map = screen.getByLabelText('Office map. Drag to pan; use arrows or WASD to move Alice; press Enter or Space to interact nearby.')
+    const alice = screen.getByRole('img', { name: 'Alice on the office map' })
+    const spawnCompass = screen.getByTestId('office-spawn-compass')
+    const quietNotice = screen.getByRole('status')
+    expect(map).toBeTruthy()
+    expect(alice.style.left).toBe('480px')
+    expect(alice.style.top).toBe('336px')
+    expect(spawnCompass.style.left).toBe(alice.style.left)
+    expect(spawnCompass.style.top).toBe(alice.style.top)
+    expect(quietNotice.dataset.kind).toBe('empty')
+    expect(screen.getByText('No Workspace yet')).toBeTruthy()
+    expect(screen.getByText('No one is at a desk in this office. Active Sessions appear here.')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'All groups' })).toBeNull()
     expect(building.querySelector<HTMLImageElement>('.oa-office-quiet__radar img')?.src)
       .toContain('/office/hud/signal-receiver-v1.png')
     expect(building.querySelector('svg')).toBeNull()
+  })
+
+  it('offers sleeping groups from the in-world quiet notice', async () => {
+    render(
+      <OfficeBuilding
+        building={{
+          config: {
+            workspaceSleepAfterMs: 1,
+            harnessMinimumVisibleGroups: { chat: 0, 'auto-quant': 0, prediction: 0, other: 0 },
+          },
+          lastSeq: 1,
+          firstSeq: 1,
+          offices: [{
+            workspace: { id: 'sleeping-1', tag: 'sleeping', harness: 'other' },
+            lastInteractionAt: 1,
+            sleeping: true,
+            employees: [],
+          }],
+        }}
+        onSelectEmployee={vi.fn()}
+        onOpenEmployee={vi.fn()}
+        onOpenFiles={vi.fn()}
+        onOpenRoster={vi.fn()}
+        onOpenLog={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('status').dataset.kind).toBe('sleeping')
+    expect(screen.getByText('All groups are asleep')).toBeTruthy()
+    expect(screen.queryByTestId('office-pod-sleeping-1')).toBeNull()
+    await userEvent.click(screen.getByRole('button', { name: 'All groups' }))
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByTestId('office-pod-sleeping-1')).toBeTruthy()
   })
 
   it('filters sleeping groups and lets Alice move around the continuous map', async () => {

--- a/ui/src/office/OfficeBuilding.tsx
+++ b/ui/src/office/OfficeBuilding.tsx
@@ -507,15 +507,27 @@ export function OfficeBuilding({
               <small>ALICE</small>
             </div>
           {groups.length === 0 && (
-            <div className="oa-office-quiet">
+            <div
+              className="oa-office-quiet"
+              role="status"
+              data-kind={building.offices.length === 0 ? 'empty' : 'sleeping'}
+            >
               <span className="oa-office-quiet__radar" aria-hidden>
                 <img src={OFFICE_HUD_ASSETS.signalReceiver} alt="" style={officePixelImg} />
               </span>
-              <p>{t('office.floorQuiet')}</p>
-              <span>{t('office.floorQuietHint', { days: sleepAfterDays })}</span>
-              <button type="button" onClick={() => setShowAll(true)}>
-                {t('office.allGroups')}
-              </button>
+              <div className="oa-office-quiet__copy">
+                <p>{building.offices.length === 0 ? t('office.noWorkspace') : t('office.floorQuiet')}</p>
+                <span>
+                  {building.offices.length === 0
+                    ? t('office.emptyFloor')
+                    : t('office.floorQuietHint', { days: sleepAfterDays })}
+                </span>
+                {building.offices.length > 0 && (
+                  <button type="button" onClick={() => setShowAll(true)}>
+                    {t('office.allGroups')}
+                  </button>
+                )}
+              </div>
             </div>
           )}
           {mapLayout.pods.map((layout) => {

--- a/ui/src/office/map-layout.spec.ts
+++ b/ui/src/office/map-layout.spec.ts
@@ -47,6 +47,17 @@ function expectValidGeometry(count: number) {
 }
 
 describe('layoutOfficeMap', () => {
+  it('keeps an empty floor centered in the default game frame', () => {
+    expect(layoutOfficeMap([])).toEqual({
+      width: 960,
+      height: 672,
+      columns: 0,
+      rows: 0,
+      alice: { x: 480, y: 336 },
+      pods: [],
+    })
+  })
+
   it.each([1, 2, 5, 17])('packs %i Workspace pods into a bounded 2D tilemap', (count) => {
     expectValidGeometry(count)
   })

--- a/ui/src/office/map-layout.ts
+++ b/ui/src/office/map-layout.ts
@@ -41,6 +41,16 @@ function candidateScore(count: number, columns: number): number {
 }
 
 export function layoutOfficeMap(inputs: readonly OfficeMapLayoutInput[]): OfficeMapLayout {
+  if (inputs.length === 0) {
+    return {
+      width: 960,
+      height: 672,
+      columns: 0,
+      rows: 0,
+      alice: { x: 480, y: 336 },
+      pods: [],
+    }
+  }
   const count = Math.max(1, inputs.length)
   let columns = 1
   let bestScore = Number.POSITIVE_INFINITY

--- a/ui/src/office/office.css
+++ b/ui/src/office/office.css
@@ -308,61 +308,6 @@
   margin: 0 auto;
 }
 
-.oa-office-quiet {
-  display: grid;
-  min-height: 280px;
-  place-items: center;
-  align-content: center;
-  gap: 8px;
-  padding: 30px;
-  border: 1px dashed color-mix(in srgb, var(--primary) 24%, transparent);
-  border-radius: 12px;
-  background:
-    radial-gradient(circle at 50% 45%, color-mix(in srgb, var(--primary) 9%, transparent), transparent 10rem),
-    color-mix(in srgb, var(--foreground) 3%, transparent);
-  text-align: center;
-}
-
-.oa-office-quiet__radar {
-  display: grid;
-  width: 48px;
-  height: 48px;
-  margin-bottom: 4px;
-  place-items: center;
-  border: 1px solid color-mix(in srgb, var(--primary) 34%, transparent);
-  border-radius: 50%;
-  color: var(--office-cyan);
-  background: color-mix(in srgb, var(--primary) 6%, transparent);
-  box-shadow: 0 0 30px color-mix(in srgb, var(--primary) 8%, transparent);
-}
-
-.oa-office-quiet p {
-  margin: 0;
-  color: var(--office-text);
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.oa-office-quiet > span:not(.oa-office-quiet__radar) {
-  max-width: 25rem;
-  color: var(--office-text-muted);
-  font-size: 11px;
-  line-height: 1.5;
-}
-
-.oa-office-quiet button {
-  min-height: 30px;
-  margin-top: 6px;
-  padding: 0 12px;
-  border: 1px solid var(--office-line);
-  border-radius: 6px;
-  color: var(--office-cyan-bright);
-  background: color-mix(in srgb, var(--primary) 7%, transparent);
-  font-size: 10px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
 .oa-office-amenity {
   position: fixed;
   z-index: 0;
@@ -2669,36 +2614,6 @@
   background: var(--gba-cream);
 }
 
-.oa-office-quiet {
-  min-height: 100%;
-  border: 4px solid var(--gba-ink);
-  border-radius: 4px;
-  color: var(--gba-ink);
-  background: var(--gba-paper);
-}
-
-.oa-office-quiet__radar {
-  border: 3px solid var(--gba-ink);
-  border-radius: 3px;
-  color: var(--gba-paper);
-  background: var(--gba-moss-dark);
-}
-
-.oa-office-quiet p {
-  color: var(--gba-ink);
-}
-
-.oa-office-quiet > span:not(.oa-office-quiet__radar) {
-  color: var(--gba-ink-soft);
-}
-
-.oa-office-quiet button {
-  border: 3px solid var(--gba-ink);
-  border-radius: 3px;
-  color: var(--gba-paper);
-  background: var(--gba-moss-dark);
-}
-
 @keyframes oa-office-gba-blink {
   50% { opacity: 0.35; }
 }
@@ -4094,19 +4009,84 @@
   object-fit: contain;
 }
 
+.oa-office-quiet {
+  position: absolute;
+  top: 280px;
+  left: 560px;
+  z-index: 500;
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  width: 320px;
+  min-height: 104px;
+  align-items: center;
+  gap: 12px;
+  box-sizing: border-box;
+  padding: 12px 14px 12px 10px;
+  border: 3px solid var(--gba-ink);
+  border-radius: 3px;
+  color: var(--gba-ink);
+  background: var(--gba-cream);
+  box-shadow:
+    inset 0 0 0 2px color-mix(in srgb, var(--gba-moss) 22%, transparent),
+    5px 6px 0 color-mix(in srgb, var(--gba-ink) 26%, transparent);
+}
+
 .oa-office-quiet__radar {
-  width: 72px;
-  height: 72px;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
+  display: grid;
+  width: 64px;
+  height: 64px;
+  place-items: center;
 }
 
 .oa-office-quiet__radar img {
   display: block;
-  width: 72px;
-  height: 72px;
+  width: 64px;
+  height: 64px;
   object-fit: contain;
+}
+
+.oa-office-quiet__copy {
+  display: grid;
+  justify-items: start;
+  gap: 4px;
+  min-width: 0;
+}
+
+.oa-office-quiet p {
+  margin: 0;
+  color: var(--gba-ink);
+  font-weight: 800;
+}
+
+.oa-office-quiet__copy > span {
+  color: var(--gba-ink-soft);
+  line-height: 1.35;
+}
+
+.oa-office-quiet button {
+  min-height: 36px;
+  margin-top: 4px;
+  padding: 0 12px;
+  border: 3px solid var(--gba-ink);
+  border-radius: 2px;
+  color: var(--gba-paper);
+  background: var(--gba-moss-dark);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.oa-office-quiet button:is(:hover, :focus-visible) {
+  border-color: var(--gba-water);
+  outline: 2px solid color-mix(in srgb, var(--gba-water) 42%, transparent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 800px) {
+  .oa-office-quiet {
+    top: 130px;
+    left: 570px;
+    width: 250px;
+  }
 }
 
 .oa-office-map-landmark {

--- a/ui/src/pages/OfficePage.spec.tsx
+++ b/ui/src/pages/OfficePage.spec.tsx
@@ -7,6 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { i18n } from '../i18n'
 import { OfficePage } from './OfficePage'
 
+const { officeFloorMock } = vi.hoisted(() => ({
+  officeFloorMock: vi.fn(),
+}))
+
 vi.mock('./OfficeRuntimeSection', () => ({
   OfficeRuntimeSection: () => <div>Office occupancy</div>,
 }))
@@ -19,26 +23,28 @@ vi.mock('../contexts/workspaces-context', () => ({
 }))
 
 vi.mock('../hooks/useOfficeFloor', () => ({
-  useOfficeFloor: () => ({
-    building: {
-      config: {
-        workspaceSleepAfterMs: 3 * 24 * 60 * 60 * 1000,
-        harnessMinimumVisibleGroups: { chat: 1, 'auto-quant': 1, prediction: 1, other: 0 },
-      },
-      lastSeq: 1,
-      firstSeq: 1,
-      offices: [{
-        workspace: { id: 'chat-1', tag: 'chat', harness: 'chat' },
-        lastInteractionAt: Date.now(),
-        sleeping: false,
-        employees: [],
-      }],
-    },
-    loading: false,
-    error: null,
-    refresh: async () => undefined,
-  }),
+  useOfficeFloor: officeFloorMock,
 }))
+
+const defaultOfficeFloor = () => ({
+  building: {
+    config: {
+      workspaceSleepAfterMs: 3 * 24 * 60 * 60 * 1000,
+      harnessMinimumVisibleGroups: { chat: 1, 'auto-quant': 1, prediction: 1, other: 0 },
+    },
+    lastSeq: 1,
+    firstSeq: 1,
+    offices: [{
+      workspace: { id: 'chat-1', tag: 'chat', harness: 'chat' },
+      lastInteractionAt: Date.now(),
+      sleeping: false,
+      employees: [],
+    }],
+  },
+  loading: false,
+  error: null,
+  refresh: async () => undefined,
+})
 
 vi.mock('../tabs/store', () => ({
   useWorkspace: (select: (state: { openOrFocus: () => void }) => unknown) =>
@@ -47,6 +53,7 @@ vi.mock('../tabs/store', () => ({
 
 beforeEach(async () => {
   await i18n.changeLanguage('zh')
+  officeFloorMock.mockReturnValue(defaultOfficeFloor())
   vi.stubGlobal('matchMedia', vi.fn(() => ({
     matches: true,
     addEventListener: vi.fn(),
@@ -57,6 +64,25 @@ beforeEach(async () => {
 afterEach(cleanup)
 
 describe('OfficePage localization', () => {
+  it('renders an empty Office as a game floor instead of page copy', () => {
+    officeFloorMock.mockReturnValue({
+      ...defaultOfficeFloor(),
+      building: {
+        ...defaultOfficeFloor().building,
+        lastSeq: 0,
+        firstSeq: 0,
+        offices: [],
+      },
+    })
+
+    render(<OfficePage />)
+
+    expect(screen.getByLabelText('Office 地图。拖动查看地图，使用方向键或 WASD 移动 Alice，靠近对象后按回车或空格互动。')).toBeTruthy()
+    expect(screen.getByRole('img', { name: 'Office 地图上的 Alice' })).toBeTruthy()
+    expect(screen.getByText('还没有 Workspace')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '所有小组' })).toBeNull()
+  })
+
   it('localizes the Office HUD and opens logs on request', async () => {
     const { container } = render(<OfficePage />)
 

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -150,10 +150,7 @@ export function OfficePage() {
       {loading && !building && (
         <p className="px-4 pt-3 text-sm text-muted-foreground md:px-6">{t('office.loadingFloor')}</p>
       )}
-      {building && building.offices.length === 0 && (
-        <p className="px-4 pt-3 text-sm text-muted-foreground md:px-6">{t('office.noWorkspace')}</p>
-      )}
-      {building && building.offices.length > 0 && (
+      {building && (
         <div className="oa-office-layout">
           <div className="oa-office-main">
             <div


### PR DESCRIPTION
## Summary
- keep the 16-bit Office map mounted when there are no Workspaces
- center Alice on an explicit zero-pod layout and replace the full-map empty card with an in-world receiver notice
- distinguish truly empty floors from sleeping groups, with a working All groups recovery action

## Design
Compared page-level copy, a full-map overlay, and a compact in-world notice. Chose the notice so the map, Alice, landmarks, Operations Board, controls, and day/night atmosphere remain visible in every data state.

## Verification
- browser-played normal, zero-Workspace, and all-sleeping Office scenes
- browser-checked 1280x720 and 760x900 with no horizontal overflow or control overlap
- npx tsc --noEmit
- cd ui && npx tsc -b
- pnpm test (599 files / 4998 tests, 1 file / 9 tests skipped)
- pnpm --filter open-alice-ui build