### PR TITLE
feat(release): activate verified CLI channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       # The tag and GitHub Release are deliberately created only after every
       # platform builds and passes Workspace acceptance.
       created: ${{ !github.event.inputs.mirror_tag && steps.check.outputs.exists == 'false' }}
+      version: ${{ steps.version.outputs.version }}
       tag: ${{ github.event.inputs.mirror_tag || steps.version.outputs.tag }}
       prerelease: ${{ steps.version.outputs.prerelease }}
       previous_tag: ${{ steps.version.outputs.previous_tag }}
@@ -820,8 +821,8 @@ jobs:
 
   publish-cli-npm:
     name: Publish npm CLI packages
-    needs: [release, publish-release, build-cli-package-channels]
-    if: needs.publish-release.result == 'success' && needs.release.outputs.prerelease == 'false' && vars.OPENALICE_PUBLISH_NPM == 'true'
+    needs: [release, publish-release, build-cli-package-channels, verify-public-cli-channels]
+    if: needs.verify-public-cli-channels.result == 'success' && needs.release.outputs.prerelease == 'false' && vars.OPENALICE_PUBLISH_NPM == 'true'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -848,6 +849,144 @@ jobs:
           npm publish "$META" --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  verify-public-cli-channels:
+    name: Verify public CLI channel assets
+    needs: [release, publish-release, build-cli-package-channels]
+    if: needs.publish-release.result == 'success' && needs.release.outputs.prerelease == 'false'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-package-channels
+          path: dist/cli-package-channels
+
+      - name: Verify accepted archives are publicly readable and unchanged
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: >-
+          node scripts/verify-public-cli-channels.mjs
+          --manifest dist/cli-package-channels/cli-package-channels/cli-package-channels.json
+          --version "$VERSION"
+          > dist/cli-package-channels/public-channel-receipt.json
+
+      - name: Compare public metadata with the accepted publication inputs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          mkdir -p dist/public-cli-channels
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --dir dist/public-cli-channels \
+            --pattern cli-package-channels.json \
+            --pattern openalice.rb \
+            --pattern PKGBUILD \
+            --pattern .SRCINFO \
+            --pattern npm-publish-order.json
+          cmp dist/cli-package-channels/cli-package-channels/cli-package-channels.json dist/public-cli-channels/cli-package-channels.json
+          cmp dist/cli-package-channels/cli-package-channels/homebrew/openalice.rb dist/public-cli-channels/openalice.rb
+          cmp dist/cli-package-channels/cli-package-channels/aur/PKGBUILD dist/public-cli-channels/PKGBUILD
+          cmp dist/cli-package-channels/cli-package-channels/aur/.SRCINFO dist/public-cli-channels/.SRCINFO
+          cmp dist/cli-package-channels/cli-npm-tarballs/npm-publish-order.json dist/public-cli-channels/npm-publish-order.json
+
+      - name: Preserve public channel verification receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-cli-channel-receipt
+          path: dist/cli-package-channels/public-channel-receipt.json
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-cli-homebrew:
+    name: Publish Homebrew tap formula
+    needs: [release, verify-public-cli-channels, build-cli-package-channels]
+    if: needs.verify-public-cli-channels.result == 'success' && vars.OPENALICE_PUBLISH_HOMEBREW == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-package-channels
+          path: dist/cli-package-channels
+
+      - uses: actions/checkout@v7
+        with:
+          repository: TraderAlice/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+          fetch-depth: 0
+
+      - name: Activate the verified formula in the TraderAlice tap
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          install -Dm644 dist/cli-package-channels/cli-package-channels/homebrew/openalice.rb tap/Formula/openalice.rb
+          cd tap
+          git config user.name OpenAlice Release Bot
+          git config user.email release-bot@openalice.ai
+          git add Formula/openalice.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula already publishes OpenAlice ${VERSION}."
+            exit 0
+          fi
+          git commit -m "openalice ${VERSION}"
+          git push
+
+  publish-cli-aur:
+    name: Publish AUR package metadata
+    needs: [release, verify-public-cli-channels, build-cli-package-channels]
+    if: needs.verify-public-cli-channels.result == 'success' && vars.OPENALICE_PUBLISH_AUR == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-package-channels
+          path: dist/cli-package-channels
+
+      - name: Check out the AUR package repository
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
+        run: |
+          test -n "$AUR_SSH_PRIVATE_KEY"
+          test -n "$AUR_KNOWN_HOSTS"
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$HOME/.ssh/id_ed25519"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$AUR_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/known_hosts"
+          git clone ssh://aur@aur.archlinux.org/openalice-bin.git aur
+
+      - name: Activate the verified package metadata in AUR
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          install -Dm644 dist/cli-package-channels/cli-package-channels/aur/PKGBUILD aur/PKGBUILD
+          install -Dm644 dist/cli-package-channels/cli-package-channels/aur/.SRCINFO aur/.SRCINFO
+          cd aur
+          git config user.name OpenAlice Release Bot
+          git config user.email release-bot@openalice.ai
+          git add PKGBUILD .SRCINFO
+          if git diff --cached --quiet; then
+            echo "AUR metadata already publishes OpenAlice ${VERSION}."
+            exit 0
+          fi
+          git commit -m "openalice-bin ${VERSION}"
+          git push
 
   mirror-release-assets:
     needs: [release, publish-release]

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -89,6 +89,32 @@ and their publication manifest. Activating the public Homebrew and AUR commands
 still requires the TraderAlice tap and AUR package repositories to publish
 those generated files after the referenced GitHub Release assets are public.
 
