### PR TITLE
Remove managed Pi from the Bun CLI runtime

### DIFF
--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -225,10 +225,34 @@ Both command families operate the same `cli-server` Guardian owner. The legacy
 `server status --json` keeps its raw payload while top-level JSON uses a
 versioned command envelope.
 
-The detached path is still source-backed: a user-owned or remote-managed
-checkout supplies the built Runtime while the installed CLI supplies lifecycle
-and transport control. A future standalone bundle changes preparation, not
-these ownership semantics.
+The source-development path remains checkout-backed: a user-owned or
+remote-managed checkout supplies the built Runtime while the CLI supplies
+lifecycle and transport control. The target-native Bun release uses the same
+commands and ownership semantics but resolves its immutable sidecar resources
+from the executable's release directory and skips source preparation.
+
+## Standalone Bun Agent Runtime boundary
+
+The Bun CLI release owns OpenAlice, its release Git, and its Workspace helper
+launchers. It does not own an Agent Runtime. Agent executables are discovered
+from the user's `PATH` and each Session starts through the existing adapter as
+an independent PTY process.
+
+Before any home-derived Pi environment is calculated, Bun launch paths remove
+only `OPENALICE_MANAGED_PI_PATH` and
+`OPENALICE_MANAGED_PI_NODE_PATH`. Those variables select Electron's packaged
+Pi and are not a CLI contract. The Bun path preserves `HOME`,
+`PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, and every other native
+Agent Runtime configuration value. Electron and source/package development
+retain their current managed-Pi behavior.
+
+`pnpm build:bun:release` verifies this boundary with an Agent executable that
+lives outside both the release and `OPENALICE_HOME`. It must be discovered as
+OpenCode, start through the real adapter in a Workspace PTY, receive the
+Workspace cwd, omit both managed-Pi selectors, and retain native Pi state. A
+local maintainer can additionally set `OPENALICE_BUN_REAL_OPENCODE_PATH` to an
+installed OpenCode executable; that optional gate launches the real TUI and
+checks that its user-owned TUI configuration remains unchanged.
 
 ## Dependency Bootstrap Direction
 
@@ -246,9 +270,10 @@ Keep bootstrap observable and layered:
 3. A later guided setup layer may present additional native Agent CLIs,
    installing only the user's selections with explicit commands, versions,
    and retry status.
-4. A future release asset can replace the source/build requirement with a
-   downloadable headless Runtime while retaining the same CLI and localhost
-   contract.
+4. The target-native Bun release asset replaces the source/build requirement
+   while retaining the same CLI and localhost contract. Installer activation
+   and package-manager distribution are specified in
+   [[docs/cli-installer.md]] and [[plans/bun-cli-distribution.md]].
 
 The same lifecycle contract survives that transition. Source-backed and
 standalone-bundle Runtime providers differ in preparation, not in ownership,

--- a/packages/cli/src/bun-standalone.mjs
+++ b/packages/cli/src/bun-standalone.mjs
@@ -19,6 +19,13 @@ export function bunGuardianProcessSpec(executable = process.execPath) {
   }
 }
 
+export function buildExternalAgentRuntimeEnvironment(env) {
+  const externalEnv = { ...env }
+  delete externalEnv.OPENALICE_MANAGED_PI_PATH
+  delete externalEnv.OPENALICE_MANAGED_PI_NODE_PATH
+  return externalEnv
+}
+
 export function buildBunRuntimeEnvironment(
   env,
   resourceRoot,
@@ -26,13 +33,14 @@ export function buildBunRuntimeEnvironment(
 ) {
   const gitRoot = join(resourceRoot, 'runtime', 'git')
   const gitBin = join(gitRoot, 'bin')
+  const runtimeEnv = buildExternalAgentRuntimeEnvironment(env)
   return {
-    ...env,
+    ...runtimeEnv,
     OPENALICE_RUNTIME_EXECUTABLE: executable,
     LOCAL_GIT_DIRECTORY: gitRoot,
     GIT_EXEC_PATH: join(gitRoot, 'libexec', 'git-core'),
     GIT_TEMPLATE_DIR: join(gitRoot, 'share', 'git-core', 'templates'),
-    PATH: env.PATH ? `${gitBin}${delimiter}${env.PATH}` : gitBin,
+    PATH: runtimeEnv.PATH ? `${gitBin}${delimiter}${runtimeEnv.PATH}` : gitBin,
   }
 }
 

--- a/packages/cli/src/bun-standalone.spec.mjs
+++ b/packages/cli/src/bun-standalone.spec.mjs
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 
 import {
   buildBunRuntimeEnvironment,
+  buildExternalAgentRuntimeEnvironment,
   bunGuardianProcessSpec,
   resolveBunContentIdentity,
   resolveBunResourceRoot,
@@ -42,6 +43,29 @@ describe('Bun standalone launch boundary', () => {
       GIT_TEMPLATE_DIR: resolve(resourceRoot, 'runtime/git/share/git-core/templates'),
       PATH: `${resolve(resourceRoot, 'runtime/git/bin')}${process.platform === 'win32' ? ';' : ':'}/usr/local/bin`,
     }))
+  })
+
+  it('removes desktop-managed Pi selection without replacing native Pi state', () => {
+    const env = {
+      OPENALICE_MANAGED_PI_PATH: '/desktop/pi/cli.js',
+      OPENALICE_MANAGED_PI_NODE_PATH: '/desktop/node',
+      PI_CODING_AGENT_DIR: '/user/pi',
+      PI_CODING_AGENT_SESSION_DIR: '/user/pi/sessions',
+      PATH: '/user/bin',
+    }
+
+    expect(buildExternalAgentRuntimeEnvironment(env)).toEqual({
+      PI_CODING_AGENT_DIR: '/user/pi',
+      PI_CODING_AGENT_SESSION_DIR: '/user/pi/sessions',
+      PATH: '/user/bin',
+    })
+    expect(env).toHaveProperty('OPENALICE_MANAGED_PI_PATH')
+
+    expect(buildBunRuntimeEnvironment(
+      env,
+      resolve('/opt/openalice/share/openalice'),
+      '/opt/openalice/bin/openalice',
+    )).not.toHaveProperty('OPENALICE_MANAGED_PI_PATH')
   })
 
   it('reads content identity from release metadata with an environment override', () => {

--- a/packages/cli/src/launch-context.spec.ts
+++ b/packages/cli/src/launch-context.spec.ts
@@ -161,6 +161,34 @@ describe('ResolvedLaunchContext', () => {
     }
   })
 
+  it('keeps user-owned Pi state and drops desktop-managed Pi in the Bun provider', () => {
+    vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true)
+    try {
+      const context = resolveLaunchContext({
+        homeDir: '/home/alice',
+        platform: 'linux',
+        env: {
+          OPENALICE_APP_HOME: '/opt/openalice/releases/v1/share/openalice',
+          OPENALICE_RUNTIME_CONTENT_IDENTITY: 'release-content-1',
+        },
+      })
+      const base = {
+        OPENALICE_MANAGED_PI_PATH: '/desktop/pi/cli.js',
+        OPENALICE_MANAGED_PI_NODE_PATH: '/desktop/node',
+        PI_CODING_AGENT_DIR: '/native/pi',
+        PI_CODING_AGENT_SESSION_DIR: '/native/pi/sessions',
+      }
+
+      expect(buildManagedPiEnv(context, base)).toEqual({
+        PI_CODING_AGENT_DIR: '/native/pi',
+        PI_CODING_AGENT_SESSION_DIR: '/native/pi/sessions',
+      })
+      expect(base).toHaveProperty('OPENALICE_MANAGED_PI_PATH')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('refuses an installed Runtime without its paired content identity', () => {
     expect(() => resolveLaunchContext({
       env: {

--- a/packages/cli/src/launch-context.ts
+++ b/packages/cli/src/launch-context.ts
@@ -7,6 +7,7 @@ import {
   type AliceProjectIdentity,
 } from './alice-project.ts'
 import {
+  buildExternalAgentRuntimeEnvironment,
   isBunStandalone,
   resolveBunContentIdentity,
   resolveBunResourceRoot,
@@ -251,6 +252,9 @@ export function buildManagedPiEnv(
   context: ResolvedLaunchContext,
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
+  if (context.runtimeProvider.kind === 'bun') {
+    return buildExternalAgentRuntimeEnvironment(baseEnv)
+  }
   return buildManagedPiEnvForHome(context.home, baseEnv)
 }
 

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -19,6 +19,7 @@ import {
 } from './server-control.mjs'
 import {
   buildBunRuntimeEnvironment,
+  buildExternalAgentRuntimeEnvironment,
   bunGuardianProcessSpec,
   isBunStandalone,
   resolveBunResourceRoot,
@@ -74,6 +75,9 @@ export async function startRuntime(options, dependencies = {}) {
   }
 
   const standalone = isBunStandalone()
+  const launchEnv = standalone
+    ? buildExternalAgentRuntimeEnvironment(env)
+    : env
   const requestedAppDir = options.appDir
     ?? env['OPENALICE_APP_HOME']?.trim()
     ?? env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
@@ -94,7 +98,7 @@ export async function startRuntime(options, dependencies = {}) {
   }
 
   const nodeBinary = dependencies.nodeBinary ?? process.execPath
-  let runtimeEnv = buildLocalRuntimeEnv(env, {
+  let runtimeEnv = buildLocalRuntimeEnv(launchEnv, {
     appDir,
     homeRoot,
     nodeBinary,

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -110,7 +110,12 @@ describe('OpenAlice Runtime lifecycle core', () => {
         runtimeProvider: { kind: 'bun', contentIdentity: 'release-content-1' },
       }, {
         detached: true,
-        env: { OPENALICE_APP_HOME: '/opt/openalice/releases/v1/share/openalice' },
+        env: {
+          OPENALICE_APP_HOME: '/opt/openalice/releases/v1/share/openalice',
+          OPENALICE_MANAGED_PI_PATH: '/desktop/pi/cli.js',
+          OPENALICE_MANAGED_PI_NODE_PATH: '/desktop/node',
+          PI_CODING_AGENT_DIR: '/native/pi',
+        },
         runtimeExecutable: '/opt/openalice/releases/v1/bin/openalice',
         prepareSource,
         resolveRoot,
@@ -131,9 +136,13 @@ describe('OpenAlice Runtime lifecycle core', () => {
           env: expect.objectContaining({
             OPENALICE_RUNTIME_PROVIDER: 'bun',
             OPENALICE_RUNTIME_EXECUTABLE: '/opt/openalice/releases/v1/bin/openalice',
+            PI_CODING_AGENT_DIR: '/native/pi',
           }),
         }),
       )
+      const spawnedEnv = spawnProcess.mock.calls[0][2].env
+      expect(spawnedEnv).not.toHaveProperty('OPENALICE_MANAGED_PI_PATH')
+      expect(spawnedEnv).not.toHaveProperty('OPENALICE_MANAGED_PI_NODE_PATH')
     } finally {
       vi.unstubAllGlobals()
     }

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -23,6 +23,7 @@ import {
 import { readRuntimeStatus as readGuardianRuntimeStatus } from './server-control.mjs'
 import {
   buildBunRuntimeEnvironment,
+  buildExternalAgentRuntimeEnvironment,
   bunGuardianProcessSpec,
   isBunStandalone,
   resolveBunResourceRoot,
@@ -131,6 +132,9 @@ export async function startLocal(options, dependencies = {}) {
   }
 
   const standalone = isBunStandalone()
+  const launchEnv = standalone
+    ? buildExternalAgentRuntimeEnvironment(env)
+    : env
   const requestedAppDir = options.appDir
     ?? env['OPENALICE_APP_HOME']?.trim()
     ?? env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()
@@ -147,7 +151,7 @@ export async function startLocal(options, dependencies = {}) {
   const spawnProcess = dependencies.spawnProcess ?? spawn
   const waitForRuntime = dependencies.waitForRuntime ?? waitForOpenAlice
   const nodeBinary = dependencies.nodeBinary ?? process.execPath
-  let runtimeEnv = buildLocalRuntimeEnv(env, {
+  let runtimeEnv = buildLocalRuntimeEnv(launchEnv, {
     appDir,
     homeRoot,
     nodeBinary,

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -227,6 +227,56 @@ describe('OpenAlice local Runtime launcher', () => {
     expect(launchBrowser).toHaveBeenCalledWith('http://127.0.0.1:41000')
   })
 
+  it('starts the Bun compatibility path without desktop-managed Pi state', async () => {
+    vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true)
+    try {
+      const child = new FakeChild()
+      const spawnProcess = vi.fn(() => child)
+      const resolveRoot = vi.fn()
+      const prepareSource = vi.fn()
+
+      await expect(startLocal(parseLocalStartArgs([
+        '--home', '/tmp/alice-home',
+        '--port', '41000',
+      ]), {
+        env: {
+          OPENALICE_APP_HOME: '/opt/openalice/releases/v1/share/openalice',
+          OPENALICE_RUNTIME_CONTENT_IDENTITY: 'release-content-1',
+          OPENALICE_MANAGED_PI_PATH: '/desktop/pi/cli.js',
+          OPENALICE_MANAGED_PI_NODE_PATH: '/desktop/node',
+          PI_CODING_AGENT_DIR: '/native/pi',
+        },
+        runtimeExecutable: '/opt/openalice/releases/v1/bin/openalice',
+        probeRuntime: async () => false,
+        readRuntimeStatus: async () => ({ class: 'absent', owner: null, endpoints: {} }),
+        resolveRoot,
+        prepareSource,
+        spawnProcess,
+        waitForRuntime: async () => ({ authed: true, tokenConfigured: false }),
+        launchBrowser: async () => child.finish(0),
+        stdout: { write: vi.fn() },
+      })).resolves.toBe(0)
+
+      expect(resolveRoot).not.toHaveBeenCalled()
+      expect(prepareSource).not.toHaveBeenCalled()
+      expect(spawnProcess).toHaveBeenCalledWith(
+        '/opt/openalice/releases/v1/bin/openalice',
+        ['--internal-role', 'guardian'],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            OPENALICE_RUNTIME_PROVIDER: 'bun',
+            PI_CODING_AGENT_DIR: '/native/pi',
+          }),
+        }),
+      )
+      const spawnedEnv = spawnProcess.mock.calls[0][2].env
+      expect(spawnedEnv).not.toHaveProperty('OPENALICE_MANAGED_PI_PATH')
+      expect(spawnedEnv).not.toHaveProperty('OPENALICE_MANAGED_PI_NODE_PATH')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('uses Corepack when pnpm is not installed', async () => {
     const commands = []
     let artifactsReady = false

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -411,9 +411,9 @@ build harness when it improves the next investigation.
   that dispatch into `openalice`.
 - [x] Materialize only files that an external Agent process must open by path;
   verify lifecycle, permissions, content identity, and update replacement.
-- [ ] Remove CLI-only `OPENALICE_MANAGED_PI_*` selection and injection without
+- [x] Remove CLI-only `OPENALICE_MANAGED_PI_*` selection and injection without
   changing Electron's bundled-Agent behavior.
-- [ ] Verify existing user-installed Agent CLIs retain their native config,
+- [x] Verify existing user-installed Agent CLIs retain their native config,
   version, executable path, and credentials.
 - [x] Ship a release-owned Git sidecar and prepend only its `bin` directory to
   Runtime children; prove init, commit, local clone, and GitHub HTTPS with no
@@ -729,3 +729,15 @@ This plan is complete only when:
   restart. Native macOS arm64, OrbStack Linux arm64, and emulated Linux x64 all
   passed with an empty `PATH`; UTA Core and the Bun release artifact remain free
   of the fixture SDK and live broker dependencies.
+- 2026-08-29: External Agent Runtime ownership increment removed Electron-only
+  `OPENALICE_MANAGED_PI_PATH` and `OPENALICE_MANAGED_PI_NODE_PATH` before any
+  Bun CLI home-derived environment is calculated, while preserving native Pi
+  state, `HOME`, `PATH`, and the source/Electron managed-Pi paths. The release
+  gate now discovers a package-external OpenCode executable and starts it via
+  the real adapter as an independent Workspace PTY on macOS arm64, OrbStack
+  Linux arm64, and emulated Linux x64. An additional native macOS run launched
+  installed OpenCode 1.17.13 from `/opt/homebrew/bin/opencode`, received its
+  real TUI output, and left its synthetic user-owned native config
+  byte-for-byte unchanged. The Linux run also exposed and fixed missing Dugite
+  core symlinks and standard `git-upload-pack`, `git-receive-pack`, and
+  `git-shell` bin entries in the portable Git layout.

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -211,7 +211,8 @@ async function buildPortableGit(source: string, destination: string): Promise<{
   const destinationCore = join(destination, 'libexec/git-core')
   const canonicalByHash = new Map<string, string>()
   canonicalByHash.set(await sha256File(join(destination, 'bin/git')), join(destination, 'bin/git'))
-  let symlinks = 0
+  await symlink(join('..', '..', 'bin', 'git'), join(destinationCore, 'git'))
+  let symlinks = 1
   for (const entry of await readdir(sourceCore, { withFileTypes: true })) {
     if (entry.isDirectory()) {
       if (entry.name === 'mergetools') {
@@ -219,10 +220,21 @@ async function buildPortableGit(source: string, destination: string): Promise<{
       }
       continue
     }
-    if (!entry.isFile() || !entry.name.startsWith('git-')) continue
+    if (!entry.name.startsWith('git-')) continue
     if (entry.name === 'git-lfs' || entry.name.startsWith('git-credential-manager')) continue
     const sourceFile = join(sourceCore, entry.name)
     const destinationFile = join(destinationCore, entry.name)
+    if (entry.isSymbolicLink()) {
+      const target = await readlink(sourceFile)
+      const resolvedTarget = resolve(sourceCore, target)
+      if (resolvedTarget !== sourceCore && !resolvedTarget.startsWith(`${sourceCore}/`)) {
+        throw new Error(`release-owned Git contains an escaping symlink: ${entry.name} -> ${target}`)
+      }
+      await symlink(target, destinationFile)
+      symlinks += 1
+      continue
+    }
+    if (!entry.isFile()) continue
     const hash = await sha256File(sourceFile)
     const canonical = canonicalByHash.get(hash)
     if (canonical) {
@@ -232,6 +244,13 @@ async function buildPortableGit(source: string, destination: string): Promise<{
       await cp(sourceFile, destinationFile)
       canonicalByHash.set(hash, destinationFile)
     }
+  }
+  // Git's local and SSH transports ask a shell to resolve these server-side
+  // programs by name. GIT_EXEC_PATH covers Git's own subcommand dispatch but
+  // does not replace the conventional bin entries on Linux.
+  for (const program of ['git-upload-pack', 'git-receive-pack', 'git-shell']) {
+    await symlink(join('..', 'libexec', 'git-core', program), join(destination, 'bin', program))
+    symlinks += 1
   }
   const entries = await releaseFiles(destination)
   const bytes = await directoryBytes(destination)
@@ -363,17 +382,52 @@ async function smokeRelease(options: {
 
   const [webPort, mcpPort, utaPort, connectorPort] = await allocatePorts(4)
   const runtimeHome = join(options.smokeHome, 'runtime-home')
+  const userHome = join(options.smokeHome, 'user-home')
+  const externalAgentRoot = join(options.smokeHome, 'external-agent')
+  const externalAgentBin = join(externalAgentRoot, 'bin')
+  const nativePiRoot = join(externalAgentRoot, 'native-pi-state')
+  const externalOpenCode = join(externalAgentBin, 'opencode')
+  const nativeOpenCodeTuiConfig = '{"theme":"system"}\n'
+  await Promise.all([
+    mkdir(externalAgentBin, { recursive: true }),
+    mkdir(join(userHome, '.config', 'opencode'), { recursive: true }),
+  ])
+  await writeFile(join(userHome, '.config', 'opencode', 'tui.json'), nativeOpenCodeTuiConfig)
+  await writeFile(externalOpenCode, `#!/bin/sh
+if [ "${'$'}{1-}" = "session" ] && [ "${'$'}{2-}" = "list" ]; then
+  printf '[]\\n'
+  exit 0
+fi
+printf 'OPENALICE_EXTERNAL_OPENCODE_OK\\n'
+printf 'CWD=%s\\n' "${'$'}PWD"
+printf 'MANAGED_PI_PATH=%s\\n' "${'$'}{OPENALICE_MANAGED_PI_PATH-unset}"
+printf 'MANAGED_PI_NODE_PATH=%s\\n' "${'$'}{OPENALICE_MANAGED_PI_NODE_PATH-unset}"
+printf 'PI_CODING_AGENT_DIR=%s\\n' "${'$'}{PI_CODING_AGENT_DIR-unset}"
+printf 'PI_CODING_AGENT_SESSION_DIR=%s\\n' "${'$'}{PI_CODING_AGENT_SESSION_DIR-unset}"
+while IFS= read -r line; do
+  printf 'INPUT=%s\\n' "${'$'}line"
+done
+`)
+  await chmod(externalOpenCode, 0o755)
   const runtimeEnv = {
-    HOME: runtimeHome,
-    PATH: '',
+    HOME: userHome,
+    PATH: externalAgentBin,
     TMPDIR: process.env['TMPDIR'] ?? '/tmp',
     OPENALICE_HOME: runtimeHome,
     OPENALICE_TRADING_MODE: 'lite',
+    OPENALICE_DISABLE_AUTH: '1',
     OPENALICE_BIND_HOST: '127.0.0.1',
     OPENALICE_WEB_PORT: String(webPort),
     OPENALICE_MCP_PORT: String(mcpPort),
     OPENALICE_UTA_PORT: String(utaPort),
     OPENALICE_CONNECTOR_PORT: String(connectorPort),
+    OPENALICE_MANAGED_PI_PATH: '/stale/desktop/pi/cli.js',
+    OPENALICE_MANAGED_PI_NODE_PATH: '/stale/desktop/node',
+    PI_CODING_AGENT_DIR: nativePiRoot,
+    PI_CODING_AGENT_SESSION_DIR: join(nativePiRoot, 'sessions'),
+    OPENALICE_TEMPLATE_SOURCE_REPOSITORY: sourceRepository,
+    OPENALICE_TEMPLATE_SOURCE_VERSION: 'HEAD',
+    OPENALICE_TEMPLATE_SOURCE_COMMIT: sourceCommit,
   }
   const runtime = Bun.spawn([
     options.executablePath,
@@ -391,6 +445,7 @@ async function smokeRelease(options: {
   const stdoutPromise = new Response(runtime.stdout).text()
   const stderrPromise = new Response(runtime.stderr).text()
   let runtimeError: unknown = null
+  let realOpenCodeReport: { path: string; version: string; ptyBytes: number } | null = null
   try {
     const root = await waitForHttp(`http://127.0.0.1:${webPort}/`, 90_000)
     if (!root.includes('<div id="root">')) throw new Error('installed release did not serve the real Web UI')
