### PR TITLE
test(release): make version checks channel-explicit

### DIFF
--- a/src/core/version.spec.ts
+++ b/src/core/version.spec.ts
@@ -100,7 +100,7 @@ describe('fetchLatestRelease (mocked fetch)', () => {
       ]),
     }) as unknown as typeof fetch
 
-    const { result } = await fetchLatestRelease()
+    const { result } = await fetchLatestRelease({ channel: 'stable' })
     expect(result?.version).toBe('1.0.0') // first non-draft
   })
 
@@ -218,7 +218,7 @@ describe('getVersionInfo', () => {
       }]),
     }) as unknown as typeof fetch
 
-    const info = await getVersionInfo()
+    const info = await getVersionInfo({ channel: 'stable' })
     expect(info.latest).toBe('999.999.999')
     expect(info.hasUpdate).toBe(true)
     expect(info.error).toBeNull()
@@ -226,13 +226,16 @@ describe('getVersionInfo', () => {
 
   it('reports hasUpdate=false when latest = current', async () => {
     const current = getCurrentVersion()
+    const isBeta = /-beta(?:\.|$)/i.test(current)
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true, status: 200, statusText: 'OK',
-      json: async () => ([{ tag_name: current, html_url: 'x', body: '', published_at: '', draft: false, prerelease: false }]),
+      json: async () => ([{ tag_name: current, html_url: 'x', body: '', published_at: '', draft: false, prerelease: isBeta }]),
     }) as unknown as typeof fetch
 
     const info = await getVersionInfo()
+    expect(info.latest).toBe(current)
     expect(info.hasUpdate).toBe(false)
+    expect(info.error).toBeNull()
   })
 
   it('returns error when GitHub fetch fails', async () => {


### PR DESCRIPTION
## Summary

- make stable-channel assertions pass the stable channel explicitly
- make equal-current fixtures represent prerelease metadata correctly
- assert equal-current lookup actually resolves the current release instead of passing on a null result

## Verification

- `pnpm exec vitest run src/core/version.spec.ts` with stable manifest: 19 passed
- `npx tsc --noEmit`
- `pnpm test` with stable manifest: 5187 passed, 9 skipped
- same targeted and full test suites with a local `0.90.2-beta.1` manifest: 19 targeted and 5187 full tests passed

## Boundary

Test-only fixture repair. No production logic, package version, lockfile, installer, or release workflow change.