### PR TITLE
fix: make desktop shutdown deterministic

### DIFF
--- a/apps/desktop/src/app-exit.spec.ts
+++ b/apps/desktop/src/app-exit.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { exitDesktopProcess } from './app-exit.js'
+
+describe('exitDesktopProcess', () => {
+  it('requests Electron exit and arms an unrefed hard-exit fallback', () => {
+    const appExit = vi.fn()
+    const processExit = vi.fn(() => undefined as never)
+    const unref = vi.fn()
+    let fallback: (() => void) | undefined
+    const schedule = vi.fn((callback: () => void, delayMs: number) => {
+      fallback = callback
+      expect(delayMs).toBe(250)
+      return { unref }
+    })
+
+    exitDesktopProcess(7, { appExit, processExit, fallbackMs: 250, schedule })
+
+    expect(appExit).toHaveBeenCalledWith(7)
+    expect(unref).toHaveBeenCalledOnce()
+    expect(processExit).not.toHaveBeenCalled()
+
+    fallback?.()
+    expect(processExit).toHaveBeenCalledWith(7)
+  })
+})

--- a/apps/desktop/src/app-exit.ts
+++ b/apps/desktop/src/app-exit.ts
@@ -1,0 +1,24 @@
+export interface DesktopExitOptions {
+  readonly appExit: (exitCode: number) => void
+  readonly processExit: (exitCode: number) => never
+  readonly fallbackMs?: number
+  readonly schedule?: (callback: () => void, delayMs: number) => Pick<ReturnType<typeof setTimeout>, 'unref'>
+}
+
+/**
+ * Finish Electron shutdown after every managed child and runtime lock is gone.
+ *
+ * `app.exit()` is the preferred Electron path, but it has occasionally left
+ * the outer process alive after the last BrowserWindow closes in packaged
+ * upgrade smoke. A short, unref'ed process fallback makes the Guardian's final
+ * lifecycle boundary deterministic without shortening child shutdown grace.
+ */
+export function exitDesktopProcess(exitCode: number, options: DesktopExitOptions): void {
+  const schedule = options.schedule ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+  const fallback = schedule(
+    () => options.processExit(exitCode),
+    options.fallbackMs ?? 1_000,
+  )
+  fallback.unref()
+  options.appExit(exitCode)
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -58,6 +58,7 @@ import {
 import { existingOwnerSmokeMode, resolveExistingOwnerStartup } from './existing-owner-startup.js'
 import { inspectPreviousUpdateAttempt, recordUpdateAttempt } from './update-attempt.js'
 import { childIsRunning, stopChild } from './child-shutdown.js'
+import { exitDesktopProcess } from './app-exit.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -1316,7 +1317,11 @@ function shutdown(): void {
   void stopChildren().finally(async () => {
     await releaseGuardianRuntimeLock()
     const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0
-    app.exit(exitCode)
+    console.log(`[guardian] shutdown complete → exit ${exitCode}`)
+    exitDesktopProcess(exitCode, {
+      appExit: (code) => app.exit(code),
+      processExit: (code) => process.exit(code),
+    })
   })
 }
 


### PR DESCRIPTION
## Outcome

Make packaged Electron shutdown deterministic after managed children and the Guardian runtime lock have already been released.

The previous Bun bootstrap increment exposed repeated N-1 upgrade-smoke timeouts after the renderer closed. The app now keeps Electron's normal `app.exit()` path and arms a short unrefed `process.exit()` fallback as the final Guardian boundary. Child shutdown grace and forced tree cleanup still complete before this fallback is armed.

## Verification

- `pnpm vitest run apps/desktop/src/app-exit.spec.ts apps/desktop/src/child-shutdown.spec.ts`
- `npx tsc -p apps/desktop/tsconfig.json --noEmit`
- `npx tsc --noEmit`
- `pnpm test` — 601 files passed, 1 skipped; 5001 tests passed, 9 skipped
- `pnpm test:guardian-recovery`
- `pnpm test:smoke`
- `pnpm electron:smoke:guardian-recovery`
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace`
- local N-1 `v0.90.0-beta` -> candidate -> candidate restart upgrade acceptance, all checks passed
- `git diff --check`

The local packaged and upgrade paths both emitted `[guardian] shutdown complete → exit 0` before the application process exited.
