### PR TITLE
Make stable release dispatch explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,19 @@
 name: Release
 
 on:
-  push:
-    # Releases are cut only from the stable user-facing lane. Routine work
-    # lands on dev first and reaches release eligibility through promotion.
-    branches: [master]
   workflow_dispatch:
     inputs:
-      mirror_tag:
-        description: Existing release tag to mirror to the download CDN without cutting a new release.
-        required: false
+      operation:
+        description: Create a new release or repair the mirrors for an existing release.
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - mirror
+      tag:
+        description: Release tag, for example v0.91.0.
+        required: true
         type: string
 
 jobs:
@@ -19,29 +23,76 @@ jobs:
     permissions:
       contents: write
     outputs:
-      # Whether this push introduces a version that does not have a tag yet.
+      # Whether this dispatch requests a new release. The tag/package version
+      # contract is validated before any expensive candidate jobs begin.
       # The tag and GitHub Release are deliberately created only after every
       # platform builds and passes Workspace acceptance.
-      created: ${{ !github.event.inputs.mirror_tag && steps.check.outputs.exists == 'false' }}
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ github.event.inputs.mirror_tag || steps.version.outputs.tag }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
-      previous_tag: ${{ steps.version.outputs.previous_tag }}
+      created: ${{ steps.plan.outputs.created }}
+      operation: ${{ steps.plan.outputs.operation }}
+      version: ${{ steps.plan.outputs.version }}
+      tag: ${{ steps.plan.outputs.tag }}
+      prerelease: ${{ steps.plan.outputs.prerelease }}
+      previous_tag: ${{ steps.plan.outputs.previous_tag }}
+      source_sha: ${{ steps.plan.outputs.source_sha }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history for git-cliff
 
-      - name: Get version from package.json
-        id: version
+      - name: Validate release intent and version authority
+        id: plan
+        env:
+          OPERATION: ${{ inputs.operation }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
-          test "$CLI_VERSION" = "$VERSION"
+          set -euo pipefail
+
+          if [ "$OPERATION" != "release" ] && [ "$OPERATION" != "mirror" ]; then
+            echo "Operation must be release or mirror, got: $OPERATION" >&2
+            exit 1
+          fi
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must look like v0.91.0 or v0.91.0-beta.1, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          if [ "$OPERATION" = "release" ]; then
+            if [ "$SOURCE_REF" != "refs/heads/master" ]; then
+              echo "Stable releases must be dispatched from master, got: $SOURCE_REF" >&2
+              exit 1
+            fi
+
+            PACKAGE_VERSION=$(node -p "require('./package.json').version")
+            CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
+            if [ "$PACKAGE_VERSION" != "$VERSION" ] || [ "$CLI_VERSION" != "$VERSION" ]; then
+              echo "Release tag $RELEASE_TAG requires package versions $VERSION; root=$PACKAGE_VERSION cli=$CLI_VERSION" >&2
+              exit 1
+            fi
+
+            if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+              echo "Release tag already exists: $RELEASE_TAG" >&2
+              exit 1
+            fi
+            CREATED=true
+          else
+            if ! git rev-parse "$RELEASE_TAG^{commit}" >/dev/null 2>&1; then
+              echo "Mirror repair requires an existing release tag: $RELEASE_TAG" >&2
+              exit 1
+            fi
+            CREATED=false
+          fi
+
+          echo "created=$CREATED" >> "$GITHUB_OUTPUT"
+          echo "operation=$OPERATION" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "previous_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
           # Determine if pre-release (contains - like beta.1, rc.1)
           if [[ "$VERSION" == *-* ]]; then
@@ -50,21 +101,12 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check if tag already exists
-        id: check
-        run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Install git-cliff
-        if: steps.check.outputs.exists == 'false' && !github.event.inputs.mirror_tag
+        if: steps.plan.outputs.created == 'true'
         uses: kenji-miyake/setup-git-cliff@v2
 
       - name: Generate release notes
-        if: steps.check.outputs.exists == 'false' && !github.event.inputs.mirror_tag
+        if: steps.plan.outputs.created == 'true'
         id: notes
         run: |
           # Generate notes for this version only (since last tag).
@@ -72,7 +114,7 @@ jobs:
           # BEFORE the tag exists (it's created only after candidate acceptance), so without
           # this the section header falls back to "[Unreleased]" instead of
           # the version. See cliff.toml's `{% if version %}` template.
-          TAG="${{ steps.version.outputs.tag }}"
+          TAG="${{ steps.plan.outputs.tag }}"
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LAST_TAG" ]; then
             git-cliff --tag "$TAG" --output notes.md
@@ -81,7 +123,7 @@ jobs:
           fi
 
       - name: Preserve release notes for gated publication
-        if: steps.check.outputs.exists == 'false' && !github.event.inputs.mirror_tag
+        if: steps.plan.outputs.created == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: release-notes
@@ -91,7 +133,7 @@ jobs:
   preflight-public-cli-authority:
     name: Preflight public CLI channel authority
     needs: release
-    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -124,7 +166,7 @@ jobs:
   # unsigned until a Windows code-signing certificate exists.
   build-desktop:
     needs: [release, preflight-public-cli-authority]
-    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true'
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -259,7 +301,7 @@ jobs:
   accept-desktop-upgrade:
     name: Accept desktop upgrade (${{ matrix.os }}, ${{ matrix.arch }})
     needs: [release, build-desktop]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -314,7 +356,7 @@ jobs:
   cli-installer-acceptance:
     name: Accept CLI installer candidate
     needs: [release, preflight-public-cli-authority]
-    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -336,7 +378,7 @@ jobs:
   build-cli-release:
     name: Build native CLI (${{ matrix.platform }}-${{ matrix.arch }})
     needs: [release, preflight-public-cli-authority]
-    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -448,7 +490,7 @@ jobs:
   build-cli-package-channels:
     name: Build CLI package-manager channels
     needs: [release, build-cli-release]
-    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -499,7 +541,7 @@ jobs:
   accept-cli-homebrew:
     name: Accept Homebrew CLI (${{ matrix.arch }})
     needs: [release, build-cli-release]
-    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -566,7 +608,7 @@ jobs:
   accept-cli-linuxbrew:
     name: Accept Linuxbrew CLI (${{ matrix.arch }})
     needs: [release, build-cli-release]
-    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -631,7 +673,7 @@ jobs:
   accept-cli-aur:
     name: Accept Arch/AUR CLI package (${{ matrix.arch }})
     needs: [release, build-cli-release]
-    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -696,7 +738,7 @@ jobs:
   accept-cli-legacy-cutover:
     name: Accept published v0.90.1 CLI cutover
     needs: [release, build-cli-release]
-    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     permissions:
@@ -734,7 +776,7 @@ jobs:
   build-broker-packs:
     name: Build Broker Packs (${{ matrix.os }}, ${{ matrix.arch }})
     needs: [release, preflight-public-cli-authority]
-    if: needs.release.outputs.created == 'true' && !github.event.inputs.mirror_tag
+    if: needs.release.outputs.created == 'true'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -828,7 +870,7 @@ jobs:
           body_path: dist/release-notes/notes.md
           prerelease: ${{ needs.release.outputs.prerelease == 'true' }}
           generate_release_notes: false
-          target_commitish: ${{ github.sha }}
+          target_commitish: ${{ needs.release.outputs.source_sha }}
           fail_on_unmatched_files: true
           files: |
             dist/release-assets/*.dmg
@@ -1018,7 +1060,7 @@ jobs:
 
   mirror-release-assets:
     needs: [release, publish-release]
-    if: always() && ((needs.release.outputs.created == 'true' && needs.publish-release.result == 'success') || github.event.inputs.mirror_tag)
+    if: always() && ((needs.release.outputs.created == 'true' && needs.publish-release.result == 'success') || needs.release.outputs.operation == 'mirror')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1029,7 +1071,7 @@ jobs:
           # A manual mirror is an idempotent repair of an existing release.
           # Always derive the installer from that tag, never from whichever
           # commit happens to be at master when the workflow is dispatched.
-          ref: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+          ref: ${{ needs.release.outputs.tag }}
 
       - uses: actions/setup-node@v7
         with:
@@ -1038,14 +1080,14 @@ jobs:
       - name: Download release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           mkdir -p dist/r2-upload
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist/r2-upload --clobber
 
       - name: Prepare release-owned CLI installer
         env:
-          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           VERSION="${TAG#v}"
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
@@ -1061,7 +1103,7 @@ jobs:
 
       - name: Prepare CDN download aliases
         env:
-          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+          TAG: ${{ needs.release.outputs.tag }}
           DOWNLOAD_BASE_URL: ${{ secrets.DOWNLOAD_BASE_URL }}
         run: |
           node scripts/prepare-desktop-release-assets.mjs mirror \
@@ -1073,7 +1115,7 @@ jobs:
       - name: Publish generated release metadata and installer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           shopt -s nullglob
           files=(dist/r2-upload/*-mac-intel.yml dist/r2-upload/*-intel-mac.yml dist/r2-upload/latest-mac-arm64.yml)
@@ -1179,7 +1221,7 @@ jobs:
         env:
           DOWNLOAD_BASE_URL: ${{ secrets.DOWNLOAD_BASE_URL }}
           PUBLIC_INSTALL_URL: https://openalice.ai/install
-          TAG: ${{ github.event.inputs.mirror_tag || needs.release.outputs.tag }}
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           BASE_URL="${DOWNLOAD_BASE_URL%/}"
           VERSION="${TAG#v}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,10 +89,13 @@ for current ownership and entry points.
 - `dev` is also the active preview channel: installer work must pass against
   both the checked-out tree and the matching `raw/.../dev/install` +
   `--branch dev` network path before promotion.
-- `master` is the stable/user-facing lane. Only human-directed promotions from
-  `dev` and explicit emergency hotfixes target `master`.
-- A merge to `master` is a versioned release event, not a post-release staging
-  step. Stable CDN aliases are updated only from the resulting tag.
+- `master` is the stable/user-facing source lane. Only human-directed
+  promotions from `dev` and explicit emergency hotfixes target `master`, but a
+  merge to `master` does not by itself choose or publish a product version.
+- Stable releases are explicit manual actions. The maintainer supplies a tag
+  from `master`; release automation requires that tag and both product package
+  manifests to declare the same version before it builds accepted candidates.
+  Stable CDN aliases are updated only from the resulting release tag.
 - Do not commit directly to `master`. Avoid direct commits to `dev` unless the
   maintainer explicitly requests integration work.
 - Never force-push or delete `master` or `dev`.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -13,11 +13,13 @@ Canonical startup rules: [[AGENTS.md]]. Guide index: [[docs/README.md]].
   testable preview environment. Merged installer changes are exercised through
   the mutable `raw/.../dev/install` endpoint with a matching `--branch dev`
   payload selector.
-- `master` is the stable/user-facing lane and the default GitHub branch. A
-  `dev` to `master` merge is a versioned release event, not another integration
-  step.
-- Release automation runs from `master` and derives public artifacts from the
-  accepted release tag. It is the only path that updates stable CDN aliases.
+- `master` is the stable/user-facing source lane and the default GitHub branch.
+  A `dev` to `master` merge establishes stable source but does not choose a
+  version or publish a release.
+- Release automation is dispatched manually from `master` with an explicit
+  tag. The tag version and both product package manifests must agree before
+  candidate work begins. The accepted tag is the only path that updates stable
+  CDN aliases.
 - `archive/dev-pre-beta6` is a historical snapshot; do not modify or delete it.
 - `local` is a legacy shared-worktree branch. It is not the default workflow;
   audit its unmerged commits before deciding whether to retain or retire it.
@@ -335,10 +337,9 @@ ownership.
 
 ## Promotion: `dev` to `master`
 
-Promotion is a human-directed, versioned release decision. Do not merge
-unreleased follow-up work to `master` merely to make a public alias catch up;
-finish and test it in the active `dev` environment, then include it in the next
-release.
+Promotion is a human-directed stable-source decision, not a release trigger.
+Do not merge unfinished follow-up work to `master` merely to make a public
+alias catch up; finish and test it in the active `dev` environment first.
 
 ```bash
 git fetch origin
@@ -354,18 +355,22 @@ Before merging a promotion:
 - follow [[docs/cli-installer.md]]; require the checkout installer/remote jobs
   and the post-merge live dev-channel job to be green, and walk the interactive
   installer locally when its human-facing flow changed;
-- confirm the new release version, notes, and tag intent; the release workflow
-  must see a version whose tag does not already exist, and the root and
-  `packages/cli` manifests must carry that same product version;
 - confirm CI and release workflow triggers still match the branch policy.
 
+After promotion, a maintainer may prepare a separate version-only change when
+the stable source is ready to release. Run the `Release` workflow manually from
+`master`, choose the `release` operation, and supply the intended `vX.Y.Z` tag.
+The workflow rejects a tag that already exists or disagrees with either the
+root or `packages/cli` package version. It binds the accepted candidates and
+the eventual tag to the dispatch commit SHA.
+
 The release workflow repeats the deterministic installer and managed-remote
-acceptance against the exact master candidate before it can create the tag and
+acceptance against that exact master candidate before it can create the tag and
 GitHub Release. It then creates the versioned installer from that tag, mirrors
 the same bytes to `download.openalice.ai/install`, writes the manifest checksum,
-and verifies both CDN objects. A manual `mirror_tag` run is recovery-only: it
-checks out that existing tag and may reproduce its bytes, but must never source
-an installer from current `master`.
+and verifies both CDN objects. A manual `mirror` operation is recovery-only: it
+requires an existing tag, checks out that tag, and may reproduce its bytes, but
+must never source an installer from current `master`.
 
 Desktop promotion evidence includes a real N-1 state journey on Apple Silicon,
 Intel macOS, and Windows. PR package jobs seed state with the previous published

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -531,6 +531,10 @@ artifacts.
 
 ### 9. Release acceptance
 
+- [x] Decouple stable-source promotion from publication: the manual Release
+  workflow accepts an explicit tag, requires it to match both product package
+  versions, binds candidates to the dispatch commit, and keeps existing-tag
+  mirror repair as a separate operation.
 - [ ] Build every required target from the accepted tagged tree.
 - [ ] Verify archive checksum and internal release metadata before upload.
 - [ ] Run clean non-admin Bash installs on macOS and Linux.
@@ -652,6 +656,13 @@ This plan is complete only when:
 
 ## Progress Log
 
+- 2026-08-30: Release entry was separated from `master` promotion without
+  changing the established candidate matrix. A manual dispatch now chooses
+  `release` or `mirror` plus an explicit tag. New releases must run from
+  `master`, the tag must not already exist, and its version must equal both the
+  root and CLI package manifests before expensive builds start. The accepted
+  tag is created only after the existing desktop, CLI, installer, Broker Pack,
+  and package-manager gates pass.
 - 2026-08-29: Maintainer selected the architecture after comparing Herdr and
   OpenCode. CLI is treated as a primary long-running distribution. The selected
   direction is one Bun-compiled OpenAlice artifact that re-executes into the

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -25,7 +25,18 @@ interface WorkflowJob {
 const root = resolve(import.meta.dirname, '..')
 const workflow = YAML.parse(
   readFileSync(resolve(root, '.github/workflows/release.yml'), 'utf8'),
-) as { jobs: Record<string, WorkflowJob> }
+) as {
+  on: {
+    workflow_dispatch?: {
+      inputs?: Record<string, {
+        required?: boolean
+        type?: string
+        options?: string[]
+      }>
+    }
+  }
+  jobs: Record<string, WorkflowJob>
+}
 
 function step(job: WorkflowJob, name: string): WorkflowStep {
   const found = job.steps?.find((candidate) => candidate.name === name)
@@ -39,6 +50,40 @@ function needs(job: WorkflowJob): string[] {
 }
 
 describe('Release workflow critical path', () => {
+  it('requires an explicit tag/package release decision instead of publishing on master push', () => {
+    expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch'])
+    expect(workflow.on.workflow_dispatch?.inputs).toMatchObject({
+      operation: {
+        required: true,
+        type: 'choice',
+        options: ['release', 'mirror'],
+      },
+      tag: {
+        required: true,
+        type: 'string',
+      },
+    })
+
+    const plan = step(workflow.jobs.release, 'Validate release intent and version authority').run ?? ''
+    expect(plan).toContain('refs/heads/master')
+    expect(plan).toContain("require('./package.json').version")
+    expect(plan).toContain("require('./packages/cli/package.json').version")
+    expect(plan).toContain('Release tag already exists')
+
+    expect(
+      step(workflow.jobs['publish-release'], 'Create tag and GitHub Release from accepted candidates')
+        .with?.target_commitish,
+    ).toBe('${{ needs.release.outputs.source_sha }}')
+  })
+
+  it('keeps existing-tag mirror repair distinct from new release creation', () => {
+    const plan = step(workflow.jobs.release, 'Validate release intent and version authority').run ?? ''
+    expect(plan).toContain('Mirror repair requires an existing release tag')
+    expect(workflow.jobs['mirror-release-assets'].if).toContain(
+      "needs.release.outputs.operation == 'mirror'",
+    )
+  })
+
   it('bounds native candidate jobs without weakening downstream gates', () => {
     expect(workflow.jobs['build-desktop']['timeout-minutes']).toBe(45)
     expect(workflow.jobs['build-broker-packs']['timeout-minutes']).toBe(30)


### PR DESCRIPTION
## Summary

- remove automatic stable release execution from master pushes
- require a manual release or mirror operation with an explicit tag
- validate new release tags against both product package versions and bind publication to the dispatch commit
- update workflow policy, release documentation, and the active CLI distribution plan

## Verification

- `npx tsc --noEmit`
- `pnpm test` (621 files passed, 5151 tests passed)
- targeted workflow contract tests (17 tests passed)
- release planner shell syntax and release/mirror guard probes
- `actionlint .github/workflows/release.yml`
- `git diff --check`