@@ -403,6 +458,94 @@ async function smokeRelease(options: {
       || status.result.status.provider.contentIdentity !== options.contentIdentity
     ) {
       throw new Error(`installed release status lost Bun provenance: ${JSON.stringify(status)}`)
+    }
+    const baseUrl = `http://127.0.0.1:${webPort}`
+    const inventory = await fetchJson(`${baseUrl}/api/workspaces/agents`) as {
+      agents?: Array<{ id?: string; installed?: boolean }>
+    }
+    if (!inventory.agents?.some((agent) => agent.id === 'opencode' && agent.installed === true)) {
+      throw new Error(`installed release did not discover the external OpenCode executable: ${JSON.stringify(inventory)}`)
+    }
+    const created = await fetchJson(`${baseUrl}/api/workspaces`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ tag: 'bun-external-opencode', template: 'chat' }),
+    }, 201) as { workspace?: { id?: string; dir?: string } }
+    const workspaceId = created.workspace?.id
+    const workspaceDir = created.workspace?.dir
+    if (!workspaceId || !workspaceDir) {
+      throw new Error(`installed release Workspace response was incomplete: ${JSON.stringify(created)}`)
+    }
+    const spawned = await fetchJson(`${baseUrl}/api/workspaces/${workspaceId}/sessions/spawn`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ agent: 'opencode' }),
+    }, 201) as { sessionId?: string }
+    if (!spawned.sessionId) {
+      throw new Error(`installed release external OpenCode spawn omitted sessionId: ${JSON.stringify(spawned)}`)
+    }
+    const marker = 'OPENALICE_EXTERNAL_OPENCODE_OK'
+    const terminal = await readPtyUntil(baseUrl, spawned.sessionId, {
+      client: 'bun-release-external-agent-smoke',
+      description: marker,
+      timeoutMs: 30_000,
+      complete: (output) => output.includes(marker),
+      settleDelayMs: 25,
+    })
+    for (const expected of [
+      `CWD=${workspaceDir}`,
+      'MANAGED_PI_PATH=unset',
+      'MANAGED_PI_NODE_PATH=unset',
+      `PI_CODING_AGENT_DIR=${nativePiRoot}`,
+      `PI_CODING_AGENT_SESSION_DIR=${join(nativePiRoot, 'sessions')}`,
+    ]) {
+      if (!terminal.includes(expected)) {
+        throw new Error(`external OpenCode process did not preserve the CLI ownership boundary (${expected}):\n${terminal}`)
+      }
+    }
+    const realOpenCodePath = process.env['OPENALICE_BUN_REAL_OPENCODE_PATH']?.trim()
+    if (realOpenCodePath) {
+      const realVersion = run([realOpenCodePath, '--version'], {
+        HOME: userHome,
+        PATH: dirname(realOpenCodePath),
+        OPENCODE_DISABLE_MODELS_FETCH: '1',
+        OPENCODE_DISABLE_AUTOUPDATE: '1',
+        OPENCODE_DISABLE_LSP_DOWNLOAD: '1',
+      }).trim()
+      await rm(externalOpenCode)
+      await symlink(realOpenCodePath, externalOpenCode)
+      const realCreated = await fetchJson(`${baseUrl}/api/workspaces`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tag: 'bun-real-opencode', template: 'chat' }),
+      }, 201) as { workspace?: { id?: string } }
+      const realWorkspaceId = realCreated.workspace?.id
+      if (!realWorkspaceId) {
+        throw new Error(`installed release real OpenCode Workspace response was incomplete: ${JSON.stringify(realCreated)}`)
+      }
+      const realSpawned = await fetchJson(`${baseUrl}/api/workspaces/${realWorkspaceId}/sessions/spawn`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent: 'opencode' }),
+      }, 201) as { sessionId?: string }
+      if (!realSpawned.sessionId) {
+        throw new Error(`installed release real OpenCode spawn omitted sessionId: ${JSON.stringify(realSpawned)}`)
+      }
+      const realTerminal = await readPtyUntil(baseUrl, realSpawned.sessionId, {
+        client: 'bun-release-real-agent-smoke',
+        description: '64 bytes of TUI output',
+        timeoutMs: 30_000,
+        complete: (output) => Buffer.byteLength(output) >= 64,
+      })
+      const retainedConfig = await readFile(join(userHome, '.config', 'opencode', 'tui.json'), 'utf8')
+      if (retainedConfig !== nativeOpenCodeTuiConfig) {
+        throw new Error('real external OpenCode launch changed the user-owned native TUI config')
+      }
+      realOpenCodeReport = {
+        path: realOpenCodePath,
+        version: realVersion,
+        ptyBytes: Buffer.byteLength(realTerminal),
+      }
     }
     // Let the foreground presenter observe the same ready status before the
     // smoke sends its ownership signal; otherwise the signal guard correctly
