### PR TITLE
Preflight public CLI channel authority

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,34 @@ jobs:
           path: notes.md
           if-no-files-found: error
 
+  preflight-public-cli-authority:
+    name: Preflight public CLI channel authority
+    needs: release
+    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - name: Verify every opted-in public channel before release publication
+        if: needs.release.outputs.prerelease == 'false'
+        run: node scripts/preflight-public-cli-authority.mjs
+        env:
+          OPENALICE_PUBLISH_NPM: ${{ vars.OPENALICE_PUBLISH_NPM }}
+          OPENALICE_PUBLISH_HOMEBREW: ${{ vars.OPENALICE_PUBLISH_HOMEBREW }}
+          OPENALICE_PUBLISH_AUR: ${{ vars.OPENALICE_PUBLISH_AUR }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
+
   # Per-platform desktop installers are built before any tag or GitHub Release
   # exists. Each runner builds only its own platform/arch, preserves the candidate
   # immediately after fast package acceptance, and leaves the slower N-1 upgrade
@@ -95,7 +123,7 @@ jobs:
   # builds are signed and notarized through Developer ID secrets; Windows remains
   # unsigned until a Windows code-signing certificate exists.
   build-desktop:
-    needs: release
+    needs: [release, preflight-public-cli-authority]
     if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
     timeout-minutes: 45
     strategy:
@@ -285,7 +313,7 @@ jobs:
 
   cli-installer-acceptance:
     name: Accept CLI installer candidate
-    needs: release
+    needs: [release, preflight-public-cli-authority]
     if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
     runs-on: ubuntu-latest
     timeout-minutes: 35
@@ -307,7 +335,7 @@ jobs:
 
   build-cli-release:
     name: Build native CLI (${{ matrix.platform }}-${{ matrix.arch }})
-    needs: release
+    needs: [release, preflight-public-cli-authority]
     if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
     strategy:
       fail-fast: false
@@ -705,7 +733,7 @@ jobs:
   # native CLI candidates instead of serializing them in desktop jobs.
   build-broker-packs:
     name: Build Broker Packs (${{ matrix.os }}, ${{ matrix.arch }})
-    needs: release
+    needs: [release, preflight-public-cli-authority]
     if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
     timeout-minutes: 30
     strategy:
@@ -756,8 +784,8 @@ jobs:
 
   publish-release:
     name: Publish accepted release
-    needs: [release, build-desktop, accept-desktop-upgrade, build-cli-release, build-cli-package-channels, accept-cli-homebrew, accept-cli-linuxbrew, accept-cli-aur, accept-cli-legacy-cutover, build-broker-packs, cli-installer-acceptance]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-cli-release.result == 'success' && needs.build-cli-package-channels.result == 'success' && needs.accept-cli-homebrew.result == 'success' && needs.accept-cli-linuxbrew.result == 'success' && needs.accept-cli-aur.result == 'success' && needs.accept-cli-legacy-cutover.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
+    needs: [release, preflight-public-cli-authority, build-desktop, accept-desktop-upgrade, build-cli-release, build-cli-package-channels, accept-cli-homebrew, accept-cli-linuxbrew, accept-cli-aur, accept-cli-legacy-cutover, build-broker-packs, cli-installer-acceptance]
+    if: needs.release.outputs.created == 'true' && needs.preflight-public-cli-authority.result == 'success' && needs.build-desktop.result == 'success' && needs.accept-desktop-upgrade.result == 'success' && needs.build-cli-release.result == 'success' && needs.build-cli-package-channels.result == 'success' && needs.accept-cli-homebrew.result == 'success' && needs.accept-cli-linuxbrew.result == 'success' && needs.accept-cli-aur.result == 'success' && needs.accept-cli-legacy-cutover.result == 'success' && needs.build-broker-packs.result == 'success' && needs.cli-installer-acceptance.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -107,6 +107,15 @@ External channels are explicit release switches:
 | Homebrew | `OPENALICE_PUBLISH_HOMEBREW=true` | `HOMEBREW_TAP_TOKEN` with write access to `TraderAlice/homebrew-tap` |
 | AUR / paru | `OPENALICE_PUBLISH_AUR=true` | dedicated `AUR_SSH_PRIVATE_KEY` plus manually verified `AUR_KNOWN_HOSTS` |
 
+Before a stable GitHub Release can be created, the release workflow preflights
+every enabled switch. npm must identify the token owner and confirm that all
+five package names already list that identity as a maintainer; the Homebrew
+token must see `TraderAlice/homebrew-tap` with push authority; and the AUR key
+plus pinned known-hosts entry must be able to read the `openalice-bin` Git
+repository. Disabled channels perform no external authority checks. This makes
+missing setup a release-planning failure instead of discovering it after the
+accepted assets are already public.
+
 The Tap and AUR writers are idempotent: if the verified metadata is already
 active, they make no commit. AUR never learns its SSH host key from the same
 untrusted connection used to publish; the maintainer supplies the verified

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -464,6 +464,9 @@ build harness when it improves the next investigation.
 - [x] Record and enforce platform-first/meta-last npm publication after the
   GitHub Release succeeds. Stable publication remains explicitly disabled
   until registry authority and package names are established.
+- [x] Preflight every opted-in public channel before expensive release builds:
+  prove npm package maintainership, Homebrew Tap push access, and pinned-host
+  AUR Git access without logging or weakening the external credentials.
 - [ ] Publish Brew/AUR metadata only after the referenced release assets are
   public and verified. The opt-in automation and public-byte receipt are ready;
   external repository creation, credentials, activation, and first public

--- a/scripts/preflight-public-cli-authority.mjs
+++ b/scripts/preflight-public-cli-authority.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const NPM_PACKAGE_NAMES = Object.freeze([
+  'openalice',
+  'openalice-darwin-arm64',
+  'openalice-darwin-x64',
+  'openalice-linux-arm64',
+  'openalice-linux-x64',
+])
+
+const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org'
+const DEFAULT_TAP_API = 'https://api.github.com/repos/TraderAlice/homebrew-tap'
+const DEFAULT_AUR_REPOSITORY = 'ssh://aur@aur.archlinux.org/openalice-bin.git'
+
+export async function preflightPublicCliAuthority({
+  env = process.env,
+  fetchImpl = fetch,
+  verifyAur = verifyAurRepository,
+  logger = console,
+} = {}) {
+  const enabled = {
+    npm: env.OPENALICE_PUBLISH_NPM === 'true',
+    homebrew: env.OPENALICE_PUBLISH_HOMEBREW === 'true',
+    aur: env.OPENALICE_PUBLISH_AUR === 'true',
+  }
+  const selected = Object.entries(enabled).filter(([, value]) => value).map(([name]) => name)
+  if (selected.length === 0) {
+    logger.log('[public-cli-authority] no external CLI channels are enabled')
+    return { enabled: selected, npmUsername: null }
+  }
+
+  const failures = []
+  let npmUsername = null
+
+  if (enabled.npm) {
+    try {
+      npmUsername = await verifyNpmAuthority({ env, fetchImpl })
+      logger.log(`[public-cli-authority] npm authority verified for ${npmUsername}`)
+    } catch (error) {
+      failures.push(message(error))
+    }
+  }
+
+  if (enabled.homebrew) {
+    try {
+      await verifyHomebrewAuthority({ env, fetchImpl })
+      logger.log('[public-cli-authority] Homebrew tap write authority verified')
+    } catch (error) {
+      failures.push(message(error))
+    }
+  }
+
+  if (enabled.aur) {
+    try {
+      requireSecret(env, 'AUR_SSH_PRIVATE_KEY', 'AUR publication')
+      requireSecret(env, 'AUR_KNOWN_HOSTS', 'AUR publication')
+      await verifyAur({ env })
+      logger.log('[public-cli-authority] AUR repository authority verified')
+    } catch (error) {
+      failures.push(message(error))
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`public CLI channel authority preflight failed:\n- ${failures.join('\n- ')}`)
+  }
+
+  return { enabled: selected, npmUsername }
+}
+
+async function verifyNpmAuthority({ env, fetchImpl }) {
+  const token = requireSecret(env, 'NPM_TOKEN', 'npm publication')
+  const registry = trimTrailingSlash(env.OPENALICE_NPM_REGISTRY_URL || DEFAULT_NPM_REGISTRY)
+  const headers = {
+    accept: 'application/json',
+    authorization: `Bearer ${token}`,
+  }
+  const whoami = await fetchJson(fetchImpl, `${registry}/-/whoami`, { headers }, 'npm token identity')
+  const username = typeof whoami.username === 'string' ? whoami.username.trim() : ''
+  if (!username) throw new Error('npm token identity did not return a username')
+
+  for (const packageName of NPM_PACKAGE_NAMES) {
+    const metadata = await fetchJson(
+      fetchImpl,
+      `${registry}/${encodeURIComponent(packageName)}`,
+      { headers },
+      `npm package ${packageName}`,
+      `npm package name ${packageName} is not reserved`,
+    )
+    const maintainers = Array.isArray(metadata.maintainers)
+      ? metadata.maintainers.map((entry) => typeof entry?.name === 'string' ? entry.name : '')
+      : []
+    if (!maintainers.includes(username)) {
+      throw new Error(`npm token identity ${username} is not a maintainer of ${packageName}`)
+    }
+  }
+
+  return username
+}
+
+async function verifyHomebrewAuthority({ env, fetchImpl }) {
+  const token = requireSecret(env, 'HOMEBREW_TAP_TOKEN', 'Homebrew publication')
+  const endpoint = env.OPENALICE_HOMEBREW_REPOSITORY_API || DEFAULT_TAP_API
+  const repository = await fetchJson(
+    fetchImpl,
+    endpoint,
+    {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28',
+      },
+    },
+    'TraderAlice/homebrew-tap repository',
+    'TraderAlice/homebrew-tap does not exist or is not visible to HOMEBREW_TAP_TOKEN',
+  )
+  if (repository.permissions?.push !== true) {
+    throw new Error('HOMEBREW_TAP_TOKEN does not have push authority for TraderAlice/homebrew-tap')
+  }
+}
+
+export function verifyAurRepository({ env }) {
+  const key = requireSecret(env, 'AUR_SSH_PRIVATE_KEY', 'AUR publication')
+  const knownHosts = requireSecret(env, 'AUR_KNOWN_HOSTS', 'AUR publication')
+  const repository = env.OPENALICE_AUR_REPOSITORY || DEFAULT_AUR_REPOSITORY
+  const root = mkdtempSync(join(tmpdir(), 'openalice-aur-preflight-'))
+  const keyPath = join(root, 'id_ed25519')
+  const knownHostsPath = join(root, 'known_hosts')
+  try {
+    writeFileSync(keyPath, `${key.trim()}\n`, { mode: 0o600 })
+    writeFileSync(knownHostsPath, `${knownHosts.trim()}\n`, { mode: 0o600 })
+    const result = spawnSync('git', ['ls-remote', repository], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_SSH_COMMAND: [
+          'ssh',
+          '-o', 'BatchMode=yes',
+          '-o', 'IdentitiesOnly=yes',
+          '-o', 'StrictHostKeyChecking=yes',
+          '-o', `UserKnownHostsFile=${knownHostsPath}`,
+          '-i', keyPath,
+        ].join(' '),
+      },
+      timeout: 30_000,
+    })
+    if (result.error) throw result.error
+    if (result.status !== 0) {
+      const detail = result.stderr.trim().split('\n').at(-1) || `git exited ${result.status}`
+      throw new Error(`AUR_SSH_PRIVATE_KEY cannot read ${repository}: ${detail}`)
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+async function fetchJson(fetchImpl, url, options, label, notFoundMessage) {
+  const response = await fetchImpl(url, options)
+  if (!response.ok) {
+    if (response.status === 404 && notFoundMessage) throw new Error(notFoundMessage)
+    throw new Error(`${label} request failed with HTTP ${response.status}`)
+  }
+  try {
+    return await response.json()
+  } catch {
+    throw new Error(`${label} returned invalid JSON`)
+  }
+}
+
+function requireSecret(env, name, purpose) {
+  const value = typeof env[name] === 'string' ? env[name].trim() : ''
+  if (!value) throw new Error(`${purpose} is enabled but ${name} is missing`)
+  return value
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '')
+}
+
+function message(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  preflightPublicCliAuthority().catch((error) => {
+    console.error(message(error))
+    process.exitCode = 1
+  })
+}

