### PR TITLE
Rollback failed native CLI activations

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -93,6 +93,7 @@ The direct installer owns only:
 - release-owned Git and OpenAlice resources;
 - `openalice` and Workspace helper launchers;
 - the `cli/current` activation pointer;
+- the direct-install `cli/activation.json` readiness receipt;
 - per-release provenance;
 - the installer lock and update-check cache;
 - its marked shell `PATH` block.
@@ -124,6 +125,7 @@ The default install root is `~/.openalice`, independent from any
 │   └── traderhub
 ├── cli/
 │   ├── current -> releases/<active-release>
+│   ├── activation.json
 │   ├── releases/<version>-<platform>-<arch>-<content-id>/
 │   ├── provenance/<release-name>.json
 │   └── staging/
@@ -166,11 +168,13 @@ After consent, the transaction:
 4. validates and smoke-runs the staged release;
 5. moves the release into its immutable content-addressed directory;
 6. writes provenance outside the release;
-7. atomically replaces `cli/current` using platform-correct symlink semantics;
+7. records the exact previous release as a pending activation, then atomically
+   replaces `cli/current` using platform-correct symlink semantics;
 8. atomically replaces installer-owned launchers;
-9. verifies the stable `openalice` launcher;
-10. retains the newest three releases by default and collects older inactive
-    installer-owned releases;
+9. verifies the stable `openalice` launcher, restoring the exact previous
+   pointer if this post-activation install step fails;
+10. retains the newest three releases by default and never collects the exact
+    pending rollback release;
 11. writes one marked PATH block when requested;
 12. releases the lock and removes staging on every exit path.
 
@@ -212,7 +216,16 @@ For a stable direct install, `openalice update` downloads the versioned Bash
 installer, verifies the installer's manifest checksum, and invokes it with the
 exact advertised `--version`, current install root, and ordinary consent. A
 running process keeps its already-mapped executable; the new pointer affects
-the next invocation.
+the next invocation. `openalice status` and an idempotent `openalice up` report
+the pending product version while an older Guardian is still active.
+
+The first successful Guardian plus Alice HTTP readiness from the newly active
+content confirms `cli/activation.json`. If that first start exits early, times
+out, or cannot execute, the CLI validates the retained provenance and restores
+the exact previous `cli/current` target atomically. It does not start that
+release automatically and it never changes user data; the error tells the user
+to run `openalice` again. An initial install has no previous release and
+therefore reports the failure without inventing a rollback target.
 
 Rollback is local and download-free:
 
