### PR TITLE
test Bun external Broker Pack loading

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -21,6 +21,7 @@ on:
       - "scripts/install-smoke/**"
       - "scripts/build-bun-cli-feasibility.ts"
       - "scripts/build-bun-alice-feasibility.ts"
+      - "scripts/bun-broker-pack-fixture.ts"
       - "scripts/build-bun-runtime-feasibility.ts"
       - "scripts/build-bun-release.ts"
       - "THIRD_PARTY_NOTICES.md"

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -195,6 +195,13 @@ npx tsc --noEmit
 cd ui && npx tsc -b
 ```
 
+The Bun CLI lane additionally runs `pnpm build:bun-runtime:feasibility`. Its
+isolated fixture uses the production active-release layout, imports a private
+SDK from Pack-local `node_modules`, requires a real platform N-API binary, and
+proves the compiled UTA role loads it again after a forced UTA restart. This is
+the external-loading gate; it does not replace building and verifying the real
+release Packs above.
+
 For desktop changes, follow [[docs/managed-workspace-runtime.md]] and require
 `pnpm electron:assert-package` plus the packaged Workspace smoke. For a broker
 implementation change, also follow the paper/demo scenarios in

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -92,6 +92,13 @@ unbounded JavaScript queue; graceful Session shutdown resumes a stopped group
 before terminating it. Electron and source-backed Node execution retain
 `node-pty` and its native stream pause/resume behavior.
 
+Optional Broker Packs keep the existing external runtime boundary. The
+compiled UTA role resolves an activated Pack under
+`OPENALICE_HOME/runtime/broker-packs`, imports its ESM entry, and lets that entry
+resolve both JavaScript and N-API dependencies from the Pack's own
+`node_modules`. The Bun artifact does not absorb live broker SDKs; Pack API
+validation and immutable activation continue to follow [[docs/broker-packs.md]].
+
 Source development continues to use `pnpm dev`, and the currently released
 installer continues to use the bundle provider until the Bun release and
 installation acceptance matrix is complete. Electron remains independent.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -371,7 +371,7 @@ Checkboxes reflect repository truth, not intent.
   high-output backpressure stops the whole PTY process group at the producer
   boundary and resumes below the existing low watermark. Do not add a Node
   sidecar as the default answer.
-- [ ] Prove an installed broker pack can still be dynamically loaded from
+- [x] Prove an installed broker pack can still be dynamically loaded from
   `OPENALICE_HOME` without bundling its SDK into UTA Core.
 - [x] Prove embedded UI/default/template reads and one materialized external
   adapter file.
@@ -588,11 +588,9 @@ These may change implementation details but not the fixed product boundaries:
 1. Can the current `@hono/node-server` paths run unchanged under Bun, or should
    the CLI build use a small runtime-neutral server adapter while Electron and
    source development retain Node?
-2. Can installed broker-pack ESM and native SDKs load dynamically from disk in
-   the compiled UTA role without broadening the base artifact?
-3. Which current filesystem callers work directly against Bun embedded assets,
+2. Which current filesystem callers work directly against Bun embedded assets,
    and which externally consumed adapter files require materialization?
-4. What signing, notarization, and malware-scanning gates are required for the
+3. What signing, notarization, and malware-scanning gates are required for the
    standalone macOS CLI binary independently of Electron?
 
 ## Explicit Non-goals
@@ -722,3 +720,12 @@ This plan is complete only when:
   This keeps pressure at the producer/kernel PTY boundary and covers Agent
   Runtime helper processes without an unbounded Bun heap queue. Native Windows
   remains part of the deferred Windows distribution lane.
+- 2026-08-29: External Broker Pack acceptance materialized a production-shaped
+  active CCXT fixture under an isolated `OPENALICE_HOME`. Its ESM entry imports
+  a private SDK from the Pack's own `node_modules`, and that SDK must load and
+  expose a real platform N-API `.node` binary before it returns its marker. The
+  separately re-executed compiled UTA role created a healthy keyless account
+  carrying that marker, then loaded the Pack again after forced UTA failure and
+  restart. Native macOS arm64, OrbStack Linux arm64, and emulated Linux x64 all
+  passed with an empty `PATH`; UTA Core and the Bun release artifact remain free
+  of the fixture SDK and live broker dependencies.

--- a/scripts/build-bun-runtime-feasibility.ts
+++ b/scripts/build-bun-runtime-feasibility.ts
@@ -3,6 +3,8 @@ import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { prepareBunBrokerPackFixture } from './bun-broker-pack-fixture.js'
+
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 const pinnedBunVersion = (await readFile(join(repositoryRoot, '.bun-version'), 'utf8')).trim()
 if (Bun.version !== pinnedBunVersion) {
@@ -31,6 +33,11 @@ await mkdir(join(smokeHome, 'data/config'), { recursive: true })
 await writeFile(
   join(smokeHome, 'data/config/connector-service.json'),
   `${JSON.stringify({ enabled: true, adapters: {} }, null, 2)}\n`,
+)
+const brokerPackFixture = await prepareBunBrokerPackFixture(
+  smokeHome,
+  product.version,
+  repositoryRoot,
 )
 
 const buildStartedAt = performance.now()
@@ -87,6 +94,7 @@ const stderrPromise = new Response(runtime.stderr).text()
 let acceptanceError: unknown = null
 let initialStatus: RuntimeStatus | null = null
 let recoveredStatus: RuntimeStatus | null = null
+let externalBrokerPack: Awaited<ReturnType<typeof waitForBrokerPackFixture>> | null = null
 let readyDurationMs = 0
 try {
   await Promise.all([
@@ -94,6 +102,7 @@ try {
     waitForHttp(`http://127.0.0.1:${utaPort}/__uta/health`, 90_000),
     waitForHttp(`http://127.0.0.1:${connectorPort}/__connector/health`, 90_000),
   ])
