### PR TITLE
test(cli): exercise Homebrew and AUR upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,29 +501,37 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
-          ASSET_BASE_URL=$(node -e "const{pathToFileURL}=require('url');const{resolve}=require('path');process.stdout.write(pathToFileURL(resolve('dist/release-cli')).href)")
+          CURRENT_ASSET_BASE_URL=$(node -e "const{pathToFileURL}=require('url');const{resolve}=require('path');process.stdout.write(pathToFileURL(resolve('dist/release-cli')).href)")
+          node scripts/prepare-cli-previous-release.mjs \
+            --input-dir dist/release-cli \
+            --output-dir dist/cli-package-homebrew-previous \
+            --version "$VERSION"
+          PREVIOUS_VERSION=$(node -p "require('./dist/cli-package-homebrew-previous/fixture.json').previousVersion")
+          PREVIOUS_ASSET_BASE_URL=$(node -e "const{pathToFileURL}=require('url');const{resolve}=require('path');process.stdout.write(pathToFileURL(resolve('dist/cli-package-homebrew-previous')).href)")
           node scripts/build-cli-package-channels.mjs \
             --input-dir dist/release-cli \
-            --output-dir dist/cli-package-homebrew-smoke \
+            --output-dir dist/cli-package-homebrew-current \
             --version "$VERSION" \
             --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --asset-base-url "$ASSET_BASE_URL" \
+            --asset-base-url "$CURRENT_ASSET_BASE_URL" \
             --require-all
-          trap 'brew uninstall --force openalice >/dev/null 2>&1 || true' EXIT
-          brew install --formula dist/cli-package-homebrew-smoke/homebrew/openalice.rb
-          EXECUTABLE="$(brew --prefix openalice)/bin/openalice"
-          HOME_ROOT="$RUNNER_TEMP/homebrew-home"
-          RUNTIME_HOME="$RUNNER_TEMP/homebrew-runtime"
-          mkdir -p "$HOME_ROOT"
-          VERSION_JSON=$(env -i HOME="$HOME_ROOT" PATH=/usr/bin:/bin "$EXECUTABLE" version --json)
-          VERSION_JSON="$VERSION_JSON" EXPECTED_VERSION="$VERSION" node -e "const v=JSON.parse(process.env.VERSION_JSON);if(v.version!==process.env.EXPECTED_VERSION||v.installSource?.method!=='brew')process.exit(1)"
-          env -i HOME="$HOME_ROOT" PATH=/usr/bin:/bin "$EXECUTABLE" up --home "$RUNTIME_HOME" --no-update-check --wait 120 --json
-          env -i HOME="$HOME_ROOT" PATH=/usr/bin:/bin "$EXECUTABLE" doctor --home "$RUNTIME_HOME" --json | grep -Fq 'Homebrew owns OpenAlice updates'
-          env -i HOME="$HOME_ROOT" PATH=/usr/bin:/bin "$EXECUTABLE" down --home "$RUNTIME_HOME" --json
-          env -i HOME="$HOME_ROOT" PATH=/usr/bin:/bin "$EXECUTABLE" uninstall --yes | grep -Fq 'brew uninstall traderalice/tap/openalice'
-          test -x "$EXECUTABLE"
-          brew uninstall --force openalice
-          test ! -e "$EXECUTABLE"
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/cli-package-homebrew-previous \
+            --output-dir dist/cli-package-homebrew-previous-channels \
+            --version "$PREVIOUS_VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url "$PREVIOUS_ASSET_BASE_URL" \
+            --require-all
+          CURRENT_ID=$(node -e "const f=require('./dist/cli-package-homebrew-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='darwin'&&t.arch==='${{ matrix.arch }}').contentIdentity)")
+          PREVIOUS_ID=$(node -e "const f=require('./dist/cli-package-homebrew-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='darwin'&&t.arch==='${{ matrix.arch }}').previousContentIdentity)")
+          node scripts/cli-system-package-manager-smoke.mjs \
+            --manager brew \
+            --previous-version "$PREVIOUS_VERSION" \
+            --current-version "$VERSION" \
+            --previous-content-identity "$PREVIOUS_ID" \
+            --current-content-identity "$CURRENT_ID" \
+            --previous-package dist/cli-package-homebrew-previous-channels/homebrew/openalice.rb \
+            --current-package dist/cli-package-homebrew-current/homebrew/openalice.rb
 
   accept-cli-aur:
     name: Accept Arch/AUR CLI package
@@ -550,34 +558,57 @@ jobs:
       - name: Build, install, and run the generated AUR package
         shell: bash
         run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
+          node scripts/prepare-cli-previous-release.mjs \
+            --input-dir dist/release-cli \
+            --output-dir dist/cli-package-aur-previous \
+            --version "$VERSION"
+          PREVIOUS_VERSION=$(node -p "require('./dist/cli-package-aur-previous/fixture.json').previousVersion")
           node scripts/build-cli-package-channels.mjs \
             --input-dir dist/release-cli \
-            --output-dir dist/cli-package-aur-smoke \
+            --output-dir dist/cli-package-aur-current \
             --version "$VERSION" \
             --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --asset-base-url file:///work/dist/release-cli \
             --require-all
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/cli-package-aur-previous \
+            --output-dir dist/cli-package-aur-previous-channels \
+            --version "$PREVIOUS_VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/cli-package-aur-previous \
+            --require-all
+          CURRENT_ID=$(node -e "const f=require('./dist/cli-package-aur-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='x64').contentIdentity)")
+          PREVIOUS_ID=$(node -e "const f=require('./dist/cli-package-aur-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='x64').previousContentIdentity)")
           docker run --rm \
             --platform linux/amd64 \