@@ -223,9 +236,11 @@ openalice rollback --to <full-retained-release-name> --yes
 ```
 
 It validates both releases and their provenance, refuses to race a live
-installer, and atomically switches only `cli/current`. It does not alter user
-data or remove releases. The current process is not hot-reloaded; run
-`openalice` again after update or rollback.
+installer, records the inverse switch as a pending activation, and atomically
+switches only `cli/current`. Its first readiness receives the same recovery
+protection as an update. It does not alter user data or remove releases. The
+current process is not hot-reloaded; run `openalice` again after update or
+rollback.
 
 ## Uninstall
 
@@ -312,4 +327,5 @@ credentials or broker accounts.
 | `failed SHA-256 verification` | Stop; artifact bytes and trusted checksum disagree |
 | `Existing release ... is damaged` | Preserve the collision for inspection; do not overwrite it |
 | `No previous OpenAlice release is retained` | Install/update once more before rollback is available |
+| startup says the activation was rolled back | The new direct-install Runtime failed first readiness; run `openalice` again to start the restored release |
 | update reports a non-stable channel | Refresh with the same selector instead of crossing trust boundaries |

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -104,6 +104,12 @@ command and never overwrite or remove manager-owned files. Stop a running
 Runtime with `openalice down` before changing the installed version; a running
 Guardian keeps its already-mapped executable until stopped.
 
+If the manager replaces the installed package while an older Guardian remains
+active, `openalice status` and `openalice up` compare content identities and
+report the new product version as pending activation. OpenAlice never rolls
+back npm, Bun, Homebrew, or AUR files: the owning manager remains the only
+writer. Stopping and starting the Runtime activates the installed package.
+
 Package-manager uninstall removes installation files only. OpenAlice data,
 AliceProjects, credentials, broker state, and user-owned Agent Runtimes remain
 outside the package manager's payload.

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -64,7 +64,7 @@ openalice project [list|use|copy-ai-creds|transfer] [options]
 | `up` | Prepare the selected provider when needed, start `cli-server` detached, and return only after Guardian control plus Alice HTTP readiness |
 | `run` | Start the same `cli-server` owner in the foreground without opening a browser; normal Ctrl+C/SIGTERM stops that self-owned tree |
 | `down` | Ask a matching Guardian to stop itself, then wait for endpoint and ownership release |
-| `status` | Read normalized status without mutation |
+| `status` | Read normalized status and activation state without mutation |
 | `logs` | Read a bounded, redacted tail from safe Runtime log rotations |
 | `doctor` | Run read-only provenance, ownership, readiness, component, provider, update-metadata, and log-layout checks |
 | `open` | Require an advertised Web endpoint and a successful `/api/auth/status` probe before invoking the platform browser opener |
@@ -74,9 +74,18 @@ when no owner exists. Ordinary start never signals another owner. `--takeover`
 delegates replacement to Guardian's established discover, TERM, grace, KILL,
 wait, then acquire ordering.
 
-Stable installs currently use the verified bundle provider. The in-progress
-Bun standalone provider skips source preparation and re-enters one executable
-as distinct Guardian/Alice/UTA/Connector processes; its release gate lives in
+Lifecycle inspection compares the installed native content identity with the
+running Guardian provider. `status`, TUI polling, and an idempotent `up` expose
+a pending activation when the installed package differs from the live Runtime.
+For direct Bash installs, first successful readiness confirms the installer's
+activation receipt; a first-start early exit, timeout, or execution failure
+restores the exact retained pointer without touching user data. A
+package-manager install is only reported as pending because its manager remains
+the sole owner of package files.
+
+Native CLI installs use the Bun standalone provider, which skips source
+preparation and re-enters one executable as distinct
+Guardian/Alice/UTA/Connector processes; its release gate lives in
 [[plans/bun-cli-distribution.md]]. `up` and `run` remain
 browserless lifecycle commands and accept home, port, wait, and takeover
 options; `--app-dir` is an advanced source override with the preparation and

--- a/install
+++ b/install
@@ -235,16 +235,68 @@ fi
 cli_root="$INSTALL_DIR/cli"
 releases_dir="$cli_root/releases"
 provenance_dir="$cli_root/provenance"
+activation_path="$cli_root/activation.json"
 bin_dir="$INSTALL_DIR/bin"
 lock_dir="$INSTALL_DIR/.cli-install.lock"
 staging_dir=""
 lock_owned=false
+previous_release_name=""
+activation_receipt_written=false
+activation_switched=false
+install_complete=false
 
 cleanup() {
+  cleanup_status=$?
+  trap - EXIT INT TERM HUP
+  if [[ "$cleanup_status" -ne 0 && "$install_complete" != true && "$activation_receipt_written" == true ]]; then
+    set +e
+    rollback_restored=true
+    if [[ "$activation_switched" == true ]]; then
+      if [[ -n "$previous_release_name" ]]; then
+        rollback_link="$cli_root/current.rollback.$$"
+        rm -f "$rollback_link"
+        if ! ln -s "releases/$previous_release_name" "$rollback_link"; then
+          rollback_restored=false
+        elif [[ "$platform" == darwin ]]; then
+          mv -fh "$rollback_link" "$cli_root/current" || rollback_restored=false
+        else
+          mv -Tf "$rollback_link" "$cli_root/current" || rollback_restored=false
+        fi
+      else
+        rm -f "$cli_root/current" || rollback_restored=false
+      fi
+    fi
+    if [[ "$rollback_restored" == true ]]; then
+      rollback_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      activation_next="$activation_path.next.$$"
+      cat >"$activation_next" <<EOF
+{
+  "schemaVersion": 1,
+  "activeRelease": "$release_name",
+  "previousRelease": $([[ -n "$previous_release_name" ]] && printf '"%s"' "$previous_release_name" || printf 'null'),
+  "productVersion": "$artifact_version",
+  "state": "rolled_back",
+  "activatedAt": "$activated_at",
+  "rolledBackAt": "$rollback_at",
+  "failureCode": "EINSTALL"
+}
+EOF
+      chmod 600 "$activation_next" && mv -f "$activation_next" "$activation_path" \
+        || printf 'Warning: restored the previous release but could not record rollback metadata.\n' >&2
+    else
+      printf 'Warning: automatic restoration of the previous OpenAlice release failed; inspect %s before retrying.\n' "$cli_root/current" >&2
+    fi
+    [[ -z "${rollback_link:-}" ]] || rm -f "$rollback_link"
+    set -e
+  fi
   [[ -z "$staging_dir" ]] || rm -rf "$staging_dir"
   if [[ "$lock_owned" == true ]]; then rm -rf "$lock_dir"; fi
+  exit "$cleanup_status"
 }
-trap cleanup EXIT INT TERM HUP
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 mkdir -p "$INSTALL_DIR"
 if [[ -d "$lock_dir" ]]; then
@@ -348,13 +400,42 @@ cat >"$provenance_dir/$release_name.json" <<EOF
 }
 EOF
 
-next_link="$cli_root/current.next.$$"
-rm -f "$next_link"
-ln -s "releases/$release_name" "$next_link"
-if [[ "$platform" == darwin ]]; then
-  mv -fh "$next_link" "$cli_root/current"
-else
-  mv -Tf "$next_link" "$cli_root/current"
+if [[ -L "$cli_root/current" ]]; then
+  previous_release_path="$(CDPATH= cd -- "$cli_root/current" && pwd -P)"
+  canonical_releases_dir="$(CDPATH= cd -- "$releases_dir" && pwd -P)"
+  [[ "$(dirname "$previous_release_path")" == "$canonical_releases_dir" ]] \
+    || fail "The active OpenAlice release pointer leaves the installer-owned releases directory"
+  previous_release_name="$(basename "$previous_release_path")"
+  [[ "$previous_release_name" =~ ^[A-Za-z0-9._+-]+$ ]] \
+    || fail "The active OpenAlice release name is invalid"
+fi
+
+if [[ "$previous_release_name" != "$release_name" ]]; then
+  activated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  activation_next="$activation_path.next.$$"
+  cat >"$activation_next" <<EOF
+{
+  "schemaVersion": 1,
+  "activeRelease": "$release_name",
+  "previousRelease": $([[ -n "$previous_release_name" ]] && printf '"%s"' "$previous_release_name" || printf 'null'),
+  "productVersion": "$artifact_version",
+  "state": "pending",
+  "activatedAt": "$activated_at"
+}
+EOF
+  chmod 600 "$activation_next"
+  mv -f "$activation_next" "$activation_path"
+  activation_receipt_written=true
+
+  next_link="$cli_root/current.next.$$"
+  rm -f "$next_link"
+  ln -s "releases/$release_name" "$next_link"
+  if [[ "$platform" == darwin ]]; then
+    mv -fh "$next_link" "$cli_root/current"
+  else
+    mv -Tf "$next_link" "$cli_root/current"
+  fi
+  activation_switched=true
 fi
 
 write_launcher() {
@@ -387,6 +468,7 @@ EOF
 write_launcher openalice
 for helper in alice alice-workspace alice-uta traderhub; do write_launcher "$helper" "$helper"; done
 "$bin_dir/openalice" --version >/dev/null
+install_complete=true
 
 if [[ "$legacy_detected" == true ]]; then
   rm -f "$bin_dir/pi" "$bin_dir/pi.cmd" "$bin_dir/openalice.cmd"
@@ -401,7 +483,9 @@ if [[ -e "${release_paths[0]}" ]]; then
   while IFS= read -r retained_release; do
     [[ -n "$retained_release" ]] || continue
     release_count=$((release_count + 1))
-    if (( release_count > KEEP_RELEASES )) && [[ "$retained_release" != "$active_release" ]]; then
+    if (( release_count > KEEP_RELEASES )) \
+      && [[ "$retained_release" != "$active_release" ]] \
+      && [[ -z "$previous_release_name" || "$retained_release" != "$releases_dir/$previous_release_name" ]]; then
       retained_name="$(basename "$retained_release")"
       rm -rf "$retained_release"
       rm -f "$provenance_dir/$retained_name.json"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,8 @@
     "src/supervisor-fleet.ts",
     "src/supervisor-transfer.ts",
     "src/supervisor-tui.ts",
+    "src/activation.mjs",
+    "src/activation-runtime.mjs",
     "src/bun-standalone.mjs",
     "src/doctor.mjs",
     "src/install-layout.mjs",
@@ -51,7 +53,7 @@
     "src/update.mjs"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/alice-project.ts && node --check src/alice-project-product.ts && node --check src/ai-credential-copy.ts && node --check src/create-alice-project.ts && node --check src/project-command.ts && node --check src/project-transfer.ts && node --check src/project-transfer-files.ts && node --check src/project-transfer-secrets.ts && node --check src/project-transfer-ssh.ts && node --check src/project-transfer-stream.ts && node --check src/machine-command.ts && node --check src/machine-inventory.ts && node --check src/machine-registry.ts && node --check src/managed-source.ts && node --check src/supervisor-config.ts && node --check src/supervisor-fleet.ts && node --check src/supervisor-transfer.ts && node --check src/bun-standalone.mjs && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/package-manager.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-bundle.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
+    "build": "tsc -p tsconfig.json --noEmit && node --check bin/openalice.ts && node --check bin/openalice.mjs && node --check src/alice-project.ts && node --check src/alice-project-product.ts && node --check src/ai-credential-copy.ts && node --check src/create-alice-project.ts && node --check src/project-command.ts && node --check src/project-transfer.ts && node --check src/project-transfer-files.ts && node --check src/project-transfer-secrets.ts && node --check src/project-transfer-ssh.ts && node --check src/project-transfer-stream.ts && node --check src/machine-command.ts && node --check src/machine-inventory.ts && node --check src/machine-registry.ts && node --check src/managed-source.ts && node --check src/supervisor-config.ts && node --check src/supervisor-fleet.ts && node --check src/supervisor-transfer.ts && node --check src/activation.mjs && node --check src/activation-runtime.mjs && node --check src/bun-standalone.mjs && node --check src/doctor.mjs && node --check src/install-layout.mjs && node --check src/install-source.mjs && node --check src/lifecycle-command.mjs && node --check src/lifecycle.mjs && node --check src/local-start.mjs && node --check src/logs.mjs && node --check src/observability-command.mjs && node --check src/package-manager.mjs && node --check src/remote.mjs && node --check src/runtime-deps.mjs && node --check src/runtime-bundle.mjs && node --check src/runtime-client.mjs && node --check src/server.mjs && node --check src/server-control.mjs && node --check src/ssh-connect.mjs && node --check src/uninstall.mjs && node --check src/update.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --root ../.. --config vitest.config.ts --project node packages/cli/src"
   },

--- a/packages/cli/src/activation-runtime.mjs
+++ b/packages/cli/src/activation-runtime.mjs
@@ -1,0 +1,173 @@
+import { realpath } from 'node:fs/promises'
+import { basename, dirname } from 'node:path'
+
+import {
+  confirmActivation,
+  markActivationRolledBack,
+  readActivationReceipt,
+} from './activation.mjs'
+import { resolveInstalledLayout } from './install-layout.mjs'
+import { CLI_VERSION, installedContentIdentity } from './install-source.mjs'
+import {
+  activateRelease,
+  assertNoLiveInstaller,
+  inspectRollback,
+} from './rollback.mjs'
+
+export async function resolveActivationContext(env, dependencies = {}) {
+  const resolveLayout = dependencies.resolveInstalledLayoutImpl ?? resolveInstalledLayout
+  const layout = Object.hasOwn(dependencies, 'activationLayout')
+    ? dependencies.activationLayout
+    : resolveLayout(import.meta.url, { env })
+  const contentIdentity = (
+    dependencies.installedContentIdentityImpl ?? installedContentIdentity
+  )(import.meta.url, {
+    env,
+    executable: dependencies.runtimeExecutable ?? process.execPath,
+  })
+  if (!layout || layout.kind !== 'bun') {
+    return {
+      layout: null,
+      receipt: null,
+      currentRelease: null,
+      currentContentIdentity: null,
+      contentIdentity,
+      productVersion: dependencies.cliVersion ?? CLI_VERSION,
+    }
+  }
+  const receipt = await (dependencies.readActivationReceiptImpl ?? readActivationReceipt)(
+    layout,
+    dependencies,
+  )
+  let currentRelease = null
+  try {
+    const realpathImpl = dependencies.realpathImpl ?? realpath
+    const currentPath = await realpathImpl(layout.currentPath)
+    const releasesPath = await realpathImpl(layout.releasesDir)
+    if (dirname(currentPath) !== releasesPath) {
+      const error = new Error('The active OpenAlice release pointer leaves the installer-owned releases directory.')
+      error.code = 'EACTIVATION'
+      throw error
+    }
+    currentRelease = basename(currentPath)
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+  return {
+    layout,
+    receipt,
+    currentRelease,
+    currentContentIdentity: /-([a-f0-9]{16})$/.exec(currentRelease ?? '')?.[1] ?? null,
+    contentIdentity,
+    productVersion: dependencies.cliVersion ?? CLI_VERSION,
+  }
+}
+
+export async function reconcileActivation(status, activation, dependencies = {}, options = {}) {
+  const providerIdentity = status.provider?.contentIdentity ?? null
+  const cliOwner = ['cli', 'cli-server'].includes(status.owner?.surface)
+  const runningInstalledContent = (
+    status.class === 'running'
+    && cliOwner
+    && activation.contentIdentity
+    && activation.contentIdentity === activation.currentContentIdentity
+    && providerIdentity === activation.contentIdentity
+  )
+  const directPending = (
+    activation.layout
+    && activation.receipt?.state === 'pending'
+    && activation.receipt.activeRelease === activation.currentRelease
+  )
+  if (directPending && runningInstalledContent) {
+    if (options.confirm === false) return { ...status, pendingActivation: null }
+    try {
+      const confirmed = await (dependencies.confirmActivationImpl ?? confirmActivation)(
+        activation.layout,
+        activation.receipt,
+        dependencies,
+      )
+      if (
+        confirmed?.state === 'confirmed'
+        && confirmed.activeRelease === activation.currentRelease
+      ) return { ...status, pendingActivation: null }
+    } catch (error) {
+      dependencies.activationWarning?.(error)
+    }
+  }
+  if (directPending) {
+    return {
+      ...status,
+      pendingActivation: {
+        productVersion: activation.receipt.productVersion,
+        restartRequired: status.class !== 'absent',
+        reason: status.class === 'absent'
+          ? 'The newly installed OpenAlice release has not completed its first successful start'
+          : 'A newly installed OpenAlice release is waiting for this Runtime to restart',
+      },
+    }
+  }
+  if (
+    status.class === 'running'
+    && cliOwner
+    && activation.contentIdentity
+    && providerIdentity !== activation.contentIdentity
+  ) {
+    return {
+      ...status,
+      pendingActivation: {
+        productVersion: activation.productVersion,
+        restartRequired: true,
+        reason: 'The installed OpenAlice package differs from the running Runtime',
+      },
+    }
+  }
+  return status
+}
+
+export async function rollbackFailedActivation(activation, error, dependencies = {}) {
+  if (
+    !['EEARLYEXIT', 'ETIMEDOUT', 'ENOENT', 'EACCES'].includes(error?.code)
+    || !activation.layout
+    || activation.receipt?.state !== 'pending'
+    || !activation.receipt.previousRelease
+    || activation.receipt.activeRelease !== activation.currentRelease
+    || activation.contentIdentity !== activation.currentContentIdentity
+  ) return null
+  try {
+    await (dependencies.assertNoLiveInstallerImpl ?? assertNoLiveInstaller)(
+      activation.layout.lockDir,
+      dependencies.processKill ?? process.kill,
+    )
+    const plan = await (dependencies.inspectRollbackImpl ?? inspectRollback)(
+      activation.layout,
+      activation.receipt.previousRelease,
+      dependencies,
+    )
+    if (
+      plan.current.name !== activation.receipt.activeRelease
+      || plan.target.name !== activation.receipt.previousRelease
+    ) return null
+    await (dependencies.activateReleaseImpl ?? activateRelease)(
+      activation.layout,
+      plan.target.name,
+      dependencies,
+    )
+    try {
+      await (dependencies.markActivationRolledBackImpl ?? markActivationRolledBack)(
+        activation.layout,
+        activation.receipt,
+        error,
+        dependencies,
+      )
+    } catch (metadataError) {
+      dependencies.activationWarning?.(metadataError)
+    }
+    return {
+      failedRelease: plan.current.name,
+      restoredRelease: plan.target.name,
+    }
+  } catch (rollbackError) {
+    dependencies.activationWarning?.(rollbackError)
+    return null
+  }
+}

--- a/packages/cli/src/activation.mjs
+++ b/packages/cli/src/activation.mjs
@@ -1,0 +1,122 @@
+import { randomUUID } from 'node:crypto'
+import { readFile, rename, rm, writeFile } from 'node:fs/promises'
+
+const RELEASE_NAME = /^[A-Za-z0-9._+-]+$/
+const STATES = new Set(['pending', 'confirmed', 'rolled_back'])
+
+export async function readActivationReceipt(layout, dependencies = {}) {
+  if (!layout?.activationPath) return null
+  let value
+  try {
+    value = JSON.parse(await (dependencies.readFileImpl ?? readFile)(layout.activationPath, 'utf8'))
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null
+    throw new Error(`OpenAlice CLI activation metadata is unreadable: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  return requireActivationReceipt(value)
+}
+
+export function requireActivationReceipt(value) {
+  if (!value || typeof value !== 'object') throw new Error('OpenAlice CLI activation metadata is invalid')
+  const previousRelease = value.previousRelease === null ? null : value.previousRelease
+  if (
+    value.schemaVersion !== 1
+    || typeof value.activeRelease !== 'string'
+    || !RELEASE_NAME.test(value.activeRelease)
+    || (previousRelease !== null && (
+      typeof previousRelease !== 'string'
+      || !RELEASE_NAME.test(previousRelease)
+      || previousRelease === value.activeRelease
+    ))
+    || typeof value.productVersion !== 'string'
+    || !/^[0-9A-Za-z][0-9A-Za-z.+_-]{0,127}$/.test(value.productVersion)
+    || !STATES.has(value.state)
+    || !validTimestamp(value.activatedAt)
+    || (value.confirmedAt !== undefined && !validTimestamp(value.confirmedAt))
+    || (value.rolledBackAt !== undefined && !validTimestamp(value.rolledBackAt))
+    || (value.failureCode !== undefined && (
+      typeof value.failureCode !== 'string'
+      || !/^[A-Z][A-Z0-9_]{0,63}$/.test(value.failureCode)
+    ))
+  ) {
+    throw new Error('OpenAlice CLI activation metadata is invalid')
+  }
+  return {
+    schemaVersion: 1,
+    activeRelease: value.activeRelease,
+    previousRelease,
+    productVersion: value.productVersion,
+    state: value.state,
+    activatedAt: value.activatedAt,
+    ...(value.confirmedAt ? { confirmedAt: value.confirmedAt } : {}),
+    ...(value.rolledBackAt ? { rolledBackAt: value.rolledBackAt } : {}),
+    ...(value.failureCode ? { failureCode: value.failureCode } : {}),
+  }
+}
+
+export async function writeActivationReceipt(layout, receipt, dependencies = {}) {
+  const value = requireActivationReceipt(receipt)
+  const temporaryPath = `${layout.activationPath}.next.${process.pid}.${randomUUID()}`
+  try {
+    await (dependencies.writeFileImpl ?? writeFile)(
+      temporaryPath,
+      `${JSON.stringify(value, null, 2)}\n`,
+      { mode: 0o600 },
+    )
+    await (dependencies.renameImpl ?? rename)(temporaryPath, layout.activationPath)
+  } finally {
+    await (dependencies.rmImpl ?? rm)(temporaryPath, { force: true })
+  }
+  return value
+}
+
+export async function recordPendingActivation(layout, activation, dependencies = {}) {
+  return writeActivationReceipt(layout, {
+    schemaVersion: 1,
+    activeRelease: activation.activeRelease,
+    previousRelease: activation.previousRelease ?? null,
+    productVersion: activation.productVersion,
+    state: 'pending',
+    activatedAt: activation.activatedAt ?? new Date().toISOString(),
+  }, dependencies)
+}
+
+export async function confirmActivation(layout, receipt, dependencies = {}) {
+  if (!receipt || receipt.state !== 'pending') return receipt
+  const latest = await readActivationReceipt(layout, dependencies)
+  if (!samePendingActivation(latest, receipt)) return latest
+  return writeActivationReceipt(layout, {
+    ...receipt,
+    state: 'confirmed',
+    confirmedAt: (dependencies.now ?? (() => new Date()))().toISOString(),
+  }, dependencies)
+}
+
+export async function markActivationRolledBack(layout, receipt, error, dependencies = {}) {
+  const latest = await readActivationReceipt(layout, dependencies)
+  if (!samePendingActivation(latest, receipt)) return latest
+  return writeActivationReceipt(layout, {
+    ...receipt,
+    state: 'rolled_back',
+    rolledBackAt: (dependencies.now ?? (() => new Date()))().toISOString(),
+    failureCode: normalizeFailureCode(error?.code),
+  }, dependencies)
+}
+
+function validTimestamp(value) {
+  return typeof value === 'string' && Number.isFinite(Date.parse(value))
+}
+
+function normalizeFailureCode(value) {
+  const normalized = String(value ?? 'ESTART').toUpperCase().replaceAll(/[^A-Z0-9_]+/g, '_')
+  return /^[A-Z]/.test(normalized) ? normalized.slice(0, 64) : `E_${normalized}`.slice(0, 64)
+}
+
+function samePendingActivation(left, right) {
+  return left?.state === 'pending'
+    && right?.state === 'pending'
+    && left.activeRelease === right.activeRelease
+    && left.previousRelease === right.previousRelease
+    && left.productVersion === right.productVersion
+    && left.activatedAt === right.activatedAt
+}

