### PR TITLE
Build installable Bun release artifact

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -21,6 +21,9 @@ on:
       - "scripts/install-smoke/**"
       - "scripts/build-bun-cli-feasibility.ts"
       - "scripts/build-bun-alice-feasibility.ts"
+      - "scripts/build-bun-runtime-feasibility.ts"
+      - "scripts/build-bun-release.ts"
+      - "THIRD_PARTY_NOTICES.md"
       - "scripts/remote-ssh-smoke.mjs"
       - "scripts/remote-smoke/**"
   push:
@@ -73,6 +76,10 @@ jobs:
       - run: pnpm build:bun-cli:feasibility
 
       - run: pnpm build:bun-alice:feasibility
+
+      - run: pnpm build:bun-runtime:feasibility
+
+      - run: pnpm build:bun:release
 
   checkout-install:
     if: github.event_name != 'push'

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,5 +1,17 @@
 # Third-Party Notices
 
+## Git and Dugite
+
+Native OpenAlice CLI release archives for macOS and Linux redistribute a
+minimal Git command-line runtime sourced from the `dugite` package. The exact
+Dugite and Git versions, platform, architecture, content identity, file hashes,
+and release-owned Git root are recorded in each archive's `release.json`.
+
+Git is licensed under GNU General Public License version 2. Its source and
+license are available from the [official Git project](https://git-scm.com/)
+and [git/git repository](https://github.com/git/git). Dugite's license is
+included in the release archive under `licenses/dugite-LICENSE`.
+
 ## stablyai/orca terminal patches and keyboard policy
 
 `patches/@xterm__addon-webgl@0.20.0-beta.286.patch` is adapted from

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -76,6 +76,13 @@ UTA, and Connector by re-entering the same bytes under separate private roles.
 Every component remains an independent OS process; the provider changes launch
 artifacts, not ownership, health, restart, signal, or lock semantics.
 
+The target-native release layout keeps `bin/openalice` beside
+`share/openalice/`. That resource root owns the real Web UI, defaults,
+templates, external adapter files, Bun Workspace helper launchers, and a
+minimal Git runtime. The Bun provider prepends only that release-owned Git to
+the inherited PATH and records the archive's content identity from
+`release.json`; it does not require or replace a user's system Git.
+
 Source development continues to use `pnpm dev`, and the currently released
 installer continues to use the bundle provider until the Bun release and
 installation acceptance matrix is complete. Electron remains independent.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:bun-cli:feasibility": "bun scripts/build-bun-cli-feasibility.ts",
     "build:bun-alice:feasibility": "bun scripts/build-bun-alice-feasibility.ts",
     "build:bun-runtime:feasibility": "bun scripts/build-bun-runtime-feasibility.ts",
+    "build:bun:release": "bun scripts/build-bun-release.ts",
     "build:migration-index": "tsx scripts/build-migration-index.ts",
     "broker-packs:build": "turbo run build --filter=./packages/uta-broker-* && tsx scripts/build-broker-packs.ts && pnpm broker-packs:verify",
     "broker-packs:upgrade-smoke": "tsx scripts/broker-pack-upgrade-smoke.ts",

--- a/packages/cli/bin/openalice-bun.ts
+++ b/packages/cli/bin/openalice-bun.ts
@@ -3,6 +3,8 @@
 import { INTERNAL_BOOTSTRAP_ROLE } from '../../../src/workspaces/bootstrap-runtime.js'
 import { parseInternalRole } from '../src/internal-role.js'
 
+const WORKSPACE_CLI_FLAG = '--workspace-cli'
+
 declare global {
   // Prevent the dynamically selected service module from also running its
   // legacy direct-entry wrapper inside the standalone executable.
@@ -12,6 +14,23 @@ declare global {
 
 async function main(): Promise<number> {
   const argv = process.argv.slice(2)
+  if (argv[0] === WORKSPACE_CLI_FLAG) {
+    const binary = argv[1]
+    if (!binary || !['alice', 'alice-workspace', 'alice-uta', 'traderhub'].includes(binary)) {
+      throw new Error(`invalid private Workspace CLI name: ${binary ?? '(missing)'}`)
+    }
+    globalThis.__OPENALICE_INTERNAL_ROLE_DISPATCH__ = true
+    process.env['OPENALICE_CLI_BIN'] = binary
+    process.argv.splice(2, process.argv.length - 2, ...argv.slice(2))
+    const loaded = await import('../../../src/workspaces/cli/bin/openalice-cli.cjs') as {
+      main?: () => Promise<void>
+      default?: { main?: () => Promise<void> }
+    }
+    const runWorkspaceCli = loaded.main ?? loaded.default?.main
+    if (!runWorkspaceCli) throw new Error('Workspace CLI payload did not export main()')
+    await runWorkspaceCli()
+    return 0
+  }
   const parsed = parseInternalRole(argv)
   if (parsed) {
     globalThis.__OPENALICE_INTERNAL_ROLE_DISPATCH__ = true

--- a/packages/cli/src/bun-standalone.mjs
+++ b/packages/cli/src/bun-standalone.mjs
@@ -1,4 +1,5 @@
-import { dirname, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { delimiter, dirname, join, resolve } from 'node:path'
 
 export function isBunStandalone() {
   return globalThis.__OPENALICE_BUN_STANDALONE__ === true
@@ -15,5 +16,36 @@ export function bunGuardianProcessSpec(executable = process.execPath) {
   return {
     cmd: executable,
     args: ['--internal-role', 'guardian'],
+  }
+}
+
+export function buildBunRuntimeEnvironment(
+  env,
+  resourceRoot,
+  executable = process.execPath,
+) {
+  const gitRoot = join(resourceRoot, 'runtime', 'git')
+  const gitBin = join(gitRoot, 'bin')
+  return {
+    ...env,
+    OPENALICE_RUNTIME_EXECUTABLE: executable,
+    LOCAL_GIT_DIRECTORY: gitRoot,
+    GIT_EXEC_PATH: join(gitRoot, 'libexec', 'git-core'),
+    GIT_TEMPLATE_DIR: join(gitRoot, 'share', 'git-core', 'templates'),
+    PATH: env.PATH ? `${gitBin}${delimiter}${env.PATH}` : gitBin,
+  }
+}
+
+export function resolveBunContentIdentity(resourceRoot, env = process.env, read = readFileSync) {
+  const explicit = env.OPENALICE_RUNTIME_CONTENT_IDENTITY?.trim()
+  if (explicit && /^[A-Za-z0-9._-]{1,128}$/.test(explicit)) return explicit
+  try {
+    const release = JSON.parse(read(resolve(resourceRoot, '..', '..', 'release.json'), 'utf8'))
+    return typeof release.contentIdentity === 'string'
+      && /^[A-Za-z0-9._-]{1,128}$/.test(release.contentIdentity)
+      ? release.contentIdentity
+      : null
+  } catch {
+    return null
   }
 }

--- a/packages/cli/src/bun-standalone.spec.mjs
+++ b/packages/cli/src/bun-standalone.spec.mjs
@@ -1,21 +1,24 @@
 import { describe, expect, it } from 'vitest'
+import { resolve } from 'node:path'
 
 import {
+  buildBunRuntimeEnvironment,
   bunGuardianProcessSpec,
+  resolveBunContentIdentity,
   resolveBunResourceRoot,
 } from './bun-standalone.mjs'
 
 describe('Bun standalone launch boundary', () => {
   it('derives an installed sidecar resource root from the executable', () => {
     expect(resolveBunResourceRoot({}, '/opt/openalice/releases/v1/bin/openalice'))
-      .toBe('/opt/openalice/releases/v1/share/openalice')
+      .toBe(resolve('/opt/openalice/releases/v1/share/openalice'))
   })
 
   it('allows an explicit resource root for development acceptance', () => {
     expect(resolveBunResourceRoot(
       { OPENALICE_APP_HOME: '/tmp/openalice-resources' },
       '/opt/openalice/bin/openalice',
-    )).toBe('/tmp/openalice-resources')
+    )).toBe(resolve('/tmp/openalice-resources'))
   })
 
   it('re-enters the executable as Guardian', () => {
@@ -23,5 +26,32 @@ describe('Bun standalone launch boundary', () => {
       cmd: '/opt/openalice/bin/openalice',
       args: ['--internal-role', 'guardian'],
     })
+  })
+
+  it('injects the release-owned Git without discarding the user PATH', () => {
+    const resourceRoot = resolve('/opt/openalice/share/openalice')
+    expect(buildBunRuntimeEnvironment(
+      { PATH: '/usr/local/bin', KEEP: 'yes' },
+      resourceRoot,
+      '/opt/openalice/bin/openalice',
+    )).toEqual(expect.objectContaining({
+      KEEP: 'yes',
+      OPENALICE_RUNTIME_EXECUTABLE: '/opt/openalice/bin/openalice',
+      LOCAL_GIT_DIRECTORY: resolve(resourceRoot, 'runtime/git'),
+      GIT_EXEC_PATH: resolve(resourceRoot, 'runtime/git/libexec/git-core'),
+      GIT_TEMPLATE_DIR: resolve(resourceRoot, 'runtime/git/share/git-core/templates'),
+      PATH: `${resolve(resourceRoot, 'runtime/git/bin')}${process.platform === 'win32' ? ';' : ':'}/usr/local/bin`,
+    }))
+  })
+
+  it('reads content identity from release metadata with an environment override', () => {
+    const read = () => JSON.stringify({ contentIdentity: 'artifact-identity' })
+    expect(resolveBunContentIdentity('/opt/release/share/openalice', {}, read))
+      .toBe('artifact-identity')
+    expect(resolveBunContentIdentity(
+      '/opt/release/share/openalice',
+      { OPENALICE_RUNTIME_CONTENT_IDENTITY: 'explicit-identity' },
+      read,
+    )).toBe('explicit-identity')
   })
 })

--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -150,8 +150,8 @@ describe('ResolvedLaunchContext', () => {
         },
       })
 
-      expect(context.appDir).toBe('/opt/openalice/releases/v1/share/openalice')
-      expect(context.aliceProject.appRoot).toBe('/opt/openalice/releases/v1/share/openalice')
+      expect(context.appDir).toBe(resolve('/opt/openalice/releases/v1/share/openalice'))
+      expect(context.aliceProject.appRoot).toBe(resolve('/opt/openalice/releases/v1/share/openalice'))
       expect(context.runtimeProvider).toEqual({
         kind: 'bun',
         contentIdentity: 'release-content-1',

--- a/packages/cli/src/launch-context.ts
+++ b/packages/cli/src/launch-context.ts
@@ -6,7 +6,11 @@ import {
   resolveAliceProjectIdentity,
   type AliceProjectIdentity,
 } from './alice-project.ts'
-import { isBunStandalone, resolveBunResourceRoot } from './bun-standalone.mjs'
+import {
+  isBunStandalone,
+  resolveBunContentIdentity,
+  resolveBunResourceRoot,
+} from './bun-standalone.mjs'
 
 const PROJECT_KEY_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/
 const DEFAULT_PORT = 47_331
@@ -185,9 +189,7 @@ export function resolveLaunchContext(
   const runtimeProvider = bunStandalone
     ? {
         kind: 'bun' as const,
-        contentIdentity: parseOptionalRuntimeContentIdentity(
-          env['OPENALICE_RUNTIME_CONTENT_IDENTITY'],
-        ),
+        contentIdentity: resolveBunContentIdentity(selectedAppDir!, env),
       }
     : appDir.provenance.source === 'installed-runtime'
     ? {
@@ -232,11 +234,6 @@ export function resolveLaunchContext(
       },
     },
   })
-}
-
-function parseOptionalRuntimeContentIdentity(raw: string | undefined): string | null {
-  const value = raw?.trim()
-  return value && /^[A-Za-z0-9._-]{1,128}$/.test(value) ? value : null
 }
 
 export function resolveSupervisorRootPath(

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -18,6 +18,7 @@ import {
   stopRuntimeServer,
 } from './server-control.mjs'
 import {
+  buildBunRuntimeEnvironment,
   bunGuardianProcessSpec,
   isBunStandalone,
   resolveBunResourceRoot,
@@ -93,7 +94,7 @@ export async function startRuntime(options, dependencies = {}) {
   }
 
   const nodeBinary = dependencies.nodeBinary ?? process.execPath
-  const runtimeEnv = buildLocalRuntimeEnv(env, {
+  let runtimeEnv = buildLocalRuntimeEnv(env, {
     appDir,
     homeRoot,
     nodeBinary,
@@ -104,7 +105,11 @@ export async function startRuntime(options, dependencies = {}) {
   runtimeEnv.OPENALICE_SERVER_MODE = detached ? 'detached' : 'foreground'
   runtimeEnv.OPENALICE_RUNTIME_PROVIDER = runtimeProvider.kind
   if (standalone) {
-    runtimeEnv.OPENALICE_RUNTIME_EXECUTABLE = dependencies.runtimeExecutable ?? process.execPath
+    runtimeEnv = buildBunRuntimeEnvironment(
+      runtimeEnv,
+      appDir,
+      dependencies.runtimeExecutable ?? process.execPath,
+    )
   }
   delete runtimeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY
   if (runtimeProvider.contentIdentity) {

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -127,7 +127,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
         '/opt/openalice/releases/v1/bin/openalice',
         ['--internal-role', 'guardian'],
         expect.objectContaining({
-          cwd: '/opt/openalice/releases/v1/share/openalice',
+          cwd: resolve('/opt/openalice/releases/v1/share/openalice'),
           env: expect.objectContaining({
             OPENALICE_RUNTIME_PROVIDER: 'bun',
             OPENALICE_RUNTIME_EXECUTABLE: '/opt/openalice/releases/v1/bin/openalice',

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -22,6 +22,7 @@ import {
 } from './runtime-deps.mjs'
 import { readRuntimeStatus as readGuardianRuntimeStatus } from './server-control.mjs'
 import {
+  buildBunRuntimeEnvironment,
   bunGuardianProcessSpec,
   isBunStandalone,
   resolveBunResourceRoot,
@@ -146,7 +147,7 @@ export async function startLocal(options, dependencies = {}) {
   const spawnProcess = dependencies.spawnProcess ?? spawn
   const waitForRuntime = dependencies.waitForRuntime ?? waitForOpenAlice
   const nodeBinary = dependencies.nodeBinary ?? process.execPath
-  const runtimeEnv = buildLocalRuntimeEnv(env, {
+  let runtimeEnv = buildLocalRuntimeEnv(env, {
     appDir,
     homeRoot,
     nodeBinary,
@@ -155,7 +156,11 @@ export async function startLocal(options, dependencies = {}) {
   })
   runtimeEnv.OPENALICE_RUNTIME_PROVIDER = runtimeProvider.kind
   if (standalone) {
-    runtimeEnv.OPENALICE_RUNTIME_EXECUTABLE = dependencies.runtimeExecutable ?? process.execPath
+    runtimeEnv = buildBunRuntimeEnvironment(
+      runtimeEnv,
+      appDir,
+      dependencies.runtimeExecutable ?? process.execPath,
+    )
   }
   delete runtimeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY
   if (runtimeProvider.contentIdentity) {

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -57,7 +57,7 @@ shrinking the ownership boundary to OpenAlice itself.
 
 Publish a native OpenAlice command for macOS and Linux that:
 
-- runs without a system Node.js or Bun installation;
+- runs without a system Node.js, Bun, or Git installation;
 - starts the existing Guardian-owned multi-process Runtime from any directory;
 - embeds or ships only OpenAlice-owned code and resources;
 - launches user-owned Agent Runtime executables as independent PTY processes;
@@ -186,6 +186,12 @@ preserve the old layout.
   releases/
     <version>-<platform>-<content-id>/
       bin/openalice[.exe]
+      share/openalice/
+        runtime/git/
+        ui/dist/
+        default/
+        src/workspaces/templates/
+        src/workspaces/cli/bin/
       adapters/
       release.json
   current -> releases/<active-release>
@@ -366,7 +372,7 @@ Checkboxes reflect repository truth, not intent.
   Node sidecar as the default answer.
 - [ ] Prove an installed broker pack can still be dynamically loaded from
   `OPENALICE_HOME` without bundling its SDK into UTA Core.
-- [ ] Prove embedded UI/default/template reads and one materialized external
+- [x] Prove embedded UI/default/template reads and one materialized external
   adapter file.
 - [ ] Record measured executable size, cold start, idle memory per role, and
   clean-build time against the released headless Runtime.
@@ -386,28 +392,31 @@ build harness when it improves the next investigation.
 - [x] Replace Guardian's child JavaScript paths with self-executable role
   spawns while preserving environment, readiness, restart, and shutdown
   behavior.
-- [ ] Bundle OpenAlice package dependencies and required platform-native
+- [x] Bundle OpenAlice package dependencies and required platform-native
   assets; keep broker packs external.
-- [ ] Generate platform archives, `release.json`, SHA-256 metadata, version,
+- [x] Generate platform archives, `release.json`, SHA-256 metadata, version,
   control compatibility, and content identity from accepted build outputs.
 - [ ] Keep source development on `pnpm dev`; it need not imitate the installed
   executable layout.
 
 ### 3. Resources and Workspace helper boundary
 
-- [ ] Embed Web UI, defaults, templates, migrations, and immutable adapter
+- [x] Ship Web UI, defaults, templates, migrations, and immutable adapter
   resources through one resource-root abstraction shared with source and
   Electron modes.
-- [ ] Serve the real UI and create every standard Workspace template from a
+- [x] Serve the real UI and create every standard Workspace template from a
   compiled executable outside the repository.
-- [ ] Replace Node-backed Workspace CLI shims with aliases or small wrappers
+- [x] Replace Node-backed Workspace CLI shims with aliases or small wrappers
   that dispatch into `openalice`.
-- [ ] Materialize only files that an external Agent process must open by path;
+- [x] Materialize only files that an external Agent process must open by path;
   verify lifecycle, permissions, content identity, and update replacement.
 - [ ] Remove CLI-only `OPENALICE_MANAGED_PI_*` selection and injection without
   changing Electron's bundled-Agent behavior.
 - [ ] Verify existing user-installed Agent CLIs retain their native config,
   version, executable path, and credentials.
+- [x] Ship a release-owned Git sidecar and prepend only its `bin` directory to
+  Runtime children; prove init, commit, local clone, and GitHub HTTPS with no
+  system Git on PATH.
 
 ### 4. Native CLI installers
 
@@ -605,7 +614,7 @@ These may change implementation details but not the fixed product boundaries:
 This plan is complete only when:
 
 1. a clean macOS or Linux CLI installation needs no preinstalled
-   Node, Bun, npm, source checkout, or Agent Runtime to run OpenAlice itself;
+   Node, Bun, npm, Git, source checkout, or Agent Runtime to run OpenAlice itself;
 2. one primary platform executable starts the existing multi-process Guardian,
    Alice, UTA, and Connector tree and every Agent Session remains an independent
    external process;
@@ -693,3 +702,14 @@ This plan is complete only when:
   PID, forced UTA failure left Alice ready, the control flag restored UTA under
   a new PID, and SIGTERM released the Guardian lock. The smoke also fixed an
   existing UTA restart deadlock by clearing a signalled child reference.
+- 2026-08-29: Release-artifact increment added a target-native archive builder
+  with per-file hashes, content identity, SHA-256 sidecar, licenses, immutable
+  resources, Bun-native Workspace helper dispatch, and a release-owned Git
+  sidecar. On macOS arm64 the expanded release measured 114,485,201 bytes and
+  the gzip archive 56,462,626 bytes; Git 2.53.0 occupied 19,168,630 bytes after
+  replacing duplicate built-in executables with 150 relative symlinks and
+  excluding GCM/LFS. Outside the checkout and with no system Node/Bun/Git on
+  PATH, acceptance passed Git init/commit/local clone, live GitHub HTTPS,
+  Chat/AutoQuant/Auto Prediction bootstrap, real `alice-workspace` manifest
+  plus invocation, default and Pi adapter materialization, content provenance,
+  and the real Web UI.

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -1,0 +1,550 @@
+import { createHash } from 'node:crypto'
+import {
+  chmod,
+  cp,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { INTERNAL_BOOTSTRAP_ROLE } from '../src/workspaces/bootstrap-runtime.js'
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+const pinnedBunVersion = (await readFile(join(repositoryRoot, '.bun-version'), 'utf8')).trim()
+if (Bun.version !== pinnedBunVersion) {
+  throw new Error(`Bun ${pinnedBunVersion} is required, but ${Bun.version} is running`)
+}
+if (!['darwin', 'linux'].includes(process.platform)) {
+  throw new Error(`Bun CLI releases are currently supported on macOS and Linux, not ${process.platform}`)
+}
+
+const product = JSON.parse(await readFile(join(repositoryRoot, 'package.json'), 'utf8')) as {
+  version?: unknown
+}
+if (typeof product.version !== 'string' || product.version.length === 0) {
+  throw new Error('package.json must contain a version')
+}
+
+const outputRoot = resolve(
+  process.env['OPENALICE_BUN_OUTPUT_DIR']
+    ?? join(repositoryRoot, 'dist/bun-release'),
+)
+const platformName = process.platform === 'darwin' ? 'darwin' : 'linux'
+const releaseName = `openalice-cli-${product.version}-${platformName}-${process.arch}`
+const releaseRoot = join(outputRoot, releaseName)
+const executablePath = join(releaseRoot, 'bin', 'openalice')
+const resourceRoot = join(releaseRoot, 'share', 'openalice')
+const gitRoot = join(resourceRoot, 'runtime', 'git')
+const archivePath = join(outputRoot, `${releaseName}.tar.gz`)
+const smokeHome = join(outputRoot, 'smoke-home')
+
+await rm(releaseRoot, { recursive: true, force: true })
+await rm(smokeHome, { recursive: true, force: true })
+await rm(archivePath, { force: true })
+await mkdir(dirname(executablePath), { recursive: true })
+await mkdir(resourceRoot, { recursive: true })
+
+for (const required of [
+  'ui/dist/index.html',
+  'src/workspaces/templates/chat/bootstrap.mjs',
+  'src/workspaces/cli/bin/pi-session-provider.ts',
+  'node_modules/dugite/git/bin/git',
+]) {
+  await stat(join(repositoryRoot, required)).catch(() => {
+    throw new Error(`required Bun release input is missing: ${required}`)
+  })
+}
+
+const buildStartedAt = performance.now()
+const build = await Bun.build({
+  entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice-bun.ts')],
+  compile: {
+    outfile: executablePath,
+    autoloadBunfig: false,
+    autoloadDotenv: false,
+  },
+  define: {
+    'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(product.version),
+    'globalThis.__OPENALICE_BUN_STANDALONE__': 'true',
+  },
+  minify: true,
+})
+if (!build.success) {
+  for (const log of build.logs) console.error(log)
+  throw new Error('Bun CLI release build failed')
+}
+const buildDurationMs = Math.round(performance.now() - buildStartedAt)
+
+await Promise.all([
+  copyTree('ui/dist'),
+  copyTree('default'),
+  copyTree('src/workspaces/templates'),
+  cp(join(repositoryRoot, 'package.json'), join(resourceRoot, 'package.json')),
+  cp(join(repositoryRoot, 'LICENSE'), join(releaseRoot, 'LICENSE')),
+  cp(join(repositoryRoot, 'THIRD_PARTY_NOTICES.md'), join(releaseRoot, 'THIRD_PARTY_NOTICES.md')),
+])
+await mkdir(join(releaseRoot, 'licenses'), { recursive: true })
+await cp(join(repositoryRoot, 'node_modules/dugite/LICENSE'), join(releaseRoot, 'licenses/dugite-LICENSE'))
+await materializeWorkspaceCli()
+const gitReport = await buildPortableGit(
+  join(repositoryRoot, 'node_modules/dugite/git'),
+  gitRoot,
+)
+
+const executableHash = await sha256File(executablePath)
+const contentIdentity = executableHash.slice(0, 16)
+const files = await releaseFiles(releaseRoot, new Set(['release.json']))
+const releaseMetadata = {
+  schemaVersion: 1,
+  product: 'OpenAlice CLI',
+  version: product.version,
+  platform: platformName,
+  arch: process.arch,
+  bunVersion: Bun.version,
+  contentIdentity,
+  executable: 'bin/openalice',
+  resourceRoot: 'share/openalice',
+  git: {
+    root: 'share/openalice/runtime/git',
+    source: 'dugite',
+    sourceVersion: JSON.parse(
+      await readFile(join(repositoryRoot, 'node_modules/dugite/package.json'), 'utf8'),
+    ).version,
+    ...gitReport,
+  },
+  files,
+}
+await writeFile(join(releaseRoot, 'release.json'), `${JSON.stringify(releaseMetadata, null, 2)}\n`)
+
+const smoke = await smokeRelease({
+  executablePath,
+  resourceRoot,
+  gitRoot,
+  smokeHome,
+  contentIdentity,
+})
+
+const archive = Bun.spawnSync([
+  'tar', '-czf', archivePath, '-C', outputRoot, releaseName,
+], {
+  cwd: outputRoot,
+  stdout: 'pipe',
+  stderr: 'pipe',
+})
+if (archive.exitCode !== 0) {
+  throw new Error(`release archive failed: ${archive.stderr.toString()}`)
+}
+const archiveHash = await sha256File(archivePath)
+await writeFile(`${archivePath}.sha256`, `${archiveHash}  ${basename(archivePath)}\n`)
+
+const report = {
+  schemaVersion: 1,
+  status: 'pass',
+  version: product.version,
+  bunVersion: Bun.version,
+  platform: platformName,
+  arch: process.arch,
+  contentIdentity,
+  buildDurationMs,
+  executableBytes: (await stat(executablePath)).size,
+  releaseBytes: await directoryBytes(releaseRoot),
+  archiveBytes: (await stat(archivePath)).size,
+  archiveSha256: archiveHash,
+  git: gitReport,
+  smoke,
+}
+await writeFile(join(outputRoot, 'report.json'), `${JSON.stringify(report, null, 2)}\n`)
+console.log(`Bun CLI release passed: ${archivePath}`)
+console.log(JSON.stringify(report))
+
+async function copyTree(relativePath: string): Promise<void> {
+  await cp(
+    join(repositoryRoot, relativePath),
+    join(resourceRoot, relativePath),
+    { recursive: true },
+  )
+}
+
+async function materializeWorkspaceCli(): Promise<void> {
+  const destination = join(resourceRoot, 'src/workspaces/cli/bin')
+  await mkdir(destination, { recursive: true })
+  await cp(
+    join(repositoryRoot, 'src/workspaces/cli/bin/pi-session-provider.ts'),
+    join(destination, 'pi-session-provider.ts'),
+  )
+  for (const binary of ['alice', 'alice-workspace', 'alice-uta', 'traderhub']) {
+    const launcher = `#!/bin/sh
+set -eu
+: "\${OPENALICE_RUNTIME_EXECUTABLE:?OpenAlice Runtime executable is not configured}"
+exec "$OPENALICE_RUNTIME_EXECUTABLE" --workspace-cli ${binary} "$@"
+`
+    const path = join(destination, binary)
+    await writeFile(path, launcher, { mode: 0o755 })
+    await chmod(path, 0o755)
+  }
+}
+
+async function buildPortableGit(source: string, destination: string): Promise<{
+  version: string
+  files: number
+  symlinks: number
+  bytes: number
+}> {
+  await mkdir(join(destination, 'bin'), { recursive: true })
+  await mkdir(join(destination, 'libexec/git-core'), { recursive: true })
+  await cp(join(source, 'bin/git'), join(destination, 'bin/git'))
+  await cp(join(source, 'etc'), join(destination, 'etc'), { recursive: true })
+  await cp(join(source, 'share/git-core'), join(destination, 'share/git-core'), { recursive: true })
+  if (await exists(join(source, 'ssl'))) {
+    await cp(join(source, 'ssl'), join(destination, 'ssl'), { recursive: true })
+  }
+
+  const sourceCore = join(source, 'libexec/git-core')
+  const destinationCore = join(destination, 'libexec/git-core')
+  const canonicalByHash = new Map<string, string>()
+  canonicalByHash.set(await sha256File(join(destination, 'bin/git')), join(destination, 'bin/git'))
+  let symlinks = 0
+  for (const entry of await readdir(sourceCore, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (entry.name === 'mergetools') {
+        await cp(join(sourceCore, entry.name), join(destinationCore, entry.name), { recursive: true })
+      }
+      continue
+    }
+    if (!entry.isFile() || !entry.name.startsWith('git-')) continue
+    if (entry.name === 'git-lfs' || entry.name.startsWith('git-credential-manager')) continue
+    const sourceFile = join(sourceCore, entry.name)
+    const destinationFile = join(destinationCore, entry.name)
+    const hash = await sha256File(sourceFile)
+    const canonical = canonicalByHash.get(hash)
+    if (canonical) {
+      await symlink(relative(dirname(destinationFile), canonical), destinationFile)
+      symlinks += 1
+    } else {
+      await cp(sourceFile, destinationFile)
+      canonicalByHash.set(hash, destinationFile)
+    }
+  }
+  const entries = await releaseFiles(destination)
+  const bytes = await directoryBytes(destination)
+  if (bytes > 80 * 1024 * 1024) {
+    throw new Error(`release-owned Git is unexpectedly large: ${bytes} bytes`)
+  }
+  const version = Bun.spawnSync([join(destination, 'bin/git'), '--version'], {
+    env: {
+      PATH: join(destination, 'bin'),
+      GIT_EXEC_PATH: join(destination, 'libexec/git-core'),
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (version.exitCode !== 0) throw new Error(`release-owned Git failed: ${version.stderr.toString()}`)
+  return {
+    version: version.stdout.toString().trim(),
+    files: entries.filter((entry) => entry.type === 'file').length,
+    symlinks,
+    bytes,
+  }
+}
+
+async function smokeRelease(options: {
+  executablePath: string
+  resourceRoot: string
+  gitRoot: string
+  smokeHome: string
+  contentIdentity: string
+}): Promise<Record<string, unknown>> {
+  await mkdir(options.smokeHome, { recursive: true })
+  const gitEnv = {
+    HOME: options.smokeHome,
+    PATH: join(options.gitRoot, 'bin'),
+    LOCAL_GIT_DIRECTORY: options.gitRoot,
+    GIT_EXEC_PATH: join(options.gitRoot, 'libexec/git-core'),
+    GIT_TEMPLATE_DIR: join(options.gitRoot, 'share/git-core/templates'),
+    GIT_CONFIG_SYSTEM: join(options.gitRoot, 'etc/gitconfig'),
+    TMPDIR: process.env['TMPDIR'] ?? '/tmp',
+  }
+  const git = join(options.gitRoot, 'bin/git')
+  const sourceRepository = join(options.smokeHome, 'git-source')
+  const clonedRepository = join(options.smokeHome, 'git-clone')
+  run([git, 'init', sourceRepository], gitEnv)
+  run([git, '-C', sourceRepository, 'config', 'user.email', 'smoke@openalice.local'], gitEnv)
+  run([git, '-C', sourceRepository, 'config', 'user.name', 'OpenAlice Smoke'], gitEnv)
+  await writeFile(join(sourceRepository, 'README.md'), 'release-owned git\n')
+  run([git, '-C', sourceRepository, 'add', 'README.md'], gitEnv)
+  run([git, '-C', sourceRepository, 'commit', '-m', 'initial'], gitEnv)
+  const sourceCommit = run([git, '-C', sourceRepository, 'rev-parse', 'HEAD'], gitEnv).trim()
+  run([git, 'clone', sourceRepository, clonedRepository], gitEnv)
+  if ((await readFile(join(clonedRepository, 'README.md'), 'utf8')).trim() !== 'release-owned git') {
+    throw new Error('release-owned Git clone did not preserve repository content')
+  }
+  if (process.env['OPENALICE_BUN_NETWORK_GIT'] === '1') {
+    run([git, 'ls-remote', 'https://github.com/git/git.git', 'HEAD'], gitEnv)
+  }
+
+  const templateRoot = join(options.resourceRoot, 'src/workspaces/templates')
+  await Promise.all([
+    stat(join(options.resourceRoot, 'default/skills')),
+    stat(join(options.resourceRoot, 'src/workspaces/cli/bin/pi-session-provider.ts')),
+  ])
+  for (const template of ['chat', 'auto-quant-v2', 'auto-prediction']) {
+    const workspace = join(options.smokeHome, `workspace-${template}`)
+    run([
+      options.executablePath,
+      INTERNAL_BOOTSTRAP_ROLE,
+      join(templateRoot, template, 'bootstrap.mjs'),
+      `bun-release-${template}`,
+      workspace,
+    ], {
+      ...gitEnv,
+      AQ_TEMPLATE_ROOT: join(templateRoot, template),
+      OPENALICE_APP_HOME: options.resourceRoot,
+      OPENALICE_TEMPLATE_SOURCE_REPOSITORY: sourceRepository,
+      OPENALICE_TEMPLATE_SOURCE_VERSION: 'HEAD',
+      OPENALICE_TEMPLATE_SOURCE_COMMIT: sourceCommit,
+      ...(template === 'auto-quant-v2' ? { AQ_TEMPLATE_DIR: sourceRepository } : {}),
+      ...(template === 'auto-prediction' ? { AUTO_PREDICTION_TEMPLATE_DIR: sourceRepository } : {}),
+    })
+    if (!(await readFile(join(workspace, '.git/HEAD'), 'utf8')).startsWith('ref: refs/heads/')) {
+      throw new Error(`${template} bootstrap did not create a Git repository`)
+    }
+  }
+
+  const helperServer = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url)
+      if (url.pathname === '/cli/ws-release/workspace/manifest') {
+        return Response.json({
+          groups: { issue: { list: { tool: 'workspace_issue_list', schema: { type: 'object', properties: {} } } } },
+          groupDescriptions: { issue: 'Issue coordination' },
+        })
+      }
+      if (url.pathname === '/cli/ws-release/workspace/invoke' && request.method === 'POST') {
+        return Response.json({ content: [{ type: 'text', text: 'BUN_WORKSPACE_CLI_OK' }] })
+      }
+      return Response.json({ error: 'not found' }, { status: 404 })
+    },
+  })
+  try {
+    const helper = await runAsync([
+      join(options.resourceRoot, 'src/workspaces/cli/bin/alice-workspace'),
+    ], {
+      ...gitEnv,
+      OPENALICE_RUNTIME_EXECUTABLE: options.executablePath,
+      OPENALICE_TOOL_URL: `http://127.0.0.1:${helperServer.port}/cli`,
+      AQ_WS_ID: 'ws-release',
+    })
+    if (!helper.includes('issue')) throw new Error('Bun Workspace CLI did not render its real manifest')
+    const invocation = await runAsync([
+      join(options.resourceRoot, 'src/workspaces/cli/bin/alice-workspace'),
+      'issue', 'list',
+    ], {
+      ...gitEnv,
+      OPENALICE_RUNTIME_EXECUTABLE: options.executablePath,
+      OPENALICE_TOOL_URL: `http://127.0.0.1:${helperServer.port}/cli`,
+      AQ_WS_ID: 'ws-release',
+    })
+    if (invocation.trim() !== 'BUN_WORKSPACE_CLI_OK') {
+      throw new Error(`Bun Workspace CLI invocation returned unexpected output: ${invocation}`)
+    }
+  } finally {
+    helperServer.stop(true)
+  }
+
+  const [webPort, mcpPort, utaPort, connectorPort] = await allocatePorts(4)
+  const runtimeHome = join(options.smokeHome, 'runtime-home')
+  const runtimeEnv = {
+    HOME: runtimeHome,
+    PATH: '',
+    TMPDIR: process.env['TMPDIR'] ?? '/tmp',
+    OPENALICE_HOME: runtimeHome,
+    OPENALICE_TRADING_MODE: 'lite',
+    OPENALICE_BIND_HOST: '127.0.0.1',
+    OPENALICE_WEB_PORT: String(webPort),
+    OPENALICE_MCP_PORT: String(mcpPort),
+    OPENALICE_UTA_PORT: String(utaPort),
+    OPENALICE_CONNECTOR_PORT: String(connectorPort),
+  }
+  const runtime = Bun.spawn([
+    options.executablePath,
+    'run',
+    '--home', runtimeHome,
+    '--port', String(webPort),
+    '--wait', '90',
+    '--no-update-check',
+  ], {
+    cwd: options.smokeHome,
+    env: runtimeEnv,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdoutPromise = new Response(runtime.stdout).text()
+  const stderrPromise = new Response(runtime.stderr).text()
+  let runtimeError: unknown = null
+  try {
+    const root = await waitForHttp(`http://127.0.0.1:${webPort}/`, 90_000)
+    if (!root.includes('<div id="root">')) throw new Error('installed release did not serve the real Web UI')
+    const status = JSON.parse(run([
+      options.executablePath,
+      'status', '--home', runtimeHome, '--wait', '3', '--json',
+    ], runtimeEnv)) as { result?: { status?: { provider?: { kind?: string; contentIdentity?: string } } } }
+    if (
+      status.result?.status?.provider?.kind !== 'bun'
+      || status.result.status.provider.contentIdentity !== options.contentIdentity
+    ) {
+      throw new Error(`installed release status lost Bun provenance: ${JSON.stringify(status)}`)
+    }
+    // Let the foreground presenter observe the same ready status before the
+    // smoke sends its ownership signal; otherwise the signal guard correctly
+    // classifies this as an interrupted startup even though Alice is serving.
+    await Bun.sleep(500)
+  } catch (error) {
+    runtimeError = error
+  } finally {
+    runtime.kill('SIGTERM')
+  }
+  const exitCode = await runtime.exited
+  const stdout = await stdoutPromise
+  const stderr = await stderrPromise
+  if (runtimeError || exitCode !== 0) {
+    throw new Error(`installed release Runtime failed: ${String(runtimeError)}\n${stdout}\n${stderr}`)
+  }
+  return {
+    nodeOrBunOnPath: false,
+    gitInitCommitClone: true,
+    networkGit: process.env['OPENALICE_BUN_NETWORK_GIT'] === '1',
+    templates: ['chat', 'auto-quant-v2', 'auto-prediction'],
+    workspaceCli: 'alice-workspace',
+    workspaceCliInvoke: true,
+    defaultResources: true,
+    materializedPiAdapter: true,
+    uiStatus: 200,
+    contentIdentity: options.contentIdentity,
+  }
+}
+
+function run(command: string[], env: Record<string, string>): string {
+  const result = Bun.spawnSync(command, {
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`${command.join(' ')} failed (${result.exitCode}): ${result.stderr.toString() || result.stdout.toString()}`)
+  }
+  return result.stdout.toString()
+}
+
+async function runAsync(command: string[], env: Record<string, string>): Promise<string> {
+  const child = Bun.spawn(command, {
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  if (exitCode !== 0) {
+    throw new Error(`${command.join(' ')} failed (${exitCode}): ${stderr || stdout}`)
+  }
+  return stdout
+}
+
+async function waitForHttp(url: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown = null
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      const body = await response.text()
+      if (response.ok) return body
+      lastError = new Error(`${url} returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await Bun.sleep(100)
+  }
+  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
+}
+
+async function releaseFiles(root: string, excluded = new Set<string>()): Promise<Array<{
+  path: string
+  type: 'file' | 'symlink'
+  bytes: number
+  sha256: string
+  target?: string
+}>> {
+  const output: Array<{
+    path: string
+    type: 'file' | 'symlink'
+    bytes: number
+    sha256: string
+    target?: string
+  }> = []
+  async function walk(current: string): Promise<void> {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const absolute = join(current, entry.name)
+      const path = relative(root, absolute)
+      if (excluded.has(path)) continue
+      if (entry.isDirectory()) {
+        await walk(absolute)
+      } else if (entry.isSymbolicLink()) {
+        const target = await readlink(absolute)
+        output.push({
+          path,
+          type: 'symlink',
+          bytes: Buffer.byteLength(target),
+          sha256: sha256(target),
+          target,
+        })
+      } else if (entry.isFile()) {
+        output.push({
+          path,
+          type: 'file',
+          bytes: (await lstat(absolute)).size,
+          sha256: await sha256File(absolute),
+        })
+      }
+    }
+  }
+  await walk(root)
+  return output.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+async function directoryBytes(root: string): Promise<number> {
+  return (await releaseFiles(root)).reduce((sum, entry) => sum + entry.bytes, 0)
+}
+
+async function sha256File(path: string): Promise<string> {
+  return sha256(await readFile(path))
+}
+
+function sha256(value: string | Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+async function exists(path: string): Promise<boolean> {
+  return stat(path).then(() => true, () => false)
+}
+
+async function allocatePorts(count: number): Promise<number[]> {
+  const ports: number[] = []
+  for (let index = 0; index < count; index += 1) {
+    const server = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } })
+    ports.push(server.port)
+    server.stop(true)
+  }
+  return ports
+}

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -413,4 +413,8 @@ function fail(msg) {
   process.exit(1)
 }
 
-main().catch((e) => fail(e && e.stack ? e.stack : String(e)))
+module.exports.main = main
+
+if (!globalThis.__OPENALICE_INTERNAL_ROLE_DISPATCH__) {
+  main().catch((e) => fail(e && e.stack ? e.stack : String(e)))
+}


### PR DESCRIPTION
## Outcome

- builds a target-native macOS/Linux archive with one Bun executable, immutable resources, `release.json`, per-file hashes, archive SHA-256, licenses, and content identity
- ships a 19 MB release-owned Git runtime instead of the 608 MB expanded Dugite payload; duplicate Git built-ins become relative symlinks and GCM/LFS stay out of the base CLI
- injects only release-owned Git into Bun Runtime children, preserving the user's existing PATH and external Agent ownership
- replaces Node-backed Workspace helper launchers in the Bun artifact with small wrappers that dispatch back into the same executable
- verifies all three standard templates, real UI, real `alice-workspace` manifest/invocation, and release provenance outside a checkout
- extends macOS/Linux Bun CI through the release artifact smoke
- makes the new provider tests path-native so the existing Windows test lane remains green without adding Windows CLI scope

## Measured macOS arm64 artifact

- executable: 72,116,978 bytes
- expanded release: 114,485,201 bytes
- gzip archive: 56,462,626 bytes
- release-owned Git 2.53.0: 19,168,630 bytes

## Verification

- `OPENALICE_BUN_NETWORK_GIT=1 bun scripts/build-bun-release.ts` with pinned Bun 1.4.0 — Git init/commit/local clone/GitHub HTTPS; Chat/AutoQuant/Auto Prediction; Workspace CLI; real Web UI
- `pnpm test` — 604 files passed, 1 skipped; 5013 tests passed, 9 skipped
- `pnpm -F @traderalice/openalice-cli test` — 37 files, 301 tests
- `npx tsc --noEmit`
- `pnpm test:guardian-recovery`
- `pnpm electron:smoke:pty`
