### PR TITLE
test(cli): gate the legacy Bun cutover

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -36,6 +36,8 @@ on:
       - "scripts/cli-aur-container-smoke.spec.mjs"
       - "scripts/cli-linuxbrew-smoke.mjs"
       - "scripts/cli-linuxbrew-smoke.spec.mjs"
+      - "scripts/cli-legacy-cutover-smoke.mjs"
+      - "scripts/cli-legacy-cutover-smoke.spec.mjs"
       - "scripts/prepare-cli-previous-release.mjs"
       - "scripts/prepare-cli-dev-assets.mjs"
       - "scripts/prepare-cli-dev-assets.spec.mjs"
@@ -352,10 +354,43 @@ jobs:
             --previous-package dist/dev-aur-previous-channels/aur/PKGBUILD \
             --current-package dist/dev-aur-current/aur/PKGBUILD
 
+  accept-dev-legacy-cutover:
+    if: github.event_name == 'push'
+    name: Accept published v0.90.1 CLI cutover
+    needs: build-dev-cli
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dev-cli-linux-x64
+          path: dist/dev-cli-linux-x64
+
+      - name: Replace the published legacy CLI with the accepted native candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          ARCHIVE=$(find dist/dev-cli-linux-x64 -maxdepth 1 -name '*.tar.gz' -print -quit)
+          SHA256=$(awk 'NR == 1 { print $1 }' "$ARCHIVE.sha256")
+          CONTENT_IDENTITY=$(node -e "const fs=require('fs');const p=fs.readdirSync('dist/dev-cli-linux-x64').find(v=>v.endsWith('.report.json'));process.stdout.write(require('./dist/dev-cli-linux-x64/'+p).contentIdentity)")
+          node scripts/cli-legacy-cutover-smoke.mjs \
+            --archive "$ARCHIVE" \
+            --sha256 "$SHA256" \
+            --expected-version "$VERSION" \
+            --expected-content-identity "$CONTENT_IDENTITY"
+
   publish-dev-cli:
     if: github.event_name == 'push'
     name: Publish dev native CLI aliases
-    needs: [build-dev-cli, accept-dev-linuxbrew, accept-dev-aur]
+    needs: [build-dev-cli, accept-dev-linuxbrew, accept-dev-aur, accept-dev-legacy-cutover]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -663,6 +663,41 @@ jobs:
             --previous-package dist/cli-package-aur-previous-channels/aur/PKGBUILD \
             --current-package dist/cli-package-aur-current/aur/PKGBUILD
 
+  accept-cli-legacy-cutover:
+    name: Accept published v0.90.1 CLI cutover
+    needs: [release, build-cli-release]
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-release-linux-x64
+          path: dist/release-cli-linux-x64
+
+      - name: Replace the published legacy CLI with the accepted native candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          ARCHIVE=$(find dist/release-cli-linux-x64 -maxdepth 1 -name '*.tar.gz' -print -quit)
+          SHA256=$(awk 'NR == 1 { print $1 }' "$ARCHIVE.sha256")
+          CONTENT_IDENTITY=$(node -e "const fs=require('fs');const p=fs.readdirSync('dist/release-cli-linux-x64').find(v=>v.endsWith('.report.json'));process.stdout.write(require('./dist/release-cli-linux-x64/'+p).contentIdentity)")
+          node scripts/cli-legacy-cutover-smoke.mjs \
+            --archive "$ARCHIVE" \
+            --sha256 "$SHA256" \
+            --expected-version "$VERSION" \
+            --expected-content-identity "$CONTENT_IDENTITY"
+
   # Broker Packs are release artifacts, not inputs to the desktop package. Build
   # and validate them on their native platforms in parallel with desktop and
   # native CLI candidates instead of serializing them in desktop jobs.