--- a/packages/cli/src/activation.spec.mjs
+++ b/packages/cli/src/activation.spec.mjs
@@ -1,0 +1,105 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  confirmActivation,
+  markActivationRolledBack,
+  readActivationReceipt,
+  recordPendingActivation,
+} from './activation.mjs'
+
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('OpenAlice direct-install activation receipt', () => {
+  it('records, confirms, and rolls back activation state atomically', async () => {
+    const layout = await makeLayout()
+    const pending = await recordPendingActivation(layout, {
+      activeRelease: '0.92.0-linux-x64-bbbbbbbbbbbbbbbb',
+      previousRelease: '0.91.0-linux-x64-aaaaaaaaaaaaaaaa',
+      productVersion: '0.92.0',
+      activatedAt: '2026-08-30T01:00:00.000Z',
+    })
+    expect(await readActivationReceipt(layout)).toEqual(pending)
+
+    const confirmed = await confirmActivation(layout, pending, {
+      now: () => new Date('2026-08-30T01:01:00.000Z'),
+    })
+    expect(confirmed).toMatchObject({
+      state: 'confirmed',
+      confirmedAt: '2026-08-30T01:01:00.000Z',
+    })
+
+    const nextPending = await recordPendingActivation(layout, {
+      activeRelease: pending.activeRelease,
+      previousRelease: pending.previousRelease,
+      productVersion: pending.productVersion,
+      activatedAt: '2026-08-30T01:01:30.000Z',
+    })
+    const rolledBack = await markActivationRolledBack(layout, nextPending, { code: 'early-exit' }, {
+      now: () => new Date('2026-08-30T01:02:00.000Z'),
+    })
+    expect(rolledBack).toMatchObject({
+      state: 'rolled_back',
+      rolledBackAt: '2026-08-30T01:02:00.000Z',
+      failureCode: 'EARLY_EXIT',
+    })
+  })
+
+  it('does not overwrite a newer activation receipt with a stale confirmation', async () => {
+    const layout = await makeLayout()
+    const stale = await recordPendingActivation(layout, {
+      activeRelease: '0.92.0-linux-x64-bbbbbbbbbbbbbbbb',
+      previousRelease: '0.91.0-linux-x64-aaaaaaaaaaaaaaaa',
+      productVersion: '0.92.0',
+      activatedAt: '2026-08-30T01:00:00.000Z',
+    })
+    const current = await recordPendingActivation(layout, {
+      activeRelease: '0.93.0-linux-x64-cccccccccccccccc',
+      previousRelease: '0.92.0-linux-x64-bbbbbbbbbbbbbbbb',
+      productVersion: '0.93.0',
+      activatedAt: '2026-08-30T01:01:00.000Z',
+    })
+
+    await expect(confirmActivation(layout, stale)).resolves.toEqual(current)
+    await expect(readActivationReceipt(layout)).resolves.toEqual(current)
+  })
+
+  it('rejects corrupt metadata instead of silently trusting it', async () => {
+    const layout = await makeLayout()
+    await writeFile(layout.activationPath, '{broken')
+    await expect(readActivationReceipt(layout)).rejects.toThrow('activation metadata is unreadable')
+  })
+
+  it('removes a temporary receipt when the atomic rename fails', async () => {
+    const layout = await makeLayout()
+    const renameImpl = vi.fn(async () => {
+      const error = new Error('rename failed')
+      error.code = 'EIO'
+      throw error
+    })
+    await expect(recordPendingActivation(layout, {
+      activeRelease: '0.92.0-linux-x64-bbbbbbbbbbbbbbbb',
+      previousRelease: null,
+      productVersion: '0.92.0',
+    }, { renameImpl })).rejects.toMatchObject({ code: 'EIO' })
+    expect(await readdir(join(layout.cliDir))).toEqual([])
+  })
+})
+
+async function makeLayout() {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-activation-'))
+  temporaryPaths.push(root)
+  const cliDir = join(root, 'cli')
+  await mkdir(cliDir, { recursive: true })
+  return {
+    cliDir,
+    activationPath: join(cliDir, 'activation.json'),
+  }
+}

