### PR TITLE
Fix Guardian port-probe startup race

### DIFF
--- a/plans/release-channels-0.90.2.md
+++ b/plans/release-channels-0.90.2.md
@@ -169,6 +169,15 @@ appropriate.
   immediately after its four native packaging jobs; full release checks remain
   on beta/stable, while PR and local lanes provide earlier feedback without
   becoming a publication dependency.
+- The first beta version rehearsal exposed stable-only version specs that had
+  relied on the old implicit release selection. Those fixtures now select the
+  stable channel explicitly and also exercise equal-current beta semantics.
+- Two same-SHA native preview attempts stalled before Guardian printed its
+  startup banner even though their reruns passed. The temporary production port
+  probe could accept an HTTP readiness connection and then wait forever for
+  that non-HTTP socket while closing. The probe now rejects accidental clients
+  immediately; the repaired `dev` source must complete preview and promotion
+  again before either 0.90.2 tag is attempted.
 
 ## Work Plan
 
@@ -221,7 +230,9 @@ appropriate.
   publication plus live installer path (PR #1257; `CLI Installer Smoke`
   run `33311979583`).
 - [ ] Promote the accepted `dev` source to `master` under the full promotion
-  gate.
+  gate. PR #1259 promoted the first accepted source, but subsequent release
+  rehearsal repairs on `dev` supersede it; repeat the promotion from the final
+  green preview SHA.
 
 ### 5. Prove 0.90.2
 

--- a/scripts/guardian/prod-ports.mjs
+++ b/scripts/guardian/prod-ports.mjs
@@ -86,7 +86,9 @@ export async function planProdPorts(
   config,
   options = {},
 ) {
-  const probe = options.probe ?? probeFreePort
+  const probe = options.probe ?? ((start, max) => probeFreePort(start, max, {
+    createServerImpl: options.createServerImpl,
+  }))
   const claim = async (name, choice, probeStart) => {
     if (choice.source === 'default') return probe(probeStart)
     try {
@@ -120,22 +122,33 @@ export async function planProdPorts(
   return { web, mcp, uta, connector }
 }
 
-async function probeFreePort(start, max = 65_535) {
+async function probeFreePort(start, max = 65_535, options = {}) {
   for (let port = start; port <= max; port += 1) {
-    if (await canListen(port)) return port
+    if (await canListen(port, options)) return port
   }
   throw new Error(
     `[guardian/prod] no free loopback port available from ${start} to ${max}`,
   )
 }
 
-function canListen(port) {
+function canListen(port, options = {}) {
   return new Promise((resolveResult) => {
-    const server = createServer()
+    const createServerImpl = options.createServerImpl ?? createServer
+    const server = createServerImpl((socket) => {
+      // A readiness client can race this temporary listener. Reject it so
+      // server.close() never waits on a non-HTTP probe connection.
+      socket.destroy()
+    })
+    let settled = false
+    const finish = (available) => {
+      if (settled) return
+      settled = true
+      resolveResult(available)
+    }
     server.unref()
-    server.once('error', () => resolveResult(false))
+    server.once('error', () => finish(false))
     server.listen(port, '127.0.0.1', () => {
-      server.close(() => resolveResult(true))
+      server.close(() => finish(true))
     })
   })
 }

--- a/scripts/guardian/prod-ports.spec.ts
+++ b/scripts/guardian/prod-ports.spec.ts
@@ -55,6 +55,58 @@ describe('built Guardian port planning', () => {
     )
   })
 
+  it('does not stall port planning when a client connects to the temporary probe', async () => {
+    const acceptedSockets: Array<{ destroy: ReturnType<typeof vi.fn> }> = []
+    const createServerImpl = vi.fn((onConnection: (
+      socket: { destroy: ReturnType<typeof vi.fn> },
+    ) => void) => {
+      const socket = { destroy: vi.fn() }
+      acceptedSockets.push(socket)
+      return {
+        unref: vi.fn(),
+        once: vi.fn(),
+        listen: vi.fn((
+          _port: number,
+          _host: string,
+          onListening: () => void,
+        ) => onListening()),
+        close: vi.fn((onClose: () => void) => {
+          onConnection(socket)
+          if (socket.destroy.mock.calls.length > 0) onClose()
+        }),
+      }
+    })
+    const config = resolveProdPortConfig({
+      OPENALICE_WEB_PORT: '49123',
+      OPENALICE_MCP_PORT: '49124',
+    }, {})
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const stalled = new Promise<'stalled'>((resolveResult) => {
+      timeout = setTimeout(() => resolveResult('stalled'), 50)
+    })
+
+    const result = await Promise.race([
+      planProdPorts(config, {
+        createServerImpl,
+        skipUta: true,
+        skipConnector: true,
+      }),
+      stalled,
+    ])
+    if (timeout !== undefined) clearTimeout(timeout)
+
+    expect(result).toEqual({
+      web: 49123,
+      mcp: 49124,
+      uta: 47333,
+      connector: 47334,
+    })
+    expect(acceptedSockets).toHaveLength(2)
+    expect(acceptedSockets.every((socket) => (
+      socket.destroy.mock.calls.length === 1
+    ))).toBe(true)
+  })
+
   it('reads and validates the persisted port file', async () => {
     await expect(readProdPortsFile('/test-home', {
       readFileImpl: async () => '{"web":49123,"connector":49126}',


### PR DESCRIPTION
## Summary
- reject accidental readiness clients accepted by the temporary production port probe
- prevent probe completion from settling twice
- add deterministic coverage for a client connecting during probe shutdown
- record why the final 0.90.2 source must be re-promoted

## Verification
- `pnpm exec vitest run scripts/guardian/prod-ports.spec.ts`
- `npx tsc --noEmit`
- Guardian recovery skill fast and full matrices
- `pnpm test` (5188 passed, 9 skipped)
- `pnpm build:server`
- `pnpm build:bun-runtime:feasibility`
- `pnpm build:bun:release`
- `pnpm test:install:docker`
- `git diff --check`

## Boundary touch
- Guardian production startup and native CLI packaging

## Non-goals
- no lock/takeover ordering changes
- no readiness timeout or retry-policy expansion