### PR TITLE
docs(cli): promote distribution activation status

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1,6 +1,7 @@
 # Bun-native CLI Distribution
 
-Status: Active — macOS/Linux implementation in progress; Windows deferred
+Status: Active — macOS/Linux dev preview accepted; stable channels pending;
+Windows deferred
 
 Delivery mode: Serial / interactive on the dedicated
 `codex/usability-improvements` integration branch. This changes a released


### PR DESCRIPTION
## Summary
- promote the corrected Bun CLI plan status to dev

## Verification
- documentation-only change
- `git diff --check`