### PR TITLE
test(cli): accept AUR on Linux arm64

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -32,6 +32,8 @@ on:
       - "scripts/cli-release-fixture.mjs"
       - "scripts/cli-release-fixture.spec.mjs"
       - "scripts/cli-system-package-manager-smoke.mjs"
+      - "scripts/cli-aur-container-smoke.mjs"
+      - "scripts/cli-aur-container-smoke.spec.mjs"
       - "scripts/cli-linuxbrew-smoke.mjs"
       - "scripts/cli-linuxbrew-smoke.spec.mjs"
       - "scripts/prepare-cli-previous-release.mjs"
@@ -287,10 +289,73 @@ jobs:
             --previous-package dist/dev-linuxbrew-previous-channels/homebrew/openalice.rb \
             --current-package dist/dev-linuxbrew-current/homebrew/openalice.rb
 
+  accept-dev-aur:
+    if: github.event_name == 'push'
+    name: Accept dev Arch/AUR CLI (${{ matrix.arch }})
+    needs: build-dev-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dev-cli-*
+          path: dist/dev-cli-candidates
+          merge-multiple: true
+
+      - name: Accept the dev archives through Arch/AUR
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          node scripts/prepare-cli-previous-release.mjs \
+            --input-dir dist/dev-cli-candidates \
+            --output-dir dist/dev-aur-previous \
+            --version "$VERSION"
+          PREVIOUS_VERSION=$(node -p "require('./dist/dev-aur-previous/fixture.json').previousVersion")
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/dev-cli-candidates \
+            --output-dir dist/dev-aur-current \
+            --version "$VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/dev-cli-candidates \
+            --require-all
+          node scripts/build-cli-package-channels.mjs \
+            --input-dir dist/dev-aur-previous \
+            --output-dir dist/dev-aur-previous-channels \
+            --version "$PREVIOUS_VERSION" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --asset-base-url file:///work/dist/dev-aur-previous \
+            --require-all
+          CURRENT_ID=$(node -e "const f=require('./dist/dev-aur-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').contentIdentity)")
+          PREVIOUS_ID=$(node -e "const f=require('./dist/dev-aur-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').previousContentIdentity)")
+          node scripts/cli-aur-container-smoke.mjs \
+            --arch "${{ matrix.arch }}" \
+            --previous-version "$PREVIOUS_VERSION" \
+            --current-version "$VERSION" \
+            --previous-content-identity "$PREVIOUS_ID" \
+            --current-content-identity "$CURRENT_ID" \
+            --previous-package dist/dev-aur-previous-channels/aur/PKGBUILD \
+            --current-package dist/dev-aur-current/aur/PKGBUILD
+
   publish-dev-cli:
     if: github.event_name == 'push'
     name: Publish dev native CLI aliases
-    needs: [build-dev-cli, accept-dev-linuxbrew]
+    needs: [build-dev-cli, accept-dev-linuxbrew, accept-dev-aur]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,11 +599,19 @@ jobs:
             --current-package dist/cli-package-linuxbrew-current/homebrew/openalice.rb
 
   accept-cli-aur:
-    name: Accept Arch/AUR CLI package
+    name: Accept Arch/AUR CLI package (${{ matrix.arch }})
     needs: [release, build-cli-release]
     if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: x64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     permissions:
       contents: read
 
@@ -644,37 +652,16 @@ jobs:
             --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --asset-base-url file:///work/dist/cli-package-aur-previous \
             --require-all
