### PR TITLE
Promote repaired 0.90.2 source to master

### DIFF
--- a/plans/release-channels-0.90.2.md
+++ b/plans/release-channels-0.90.2.md
@@ -169,6 +169,15 @@ appropriate.
   immediately after its four native packaging jobs; full release checks remain
   on beta/stable, while PR and local lanes provide earlier feedback without
   becoming a publication dependency.
+- The first beta version rehearsal exposed stable-only version specs that had
+  relied on the old implicit release selection. Those fixtures now select the
+  stable channel explicitly and also exercise equal-current beta semantics.
+- Two same-SHA native preview attempts stalled before Guardian printed its
+  startup banner even though their reruns passed. The temporary production port
+  probe could accept an HTTP readiness connection and then wait forever for
+  that non-HTTP socket while closing. The probe now rejects accidental clients
+  immediately; the repaired `dev` source must complete preview and promotion
+  again before either 0.90.2 tag is attempted.
 
 ## Work Plan
 
@@ -221,7 +230,9 @@ appropriate.
   publication plus live installer path (PR #1257; `CLI Installer Smoke`
   run `33311979583`).
 - [ ] Promote the accepted `dev` source to `master` under the full promotion
-  gate.
+  gate. PR #1259 promoted the first accepted source, but subsequent release
+  rehearsal repairs on `dev` supersede it; repeat the promotion from the final
+  green preview SHA.
 
 ### 5. Prove 0.90.2
 

