### PR TITLE
Prove compiled Alice boot under Bun

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -11,11 +11,16 @@ on:
       - "install"
       - "package.json"
       - "packages/cli/**"
+      - "packages/guardian-runtime/**"
+      - "packages/uta-protocol/**"
+      - "src/**"
+      - "ui/**"
       - "scripts/install-docker-smoke.mjs"
       - "scripts/install-channel-smoke.mjs"
       - "scripts/install-channel-smoke/**"
       - "scripts/install-smoke/**"
       - "scripts/build-bun-cli-feasibility.ts"
+      - "scripts/build-bun-alice-feasibility.ts"
       - "scripts/remote-ssh-smoke.mjs"
       - "scripts/remote-smoke/**"
   push:
@@ -39,13 +44,13 @@ concurrency:
 jobs:
   bun-cli-feasibility:
     if: github.event_name != 'push'
-    name: Bun CLI feasibility (${{ matrix.os }})
+    name: Bun feasibility (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v7
@@ -61,9 +66,13 @@ jobs:
         with:
           bun-version-file: ".bun-version"
 
-      - run: pnpm install --frozen-lockfile --filter=@traderalice/openalice-cli...
+      - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
+
+      - run: pnpm build:server
 
       - run: pnpm build:bun-cli:feasibility
+
+      - run: pnpm build:bun-alice:feasibility
 
   checkout-install:
     if: github.event_name != 'push'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:server": "turbo run build --filter=!@traderalice/desktop --filter=!./packages/uta-broker-* && tsup src/main.ts --format esm --dts",
     "build:headless-runtime": "tsx scripts/build-headless-runtime.ts",
     "build:bun-cli:feasibility": "bun scripts/build-bun-cli-feasibility.ts",
+    "build:bun-alice:feasibility": "bun scripts/build-bun-alice-feasibility.ts",
     "build:migration-index": "tsx scripts/build-migration-index.ts",
     "broker-packs:build": "turbo run build --filter=./packages/uta-broker-* && tsx scripts/build-broker-packs.ts && pnpm broker-packs:verify",
     "broker-packs:upgrade-smoke": "tsx scripts/broker-pack-upgrade-smoke.ts",

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -351,7 +351,7 @@ Checkboxes reflect repository truth, not intent.
 - [x] Pin the Bun build tool version used by CI and local release builds.
 - [x] Compile the TypeScript CLI and Supervisor TUI for the current host with
   no system Node requirement in the output.
-- [ ] Compile and boot Alice from an isolated `OPENALICE_HOME` with the real Web
+- [x] Compile and boot Alice from an isolated `OPENALICE_HOME` with the real Web
   UI and auth-status route.
 - [ ] Re-execute the compiled binary as Guardian, Alice, UTA, and Connector;
   prove separate PIDs, signal propagation, component failure isolation, and
@@ -649,3 +649,12 @@ This plan is complete only when:
   OrbStack Linux arm64 produced 94,087,312 bytes in 232 ms; emulated Linux x64
   produced 94,079,104 bytes in 480 ms. This proves the command shell only;
   Alice/component boot, PTY, resources, and external broker packs remain open.
+- 2026-08-29: Feasibility increment 2 made `node-pty` lazy at the Session/probe
+  boundary and established `native/node-pty` beside the compiled executable as
+  the candidate native sidecar. Alice now boots from a Bun executable with an
+  empty `PATH`, isolated `OPENALICE_HOME`, and checkout-backed resources; the
+  real UI and `/api/auth/status` both return 200. macOS arm64 measured
+  67,937,378 bytes and 1,433 ms to readiness; OrbStack Linux arm64 measured
+  98,150,544 bytes and 735 ms; emulated Linux x64 measured 98,093,184 bytes and
+  4,047 ms. This does not yet prove PTY loading from the sidecar or embedded
+  resources outside a checkout.

--- a/scripts/build-bun-alice-feasibility.ts
+++ b/scripts/build-bun-alice-feasibility.ts
@@ -1,0 +1,164 @@
+import { createServer } from 'node:net'
+import { cp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, join, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+const pinnedBunVersion = (await readFile(join(repositoryRoot, '.bun-version'), 'utf8')).trim()
+if (Bun.version !== pinnedBunVersion) {
+  throw new Error(`Bun ${pinnedBunVersion} is required, but ${Bun.version} is running`)
+}
+
+const outputRoot = resolve(
+  process.env['OPENALICE_BUN_OUTPUT_DIR']
+    ?? join(repositoryRoot, 'dist/bun-alice-feasibility'),
+)
+const executableName = process.platform === 'win32' ? 'alice.exe' : 'alice'
+const executablePath = join(outputRoot, executableName)
+const smokeHome = join(outputRoot, 'smoke-home')
+
+await rm(outputRoot, { recursive: true, force: true })
+await mkdir(outputRoot, { recursive: true })
+process.chdir(outputRoot)
+
+const nodePtyPackage = dirname(
+  createRequire(import.meta.url).resolve('node-pty/package.json'),
+)
+const nodePtySidecar = join(outputRoot, 'native', 'node-pty')
+await cp(nodePtyPackage, nodePtySidecar, { recursive: true, dereference: true })
+
+const buildStartedAt = performance.now()
+const result = await Bun.build({
+  entrypoints: [join(repositoryRoot, 'src/main.ts')],
+  compile: {
+    outfile: executablePath,
+    autoloadBunfig: false,
+    autoloadDotenv: false,
+  },
+  define: {
+    'globalThis.__OPENALICE_BUN_STANDALONE__': 'true',
+  },
+  minify: true,
+})
+const buildDurationMs = performance.now() - buildStartedAt
+if (!result.success) {
+  for (const log of result.logs) console.error(log)
+  throw new Error('Bun Alice feasibility build failed')
+}
+
+const [webPort, mcpPort, utaPort, connectorPort] = await allocatePorts(4)
+const startedAt = performance.now()
+const child = Bun.spawn([executablePath], {
+  cwd: outputRoot,
+  env: {
+    HOME: smokeHome,
+    PATH: '',
+    TMPDIR: process.env['TMPDIR'] ?? '/tmp',
+    OPENALICE_HOME: smokeHome,
+    OPENALICE_APP_HOME: repositoryRoot,
+    OPENALICE_TRADING_MODE: 'lite',
+    OPENALICE_BIND_HOST: '127.0.0.1',
+    OPENALICE_WEB_PORT: String(webPort),
+    OPENALICE_MCP_PORT: String(mcpPort),
+    OPENALICE_UTA_PORT: String(utaPort),
+    OPENALICE_CONNECTOR_PORT: String(connectorPort),
+  },
+  stdout: 'pipe',
+  stderr: 'pipe',
+})
+const stdoutPromise = new Response(child.stdout).text()
+const stderrPromise = new Response(child.stderr).text()
+
+let authStatus = 0
+let rootStatus = 0
+let readyDurationMs = 0
+let probeError: unknown = null
+try {
+  const auth = await waitForHttp(`http://127.0.0.1:${webPort}/api/auth/status`, 30_000)
+  authStatus = auth.status
+  JSON.parse(auth.body)
+  readyDurationMs = Math.round(performance.now() - startedAt)
+  const root = await waitForHttp(`http://127.0.0.1:${webPort}/`, 10_000)
+  rootStatus = root.status
+  if (!root.body.includes('<div id="root">')) {
+    throw new Error('compiled Alice root did not serve the real Web UI shell')
+  }
+} catch (error) {
+  probeError = error
+} finally {
+  child.kill('SIGTERM')
+}
+const exitCode = await child.exited
+const stdout = await stdoutPromise
+const stderr = await stderrPromise
+if (exitCode !== 0) {
+  throw new Error(`compiled Alice exited with ${exitCode}: ${stderr || stdout}`)
+}
+if (probeError) {
+  throw new Error(`compiled Alice probe failed: ${String(probeError)}\n${stderr || stdout}`)
+}
+if (authStatus !== 200 || rootStatus !== 200) {
+  throw new Error(`compiled Alice HTTP probes failed: auth=${authStatus} root=${rootStatus}`)
+}
+
+const executable = await stat(executablePath)
+const report = {
+  schemaVersion: 1,
+  status: 'pass',
+  bunVersion: Bun.version,
+  platform: process.platform,
+  arch: process.arch,
+  executable: basename(executablePath),
+  executableBytes: executable.size,
+  buildDurationMs: Math.round(buildDurationMs),
+  readyDurationMs,
+  authStatus,
+  rootStatus,
+  ptySidecar: 'native/node-pty',
+  smokePath: '',
+}
+await writeFile(join(outputRoot, 'report.json'), `${JSON.stringify(report, null, 2)}\n`)
+console.log(`Bun Alice feasibility boot passed: ${executablePath}`)
+console.log(JSON.stringify(report))
+
+async function waitForHttp(
+  url: string,
+  timeoutMs: number,
+): Promise<{ status: number; body: string }> {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown = null
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      const body = await response.text()
+      if (response.status === 200) return { status: response.status, body }
+      lastError = new Error(`${url} returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(100)
+  }
+  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
+}
+
+async function allocatePorts(count: number): Promise<number[]> {
+  const ports: number[] = []
+  for (let index = 0; index < count; index += 1) {
+    const server = createServer()
+    await new Promise<void>((resolveListen, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolveListen)
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      server.close()
+      throw new Error('Could not allocate an isolated loopback port')
+    }
+    ports.push(address.port)
+    await new Promise<void>((resolveClose, reject) => {
+      server.close((error) => error ? reject(error) : resolveClose())
+    })
+  }
+  return ports
+}

--- a/src/workspaces/persistent-session.spec.ts
+++ b/src/workspaces/persistent-session.spec.ts
@@ -83,6 +83,7 @@ function makeOptions(over: Partial<PersistentSessionOptions> = {}): PersistentSe
     highWatermarkBytes: 1024, // small so one write trips backpressure
     lowWatermarkBytes: 256,
     onDisposed: () => {},
+    pty: { spawn: mockSpawn },
     ...over,
   };
 }

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -1,7 +1,8 @@
-import * as pty from 'node-pty';
+import type * as NodePty from 'node-pty';
 import type { WebSocket } from 'ws';
 
 import type { Logger } from './logger.js';
+import { loadNodePty } from './pty-runtime.js';
 import { HeadlessTerminalSnapshot } from './headless-terminal-snapshot.js';
 import {
   isClientControlMessage,
@@ -31,6 +32,8 @@ export interface PersistentSessionOptions {
   readonly highWatermarkBytes: number;
   readonly lowWatermarkBytes: number;
   readonly onDisposed: () => void;
+  /** Test seam; production loads the platform module only when spawning. */
+  readonly pty?: Pick<NodePtyModule, 'spawn'>;
   readonly initialTerminalViewAttributes?: TerminalViewAttributes;
   readonly onTerminalViewAttributes?: (attributes: TerminalViewAttributes) => void;
   /**
@@ -84,8 +87,10 @@ const RESPAWN_WINDOW_LIMIT = 3;
  * the client can persist `lastSeq` and request a tight replay window on
  * reattach.
  */
+type NodePtyModule = typeof import('node-pty');
+
 export class PersistentSession {
-  private term: pty.IPty;
+  private term: NodePty.IPty;
   private readonly buffer: ReplayBuffer;
   private readonly headless: HeadlessTerminalSnapshot;
   private terminalViewAttributes: TerminalViewAttributes | null = null;
@@ -160,7 +165,7 @@ export class PersistentSession {
     });
   }
 
-  private spawnChild(): pty.IPty {
+  private spawnChild(): NodePty.IPty {
     if (this.opts.command.length === 0) {
       throw new Error('command must contain at least one argv element');
     }
@@ -173,7 +178,7 @@ export class PersistentSession {
     }).argv;
     if (!argv0) throw new Error('command must contain at least one argv element');
 
-    const term = pty.spawn(argv0, args, {
+    const term = (this.opts.pty ?? loadNodePty()).spawn(argv0, args, {
       name: 'xterm-256color',
       cols: this.currentCols,
       rows: this.currentRows,
@@ -195,7 +200,7 @@ export class PersistentSession {
    * we open the circuit breaker and dispose for real.
    */
   private onChildExit(
-    exited: pty.IPty,
+    exited: NodePty.IPty,
     exitCode: number,
     signalRaw: number | undefined,
   ): void {

--- a/src/workspaces/probe.ts
+++ b/src/workspaces/probe.ts
@@ -24,9 +24,8 @@
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import * as pty from 'node-pty';
-
 import type { Logger } from './logger.js';
+import { loadNodePty } from './pty-runtime.js';
 import { resolveLaunchCommand } from './win-command.js';
 
 export interface HeadlessProbeArgs {
@@ -40,6 +39,8 @@ export interface HeadlessProbeArgs {
   readonly logger: Logger;
   /** Closes directory-operation start races once the PTY actually exists. */
   readonly onSpawned?: () => void;
+  /** Test seam; production loads the platform module only when probing. */
+  readonly pty?: Pick<typeof import('node-pty'), 'spawn'>;
 }
 
 export interface JsonlFileDelta {
@@ -87,7 +88,7 @@ export async function runHeadlessProbe(args: HeadlessProbeArgs): Promise<Headles
   let signal: number | null = null;
   let killed = false;
 
-  const child = pty.spawn(argv0, argv1, {
+  const child = (args.pty ?? loadNodePty()).spawn(argv0, argv1, {
     cwd,
     env: env as { [key: string]: string },
     cols: 80,

--- a/src/workspaces/pty-runtime.ts
+++ b/src/workspaces/pty-runtime.ts
@@ -1,0 +1,27 @@
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+type NodePtyModule = typeof import('node-pty')
+
+const runtimeRequire = createRequire(import.meta.url)
+let cachedNodePty: NodePtyModule | null = null
+
+/**
+ * Load the platform PTY only when a Session or probe actually needs it.
+ *
+ * Source and Electron modes resolve the ordinary workspace dependency. A Bun
+ * standalone resolves the installer-owned native sidecar beside the primary
+ * executable, keeping native code out of startup for users who never launch an
+ * Agent Runtime.
+ */
+export function loadNodePty(): NodePtyModule {
+  if (cachedNodePty) return cachedNodePty
+  const standalone = (
+    globalThis as { __OPENALICE_BUN_STANDALONE__?: boolean }
+  ).__OPENALICE_BUN_STANDALONE__ === true
+  const modulePath = standalone
+    ? join(dirname(process.execPath), 'native', 'node-pty')
+    : 'node-pty'
+  cachedNodePty = runtimeRequire(modulePath) as NodePtyModule
+  return cachedNodePty
+}


### PR DESCRIPTION
## What changed

- compile Alice itself as a Bun standalone executable and boot it with an empty `PATH` plus isolated `OPENALICE_HOME`
- verify the real UI shell and `/api/auth/status` instead of treating a successful compile as runtime proof
- defer `node-pty` loading until a Session or probe actually spawns, preserving source and Electron behavior
- stage `native/node-pty` beside the executable as the candidate native sidecar for the next PTY increment
- run both Bun feasibility probes on macOS and Ubuntu CI when runtime, UI, or packaging inputs change
- record the measured feasibility results and remaining gates in the canonical plan

## Verification

- `pnpm build:bun-alice:feasibility` — macOS arm64, empty PATH, UI/auth 200
- OrbStack `oven/bun:1.3.14` — Linux arm64 and emulated Linux x64, empty PATH, UI/auth 200
- `pnpm build:bun-cli:feasibility`
- `npx vitest run src/workspaces/persistent-session.spec.ts src/workspaces/agent-probe.spec.ts`
- `npx tsc --noEmit`
- `pnpm test` — 4,998 passed, 9 skipped
- `pnpm build`
- `pnpm electron:smoke:pty`
- `pnpm test:install:docker`
- workflow YAML parse and `git diff --check`

## Deliberately still open

- loading and exercising `node-pty` from the compiled distribution sidecar
- self-reexec as Guardian/Alice/UTA/Connector with separate PID and signal proofs
- embedded production resources without a checkout-backed `OPENALICE_APP_HOME`
- external broker packs and Windows-native acceptance
