### PR TITLE
test(cli): promote native Linuxbrew acceptance

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -32,6 +32,8 @@ on:
       - "scripts/cli-release-fixture.mjs"
       - "scripts/cli-release-fixture.spec.mjs"
       - "scripts/cli-system-package-manager-smoke.mjs"
+      - "scripts/cli-linuxbrew-smoke.mjs"
+      - "scripts/cli-linuxbrew-smoke.spec.mjs"
       - "scripts/prepare-cli-previous-release.mjs"
       - "scripts/prepare-cli-dev-assets.mjs"
       - "scripts/prepare-cli-dev-assets.spec.mjs"
@@ -222,10 +224,73 @@ jobs:
           compression-level: 0
           retention-days: 1
 
+  accept-dev-linuxbrew:
+    if: github.event_name == 'push'
+    name: Accept dev Linuxbrew CLI (${{ matrix.arch }})
+    needs: build-dev-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dev-cli-*
+          path: dist/dev-cli-candidates
+          merge-multiple: true
+
+      - name: Accept the dev archives through Linuxbrew
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          node scripts/prepare-cli-previous-release.mjs \
+            --input-dir dist/dev-cli-candidates \
+            --output-dir dist/dev-linuxbrew-previous \
+            --version "$VERSION"
+          PREVIOUS_VERSION=$(node -p "require('./dist/dev-linuxbrew-previous/fixture.json').previousVersion")
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/dev-cli-candidates \
+            --output-dir dist/dev-linuxbrew-current \
+            --version "$VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/dev-cli-candidates \
+            --require-all
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/dev-linuxbrew-previous \
+            --output-dir dist/dev-linuxbrew-previous-channels \
+            --version "$PREVIOUS_VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/dev-linuxbrew-previous \
+            --require-all
+          CURRENT_ID=$(node -e "const f=require('./dist/dev-linuxbrew-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').contentIdentity)")
+          PREVIOUS_ID=$(node -e "const f=require('./dist/dev-linuxbrew-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').previousContentIdentity)")
+          node scripts/cli-linuxbrew-smoke.mjs \
+            --arch "${{ matrix.arch }}" \
+            --previous-version "$PREVIOUS_VERSION" \
+            --current-version "$VERSION" \
+            --previous-content-identity "$PREVIOUS_ID" \
+            --current-content-identity "$CURRENT_ID" \
+            --previous-package dist/dev-linuxbrew-previous-channels/homebrew/openalice.rb \
+            --current-package dist/dev-linuxbrew-current/homebrew/openalice.rb
+
   publish-dev-cli:
     if: github.event_name == 'push'
     name: Publish dev native CLI aliases
-    needs: build-dev-cli
+    needs: [build-dev-cli, accept-dev-linuxbrew]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,6 +533,71 @@ jobs:
             --previous-package dist/cli-package-homebrew-previous-channels/homebrew/openalice.rb \
             --current-package dist/cli-package-homebrew-current/homebrew/openalice.rb
 