+## Public channel activation
+
+For every non-prerelease, the release workflow first downloads all four
+archives anonymously from their final public GitHub Release URLs and verifies
+their bytes plus public SHA-256 sidecars against the accepted channel manifest.
+It then downloads the public formula, `PKGBUILD`, `.SRCINFO`, and npm publish
+order and compares them byte-for-byte with the preserved publication inputs. A
+30-day verification receipt is retained. npm, Tap, and AUR publication all
+depend on that receipt; none can publish from a private Actions artifact alone.
+
+External channels are explicit release switches:
+
+| Channel | Repository variable | Required authority |
+|---|---|---|
+| npm + Bun | `OPENALICE_PUBLISH_NPM=true` | `NPM_TOKEN` for all five public package names |
+| Homebrew | `OPENALICE_PUBLISH_HOMEBREW=true` | `HOMEBREW_TAP_TOKEN` with write access to `TraderAlice/homebrew-tap` |
+| AUR / paru | `OPENALICE_PUBLISH_AUR=true` | dedicated `AUR_SSH_PRIVATE_KEY` plus manually verified `AUR_KNOWN_HOSTS` |
+
+The Tap and AUR writers are idempotent: if the verified metadata is already
+active, they make no commit. AUR never learns its SSH host key from the same
+untrusted connection used to publish; the maintainer supplies the verified
+known-hosts entry as a secret. Creating registry packages, creating the Tap,
+and enrolling the AUR key remain deliberate maintainer actions. Enabling a
+switch without its external repository or authority is a release failure, not
+permission to invent another channel or silently skip publication.
+
 ## Update and uninstall ownership
 
 The installer that owns the visible command also owns later file mutation:
@@ -156,6 +182,6 @@ version transitions. Lifecycle assertions stay shared while file mutation
 remains owned by the manager under test.
 
 The release job derives every channel only after all native candidates pass,
-attaches the generated publication inputs to the GitHub Release, and publishes
-the npm meta package last. Tap/AUR publication must likewise happen only after
-the referenced release URLs and checksums are public.
+attaches the generated publication inputs to the GitHub Release, verifies that
+public release surface, and publishes the npm meta package last. Opted-in Tap
+and AUR jobs commit only the byte-identical metadata covered by that receipt.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -465,7 +465,9 @@ build harness when it improves the next investigation.
   GitHub Release succeeds. Stable publication remains explicitly disabled
   until registry authority and package names are established.
 - [ ] Publish Brew/AUR metadata only after the referenced release assets are
-  public and verified.
+  public and verified. The opt-in automation and public-byte receipt are ready;
+  external repository creation, credentials, activation, and first public
+  command walks still require maintainer authority.
 
 ### 6. Cutover and updates
 
@@ -893,3 +895,12 @@ This plan is complete only when:
   state, restart activation, local rollback, uninstall, and data preservation;
   every native dev and stable candidate now repeats the relevant artifact and
   component gates.