+  externalBrokerPack = await waitForBrokerPackFixture(utaPort, brokerPackFixture)
   initialStatus = await waitForRuntimeStatus(smokeEnvironment, (status) => (
     status.class === 'running'
       && status.provider?.kind === 'bun'
@@ -135,6 +144,7 @@ try {
       && typeof status.componentDetail?.uta?.pid === 'number'
       && status.componentDetail.uta.pid !== utaPid
   ), 30_000)
+  await waitForBrokerPackFixture(utaPort, brokerPackFixture)
 } catch (error) {
   acceptanceError = error
 } finally {
@@ -180,6 +190,7 @@ const report = {
     utaRestartedOnControlFlag: true,
     runtimeLockReleasedAfterSignal: true,
   },
+  externalBrokerPack,
   nodeOrBunOnPath: false,
 }
 await writeFile(join(outputRoot, 'report.json'), `${JSON.stringify(report, null, 2)}\n`)
@@ -267,6 +278,53 @@ async function waitForHttp(url: string, timeoutMs: number): Promise<void> {
   throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
 }
 
+async function waitForBrokerPackFixture(
+  utaPort: number,
+  fixture: {
+    engine: string
+    release: string
+    accountId: string
+    sdkMarker: string
+    expectedLabel: string
+  },
+  timeoutMs = 30_000,
+): Promise<{
+  engine: string
+  release: string
+  accountId: string
+  sdkMarker: string
+  loadedFromOpenAliceHome: true
+}> {
+  const url = `http://127.0.0.1:${utaPort}/api/trading/uta`
+  const deadline = Date.now() + timeoutMs
+  let last = ''
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      last = await response.text()
+      if (response.ok) {
+        const body = JSON.parse(last) as {
+          utas?: Array<{ id?: string; label?: string; health?: { reach?: string } }>
+        }
+        const account = body.utas?.find((candidate) => candidate.id === fixture.accountId)
+        if (account?.label === fixture.expectedLabel && account.health?.reach === 'connected') {
+          return {
+            engine: fixture.engine,
+            release: fixture.release,
+            accountId: fixture.accountId,
+            sdkMarker: fixture.sdkMarker,
+            loadedFromOpenAliceHome: true,
+          }
+        }
+      }
+    } catch (error) {
+      last = String(error)
+    }
+    await Bun.sleep(100)
+  }
+  throw new Error(`Timed out waiting for compiled UTA to load external Broker Pack: ${last}`)
+}
+
 function minimalSmokeEnvironment(options: {
   home: string
   executable: string
@@ -290,6 +348,8 @@ function minimalSmokeEnvironment(options: {
     OPENALICE_MCP_PORT: String(options.mcpPort),
     OPENALICE_UTA_PORT: String(options.utaPort),
     OPENALICE_CONNECTOR_PORT: String(options.connectorPort),
+    OPENALICE_BROKER_PACK_ALLOW_WORKSPACE: '0',
+    OPENALICE_BROKER_PACK_AUTO_UPDATE: '0',
     ELECTRON_RUN_AS_NODE: '1',
     ...(process.env['SystemRoot'] ? { SystemRoot: process.env['SystemRoot'] } : {}),
   }

--- a/scripts/bun-broker-pack-fixture.ts
+++ b/scripts/bun-broker-pack-fixture.ts
@@ -1,0 +1,182 @@
+import { copyFile, mkdir, readdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const ENGINE = 'ccxt'
+const RELEASE = 'bun-external-fixture'
+const ACCOUNT_ID = 'binance-readonly'
+const SDK_MARKER = 'external-broker-sdk-native-v1'
+
+export interface BunBrokerPackFixture {
+  readonly engine: typeof ENGINE
+  readonly release: typeof RELEASE
+  readonly accountId: typeof ACCOUNT_ID
+  readonly sdkMarker: typeof SDK_MARKER
+  readonly expectedLabel: string
+}
+
+/**
+ * Materialize a production-shaped active Broker Pack under OPENALICE_HOME.
+ * The Pack entry imports a dependency from its own node_modules tree so the
+ * compiled Bun UTA acceptance proves the external module-resolution boundary,
+ * not merely a standalone file URL import.
+ */
+export async function prepareBunBrokerPackFixture(
+  home: string,
+  productVersion: string,
+  repositoryRoot: string,
+): Promise<BunBrokerPackFixture> {
+  const engineRoot = join(home, 'runtime', 'broker-packs', ENGINE)
+  const releaseRoot = join(engineRoot, 'releases', RELEASE)
+  const sdkRoot = join(
+    releaseRoot,
+    'node_modules',
+    '@openalice-fixture',
+    'broker-sdk',
+  )
+  await Promise.all([
+    mkdir(join(home, 'data', 'config'), { recursive: true }),
+    mkdir(join(releaseRoot, 'dist'), { recursive: true }),
+    mkdir(sdkRoot, { recursive: true }),
+  ])
+
+  await Promise.all([
+    writeFile(
+      join(home, 'data', 'config', 'trading.json'),
+      `${JSON.stringify({ keylessDataSources: ['binance'] }, null, 2)}\n`,
+    ),
+    writeFile(
+      join(engineRoot, 'active.json'),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        engine: ENGINE,
+        release: RELEASE,
+        activatedAt: '2026-08-29T00:00:00.000Z',
+      }, null, 2)}\n`,
+    ),
+    writeFile(
+      join(releaseRoot, 'broker-pack.json'),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        engine: ENGINE,
+        version: productVersion,
+        entry: 'dist/index.js',
+        contentId: RELEASE,
+        installedAt: '2026-08-29T00:00:00.000Z',
+      }, null, 2)}\n`,
+    ),
+    writeFile(
+      join(releaseRoot, 'package.json'),
+      `${JSON.stringify({
+        name: '@traderalice/uta-broker-ccxt',
+        version: productVersion,
+        type: 'module',
+        dependencies: {
+          '@openalice-fixture/broker-sdk': '1.0.0',
+        },
+      }, null, 2)}\n`,
+    ),
+    writeFile(join(releaseRoot, 'dist', 'index.js'), brokerPackModuleSource()),
+    writeFile(
+      join(sdkRoot, 'package.json'),
+      `${JSON.stringify({
+        name: '@openalice-fixture/broker-sdk',
+        version: '1.0.0',
+        type: 'module',
+        exports: './index.js',
+      }, null, 2)}\n`,
+    ),
+    writeFile(
+      join(sdkRoot, 'index.js'),
+      nativeSdkModuleSource(),
+    ),
+    copyFile(
+      await resolveNativeFixtureBinary(repositoryRoot),
+      join(sdkRoot, 'native-addon.node'),
+    ),
+  ])
+
+  return {
+    engine: ENGINE,
+    release: RELEASE,
+    accountId: ACCOUNT_ID,
+    sdkMarker: SDK_MARKER,
+    expectedLabel: `Binance (read-only data) [${SDK_MARKER}]`,
+  }
+}
+
+async function resolveNativeFixtureBinary(repositoryRoot: string): Promise<string> {
+  const pnpmRoot = join(repositoryRoot, 'node_modules', '.pnpm')
+  const storeEntry = (await readdir(pnpmRoot))
+    .find((name) => name.startsWith('dprint-node@'))
+  if (!storeEntry) {
+    throw new Error('dprint-node native fixture package is missing from node_modules')
+  }
+  const suffix = process.platform === 'darwin'
+    ? `darwin-${process.arch}`
+    : process.platform === 'linux'
+      ? `linux-${process.arch}-gnu`
+      : null
+  if (!suffix) throw new Error(`Bun Broker Pack native fixture does not support ${process.platform}`)
+  return join(
+    pnpmRoot,
+    storeEntry,
+    'node_modules',
+    'dprint-node',
+    `dprint-node.${suffix}.node`,
+  )
+}
+
+function nativeSdkModuleSource(): string {
+  return `import { createRequire } from 'node:module'
+
+const nativeAddon = createRequire(import.meta.url)('./native-addon.node')
+if (typeof nativeAddon.format !== 'function') {
+  throw new Error('external Broker Pack native SDK did not load')
+}
+
+export const externalSdkMarker = ${JSON.stringify(SDK_MARKER)}
+`
+}
+
+function brokerPackModuleSource(): string {
+  return `import { externalSdkMarker } from '@openalice-fixture/broker-sdk'
+
+export const BROKER_PACK_API_VERSION = 1
+export const BROKER_ENGINE = 'ccxt'
+export const configSchema = {
+  parse(value) {
+    if (externalSdkMarker !== ${JSON.stringify(SDK_MARKER)}) {
+      throw new Error('external Broker Pack SDK did not load')
+    }
+    return value
+  },
+}
+
+export function createBroker(config) {
+  const unsupported = async () => { throw new Error('fixture broker operation is unavailable') }
+  return {
+    id: config.id,
+    label: \`${'${config.label ?? config.id}'} [${'${externalSdkMarker}'}]\`,
+    brokerEngine: BROKER_ENGINE,
+    init: async () => {},
+    close: async () => {},
+    searchContracts: async () => [],
+    getContractDetails: async () => null,
+    placeOrder: unsupported,
+    modifyOrder: unsupported,
+    cancelOrder: unsupported,
+    closePosition: unsupported,
+    getAccount: unsupported,
+    getPositions: async () => [],
+    getOrders: async () => [],
+    getOrder: async () => null,
+    getQuote: unsupported,
+    getMarketClock: unsupported,
+    getCapabilities: () => ({ marketData: true, trading: false }),
+    getNativeKey: (contract) => String(contract?.symbol ?? ''),
+    resolveNativeKey: (nativeKey) => ({ symbol: nativeKey }),
+  }
+}
+`
+}


### PR DESCRIPTION
## Outcome

Closes the compiled-Bun external Broker Pack feasibility gate without changing the production Pack boundary. The Bun multiprocess acceptance now activates a production-shaped fixture under an isolated OPENALICE_HOME, loads its ESM entry plus Pack-local dependency and real platform N-API binary in the separately re-executed UTA role, then proves the Pack loads again after forced UTA restart.

## Acceptance

- Bun 1.4 multiprocess smoke passed on native macOS arm64
- same full smoke passed in OrbStack Linux arm64 and emulated Linux x64, all with empty PATH
- all five real Broker Pack artifacts built and passed clean-process archive verification on macOS arm64
- focused Broker Pack/UI tests: 33 passed
- root suite: 604 files passed, 1 skipped; 5,013 tests passed
- CLI suite: 37 files, 301 tests passed
- root and UI TypeScript checks passed

The previous-release upgrade smoke was started but its GitHub Release download produced no output for about two minutes, so it was stopped before staging or activation. This increment does not change the installer/update transaction; that network-dependent gate remains part of the installation increment.