+  accept-cli-linuxbrew:
+    name: Accept Linuxbrew CLI (${{ matrix.arch }})
+    needs: [release, build-cli-release]
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cli-release-*
+          path: dist/release-cli
+          merge-multiple: true
+
+      - name: Install and run the accepted archive through Linuxbrew
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          node scripts/prepare-cli-previous-release.mjs \
+            --input-dir dist/release-cli \
+            --output-dir dist/cli-package-linuxbrew-previous \
+            --version "$VERSION"
+          PREVIOUS_VERSION=$(node -p "require('./dist/cli-package-linuxbrew-previous/fixture.json').previousVersion")
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/release-cli \
+            --output-dir dist/cli-package-linuxbrew-current \
+            --version "$VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/release-cli \
+            --require-all
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/cli-package-linuxbrew-previous \
+            --output-dir dist/cli-package-linuxbrew-previous-channels \
+            --version "$PREVIOUS_VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/cli-package-linuxbrew-previous \
+            --require-all
+          CURRENT_ID=$(node -e "const f=require('./dist/cli-package-linuxbrew-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').contentIdentity)")
+          PREVIOUS_ID=$(node -e "const f=require('./dist/cli-package-linuxbrew-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').previousContentIdentity)")
+          node scripts/cli-linuxbrew-smoke.mjs \
+            --arch "${{ matrix.arch }}" \
+            --previous-version "$PREVIOUS_VERSION" \
+            --current-version "$VERSION" \
+            --previous-content-identity "$PREVIOUS_ID" \
+            --current-content-identity "$CURRENT_ID" \
+            --previous-package dist/cli-package-linuxbrew-previous-channels/homebrew/openalice.rb \
+            --current-package dist/cli-package-linuxbrew-current/homebrew/openalice.rb
+
   accept-cli-aur:
     name: Accept Arch/AUR CLI package
     needs: [release, build-cli-release]
