### PR TITLE
fix: run Bun workspace bootstrap through standalone

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -670,3 +670,16 @@ This plan is complete only when:
   sidecar. Bun's current Terminal API has no output pause/resume equivalent,
   and its 1.4 type contract still describes PTY support as POSIX-only, so
   high-output backpressure and native Windows x64 remain explicit gates.
+- 2026-08-29: A real isolated `Bun Grok Live` AliceProject exposed that the
+  standalone executable could boot and serve the UI but could not initialize
+  its first Chat Workspace: `process.execPath` re-launched Alice instead of
+  interpreting `bootstrap.mjs`, then an external dynamic import could not
+  resolve `dugite`. The Bun build now re-enters the same executable through an
+  internal bootstrap role and supplies the bundled git executor to the plain
+  ESM template helper. The compiled build gate materializes a real Chat
+  Workspace with an empty `PATH`. After rebuilding, the browser created the
+  Workspace, launched installed Grok Build 1.0.13 as an independent Bun-native
+  PTY process, received `BUN_PTY_GROK_OK` plus the correct Workspace cwd,
+  stopped it without stopping Alice, restarted Alice under the same named
+  project identity, resumed the native Grok session, and received
+  `REATTACH_OK`.

--- a/scripts/build-bun-alice-feasibility.ts
+++ b/scripts/build-bun-alice-feasibility.ts
@@ -3,6 +3,8 @@ import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { INTERNAL_BOOTSTRAP_ROLE } from '../src/workspaces/bootstrap-runtime.js'
+
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 const pinnedBunVersion = (await readFile(join(repositoryRoot, '.bun-version'), 'utf8')).trim()
 if (Bun.version !== pinnedBunVersion) {
@@ -18,6 +20,7 @@ const executablePath = join(outputRoot, executableName)
 const ptySmokeName = process.platform === 'win32' ? 'pty-smoke.exe' : 'pty-smoke'
 const ptySmokePath = join(outputRoot, ptySmokeName)
 const smokeHome = join(outputRoot, 'smoke-home')
+const bootstrapWorkspace = join(outputRoot, 'bootstrap-workspace')
 
 await rm(outputRoot, { recursive: true, force: true })
 await mkdir(outputRoot, { recursive: true })
@@ -31,12 +34,58 @@ const result = await Bun.build({
     autoloadBunfig: false,
     autoloadDotenv: false,
   },
+  define: {
+    'globalThis.__OPENALICE_BUN_STANDALONE__': 'true',
+  },
   minify: true,
 })
 const buildDurationMs = performance.now() - buildStartedAt
 if (!result.success) {
   for (const log of result.logs) console.error(log)
   throw new Error('Bun Alice feasibility build failed')
+}
+
+const bootstrapProbe = Bun.spawn([
+  executablePath,
+  INTERNAL_BOOTSTRAP_ROLE,
+  join(repositoryRoot, 'src/workspaces/templates/chat/bootstrap.mjs'),
+  'bun-feasibility',
+  bootstrapWorkspace,
+], {
+  cwd: outputRoot,
+  env: {
+    HOME: smokeHome,
+    PATH: '',
+    TMPDIR: process.env['TMPDIR'] ?? '/tmp',
+    ELECTRON_RUN_AS_NODE: '1',
+    AQ_TEMPLATE_ROOT: join(repositoryRoot, 'src/workspaces/templates/chat'),
+    ...(process.env['LOCAL_GIT_DIRECTORY']
+      ? { LOCAL_GIT_DIRECTORY: process.env['LOCAL_GIT_DIRECTORY'] }
+      : {}),
+    ...(process.env['GIT_EXEC_PATH']
+      ? { GIT_EXEC_PATH: process.env['GIT_EXEC_PATH'] }
+      : {}),
+    ...(process.env['SystemRoot'] ? { SystemRoot: process.env['SystemRoot'] } : {}),
+  },
+  stdout: 'pipe',
+  stderr: 'pipe',
+})
+const [bootstrapExitCode, bootstrapStdout, bootstrapStderr] = await Promise.all([
+  bootstrapProbe.exited,
+  new Response(bootstrapProbe.stdout).text(),
+  new Response(bootstrapProbe.stderr).text(),
+])
+if (bootstrapExitCode !== 0) {
+  throw new Error(
+    `compiled Bun workspace bootstrap exited with ${bootstrapExitCode}: ${bootstrapStderr || bootstrapStdout}`,
+  )
+}
+const [bootstrapHead, bootstrapReadme] = await Promise.all([
+  readFile(join(bootstrapWorkspace, '.git/HEAD'), 'utf8'),
+  readFile(join(bootstrapWorkspace, 'README.md'), 'utf8'),
+])
+if (!bootstrapHead.startsWith('ref: refs/heads/') || bootstrapReadme.trim().length === 0) {
+  throw new Error('compiled Bun workspace bootstrap did not materialize the Chat template')
 }
 
 const ptyBuild = await Bun.build({
@@ -151,6 +200,11 @@ const report = {
   authStatus,
   rootStatus,
   pty: ptyReport,
+  workspaceBootstrap: {
+    status: 'pass',
+    template: 'chat',
+    nodeOrBunOnPath: false,
+  },
   smokePath: '',
 }
 await writeFile(join(outputRoot, 'report.json'), `${JSON.stringify(report, null, 2)}\n`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ import { createInboxStore } from './core/inbox-store.js'
 import { startInboxConnectorBridge } from './services/connector-client/index.js'
 import { startConnectorActionBridge } from './services/connector-client/action-bridge.js'
 import { createWorkspaceConversationControl } from './workspaces/conversation-control.js'
+import { runInternalBootstrapRole } from './workspaces/bootstrap-runtime.js'
 import { startTelegramDeskInboundPoll, telegramDeskHasRunningWork } from './workspaces/issues/telegram-desk-chat.js'
 import { ToolCenter } from './core/tool-center.js'
 import { WorkspaceToolCenter } from './core/workspace-tool-center.js'
@@ -477,7 +478,12 @@ function positiveInteger(raw: string | undefined): number | undefined {
   return Number.isInteger(value) && value > 0 ? value : undefined
 }
 
-start().catch((err) => {
+async function runEntrypoint(): Promise<void> {
+  if (await runInternalBootstrapRole()) return
+  await start()
+}
+
+runEntrypoint().catch((err) => {
   console.error('fatal:', err)
   process.exit(1)
 })

--- a/src/workspaces/bootstrap-runtime.ts
+++ b/src/workspaces/bootstrap-runtime.ts
@@ -1,0 +1,56 @@
+import { pathToFileURL } from 'node:url';
+
+import { exec as bundledGitExec } from 'dugite';
+
+export const INTERNAL_BOOTSTRAP_ROLE = '--openalice-internal-bootstrap';
+
+export interface BootstrapInvocation {
+  readonly command: string;
+  readonly args: string[];
+}
+
+/**
+ * A Bun-compiled executable cannot interpret an external `.mjs` file merely
+ * by re-executing `process.execPath`: that path is Alice itself. Re-enter the
+ * same executable through a private role so the embedded Bun runtime imports
+ * the bootstrap without requiring a system Node or Bun installation.
+ */
+export function resolveMjsBootstrapInvocation(
+  script: string,
+  args: readonly string[],
+): BootstrapInvocation {
+  const standalone = (
+    globalThis as { __OPENALICE_BUN_STANDALONE__?: boolean }
+  ).__OPENALICE_BUN_STANDALONE__ === true;
+  return {
+    command: process.execPath,
+    args: standalone
+      ? [INTERNAL_BOOTSTRAP_ROLE, script, ...args]
+      : [script, ...args],
+  };
+}
+
+/** Execute one external bootstrap in the Bun standalone's child process. */
+export async function runInternalBootstrapRole(
+  argv: readonly string[] = process.argv,
+): Promise<boolean> {
+  const roleIndex = argv.indexOf(INTERNAL_BOOTSTRAP_ROLE);
+  if (roleIndex < 0) return false;
+
+  const script = argv[roleIndex + 1];
+  if (!script?.endsWith('.mjs')) {
+    throw new Error(`${INTERNAL_BOOTSTRAP_ROLE} requires an .mjs script path`);
+  }
+  const scriptArgs = argv.slice(roleIndex + 2);
+  process.argv = [process.execPath, script, ...scriptArgs];
+  const runtimeGlobal = globalThis as typeof globalThis & {
+    __OPENALICE_BOOTSTRAP_GIT_EXEC__?: typeof bundledGitExec;
+  };
+  runtimeGlobal.__OPENALICE_BOOTSTRAP_GIT_EXEC__ = bundledGitExec;
+  try {
+    await import(pathToFileURL(script).href);
+  } finally {
+    delete runtimeGlobal.__OPENALICE_BOOTSTRAP_GIT_EXEC__;
+  }
+  return true;
+}

--- a/src/workspaces/templates/_common.mjs
+++ b/src/workspaces/templates/_common.mjs
@@ -2,11 +2,10 @@
  * Shared helpers for the Node workspace bootstrap scripts — the cross-platform
  * port of `_common.sh`.
  *
- * Plain ESM, run directly by the Electron-bundled Node (the launcher spawns it
- * via `process.execPath` + `ELECTRON_RUN_AS_NODE`). So: NO TypeScript syntax,
- * only `node:*` builtins + `dugite`. Resolved via node walk-up from the
- * template dir to the app's `node_modules` (works in dev and in the packaged
- * `asar:false` app).
+ * Plain ESM, run by the Electron-bundled Node or by the Bun standalone's
+ * internal bootstrap role. So: NO TypeScript syntax, only `node:*` builtins
+ * plus the launcher-owned dugite executor. Node resolves dugite through the
+ * packaged dependency tree; the compiled Bun role injects its bundled copy.
  *
  * This is the SOLE importer of `dugite` among the templates: all git goes
  * through `git()` so workspace creation uses OpenAlice's bundled git — no
@@ -17,7 +16,10 @@
 
 import { existsSync, mkdirSync, copyFileSync, appendFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { exec } from 'dugite'
+const injectedGitExec = globalThis.__OPENALICE_BOOTSTRAP_GIT_EXEC__
+const exec = typeof injectedGitExec === 'function'
+  ? injectedGitExec
+  : (await import('dugite')).exec
 
 /**
  * Run a git command via the bundled git, rooted at `cwd`. Throws on a non-zero

--- a/src/workspaces/workspace-creator.spec.ts
+++ b/src/workspaces/workspace-creator.spec.ts
@@ -15,6 +15,7 @@ import * as childProcess from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { orderCreateAdapters, resolveTemplateSource, runScript } from './workspace-creator.js';
+import { INTERNAL_BOOTSTRAP_ROLE } from './bootstrap-runtime.js';
 import type { TemplateMeta } from './template-registry.js';
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -130,6 +131,7 @@ describe('runScript platform branching', () => {
   afterEach(() => {
     setPlatform(originalPlatform);
     mockSpawn.mockReset();
+    vi.unstubAllGlobals();
   });
 
   it('on macOS / Linux, spawns the script directly so kernel reads the shebang', async () => {
@@ -212,6 +214,24 @@ describe('runScript platform branching', () => {
     expect(mockSpawn).toHaveBeenCalledWith(
       process.execPath,
       ['/tmp/foo/bootstrap.mjs', 't', '/out'],
+      expect.objectContaining({ env: expect.objectContaining({ ELECTRON_RUN_AS_NODE: '1' }) }),
+    );
+  });
+
+  it('a Bun standalone re-enters Alice through the internal bootstrap role', async () => {
+    setPlatform('darwin');
+    vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true);
+    const child = makeFakeChild();
+    mockSpawn.mockReturnValue(child as unknown as childProcess.ChildProcess);
+
+    const promise = runScript('/tmp/foo/bootstrap.mjs', ['t', '/out'], {}, 60_000);
+    child.emit('close', 0);
+    const res = await promise;
+
+    expect(res.ok).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      process.execPath,
+      [INTERNAL_BOOTSTRAP_ROLE, '/tmp/foo/bootstrap.mjs', 't', '/out'],
       expect.objectContaining({ env: expect.objectContaining({ ELECTRON_RUN_AS_NODE: '1' }) }),
     );
   });

--- a/src/workspaces/workspace-creator.ts
+++ b/src/workspaces/workspace-creator.ts
@@ -12,6 +12,7 @@ import {
 } from '@/core/config.js';
 
 import { prepareAgentRuntimeWorkspace, type AdapterRegistry } from './cli-adapter.js';
+import { resolveMjsBootstrapInvocation } from './bootstrap-runtime.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import { credentialToWorkspaceAiCred } from './credential-injection.js';
 import type { Logger } from './logger.js';
@@ -511,19 +512,24 @@ export function runScript(
   const isMjs = script.endsWith('.mjs');
   const isWindows = process.platform === 'win32';
 
-  // `.mjs` (built-in templates): run on the Electron-bundled Node. In the
-  // packaged app `process.execPath` is the Electron binary; ELECTRON_RUN_AS_NODE
-  // flips it to pure-Node mode (a harmless no-op for a plain `node` execPath in
-  // dev). No bash, no shebang reliance → works on a bare Windows/Mac box.
+  // `.mjs` (built-in templates): Node/Electron uses its bundled Node runtime.
+  // A Bun standalone re-enters the same Alice executable through a private
+  // bootstrap role because its process.execPath is the product binary, not a
+  // general-purpose Bun interpreter. No system Node/Bun/bash is required.
+  // ELECTRON_RUN_AS_NODE flips Electron to pure-Node mode and is harmless for
+  // the other runtimes.
   // `.sh` (third-party fallback): unix reads the `#!/usr/bin/env bash` shebang;
   // Windows has no native bash, so invoke the Git-for-Windows executable we
   // resolved above (with a final bare-name fallback for WSL/custom PATHs).
-  const cmd = isMjs
-    ? process.execPath
+  const mjsInvocation = isMjs
+    ? resolveMjsBootstrapInvocation(script, args)
+    : null;
+  const cmd = mjsInvocation
+    ? mjsInvocation.command
     : isWindows
       ? resolveBashPath(process.env, 'win32') ?? 'bash'
       : script;
-  const cmdArgs = isMjs || isWindows ? [script, ...args] : args;
+  const cmdArgs = mjsInvocation?.args ?? (isWindows ? [script, ...args] : args);
   const env = isMjs
     ? { ...process.env, ...extraEnv, ELECTRON_RUN_AS_NODE: '1' }
     : { ...process.env, ...extraEnv };


### PR DESCRIPTION
## Outcome

Make the compiled Bun Alice executable bootstrap Workspace templates through a private self-reentry role, so the CLI runtime does not need Node or Bun on PATH while preserving the existing multi-process agent-runtime model.

## Real runtime evidence

- Created a fresh named Trader AliceProject and started the compiled Bun Alice server.
- Initialized a real Chat Workspace from the UI.
- Selected the locally installed Grok Build adapter and launched it as an independent child process through the Bun-native PTY backend.
- Grok returned `BUN_PTY_GROK_OK` and the exact new Workspace cwd.
- Stopped the Grok process without stopping Alice.
- Restarted Alice with the same AliceProject identity, resumed the Workspace, and received `REATTACH_OK`.

## Blockers found and fixed

1. A compiled Bun executable cannot use `process.execPath` as though it were Node: doing so re-entered normal Alice startup and collided with `runtime.lock`.
2. An external bootstrap module could not dynamically resolve `dugite` from the compiled executable.

The standalone build now recognizes an internal bootstrap role before normal startup and injects the statically bundled Git executor into the external template bootstrap. Node/Electron behavior remains unchanged.

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 600 files passed, 1 skipped; 5000 tests passed, 9 skipped
- targeted Workspace/PTY/session specs — 27 tests passed
- Workspace creation E2E — 4 tests passed
- macOS arm64 Bun 1.4 build, Alice boot, two PTYs, and Chat Workspace bootstrap with no Node/Bun on PATH
- Orb Linux arm64 and emulated Linux x64 Bun build/runtime/bootstrap smoke
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- `git diff --check`

## Remaining feasibility gates

- Windows Bun PTY behavior is not yet proven.
- Bun output pause/resume/backpressure remains open.
- Final CLI artifact still needs an explicit Git distribution boundary. The local macOS proof used checkout-backed Dugite Git; Linux used container system Git.
- This increment proves the Alice component and real Workspace/agent path; it does not yet bundle Guardian, UTA, or Connector into the Bun CLI distribution.
