### PR TITLE
docs(cli): clarify distribution activation status

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1,6 +1,7 @@
 # Bun-native CLI Distribution
 
-Status: Active — macOS/Linux implementation in progress; Windows deferred
+Status: Active — macOS/Linux dev preview accepted; stable channels pending;
+Windows deferred
 
 Delivery mode: Serial / interactive on the dedicated
 `codex/usability-improvements` integration branch. This changes a released


### PR DESCRIPTION
## Summary
- state that macOS/Linux dev preview acceptance is complete
- distinguish pending stable-channel activation from deferred Windows work

## Verification
- documentation-only change
- `git diff --check`