### PR TITLE
docs: define feature-branch iteration hold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,10 +105,19 @@ for current ownership and entry points.
 
 Choose delivery authority before implementation:
 
+Feature-branch iteration is an explicit integration hold, not a third delivery
+mode. When the maintainer says to keep iterating on a feature branch until they
+are satisfied, keep all related increments on one owned branch and do not open
+or merge its PR to `dev` until the maintainer says it is ready. This instruction
+applies independently to serial or parallel work. It does not relax
+verification, known-failure handling, scope coherence, or the single-integrator
+rule; parallel workers still hand commits to the branch owner instead of racing
+to push it.
+
 | Mode | Trigger | Delivery to `dev` |
 |---|---|---|
-| Serial / interactive | Default: the user is actively requesting and steering concrete work | After proportional local verification, open and merge the PR without waiting for pending remote CI; delete the feature branch and return to updated `dev` unless the user says to pause |
-| Autonomous / topic contribution | Explicit `/goal` or direct request to autonomously find and contribute improvements | Keep one community-facing Draft PR for the active topic, add related work as atomic commits, and leave the topic unmerged for later acceptance |
+| Serial / interactive | Default: the user is actively requesting and steering concrete work | After proportional local verification, open and merge the PR without waiting for pending remote CI; delete the feature branch and return to updated `dev` unless the user says to pause or declares feature-branch iteration |
+| Autonomous / topic contribution | Explicit `/goal` or direct request to autonomously find and contribute improvements | Keep one community-facing Draft PR for the active topic, add related work as atomic commits, and leave the topic unmerged for later acceptance; an explicit feature-branch iteration hold delays opening that PR until the maintainer says the branch is ready |
 
 Internal agent decomposition must not become one GitHub PR per finding. Define a
 coherent topic and acceptance boundary, keep a single integrator responsible for

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -52,6 +52,36 @@ Then establish ownership of the checkout:
 
 Delivery mode controls merge authority, not implementation quality.
 
+### Feature-branch iteration hold
+
+Feature-branch iteration is an explicit natural-language instruction, not a
+third delivery mode or a configuration schema. A maintainer may say, for
+example, “keep this on a feature branch and iterate until I am satisfied.” The
+hold applies independently to serial or parallel work and overrides their
+normal PR timing without changing their implementation or review standards.
+
+While the hold is active:
+
+1. keep the coherent initiative on one named branch based on `dev`;
+2. keep one integrator responsible for that branch; parallel workers use
+   temporary branches or worktrees and hand off commits;
+3. commit and push verified increments to the feature branch, but do not open
+   or merge a PR to `dev` yet;
+4. keep substantial multi-session scope and acceptance progress current in its
+   canonical `plans/<topic>.md` file using ordinary prose;
+5. continue to inspect known CI or integration failures before adding scope,
+   and periodically incorporate current `dev` without rewriting shared branch
+   history; and
+6. remain in the hold until the maintainer explicitly says the result is ready
+   for a PR, or explicitly abandons the branch.
+
+When the maintainer accepts the branch, first reconcile it with current `dev`,
+run the complete proportional verification for the accumulated diff, and then
+open the normal PR to `dev`. “Keep working,” an interactive follow-up, or a
+successful local increment does not implicitly end the hold. A held branch is
+also not a preview or release lane: `dev` and `master` retain their existing
+integration and promotion ownership.
+
 ### Serial / interactive
 
 This is the default when the user is actively requesting, reviewing, and
@@ -64,7 +94,8 @@ steering concrete work.
    and its post-merge `dev` run. Repair a completed failure before stacking more
    work; record a still-pending run without waiting on it.
 5. Open a PR to `dev`, confirm the intended base and head, and merge immediately
-   unless the user requests a review pause or earlier CI has a known failure.
+   unless the user requests a review pause, declares a feature-branch iteration
+   hold, or earlier CI has a known failure.
 6. Delete the merged feature branch and return to updated `dev`.
 
 The PR durably integrates the completed increment into `dev` and records its
@@ -84,7 +115,8 @@ into a coherent topic that a reviewer can understand as one product outcome:
 1. define the topic in one sentence and record its acceptance boundary and
    non-goals;
 2. start from latest `dev` on one topic branch and open a Draft PR after the
-   first verified increment;
+   first verified increment, unless a feature-branch iteration hold delays the
+   PR until maintainer acceptance;
 3. keep one integrator responsible for that branch; parallel workers use
    temporary branches or worktrees and hand off commits rather than racing to
    push the topic branch;


### PR DESCRIPTION
## Summary
- define feature-branch iteration as a natural-language integration hold
- make the hold independent from serial or parallel delivery mode
- delay both automatic serial integration and autonomous Draft PR creation until maintainer acceptance

## Verification
- `git diff --check`

## Boundary touch
- development workflow documentation only

## Non-goals
- no YAML, persisted state, labels, CI changes, or new release lane