-          CURRENT_ID=$(node -e "const f=require('./dist/cli-package-aur-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='x64').contentIdentity)")
-          PREVIOUS_ID=$(node -e "const f=require('./dist/cli-package-aur-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='x64').previousContentIdentity)")
-          docker run --rm \
-            --platform linux/amd64 \
-            --env CURRENT_ID="$CURRENT_ID" \
-            --env CURRENT_VERSION="$VERSION" \
-            --env PREVIOUS_ID="$PREVIOUS_ID" \
-            --env PREVIOUS_VERSION="$PREVIOUS_VERSION" \
-            --volume "$GITHUB_WORKSPACE:/work" \
-            --workdir /work \
-            archlinux:base-devel@sha256:68bfc3b0d277b08a99101dc9b94aaa03e5ae70cf1b4fb965c03b2b87b915760d \
-            bash -euxo pipefail -c '
-              pacman -Syu --noconfirm nodejs
-              useradd --create-home builder
-              chown -R builder:builder \
-                /work/dist/cli-package-aur-current \
-                /work/dist/cli-package-aur-previous \
-                /work/dist/cli-package-aur-previous-channels
-              su builder -c "cd /work/dist/cli-package-aur-previous-channels/aur && makepkg --nodeps --noconfirm"
-              mv /work/dist/cli-package-aur-previous-channels/aur/openalice-bin-*.pkg.tar.zst /tmp/openalice-previous.pkg.tar.zst
-              su builder -c "cd /work/dist/cli-package-aur-current/aur && makepkg --nodeps --noconfirm"
-              mv /work/dist/cli-package-aur-current/aur/openalice-bin-*.pkg.tar.zst /tmp/openalice-current.pkg.tar.zst
-              /usr/bin/node /work/scripts/cli-system-package-manager-smoke.mjs \
-                --manager aur \
-                --previous-version "$PREVIOUS_VERSION" \
-                --current-version "$CURRENT_VERSION" \
-                --previous-content-identity "$PREVIOUS_ID" \
-                --current-content-identity "$CURRENT_ID" \
-                --previous-package /tmp/openalice-previous.pkg.tar.zst \
-                --current-package /tmp/openalice-current.pkg.tar.zst
-            '
+          CURRENT_ID=$(node -e "const f=require('./dist/cli-package-aur-current/cli-package-channels.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').contentIdentity)")
+          PREVIOUS_ID=$(node -e "const f=require('./dist/cli-package-aur-previous/fixture.json');process.stdout.write(f.targets.find(t=>t.platform==='linux'&&t.arch==='${{ matrix.arch }}').previousContentIdentity)")
+          node scripts/cli-aur-container-smoke.mjs \
+            --arch "${{ matrix.arch }}" \
+            --previous-version "$PREVIOUS_VERSION" \
+            --current-version "$VERSION" \
+            --previous-content-identity "$PREVIOUS_ID" \
+            --current-content-identity "$CURRENT_ID" \
+            --previous-package dist/cli-package-aur-previous-channels/aur/PKGBUILD \
+            --current-package dist/cli-package-aur-current/aur/PKGBUILD
 
   # Broker Packs are release artifacts, not inputs to the desktop package. Build
   # and validate them on their native platforms in parallel with desktop and

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -134,11 +134,11 @@ and Bun. Every `dev` push and the formal release matrix repeat npm/Bun acceptanc
 on all four targets before preserving the candidate. Release acceptance also
 installs the formula on native arm64 and Intel macOS runners, repeats the full
 formula lifecycle on native Linux arm64/x64 runners inside pinned official
-Homebrew images, and builds plus installs the x64 `openalice-bin` in a pinned
-clean Arch container.
-The official `archlinux:base-devel` image currently has no arm64 manifest, so
-arm64 AUR metadata is generated and checksum-bound but still needs a native
-Arch Linux ARM acceptance host. Each smoke uses an isolated home, exercises
+Homebrew images, and builds plus installs `openalice-bin` on native Linux x64
+and arm64 runners. The x64 AUR lane uses the pinned official Arch image; because
+that image has no arm64 manifest, the arm64 lane uses a pinned Arch Linux ARM
+image built from signature-checked upstream repositories. Each smoke uses an
+isolated home, exercises
 an actual stopped upgrade and removal, then starts a synthetic prior candidate
 and replaces it through the manager while Guardian is active. The new command
 must report the older running content as pending activation, preserve that

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -451,9 +451,8 @@ build harness when it improves the next investigation.
   checksums. The release gate covers native macOS arm64/x64 and Linuxbrew
   arm64/x64 installation.
 - [x] Generate the `openalice-bin` AUR `PKGBUILD` and `.SRCINFO` from the
-  accepted Linux archives and configure a pinned clean Arch x64 build/install
-  gate. Native Arch Linux ARM acceptance remains open because the official
-  base-devel container has no arm64 image.
+  accepted Linux archives and configure pinned clean Arch x64 and Arch Linux
+  ARM build/install gates.
 - [ ] Publish the generated formula to the TraderAlice tap and `openalice-bin`
   to AUR, then test the public `brew` and `paru` commands.
 - [x] Record channel provenance without rebuilding or modifying the native
