### PR TITLE
Exercise native package manager upgrade lifecycles

### DIFF
--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -132,8 +132,15 @@ builds plus installs the x64 `openalice-bin` in a pinned clean Arch container.
 The official `archlinux:base-devel` image currently has no arm64 manifest, so
 arm64 AUR metadata is generated and checksum-bound but still needs a native
 Arch Linux ARM acceptance host. Each smoke uses an isolated home, exercises
-`up`, Doctor, `down`, manager-owned uninstall guidance, and actual manager
-removal without broker credentials or live trading.
+an actual stopped upgrade and removal, then starts a synthetic prior candidate
+and replaces it through the manager while Guardian is active. The new command
+must report the older running content as pending activation, preserve that
+result through idempotent `up`, route Doctor/update/uninstall back to the
+manager, and activate only after `down` plus a fresh `up`. The fixture rewrites
+only an isolated copy of an already accepted native candidate, refreshes its
+version/content hashes, and uses ad-hoc signing on macOS; it is never a
+publication input. Every Runtime uses isolated state without broker credentials
+or live trading.
 
 The release job derives every channel only after all native candidates pass,
 attaches the generated publication inputs to the GitHub Release, and publishes

--- a/install
+++ b/install
@@ -311,6 +311,7 @@ mkdir "$lock_dir"
 printf '%s\n' "$$" >"$lock_dir/pid"
 lock_owned=true
 mkdir -p "$releases_dir" "$provenance_dir" "$bin_dir" "$cli_root/staging"
+releases_dir="$(CDPATH= cd -- "$releases_dir" && pwd -P)"
 staging_dir="$(mktemp -d "$cli_root/staging/install.XXXXXX")"
 downloaded_archive="$staging_dir/release.tar.gz"
 

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { chmod, mkdir, mkdtemp, readlink, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -108,7 +108,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
     expect((await readActivationReceipt(fixture.layout)).state).toBe('pending')
   })
 
-  it('restores the exact previous direct release when first readiness exits early', async () => {
+  it.skipIf(process.platform === 'win32')('restores the exact previous direct release when first readiness exits early', async () => {
     const fixture = await makeActivationLayout()
     await recordPendingActivation(fixture.layout, {
       activeRelease: fixture.currentName,
@@ -143,7 +143,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
         restoredRelease: fixture.previousName,
       },
     })
-    expect(await readlink(fixture.layout.currentPath)).toBe(`releases/${fixture.previousName}`)
+    expect(await readlink(fixture.layout.currentPath)).toBe(join('releases', fixture.previousName))
     expect(await readActivationReceipt(fixture.layout)).toMatchObject({
       state: 'rolled_back',
       failureCode: 'EEARLYEXIT',
@@ -180,7 +180,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
       readStatus: async () => absentStatus(),
       sleep: async () => new Promise(() => undefined),
     })).rejects.toMatchObject({ code: 'EEARLYEXIT' })
-    expect(await readlink(fixture.layout.currentPath)).toBe(`releases/${fixture.currentName}`)
+    expect(await readlink(fixture.layout.currentPath)).toBe(join('releases', fixture.currentName))
     expect((await readActivationReceipt(fixture.layout)).state).toBe('pending')
   })
 

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -817,3 +817,12 @@ This plan is complete only when:
   and no configured accounts. Release and feasibility reports now preserve
   compile, artifact, total, cold-start, and per-role memory evidence. Source
   development remains the unchanged `pnpm dev` path.
+- 2026-08-30: Expanded the npm/Bun native package smoke from one install/remove
+  pass into two real manager-owned candidates. Each manager now upgrades and
+  removes with the Runtime stopped, then replaces a running prior candidate and
+  proves the new native command sees the old Guardian content as pending,
+  idempotent `up` preserves that result, CLI update/uninstall remain guidance
+  only, and `down` plus a fresh `up` activates the new content. Native macOS
+  arm64 passed through npm and pinned Bun 1.4.0; the PR matrix repeats the same
+  journey on Linux. Homebrew and AUR lifecycle expansion remains separate from
+  this npm/Bun increment.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -826,3 +826,11 @@ This plan is complete only when:
   arm64 passed through npm and pinned Bun 1.4.0; the PR matrix repeats the same
   journey on Linux. Homebrew and AUR lifecycle expansion remains separate from
   this npm/Bun increment.