+            --env CURRENT_ID="$CURRENT_ID" \
+            --env CURRENT_VERSION="$VERSION" \
+            --env PREVIOUS_ID="$PREVIOUS_ID" \
+            --env PREVIOUS_VERSION="$PREVIOUS_VERSION" \
             --volume "$GITHUB_WORKSPACE:/work" \
-            --workdir /work/dist/cli-package-aur-smoke/aur \
+            --workdir /work \
             archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d \
             bash -euxo pipefail -c '
+              pacman -Syu --noconfirm nodejs
               useradd --create-home builder
-              chown -R builder:builder /work/dist/cli-package-aur-smoke
-              su builder -c "makepkg --nodeps --noconfirm"
-              pacman -U --noconfirm ./openalice-bin-*.pkg.tar.zst
-              mkdir -p /tmp/openalice-home /tmp/openalice-runtime
-              VERSION_JSON=$(env -i HOME=/tmp/openalice-home PATH=/usr/bin:/bin /usr/bin/openalice version --json)
-              printf "%s" "$VERSION_JSON" | grep -Eq "\"method\"[[:space:]]*:[[:space:]]*\"aur\""
-              env -i HOME=/tmp/openalice-home PATH=/usr/bin:/bin /usr/bin/openalice up --home /tmp/openalice-runtime --no-update-check --wait 120 --json
-              env -i HOME=/tmp/openalice-home PATH=/usr/bin:/bin /usr/bin/openalice doctor --home /tmp/openalice-runtime --json | grep -Fq "pacman/AUR owns OpenAlice updates"
-              env -i HOME=/tmp/openalice-home PATH=/usr/bin:/bin /usr/bin/openalice down --home /tmp/openalice-runtime --json
-              env -i HOME=/tmp/openalice-home PATH=/usr/bin:/bin /usr/bin/openalice uninstall --yes | grep -Fq "paru -Rns openalice-bin"
-              test -x /usr/bin/openalice
-              pacman -Rns --noconfirm openalice-bin
-              test ! -e /usr/bin/openalice
+              chown -R builder:builder \
+                /work/dist/cli-package-aur-current \
+                /work/dist/cli-package-aur-previous \
+                /work/dist/cli-package-aur-previous-channels
+              su builder -c "cd /work/dist/cli-package-aur-previous-channels/aur && makepkg --nodeps --noconfirm"
+              mv /work/dist/cli-package-aur-previous-channels/aur/openalice-bin-*.pkg.tar.zst /tmp/openalice-previous.pkg.tar.zst
+              su builder -c "cd /work/dist/cli-package-aur-current/aur && makepkg --nodeps --noconfirm"
+              mv /work/dist/cli-package-aur-current/aur/openalice-bin-*.pkg.tar.zst /tmp/openalice-current.pkg.tar.zst
+              /usr/bin/node /work/scripts/cli-system-package-manager-smoke.mjs \
+                --manager aur \
+                --previous-version "$PREVIOUS_VERSION" \
+                --current-version "$CURRENT_VERSION" \
+                --previous-content-identity "$PREVIOUS_ID" \
+                --current-content-identity "$CURRENT_ID" \
+                --previous-package /tmp/openalice-previous.pkg.tar.zst \
+                --current-package /tmp/openalice-current.pkg.tar.zst
             '
 
   # Broker Packs are release artifacts, not inputs to the desktop package. Build

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -75,7 +75,9 @@ Stable npm publication is disabled unless the repository explicitly enables
 The generated Homebrew formula selects the accepted archive and SHA-256 for the
 current macOS or Linux architecture. It installs the executable, immutable
 resources, release metadata, notices, and Homebrew provenance without compiling
-the repository.
+the repository. The formula treats Homebrew's extracted build directory as the
+archive release root and copies release metadata to both the keg root and the
+Runtime resource tree; it does not guess at an extra directory level.
 
 The generated `openalice-bin` `PKGBUILD` and `.SRCINFO` select the accepted
 Linux archive for `aarch64` or `x86_64`, verify its checksum, and install the
@@ -120,8 +122,10 @@ For channel changes run:
 
 ```bash
 pnpm exec vitest run \
+  scripts/cli-release-fixture.spec.mjs \
   scripts/build-cli-package-channels.spec.mjs \
   scripts/pack-cli-npm-packages.spec.mjs \
+  scripts/release-workflow.spec.ts \
   packages/cli/src/package-manager.spec.mjs
 ```
 
@@ -141,6 +145,12 @@ only an isolated copy of an already accepted native candidate, refreshes its
 version/content hashes, and uses ad-hoc signing on macOS; it is never a
 publication input. Every Runtime uses isolated state without broker credentials
 or live trading.
+
+The npm/Bun smoke operates on generated platform packages. The Homebrew/AUR
+smoke first derives the same isolated prior archive set from the accepted
+candidate, then lets a local Git-backed tap or real `pacman -U` perform both
+version transitions. Lifecycle assertions stay shared while file mutation
+remains owned by the manager under test.
 
 The release job derives every channel only after all native candidates pass,
 attaches the generated publication inputs to the GitHub Release, and publishes

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -459,7 +459,7 @@ build harness when it improves the next investigation.
   executable bytes.
 - [x] Detect manager-owned installs in update/Doctor output and route update
   and uninstall guidance back to the owning manager.
-- [ ] Exercise each manager's upgrade and removal while a Runtime is stopped,
+- [x] Exercise each manager's upgrade and removal while a Runtime is stopped,
   then exercise its documented behavior while Guardian is active.
 - [x] Record and enforce platform-first/meta-last npm publication after the
   GitHub Release succeeds. Stable publication remains explicitly disabled
@@ -834,3 +834,16 @@ This plan is complete only when:
   replacement rollback case is explicitly skipped on Windows while native
   Windows activation remains a deferred distribution lane. Type checking, 335
   CLI tests, 5,062 root tests, and the non-root Orb Linux installer smoke pass.
