### PR TITLE
fix Bun PTY output backpressure

### DIFF
--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -83,6 +83,15 @@ minimal Git runtime. The Bun provider prepends only that release-owned Git to
 the inherited PATH and records the archive's content identity from
 `release.json`; it does not require or replace a user's system Git.
 
+On supported POSIX targets, Bun's native `Terminal` remains behind the same PTY
+contract as `node-pty`. Since Bun 1.4 does not expose a read-side pause method,
+the Bun backend implements the existing WebSocket high/low-watermark flow
+control by stopping and continuing the PTY process group. Pressure therefore
+stays at the producer and kernel PTY boundary instead of accumulating in an
+unbounded JavaScript queue; graceful Session shutdown resumes a stopped group
+before terminating it. Electron and source-backed Node execution retain
+`node-pty` and its native stream pause/resume behavior.
+
 Source development continues to use `pnpm dev`, and the currently released
 installer continues to use the bundle provider until the Bun release and
 installation acceptance matrix is complete. Electron remains independent.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -364,12 +364,13 @@ Checkboxes reflect repository truth, not intent.
 - [x] Re-execute the compiled binary as Guardian, Alice, UTA, and Connector;
   prove separate PIDs, signal propagation, component failure isolation, and
   clean lock release.
-- [ ] Launch at least two independent fake or real Agent CLI PTYs; stopping one
+- [x] Launch at least two independent fake or real Agent CLI PTYs; stopping one
   must not stop the other, Alice, or Guardian.
-- [ ] Finish the Bun-native PTY gate. Bun 1.4 `Terminal` is accepted on macOS
+- [x] Finish the Bun-native PTY gate. Bun 1.4 `Terminal` is accepted on macOS
   arm64, Linux arm64, and Linux x64 behind the existing PTY ownership boundary;
-  high-output backpressure remains unproved. Do not add a
-  Node sidecar as the default answer.
+  high-output backpressure stops the whole PTY process group at the producer
+  boundary and resumes below the existing low watermark. Do not add a Node
+  sidecar as the default answer.
 - [ ] Prove an installed broker pack can still be dynamically loaded from
   `OPENALICE_HOME` without bundling its SDK into UTA Core.
 - [x] Prove embedded UI/default/template reads and one materialized external
@@ -584,17 +585,14 @@ live-paper trading is not part of packaging verification.
 
 These may change implementation details but not the fixed product boundaries:
 
-1. Does Bun need an OpenAlice-owned output-pressure buffer to replace
-   `node-pty` pause/resume semantics? The Windows PTY backend is deferred with
-   the rest of native Windows distribution.
-2. Can the current `@hono/node-server` paths run unchanged under Bun, or should
+1. Can the current `@hono/node-server` paths run unchanged under Bun, or should
    the CLI build use a small runtime-neutral server adapter while Electron and
    source development retain Node?
-3. Can installed broker-pack ESM and native SDKs load dynamically from disk in
+2. Can installed broker-pack ESM and native SDKs load dynamically from disk in
    the compiled UTA role without broadening the base artifact?
-4. Which current filesystem callers work directly against Bun embedded assets,
+3. Which current filesystem callers work directly against Bun embedded assets,
    and which externally consumed adapter files require materialization?
-5. What signing, notarization, and malware-scanning gates are required for the
+4. What signing, notarization, and malware-scanning gates are required for the
    standalone macOS CLI binary independently of Electron?
 
 ## Explicit Non-goals
@@ -713,3 +711,14 @@ This plan is complete only when:
   Chat/AutoQuant/Auto Prediction bootstrap, real `alice-workspace` manifest
   plus invocation, default and Pi adapter materialization, content provenance,
   and the real Web UI.
+- 2026-08-29: PTY backpressure increment completed the Bun-native PTY gate
+  without a Node sidecar or an application-level output spool. Because Bun
+  1.4's callback-only `Terminal` has no read-side pause API, the Bun backend
+  maps the existing high/low-watermark contract to `SIGSTOP`/`SIGCONT` on the
+  PTY's POSIX process group. A compiled high-output probe used a child writer
+  behind its parent shell, held output byte-for-byte stable while paused,
+  resumed past another 512 KiB, and exited normally when killed from the paused
+  state on native macOS arm64, OrbStack Linux arm64, and emulated Linux x64.
+  This keeps pressure at the producer/kernel PTY boundary and covers Agent
+  Runtime helper processes without an unbounded Bun heap queue. Native Windows
+  remains part of the deferred Windows distribution lane.