@@ -719,8 +754,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, accept-desktop-upgrade, build-cli-release, build-cli-package-channels, accept-cli-homebrew, accept-cli-linuxbrew, accept-cli-aur, build-broker-packs, cli-installer-acceptance]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-cli-release.result == 'success' && needs.build-cli-package-channels.result == 'success' && needs.accept-cli-homebrew.result == 'success' && needs.accept-cli-linuxbrew.result == 'success' && needs.accept-cli-aur.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
+    needs: [release, build-desktop, accept-desktop-upgrade, build-cli-release, build-cli-package-channels, accept-cli-homebrew, accept-cli-linuxbrew, accept-cli-aur, accept-cli-legacy-cutover, build-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-cli-release.result == 'success' && needs.build-cli-package-channels.result == 'success' && needs.accept-cli-homebrew.result == 'success' && needs.accept-cli-linuxbrew.result == 'success' && needs.accept-cli-aur.result == 'success' && needs.accept-cli-legacy-cutover.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -253,6 +253,23 @@ protection as an update. It does not alter user data or remove releases. The
 current process is not hot-reloaded; run `openalice` again after update or
 rollback.
 
+## v0.90.1 cutover
+
+The native installer recognizes the last expanded CLI layout under
+`cli-versions/`. It stages and validates the Bun release first, then removes
+only that installer-owned tree and its managed-Pi launchers. Product data,
+credentials, AliceProjects, and Agent Runtimes elsewhere on `PATH` remain
+untouched. Normal startup after activation knows only the native layout; there
+is no permanent dual-runtime resolver.
+
+Both `dev` alias publication and stable release publication replay this cutover
+from the published v0.90.1 installer on Linux x64. The acceptance fixture pins
+the historical Pi manifests by SHA-256 because the upstream Pi release assets
+are not part of OpenAlice's durable release surface. It then proves native
+`version`, detached `up`, `status`, `down`, and uninstall with Node and Agent
+Runtimes absent from the new Runtime path, while preserving a data marker and a
+user-owned external Pi executable.
+
 ## Uninstall
 
 Review first:

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -530,9 +530,10 @@ artifacts.
 - [ ] Deferred Windows lane: run a clean standard-user PowerShell install.
 - [ ] Install and run the accepted release through npm, Bun, Homebrew, and
   `paru`, then verify manager-owned update and uninstall guidance.
-- [ ] Exercise the documented old-to-new cutover once on a currently supported
+- [x] Exercise the documented old-to-new cutover once on a currently supported
   v0.90.1 CLI host; this is evidence for the guidance, not a cross-platform
-  compatibility matrix or a release blocker for the Bun architecture.
+  compatibility matrix. Keep the real published v0.90.1 replacement as a
+  required Linux x64 `dev` and stable-release acceptance gate.
 - [ ] Prove `up`, detach, `status`, `open`, multiple independent Agent PTYs,
   component restart, `down`, update activation, rollback, and uninstall.
 - [ ] Run the root TypeScript/tests, UI typecheck, Guardian recovery, CLI PTY,
@@ -871,3 +872,13 @@ This plan is complete only when:
   generated `openalice-bin`, install it through `pacman`, and repeat stopped
   and active upgrade, ownership, restart activation, and removal checks before
   dev aliases or a stable release can publish.
+- 2026-08-30: Replayed the published v0.90.1 installer into an isolated macOS
+  home, replaced its expanded Node Runtime and managed Pi with the accepted Bun
+  candidate, and proved native `version`, detached `up`, `status`, `down`, and
+  uninstall with a minimal Runtime `PATH`. The cutover removed only
+  installer-owned `cli-versions` and Pi launchers while preserving product data
+  and an external user-owned Pi byte-for-byte. Dev and stable publication now
+  repeat the same bounded journey on native Linux x64. The historical Pi
+  manifests are fetched from the v0.90.1 OpenAlice tag and verified against the
+  hashes embedded by that published installer, avoiding dependence on the
+  upstream Pi asset URL that has since disappeared.

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -65,7 +65,12 @@ describe('CLI installer dev publication workflow', () => {
 
   it('validates candidates before uploading immutable assets and fixed aliases', () => {
     const publish = workflow.jobs['publish-dev-cli']
-    expect(publish.needs).toEqual(['build-dev-cli', 'accept-dev-linuxbrew', 'accept-dev-aur'])
+    expect(publish.needs).toEqual([
+      'build-dev-cli',
+      'accept-dev-linuxbrew',
+      'accept-dev-aur',
+      'accept-dev-legacy-cutover',
+    ])
     expect(step(publish, 'Validate candidates and prepare channel aliases').run)
       .toContain('prepare-cli-dev-assets.mjs')
     const upload = step(publish, 'Publish immutable candidates and activate dev aliases').run ?? ''
@@ -94,6 +99,13 @@ describe('CLI installer dev publication workflow', () => {
     ])
     expect(step(aur, 'Accept the dev archives through Arch/AUR').run)
       .toContain('cli-aur-container-smoke.mjs')
+  })
+
+  it('replaces the published v0.90.1 layout before dev publication', () => {
+    const cutover = workflow.jobs['accept-dev-legacy-cutover']
+    expect(cutover.needs).toBe('build-dev-cli')
+    expect(step(cutover, 'Replace the published legacy CLI with the accepted native candidate').run)
+      .toContain('cli-legacy-cutover-smoke.mjs')
   })
 
   it('runs the live network install only after a successful push publication', () => {

--- a/scripts/cli-legacy-cutover-smoke.mjs
+++ b/scripts/cli-legacy-cutover-smoke.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const DEFAULT_LEGACY_VERSION = '0.90.1'
+export const DEFAULT_LEGACY_INSTALLER_URL =
+  `https://github.com/TraderAlice/OpenAlice/releases/download/v${DEFAULT_LEGACY_VERSION}/OpenAlice-${DEFAULT_LEGACY_VERSION}-install`
+export const LEGACY_PI_ASSETS = Object.freeze({
+  'package.json': {
+    url: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${DEFAULT_LEGACY_VERSION}/scripts/install-smoke/pi-assets/package.json`,
+    sha256: '41f07a3eb41227905ac436ad41d949e4589dcc34c15454d718f85f399b533cb6',
+  },
+  'package-lock.json': {
+    url: `https://raw.githubusercontent.com/TraderAlice/OpenAlice/v${DEFAULT_LEGACY_VERSION}/scripts/install-smoke/pi-assets/package-lock.json`,
+    sha256: 'f5cb41dcfc60561ba54490b49c17beecec202900f73eb5f104b34f8b2a79a0af',
+  },
+})
+
+export function runLegacyCutoverSmoke(options) {
+  const root = mkdtempSync(join(tmpdir(), 'openalice-legacy-cutover-'))
+  const home = join(root, 'home')
+  const installRoot = join(root, 'install')
+  const runtimeHome = join(root, 'runtime-home')
+  const legacyInstaller = join(root, 'legacy-install')
+  const legacyPiAssets = join(root, 'legacy-pi-assets')
+  const dataMarker = join(installRoot, 'data', 'cutover-marker.txt')
+  const externalPi = join(root, 'external-bin', 'pi')
+  const executable = join(installRoot, 'bin', 'openalice')
+  const inheritedPath = process.env.PATH ?? '/usr/bin:/bin'
+  const legacyEnv = { ...process.env, HOME: home, PATH: inheritedPath }
+  const nativeEnv = { HOME: home, PATH: '/usr/bin:/bin' }
+
+  mkdirSync(home, { recursive: true })
+  mkdirSync(dirname(externalPi), { recursive: true })
+  writeFileSync(externalPi, '#!/bin/sh\nprintf external-pi-preserved\\n\n')
+  chmodSync(externalPi, 0o755)
+
+  try {
+    run(options.curl, [
+      '-fsSL', '--retry', '3', '--retry-delay', '2',
+      '-o', legacyInstaller, options.legacyInstallerUrl,
+    ], legacyEnv, 5 * 60_000)
+    chmodSync(legacyInstaller, 0o755)
+    prepareLegacyPiAssets(options.curl, legacyPiAssets, legacyEnv)
+    run(legacyInstaller, [
+      '--version', `v${options.legacyVersion}`,
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--yes',
+    ], { ...legacyEnv, OPENALICE_PI_SOURCE_DIR: legacyPiAssets }, 15 * 60_000)
+
+    if (!existsSync(join(installRoot, 'cli-versions'))) {
+      fail('published legacy installer did not create the expected cli-versions layout')
+    }
+    if (!existsSync(executable)) fail('published legacy installer did not create openalice')
+    if (!existsSync(join(installRoot, 'bin', 'pi'))) {
+      fail('published legacy installer did not create its managed Pi launcher')
+    }
+
+    mkdirSync(dirname(dataMarker), { recursive: true })
+    writeFileSync(dataMarker, 'preserve-product-data\n')
+    const externalPiBefore = readFileSync(externalPi, 'utf8')
+
+    run(options.installer, [
+      '--archive', options.archive,
+      '--sha256', options.sha256,
+      '--install-dir', installRoot,
+      '--no-modify-path',
+      '--yes',
+    ], { ...legacyEnv, PATH: `${dirname(externalPi)}:${inheritedPath}` }, 5 * 60_000)
+
+    if (existsSync(join(installRoot, 'cli-versions'))) {
+      fail('native cutover left the installer-owned legacy cli-versions layout behind')
+    }
+    for (const launcher of ['pi', 'pi.cmd']) {
+      if (existsSync(join(installRoot, 'bin', launcher))) {
+        fail(`native cutover left the installer-owned ${launcher} launcher behind`)
+      }
+    }
+    assertPreserved(dataMarker, 'preserve-product-data\n', 'product data marker')
+    assertPreserved(externalPi, externalPiBefore, 'external Pi executable')
+
+    const version = JSON.parse(capture(executable, ['version', '--json'], nativeEnv))
+    if (version.version !== options.expectedVersion) {
+      fail(`native cutover installed ${version.version}, expected ${options.expectedVersion}`)
+    }
+    if (version.contentIdentity !== options.expectedContentIdentity) {
+      fail(`native cutover content identity is ${version.contentIdentity}, expected ${options.expectedContentIdentity}`)
+    }
+    if (version.installSource?.method !== 'direct') {
+      fail(`native cutover provenance method is ${version.installSource?.method}, expected direct`)
+    }
+
+    run(executable, [
+      'up', '--home', runtimeHome, '--no-update-check', '--wait', '120', '--json',
+    ], nativeEnv, 150_000)
+    const status = JSON.parse(capture(executable, [
+      'status', '--home', runtimeHome, '--wait', '3', '--json',
+    ], nativeEnv)).result?.status
+    if (status?.class !== 'running' || status.provider?.contentIdentity !== options.expectedContentIdentity) {
+      fail(`native Runtime did not become ready after cutover: ${JSON.stringify(status)}`)
+    }
+    run(executable, ['down', '--home', runtimeHome, '--json'], nativeEnv, 30_000)
+
+    run(executable, ['uninstall', '--yes'], nativeEnv, 30_000)
+    if (existsSync(executable)) fail('direct uninstall left the openalice launcher behind')
+    assertPreserved(dataMarker, 'preserve-product-data\n', 'product data marker after uninstall')
+    assertPreserved(externalPi, externalPiBefore, 'external Pi executable after uninstall')
+
+    process.stdout.write(
+      `[cli-legacy-cutover] ${options.legacyVersion} -> ${options.expectedVersion} passed ${process.platform}-${process.arch}\n`,
+    )
+  } finally {
+    if (existsSync(executable)) {
+      spawnSync(executable, ['down', '--home', runtimeHome, '--json'], {
+        env: nativeEnv,
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: 30_000,
+      })
+    }
+    if (options.keep) process.stdout.write(`[cli-legacy-cutover] kept ${root}\n`)
+    else rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function prepareLegacyPiAssets(curl, destination, env) {
+  mkdirSync(destination, { recursive: true })
+  for (const [name, asset] of Object.entries(LEGACY_PI_ASSETS)) {
+    const path = join(destination, name)
+    run(curl, [
+      '-fsSL', '--retry', '3', '--retry-delay', '2',
+      '-o', path, asset.url,
+    ], env, 60_000)
+    const actual = createHash('sha256').update(readFileSync(path)).digest('hex')
+    if (actual !== asset.sha256) fail(`published legacy Pi fixture failed verification: ${name}`)
+  }
+}
+
+export function parseArgs(argv) {
+  const result = {
+    curl: 'curl',
+    installer: resolve(import.meta.dirname, '..', 'install'),
+    legacyversion: DEFAULT_LEGACY_VERSION,
+    legacyinstallerurl: DEFAULT_LEGACY_INSTALLER_URL,
+    keep: false,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index]
+    if (name === '--keep') {
+      result.keep = true
+      continue
+    }
+    if (![
+      '--archive', '--sha256', '--expected-version', '--expected-content-identity',
+      '--legacy-version', '--legacy-installer-url', '--installer', '--curl',
+    ].includes(name)) fail(`unknown option: ${name}\n${usage()}`)
+    const value = argv[++index]
+    if (!value || value.startsWith('--')) fail(`${name} requires a value\n${usage()}`)
+    result[name.slice(2).replaceAll('-', '')] = value
+  }
+  if (!result.archive || !result.sha256 || !result.expectedversion || !result.expectedcontentidentity) {
+    fail(usage())
+  }
+  if (!/^[a-f0-9]{64}$/.test(result.sha256)) fail('--sha256 must be 64 lowercase hex characters')
+  if (!/^[a-f0-9]{16}$/.test(result.expectedcontentidentity)) {
+    fail('--expected-content-identity must be 16 lowercase hex characters')
+  }
+  for (const version of [result.legacyversion, result.expectedversion]) {
+    if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
+      fail(`invalid OpenAlice version: ${version}`)
+    }
+  }
+  return {
+    archive: resolve(result.archive),
+    sha256: result.sha256,
+    expectedVersion: result.expectedversion,
+    expectedContentIdentity: result.expectedcontentidentity,
+    legacyVersion: result.legacyversion,
+    legacyInstallerUrl: result.legacyinstallerurl,
+    installer: resolve(result.installer),
+    curl: result.curl,
+    keep: result.keep,
+  }
+}
+
+function assertPreserved(path, expected, label) {
+  if (!existsSync(path) || readFileSync(path, 'utf8') !== expected) fail(`${label} was not preserved`)
+}
+
+function run(command, args, env, timeout) {
+  const result = spawnSync(command, args, {
+    env,
+    encoding: 'utf8',
+    stdio: 'inherit',
+    timeout,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`${command} ${args[0]} failed (${result.status})`)
+  return result
+}
+
+function capture(command, args, env) {
+  const result = spawnSync(command, args, {
+    env,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: 30_000,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args[0]} failed (${result.status}):\n${result.stdout}\n${result.stderr}`)
+  }
+  return result.stdout
+}
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function usage() {
+  return 'Usage: cli-legacy-cutover-smoke.mjs --archive <tar.gz> --sha256 <hex> --expected-version <version> --expected-content-identity <id> [--legacy-version <version>] [--legacy-installer-url <url>] [--installer <path>] [--curl <command>] [--keep]'
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    runLegacyCutoverSmoke(parseArgs(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`Legacy CLI cutover smoke: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/cli-legacy-cutover-smoke.spec.mjs
+++ b/scripts/cli-legacy-cutover-smoke.spec.mjs
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_LEGACY_INSTALLER_URL,
+  DEFAULT_LEGACY_VERSION,
+  LEGACY_PI_ASSETS,
+  parseArgs,
+} from './cli-legacy-cutover-smoke.mjs'
+
+describe('legacy CLI cutover smoke', () => {
+  it('defaults to the published v0.90.1 installer', () => {
+    const options = parseArgs([
+      '--archive', 'dist/openalice-cli.tar.gz',
+      '--sha256', 'a'.repeat(64),
+      '--expected-version', '0.91.0',
+      '--expected-content-identity', '0123456789abcdef',
+    ])
+    expect(options).toMatchObject({
+      legacyVersion: DEFAULT_LEGACY_VERSION,
+      legacyInstallerUrl: DEFAULT_LEGACY_INSTALLER_URL,
+      expectedVersion: '0.91.0',
+      keep: false,
+    })
+    expect(DEFAULT_LEGACY_INSTALLER_URL).toContain('/v0.90.1/OpenAlice-0.90.1-install')
+    expect(LEGACY_PI_ASSETS['package.json'].url).toContain('/v0.90.1/')
+    expect(LEGACY_PI_ASSETS['package.json'].sha256).toMatch(/^[a-f0-9]{64}$/)
+    expect(LEGACY_PI_ASSETS['package-lock.json'].sha256).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('accepts an explicit historical installer fixture', () => {
+    expect(parseArgs([
+      '--archive', 'dist/openalice-cli.tar.gz',
+      '--sha256', 'b'.repeat(64),
+      '--expected-version', '0.91.0-beta.1',
+      '--expected-content-identity', 'fedcba9876543210',
+      '--legacy-version', '0.90.0',
+      '--legacy-installer-url', 'https://example.test/legacy-install',
+      '--installer', './install',
+      '--curl', '/usr/bin/curl',
+      '--keep',
+    ])).toMatchObject({
+      legacyVersion: '0.90.0',
+      legacyInstallerUrl: 'https://example.test/legacy-install',
+      curl: '/usr/bin/curl',
+      keep: true,
+    })
+  })
+
+  it('rejects malformed checksums and content identities', () => {
+    const args = [
+      '--archive', 'dist/openalice-cli.tar.gz',
+      '--sha256', 'bad',
+      '--expected-version', '0.91.0',
+      '--expected-content-identity', '0123456789abcdef',
+    ]
+    expect(() => parseArgs(args)).toThrow('--sha256 must be 64 lowercase hex characters')
+    args[3] = 'a'.repeat(64)
+    args[7] = 'bad'
+    expect(() => parseArgs(args)).toThrow('--expected-content-identity')
+  })
+})

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -82,6 +82,7 @@ describe('Release workflow critical path', () => {
       'build-cli-package-channels',
       'accept-cli-homebrew',
       'accept-cli-aur',
+      'accept-cli-legacy-cutover',
       'cli-installer-acceptance',
     ]))
   })
@@ -137,6 +138,10 @@ describe('Release workflow critical path', () => {
     ])
     expect(step(aur, 'Build, install, and run the generated AUR package').run)
       .toContain('cli-aur-container-smoke.mjs')
+    const cutover = workflow.jobs['accept-cli-legacy-cutover']
+    expect(needs(cutover)).toEqual(['release', 'build-cli-release'])
+    expect(step(cutover, 'Replace the published legacy CLI with the accepted native candidate').run)
+      .toContain('cli-legacy-cutover-smoke.mjs')
   })
 
   it('publishes npm platform packages before the stable meta package', () => {


### PR DESCRIPTION
## Summary
- replay the published v0.90.1 expanded CLI install before replacing it with the accepted Bun-native archive
- preserve user data and an external Agent Runtime while removing only legacy installer-owned files
- gate dev aliases and stable release publication on the Linux x64 cutover journey

## Verification
- real macOS arm64 v0.90.1 -> native Bun cutover, up/status/down/uninstall
- npx tsc --noEmit
- pnpm test (615 files passed, 1 skipped; 5,079 tests passed, 9 skipped)
- pnpm -F @traderalice/openalice-cli test (335 passed)
- pnpm test:install:docker
- targeted workflow and cutover specs (18 passed)