### PR TITLE
test(cli): consolidate native lifecycle acceptance

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Build Alice and native CLI
         run: |
           pnpm build:server
+          pnpm build:bun-runtime:feasibility
           pnpm build:bun:release
 
       - name: Accept npm and Bun installs from the dev native candidate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,7 @@ jobs:
       - name: Build Alice and native CLI
         run: |
           pnpm build:server
+          pnpm build:bun-runtime:feasibility
           pnpm build:bun:release
 
       - name: Install and boot the native candidate outside the checkout

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -163,3 +163,12 @@ The native Runtime acceptance must prove:
 
 Routine verification is non-trading and uses isolated homes. Live-paper broker
 acceptance remains a separate explicit lane under [[docs/uta-live-testing.md]].
+
+Every native `dev` and stable candidate runs the artifact acceptance itself:
+the compiled CLI opens a captured platform browser command, launches two
+external OpenCode-adapter PTYs with distinct PIDs, sends independent input and
+resize messages, stops one Session, and proves the other remains interactive.
+The same candidate lane also runs the four-process feasibility receipt, which
+forces Connector and UTA failures and proves they recover without restarting
+Alice. Installer and package-manager receipts separately cover stopped and
+active upgrades, activation on restart, rollback, and data-preserving removal.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -534,7 +534,7 @@ artifacts.
   v0.90.1 CLI host; this is evidence for the guidance, not a cross-platform
   compatibility matrix. Keep the real published v0.90.1 replacement as a
   required Linux x64 `dev` and stable-release acceptance gate.
-- [ ] Prove `up`, detach, `status`, `open`, multiple independent Agent PTYs,
+- [x] Prove `up`, detach, `status`, `open`, multiple independent Agent PTYs,
   component restart, `down`, update activation, rollback, and uninstall.
 - [ ] Run the root TypeScript/tests, UI typecheck, Guardian recovery, CLI PTY,
   installer, managed remote, and relevant Electron regression lanes.
@@ -882,3 +882,14 @@ This plan is complete only when:
   manifests are fetched from the v0.90.1 OpenAlice tag and verified against the
   hashes embedded by that published installer, avoiding dependence on the
   upstream Pi asset URL that has since disappeared.
