### PR TITLE
Record native CLI acceptance metrics

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -85,6 +85,17 @@ published last as the completed-set receipt. Stable releases publish the same
 four versioned archives and sidecars as GitHub Release assets and mirror them
 unchanged to the download CDN.
 
+Each native build also emits `report.json`. `buildDurationMs` is the clean Bun
+standalone compile, `artifactBuildDurationMs` is assembly plus archive creation
+with already-built server inputs, and `totalDurationMs` includes the real
+acceptance smoke. `smoke.coldStartReadyMs` runs from process spawn until
+Guardian reports Alice ready. `smoke.idleMemoryBytes` samples Guardian and
+Alice RSS three times after a one-second settling period and records the
+median. The separate multiprocess feasibility report applies the same method
+to Guardian, Alice, UTA, and Connector. These are target-run acceptance
+measurements, not cross-host performance promises; compare builds on the same
+runner and preserve the report beside its archive.
+
 ## Ownership boundary
 
 The direct installer owns only:
@@ -313,6 +324,9 @@ Before promotion also:
    `--branch dev` network path;
 6. verify release assets and sidecar checksums before making any stable alias
    visible.
+
+Treat missing or non-positive build, readiness, or per-role memory metrics as
+an invalid native acceptance report. A compile-only result is not sufficient.
 
 Routine acceptance is non-trading and uses isolated homes without real
 credentials or broker accounts.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -377,9 +377,9 @@ Checkboxes reflect repository truth, not intent.
   `OPENALICE_HOME` without bundling its SDK into UTA Core.
 - [x] Prove embedded UI/default/template reads and one materialized external
   adapter file.
-- [ ] Record measured executable size, cold start, idle memory per role, and
+- [x] Record measured executable size, cold start, idle memory per role, and
   clean-build time against the released headless Runtime.
-- [ ] Decide go/no-go from real macOS and Linux evidence. A compile-only
+- [x] Decide go/no-go from real macOS and Linux evidence. A compile-only
   success is insufficient.
 
 No public installer or durable compatibility layer changes in this increment.
@@ -399,7 +399,7 @@ build harness when it improves the next investigation.
   assets; keep broker packs external.
 - [x] Generate platform archives, `release.json`, SHA-256 metadata, version,
   control compatibility, and content identity from accepted build outputs.
-- [ ] Keep source development on `pnpm dev`; it need not imitate the installed
+- [x] Keep source development on `pnpm dev`; it need not imitate the installed
   executable layout.
 
 ### 3. Resources and Workspace helper boundary
@@ -803,3 +803,17 @@ This plan is complete only when:
   cannot collect the pending target. Package-manager upgrades remain
   manager-owned: CLI/TUI status compares content identities and reports restart
   activation without modifying npm, Bun, Homebrew, or AUR files.
+- 2026-08-30: Recorded a go decision from same-host v0.90.1 expanded Runtime
+  and Bun-native measurements. On macOS arm64, archive size fell from 112.5 to
+  53.8 MiB, expanded size from 528.5 to 113.8 MiB, four-role readiness improved
+  from 1,548 to 1,326 ms, and median idle RSS fell from 539.0 to 440.4 MiB. On
+  native OrbStack Linux arm64, archive size fell from 76.9 to 64.4 MiB,
+  expanded size from 419.2 to 128.4 MiB, readiness was effectively flat at 935
+  versus 959 ms, and idle RSS fell from 525.5 to 391.8 MiB. Rebuilding the
+  v0.90.1 headless artifact from its tag with prebuilt server inputs took 66.52
+  seconds on that Linux host; the Bun artifact assembly plus archive took 4.83
+  seconds, with a 0.93-second standalone compile. Both paths used isolated
+  homes, all four real process roles, three RSS samples at 500 ms intervals,
+  and no configured accounts. Release and feasibility reports now preserve
+  compile, artifact, total, cold-start, and per-role memory evidence. Source
+  development remains the unchanged `pnpm dev` path.

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -45,6 +45,7 @@ const resourceRoot = join(releaseRoot, 'share', 'openalice')
 const gitRoot = join(resourceRoot, 'runtime', 'git')
 const archivePath = join(outputRoot, `${releaseName}.tar.gz`)
 const smokeHome = join(outputRoot, 'smoke-home')