--- a/scripts/preflight-public-cli-authority.spec.mjs
+++ b/scripts/preflight-public-cli-authority.spec.mjs
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  NPM_PACKAGE_NAMES,
+  preflightPublicCliAuthority,
+} from './preflight-public-cli-authority.mjs'
+
+function response(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body
+    },
+  }
+}
+
+describe('public CLI authority preflight', () => {
+  it('does no external work while every publication switch is disabled', async () => {
+    const fetchImpl = vi.fn()
+    const verifyAur = vi.fn()
+    const logger = { log: vi.fn() }
+
+    await expect(preflightPublicCliAuthority({ env: {}, fetchImpl, verifyAur, logger }))
+      .resolves.toEqual({ enabled: [], npmUsername: null })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(verifyAur).not.toHaveBeenCalled()
+  })
+
+  it('verifies the npm identity owns all names and the Tap token can push', async () => {
+    const env = {
+      OPENALICE_PUBLISH_NPM: 'true',
+      OPENALICE_PUBLISH_HOMEBREW: 'true',
+      OPENALICE_PUBLISH_AUR: 'true',
+      NPM_TOKEN: 'npm-secret',
+      HOMEBREW_TAP_TOKEN: 'tap-secret',
+      AUR_SSH_PRIVATE_KEY: 'aur-secret',
+      AUR_KNOWN_HOSTS: 'aur.example ssh-ed25519 key',
+    }
+    const fetchImpl = vi.fn(async (url) => {
+      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
+      if (url.includes('api.github.com')) return response(200, { permissions: { push: true } })
+      return response(200, { maintainers: [{ name: 'alice-release' }] })
+    })
+    const verifyAur = vi.fn(async () => {})
+
+    await expect(preflightPublicCliAuthority({
+      env,
+      fetchImpl,
+      verifyAur,
+      logger: { log: vi.fn() },
+    })).resolves.toEqual({
+      enabled: ['npm', 'homebrew', 'aur'],
+      npmUsername: 'alice-release',
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(NPM_PACKAGE_NAMES.length + 2)
+    expect(verifyAur).toHaveBeenCalledWith({ env })
+  })
+
+  it('reports every enabled channel that is missing authority', async () => {
+    const env = {
+      OPENALICE_PUBLISH_NPM: 'true',
+      OPENALICE_PUBLISH_HOMEBREW: 'true',
+      OPENALICE_PUBLISH_AUR: 'true',
+    }
+
+    await expect(preflightPublicCliAuthority({
+      env,
+      fetchImpl: vi.fn(),
+      verifyAur: vi.fn(),
+      logger: { log: vi.fn() },
+    })).rejects.toThrow(new RegExp([
+      'NPM_TOKEN is missing',
+      'HOMEBREW_TAP_TOKEN is missing',
+      'AUR_SSH_PRIVATE_KEY is missing',
+    ].join('[\\s\\S]*')))
+  })
+
+  it('rejects an authenticated npm token that does not own the reserved names', async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
+      return response(200, { maintainers: [{ name: 'someone-else' }] })
+    })
+
+    await expect(preflightPublicCliAuthority({
+      env: {
+        OPENALICE_PUBLISH_NPM: 'true',
+        NPM_TOKEN: 'npm-secret',
+      },
+      fetchImpl,
+      logger: { log: vi.fn() },
+    })).rejects.toThrow('npm token identity alice-release is not a maintainer of openalice')
+  })
+
+  it('rejects unreserved npm names, read-only Tap tokens, and inaccessible AUR repos', async () => {
+    const env = {
+      OPENALICE_PUBLISH_NPM: 'true',
+      OPENALICE_PUBLISH_HOMEBREW: 'true',
+      OPENALICE_PUBLISH_AUR: 'true',
+      NPM_TOKEN: 'npm-secret',
+      HOMEBREW_TAP_TOKEN: 'tap-secret',
+      AUR_SSH_PRIVATE_KEY: 'aur-secret',
+      AUR_KNOWN_HOSTS: 'aur.example ssh-ed25519 key',
+    }
+    const fetchImpl = vi.fn(async (url) => {
+      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
+      if (url.includes('api.github.com')) return response(200, { permissions: { push: false } })
+      return response(404, {})
+    })
+
+    await expect(preflightPublicCliAuthority({
+      env,
+      fetchImpl,
+      verifyAur: vi.fn(async () => { throw new Error('AUR repository is unavailable') }),
+      logger: { log: vi.fn() },
+    })).rejects.toThrow(new RegExp([
+      'npm package name openalice is not reserved',
+      'HOMEBREW_TAP_TOKEN does not have push authority',
+      'AUR repository is unavailable',
+    ].join('[\\s\\S]*')))
+  })
+})

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -76,6 +76,7 @@ describe('Release workflow critical path', () => {
 
   it('keeps publication gated on both candidate builds and upgrade receipts', () => {
     expect(needs(workflow.jobs['publish-release'])).toEqual(expect.arrayContaining([
+      'preflight-public-cli-authority',
       'build-desktop',
       'accept-desktop-upgrade',
       'build-broker-packs',
@@ -86,6 +87,26 @@ describe('Release workflow critical path', () => {
       'accept-cli-legacy-cutover',
       'cli-installer-acceptance',
     ]))
+    expect(workflow.jobs['publish-release'].if).toContain(
+      "needs.preflight-public-cli-authority.result == 'success'",
+    )
+  })
+
+  it('preflights every enabled public CLI channel before creating the release', () => {
+    const preflight = workflow.jobs['preflight-public-cli-authority']
+    expect(needs(preflight)).toEqual(['release'])
+    expect(preflight['timeout-minutes']).toBe(5)
+    const verify = step(preflight, 'Verify every opted-in public channel before release publication')
+    expect(verify.if).toContain("needs.release.outputs.prerelease == 'false'")
+    expect(verify.run).toBe('node scripts/preflight-public-cli-authority.mjs')
+    for (const job of [
+      'build-desktop',
+      'cli-installer-acceptance',
+      'build-cli-release',
+      'build-broker-packs',
+    ]) {
+      expect(needs(workflow.jobs[job])).toContain('preflight-public-cli-authority')
+    }
   })
 
   it('publishes the four accepted native CLI archives and checksums', () => {


### PR DESCRIPTION
## Summary
- fail stable release planning early when an enabled npm, Homebrew, or AUR channel lacks real publication authority
- gate expensive candidate builds on that fast check
- preserve disabled-channel and prerelease behavior

## Verification
- targeted preflight/workflow tests: 14 passed
- npx tsc --noEmit
- pnpm test: 617 files passed, 1 skipped; 5088 tests passed, 9 skipped

No external channel was activated.