+- 2026-08-30: Consolidated the full Runtime lifecycle evidence into native
+  candidate gates. The compiled macOS arm64 artifact captured the exact URL
+  passed through `open`, created two external OpenCode-adapter Sessions with
+  distinct PIDs, delivered independent binary input after WebSocket resize,
+  stopped one Session, and kept the other interactive. The four-process
+  feasibility receipt forced Connector and UTA failures, recovered both with
+  new PIDs while Alice stayed ready, and released the Guardian lock after
+  shutdown. Existing direct and package-manager receipts cover update pending
+  state, restart activation, local rollback, uninstall, and data preservation;
+  every native dev and stable candidate now repeats the relevant artifact and
+  component gates.

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -398,6 +398,9 @@ async function smokeRelease(options: {
   const externalAgentBin = join(externalAgentRoot, 'bin')
   const nativePiRoot = join(externalAgentRoot, 'native-pi-state')
   const externalOpenCode = join(externalAgentBin, 'opencode')
+  const openReceipt = join(options.smokeHome, 'browser-open.txt')
+  const opener = join(externalAgentBin, process.platform === 'darwin' ? 'open' : 'xdg-open')
+  const stty = await exists('/bin/stty') ? '/bin/stty' : '/usr/bin/stty'
   const nativeOpenCodeTuiConfig = '{"theme":"system"}\n'
   await Promise.all([
     mkdir(externalAgentBin, { recursive: true }),
@@ -415,11 +418,15 @@ printf 'MANAGED_PI_PATH=%s\\n' "${'$'}{OPENALICE_MANAGED_PI_PATH-unset}"
 printf 'MANAGED_PI_NODE_PATH=%s\\n' "${'$'}{OPENALICE_MANAGED_PI_NODE_PATH-unset}"
 printf 'PI_CODING_AGENT_DIR=%s\\n' "${'$'}{PI_CODING_AGENT_DIR-unset}"
 printf 'PI_CODING_AGENT_SESSION_DIR=%s\\n' "${'$'}{PI_CODING_AGENT_SESSION_DIR-unset}"
+printf 'PID=%s\\n' "${'$'}${'$'}"
 while IFS= read -r line; do
-  printf 'INPUT=%s\\n' "${'$'}line"
+  printf 'INPUT=%s SIZE=%s\\n' "${'$'}line" "${'$'}(${stty} size)"
 done
 `)
-  await chmod(externalOpenCode, 0o755)
+  await writeFile(opener, `#!/bin/sh
+printf '%s\\n' "${'$'}1" > "${'$'}OPENALICE_SMOKE_OPEN_RECEIPT"
+`)
+  await Promise.all([chmod(externalOpenCode, 0o755), chmod(opener, 0o755)])
   const runtimeEnv = {
     HOME: userHome,
     PATH: externalAgentBin,
@@ -432,6 +439,7 @@ done
     OPENALICE_MCP_PORT: String(mcpPort),
     OPENALICE_UTA_PORT: String(utaPort),
     OPENALICE_CONNECTOR_PORT: String(connectorPort),
+    OPENALICE_SMOKE_OPEN_RECEIPT: openReceipt,
     OPENALICE_MANAGED_PI_PATH: '/stale/desktop/pi/cli.js',
     OPENALICE_MANAGED_PI_NODE_PATH: '/stale/desktop/node',
     PI_CODING_AGENT_DIR: nativePiRoot,
@@ -458,6 +466,14 @@ done
   const stderrPromise = new Response(runtime.stderr).text()
   let runtimeError: unknown = null
   let realOpenCodeReport: { path: string; version: string; ptyBytes: number } | null = null
+  let browserOpenUrl: string | null = null
+  let agentPtyReport: {
+    sessions: number
+    distinctPids: boolean
+    resize: boolean
+    input: boolean
+    stopIsolation: boolean
+  } | null = null
   let coldStartReadyMs = 0
   let idleMemoryBytes: {
     sampleCount: number
@@ -499,6 +515,14 @@ done
       total: guardian + alice,
     }
     const baseUrl = `http://127.0.0.1:${webPort}`
+    const openOutput = run([
+      options.executablePath,
+      'open', '--home', runtimeHome, '--wait', '3',
+    ], runtimeEnv)
+    browserOpenUrl = (await waitForFileText(openReceipt, 5_000)).trim()
+    if (browserOpenUrl !== baseUrl || !openOutput.includes(`Opened OpenAlice Web UI: ${baseUrl}`)) {
+      throw new Error(`compiled CLI did not open its verified Web endpoint: ${openOutput} / ${browserOpenUrl}`)
+    }
     const inventory = await fetchJson(`${baseUrl}/api/workspaces/agents`) as {
       agents?: Array<{ id?: string; installed?: boolean }>
     }
@@ -515,22 +539,44 @@ done
     if (!workspaceId || !workspaceDir) {
       throw new Error(`installed release Workspace response was incomplete: ${JSON.stringify(created)}`)
     }
-    const spawned = await fetchJson(`${baseUrl}/api/workspaces/${workspaceId}/sessions/spawn`, {
+    const spawnExternalAgent = () => fetchJson(`${baseUrl}/api/workspaces/${workspaceId}/sessions/spawn`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ agent: 'opencode' }),
-    }, 201) as { sessionId?: string }
-    if (!spawned.sessionId) {
-      throw new Error(`installed release external OpenCode spawn omitted sessionId: ${JSON.stringify(spawned)}`)
+    }, 201) as Promise<{ sessionId?: string; pid?: number }>
+    const spawned = await spawnExternalAgent()
+    const spawnedTwo = await spawnExternalAgent()
+    if (
+      !spawned.sessionId || !spawned.pid
+      || !spawnedTwo.sessionId || !spawnedTwo.pid
+      || spawned.sessionId === spawnedTwo.sessionId
+      || spawned.pid === spawnedTwo.pid
+    ) {
+      throw new Error(`installed release did not create two independent Agent PTYs: ${JSON.stringify([spawned, spawnedTwo])}`)
     }
     const marker = 'OPENALICE_EXTERNAL_OPENCODE_OK'
-    const terminal = await readPtyUntil(baseUrl, spawned.sessionId, {
-      client: 'bun-release-external-agent-smoke',
-      description: marker,
-      timeoutMs: 30_000,
-      complete: (output) => output.includes(marker),
-      settleDelayMs: 25,
-    })
+    const [terminal, terminalTwo] = await Promise.all([
+      readPtyUntil(baseUrl, spawned.sessionId, {
+        client: 'bun-release-external-agent-smoke-one',
+        description: 'first Agent input after resize',
+        timeoutMs: 30_000,
+        onOpen: (socket) => {
+          socket.send(JSON.stringify({ type: 'resize', cols: 91, rows: 31 }))
+          socket.send(new TextEncoder().encode('alpha\n'))
+        },
+        complete: (output) => output.includes(marker) && output.includes('INPUT=alpha SIZE=31 91'),
+      }),
+      readPtyUntil(baseUrl, spawnedTwo.sessionId, {
+        client: 'bun-release-external-agent-smoke-two',
+        description: 'second Agent input after resize',
+        timeoutMs: 30_000,
+        onOpen: (socket) => {
+          socket.send(JSON.stringify({ type: 'resize', cols: 103, rows: 37 }))
+          socket.send(new TextEncoder().encode('beta\n'))
+        },
+        complete: (output) => output.includes(marker) && output.includes('INPUT=beta SIZE=37 103'),
+      }),
+    ])
     for (const expected of [
       `CWD=${workspaceDir}`,
       'MANAGED_PI_PATH=unset',
@@ -541,6 +587,26 @@ done
       if (!terminal.includes(expected)) {
         throw new Error(`external OpenCode process did not preserve the CLI ownership boundary (${expected}):\n${terminal}`)
       }
+    }
+    if (terminal.includes('INPUT=beta') || terminalTwo.includes('INPUT=alpha')) {
+      throw new Error('independent Agent PTYs received each other\'s input')
+    }
+    await fetchJson(`${baseUrl}/api/workspaces/${workspaceId}/sessions/${spawned.sessionId}`, {
+      method: 'DELETE',
+    })
+    const survivingTerminal = await readPtyUntil(baseUrl, spawnedTwo.sessionId, {
+      client: 'bun-release-external-agent-smoke-survivor',
+      description: 'surviving Agent input after peer stop',
+      timeoutMs: 30_000,
+      onOpen: (socket) => socket.send(new TextEncoder().encode('still-alive\n')),
+      complete: (output) => output.includes('INPUT=still-alive'),
+    })
+    agentPtyReport = {
+      sessions: 2,
+      distinctPids: true,
+      resize: true,
+      input: true,
+      stopIsolation: survivingTerminal.includes('INPUT=still-alive'),
     }
     const realOpenCodePath = process.env['OPENALICE_BUN_REAL_OPENCODE_PATH']?.trim()
     if (realOpenCodePath) {
@@ -611,6 +677,8 @@ done
     externalAgentRuntime: 'opencode',
     externalAgentRuntimeProcess: true,
     externalAgentRuntimeManagedPi: false,
+    browserOpenUrl,
+    agentPtys: agentPtyReport,
     realExternalAgentRuntime: realOpenCodeReport,
     defaultResources: true,
     materializedPiAdapter: true,
@@ -700,6 +768,7 @@ function readPtyUntil(
     timeoutMs: number
     complete: (output: string) => boolean
     settleDelayMs?: number
+    onOpen?: (socket: WebSocket) => void
   },
 ): Promise<string> {
   const wsUrl = new URL('/api/workspaces/pty', baseUrl)
@@ -727,6 +796,7 @@ function readPtyUntil(
     const timeout = setTimeout(() => {
       finish(new Error(`external Agent Runtime PTY timed out waiting for ${options.description}:\n${output.slice(-4_000)}`))
     }, options.timeoutMs)
+    socket.addEventListener('open', () => options.onOpen?.(socket))
     socket.addEventListener('message', (event) => {
       const chunk = typeof event.data === 'string'
         ? event.data
@@ -743,6 +813,18 @@ function readPtyUntil(
       if (!settled) finish(new Error(`external Agent Runtime PTY closed before ${options.description}:\n${output}`))
     })
   })
+}
+
+async function waitForFileText(path: string, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(path, 'utf8')
+    } catch {
+      await Bun.sleep(25)
+    }
+  }
+  throw new Error(`timed out waiting for file: ${path}`)
 }
 
 function run(command: string[], env: Record<string, string>): string {

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -42,6 +42,7 @@ describe('CLI installer dev publication workflow', () => {
       { os: 'ubuntu-24.04-arm', platform: 'linux', arch: 'arm64' },
     ])
     expect(build.steps?.some((candidate) => candidate.uses === 'oven-sh/setup-bun@v2')).toBe(true)
+    expect(step(build, 'Build Alice and native CLI').run).toContain('build:bun-runtime:feasibility')
     expect(step(build, 'Preserve accepted dev candidate').with?.name).toBe(
       'dev-cli-${{ matrix.platform }}-${{ matrix.arch }}',
     )

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -98,6 +98,7 @@ describe('Release workflow critical path', () => {
       { os: 'ubuntu-24.04-arm', platform: 'linux', arch: 'arm64' },
     ])
     expect(nativeCli.steps?.some((candidate) => candidate.uses === 'oven-sh/setup-bun@v2')).toBe(true)
+    expect(step(nativeCli, 'Build Alice and native CLI').run).toContain('build:bun-runtime:feasibility')
     expect(step(nativeCli, 'Preserve accepted native CLI').with?.name).toBe(
       'cli-release-${{ matrix.platform }}-${{ matrix.arch }}',
     )


### PR DESCRIPTION
## Summary
- make every native candidate prove the real `open` command with a captured platform browser launch
- exercise two distinct external Agent PTYs through the packaged WebSocket surface, including resize, binary input, and isolated termination
- repeat four-process Connector/UTA recovery on dev and stable candidate lanes

## Verification
- pinned Bun 1.4.0 native macOS arm64 release acceptance passed
- browser open URL captured from the compiled CLI
- two PTYs passed distinct PID, resize, input, and stop isolation checks
- four-process feasibility passed Connector/UTA recovery with Alice remaining ready
- npx tsc --noEmit
- pnpm test (615 files passed, 1 skipped; 5,079 tests passed, 9 skipped)
- targeted workflow specs (15 passed)