### PR TITLE
test(cli): accept npm and Bun on every native target

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -29,6 +29,10 @@ on:
       - "scripts/pack-cli-npm-packages.mjs"
       - "scripts/pack-cli-npm-packages.spec.mjs"
       - "scripts/cli-package-manager-smoke.mjs"
+      - "scripts/cli-release-fixture.mjs"
+      - "scripts/cli-release-fixture.spec.mjs"
+      - "scripts/cli-system-package-manager-smoke.mjs"
+      - "scripts/prepare-cli-previous-release.mjs"
       - "scripts/prepare-cli-dev-assets.mjs"
       - "scripts/prepare-cli-dev-assets.spec.mjs"
       - "THIRD_PARTY_NOTICES.md"
@@ -177,6 +181,28 @@ jobs:
         run: |
           pnpm build:server
           pnpm build:bun:release
+
+      - name: Accept npm and Bun installs from the dev native candidate
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          CONTENT_IDENTITY=$(node -p "require('./dist/bun-release/report.json').contentIdentity")
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/bun-release \
+            --output-dir "$RUNNER_TEMP/cli-package-channels" \
+            --version "$VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --npm-only
+          node scripts/cli-package-manager-smoke.mjs \
+            --manager npm \
+            --packages-dir "$RUNNER_TEMP/cli-package-channels/npm" \
+            --expected-version "$VERSION" \
+            --expected-content-identity "$CONTENT_IDENTITY"
+          node scripts/cli-package-manager-smoke.mjs \
+            --manager bun \
+            --packages-dir "$RUNNER_TEMP/cli-package-channels/npm" \
+            --expected-version "$VERSION" \
+            --expected-content-identity "$CONTENT_IDENTITY"
 
       - name: Name the native acceptance report
         shell: bash

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -129,10 +129,11 @@ pnpm exec vitest run \
   packages/cli/src/package-manager.spec.mjs
 ```
 
-The PR workflow builds native macOS and Linux candidates and installs each
-through npm and Bun. The formal release matrix repeats npm/Bun acceptance on all
-four targets, installs the formula on native arm64 and Intel macOS runners, and
-builds plus installs the x64 `openalice-bin` in a pinned clean Arch container.
+The PR workflow samples native macOS arm64 and Linux x64 candidates through npm
+and Bun. Every `dev` push and the formal release matrix repeat npm/Bun acceptance
+on all four targets before preserving the candidate. Release acceptance also
+installs the formula on native arm64 and Intel macOS runners, and builds plus
+installs the x64 `openalice-bin` in a pinned clean Arch container.
 The official `archlinux:base-devel` image currently has no arm64 manifest, so
 arm64 AUR metadata is generated and checksum-bound but still needs a native
 Arch Linux ARM acceptance host. Each smoke uses an isolated home, exercises

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -55,6 +55,14 @@ describe('CLI installer dev publication workflow', () => {
     expect(acceptance).toContain('--npm-only')
   })
 
+  it('repeats npm and Bun lifecycle acceptance on every dev target', () => {
+    const build = workflow.jobs['build-dev-cli']
+    const acceptance = step(build, 'Accept npm and Bun installs from the dev native candidate').run ?? ''
+    expect(acceptance).toContain('--manager npm')
+    expect(acceptance).toContain('--manager bun')
+    expect(acceptance).toContain('--expected-content-identity')
+  })
+
   it('validates candidates before uploading immutable assets and fixed aliases', () => {
     const publish = workflow.jobs['publish-dev-cli']
     expect(publish.needs).toBe('build-dev-cli')


### PR DESCRIPTION
## Summary

- run npm and Bun stopped/active lifecycle acceptance in each of the four dev native build jobs
- keep candidate upload gated on successful manager installation for that exact OS and CPU
- make shared package-manager fixture changes trigger the CLI installer workflow

## Verification

- `npx tsc --noEmit`
- `pnpm test` (5,067 tests)
- targeted workflow/package-manager suite (25 tests)
- current dev raw network install passed on clean Linux and isolated macOS arm64