@@ -426,11 +569,86 @@ async function smokeRelease(options: {
     templates: ['chat', 'auto-quant-v2', 'auto-prediction'],
     workspaceCli: 'alice-workspace',
     workspaceCliInvoke: true,
+    externalAgentRuntime: 'opencode',
+    externalAgentRuntimeProcess: true,
+    externalAgentRuntimeManagedPi: false,
+    realExternalAgentRuntime: realOpenCodeReport,
     defaultResources: true,
     materializedPiAdapter: true,
     uiStatus: 200,
     contentIdentity: options.contentIdentity,
   }
+}
+
+async function fetchJson(
+  url: string,
+  init?: RequestInit,
+  expectedStatus = 200,
+): Promise<unknown> {
+  const response = await fetch(url, init)
+  const text = await response.text()
+  if (response.status !== expectedStatus) {
+    throw new Error(`${init?.method ?? 'GET'} ${url} returned ${response.status}: ${text}`)
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new Error(`${init?.method ?? 'GET'} ${url} returned invalid JSON: ${text}`)
+  }
+}
+
+function readPtyUntil(
+  baseUrl: string,
+  sessionId: string,
+  options: {
+    client: string
+    description: string
+    timeoutMs: number
+    complete: (output: string) => boolean
+    settleDelayMs?: number
+  },
+): Promise<string> {
+  const wsUrl = new URL('/api/workspaces/pty', baseUrl)
+  wsUrl.protocol = 'ws:'
+  wsUrl.searchParams.set('session', sessionId)
+  wsUrl.searchParams.set('cols', '120')
+  wsUrl.searchParams.set('rows', '32')
+  wsUrl.searchParams.set('client', options.client)
+  wsUrl.searchParams.set('kind', 'smoke')
+  wsUrl.searchParams.set('takeover', '1')
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const socket = new WebSocket(wsUrl)
+    socket.binaryType = 'arraybuffer'
+    let output = ''
+    let settled = false
+    const finish = (error?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      socket.close()
+      if (error) rejectPromise(error)
+      else resolvePromise(output)
+    }
+    const timeout = setTimeout(() => {
+      finish(new Error(`external Agent Runtime PTY timed out waiting for ${options.description}:\n${output.slice(-4_000)}`))
+    }, options.timeoutMs)
+    socket.addEventListener('message', (event) => {
+      const chunk = typeof event.data === 'string'
+        ? event.data
+        : event.data instanceof ArrayBuffer
+          ? Buffer.from(event.data).toString('utf8')
+          : String(event.data)
+      output += chunk
+      if (!options.complete(output)) return
+      if (options.settleDelayMs) setTimeout(() => finish(), options.settleDelayMs)
+      else finish()
+    })
+    socket.addEventListener('error', () => finish(new Error('external Agent Runtime PTY WebSocket failed')))
+    socket.addEventListener('close', () => {
+      if (!settled) finish(new Error(`external Agent Runtime PTY closed before ${options.description}:\n${output}`))
+    })
+  })
 }
 
 function run(command: string[], env: Record<string, string>): string {


### PR DESCRIPTION
## Summary
- strip Electron-only managed Pi selectors before Bun CLI launch environment derivation while preserving user-owned Agent Runtime state
- exercise an external OpenCode-compatible executable through the real Workspace PTY and optionally a real installed OpenCode binary
- preserve Linux Dugite core symlinks and expose standard portable Git transport commands
- document the standalone Agent Runtime ownership boundary

## Verification
- `npx tsc --noEmit`
- `pnpm test` (604 files passed, 1 skipped; 5015 tests passed, 9 skipped)
- focused CLI tests (54 passed)
- `pnpm electron:smoke:pty`
- Bun release smoke: macOS arm64, OrbStack Linux arm64, emulated Linux x64
- real OpenCode 1.17.13 PTY smoke from `/opt/homebrew/bin/opencode`