@@ -667,8 +732,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, accept-desktop-upgrade, build-cli-release, build-cli-package-channels, accept-cli-homebrew, accept-cli-aur, build-broker-packs, cli-installer-acceptance]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-cli-release.result == 'success' && needs.build-cli-package-channels.result == 'success' && needs.accept-cli-homebrew.result == 'success' && needs.accept-cli-aur.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
+    needs: [release, build-desktop, accept-desktop-upgrade, build-cli-release, build-cli-package-channels, accept-cli-homebrew, accept-cli-linuxbrew, accept-cli-aur, build-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-cli-release.result == 'success' && needs.build-cli-package-channels.result == 'success' && needs.accept-cli-homebrew.result == 'success' && needs.accept-cli-linuxbrew.result == 'success' && needs.accept-cli-aur.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -132,8 +132,10 @@ pnpm exec vitest run \
 The PR workflow samples native macOS arm64 and Linux x64 candidates through npm
 and Bun. Every `dev` push and the formal release matrix repeat npm/Bun acceptance
 on all four targets before preserving the candidate. Release acceptance also
-installs the formula on native arm64 and Intel macOS runners, and builds plus
-installs the x64 `openalice-bin` in a pinned clean Arch container.
+installs the formula on native arm64 and Intel macOS runners, repeats the full
+formula lifecycle on native Linux arm64/x64 runners inside pinned official
+Homebrew images, and builds plus installs the x64 `openalice-bin` in a pinned
+clean Arch container.
 The official `archlinux:base-devel` image currently has no arm64 manifest, so
 arm64 AUR metadata is generated and checksum-bound but still needs a native
 Arch Linux ARM acceptance host. Each smoke uses an isolated home, exercises

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -448,8 +448,8 @@ build harness when it improves the next investigation.
   platform; verify that the final command is the native executable and does
   not require the package manager at runtime.
 - [x] Generate the TraderAlice Homebrew formula from accepted archive URLs and
-  checksums. The release gate is configured for native macOS arm64/x64
-  installation; Linuxbrew remains a release acceptance gap.
+  checksums. The release gate covers native macOS arm64/x64 and Linuxbrew
+  arm64/x64 installation.
 - [x] Generate the `openalice-bin` AUR `PKGBUILD` and `.SRCINFO` from the
   accepted Linux archives and configure a pinned clean Arch x64 build/install
   gate. Native Arch Linux ARM acceptance remains open because the official
@@ -859,3 +859,9 @@ This plan is complete only when:
   absent from the Runtime `PATH`. Stable registry/tap/AUR publication and the
   tagged-release matrix remain release activation work; Windows remains
   deferred.
+- 2026-08-30: Closed the Linuxbrew acceptance gap with pinned official
+  Homebrew 6.0.15 images for native Linux arm64 and x64 runners. The shared
+  system-package lifecycle now accepts Homebrew on macOS or Linux, while a
+  release-gating Linuxbrew matrix repeats stopped and active upgrades,
+  ownership guidance, restart activation, and removal against the exact
+  accepted Linux archives.

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -65,13 +65,24 @@ describe('CLI installer dev publication workflow', () => {
 
   it('validates candidates before uploading immutable assets and fixed aliases', () => {
     const publish = workflow.jobs['publish-dev-cli']
-    expect(publish.needs).toBe('build-dev-cli')
+    expect(publish.needs).toEqual(['build-dev-cli', 'accept-dev-linuxbrew'])
     expect(step(publish, 'Validate candidates and prepare channel aliases').run)
       .toContain('prepare-cli-dev-assets.mjs')
     const upload = step(publish, 'Publish immutable candidates and activate dev aliases').run ?? ''
     expect(upload.indexOf('cli/dev/releases/${GITHUB_SHA}')).toBeGreaterThanOrEqual(0)
     expect(upload.indexOf('aliases/*.tar.gz')).toBeLessThan(upload.indexOf('aliases/*.sha256'))
     expect(upload.indexOf('aliases/*.sha256')).toBeLessThan(upload.indexOf('manifest.json'))
+  })
+
+  it('accepts Linuxbrew on both native Linux architectures before publication', () => {
+    const linuxbrew = workflow.jobs['accept-dev-linuxbrew']
+    expect(linuxbrew.needs).toBe('build-dev-cli')
+    expect(linuxbrew.strategy?.matrix?.include).toEqual([
+      { os: 'ubuntu-24.04', arch: 'x64' },
+      { os: 'ubuntu-24.04-arm', arch: 'arm64' },
+    ])
+    expect(step(linuxbrew, 'Accept the dev archives through Linuxbrew').run)
+      .toContain('cli-linuxbrew-smoke.mjs')
   })
 
   it('runs the live network install only after a successful push publication', () => {

--- a/scripts/cli-linuxbrew-smoke.mjs
+++ b/scripts/cli-linuxbrew-smoke.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { relative, resolve, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+
+export const LINUXBREW_IMAGES = Object.freeze({
+  arm64: {
+    platform: 'linux/arm64',
+    image: 'ghcr.io/homebrew/brew@sha256:bfeda232fd598c5b445ef75dc05b828c1037e50b4fdade546714280a2cb5c7c2',
+  },
+  x64: {
+    platform: 'linux/amd64',
+    image: 'ghcr.io/homebrew/brew@sha256:1c42d9bcdb1ff1a017dca941a87c041e5b7a20c6f75ba022c367bd838865f6b7',
+  },
+})
+
+export function runLinuxbrewSmoke(options) {
+  const target = LINUXBREW_IMAGES[options.arch]
+  if (!target) throw new Error(`unsupported Linuxbrew architecture: ${options.arch}`)
+  const previousPackage = containerPath(options.previousPackage)
+  const currentPackage = containerPath(options.currentPackage)
+  const command = [
+    'sudo apt-get update -qq',
+    'sudo apt-get install -y -qq nodejs >/dev/null',
+    [
+      'exec /usr/bin/node /work/scripts/cli-system-package-manager-smoke.mjs',
+      '--manager brew',
+      '--previous-version "$PREVIOUS_VERSION"',
+      '--current-version "$CURRENT_VERSION"',
+      '--previous-content-identity "$PREVIOUS_CONTENT_IDENTITY"',
+      '--current-content-identity "$CURRENT_CONTENT_IDENTITY"',
+      '--previous-package "$PREVIOUS_PACKAGE"',
+      '--current-package "$CURRENT_PACKAGE"',
+      '--brew /home/linuxbrew/.linuxbrew/bin/brew',
+    ].join(' '),
+  ].join(' && ')
+  const args = [
+    'run', '--rm',
+    '--platform', target.platform,
+    '--env', `PREVIOUS_VERSION=${options.previousVersion}`,
+    '--env', `CURRENT_VERSION=${options.currentVersion}`,
+    '--env', `PREVIOUS_CONTENT_IDENTITY=${options.previousContentIdentity}`,
+    '--env', `CURRENT_CONTENT_IDENTITY=${options.currentContentIdentity}`,
+    '--env', `PREVIOUS_PACKAGE=${previousPackage}`,
+    '--env', `CURRENT_PACKAGE=${currentPackage}`,
+    '--volume', `${repositoryRoot}:/work:ro`,
+    target.image,
+    'bash', '-lc', command,
+  ]
+  const result = spawnSync(options.docker, args, {
+    cwd: repositoryRoot,
+    stdio: 'inherit',
+    timeout: 15 * 60_000,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`Linuxbrew lifecycle smoke failed (${result.status})`)
+}
+
+export function parseArgs(argv) {
+  const result = { docker: 'docker' }
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index]
+    const value = argv[index + 1]
+    if (![
+      '--arch', '--previous-version', '--current-version',
+      '--previous-content-identity', '--current-content-identity',
+      '--previous-package', '--current-package', '--docker',
+    ].includes(name) || !value) {
+      throw new Error(usage())
+    }
+    result[name.slice(2).replaceAll('-', '')] = value
+  }
+  if (!['arm64', 'x64'].includes(result.arch)) throw new Error('--arch must be arm64 or x64')
+  for (const field of [
+    'previousversion', 'currentversion', 'previouscontentidentity',
+    'currentcontentidentity', 'previouspackage', 'currentpackage',
+  ]) {
+    if (!result[field]) throw new Error(`missing required Linuxbrew option: ${field}`)
+  }
+  for (const field of ['previousversion', 'currentversion']) {
+    if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(result[field])) {
+      throw new Error(`invalid OpenAlice version: ${result[field]}`)
+    }
+  }
+  for (const field of ['previouscontentidentity', 'currentcontentidentity']) {
+    if (!/^[a-f0-9]{16}$/.test(result[field])) throw new Error(`invalid content identity: ${result[field]}`)
+  }
+  return {
+    arch: result.arch,
+    previousVersion: result.previousversion,
+    currentVersion: result.currentversion,
+    previousContentIdentity: result.previouscontentidentity,
+    currentContentIdentity: result.currentcontentidentity,
+    previousPackage: result.previouspackage,
+    currentPackage: result.currentpackage,
+    docker: result.docker,
+  }
+}
+
+function containerPath(input) {
+  const absolute = resolve(repositoryRoot, input)
+  const local = relative(repositoryRoot, absolute)
+  if (!local || local === '..' || local.startsWith(`..${sep}`) || !existsSync(absolute)) {
+    throw new Error(`Linuxbrew package must exist inside the repository: ${input}`)
+  }
+  return `/work/${local.split(sep).join('/')}`
+}
+
+function usage() {
+  return 'Usage: cli-linuxbrew-smoke.mjs --arch <arm64|x64> --previous-version <version> --current-version <version> --previous-content-identity <hash> --current-content-identity <hash> --previous-package <formula> --current-package <formula> [--docker <command>]'
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    runLinuxbrewSmoke(parseArgs(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`Linuxbrew smoke: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/cli-linuxbrew-smoke.spec.mjs
+++ b/scripts/cli-linuxbrew-smoke.spec.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { LINUXBREW_IMAGES, parseArgs } from './cli-linuxbrew-smoke.mjs'
+
+describe('Linuxbrew lifecycle smoke', () => {
+  it('pins official Homebrew images for both native Linux architectures', () => {
+    expect(LINUXBREW_IMAGES.arm64).toMatchObject({ platform: 'linux/arm64' })
+    expect(LINUXBREW_IMAGES.x64).toMatchObject({ platform: 'linux/amd64' })
+    expect(LINUXBREW_IMAGES.arm64.image).toMatch(/^ghcr\.io\/homebrew\/brew@sha256:[a-f0-9]{64}$/)
+    expect(LINUXBREW_IMAGES.x64.image).toMatch(/^ghcr\.io\/homebrew\/brew@sha256:[a-f0-9]{64}$/)
+  })
+
+  it('parses a complete arm64 lifecycle request', () => {
+    expect(parseArgs([
+      '--arch', 'arm64',
+      '--previous-version', '0.90.0',
+      '--current-version', '0.90.1',
+      '--previous-content-identity', '0123456789abcdef',
+      '--current-content-identity', 'fedcba9876543210',
+      '--previous-package', 'dist/previous/openalice.rb',
+      '--current-package', 'dist/current/openalice.rb',
+    ])).toMatchObject({
+      arch: 'arm64',
+      docker: 'docker',
+      currentVersion: '0.90.1',
+    })
+  })
+
+  it('rejects unsupported architectures and malformed identities', () => {
+    const base = [
+      '--arch', 'riscv64',
+      '--previous-version', '0.90.0',
+      '--current-version', '0.90.1',
+      '--previous-content-identity', '0123456789abcdef',
+      '--current-content-identity', 'fedcba9876543210',
+      '--previous-package', 'dist/previous/openalice.rb',
+      '--current-package', 'dist/current/openalice.rb',
+    ]
+    expect(() => parseArgs(base)).toThrow('--arch must be arm64 or x64')
+    base[1] = 'x64'
+    base[9] = 'not-a-hash'
+    expect(() => parseArgs(base)).toThrow('invalid content identity')
+  })
+})

--- a/scripts/cli-system-package-manager-smoke.mjs
+++ b/scripts/cli-system-package-manager-smoke.mjs
@@ -107,7 +107,9 @@ try {
 }
 
 function prepareBrewManager() {
-  if (process.platform !== 'darwin') fail('Homebrew lifecycle smoke requires native macOS')
+  if (!['darwin', 'linux'].includes(process.platform)) {
+    fail('Homebrew lifecycle smoke requires macOS or Linux')
+  }
   const tap = 'openalice-smoke/lifecycle'
   const source = join(root, 'tap-source')
   const formula = join(source, 'Formula/openalice.rb')

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -108,6 +108,7 @@ describe('Release workflow critical path', () => {
     const nativeCli = workflow.jobs['build-cli-release']
     const channels = workflow.jobs['build-cli-package-channels']
     const homebrew = workflow.jobs['accept-cli-homebrew']
+    const linuxbrew = workflow.jobs['accept-cli-linuxbrew']
     const aur = workflow.jobs['accept-cli-aur']
 
     const npmAndBun = step(nativeCli, 'Accept npm and Bun installs from the native candidate').run ?? ''
@@ -124,6 +125,12 @@ describe('Release workflow critical path', () => {
       .toContain('--manager brew')
     expect(step(homebrew, 'Install and run the accepted archive through Homebrew').run)
       .toContain('prepare-cli-previous-release.mjs')
+    expect(linuxbrew.strategy?.matrix?.include).toEqual([
+      { os: 'ubuntu-24.04', arch: 'x64' },
+      { os: 'ubuntu-24.04-arm', arch: 'arm64' },
+    ])
+    expect(step(linuxbrew, 'Install and run the accepted archive through Linuxbrew').run)
+      .toContain('cli-linuxbrew-smoke.mjs')
     expect(step(aur, 'Build, install, and run the generated AUR package').run)
       .toContain('archlinux:base-devel')
     expect(step(aur, 'Build, install, and run the generated AUR package').run)


### PR DESCRIPTION
## Summary
- promote native Linux arm64/x64 Homebrew lifecycle gates
- require Linuxbrew acceptance before dev alias and stable release publication

## Verification
- `npx tsc --noEmit`
- `pnpm test` (5,071 passed, 9 skipped)
- native OrbStack Linux arm64 lifecycle passed