+const releaseStartedAt = performance.now()
 
 await rm(releaseRoot, { recursive: true, force: true })
 await rm(smokeHome, { recursive: true, force: true })
@@ -123,7 +124,9 @@ const releaseMetadata = {
   files,
 }
 await writeFile(join(releaseRoot, 'release.json'), `${JSON.stringify(releaseMetadata, null, 2)}\n`)
+const assemblyDurationMs = Math.round(performance.now() - releaseStartedAt)
 
+const smokeStartedAt = performance.now()
 const smoke = await smokeRelease({
   executablePath,
   resourceRoot,
@@ -131,7 +134,9 @@ const smoke = await smokeRelease({
   smokeHome,
   contentIdentity,
 })
+const smokeDurationMs = Math.round(performance.now() - smokeStartedAt)
 
+const archiveStartedAt = performance.now()
 const archive = Bun.spawnSync([
   'tar', '-czf', archivePath, '-C', outputRoot, releaseName,
 ], {
@@ -144,6 +149,7 @@ if (archive.exitCode !== 0) {
 }
 const archiveHash = await sha256File(archivePath)
 await writeFile(`${archivePath}.sha256`, `${archiveHash}  ${basename(archivePath)}\n`)
+const archiveDurationMs = Math.round(performance.now() - archiveStartedAt)
 
 const report = {
   schemaVersion: 1,
@@ -154,6 +160,11 @@ const report = {
   arch: process.arch,
   contentIdentity,
   buildDurationMs,
+  artifactBuildDurationMs: assemblyDurationMs + archiveDurationMs,
+  assemblyDurationMs,
+  archiveDurationMs,
+  smokeDurationMs,
+  totalDurationMs: Math.round(performance.now() - releaseStartedAt),
   executableBytes: (await stat(executablePath)).size,
   releaseBytes: await directoryBytes(releaseRoot),
   archiveBytes: (await stat(archivePath)).size,
@@ -429,6 +440,7 @@ done
     OPENALICE_TEMPLATE_SOURCE_VERSION: 'HEAD',
     OPENALICE_TEMPLATE_SOURCE_COMMIT: sourceCommit,
   }
+  const runtimeStartedAt = performance.now()
   const runtime = Bun.spawn([
     options.executablePath,
     'run',
@@ -446,18 +458,45 @@ done
   const stderrPromise = new Response(runtime.stderr).text()
   let runtimeError: unknown = null
   let realOpenCodeReport: { path: string; version: string; ptyBytes: number } | null = null
+  let coldStartReadyMs = 0
+  let idleMemoryBytes: {
+    sampleCount: number
+    sampleIntervalMs: number
+    guardian: number
+    alice: number
+    total: number
+  } | null = null
   try {
     const root = await waitForHttp(`http://127.0.0.1:${webPort}/`, 90_000)
     if (!root.includes('<div id="root">')) throw new Error('installed release did not serve the real Web UI')
-    const status = JSON.parse(run([
+    const status = await waitForReleaseRuntimeStatus(
       options.executablePath,
-      'status', '--home', runtimeHome, '--wait', '3', '--json',
-    ], runtimeEnv)) as { result?: { status?: { provider?: { kind?: string; contentIdentity?: string } } } }
+      runtimeHome,
+      runtimeEnv,
+    )
     if (
-      status.result?.status?.provider?.kind !== 'bun'
+      status.result?.status?.class !== 'running'
+      || status.result.status.componentDetail?.alice?.state !== 'ready'
+      || status.result.status.provider?.kind !== 'bun'
       || status.result.status.provider.contentIdentity !== options.contentIdentity
     ) {
       throw new Error(`installed release status lost Bun provenance: ${JSON.stringify(status)}`)
+    }
+    coldStartReadyMs = Math.round(performance.now() - runtimeStartedAt)
+    const guardianPid = status.result.status.owner?.pid
+    const alicePid = status.result.status.componentDetail?.alice?.pid
+    if (!guardianPid || !alicePid || guardianPid === alicePid) {
+      throw new Error(`installed release status omitted distinct Guardian/Alice PIDs: ${JSON.stringify(status)}`)
+    }
+    await Bun.sleep(1_000)
+    const guardian = await medianResidentSetBytes(guardianPid)
+    const alice = await medianResidentSetBytes(alicePid)
+    idleMemoryBytes = {
+      sampleCount: 3,
+      sampleIntervalMs: 500,
+      guardian,
+      alice,
+      total: guardian + alice,
     }
     const baseUrl = `http://127.0.0.1:${webPort}`
     const inventory = await fetchJson(`${baseUrl}/api/workspaces/agents`) as {
@@ -577,7 +616,62 @@ done
     materializedPiAdapter: true,
     uiStatus: 200,
     contentIdentity: options.contentIdentity,
+    coldStartReadyMs,
+    idleMemoryBytes,
   }
+}
+
+async function medianResidentSetBytes(pid: number): Promise<number> {
+  const samples: number[] = []
+  for (let index = 0; index < 3; index += 1) {
+    const probe = Bun.spawnSync(['/bin/ps', '-o', 'rss=', '-p', String(pid)], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const residentKiB = Number.parseInt(probe.stdout.toString().trim(), 10)
+    if (probe.exitCode !== 0 || !Number.isFinite(residentKiB) || residentKiB <= 0) {
+      throw new Error(`failed to measure resident memory for PID ${pid}: ${probe.stderr.toString()}`)
+    }
+    samples.push(residentKiB * 1024)
+    if (index < 2) await Bun.sleep(500)
+  }
+  samples.sort((left, right) => left - right)
+  return samples[1]
+}
+
+interface ReleaseRuntimeStatusEnvelope {
+  result?: {
+    status?: {
+      class?: string
+      provider?: { kind?: string; contentIdentity?: string }
+      owner?: { pid?: number }
+      componentDetail?: Record<string, { state?: string; pid?: number }>
+    }
+  }
+}
+
+async function waitForReleaseRuntimeStatus(
+  executable: string,
+  runtimeHome: string,
+  env: Record<string, string>,
+  timeoutMs = 15_000,
+): Promise<ReleaseRuntimeStatusEnvelope> {
+  const deadline = Date.now() + timeoutMs
+  let last: ReleaseRuntimeStatusEnvelope | null = null
+  while (Date.now() < deadline) {
+    last = JSON.parse(run([
+      executable,
+      'status', '--home', runtimeHome, '--wait', '1', '--json',
+    ], env)) as ReleaseRuntimeStatusEnvelope
+    if (
+      last.result?.status?.class === 'running'
+      && last.result.status.componentDetail?.alice?.state === 'ready'
+    ) {
+      return last
+    }
+    await Bun.sleep(100)
+  }
+  throw new Error(`installed release did not become ready: ${JSON.stringify(last)}`)
 }
 
 async function fetchJson(

--- a/scripts/build-bun-runtime-feasibility.ts
+++ b/scripts/build-bun-runtime-feasibility.ts
@@ -96,13 +96,13 @@ let initialStatus: RuntimeStatus | null = null
 let recoveredStatus: RuntimeStatus | null = null
 let externalBrokerPack: Awaited<ReturnType<typeof waitForBrokerPackFixture>> | null = null
 let readyDurationMs = 0
+let idleMemoryBytes: RuntimeMemoryReport | null = null
 try {
   await Promise.all([
     waitForHttp(`http://127.0.0.1:${webPort}/api/auth/status`, 90_000),
     waitForHttp(`http://127.0.0.1:${utaPort}/__uta/health`, 90_000),
     waitForHttp(`http://127.0.0.1:${connectorPort}/__connector/health`, 90_000),
   ])
-  externalBrokerPack = await waitForBrokerPackFixture(utaPort, brokerPackFixture)
   initialStatus = await waitForRuntimeStatus(smokeEnvironment, (status) => (
     status.class === 'running'
       && status.provider?.kind === 'bun'
@@ -115,6 +115,9 @@ try {
   if (new Set(initialPids).size !== 4) {
     throw new Error(`Guardian/Alice/UTA/Connector did not have four distinct PIDs: ${initialPids}`)
   }
+  externalBrokerPack = await waitForBrokerPackFixture(utaPort, brokerPackFixture)
+  await Bun.sleep(1_000)
+  idleMemoryBytes = await measureRuntimeMemory(initialStatus)
 
   const connectorPid = initialStatus.componentDetail?.connector?.pid
   if (!connectorPid) throw new Error('Connector PID was missing from Runtime status')
@@ -176,6 +179,8 @@ const report = {
   executableBytes: executable.size,
   buildDurationMs,
   readyDurationMs,
+  coldStartReadyMs: readyDurationMs,
+  idleMemoryBytes,
   processModel: {
     guardianPid: initialStatus?.owner?.pid,
     alicePid: initialStatus?.componentDetail?.alice?.pid,
@@ -204,6 +209,16 @@ interface RuntimeStatus {
   componentDetail?: Record<string, { state?: string; pid?: number }>
 }
 
+interface RuntimeMemoryReport {
+  sampleCount: number
+  sampleIntervalMs: number
+  guardian: number
+  alice: number
+  uta: number
+  connector: number
+  total: number
+}
+
 function runtimePids(status: RuntimeStatus): number[] {
   const pids = [
     status.owner?.pid,
@@ -215,6 +230,46 @@ function runtimePids(status: RuntimeStatus): number[] {
     throw new Error(`Runtime status omitted a component PID: ${JSON.stringify(status)}`)
   }
   return pids as number[]
+}
+
+async function measureRuntimeMemory(status: RuntimeStatus): Promise<RuntimeMemoryReport> {
+  const pids = runtimePids(status)
+  const samples = new Map<number, number[]>()
+  for (const pid of pids) samples.set(pid, [])
+  const sampleCount = 3
+  const sampleIntervalMs = 500
+  for (let sample = 0; sample < sampleCount; sample += 1) {
+    for (const pid of pids) samples.get(pid)?.push(readResidentSetBytes(pid))
+    if (sample + 1 < sampleCount) await Bun.sleep(sampleIntervalMs)
+  }
+  const [guardian, alice, uta, connector] = pids.map((pid) => median(samples.get(pid) ?? []))
+  return {
+    sampleCount,
+    sampleIntervalMs,
+    guardian,
+    alice,
+    uta,
+    connector,
+    total: guardian + alice + uta + connector,
+  }
+}
+
+function readResidentSetBytes(pid: number): number {
+  const probe = Bun.spawnSync(['/bin/ps', '-o', 'rss=', '-p', String(pid)], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const residentKiB = Number.parseInt(probe.stdout.toString().trim(), 10)
+  if (probe.exitCode !== 0 || !Number.isFinite(residentKiB) || residentKiB <= 0) {
+    throw new Error(`failed to measure resident memory for PID ${pid}: ${probe.stderr.toString()}`)
+  }
+  return residentKiB * 1024
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) throw new Error('cannot calculate a median without samples')
+  const sorted = [...values].sort((left, right) => left - right)
+  return sorted[Math.floor(sorted.length / 2)]
 }
 
 async function waitForRuntimeStatus(


### PR DESCRIPTION
## Summary
- record cold-start and median per-role RSS in native Bun feasibility and release reports
- separate compile, artifact assembly, archive, smoke, and total build timing
- document same-host v0.90.1 comparisons and the macOS/Linux go decision

## Verification
- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli test` (335 tests)
- `pnpm test` (5062 passed, 9 skipped)
- pinned Bun 1.4.0 native macOS arm64 multiprocess feasibility and release build
- OrbStack native Linux arm64 multiprocess feasibility and release build
- same-host v0.90.1 expanded Runtime cold-start/RSS and artifact-build comparison