--- a/packages/cli/src/install-layout.mjs
+++ b/packages/cli/src/install-layout.mjs
@@ -19,6 +19,7 @@ export function resolveInstalledLayout(moduleUrl = import.meta.url, options = {}
       releaseDir,
       currentPath: join(cliDir, 'current'),
       provenanceDir: join(cliDir, 'provenance'),
+      activationPath: join(cliDir, 'activation.json'),
       binDir: join(installRoot, 'bin'),
       lockDir: join(installRoot, '.cli-install.lock'),
       updateCachePath: join(installRoot, '.cli-update-check.json'),

--- a/packages/cli/src/install-layout.spec.mjs
+++ b/packages/cli/src/install-layout.spec.mjs
@@ -42,6 +42,7 @@ describe('OpenAlice installed layout', () => {
       releaseDir,
       currentPath: join(installRoot, 'cli', 'current'),
       provenanceDir: join(installRoot, 'cli', 'provenance'),
+      activationPath: join(installRoot, 'cli', 'activation.json'),
       binDir: join(installRoot, 'bin'),
       lockDir: join(installRoot, '.cli-install.lock'),
       updateCachePath: join(installRoot, '.cli-update-check.json'),

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -51,6 +51,13 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
 
     expect(result.stdout).toContain('Agent Runtimes remain user-owned')
     expect(await readlink(join(installRoot, 'cli', 'current'))).toBe(`releases/${releaseName}`)
+    expect(JSON.parse(await readFile(join(installRoot, 'cli', 'activation.json'), 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      activeRelease: releaseName,
+      previousRelease: null,
+      productVersion: '0.91.0',
+      state: 'pending',
+    })
     const provenance = JSON.parse(await readFile(join(installRoot, 'cli', 'provenance', `${releaseName}.json`), 'utf8'))
     expect(provenance).toMatchObject({
       schemaVersion: 3,
@@ -86,6 +93,12 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
       `0.91.0-${platform}-${architecture}-${'3'.repeat(16)}`,
       `0.92.0-${platform}-${architecture}-${'4'.repeat(16)}`,
     ])
+    expect(JSON.parse(await readFile(join(installRoot, 'cli', 'activation.json'), 'utf8'))).toMatchObject({
+      activeRelease: `0.92.0-${platform}-${architecture}-${'4'.repeat(16)}`,
+      previousRelease: `0.91.0-${platform}-${architecture}-${'3'.repeat(16)}`,
+      productVersion: '0.92.0',
+      state: 'pending',
+    })
     const debug = await execFileAsync(join(installRoot, 'bin', 'openalice'), ['debug-env'])
     expect(debug.stdout).toContain(`|${'4'.repeat(16)}|direct`)
   })
@@ -108,6 +121,42 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
     await expect(readFile(join(installRoot, 'data', 'preserved'), 'utf8')).resolves.toBe('state')
     await expect(execFileAsync(join(installRoot, 'bin', 'openalice'), ['--version']))
       .resolves.toMatchObject({ stdout: '0.91.0\n' })
+  })
+
+  it('retains the exact pending rollback release even when retention is one', async () => {
+    const first = await makeReleaseArchive('0.91.0', 'a'.repeat(16))
+    const second = await makeReleaseArchive('0.92.0', 'b'.repeat(16))
+    const installRoot = join(first.root, 'installed')
+    await runInstaller(first, installRoot, ['--yes'], { OPENALICE_INSTALL_KEEP_RELEASES: '1' })
+    await runInstaller(second, installRoot, ['--yes'], { OPENALICE_INSTALL_KEEP_RELEASES: '1' })
+
+    expect((await readdir(join(installRoot, 'cli', 'releases'))).sort()).toEqual([
+      `0.91.0-${platform}-${architecture}-${'a'.repeat(16)}`,
+      `0.92.0-${platform}-${architecture}-${'b'.repeat(16)}`,
+    ])
+  })
+
+  it('restores the exact previous pointer when installation fails after activation', async () => {
+    const first = await makeReleaseArchive('0.91.0', 'c'.repeat(16))
+    const second = await makeReleaseArchive('0.92.0', 'd'.repeat(16))
+    const installRoot = join(first.root, 'installed')
+    const previousName = `0.91.0-${platform}-${architecture}-${'c'.repeat(16)}`
+    const failedName = `0.92.0-${platform}-${architecture}-${'d'.repeat(16)}`
+    await runInstaller(first, installRoot, ['--yes'])
+    await mkdir(join(installRoot, 'data'), { recursive: true })
+    await writeFile(join(installRoot, 'data', 'preserved'), 'state')
+    await rm(join(installRoot, 'bin', 'openalice'))
+    await mkdir(join(installRoot, 'bin', 'openalice'))
+
+    await expect(runInstaller(second, installRoot, ['--yes'])).rejects.toBeTruthy()
+    expect(await readlink(join(installRoot, 'cli', 'current'))).toBe(`releases/${previousName}`)
+    expect(JSON.parse(await readFile(join(installRoot, 'cli', 'activation.json'), 'utf8'))).toMatchObject({
+      activeRelease: failedName,
+      previousRelease: previousName,
+      state: 'rolled_back',
+      failureCode: 'EINSTALL',
+    })
+    await expect(readFile(join(installRoot, 'data', 'preserved'), 'utf8')).resolves.toBe('state')
   })
 
   it('rejects missing consent and a bad archive checksum before activation', async () => {
@@ -190,14 +239,14 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
   })
 })
 