+- 2026-08-30: Added the external-channel activation chain without silently
+  claiming registry ownership. Every stable release now re-downloads all four
+  public archives and sidecars, verifies their accepted hashes, compares the
+  public formula/AUR/npm metadata byte-for-byte with the preserved inputs, and
+  retains a receipt before any registry writer can run. npm/Bun, the
+  TraderAlice Tap, and AUR have separate opt-in variables and least-scope
+  credentials; Tap/AUR commits are idempotent. Package-name reservation, Tap
+  creation, AUR key enrollment, enabling the switches, and the first public
+  install journeys remain explicit maintainer actions.

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -11,6 +11,7 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
+  if?: string
   needs?: string | string[]
   'timeout-minutes'?: number
   steps?: WorkflowStep[]
@@ -147,8 +148,40 @@ describe('Release workflow critical path', () => {
 
   it('publishes npm platform packages before the stable meta package', () => {
     const npm = workflow.jobs['publish-cli-npm']
-    expect(needs(npm)).toEqual(['release', 'publish-release', 'build-cli-package-channels'])
+    expect(needs(npm)).toEqual([
+      'release',
+      'publish-release',
+      'build-cli-package-channels',
+      'verify-public-cli-channels',
+    ])
+    expect(npm.if).toContain("needs.verify-public-cli-channels.result == 'success'")
     const publish = step(npm, 'Publish platform packages before the meta package').run ?? ''
     expect(publish.indexOf('packages.slice(0,-1)')).toBeLessThan(publish.indexOf('packages.at(-1)'))
+  })
+
+  it('verifies public release bytes before activating external package channels', () => {
+    const verify = workflow.jobs['verify-public-cli-channels']
+    expect(needs(verify)).toEqual(['release', 'publish-release', 'build-cli-package-channels'])
+    expect(step(verify, 'Verify accepted archives are publicly readable and unchanged').run)
+      .toContain('verify-public-cli-channels.mjs')
+    expect(step(verify, 'Compare public metadata with the accepted publication inputs').run)
+      .toContain('cmp dist/cli-package-channels/cli-package-channels/homebrew/openalice.rb')
+
+    const homebrew = workflow.jobs['publish-cli-homebrew']
+    expect(needs(homebrew)).toContain('verify-public-cli-channels')
+    expect(homebrew.if).toContain("vars.OPENALICE_PUBLISH_HOMEBREW == 'true'")
+    const tapCheckout = homebrew.steps?.find((candidate) => candidate.uses === 'actions/checkout@v7')
+    expect(tapCheckout?.with?.repository).toBe('TraderAlice/homebrew-tap')
+    expect(step(homebrew, 'Activate the verified formula in the TraderAlice tap').run)
+      .toContain('git diff --cached --quiet')
+
+    const aur = workflow.jobs['publish-cli-aur']
+    expect(needs(aur)).toContain('verify-public-cli-channels')
+    expect(aur.if).toContain("vars.OPENALICE_PUBLISH_AUR == 'true'")
+    const aurCheckout = step(aur, 'Check out the AUR package repository').run ?? ''
+    expect(aurCheckout).toContain('AUR_KNOWN_HOSTS')
+    expect(aurCheckout).not.toContain('ssh-keyscan')
+    expect(step(aur, 'Activate the verified package metadata in AUR').run)
+      .toContain('git diff --cached --quiet')
   })
 })