--- a/scripts/guardian/prod-ports.mjs
+++ b/scripts/guardian/prod-ports.mjs
@@ -86,7 +86,9 @@ export async function planProdPorts(
   config,
   options = {},
 ) {
-  const probe = options.probe ?? probeFreePort
+  const probe = options.probe ?? ((start, max) => probeFreePort(start, max, {
+    createServerImpl: options.createServerImpl,
+  }))
   const claim = async (name, choice, probeStart) => {
     if (choice.source === 'default') return probe(probeStart)
     try {
@@ -120,22 +122,33 @@ export async function planProdPorts(
   return { web, mcp, uta, connector }
 }
 
-async function probeFreePort(start, max = 65_535) {
+async function probeFreePort(start, max = 65_535, options = {}) {
   for (let port = start; port <= max; port += 1) {
-    if (await canListen(port)) return port
+    if (await canListen(port, options)) return port
   }
   throw new Error(
     `[guardian/prod] no free loopback port available from ${start} to ${max}`,
   )
 }
 
-function canListen(port) {
+function canListen(port, options = {}) {
   return new Promise((resolveResult) => {
-    const server = createServer()
+    const createServerImpl = options.createServerImpl ?? createServer
+    const server = createServerImpl((socket) => {
+      // A readiness client can race this temporary listener. Reject it so
+      // server.close() never waits on a non-HTTP probe connection.
+      socket.destroy()
+    })
+    let settled = false
+    const finish = (available) => {
+      if (settled) return
+      settled = true
+      resolveResult(available)
+    }
     server.unref()
-    server.once('error', () => resolveResult(false))
+    server.once('error', () => finish(false))
     server.listen(port, '127.0.0.1', () => {
-      server.close(() => resolveResult(true))
+      server.close(() => finish(true))
     })
   })
 }

--- a/scripts/guardian/prod-ports.spec.ts
+++ b/scripts/guardian/prod-ports.spec.ts
@@ -55,6 +55,58 @@ describe('built Guardian port planning', () => {
     )
   })
 
+  it('does not stall port planning when a client connects to the temporary probe', async () => {
+    const acceptedSockets: Array<{ destroy: ReturnType<typeof vi.fn> }> = []
+    const createServerImpl = vi.fn((onConnection: (
+      socket: { destroy: ReturnType<typeof vi.fn> },
+    ) => void) => {
+      const socket = { destroy: vi.fn() }
+      acceptedSockets.push(socket)
+      return {
+        unref: vi.fn(),
+        once: vi.fn(),
+        listen: vi.fn((
+          _port: number,
+          _host: string,
+          onListening: () => void,
+        ) => onListening()),
+        close: vi.fn((onClose: () => void) => {
+          onConnection(socket)
+          if (socket.destroy.mock.calls.length > 0) onClose()
+        }),
+      }
+    })
+    const config = resolveProdPortConfig({
+      OPENALICE_WEB_PORT: '49123',
+      OPENALICE_MCP_PORT: '49124',
+    }, {})
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const stalled = new Promise<'stalled'>((resolveResult) => {
+      timeout = setTimeout(() => resolveResult('stalled'), 50)
+    })
+
+    const result = await Promise.race([
+      planProdPorts(config, {
+        createServerImpl,
+        skipUta: true,
+        skipConnector: true,
+      }),
+      stalled,
+    ])
+    if (timeout !== undefined) clearTimeout(timeout)
+
+    expect(result).toEqual({
+      web: 49123,
+      mcp: 49124,
+      uta: 47333,
+      connector: 47334,
+    })
+    expect(acceptedSockets).toHaveLength(2)
+    expect(acceptedSockets.every((socket) => (
+      socket.destroy.mock.calls.length === 1
+    ))).toBe(true)
+  })
+
   it('reads and validates the persisted port file', async () => {
     await expect(readProdPortsFile('/test-home', {
       readFileImpl: async () => '{"web":49123,"connector":49126}',

--- a/src/core/version.spec.ts
+++ b/src/core/version.spec.ts
@@ -100,7 +100,7 @@ describe('fetchLatestRelease (mocked fetch)', () => {
       ]),
     }) as unknown as typeof fetch
 
-    const { result } = await fetchLatestRelease()
+    const { result } = await fetchLatestRelease({ channel: 'stable' })
     expect(result?.version).toBe('1.0.0') // first non-draft
   })
 
@@ -218,7 +218,7 @@ describe('getVersionInfo', () => {
       }]),
     }) as unknown as typeof fetch
 
-    const info = await getVersionInfo()
+    const info = await getVersionInfo({ channel: 'stable' })
     expect(info.latest).toBe('999.999.999')
     expect(info.hasUpdate).toBe(true)
     expect(info.error).toBeNull()
@@ -226,13 +226,16 @@ describe('getVersionInfo', () => {
 
   it('reports hasUpdate=false when latest = current', async () => {
     const current = getCurrentVersion()
+    const isBeta = /-beta(?:\.|$)/i.test(current)
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true, status: 200, statusText: 'OK',
-      json: async () => ([{ tag_name: current, html_url: 'x', body: '', published_at: '', draft: false, prerelease: false }]),
+      json: async () => ([{ tag_name: current, html_url: 'x', body: '', published_at: '', draft: false, prerelease: isBeta }]),
     }) as unknown as typeof fetch
 
     const info = await getVersionInfo()
+    expect(info.latest).toBe(current)
     expect(info.hasUpdate).toBe(false)
+    expect(info.error).toBeNull()
   })
 
   it('returns error when GitHub fetch fails', async () => {


### PR DESCRIPTION
## Summary
- promote the final 0.90.2 source after channel-explicit version test repair
- include the Guardian production-port probe race fix discovered during native preview acceptance
- supersede the earlier master source before any beta tag or Release exists

## Included increments
- PR #1260: make release-version tests channel-explicit
- PR #1261: reject accidental clients during Guardian port availability probing

## Verification
- local `npx tsc --noEmit` and full `pnpm test` (5188 passed, 9 skipped)
- Guardian recovery fast/full matrices and real dev startup smoke
- local Bun multiprocess Runtime and installed native release smoke
- OrbStack Debian installer smoke
- post-merge dev CI: https://github.com/TraderAlice/OpenAlice/actions/runs/33315441530
- four-platform dev native publication and live raw installer: https://github.com/TraderAlice/OpenAlice/actions/runs/33315441531

## Boundary touch
- release validation and Guardian/native CLI startup

## Non-goals
- no product version bump
- no tag, GitHub Release, or public stable/beta publication