--- a/scripts/build-bun-alice-feasibility.ts
+++ b/scripts/build-bun-alice-feasibility.ts
@@ -126,8 +126,23 @@ const ptyReport = JSON.parse(ptyStdout.trim()) as {
   backend: string
   supportsFlowControl: boolean
   pids: number[]
+  flowControl?: {
+    pid: number
+    bytesBeforePause: number
+    bytesWhilePaused: number
+    bytesAfterResume: number
+    gracefulKillWhilePaused: boolean
+  }
 }
-if (ptyReport.status !== 'pass' || ptyReport.backend !== 'bun-native') {
+if (
+  ptyReport.status !== 'pass'
+  || ptyReport.backend !== 'bun-native'
+  || !ptyReport.supportsFlowControl
+  || !ptyReport.flowControl
+  || ptyReport.flowControl.bytesWhilePaused !== ptyReport.flowControl.bytesBeforePause
+  || ptyReport.flowControl.bytesAfterResume <= ptyReport.flowControl.bytesWhilePaused
+  || !ptyReport.flowControl.gracefulKillWhilePaused
+) {
   throw new Error(`compiled Bun PTY smoke returned an invalid report: ${ptyStdout}`)
 }
 

--- a/scripts/bun-native-pty-smoke.ts
+++ b/scripts/bun-native-pty-smoke.ts
@@ -13,6 +13,7 @@ const env = Object.fromEntries(
 )
 const one = spawnInteractive('ONE')
 const two = spawnInteractive('TWO')
+let flowControl: Awaited<ReturnType<typeof probeFlowControl>> | undefined
 
 if (one.term.pid === two.term.pid) {
   throw new Error(`PTY sessions reused pid ${one.term.pid}`)
@@ -38,6 +39,7 @@ try {
 
   two.term.write('still-alive\n')
   await waitForOutput(two, 'OA_TWO_INPUT:still-alive')
+  flowControl = await probeFlowControl()
 } finally {
   try {
     one.term.kill()
@@ -57,7 +59,84 @@ console.log(JSON.stringify({
   backend: backend.name,
   supportsFlowControl: backend.supportsFlowControl,
   pids: [one.term.pid, two.term.pid],
+  flowControl,
 }))
+
+async function probeFlowControl(): Promise<{
+  pid: number
+  bytesBeforePause: number
+  bytesWhilePaused: number
+  bytesAfterResume: number
+  gracefulKillWhilePaused: true
+}> {
+  if (!backend.supportsFlowControl) {
+    throw new Error('Bun PTY backend did not advertise output flow control')
+  }
+
+  const marker = 'OA_FLOW_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\n'
+  const session = {
+    bytes: 0,
+    term: backend.spawn('/bin/sh', [
+      '-c',
+      `while :; do printf '${marker.replace('\n', '\\n')}'; done & wait`,
+    ], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: process.cwd(),
+      env,
+    }),
+    exited: Promise.resolve(),
+  }
+  session.term.onData((data) => {
+    session.bytes += Buffer.isBuffer(data) ? data.byteLength : Buffer.byteLength(data)
+  })
+  session.exited = new Promise<void>((resolve) => {
+    session.term.onExit(() => resolve())
+  })
+
+  try {
+    await waitForBytes(session, 512 * 1024)
+    session.term.pause?.()
+
+    // Let bytes already read from the PTY master settle, then prove the
+    // producer group is stopped rather than copied into an unbounded JS queue.
+    await Bun.sleep(200)
+    const bytesBeforePause = session.bytes
+    await Bun.sleep(300)
+    const bytesWhilePaused = session.bytes
+    if (bytesWhilePaused !== bytesBeforePause) {
+      throw new Error(
+        `PTY output kept growing while paused: ${bytesBeforePause} -> ${bytesWhilePaused}`,
+      )
+    }
+
+    session.term.resume?.()
+    await waitForBytes(session, bytesWhilePaused + (512 * 1024))
+    const bytesAfterResume = session.bytes
+
+    // A stopped process cannot run a SIGTERM handler until continued. The
+    // backend must unstop the group as part of a normal Session shutdown.
+    session.term.pause?.()
+    await Bun.sleep(100)
+    session.term.kill()
+    await waitForPromise(session.exited, 'graceful PTY exit while paused')
+    return {
+      pid: session.term.pid,
+      bytesBeforePause,
+      bytesWhilePaused,
+      bytesAfterResume,
+      gracefulKillWhilePaused: true,
+    }
+  } finally {
+    try {
+      session.term.kill('SIGKILL')
+    } catch {
+      // already stopped
+    }
+    await session.exited
+  }
+}
 
 function spawnInteractive(label: string): {
   term: PtyProcess
@@ -119,4 +198,35 @@ async function waitForOutput(
     await Bun.sleep(20)
   }
   throw new Error(`Timed out waiting for ${expected}; output=${JSON.stringify(session.output)}`)
+}
+
+async function waitForBytes(
+  session: { bytes: number },
+  minimum: number,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (session.bytes >= minimum) return
+    await Bun.sleep(20)
+  }
+  throw new Error(`Timed out waiting for ${minimum} PTY bytes; received=${session.bytes}`)
+}
+
+async function waitForPromise(
+  promise: Promise<void>,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
 }

--- a/src/workspaces/pty-bun.ts
+++ b/src/workspaces/pty-bun.ts
@@ -43,12 +43,13 @@ const bunRuntime = (globalThis as typeof globalThis & { Bun: BunPtyRuntime }).Bu
 
 export const ptyBackend: PtyBackend = {
   name: 'bun-native',
-  supportsFlowControl: false,
+  supportsFlowControl: true,
   spawn(file, args, options) {
     const dataListeners = new Set<(data: Buffer) => void>();
     const exitListeners = new Set<(event: PtyExitEvent) => void>();
     const pendingData: Buffer[] = [];
     let exitEvent: PtyExitEvent | undefined;
+    let paused = false;
 
     const child = bunRuntime.spawn([file, ...args], {
       cwd: options.cwd,
@@ -70,6 +71,7 @@ export const ptyBackend: PtyBackend = {
         },
       },
       onExit(_child, exitCode, signalCode) {
+        paused = false;
         exitEvent = {
           exitCode: exitCode ?? 1,
           signal: signalCode ?? undefined,
@@ -113,8 +115,61 @@ export const ptyBackend: PtyBackend = {
         terminal.resize(cols, rows);
       },
       kill(signal) {
-        child.kill(signal as NodeJS.Signals | undefined);
+        const requestedSignal = signal as NodeJS.Signals | undefined;
+        // A graceful signal remains pending while the process group is
+        // stopped. Resume first so shutdown handlers can actually run.
+        if (paused && requestedSignal !== 'SIGKILL') {
+          signalProcessGroup(child, 'SIGCONT');
+          paused = false;
+        }
+        signalProcessGroup(child, requestedSignal ?? 'SIGTERM');
+      },
+      pause() {
+        if (paused || exitEvent) return;
+        if (signalProcessGroup(child, 'SIGSTOP')) paused = true;
+      },
+      resume() {
+        if (!paused || exitEvent) return;
+        if (signalProcessGroup(child, 'SIGCONT')) paused = false;
       },
     } satisfies PtyProcess;
   },
 };
+
+/**
+ * Bun.Terminal is callback-only and currently has no read-side pause method.
+ * A PTY child is its own POSIX session/process-group leader, so stopping that
+ * group moves output pressure back to the producer without buffering an
+ * unbounded copy in the Bun heap. Group signalling also covers helper
+ * processes spawned by an Agent Runtime.
+ */
+function signalProcessGroup(
+  child: BunPtySubprocess,
+  signal: NodeJS.Signals,
+): boolean {
+  try {
+    process.kill(-child.pid, signal);
+    return true;
+  } catch (error) {
+    if (!isMissingProcessError(error)) throw error;
+  }
+
+  // Bun's PTY contract creates a process group whose id matches the child pid.
+  // Keep a direct-child fallback for an exit race or a future runtime change.
+  try {
+    child.kill(signal);
+    return true;
+  } catch (error) {
+    if (isMissingProcessError(error)) return false;
+    throw error;
+  }
+}
+
+function isMissingProcessError(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === 'ESRCH'
+  );
+}


### PR DESCRIPTION
## Outcome

Completes the Bun-native PTY flow-control gate without a Node sidecar or unbounded application queue. The Bun backend maps the existing WebSocket high/low-watermark contract to POSIX process-group stop/continue signals and resumes a stopped group before graceful shutdown.

## Acceptance

- compiled Bun 1.4 PTY probe on native macOS arm64
- compiled probe in OrbStack Linux arm64 and emulated Linux x64 with empty PATH
- high-output child writer remains byte-stable while paused, resumes past another 512 KiB, and exits normally from the paused state
- two independent PTYs retain input/resize/stop isolation
- full root suite: 604 files passed, 1 skipped; 5,013 tests passed
- CLI suite: 37 files, 301 tests passed
- root TypeScript check
- rebuilt installable Bun release smoke
- Electron PTY smoke (node-pty lane)