### PR TITLE
fix(workspaces): preserve streaming markdown whitespace

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -131,6 +131,12 @@ control, whether it resolves from login, environment, user settings, or local
 project files. Launcher-owned explicit `--settings` remain available in both
 modes.
 
+Headless streaming adapters must preserve incremental assistant text exactly,
+including standalone spaces and newlines. Those whitespace-only deltas carry
+Markdown structure and must not pass through truthiness checks based on
+`trim()`. Trimming remains appropriate only at a final-result or display
+boundary where the adapter has received one complete message.
+
 A registered provider default is descriptive model metadata, not an implicit
 Session launch parameter. OpenAlice may label that default in selection help,
 but it persists and projects an effort only when a Workspace preference, Issue,

--- a/src/workspaces/adapters/agy.spec.ts
+++ b/src/workspaces/adapters/agy.spec.ts
@@ -281,8 +281,26 @@ describe('agy headless extractors', () => {
     expect(agyAdapter.extractHeadlessAssistantText?.(assistant)).toBeNull();
     expect(agyAdapter.extractHeadlessAssistantText?.(result)).toBe('Git rebase rewrites history.\n');
     expect(agyAdapter.extractHeadlessOutputEvents?.(assistant)).toEqual([
-      { type: 'text', text: 'Git rebase rewrites history.\n' },
+      { type: 'text', text: 'Git rebase rewrites history.\n', delta: true },
     ]);
+  });
+
+  it('preserves and joins standalone whitespace text deltas', () => {
+    const chunks = ['#', ' ', 'Heading', '\n\n', '-', ' ', 'item'];
+    for (const chunk of chunks) {
+      expect(agyAdapter.extractHeadlessOutputEvents?.(JSON.stringify({
+        event: 'step_update',
+        step_update: { step_type: 'agent_response', text_delta: chunk },
+      }))).toEqual([{ type: 'text', text: chunk, delta: true }]);
+    }
+
+    expect(parseHeadlessOutputText({
+      text: chunks.map((text_delta) => JSON.stringify({
+        event: 'step_update',
+        step_update: { step_type: 'agent_response', text_delta },
+      })).join('\n'),
+      extractEvents: agyAdapter.extractHeadlessOutputEvents!.bind(agyAdapter),
+    }).assistantText).toBe('# Heading\n\n- item');
   });
 
   it('reads documented tool step_update events', () => {
@@ -330,7 +348,7 @@ describe('agy headless extractors', () => {
       schemaVersion: 1,
       assistantText: 'Git rebase rewrites history.',
       blocks: [
-        { type: 'text', text: 'Git rebase rewrites history.' },
+        { type: 'text', text: 'Git rebase rewrites history.\n' },
         {
           type: 'tool',
           id: 'step-4',

--- a/src/workspaces/adapters/agy.ts
+++ b/src/workspaces/adapters/agy.ts
@@ -262,7 +262,7 @@ export const agyAdapter: CliAdapter = {
     if (evt['event'] === 'step_update' && isRecord(evt['step_update'])) {
       const step = evt['step_update'];
       if (step['step_type'] === 'agent_response' && typeof step['text_delta'] === 'string' && step['text_delta']) {
-        return [{ type: 'text', text: step['text_delta'] }];
+        return [{ type: 'text', text: step['text_delta'], delta: true }];
       }
       if (step['step_type'] === 'tool') return agyToolEvents(step);
       return [];

--- a/src/workspaces/adapters/grok.spec.ts
+++ b/src/workspaces/adapters/grok.spec.ts
@@ -248,6 +248,21 @@ describe('grok headless extractors', () => {
     expect(grokAdapter.extractHeadlessAssistantText?.('  "text": "PONG",')).toBeNull();
   });
 
+  it('preserves standalone whitespace deltas used by Markdown layout', () => {
+    const chunks = ['#', ' ', 'Heading', '\n\n', '-', ' ', 'item'];
+    for (const chunk of chunks) {
+      expect(grokAdapter.extractHeadlessOutputEvents?.(JSON.stringify({
+        type: 'text',
+        data: chunk,
+      }))).toEqual([{ type: 'text', text: chunk, delta: true }]);
+    }
+
+    expect(parseHeadlessOutputText({
+      text: chunks.map((data) => JSON.stringify({ type: 'text', data })).join('\n'),
+      extractEvents: grokAdapter.extractHeadlessOutputEvents!.bind(grokAdapter),
+    }).assistantText).toBe('# Heading\n\n- item');
+  });
+
   it('reads live 1.0.4 flattened tool_call / tool_call_update lines', () => {
     const started = JSON.stringify({
       type: 'tool_call',

--- a/src/workspaces/adapters/grok.ts
+++ b/src/workspaces/adapters/grok.ts
@@ -112,7 +112,10 @@ function bytesToUtf8(value: unknown): string | null {
 }
 
 function textFromContent(value: unknown): string | null {
-  if (typeof value === 'string' && value.trim()) return value;
+  // Streaming text can legitimately arrive as a standalone space or newline.
+  // Reject only empty strings so concatenating deltas preserves the model's
+  // exact Markdown layout.
+  if (typeof value === 'string' && value.length > 0) return value;
   if (Array.isArray(value)) {
     const parts = value.flatMap((item) => {
       if (!isRecord(item)) return [];
@@ -126,8 +129,8 @@ function textFromContent(value: unknown): string | null {
     return parts.length > 0 ? parts.join('') : null;
   }
   if (!isRecord(value)) return null;
-  if (typeof value['text'] === 'string' && value['text'].trim()) return value['text'];
-  if (typeof value['data'] === 'string' && value['data'].trim()) return value['data'];
+  if (typeof value['text'] === 'string' && value['text'].length > 0) return value['text'];
+  if (typeof value['data'] === 'string' && value['data'].length > 0) return value['data'];
   return null;
 }
 

--- a/src/workspaces/headless-output.spec.ts
+++ b/src/workspaces/headless-output.spec.ts
@@ -294,7 +294,7 @@ describe('headless structured output', () => {
     ])
     expect(output.assistantText).toBe('Git rebase rewrites history.')
     expect(output.blocks).toEqual([
-      { type: 'text', text: 'Git rebase rewrites history.' },
+      { type: 'text', text: 'Git rebase rewrites history.\n' },
       {
         type: 'tool',
         id: 'step-4',


### PR DESCRIPTION
## Summary
- preserve standalone spaces and newlines in Grok streaming text deltas
- mark Antigravity `text_delta` events as incremental so they assemble losslessly
- document and test the cross-adapter whitespace-preservation contract

## Root cause
Grok Build emitted valid standalone whitespace deltas, but the adapter rejected them with `trim()`. Markdown headings, lists, separators, and some ordinary spaces were therefore collapsed before Telegram delivery.

## Verification
- `pnpm exec vitest run src/workspaces/adapters/grok.spec.ts src/workspaces/adapters/agy.spec.ts src/workspaces/adapters/headless-assistant-output.spec.ts src/workspaces/headless-output.spec.ts` (70 passed)
- `npx tsc --noEmit`
- `pnpm test` (5000 passed, 9 skipped)
- replayed the captured Grok stdout from the reported incident: restored 86 newlines and the expected heading/list/spacing structure