-async function runInstaller(fixture, installRoot, extraArgs) {
+async function runInstaller(fixture, installRoot, extraArgs, extraEnv = {}) {
   return await execFileAsync('bash', [installer,
     '--archive', fixture.archive,
     '--sha256', fixture.sha256,
     '--install-dir', installRoot,
     '--no-modify-path',
     ...extraArgs,
-  ], { env: { ...process.env, HOME: fixture.root } })
+  ], { env: { ...process.env, HOME: fixture.root, ...extraEnv } })
 }
 
 async function makeReleaseArchive(version, contentIdentity) {

--- a/packages/cli/src/lifecycle-command.mjs
+++ b/packages/cli/src/lifecycle-command.mjs
@@ -443,6 +443,9 @@ function formatExistingRuntime(status) {
   const lines = [`OpenAlice Runtime is already running at ${status.endpoints.web ?? 'an unknown endpoint'}`]
   lines.push(`Home: ${status.home}`)
   if (status.owner) lines.push(`Owner: ${status.owner.surface} (pid ${status.owner.pid})`)
+  if (status.pendingActivation?.productVersion) {
+    lines.push(`Pending activation: ${status.pendingActivation.productVersion}${status.pendingActivation.restartRequired ? ' (restart required)' : ''}`)
+  }
   return `${lines.join('\n')}\n`
 }
 

--- a/packages/cli/src/lifecycle-command.spec.mjs
+++ b/packages/cli/src/lifecycle-command.spec.mjs
@@ -124,6 +124,25 @@ describe('OpenAlice top-level lifecycle commands', () => {
     expect(openRuntime).toHaveBeenCalledOnce()
   })
 
+  it('shows a pending activation when up finds an older Runtime already running', async () => {
+    const stdout = output()
+    await expect(runLifecycleCommand('up', parseLifecycleArgs('up', []), {
+      startRuntime: async () => ({
+        ...startedResult(),
+        outcome: 'already-running',
+        status: {
+          ...runningStatus(),
+          pendingActivation: {
+            productVersion: '0.92.0',
+            restartRequired: true,
+          },
+        },
+      }),
+      stdout,
+    })).resolves.toBe(0)
+    expect(stdout.text()).toContain('Pending activation: 0.92.0 (restart required)')
+  })
+
   it('shares named-home and managed-Pi isolation with noninteractive startup', async () => {
     const startRuntime = vi.fn(async () => startedResult())
     await expect(runLifecycleCommand('up', parseLifecycleArgs('up', [

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -3,6 +3,12 @@ import { mkdir, open } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 import {
+  reconcileActivation,
+  resolveActivationContext,
+  rollbackFailedActivation,
+} from './activation-runtime.mjs'
+
+import {
   buildLocalRuntimeEnv,
   findOpenAliceRoot,
   prepareSourceCheckout,
@@ -29,10 +35,12 @@ const NULL_OUTPUT = Object.freeze({ write: () => undefined })
 
 export async function inspectRuntime(options = {}, dependencies = {}) {
   const readStatus = dependencies.readStatus ?? readRuntimeStatus
-  return readStatus({
+  const status = await readStatus({
     homeRoot: options.homeRoot,
     timeoutMs: options.waitMs,
   }, dependencies)
+  const activation = await resolveActivationContext(dependencies.env ?? process.env, dependencies)
+  return reconcileActivation(status, activation, dependencies, { confirm: false })
 }
 
 export async function startRuntime(options, dependencies = {}) {
@@ -44,9 +52,11 @@ export async function startRuntime(options, dependencies = {}) {
     homeDir: dependencies.homeDir,
   })
   const readStatus = dependencies.readStatus ?? readRuntimeStatus
+  const activation = await resolveActivationContext(env, dependencies)
   let status = await readStatus({ homeRoot, timeoutMs: 1_000 }, dependencies)
 
   if (status.owner?.surface === 'cli-server' && status.class === 'running') {
+    status = await reconcileActivation(status, activation, dependencies)
     return {
       outcome: 'already-running',
       mode: status.owner.mode ?? (detached ? 'detached' : 'foreground'),
@@ -61,6 +71,7 @@ export async function startRuntime(options, dependencies = {}) {
       ...dependencies,
       readStatus,
     })
+    status = await reconcileActivation(status, activation, dependencies)
     return {
       outcome: 'already-running',
       mode: status.owner?.mode ?? (detached ? 'detached' : 'foreground'),
@@ -189,6 +200,7 @@ export async function startRuntime(options, dependencies = {}) {
       startupSignals.promise,
     ])
     ready = true
+    status = await reconcileActivation(status, activation, dependencies)
     const launch = {
       outcome: 'started',
       mode: detached ? 'detached' : 'foreground',
@@ -211,13 +223,27 @@ export async function startRuntime(options, dependencies = {}) {
     readinessAbort.abort()
     startupSignals.release()
     runtime.kill('SIGTERM')
+    const rollback = await rollbackFailedActivation(activation, error, dependencies)
+    const rollbackMessage = rollback
+      ? ` The failed direct-install activation was rolled back to ${rollback.restoredRelease}. Run openalice again to start the restored release. User data was not changed.`
+      : ''
     if (detached) {
       const wrapped = lifecycleError(
         error?.code ?? 'ESTART',
-        `${error instanceof Error ? error.message : String(error)}. See the Runtime log at ${logPath}`,
+        `${error instanceof Error ? error.message : String(error)}.${rollbackMessage} See the Runtime log at ${logPath}`,
       )
       wrapped.cause = error
       wrapped.logPath = logPath
+      if (rollback) wrapped.rollback = rollback
+      throw wrapped
+    }
+    if (rollback) {
+      const wrapped = lifecycleError(
+        error?.code ?? 'ESTART',
+        `${error instanceof Error ? error.message : String(error)}.${rollbackMessage}`,
+      )
+      wrapped.cause = error
+      wrapped.rollback = rollback
       throw wrapped
     }
     throw error

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -1,7 +1,11 @@
 import { EventEmitter } from 'node:events'
+import { chmod, mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { readActivationReceipt, recordPendingActivation } from './activation.mjs'
 
 import {
   inspectRuntime,
@@ -9,6 +13,12 @@ import {
   startRuntime,
   stopRuntime,
 } from './lifecycle.mjs'
+
+const temporaryPaths = []
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
 
 describe('OpenAlice Runtime lifecycle core', () => {
   it('inspects the selected complete home without presentation side effects', async () => {
@@ -36,6 +46,184 @@ describe('OpenAlice Runtime lifecycle core', () => {
       status: expect.objectContaining({ class: 'running' }),
     }))
     expect(resolveRoot).not.toHaveBeenCalled()
+  })
+
+  it('reports a package-manager activation when installed and running content differ', async () => {
+    const status = await inspectRuntime(startOptions(), {
+      activationLayout: null,
+      installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+      cliVersion: '0.92.0',
+      readStatus: async () => runningStatus('aaaaaaaaaaaaaaaa'),
+    })
+    expect(status.pendingActivation).toEqual({
+      productVersion: '0.92.0',
+      restartRequired: true,
+      reason: 'The installed OpenAlice package differs from the running Runtime',
+    })
+  })
+
+  it('reports a direct activation against an older live Runtime and confirms matching up readiness', async () => {
+    const fixture = await makeActivationLayout()
+    await recordPendingActivation(fixture.layout, {
+      activeRelease: fixture.currentName,
+      previousRelease: fixture.previousName,
+      productVersion: '0.92.0',
+    })
+    const dependencies = {
+      activationLayout: fixture.layout,
+      installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+    }
+
+    const pending = await inspectRuntime(startOptions(), {
+      ...dependencies,
+      readStatus: async () => runningStatus('aaaaaaaaaaaaaaaa'),
+    })
+    expect(pending.pendingActivation).toMatchObject({
+      productVersion: '0.92.0',
+      restartRequired: true,
+    })
+    expect((await readActivationReceipt(fixture.layout)).state).toBe('pending')
+
+    const confirmed = await startRuntime(startOptions(), {
+      ...dependencies,
+      readStatus: async () => runningStatus('bbbbbbbbbbbbbbbb'),
+    })
+    expect(confirmed.status.pendingActivation).toBeNull()
+    expect((await readActivationReceipt(fixture.layout)).state).toBe('confirmed')
+  })
+
+  it('does not let a still-running previous CLI confirm the new direct activation', async () => {
+    const fixture = await makeActivationLayout()
+    await recordPendingActivation(fixture.layout, {
+      activeRelease: fixture.currentName,
+      previousRelease: fixture.previousName,
+      productVersion: '0.92.0',
+    })
+    const result = await startRuntime(startOptions(), {
+      activationLayout: fixture.layout,
+      installedContentIdentityImpl: () => 'aaaaaaaaaaaaaaaa',
+      readStatus: async () => runningStatus('aaaaaaaaaaaaaaaa'),
+    })
+    expect(result.status.pendingActivation).toMatchObject({ productVersion: '0.92.0' })
+    expect((await readActivationReceipt(fixture.layout)).state).toBe('pending')
+  })
+
+  it('restores the exact previous direct release when first readiness exits early', async () => {
+    const fixture = await makeActivationLayout()
+    await recordPendingActivation(fixture.layout, {
+      activeRelease: fixture.currentName,
+      previousRelease: fixture.previousName,
+      productVersion: '0.92.0',
+    })
+    const child = new FakeChild()
+    child.pid = 456
+    const spawnProcess = () => {
+      setImmediate(() => child.emit('exit', 1, null))
+      return child
+    }
+
+    await expect(startRuntime(startOptions(), {
+      activationLayout: fixture.layout,
+      installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+      detached: true,
+      env: {},
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess,
+      openFile: async () => ({ fd: 9, close: async () => undefined }),
+      mkdirImpl: async () => undefined,
+      readStatus: async () => absentStatus(),
+      sleep: async () => new Promise(() => undefined),
+    })).rejects.toMatchObject({
+      code: 'EEARLYEXIT',
+      message: expect.stringContaining(`rolled back to ${fixture.previousName}`),
+      rollback: {
+        failedRelease: fixture.currentName,
+        restoredRelease: fixture.previousName,
+      },
+    })
+    expect(await readlink(fixture.layout.currentPath)).toBe(`releases/${fixture.previousName}`)
+    expect(await readActivationReceipt(fixture.layout)).toMatchObject({
+      state: 'rolled_back',
+      failureCode: 'EEARLYEXIT',
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('does not race a live installer while handling readiness failure', async () => {
+    const fixture = await makeActivationLayout()
+    await recordPendingActivation(fixture.layout, {
+      activeRelease: fixture.currentName,
+      previousRelease: fixture.previousName,
+      productVersion: '0.92.0',
+    })
+    await mkdir(fixture.layout.lockDir)
+    await writeFile(resolve(fixture.layout.lockDir, 'pid'), `${process.pid}\n`)
+    const child = new FakeChild()
+    const spawnProcess = () => {
+      setImmediate(() => child.emit('exit', 1, null))
+      return child
+    }
+
+    await expect(startRuntime(startOptions(), {
+      activationLayout: fixture.layout,
+      installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+      detached: true,
+      env: {},
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess,
+      openFile: async () => ({ fd: 9, close: async () => undefined }),
+      mkdirImpl: async () => undefined,
+      readStatus: async () => absentStatus(),
+      sleep: async () => new Promise(() => undefined),
+    })).rejects.toMatchObject({ code: 'EEARLYEXIT' })
+    expect(await readlink(fixture.layout.currentPath)).toBe(`releases/${fixture.currentName}`)
+    expect((await readActivationReceipt(fixture.layout)).state).toBe('pending')
+  })
+
+  it('does not roll back a confirmed activation or an initial install without a previous release', async () => {
+    for (const receipt of [
+      { state: 'confirmed', previousRelease: 'previous-release' },
+      { state: 'pending', previousRelease: null },
+    ]) {
+      const child = new FakeChild()
+      const activateReleaseImpl = vi.fn()
+      const spawnProcess = () => {
+        setImmediate(() => child.emit('exit', 1, null))
+        return child
+      }
+      await expect(startRuntime(startOptions(), {
+        activationLayout: {
+          kind: 'bun',
+          currentPath: '/cli/current',
+          releasesDir: '/releases',
+        },
+        readActivationReceiptImpl: async () => ({
+          schemaVersion: 1,
+          activeRelease: 'current-release',
+          productVersion: '0.92.0',
+          activatedAt: '2026-08-30T01:00:00.000Z',
+          ...receipt,
+        }),
+        realpathImpl: async (path) => path.endsWith('current') ? '/releases/current-release' : '/releases',
+        installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+        activateReleaseImpl,
+        detached: true,
+        env: {},
+        nodeBinary: '/test/node',
+        resolveRoot: async (path) => path,
+        prepareSource: async () => ({ prepared: false }),
+        spawnProcess,
+        openFile: async () => ({ fd: 9, close: async () => undefined }),
+        mkdirImpl: async () => undefined,
+        readStatus: async () => absentStatus(),
+        sleep: async () => new Promise(() => undefined),
+      })).rejects.toMatchObject({ code: 'EEARLYEXIT' })
+      expect(activateReleaseImpl).not.toHaveBeenCalled()
+    }
   })
 
   it('starts a detached Guardian and emits readiness as structured state', async () => {
@@ -287,7 +475,7 @@ function startOptions() {
   }
 }
 
-function runningStatus() {
+function runningStatus(contentIdentity = null) {
   return {
     protocol: 1,
     class: 'running',
@@ -302,6 +490,10 @@ function runningStatus() {
       launchRoot: '/tmp/OpenAlice',
     },
     endpoints: { web: 'http://127.0.0.1:41000' },
+    provider: {
+      kind: contentIdentity ? 'bun' : 'source',
+      ...(contentIdentity ? { contentIdentity } : {}),
+    },
     components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
     capabilities: ['runtime.stop'],
   }
@@ -326,4 +518,46 @@ class FakeChild extends EventEmitter {
   signalCode = null
   kill = vi.fn()
   unref = vi.fn()
+}
+
+async function makeActivationLayout() {
+  const root = await mkdtemp(resolve(tmpdir(), 'openalice-lifecycle-'))
+  temporaryPaths.push(root)
+  const cliDir = resolve(root, 'cli')
+  const releasesDir = resolve(cliDir, 'releases')
+  const provenanceDir = resolve(cliDir, 'provenance')
+  const previousName = '0.91.0-linux-x64-aaaaaaaaaaaaaaaa'
+  const currentName = '0.92.0-linux-x64-bbbbbbbbbbbbbbbb'
+  await mkdir(provenanceDir, { recursive: true })
+  for (const [name, version] of [[previousName, '0.91.0'], [currentName, '0.92.0']]) {
+    const executable = resolve(releasesDir, name, 'bin', 'openalice')
+    await mkdir(resolve(executable, '..'), { recursive: true })
+    await writeFile(executable, '#!/bin/sh\nexit 0\n')
+    await chmod(executable, 0o755)
+    await writeFile(resolve(provenanceDir, `${name}.json`), `${JSON.stringify({
+      schemaVersion: 3,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: version,
+      selector: { kind: 'version', value: `v${version}` },
+      installerUrl: 'https://openalice.ai/install',
+      updateChannel: 'stable',
+      method: 'direct',
+      artifact: { platform: 'linux', arch: 'x64', sha256: '0'.repeat(64) },
+      installedAt: '2026-08-30T01:00:00.000Z',
+    })}\n`)
+  }
+  await symlink(`releases/${currentName}`, resolve(cliDir, 'current'))
+  return {
+    previousName,
+    currentName,
+    layout: {
+      kind: 'bun',
+      cliDir,
+      releasesDir,
+      currentPath: resolve(cliDir, 'current'),
+      provenanceDir,
+      activationPath: resolve(cliDir, 'activation.json'),
+      lockDir: resolve(root, '.cli-install.lock'),
+    },
+  }
 }

--- a/packages/cli/src/local-start.mjs
+++ b/packages/cli/src/local-start.mjs
@@ -7,6 +7,11 @@ import {
   aliceProjectEnvironment,
   resolveAliceProjectIdentity,
 } from './alice-project.ts'
+import {
+  reconcileActivation,
+  resolveActivationContext,
+  rollbackFailedActivation,
+} from './activation-runtime.mjs'
 
 import { buildManagedPiEnvForHome } from './launch-context.ts'
 import {
@@ -111,21 +116,25 @@ export async function startLocal(options, dependencies = {}) {
   const localUrl = `http://${LOOPBACK}:${options.port}`
   const probeRuntime = dependencies.probeRuntime ?? probeOpenAlice
   const launchBrowser = dependencies.launchBrowser ?? openBrowser
+  const readRuntimeStatus = dependencies.readRuntimeStatus ?? readGuardianRuntimeStatus
+  const readConfiguredWebPort = dependencies.readConfiguredWebPort ?? readHomeWebPort
+  const activation = await resolveActivationContext(env, dependencies)
 
   if (await probeRuntime(localUrl)) {
+    const status = await readRuntimeStatus({ homeRoot, timeoutMs: 500 }, { ...dependencies, env, homeDir })
+    await reconcileActivation(status, activation, dependencies)
     stdout.write(`OpenAlice is already running at ${localUrl}\n`)
     if (options.openBrowser) await launchBrowser(localUrl)
     return 0
   }
 
-  const readRuntimeStatus = dependencies.readRuntimeStatus ?? readGuardianRuntimeStatus
-  const readConfiguredWebPort = dependencies.readConfiguredWebPort ?? readHomeWebPort
-  const status = await readRuntimeStatus({ homeRoot, timeoutMs: 500 }, { env, homeDir })
+  const status = await readRuntimeStatus({ homeRoot, timeoutMs: 500 }, { ...dependencies, env, homeDir })
   const discoveredUrl = status.endpoints?.web
     ?? (status.class === 'owned_elsewhere'
       ? configuredLocalUrl(await readConfiguredWebPort(homeRoot))
       : null)
   if (discoveredUrl && discoveredUrl !== localUrl && await probeRuntime(discoveredUrl)) {
+    await reconcileActivation(status, activation, dependencies)
     stdout.write(`OpenAlice is already running at ${discoveredUrl} for ${homeRoot}\n`)
     if (options.openBrowser) await launchBrowser(discoveredUrl)
     return 0
@@ -144,7 +153,7 @@ export async function startLocal(options, dependencies = {}) {
   const appDir = standalone
     ? resolveBunResourceRoot(env, dependencies.runtimeExecutable ?? process.execPath)
     : await resolveRoot(requestedAppDir)
-  const runtimeProvider = resolveLocalRuntimeProvider(appDir, env)
+  const runtimeProvider = resolveLocalRuntimeProvider(appDir, env, activation.contentIdentity)
   const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
   if (!standalone) await prepareSource(appDir, options, { stdout, env })
 
@@ -187,7 +196,9 @@ export async function startLocal(options, dependencies = {}) {
     runtime.once('error', reject)
     runtime.once('exit', (code, signal) => {
       if (!ready) {
-        reject(new Error(`Local OpenAlice exited before it was ready (code=${String(code)}, signal=${String(signal)})`))
+        const error = new Error(`Local OpenAlice exited before it was ready (code=${String(code)}, signal=${String(signal)})`)
+        error.code = 'EEARLYEXIT'
+        reject(error)
       }
     })
   })
@@ -199,6 +210,11 @@ export async function startLocal(options, dependencies = {}) {
       startupSignals.promise,
     ])
     ready = true
+    const readyStatus = await readRuntimeStatus(
+      { homeRoot, timeoutMs: 1_000 },
+      { ...dependencies, env: runtimeEnv, homeDir },
+    )
+    await reconcileActivation(readyStatus, activation, dependencies)
     const runtimeExit = holdRuntime(runtime)
     startupSignals.release()
     stdout.write(`OpenAlice source: ${appDir}\n`)
@@ -211,15 +227,32 @@ export async function startLocal(options, dependencies = {}) {
     readinessAbort.abort()
     startupSignals.release()
     runtime.kill('SIGTERM')
+    if (
+      !error?.code
+      && error instanceof Error
+      && error.message.startsWith('OpenAlice did not become ready')
+    ) error.code = 'ETIMEDOUT'
+    const rollback = await rollbackFailedActivation(activation, error, dependencies)
+    if (rollback) {
+      const wrapped = new Error(
+        `${error instanceof Error ? error.message : String(error)}. The failed direct-install activation was rolled back to ${rollback.restoredRelease}. Run openalice again to start the restored release. User data was not changed.`,
+      )
+      wrapped.code = error?.code ?? 'ESTART'
+      wrapped.cause = error
+      wrapped.rollback = rollback
+      throw wrapped
+    }
     throw error
   }
 }
 
-function resolveLocalRuntimeProvider(appDir, env) {
+function resolveLocalRuntimeProvider(appDir, env, installedIdentity = null) {
   if (isBunStandalone()) {
     return {
       kind: 'bun',
-      contentIdentity: env['OPENALICE_RUNTIME_CONTENT_IDENTITY']?.trim() || null,
+      contentIdentity: env['OPENALICE_RUNTIME_CONTENT_IDENTITY']?.trim()
+        || installedIdentity
+        || null,
     }
   }
   const managedPath = env['OPENALICE_MANAGED_RUNTIME_PATH']?.trim()

--- a/packages/cli/src/local-start.spec.mjs
+++ b/packages/cli/src/local-start.spec.mjs
@@ -277,6 +277,115 @@ describe('OpenAlice local Runtime launcher', () => {
     }
   })
 
+  it('confirms direct activation through the Bun compatibility launcher', async () => {
+    vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true)
+    try {
+      const pending = {
+        schemaVersion: 1,
+        activeRelease: '0.92.0-darwin-arm64-bbbbbbbbbbbbbbbb',
+        previousRelease: '0.91.0-darwin-arm64-aaaaaaaaaaaaaaaa',
+        productVersion: '0.92.0',
+        state: 'pending',
+        activatedAt: '2026-08-30T01:00:00.000Z',
+      }
+      const confirmActivationImpl = vi.fn(async () => ({
+        ...pending,
+        state: 'confirmed',
+        confirmedAt: '2026-08-30T01:01:00.000Z',
+      }))
+      await expect(startLocal({
+        ...parseLocalStartArgs(['--no-open']),
+        homeRoot: '/tmp/alice-home',
+      }, {
+        activationLayout: {
+          kind: 'bun',
+          currentPath: '/cli/current',
+          releasesDir: '/cli/releases',
+        },
+        readActivationReceiptImpl: async () => pending,
+        realpathImpl: async (path) => path.endsWith('current')
+          ? '/cli/releases/0.92.0-darwin-arm64-bbbbbbbbbbbbbbbb'
+          : '/cli/releases',
+        installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+        confirmActivationImpl,
+        probeRuntime: async () => true,
+        readRuntimeStatus: async () => ({
+          class: 'running',
+          owner: { surface: 'cli', pid: 123 },
+          provider: { kind: 'bun', contentIdentity: 'bbbbbbbbbbbbbbbb' },
+          endpoints: { web: 'http://127.0.0.1:47331' },
+        }),
+        stdout: { write: vi.fn() },
+      })).resolves.toBe(0)
+      expect(confirmActivationImpl).toHaveBeenCalledOnce()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('rolls back direct activation when the Bun compatibility launcher exits early', async () => {
+    vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true)
+    try {
+      const child = new FakeChild()
+      const pending = {
+        schemaVersion: 1,
+        activeRelease: '0.92.0-darwin-arm64-bbbbbbbbbbbbbbbb',
+        previousRelease: '0.91.0-darwin-arm64-aaaaaaaaaaaaaaaa',
+        productVersion: '0.92.0',
+        state: 'pending',
+        activatedAt: '2026-08-30T01:00:00.000Z',
+      }
+      const activateReleaseImpl = vi.fn(async () => undefined)
+      const spawnProcess = () => {
+        setImmediate(() => child.emit('exit', 1, null))
+        return child
+      }
+      await expect(startLocal(parseLocalStartArgs([
+        '--home', '/tmp/alice-home',
+        '--no-open',
+      ]), {
+        env: { OPENALICE_APP_HOME: '/release/share/openalice' },
+        activationLayout: {
+          kind: 'bun',
+          currentPath: '/cli/current',
+          releasesDir: '/cli/releases',
+          lockDir: '/cli/install.lock',
+        },
+        readActivationReceiptImpl: async () => pending,
+        realpathImpl: async (path) => path.endsWith('current')
+          ? `/cli/releases/${pending.activeRelease}`
+          : '/cli/releases',
+        installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+        assertNoLiveInstallerImpl: async () => undefined,
+        inspectRollbackImpl: async () => ({
+          current: { name: pending.activeRelease },
+          target: { name: pending.previousRelease },
+        }),
+        activateReleaseImpl,
+        markActivationRolledBackImpl: async () => undefined,
+        runtimeExecutable: '/release/bin/openalice',
+        probeRuntime: async () => false,
+        readRuntimeStatus: async () => ({ class: 'absent', owner: null, endpoints: {} }),
+        spawnProcess,
+        waitForRuntime: async () => new Promise(() => undefined),
+        stdout: { write: vi.fn() },
+      })).rejects.toMatchObject({
+        code: 'EEARLYEXIT',
+        rollback: {
+          failedRelease: pending.activeRelease,
+          restoredRelease: pending.previousRelease,
+        },
+      })
+      expect(activateReleaseImpl).toHaveBeenCalledWith(
+        expect.any(Object),
+        pending.previousRelease,
+        expect.any(Object),
+      )
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('uses Corepack when pnpm is not installed', async () => {
     const commands = []
     let artifactsReady = false

--- a/packages/cli/src/rollback.mjs
+++ b/packages/cli/src/rollback.mjs
@@ -13,6 +13,7 @@ import {
 import { basename, dirname, join } from 'node:path'
 import { createInterface } from 'node:readline/promises'
 
+import { recordPendingActivation } from './activation.mjs'
 import { resolveInstalledLayout } from './install-layout.mjs'
 import { requireInstallSource } from './install-source.mjs'
 
@@ -62,6 +63,11 @@ export async function runRollbackCommand(argv, dependencies = {}) {
   }
 
   await assertNoLiveInstaller(layout.lockDir, dependencies.processKill ?? process.kill)
+  await (dependencies.recordPendingActivationImpl ?? recordPendingActivation)(layout, {
+    activeRelease: plan.target.name,
+    previousRelease: plan.current.name,
+    productVersion: plan.target.source.cliVersion,
+  }, dependencies)
   await activateRelease(layout, plan.target.name, dependencies)
   stdout.write(`\nOpenAlice rollback complete: ${plan.target.name}\n`)
   stdout.write('Run openalice again to use the activated release. User data was not changed.\n')
@@ -160,7 +166,7 @@ async function confirmRollback({ stdin, stdout }) {
   }
 }
 
-async function assertNoLiveInstaller(lockDir, processKill) {
+export async function assertNoLiveInstaller(lockDir, processKill) {
   let pid
   try {
     pid = Number((await readFile(join(lockDir, 'pid'), 'utf8')).trim())

--- a/packages/cli/src/rollback.spec.mjs
+++ b/packages/cli/src/rollback.spec.mjs
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -45,6 +45,12 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI rollback transactio
       stdin: { isTTY: false },
     })).resolves.toBe(0)
     expect(await readlink(layout.currentPath)).toBe('releases/0.90.0-linux-x64-aaaaaaaaaaaaaaaa')
+    expect(JSON.parse(await readFile(layout.activationPath, 'utf8'))).toMatchObject({
+      activeRelease: '0.90.0-linux-x64-aaaaaaaaaaaaaaaa',
+      previousRelease: '0.91.0-linux-x64-bbbbbbbbbbbbbbbb',
+      productVersion: '0.90.0',
+      state: 'pending',
+    })
     expect(output.join('')).toContain('User data was not changed')
   })
 
@@ -98,6 +104,7 @@ async function makeInstalledLayout(options = {}) {
     releaseDir: join(releasesDir, currentName),
     currentPath: join(cliDir, 'current'),
     provenanceDir,
+    activationPath: join(cliDir, 'activation.json'),
     binDir: join(installRoot, 'bin'),
     lockDir: join(installRoot, '.cli-install.lock'),
     updateCachePath: join(installRoot, '.cli-update-check.json'),

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -482,7 +482,7 @@ build harness when it improves the next investigation.
 - [x] For Bun-to-Bun updates, preserve a running old Guardian until explicit
   restart and report pending activation; do not replace a running executable
   in place.
-- [ ] Roll back the active pointer when new-runtime readiness fails.
+- [x] Roll back the active pointer when new-runtime readiness fails.
 - [x] Remove obsolete managed `pi` launchers only after the new OpenAlice
   command is validated; never remove a user-owned `pi` elsewhere on PATH.
 - [x] Keep bounded prior OpenAlice releases for rollback and collect only
@@ -795,3 +795,11 @@ This plan is complete only when:
   Arch base-devel image currently lacks arm64, so native Arch Linux ARM remains
   an explicit acceptance gap. Public registry name reservation and external
   tap/AUR publication remain activation work rather than hidden fallbacks.
+- 2026-08-30: Direct installs now record an atomic pending activation receipt
+  with the exact previous immutable release. Matching first readiness confirms
+  it; early exit, timeout, or executable failure restores the validated pointer
+  without starting the prior Runtime or touching user data. Installer failure
+  after pointer activation performs the same exact rollback, and retention
+  cannot collect the pending target. Package-manager upgrades remain
+  manager-owned: CLI/TUI status compares content identities and reports restart
+  activation without modifying npm, Bun, Homebrew, or AUR files.

--- a/scripts/install-smoke/run.sh
+++ b/scripts/install-smoke/run.sh
@@ -83,12 +83,29 @@ for helper in openalice alice alice-workspace alice-uta traderhub; do
   [[ -x "$install_root/bin/$helper" ]] || fail "missing launcher $helper"
 done
 
-bash /fixture/install --archive "$archive_v2" --sha256 "$sha_v2" --install-dir "$install_root" --yes
+mkdir -p "$install_root/data"
+printf 'preserved\n' >"$install_root/data/state"
+rm "$install_root/bin/openalice"
+mkdir "$install_root/bin/openalice"
+if bash /fixture/install --archive "$archive_v2" --sha256 "$sha_v2" --install-dir "$install_root" --yes >/tmp/failed-update.log 2>&1; then
+  fail "post-activation launcher failure unexpectedly succeeded"
+fi
+[[ "$(readlink "$install_root/cli/current")" == "releases/0.91.0-${platform}-${architecture}-aaaaaaaaaaaaaaaa" ]] \
+  || fail "failed install did not restore the exact previous pointer"
+grep -Fq '"state": "rolled_back"' "$install_root/cli/activation.json" \
+  || fail "failed install did not record rolled-back activation"
+[[ "$(cat "$install_root/data/state")" == preserved ]] || fail "failed install changed user data"
+rm -rf "$install_root/bin/openalice"
+
+OPENALICE_INSTALL_KEEP_RELEASES=1 bash /fixture/install \
+  --archive "$archive_v2" --sha256 "$sha_v2" --install-dir "$install_root" --yes
 [[ "$("$install_root/bin/openalice" --version)" == 0.92.0 ]] || fail "updated native release is not runnable"
 [[ "$(readlink "$install_root/cli/current")" == "releases/0.92.0-${platform}-${architecture}-bbbbbbbbbbbbbbbb" ]] \
   || fail "update did not atomically switch the active pointer"
 [[ -d "$install_root/cli/releases/0.91.0-${platform}-${architecture}-aaaaaaaaaaaaaaaa" ]] \
-  || fail "update removed the rollback release"
+  || fail "retention removed the pending rollback release"
+grep -Fq '"state": "pending"' "$install_root/cli/activation.json" \
+  || fail "update did not record pending activation"
 grep -Fq '# >>> OpenAlice CLI >>>' "$HOME/.bashrc" || fail "installer did not add its managed PATH block"
 [[ ! -e "$install_root/.cli-install.lock" ]] || fail "installer lock was not released"
 


### PR DESCRIPTION
## Summary
- record direct-install activations with an exact previous immutable release and preserve it through retention
- confirm activation only after matching Guardian and Alice readiness, then atomically restore the prior pointer on first-start failure
- report package-manager and direct-install pending activation without mutating manager-owned files or read-only status commands
- cover `up`, `run`, `server start`, and compatibility `start`, including stale CLI and live-installer races

## Verification
- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli test` (40 files, 335 tests)
- `pnpm -F @traderalice/openalice-cli build`
- `pnpm test` (611 files passed, 1 skipped; 5062 tests passed, 9 skipped)
- Guardian recovery fast matrix (51 tests plus real recovery smoke)
- `pnpm test:install:docker` with post-activation failure, exact rollback, data preservation, and retention=1
- pinned Bun 1.4.0 native macOS arm64 release build plus isolated install / `up` / `status` / `down`; activation confirmed
- `pnpm electron:smoke:pty`