+- 2026-08-30: Repaired cross-platform acceptance exposed by the package-manager
+  increment. The Bash installer now canonicalizes its release root before
+  retention comparisons, so macOS `/var` to `/private/var` resolution cannot
+  collect the active rollback release. npm package assembly selects `npm.cmd`
+  on Windows, path assertions use native separators, and the direct symlink
+  replacement rollback case is explicitly skipped on Windows while native
+  Windows activation remains a deferred distribution lane. Type checking, 335
+  CLI tests, 5,062 root tests, and the non-root Orb Linux installer smoke pass.

--- a/scripts/cli-package-manager-smoke.mjs
+++ b/scripts/cli-package-manager-smoke.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import {
   cpSync,
   existsSync,
@@ -17,70 +18,98 @@ import { join, resolve } from 'node:path'
 
 const options = parseArgs(process.argv.slice(2))
 const root = mkdtempSync(join(tmpdir(), `openalice-${options.manager}-package-smoke-`))
-const packagesRoot = join(root, 'packages')
 const sourcePackages = resolve(options.packagesDir)
-cpSync(sourcePackages, packagesRoot, { recursive: true })
+const currentPackagesRoot = join(root, 'packages-current')
+const previousPackagesRoot = join(root, 'packages-previous')
+cpSync(sourcePackages, currentPackagesRoot, { recursive: true })
+cpSync(sourcePackages, previousPackagesRoot, { recursive: true })
 
 const packageName = `openalice-${process.platform}-${process.arch}`
-const platformRoot = join(packagesRoot, packageName)
-const metaRoot = join(packagesRoot, 'openalice')
-if (!existsSync(join(platformRoot, 'package.json'))) {
+if (!existsSync(join(currentPackagesRoot, packageName, 'package.json'))) {
   fail(`generated package set does not contain ${packageName}`)
 }
-const tarballRoot = join(root, 'tarballs')
-mkdirSync(tarballRoot, { recursive: true })
-const platformTarball = pack(platformRoot, tarballRoot)
-const metaPackagePath = join(metaRoot, 'package.json')
-const metaPackage = JSON.parse(readFileSync(metaPackagePath, 'utf8'))
-metaPackage.optionalDependencies = {
-  [packageName]: `file:${platformTarball}`,
-}
-writeFileSync(metaPackagePath, `${JSON.stringify(metaPackage, null, 2)}\n`)
-const metaTarball = pack(metaRoot, tarballRoot)
+const previousVersion = syntheticPreviousVersion(options.expectedVersion)
+const previousContentIdentity = rewritePackageSetVersion({
+  packagesRoot: previousPackagesRoot,
+  packageName,
+  fromVersion: options.expectedVersion,
+  toVersion: previousVersion,
+})
+const previousMetaTarball = packPackageSet(
+  previousPackagesRoot,
+  join(root, 'tarballs-previous'),
+  packageName,
+)
+const currentMetaTarball = packPackageSet(
+  currentPackagesRoot,
+  join(root, 'tarballs-current'),
+  packageName,
+)
 
-const managerRoot = join(root, 'manager')
 const home = join(root, 'home')
 const runtimeHome = join(root, 'runtime-home')
-const baseEnv = {
-  ...process.env,
-  HOME: home,
-  XDG_CACHE_HOME: join(root, 'cache'),
-  npm_config_cache: join(root, 'npm-cache'),
-  BUN_INSTALL: managerRoot,
-}
+const bunExecutable = options.manager === 'bun'
+  ? realpathSync(resolveExecutable(options.bun))
+  : null
+const bunOnlyPath = options.manager === 'bun'
+  ? prepareBunOnlyPath(bunExecutable)
+  : null
+const activeManager = managerContext(join(root, 'manager'), 'active')
+const stoppedManager = managerContext(join(root, 'manager-stopped'), 'stopped')
 
 try {
-  if (options.manager === 'npm') {
-    run(options.npm, ['install', '--global', '--prefix', managerRoot, metaTarball], baseEnv)
-  } else {
-    const bunExecutable = realpathSync(resolveExecutable(options.bun))
-    const bunOnlyPath = join(root, 'bun-only-path')
-    mkdirSync(bunOnlyPath, { recursive: true })
-    symlinkSync(bunExecutable, join(bunOnlyPath, 'bun'))
-    run(bunExecutable, ['add', '--global', '--trust', metaTarball], {
-      ...baseEnv,
-      PATH: `${bunOnlyPath}:/usr/bin:/bin`,
-    })
+  installPackage(previousMetaTarball, stoppedManager)
+  assertInstalled(
+    stoppedManager.executable,
+    { HOME: home, PATH: '/usr/bin:/bin' },
+    previousVersion,
+    previousContentIdentity,
+  )
+  installPackage(currentMetaTarball, stoppedManager, { force: true })
+  assertInstalled(
+    stoppedManager.executable,
+    { HOME: home, PATH: '/usr/bin:/bin' },
+    options.expectedVersion,
+    options.expectedContentIdentity,
+  )
+  removePackage(stoppedManager)
+  if (existsSync(stoppedManager.executable)) {
+    fail(`${options.manager} stopped removal left the openalice command behind`)
   }
 
-  const executable = join(managerRoot, 'bin', 'openalice')
+  installPackage(previousMetaTarball, activeManager)
+
+  const executable = activeManager.executable
   if (!existsSync(executable)) fail(`${options.manager} did not install the openalice command`)
   const runtimeEnv = {
     HOME: home,
     PATH: '/usr/bin:/bin',
   }
-  const version = JSON.parse(capture(executable, ['version', '--json'], runtimeEnv))
-  if (version.version !== options.expectedVersion) fail(`installed version is ${version.version}`)
-  if (version.contentIdentity !== options.expectedContentIdentity) {
-    fail(`installed content identity is ${version.contentIdentity}`)
-  }
-  if (version.installSource?.method !== options.manager) {
-    fail(`installed provenance method is ${version.installSource?.method}`)
-  }
-  if (version.installSource?.artifact?.platform !== process.platform) fail('installed platform provenance is wrong')
-  if (version.installSource?.artifact?.arch !== process.arch) fail('installed architecture provenance is wrong')
+  assertInstalled(executable, runtimeEnv, previousVersion, previousContentIdentity)
 
   run(executable, ['up', '--home', runtimeHome, '--no-update-check', '--wait', '120', '--json'], runtimeEnv)
+  const previousStatus = runtimeStatus(executable, runtimeHome, runtimeEnv)
+  if (previousStatus.provider?.contentIdentity !== previousContentIdentity) {
+    fail('synthetic prior Runtime did not report its content identity')
+  }
+
+  installPackage(currentMetaTarball, activeManager, { force: true })
+  assertInstalled(executable, runtimeEnv, options.expectedVersion, options.expectedContentIdentity)
+  const pendingStatus = runtimeStatus(executable, runtimeHome, runtimeEnv)
+  if (
+    pendingStatus.class !== 'running'
+    || pendingStatus.provider?.contentIdentity !== previousContentIdentity
+    || pendingStatus.pendingActivation?.productVersion !== options.expectedVersion
+    || pendingStatus.pendingActivation?.restartRequired !== true
+  ) {
+    fail(`active manager upgrade did not report pending activation: ${JSON.stringify(pendingStatus)}`)
+  }
+  const idempotentUp = JSON.parse(capture(executable, [
+    'up', '--home', runtimeHome, '--no-update-check', '--wait', '3', '--json',
+  ], runtimeEnv))
+  if (idempotentUp.result?.runtime?.status?.pendingActivation?.restartRequired !== true) {
+    fail('idempotent up did not preserve active manager upgrade reporting')
+  }
   const doctor = JSON.parse(capture(executable, ['doctor', '--home', runtimeHome, '--json'], runtimeEnv))
   const updateOwner = doctor.result?.doctor?.checks?.find((check) => check.id === 'update.metadata')
   if (updateOwner?.status !== 'pass' || !updateOwner.summary.includes('owns OpenAlice updates')) {
@@ -93,7 +122,6 @@ try {
   if (!update.includes('openalice down') || !update.includes(expectedUpdate)) {
     fail('update guidance did not return to the package manager while Runtime was active')
   }
-  run(executable, ['down', '--home', runtimeHome, '--json'], runtimeEnv)
   const uninstall = capture(executable, ['uninstall', '--yes'], runtimeEnv)
   const expectedRemoval = options.manager === 'npm'
     ? 'npm uninstall -g openalice'
@@ -101,19 +129,104 @@ try {
   if (!uninstall.includes(expectedRemoval)) fail('uninstall guidance did not return to the package manager')
   if (!existsSync(executable)) fail('OpenAlice removed package-manager-owned files')
 
-  if (options.manager === 'npm') {
-    run(options.npm, ['uninstall', '--global', '--prefix', managerRoot, 'openalice'], baseEnv)
-  } else {
-    run(options.bun, ['remove', '--global', 'openalice'], baseEnv)
+  run(executable, ['down', '--home', runtimeHome, '--json'], runtimeEnv)
+  run(executable, ['up', '--home', runtimeHome, '--no-update-check', '--wait', '120', '--json'], runtimeEnv)
+  const activatedStatus = runtimeStatus(executable, runtimeHome, runtimeEnv)
+  if (
+    activatedStatus.provider?.contentIdentity !== options.expectedContentIdentity
+    || activatedStatus.pendingActivation !== null
+  ) {
+    fail(`stopped restart did not activate the manager upgrade: ${JSON.stringify(activatedStatus)}`)
   }
+  run(executable, ['down', '--home', runtimeHome, '--json'], runtimeEnv)
+
+  removePackage(activeManager)
   if (existsSync(executable)) fail(`${options.manager} removal left the openalice command behind`)
   process.stdout.write(`[cli-package-smoke] ${options.manager} passed ${process.platform}-${process.arch}\n`)
 } finally {
+  if (existsSync(activeManager.executable)) {
+    spawnSync(activeManager.executable, [
+      'down', '--home', runtimeHome, '--json',
+    ], {
+      env: { HOME: home, PATH: '/usr/bin:/bin' },
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 20_000,
+    })
+  }
   if (options.keep) {
     process.stdout.write(`[cli-package-smoke] kept ${root}\n`)
   } else {
     rmSync(root, { recursive: true, force: true })
   }
+}
+
+function installPackage(metaTarball, manager, { force = false } = {}) {
+  if (options.manager === 'npm') {
+    run(options.npm, [
+      'install', '--global', '--prefix', manager.root,
+      ...(force ? ['--force'] : []),
+      metaTarball,
+    ], manager.baseEnv)
+    return
+  }
+  run(bunExecutable, [
+    'add', '--global', '--trust',
+    ...(force ? ['--force'] : []),
+    metaTarball,
+  ], manager.managerEnv)
+}
+
+function removePackage(manager) {
+  if (options.manager === 'npm') {
+    run(options.npm, ['uninstall', '--global', '--prefix', manager.root, 'openalice'], manager.baseEnv)
+  } else {
+    run(bunExecutable, ['remove', '--global', 'openalice'], manager.managerEnv)
+  }
+}
+
+function prepareBunOnlyPath(executable) {
+  const bunOnlyPath = join(root, 'bun-only-path')
+  mkdirSync(bunOnlyPath, { recursive: true })
+  symlinkSync(executable, join(bunOnlyPath, 'bun'))
+  return bunOnlyPath
+}
+
+function managerContext(managerRoot, cacheName) {
+  const baseEnv = {
+    ...process.env,
+    HOME: home,
+    XDG_CACHE_HOME: join(root, `cache-${cacheName}`),
+    npm_config_cache: join(root, `npm-cache-${cacheName}`),
+    BUN_INSTALL: managerRoot,
+  }
+  return {
+    root: managerRoot,
+    executable: join(managerRoot, 'bin', 'openalice'),
+    baseEnv,
+    managerEnv: options.manager === 'bun'
+      ? { ...baseEnv, PATH: `${bunOnlyPath}:/usr/bin:/bin` }
+      : baseEnv,
+  }
+}
+
+function assertInstalled(executable, env, expectedVersion, expectedIdentity) {
+  const version = JSON.parse(capture(executable, ['version', '--json'], env))
+  if (version.version !== expectedVersion) fail(`installed version is ${version.version}, expected ${expectedVersion}`)
+  if (version.contentIdentity !== expectedIdentity) {
+    fail(`installed content identity is ${version.contentIdentity}, expected ${expectedIdentity}`)
+  }
+  if (version.installSource?.method !== options.manager) {
+    fail(`installed provenance method is ${version.installSource?.method}`)
+  }
+  if (version.installSource?.artifact?.platform !== process.platform) fail('installed platform provenance is wrong')
+  if (version.installSource?.artifact?.arch !== process.arch) fail('installed architecture provenance is wrong')
+}
+
+function runtimeStatus(executable, runtimeHome, env) {
+  return JSON.parse(capture(executable, [
+    'status', '--home', runtimeHome, '--wait', '3', '--json',
+  ], env)).result?.status
 }
 
 function run(command, args, env) {
@@ -127,6 +240,97 @@ function run(command, args, env) {
 
 function capture(command, args, env) {
   return run(command, args, env).stdout
+}
+
+function packPackageSet(packagesRoot, destination, nativePackageName) {
+  mkdirSync(destination, { recursive: true })
+  const platformTarball = pack(join(packagesRoot, nativePackageName), destination)
+  const metaRoot = join(packagesRoot, 'openalice')
+  const metaPackagePath = join(metaRoot, 'package.json')
+  const metaPackage = JSON.parse(readFileSync(metaPackagePath, 'utf8'))
+  metaPackage.optionalDependencies = {
+    [nativePackageName]: `file:${platformTarball}`,
+  }
+  writeFileSync(metaPackagePath, `${JSON.stringify(metaPackage, null, 2)}\n`)
+  return pack(metaRoot, destination)
+}
+
+function rewritePackageSetVersion({ packagesRoot, packageName, fromVersion, toVersion }) {
+  const platformRoot = join(packagesRoot, packageName)
+  const executablePath = join(platformRoot, 'release', 'bin', 'openalice')
+  const executable = readFileSync(executablePath)
+  const from = Buffer.from(fromVersion)
+  const to = Buffer.from(toVersion)
+  if (from.length !== to.length) fail('synthetic package-manager versions must have equal byte length')
+  let replacements = 0
+  for (let offset = executable.indexOf(from); offset >= 0; offset = executable.indexOf(from, offset + to.length)) {
+    to.copy(executable, offset)
+    replacements += 1
+  }
+  if (replacements === 0) fail(`native executable did not contain embedded version ${fromVersion}`)
+  writeFileSync(executablePath, executable)
+  if (process.platform === 'darwin') {
+    run('/usr/bin/codesign', ['--force', '--sign', '-', executablePath], process.env)
+  }
+  const rewrittenExecutable = readFileSync(executablePath)
+  const executableSha256 = sha256(rewrittenExecutable)
+  const contentIdentity = executableSha256.slice(0, 16)
+
+  const resourcePackagePath = join(platformRoot, 'release', 'share', 'openalice', 'package.json')
+  const resourcePackage = JSON.parse(readFileSync(resourcePackagePath, 'utf8'))
+  resourcePackage.version = toVersion
+  writeFileSync(resourcePackagePath, `${JSON.stringify(resourcePackage, null, 2)}\n`)
+
+  const releasePath = join(platformRoot, 'release', 'release.json')
+  const release = JSON.parse(readFileSync(releasePath, 'utf8'))
+  release.version = toVersion
+  release.contentIdentity = contentIdentity
+  updateReleaseFile(release, 'bin/openalice', executablePath)
+  updateReleaseFile(release, 'share/openalice/package.json', resourcePackagePath)
+  writeFileSync(releasePath, `${JSON.stringify(release, null, 2)}\n`)
+
+  const platformPackagePath = join(platformRoot, 'package.json')
+  const platformPackage = JSON.parse(readFileSync(platformPackagePath, 'utf8'))
+  platformPackage.version = toVersion
+  platformPackage.openalice.contentIdentity = contentIdentity
+  platformPackage.openalice.artifactSha256 = executableSha256
+  writeFileSync(platformPackagePath, `${JSON.stringify(platformPackage, null, 2)}\n`)
+
+  const metaPackagePath = join(packagesRoot, 'openalice', 'package.json')
+  const metaPackage = JSON.parse(readFileSync(metaPackagePath, 'utf8'))
+  metaPackage.version = toVersion
+  metaPackage.optionalDependencies = { [packageName]: toVersion }
+  writeFileSync(metaPackagePath, `${JSON.stringify(metaPackage, null, 2)}\n`)
+  return contentIdentity
+}
+
+function updateReleaseFile(release, relativePath, sourcePath) {
+  const entry = release.files?.find((candidate) => candidate.path === relativePath)
+  if (!entry || entry.type !== 'file') fail(`release metadata omitted ${relativePath}`)
+  const content = readFileSync(sourcePath)
+  entry.bytes = content.length
+  entry.sha256 = sha256(content)
+}
+
+function syntheticPreviousVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) fail(`package-manager smoke requires a stable numeric version, got ${version}`)
+  const [, majorRaw, minorRaw, patchRaw] = match
+  const major = Number(majorRaw)
+  const minor = Number(minorRaw)
+  const patch = Number(patchRaw)
+  const candidates = [
+    ...(patch > 0 ? [`${majorRaw}.${minorRaw}.${patch - 1}`] : []),
+    ...(minor > 0 ? [`${majorRaw}.${minor - 1}.${'9'.repeat(patchRaw.length)}`] : []),
+    ...(major > 0 ? [`${major - 1}.${'9'.repeat(minorRaw.length)}.${'9'.repeat(patchRaw.length)}`] : []),
+  ]
+  const candidate = candidates.find((value) => value.length === version.length)
+  if (candidate) return candidate
+  fail(`cannot derive a prior package-manager fixture version from ${version}`)
+}
+
+function sha256(content) {
+  return createHash('sha256').update(content).digest('hex')
 }
 
 function pack(packageRoot, destination) {

--- a/scripts/pack-cli-npm-packages.mjs
+++ b/scripts/pack-cli-npm-packages.mjs
@@ -14,7 +14,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 
-export function packCliNpmPackages({ inputDir, outputDir, npm = 'npm' }) {
+export function packCliNpmPackages({
+  inputDir,
+  outputDir,
+  npm = process.platform === 'win32' ? 'npm.cmd' : 'npm',
+}) {
   const inputRoot = resolve(inputDir)
   const outputRoot = resolve(outputDir)
   assertSafeOutputRoot(outputRoot, inputRoot)
@@ -103,7 +107,7 @@ function assertSafeOutputRoot(outputRoot, inputRoot) {
 }
 
 function parseArgs(argv) {
-  const options = { npm: 'npm' }
+  const options = { npm: process.platform === 'win32' ? 'npm.cmd' : 'npm' }
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (['--input-dir', '--output-dir', '--npm'].includes(arg)) {


### PR DESCRIPTION
## Summary
- make npm/Bun acceptance install two distinct native candidates
- prove stopped upgrade/removal and active-content pending activation behavior
- verify Doctor/update/uninstall stay manager-owned and fresh startup activates the replacement

## Verification
- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli test` (335 tests)
- `pnpm test` (5062 passed, 9 skipped)
- targeted package channel tests (11 tests)
- real macOS arm64 npm lifecycle smoke
- real macOS arm64 pinned Bun 1.4.0 lifecycle smoke