### PR TITLE
Add read-only CLI channel authority rehearsal

### DIFF
--- a/.github/workflows/cli-channel-authority.yml
+++ b/.github/workflows/cli-channel-authority.yml
@@ -1,0 +1,58 @@
+name: Public CLI Channel Authority
+
+on:
+  workflow_dispatch:
+    inputs:
+      npm:
+        description: Verify npm and Bun package-name authority.
+        required: true
+        default: true
+        type: boolean
+      homebrew:
+        description: Verify TraderAlice Homebrew Tap write authority.
+        required: true
+        default: true
+        type: boolean
+      aur:
+        description: Verify AUR openalice-bin Git authority.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Verify selected public CLI channels
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - name: Require at least one selected channel
+        env:
+          CHECK_NPM: ${{ inputs.npm }}
+          CHECK_HOMEBREW: ${{ inputs.homebrew }}
+          CHECK_AUR: ${{ inputs.aur }}
+        run: |
+          if [ "$CHECK_NPM" != "true" ] && [ "$CHECK_HOMEBREW" != "true" ] && [ "$CHECK_AUR" != "true" ]; then
+            echo "::error::Select at least one public CLI channel to verify."
+            exit 1
+          fi
+
+      - name: Verify selected channel authority without publishing
+        run: node scripts/preflight-public-cli-authority.mjs
+        env:
+          OPENALICE_PUBLISH_NPM: ${{ inputs.npm }}
+          OPENALICE_PUBLISH_HOMEBREW: ${{ inputs.homebrew }}
+          OPENALICE_PUBLISH_AUR: ${{ inputs.aur }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -116,6 +116,12 @@ repository. Disabled channels perform no external authority checks. This makes
 missing setup a release-planning failure instead of discovering it after the
 accepted assets are already public.
 
+The `Public CLI Channel Authority` workflow exposes the same checks as a manual
+read-only rehearsal. Select npm, Homebrew, AUR, or any combination before a
+stable promotion; the run uses repository secrets but cannot publish packages,
+push metadata, or create a GitHub Release. Use it after reserving names and
+installing credentials, before enabling the corresponding release switch.
+
 The Tap and AUR writers are idempotent: if the verified metadata is already
 active, they make no commit. AUR never learns its SSH host key from the same
 untrusted connection used to publish; the maintainer supplies the verified

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -467,6 +467,8 @@ build harness when it improves the next investigation.
 - [x] Preflight every opted-in public channel before expensive release builds:
   prove npm package maintainership, Homebrew Tap push access, and pinned-host
   AUR Git access without logging or weakening the external credentials.
+- [x] Expose the authority preflight as a bounded manual, read-only rehearsal
+  that cannot publish packages, push metadata, or create a release.
 - [ ] Publish Brew/AUR metadata only after the referenced release assets are
   public and verified. The opt-in automation and public-byte receipt are ready;
   external repository creation, credentials, activation, and first public

--- a/scripts/cli-channel-authority-workflow.spec.ts
+++ b/scripts/cli-channel-authority-workflow.spec.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  run?: string
+}
+
+const root = resolve(import.meta.dirname, '..')
+const workflow = YAML.parse(
+  readFileSync(resolve(root, '.github/workflows/cli-channel-authority.yml'), 'utf8'),
+) as {
+  on: Record<string, unknown>
+  permissions: Record<string, string>
+  jobs: Record<string, {
+    'timeout-minutes'?: number
+    steps?: WorkflowStep[]
+  }>
+}
+
+describe('Public CLI channel authority workflow', () => {
+  it('is a bounded manual read-only rehearsal', () => {
+    expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch'])
+    expect(workflow.permissions).toEqual({ contents: 'read' })
+    expect(workflow.jobs.preflight['timeout-minutes']).toBe(5)
+  })
+
+  it('requires a selection and calls the non-publishing preflight', () => {
+    const steps = workflow.jobs.preflight.steps ?? []
+    expect(steps.find((step) => step.name === 'Require at least one selected channel')?.run)
+      .toContain('Select at least one public CLI channel')
+    expect(steps.find((step) => step.name === 'Verify selected channel authority without publishing')?.run)
+      .toBe('node scripts/preflight-public-cli-authority.mjs')
+    expect(steps.map((step) => step.run ?? '').join('\n')).not.toMatch(/npm publish|git push|gh release/)
+  })
+})


### PR DESCRIPTION
## Summary
- add a manually triggered, read-only rehearsal for npm, Homebrew, and AUR authority
- allow credential verification before stable promotion without publishing anything

## Verification
- targeted workflow/preflight tests: 16 passed
- npx tsc --noEmit
- pnpm test: 618 files passed, 1 skipped; 5091 tests passed, 9 skipped