--- a/scripts/verify-public-cli-channels.mjs
+++ b/scripts/verify-public-cli-channels.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const TARGETS = Object.freeze([
+  ['darwin', 'arm64'],
+  ['darwin', 'x64'],
+  ['linux', 'arm64'],
+  ['linux', 'x64'],
+])
+
+export async function verifyPublicCliChannels({
+  manifestPath,
+  version,
+  repository = 'TraderAlice/OpenAlice',
+  fetchImpl = fetch,
+}) {
+  const manifest = JSON.parse(readFileSync(resolve(manifestPath), 'utf8'))
+  const expectedBase = `https://github.com/${repository}/releases/download/v${version}`
+  if (manifest.schemaVersion !== 1 || manifest.version !== version) {
+    throw new Error(`CLI channel manifest does not describe ${version}`)
+  }
+  if (manifest.assetBaseUrl !== expectedBase) {
+    throw new Error(`CLI channel asset base is ${manifest.assetBaseUrl}, expected ${expectedBase}`)
+  }
+  if (!Array.isArray(manifest.targets) || manifest.targets.length !== TARGETS.length) {
+    throw new Error(`CLI channel manifest must contain ${TARGETS.length} native targets`)
+  }
+
+  const receipts = []
+  for (const [platform, arch] of TARGETS) {
+    const target = manifest.targets.find((candidate) => (
+      candidate?.platform === platform && candidate?.arch === arch
+    ))
+    if (!target || !/^[a-f0-9]{64}$/.test(target.sha256 ?? '')) {
+      throw new Error(`CLI channel manifest is missing a valid ${platform}-${arch} checksum`)
+    }
+    if (!/^[a-f0-9]{16}$/.test(target.contentIdentity ?? '')) {
+      throw new Error(`CLI channel manifest is missing a valid ${platform}-${arch} content identity`)
+    }
+    const archive = `openalice-cli-${version}-${platform}-${arch}.tar.gz`
+    const archiveUrl = `${expectedBase}/${archive}`
+    const bytes = await fetchBytes(fetchImpl, archiveUrl)
+    const actual = createHash('sha256').update(bytes).digest('hex')
+    if (actual !== target.sha256) {
+      throw new Error(`public ${archive} checksum is ${actual}, expected ${target.sha256}`)
+    }
+    const sidecar = (await fetchText(fetchImpl, `${archiveUrl}.sha256`)).trim().split(/\s+/)[0]
+    if (sidecar !== target.sha256) {
+      throw new Error(`public ${archive}.sha256 does not match the accepted archive`)
+    }
+    receipts.push({
+      platform,
+      arch,
+      archive,
+      sha256: target.sha256,
+      contentIdentity: target.contentIdentity,
+      public: true,
+    })
+  }
+  return {
+    schemaVersion: 1,
+    status: 'pass',
+    repository,
+    version,
+    assetBaseUrl: expectedBase,
+    targets: receipts,
+  }
+}
+
+async function fetchBytes(fetchImpl, url) {
+  const response = await fetchWithRetry(fetchImpl, url)
+  return new Uint8Array(await response.arrayBuffer())
+}
+
+async function fetchText(fetchImpl, url) {
+  const response = await fetchWithRetry(fetchImpl, url)
+  return response.text()
+}
+
+async function fetchWithRetry(fetchImpl, url) {
+  let lastError = null
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, {
+        redirect: 'follow',
+        headers: { 'user-agent': 'OpenAlice-release-verifier' },
+        signal: AbortSignal.timeout(60_000),
+      })
+      if (response.ok) return response
+      lastError = new Error(`${url} returned HTTP ${response.status}`)
+      if (response.status < 500 && response.status !== 404) break
+    } catch (error) {
+      lastError = error
+    }
+    if (attempt < 4) await new Promise((resolvePromise) => setTimeout(resolvePromise, attempt * 1_000))
+  }
+  throw new Error(`public release asset is unavailable: ${url} (${String(lastError)})`)
+}
+
+export function parseArgs(argv) {
+  const result = { repository: 'TraderAlice/OpenAlice' }
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index]
+    const value = argv[index + 1]
+    if (!['--manifest', '--version', '--repository'].includes(name) || !value) {
+      throw new Error(usage())
+    }
+    result[name.slice(2)] = value
+  }
+  if (!result.manifest || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(result.version ?? '')) {
+    throw new Error(usage())
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(result.repository)) {
+    throw new Error('invalid GitHub repository')
+  }
+  return {
+    manifestPath: result.manifest,
+    version: result.version,
+    repository: result.repository,
+  }
+}
+
+function usage() {
+  return 'Usage: verify-public-cli-channels.mjs --manifest <path> --version <version> [--repository <owner/repo>]'
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const receipt = await verifyPublicCliChannels(parseArgs(process.argv.slice(2)))
+    process.stdout.write(`${JSON.stringify(receipt)}\n`)
+  } catch (error) {
+    process.stderr.write(`verify public CLI channels: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/verify-public-cli-channels.spec.mjs
+++ b/scripts/verify-public-cli-channels.spec.mjs
@@ -1,0 +1,88 @@
+import { createHash } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { parseArgs, verifyPublicCliChannels } from './verify-public-cli-channels.mjs'
+
+const roots = []
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('public CLI channel verification', () => {
+  it('verifies every public archive and sidecar against the accepted manifest', async () => {
+    const fixture = createFixture()
+    const receipt = await verifyPublicCliChannels({
+      manifestPath: fixture.manifestPath,
+      version: fixture.version,
+      fetchImpl: fixture.fetchImpl,
+    })
+    expect(receipt.status).toBe('pass')
+    expect(receipt.targets).toHaveLength(4)
+    expect(receipt.targets.every((target) => target.public)).toBe(true)
+  })
+
+  it('rejects a public archive whose bytes differ from the accepted checksum', async () => {
+    const fixture = createFixture()
+    await expect(verifyPublicCliChannels({
+      manifestPath: fixture.manifestPath,
+      version: fixture.version,
+      fetchImpl: async (url, init) => {
+        if (String(url).includes('linux-x64.tar.gz') && !String(url).endsWith('.sha256')) {
+          return new Response('tampered')
+        }
+        return fixture.fetchImpl(url, init)
+      },
+    })).rejects.toThrow('public openalice-cli-0.91.0-linux-x64.tar.gz checksum')
+  })
+
+  it('rejects a non-release asset base and malformed CLI arguments', async () => {
+    const fixture = createFixture({ assetBaseUrl: 'https://example.test/assets' })
+    await expect(verifyPublicCliChannels({
+      manifestPath: fixture.manifestPath,
+      version: fixture.version,
+      fetchImpl: fixture.fetchImpl,
+    })).rejects.toThrow('asset base')
+    expect(() => parseArgs(['--manifest', 'manifest.json', '--version', 'latest'])).toThrow('Usage:')
+  })
+})
+
+function createFixture(overrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'openalice-public-channel-'))
+  roots.push(root)
+  const version = '0.91.0'
+  const repository = 'TraderAlice/OpenAlice'
+  const assetBaseUrl = overrides.assetBaseUrl
+    ?? `https://github.com/${repository}/releases/download/v${version}`
+  const bytes = new Map()
+  const targets = [
+    ['darwin', 'arm64'],
+    ['darwin', 'x64'],
+    ['linux', 'arm64'],
+    ['linux', 'x64'],
+  ].map(([platform, arch], index) => {
+    const archive = `openalice-cli-${version}-${platform}-${arch}.tar.gz`
+    const body = Buffer.from(`accepted-${platform}-${arch}`)
+    const sha256 = createHash('sha256').update(body).digest('hex')
+    bytes.set(`${assetBaseUrl}/${archive}`, body)
+    bytes.set(`${assetBaseUrl}/${archive}.sha256`, Buffer.from(`${sha256}  ${archive}\n`))
+    return { platform, arch, sha256, contentIdentity: String(index).repeat(16) }
+  })
+  const manifestPath = join(root, 'cli-package-channels.json')
+  writeFileSync(manifestPath, JSON.stringify({
+    schemaVersion: 1,
+    version,
+    assetBaseUrl,
+    targets,
+  }))
+  return {
+    version,
+    manifestPath,
+    fetchImpl: async (url) => {
+      const body = bytes.get(String(url))
+      return body ? new Response(body) : new Response('not found', { status: 404 })
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- verify every public native archive and SHA-256 sidecar against the accepted manifest after GitHub Release publication
- compare public Homebrew, AUR, and npm metadata byte-for-byte with preserved publication inputs
- add opt-in, idempotent npm, TraderAlice Tap, and AUR activation jobs with separate least-scope credentials

## Safety boundary
- all external writers remain disabled by repository variables
- no registry names or external repositories are created by this change
- AUR requires a maintainer-verified known-hosts secret; the job does not trust an online key scan

## Verification
- npx tsc --noEmit
- pnpm test (616 files passed, 1 skipped; 5,083 tests passed, 9 skipped)
- public channel verifier and workflow specs (11 passed)
- workflow YAML parsed by the release workflow spec