+- 2026-08-30: Completed local system-package-manager lifecycle acceptance.
+  Homebrew now consumes the archive's actual extracted release root and copies
+  `release.json` instead of trying to move one source twice. A shared fixture
+  derives a hash-refreshed N-1 archive set from accepted candidates, after
+  which a local Git-backed tap and an x64 Arch container perform real stopped
+  and active upgrades, restart activation, and removal. Native macOS arm64
+  Homebrew and Orb-emulated Linux x64 `makepkg`/`pacman` both passed with an
+  empty Runtime `PATH`; the formal release matrix repeats Homebrew on Intel and
+  arm64 runners and AUR on native x64. Windows distribution remains deferred.
+- 2026-08-30: Rebuilt the current macOS arm64 native candidate and repeated the
+  complete npm and Bun stopped/active lifecycle after the shared-fixture
+  refactor; both passed. `npx tsc --noEmit`, all 335 CLI tests, all 5,064 root
+  tests, and the non-root Orb Linux installer smoke also pass.

--- a/scripts/build-cli-package-channels.mjs
+++ b/scripts/build-cli-package-channels.mjs
@@ -222,11 +222,13 @@ function homebrewTargetBlock(version, target, assetBaseUrl) {
       sha256 "${target.checksum}"
 
       def install
-        bin.install "bin/openalice"
-        share.install "share/openalice"
-        (share/"openalice").install "release.json"
-        prefix.install "release.json"
-        prefix.install "THIRD_PARTY_NOTICES.md"
+        release = buildpath
+        release_metadata = (release/"release.json").read
+        bin.install release/"bin/openalice"
+        share.install release/"share/openalice"
+        prefix.install release/"release.json"
+        (share/"openalice/release.json").write(release_metadata)
+        prefix.install release/"THIRD_PARTY_NOTICES.md"
         metadata = JSON.parse("${json}")
         metadata["installedAt"] = Time.now.utc.iso8601
         content = JSON.pretty_generate(metadata) + "\\n"

--- a/scripts/build-cli-package-channels.spec.mjs
+++ b/scripts/build-cli-package-channels.spec.mjs
@@ -59,7 +59,7 @@ describe.skipIf(process.platform === 'win32')('CLI package-manager channel gener
     const formula = await readFile(join(output, 'homebrew/openalice.rb'), 'utf8')
     expect(formula.match(/releases\/download\/v0\.90\.1/g)).toHaveLength(4)
     expect(formula).toContain('method\\\":\\\"brew')
-    expect(formula).toContain('(share/"openalice").install "release.json"')
+    expect(formula).toContain('(share/"openalice/release.json").write(release_metadata)')
     expect(formula).toContain('(share/"openalice/install-source.json").write(content)')
     const pkgbuild = await readFile(join(output, 'aur/PKGBUILD'), 'utf8')
     await expect(execFileAsync('bash', ['-n', join(output, 'aur/PKGBUILD')])).resolves.toBeDefined()

--- a/scripts/cli-package-manager-smoke.mjs
+++ b/scripts/cli-package-manager-smoke.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
 import {
   cpSync,
   existsSync,
@@ -15,6 +14,11 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+
+import {
+  rewriteExpandedCliRelease,
+  syntheticPreviousVersion,
+} from './cli-release-fixture.mjs'
 
 const options = parseArgs(process.argv.slice(2))
 const root = mkdtempSync(join(tmpdir(), `openalice-${options.manager}-package-smoke-`))
@@ -257,37 +261,11 @@ function packPackageSet(packagesRoot, destination, nativePackageName) {
 
 function rewritePackageSetVersion({ packagesRoot, packageName, fromVersion, toVersion }) {
   const platformRoot = join(packagesRoot, packageName)
-  const executablePath = join(platformRoot, 'release', 'bin', 'openalice')
-  const executable = readFileSync(executablePath)
-  const from = Buffer.from(fromVersion)
-  const to = Buffer.from(toVersion)
-  if (from.length !== to.length) fail('synthetic package-manager versions must have equal byte length')
-  let replacements = 0
-  for (let offset = executable.indexOf(from); offset >= 0; offset = executable.indexOf(from, offset + to.length)) {
-    to.copy(executable, offset)
-    replacements += 1
-  }
-  if (replacements === 0) fail(`native executable did not contain embedded version ${fromVersion}`)
-  writeFileSync(executablePath, executable)
-  if (process.platform === 'darwin') {
-    run('/usr/bin/codesign', ['--force', '--sign', '-', executablePath], process.env)
-  }
-  const rewrittenExecutable = readFileSync(executablePath)
-  const executableSha256 = sha256(rewrittenExecutable)
-  const contentIdentity = executableSha256.slice(0, 16)
-
-  const resourcePackagePath = join(platformRoot, 'release', 'share', 'openalice', 'package.json')
-  const resourcePackage = JSON.parse(readFileSync(resourcePackagePath, 'utf8'))
-  resourcePackage.version = toVersion
-  writeFileSync(resourcePackagePath, `${JSON.stringify(resourcePackage, null, 2)}\n`)
-
-  const releasePath = join(platformRoot, 'release', 'release.json')
-  const release = JSON.parse(readFileSync(releasePath, 'utf8'))
-  release.version = toVersion
-  release.contentIdentity = contentIdentity
-  updateReleaseFile(release, 'bin/openalice', executablePath)
-  updateReleaseFile(release, 'share/openalice/package.json', resourcePackagePath)
-  writeFileSync(releasePath, `${JSON.stringify(release, null, 2)}\n`)
+  const { contentIdentity, executableSha256 } = rewriteExpandedCliRelease({
+    releaseRoot: join(platformRoot, 'release'),
+    fromVersion,
+    toVersion,
+  })
 
   const platformPackagePath = join(platformRoot, 'package.json')
   const platformPackage = JSON.parse(readFileSync(platformPackagePath, 'utf8'))
@@ -302,35 +280,6 @@ function rewritePackageSetVersion({ packagesRoot, packageName, fromVersion, toVe
   metaPackage.optionalDependencies = { [packageName]: toVersion }
   writeFileSync(metaPackagePath, `${JSON.stringify(metaPackage, null, 2)}\n`)
   return contentIdentity
-}
-
-function updateReleaseFile(release, relativePath, sourcePath) {
-  const entry = release.files?.find((candidate) => candidate.path === relativePath)
-  if (!entry || entry.type !== 'file') fail(`release metadata omitted ${relativePath}`)
-  const content = readFileSync(sourcePath)
-  entry.bytes = content.length
-  entry.sha256 = sha256(content)
-}
-
-function syntheticPreviousVersion(version) {
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
-  if (!match) fail(`package-manager smoke requires a stable numeric version, got ${version}`)
-  const [, majorRaw, minorRaw, patchRaw] = match
-  const major = Number(majorRaw)
-  const minor = Number(minorRaw)
-  const patch = Number(patchRaw)
-  const candidates = [
-    ...(patch > 0 ? [`${majorRaw}.${minorRaw}.${patch - 1}`] : []),
-    ...(minor > 0 ? [`${majorRaw}.${minor - 1}.${'9'.repeat(patchRaw.length)}`] : []),
-    ...(major > 0 ? [`${major - 1}.${'9'.repeat(minorRaw.length)}.${'9'.repeat(patchRaw.length)}`] : []),
-  ]
-  const candidate = candidates.find((value) => value.length === version.length)
-  if (candidate) return candidate
-  fail(`cannot derive a prior package-manager fixture version from ${version}`)
-}
-
-function sha256(content) {
-  return createHash('sha256').update(content).digest('hex')
 }
 
 function pack(packageRoot, destination) {

--- a/scripts/cli-release-fixture.mjs
+++ b/scripts/cli-release-fixture.mjs
@@ -1,0 +1,162 @@
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { basename, join, parse, resolve } from 'node:path'
+
+import {
+  CLI_RELEASE_TARGETS,
+  validateCliReleaseArchive,
+} from './prepare-cli-dev-assets.mjs'
+
+export function preparePreviousCliReleaseArchives({ inputDir, outputDir, version }) {
+  const inputRoot = resolve(inputDir)
+  const outputRoot = resolve(outputDir)
+  assertSafeOutputRoot(outputRoot, inputRoot)
+  const previousVersion = syntheticPreviousVersion(version)
+  rmSync(outputRoot, { recursive: true, force: true })
+  mkdirSync(outputRoot, { recursive: true })
+
+  const targets = []
+  for (const [platform, arch] of CLI_RELEASE_TARGETS) {
+    const currentArchive = join(inputRoot, `openalice-cli-${version}-${platform}-${arch}.tar.gz`)
+    const current = validateCliReleaseArchive({
+      archivePath: currentArchive,
+      version,
+      platform,
+      arch,
+    })
+    const stagingRoot = mkdtempSync(join(tmpdir(), 'openalice-cli-previous-'))
+    try {
+      execFileSync('tar', ['-xzf', currentArchive, '-C', stagingRoot])
+      const currentReleaseRoot = join(stagingRoot, current.releaseName)
+      const rewritten = rewriteExpandedCliRelease({
+        releaseRoot: currentReleaseRoot,
+        fromVersion: version,
+        toVersion: previousVersion,
+      })
+      const previousName = `openalice-cli-${previousVersion}-${platform}-${arch}`
+      const previousReleaseRoot = join(stagingRoot, previousName)
+      renameSync(currentReleaseRoot, previousReleaseRoot)
+      const previousArchive = join(outputRoot, `${previousName}.tar.gz`)
+      execFileSync('tar', ['-czf', previousArchive, '-C', stagingRoot, previousName])
+      const checksum = sha256(readFileSync(previousArchive))
+      writeFileSync(`${previousArchive}.sha256`, `${checksum}  ${basename(previousArchive)}\n`)
+      validateCliReleaseArchive({
+        archivePath: previousArchive,
+        version: previousVersion,
+        platform,
+        arch,
+      })
+      targets.push({
+        platform,
+        arch,
+        currentContentIdentity: current.metadata.contentIdentity,
+        previousContentIdentity: rewritten.contentIdentity,
+      })
+    } finally {
+      rmSync(stagingRoot, { recursive: true, force: true })
+    }
+  }
+
+  const manifest = { schemaVersion: 1, version, previousVersion, targets }
+  writeFileSync(join(outputRoot, 'fixture.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  return manifest
+}
+
+export function rewriteExpandedCliRelease({ releaseRoot, fromVersion, toVersion }) {
+  const executablePath = join(releaseRoot, 'bin', 'openalice')
+  const executable = readFileSync(executablePath)
+  const from = Buffer.from(fromVersion)
+  const to = Buffer.from(toVersion)
+  if (from.length !== to.length) {
+    throw new Error('synthetic package-manager versions must have equal byte length')
+  }
+  let replacements = 0
+  for (let offset = executable.indexOf(from); offset >= 0; offset = executable.indexOf(from, offset + to.length)) {
+    to.copy(executable, offset)
+    replacements += 1
+  }
+  if (replacements === 0) {
+    throw new Error(`native executable did not contain embedded version ${fromVersion}`)
+  }
+  writeFileSync(executablePath, executable)
+  if (process.platform === 'darwin' && isMachO(executable)) {
+    execFileSync('/usr/bin/codesign', ['--force', '--sign', '-', executablePath])
+  }
+  const rewrittenExecutable = readFileSync(executablePath)
+  const executableSha256 = sha256(rewrittenExecutable)
+  const contentIdentity = executableSha256.slice(0, 16)
+
+  const resourcePackagePath = join(releaseRoot, 'share', 'openalice', 'package.json')
+  const resourcePackage = JSON.parse(readFileSync(resourcePackagePath, 'utf8'))
+  resourcePackage.version = toVersion
+  writeFileSync(resourcePackagePath, `${JSON.stringify(resourcePackage, null, 2)}\n`)
+
+  const releasePath = join(releaseRoot, 'release.json')
+  const release = JSON.parse(readFileSync(releasePath, 'utf8'))
+  if (release.version !== fromVersion) {
+    throw new Error(`release metadata version is ${release.version}, expected ${fromVersion}`)
+  }
+  release.version = toVersion
+  release.contentIdentity = contentIdentity
+  updateReleaseFile(release, 'bin/openalice', executablePath)
+  updateReleaseFile(release, 'share/openalice/package.json', resourcePackagePath)
+  writeFileSync(releasePath, `${JSON.stringify(release, null, 2)}\n`)
+  return { contentIdentity, executableSha256, replacements }
+}
+
+export function syntheticPreviousVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+  if (!match) throw new Error(`package-manager smoke requires a stable numeric version, got ${version}`)
+  const [, majorRaw, minorRaw, patchRaw] = match
+  const major = Number(majorRaw)
+  const minor = Number(minorRaw)
+  const patch = Number(patchRaw)
+  const candidates = [
+    ...(patch > 0 ? [`${majorRaw}.${minorRaw}.${patch - 1}`] : []),
+    ...(minor > 0 ? [`${majorRaw}.${minor - 1}.${'9'.repeat(patchRaw.length)}`] : []),
+    ...(major > 0 ? [`${major - 1}.${'9'.repeat(minorRaw.length)}.${'9'.repeat(patchRaw.length)}`] : []),
+  ]
+  const candidate = candidates.find((value) => value.length === version.length)
+  if (candidate) return candidate
+  throw new Error(`cannot derive a prior package-manager fixture version from ${version}`)
+}
+
+function updateReleaseFile(release, relativePath, sourcePath) {
+  const entry = release.files?.find((candidate) => candidate.path === relativePath)
+  if (!entry || entry.type !== 'file') throw new Error(`release metadata omitted ${relativePath}`)
+  const content = readFileSync(sourcePath)
+  entry.bytes = content.length
+  entry.sha256 = sha256(content)
+}
+
+function isMachO(content) {
+  if (content.length < 4) return false
+  return new Set(['cffaedfe', 'feedfacf', 'cafebabe', 'bebafeca']).has(content.subarray(0, 4).toString('hex'))
+}
+
+function sha256(content) {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+function assertSafeOutputRoot(outputRoot, inputRoot) {
+  if (
+    outputRoot === parse(outputRoot).root
+    || outputRoot === homedir()
+    || outputRoot === resolve('.')
+    || outputRoot === inputRoot
+    || inputRoot.startsWith(`${outputRoot}/`)
+  ) {
+    throw new Error(`refusing unsafe CLI fixture output directory: ${outputRoot}`)
+  }
+  if (!existsSync(inputRoot)) throw new Error(`CLI release input directory does not exist: ${inputRoot}`)
+}

--- a/scripts/cli-release-fixture.spec.mjs
+++ b/scripts/cli-release-fixture.spec.mjs
@@ -1,0 +1,107 @@
+import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  preparePreviousCliReleaseArchives,
+  syntheticPreviousVersion,
+} from './cli-release-fixture.mjs'
+
+const execFileAsync = promisify(execFile)
+const temporaryPaths = []
+const version = '0.90.1'
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe.skipIf(process.platform === 'win32')('CLI prior-release fixture', () => {
+  it('derives an isolated N-1 archive set and refreshes release identities', async () => {
+    const root = await fixture()
+    const output = join(root, 'previous')
+    const manifest = preparePreviousCliReleaseArchives({
+      inputDir: join(root, 'current'),
+      outputDir: output,
+      version,
+    })
+
+    expect(manifest.previousVersion).toBe('0.90.0')
+    expect(manifest.targets).toHaveLength(4)
+    for (const target of manifest.targets) {
+      expect(target.previousContentIdentity).not.toBe(target.currentContentIdentity)
+      const name = `openalice-cli-0.90.0-${target.platform}-${target.arch}`
+      const archive = join(output, `${name}.tar.gz`)
+      const release = JSON.parse((await execFileAsync('tar', [
+        '-xOzf', archive, `${name}/release.json`,
+      ])).stdout)
+      expect(release).toMatchObject({
+        version: '0.90.0',
+        contentIdentity: target.previousContentIdentity,
+      })
+      expect((await execFileAsync('tar', [
+        '-xOzf', archive, `${name}/bin/openalice`,
+      ])).stdout).toContain('0.90.0')
+      const sidecar = await readFile(`${archive}.sha256`, 'utf8')
+      expect(sidecar).toBe(`${sha256(await readFile(archive))}  ${basename(archive)}\n`)
+    }
+  })
+
+  it('keeps the synthetic version byte length stable', () => {
+    expect(syntheticPreviousVersion('1.10.0')).toBe('0.99.9')
+    expect(() => syntheticPreviousVersion('0.0.0')).toThrow('cannot derive')
+    expect(() => syntheticPreviousVersion('0.91.0-beta.1')).toThrow('stable numeric version')
+  })
+})
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-cli-release-fixture-'))
+  temporaryPaths.push(root)
+  const input = join(root, 'current')
+  await mkdir(input)
+  for (const [platform, arch] of [
+    ['darwin', 'arm64'],
+    ['darwin', 'x64'],
+    ['linux', 'arm64'],
+    ['linux', 'x64'],
+  ]) {
+    const releaseName = `openalice-cli-${version}-${platform}-${arch}`
+    const releaseRoot = join(root, releaseName)
+    const executablePath = join(releaseRoot, 'bin/openalice')
+    const packagePath = join(releaseRoot, 'share/openalice/package.json')
+    await mkdir(join(releaseRoot, 'bin'), { recursive: true })
+    await mkdir(join(releaseRoot, 'share/openalice'), { recursive: true })
+    await writeFile(executablePath, `#!/bin/sh\nprintf '${version}\\n'\n`)
+    await chmod(executablePath, 0o755)
+    await writeFile(packagePath, `${JSON.stringify({ version })}\n`)
+    await writeFile(join(releaseRoot, 'release.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      product: 'OpenAlice CLI',
+      version,
+      platform,
+      arch,
+      bunVersion: '1.4.0',
+      contentIdentity: sha256(Buffer.from(`${platform}-${arch}`)).slice(0, 16),
+      files: [
+        fileEntry('bin/openalice', await readFile(executablePath)),
+        fileEntry('share/openalice/package.json', await readFile(packagePath)),
+      ],
+    }, null, 2)}\n`)
+    const archive = join(input, `${releaseName}.tar.gz`)
+    await execFileAsync('tar', ['-czf', archive, '-C', root, releaseName])
+    await writeFile(`${archive}.sha256`, `${sha256(await readFile(archive))}  ${basename(archive)}\n`)
+  }
+  return root
+}
+
+function fileEntry(path, content) {
+  return { path, type: 'file', bytes: content.length, sha256: sha256(content) }
+}
+
+function sha256(content) {
+  return createHash('sha256').update(content).digest('hex')
+}

--- a/scripts/cli-system-package-manager-smoke.mjs
+++ b/scripts/cli-system-package-manager-smoke.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const options = parseArgs(process.argv.slice(2))
+const root = mkdtempSync(join(tmpdir(), `openalice-${options.manager}-lifecycle-`))
+const home = join(root, 'home')
+const runtimeHome = join(root, 'runtime-home')
+const emptyPath = join(root, 'runtime-path')
+mkdirSync(home, { recursive: true })
+mkdirSync(emptyPath, { recursive: true })
+
+const manager = options.manager === 'brew'
+  ? prepareBrewManager()
+  : prepareAurManager()
+const runtimeEnv = { HOME: home, PATH: emptyPath }
+
+try {
+  manager.installPrevious()
+  assertInstalled(options.previousVersion, options.previousContentIdentity)
+  manager.upgradeCurrent()
+  assertInstalled(options.currentVersion, options.currentContentIdentity)
+  manager.remove()
+  assertRemoved()
+
+  manager.installPrevious()
+  assertInstalled(options.previousVersion, options.previousContentIdentity)
+  run(manager.executable, [
+    'up', '--home', runtimeHome, '--no-update-check', '--wait', '120', '--json',
+  ], runtimeEnv)
+  const previousStatus = runtimeStatus()
+  if (previousStatus.provider?.contentIdentity !== options.previousContentIdentity) {
+    fail('synthetic prior Runtime did not report its content identity')
+  }
+
+  manager.upgradeCurrent()
+  assertInstalled(options.currentVersion, options.currentContentIdentity)
+  const pendingStatus = runtimeStatus()
+  if (
+    pendingStatus.class !== 'running'
+    || pendingStatus.provider?.contentIdentity !== options.previousContentIdentity
+    || pendingStatus.pendingActivation?.productVersion !== options.currentVersion
+    || pendingStatus.pendingActivation?.restartRequired !== true
+  ) {
+    fail(`active ${options.manager} upgrade did not report pending activation: ${JSON.stringify(pendingStatus)}`)
+  }
+  const idempotentUp = JSON.parse(capture(manager.executable, [
+    'up', '--home', runtimeHome, '--no-update-check', '--wait', '3', '--json',
+  ], runtimeEnv))
+  if (idempotentUp.result?.runtime?.status?.pendingActivation?.restartRequired !== true) {
+    fail('idempotent up did not preserve active manager upgrade reporting')
+  }
+  const doctor = JSON.parse(capture(manager.executable, [
+    'doctor', '--home', runtimeHome, '--json',
+  ], runtimeEnv))
+  const updateOwner = doctor.result?.doctor?.checks?.find((check) => check.id === 'update.metadata')
+  if (updateOwner?.status !== 'pass' || !updateOwner.summary.includes(manager.ownerLabel)) {
+    fail(`Doctor did not report ${options.manager} update ownership`)
+  }
+  const update = capture(manager.executable, ['update'], runtimeEnv)
+  if (!update.includes('openalice down') || !update.includes(manager.updateGuidance)) {
+    fail(`update guidance did not return to ${options.manager}`)
+  }
+  const uninstall = capture(manager.executable, ['uninstall', '--yes'], runtimeEnv)
+  if (!uninstall.includes(manager.uninstallGuidance)) {
+    fail(`uninstall guidance did not return to ${options.manager}`)
+  }
+  if (!existsSync(manager.executable)) fail('OpenAlice removed package-manager-owned files')
+
+  run(manager.executable, ['down', '--home', runtimeHome, '--json'], runtimeEnv)
+  run(manager.executable, [
+    'up', '--home', runtimeHome, '--no-update-check', '--wait', '120', '--json',
+  ], runtimeEnv)
+  const activatedStatus = runtimeStatus()
+  if (
+    activatedStatus.provider?.contentIdentity !== options.currentContentIdentity
+    || activatedStatus.pendingActivation !== null
+  ) {
+    fail(`stopped restart did not activate the ${options.manager} upgrade: ${JSON.stringify(activatedStatus)}`)
+  }
+  run(manager.executable, ['down', '--home', runtimeHome, '--json'], runtimeEnv)
+
+  manager.remove()
+  assertRemoved()
+  process.stdout.write(`[cli-system-package-smoke] ${options.manager} passed ${process.platform}-${process.arch}\n`)
+} finally {
+  if (existsSync(manager.executable)) {
+    spawnSync(manager.executable, ['down', '--home', runtimeHome, '--json'], {
+      env: runtimeEnv,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 20_000,
+    })
+  }
+  manager.cleanup()
+  if (options.keep) process.stdout.write(`[cli-system-package-smoke] kept ${root}\n`)
+  else rmSync(root, { recursive: true, force: true })
+}
+
+function prepareBrewManager() {
+  if (process.platform !== 'darwin') fail('Homebrew lifecycle smoke requires native macOS')
+  const tap = 'openalice-smoke/lifecycle'
+  const source = join(root, 'tap-source')
+  const formula = join(source, 'Formula/openalice.rb')
+  mkdirSync(join(source, 'Formula'), { recursive: true })
+  copyFileSync(resolve(options.previousPackage), formula)
+  run('git', ['init', '--initial-branch=main', source], process.env)
+  run('git', ['-C', source, 'config', 'user.name', 'OpenAlice Smoke'], process.env)
+  run('git', ['-C', source, 'config', 'user.email', 'smoke@openalice.invalid'], process.env)
+  commitFormula(source, 'previous')
+  const brewEnv = {
+    ...process.env,
+    HOMEBREW_NO_AUTO_UPDATE: '1',
+    HOMEBREW_NO_ENV_HINTS: '1',
+    HOMEBREW_NO_INSTALL_CLEANUP: '1',
+  }
+  run(options.brew, ['untap', '--force', tap], brewEnv, { allowFailure: true })
+  run(options.brew, ['tap', tap, `file://${source}`], brewEnv)
+  const tapped = capture(options.brew, ['--repository', tap], brewEnv).trim()
+  const tappedFormula = join(tapped, 'Formula/openalice.rb')
+
+  const setFormula = (sourceFormula, message) => {
+    copyFileSync(resolve(sourceFormula), formula)
+    commitFormula(source, message)
+    run('git', ['-C', tapped, 'pull', '--ff-only'], brewEnv)
+    if (!existsSync(tappedFormula)) fail('local Homebrew tap lost its formula')
+  }
+
+  return {
+    executable: join(capture(options.brew, ['--prefix'], brewEnv).trim(), 'bin/openalice'),
+    ownerLabel: 'Homebrew owns OpenAlice updates',
+    updateGuidance: 'brew upgrade traderalice/tap/openalice',
+    uninstallGuidance: 'brew uninstall traderalice/tap/openalice',
+    installPrevious() {
+      setFormula(options.previousPackage, `previous-${Date.now()}`)
+      run(options.brew, ['install', `${tap}/openalice`], brewEnv)
+    },
+    upgradeCurrent() {
+      setFormula(options.currentPackage, `current-${Date.now()}`)
+      run(options.brew, ['upgrade', `${tap}/openalice`], brewEnv)
+    },
+    remove() {
+      run(options.brew, ['uninstall', '--force', 'openalice'], brewEnv)
+    },
+    cleanup() {
+      run(options.brew, ['uninstall', '--force', 'openalice'], brewEnv, { allowFailure: true })
+      run(options.brew, ['untap', '--force', tap], brewEnv, { allowFailure: true })
+    },
+  }
+}
+
+function prepareAurManager() {
+  if (process.platform !== 'linux') fail('AUR lifecycle smoke requires Linux')
+  return {
+    executable: '/usr/bin/openalice',
+    ownerLabel: 'pacman/AUR owns OpenAlice updates',
+    updateGuidance: 'paru -S openalice-bin',
+    uninstallGuidance: 'paru -Rns openalice-bin',
+    installPrevious() {
+      run(options.pacman, ['-U', '--noconfirm', resolve(options.previousPackage)], process.env)
+    },
+    upgradeCurrent() {
+      run(options.pacman, ['-U', '--noconfirm', resolve(options.currentPackage)], process.env)
+    },
+    remove() {
+      run(options.pacman, ['-Rns', '--noconfirm', 'openalice-bin'], process.env)
+    },
+    cleanup() {
+      run(options.pacman, ['-Rns', '--noconfirm', 'openalice-bin'], process.env, { allowFailure: true })
+    },
+  }
+}
+
+function commitFormula(source, message) {
+  run('git', ['-C', source, 'add', 'Formula/openalice.rb'], process.env)
+  run('git', ['-C', source, 'commit', '--allow-empty', '-m', message], process.env)
+}
+
+function assertInstalled(expectedVersion, expectedIdentity) {
+  if (!existsSync(manager.executable)) fail(`${options.manager} did not install the openalice command`)
+  const version = JSON.parse(capture(manager.executable, ['version', '--json'], runtimeEnv))
+  if (version.version !== expectedVersion || version.contentIdentity !== expectedIdentity) {
+    fail(`installed identity mismatch: ${JSON.stringify(version)}`)
+  }
+  if (version.installSource?.method !== options.manager) {
+    fail(`installed provenance method is ${version.installSource?.method}`)
+  }
+  if (
+    version.installSource?.artifact?.platform !== process.platform
+    || version.installSource?.artifact?.arch !== process.arch
+  ) {
+    fail('installed target provenance does not match the host')
+  }
+}
+
+function assertRemoved() {
+  if (existsSync(manager.executable)) fail(`${options.manager} removal left the openalice command behind`)
+}
+
+function runtimeStatus() {
+  return JSON.parse(capture(manager.executable, [
+    'status', '--home', runtimeHome, '--wait', '3', '--json',
+  ], runtimeEnv)).result?.status
+}
+
+function run(command, args, env, { allowFailure = false } = {}) {
+  const result = spawnSync(command, args, {
+    env,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: 180_000,
+  })
+  if (result.error && !allowFailure) throw result.error
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(`${command} ${args[0]} failed (${result.status}):\n${result.stdout}\n${result.stderr}`)
+  }
+  return result
+}
+
+function capture(command, args, env) {
+  return run(command, args, env).stdout
+}
+
+function parseArgs(argv) {
+  const result = { brew: 'brew', pacman: 'pacman', keep: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--keep') result.keep = true
+    else if ([
+      '--manager', '--previous-version', '--current-version',
+      '--previous-content-identity', '--current-content-identity',
+      '--previous-package', '--current-package', '--brew', '--pacman',
+    ].includes(arg)) {
+      const value = argv[++index]
+      if (!value || value.startsWith('--')) fail(`${arg} requires a value`)
+      result[arg.slice(2).replaceAll('-', '')] = value
+    } else fail(`unknown option: ${arg}`)
+  }
+  if (!['brew', 'aur'].includes(result.manager)) fail('--manager must be brew or aur')
+  for (const field of [
+    'previousversion', 'currentversion', 'previouscontentidentity',
+    'currentcontentidentity', 'previouspackage', 'currentpackage',
+  ]) {
+    if (!result[field]) fail(`missing required lifecycle option: ${field}`)
+  }
+  if (
+    !/^[a-f0-9]{16}$/.test(result.previouscontentidentity)
+    || !/^[a-f0-9]{16}$/.test(result.currentcontentidentity)
+  ) fail('content identities must be 16 lowercase hexadecimal characters')
+  return {
+    manager: result.manager,
+    previousVersion: result.previousversion,
+    currentVersion: result.currentversion,
+    previousContentIdentity: result.previouscontentidentity,
+    currentContentIdentity: result.currentcontentidentity,
+    previousPackage: result.previouspackage,
+    currentPackage: result.currentpackage,
+    brew: result.brew,
+    pacman: result.pacman,
+    keep: result.keep,
+  }
+}
+
+function fail(message) {
+  throw new Error(message)
+}

--- a/scripts/pack-cli-npm-packages.mjs
+++ b/scripts/pack-cli-npm-packages.mjs
@@ -67,7 +67,11 @@ export function packCliNpmPackages({
 function pack(packageRoot, outputRoot, npm) {
   const result = spawnSync(npm, [
     'pack', packageRoot, '--json', '--pack-destination', outputRoot,
-  ], { encoding: 'utf8', stdio: 'pipe' })
+  ], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: process.platform === 'win32',
+  })
   if (result.error) throw result.error
   if (result.status !== 0) {
     throw new Error(`npm pack failed for ${packageRoot}:\n${result.stdout}\n${result.stderr}`)

--- a/scripts/prepare-cli-previous-release.mjs
+++ b/scripts/prepare-cli-previous-release.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url'
+
+import { preparePreviousCliReleaseArchives } from './cli-release-fixture.mjs'
+
+function parseArgs(argv) {
+  const options = {}
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index]
+    const value = argv[index + 1]
+    if (!['--input-dir', '--output-dir', '--version'].includes(name) || !value) {
+      throw new Error('Usage: prepare-cli-previous-release.mjs --input-dir <dir> --output-dir <dir> --version <version>')
+    }
+    options[name.slice(2)] = value
+  }
+  if (argv.length !== 6 || Object.keys(options).length !== 3) {
+    throw new Error('Usage: prepare-cli-previous-release.mjs --input-dir <dir> --output-dir <dir> --version <version>')
+  }
+  return {
+    inputDir: options['input-dir'],
+    outputDir: options['output-dir'],
+    version: options.version,
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const manifest = preparePreviousCliReleaseArchives(parseArgs(process.argv.slice(2)))
+    process.stdout.write(`${JSON.stringify(manifest)}\n`)
+  } catch (error) {
+    process.stderr.write(`prepare previous CLI release: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -121,9 +121,13 @@ describe('Release workflow critical path', () => {
       { os: 'macos-15-intel', arch: 'x64' },
     ])
     expect(step(homebrew, 'Install and run the accepted archive through Homebrew').run)
-      .toContain('brew install --formula')
+      .toContain('--manager brew')
+    expect(step(homebrew, 'Install and run the accepted archive through Homebrew').run)
+      .toContain('prepare-cli-previous-release.mjs')
     expect(step(aur, 'Build, install, and run the generated AUR package').run)
       .toContain('archlinux:base-devel')
+    expect(step(aur, 'Build, install, and run the generated AUR package').run)
+      .toContain('--manager aur')
   })
 
   it('publishes npm platform packages before the stable meta package', () => {


### PR DESCRIPTION
## Summary

- derive a byte-stable synthetic previous CLI release from accepted Bun archives
- run real stopped and active upgrade/removal lifecycles through Homebrew and pacman/AUR
- fix the generated Homebrew formula's extracted-root handling and Windows npm packing invocation
- share lifecycle fixture logic across npm, Bun, Homebrew, and AUR acceptance

## Verification

- `npx tsc --noEmit`
- `pnpm -F @traderalice/openalice-cli test` (335 tests)
- `pnpm test` (5,064 tests)
- `pnpm test:install:docker`
- native macOS arm64 npm, Bun, and Homebrew stopped/active lifecycle smokes
- Orb/QEMU Linux x64 makepkg + pacman stopped/active lifecycle smoke

Windows native CLI distribution remains explicitly deferred by the active plan.