@@ -865,3 +864,10 @@ This plan is complete only when:
   release-gating Linuxbrew matrix repeats stopped and active upgrades,
   ownership guidance, restart activation, and removal against the exact
   accepted Linux archives.
+- 2026-08-30: Closed native Arch Linux ARM package acceptance. The x64 lane
+  remains on the pinned official Arch base-devel image; the arm64 lane uses a
+  pinned Arch Linux ARM base-devel image whose audited build consumes
+  signature-checked upstream repositories. Both native runner lanes build the
+  generated `openalice-bin`, install it through `pacman`, and repeat stopped
+  and active upgrade, ownership, restart activation, and removal checks before
+  dev aliases or a stable release can publish.

--- a/scripts/cli-aur-container-smoke.mjs
+++ b/scripts/cli-aur-container-smoke.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, relative, resolve, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
+
+export const AUR_IMAGES = Object.freeze({
+  arm64: {
+    platform: 'linux/arm64',
+    // The official Arch image is amd64-only. This digest is built from the
+    // signature-checked Arch Linux ARM repositories by the audited source at
+    // https://github.com/Menci/docker-archlinuxarm.
+    image: 'menci/archlinuxarm:base-devel@sha256:e636d0261d62f2f6a3f97e16d71a2ebb9e87f952d696890d1fb0d722f9286163',
+  },
+  x64: {
+    platform: 'linux/amd64',
+    image: 'archlinux:base-devel@sha256:a26046b7363dad8e2614858f4313949ae9b05c9c5f31de343a54864b9e20806f',
+  },
+})
+
+export function runAurContainerSmoke(options) {
+  const target = AUR_IMAGES[options.arch]
+  if (!target) throw new Error(`unsupported AUR architecture: ${options.arch}`)
+  const previousPackageRoot = containerDirectory(options.previousPackage)
+  const currentPackageRoot = containerDirectory(options.currentPackage)
+  const command = [
+    // GitHub and OrbStack containers do not expose Landlock. Pacman 7's
+    // download sandbox must be disabled explicitly inside this disposable,
+    // digest-pinned acceptance container.
+    'pacman --disable-sandbox -Syu --noconfirm nodejs',
+    'useradd --create-home builder',
+    'install -d -o builder -g builder /tmp/openalice-aur-previous /tmp/openalice-aur-current',
+    'cp -a "$PREVIOUS_PACKAGE_ROOT/." /tmp/openalice-aur-previous/',
+    'cp -a "$CURRENT_PACKAGE_ROOT/." /tmp/openalice-aur-current/',
+    'chown -R builder:builder /tmp/openalice-aur-previous /tmp/openalice-aur-current',
+    'su builder -c "cd /tmp/openalice-aur-previous && makepkg --nodeps --noconfirm"',
+    'su builder -c "cd /tmp/openalice-aur-current && makepkg --nodeps --noconfirm"',
+    'PREVIOUS_BUILT_PACKAGE=$(find /tmp/openalice-aur-previous -maxdepth 1 -name "openalice-bin-*.pkg.tar.*" -print -quit)',
+    'CURRENT_BUILT_PACKAGE=$(find /tmp/openalice-aur-current -maxdepth 1 -name "openalice-bin-*.pkg.tar.*" -print -quit)',
+    'test -n "$PREVIOUS_BUILT_PACKAGE" -a -n "$CURRENT_BUILT_PACKAGE"',
+    [
+      'exec /usr/bin/node /work/scripts/cli-system-package-manager-smoke.mjs',
+      '--manager aur',
+      '--previous-version "$PREVIOUS_VERSION"',
+      '--current-version "$CURRENT_VERSION"',
+      '--previous-content-identity "$PREVIOUS_CONTENT_IDENTITY"',
+      '--current-content-identity "$CURRENT_CONTENT_IDENTITY"',
+      '--previous-package "$PREVIOUS_BUILT_PACKAGE"',
+      '--current-package "$CURRENT_BUILT_PACKAGE"',
+    ].join(' '),
+  ].join(' && ')
+  const args = [
+    'run', '--rm',
+    '--platform', target.platform,
+    '--env', `PREVIOUS_VERSION=${options.previousVersion}`,
+    '--env', `CURRENT_VERSION=${options.currentVersion}`,
+    '--env', `PREVIOUS_CONTENT_IDENTITY=${options.previousContentIdentity}`,
+    '--env', `CURRENT_CONTENT_IDENTITY=${options.currentContentIdentity}`,
+    '--env', `PREVIOUS_PACKAGE_ROOT=${previousPackageRoot}`,
+    '--env', `CURRENT_PACKAGE_ROOT=${currentPackageRoot}`,
+    '--volume', `${repositoryRoot}:/work:ro`,
+    '--workdir', '/work',
+    target.image,
+    'bash', '-lc', command,
+  ]
+  const result = spawnSync(options.docker, args, {
+    cwd: repositoryRoot,
+    stdio: 'inherit',
+    timeout: 20 * 60_000,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`AUR lifecycle smoke failed (${result.status})`)
+}
+
+export function parseArgs(argv) {
+  const result = { docker: 'docker' }
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index]
+    const value = argv[index + 1]
+    if (![
+      '--arch', '--previous-version', '--current-version',
+      '--previous-content-identity', '--current-content-identity',
+      '--previous-package', '--current-package', '--docker',
+    ].includes(name) || !value) {
+      throw new Error(usage())
+    }
+    result[name.slice(2).replaceAll('-', '')] = value
+  }
+  if (!['arm64', 'x64'].includes(result.arch)) throw new Error('--arch must be arm64 or x64')
+  for (const field of [
+    'previousversion', 'currentversion', 'previouscontentidentity',
+    'currentcontentidentity', 'previouspackage', 'currentpackage',
+  ]) {
+    if (!result[field]) throw new Error(`missing required AUR option: ${field}`)
+  }
+  for (const field of ['previousversion', 'currentversion']) {
+    if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(result[field])) {
+      throw new Error(`invalid OpenAlice version: ${result[field]}`)
+    }
+  }
+  for (const field of ['previouscontentidentity', 'currentcontentidentity']) {
+    if (!/^[a-f0-9]{16}$/.test(result[field])) throw new Error(`invalid content identity: ${result[field]}`)
+  }
+  return {
+    arch: result.arch,
+    previousVersion: result.previousversion,
+    currentVersion: result.currentversion,
+    previousContentIdentity: result.previouscontentidentity,
+    currentContentIdentity: result.currentcontentidentity,
+    previousPackage: result.previouspackage,
+    currentPackage: result.currentpackage,
+    docker: result.docker,
+  }
+}
+
+function containerDirectory(input) {
+  const absolute = resolve(repositoryRoot, dirname(input))
+  const local = relative(repositoryRoot, absolute)
+  if (!local || local === '..' || local.startsWith(`..${sep}`) || !existsSync(resolve(repositoryRoot, input))) {
+    throw new Error(`AUR package must exist inside the repository: ${input}`)
+  }
+  return `/work/${local.split(sep).join('/')}`
+}
+
+function usage() {
+  return 'Usage: cli-aur-container-smoke.mjs --arch <arm64|x64> --previous-version <version> --current-version <version> --previous-content-identity <hash> --current-content-identity <hash> --previous-package <PKGBUILD> --current-package <PKGBUILD> [--docker <command>]'
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    runAurContainerSmoke(parseArgs(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`AUR container smoke: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/cli-aur-container-smoke.spec.mjs
+++ b/scripts/cli-aur-container-smoke.spec.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { AUR_IMAGES, parseArgs } from './cli-aur-container-smoke.mjs'
+
+describe('AUR container lifecycle smoke', () => {
+  it('pins native Arch-family images for Linux arm64 and x64', () => {
+    expect(AUR_IMAGES.arm64).toMatchObject({ platform: 'linux/arm64' })
+    expect(AUR_IMAGES.x64).toMatchObject({ platform: 'linux/amd64' })
+    expect(AUR_IMAGES.arm64.image).toMatch(/^menci\/archlinuxarm:base-devel@sha256:[a-f0-9]{64}$/)
+    expect(AUR_IMAGES.x64.image).toMatch(/^archlinux:base-devel@sha256:[a-f0-9]{64}$/)
+  })
+
+  it('parses a complete x64 lifecycle request', () => {
+    expect(parseArgs([
+      '--arch', 'x64',
+      '--previous-version', '0.90.0',
+      '--current-version', '0.90.1',
+      '--previous-content-identity', '0123456789abcdef',
+      '--current-content-identity', 'fedcba9876543210',
+      '--previous-package', 'dist/previous/aur/PKGBUILD',
+      '--current-package', 'dist/current/aur/PKGBUILD',
+    ])).toMatchObject({
+      arch: 'x64',
+      docker: 'docker',
+      currentVersion: '0.90.1',
+    })
+  })
+
+  it('rejects unsupported architectures and malformed versions', () => {
+    const base = [
+      '--arch', 'riscv64',
+      '--previous-version', '0.90.0',
+      '--current-version', '0.90.1',
+      '--previous-content-identity', '0123456789abcdef',
+      '--current-content-identity', 'fedcba9876543210',
+      '--previous-package', 'dist/previous/aur/PKGBUILD',
+      '--current-package', 'dist/current/aur/PKGBUILD',
+    ]
+    expect(() => parseArgs(base)).toThrow('--arch must be arm64 or x64')
+    base[1] = 'arm64'
+    base[5] = 'not-a-version'
+    expect(() => parseArgs(base)).toThrow('invalid OpenAlice version')
+  })
+})

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -65,7 +65,7 @@ describe('CLI installer dev publication workflow', () => {
 
   it('validates candidates before uploading immutable assets and fixed aliases', () => {
     const publish = workflow.jobs['publish-dev-cli']
-    expect(publish.needs).toEqual(['build-dev-cli', 'accept-dev-linuxbrew'])
+    expect(publish.needs).toEqual(['build-dev-cli', 'accept-dev-linuxbrew', 'accept-dev-aur'])
     expect(step(publish, 'Validate candidates and prepare channel aliases').run)
       .toContain('prepare-cli-dev-assets.mjs')
     const upload = step(publish, 'Publish immutable candidates and activate dev aliases').run ?? ''
@@ -83,6 +83,17 @@ describe('CLI installer dev publication workflow', () => {
     ])
     expect(step(linuxbrew, 'Accept the dev archives through Linuxbrew').run)
       .toContain('cli-linuxbrew-smoke.mjs')
+  })
+
+  it('accepts Arch/AUR packages on both native Linux architectures before publication', () => {
+    const aur = workflow.jobs['accept-dev-aur']
+    expect(aur.needs).toBe('build-dev-cli')
+    expect(aur.strategy?.matrix?.include).toEqual([
+      { os: 'ubuntu-24.04', arch: 'x64' },
+      { os: 'ubuntu-24.04-arm', arch: 'arm64' },
+    ])
+    expect(step(aur, 'Accept the dev archives through Arch/AUR').run)
+      .toContain('cli-aur-container-smoke.mjs')
   })
 
   it('runs the live network install only after a successful push publication', () => {

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -131,10 +131,12 @@ describe('Release workflow critical path', () => {
     ])
     expect(step(linuxbrew, 'Install and run the accepted archive through Linuxbrew').run)
       .toContain('cli-linuxbrew-smoke.mjs')
+    expect(aur.strategy?.matrix?.include).toEqual([
+      { os: 'ubuntu-24.04', arch: 'x64' },
+      { os: 'ubuntu-24.04-arm', arch: 'arm64' },
+    ])
     expect(step(aur, 'Build, install, and run the generated AUR package').run)
-      .toContain('archlinux:base-devel')
-    expect(step(aur, 'Build, install, and run the generated AUR package').run)
-      .toContain('--manager aur')
+      .toContain('cli-aur-container-smoke.mjs')
   })
 
   it('publishes npm platform packages before the stable meta package', () => {


### PR DESCRIPTION
## Summary
- add digest-pinned native Arch/AUR lifecycle harnesses for Linux arm64 and x64
- gate dev alias and stable release publication on both native AUR targets
- build packages outside the read-only checkout and reuse the shared manager lifecycle assertions

## Verification
- `npx tsc --noEmit`
- `pnpm test` (614 files passed, 1 skipped; 5,075 tests passed, 9 skipped)
- targeted workflow/package tests (21 passed)
- native OrbStack Linux arm64 AUR lifecycle passed
- emulated Linux x64 AUR lifecycle passed; CI repeats it on a native x64 runner