### PR TITLE
Prepare OpenAlice 0.90.2 beta 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.90.1",
+  "version": "0.90.2-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.90.1",
+  "version": "0.90.2-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- set the root product version to `0.90.2-beta.1`
- set the native CLI package version to the same release authority
- prepare the exact master candidate for manual `beta` + `v0.90.2-beta.1` dispatch

## Verification
- `pnpm install --frozen-lockfile`
- release/channel targeted tests: 33 passed
- `npx tsc --noEmit`
- `pnpm test`: 5188 passed, 9 skipped (first run hit the known Guardian heartbeat-directory teardown race; targeted 15/15 and full rerun passed)
- `pnpm build:server`
- local `pnpm build:bun:release`: `0.90.2-beta.1`, installed Runtime/UI/PTY smoke passed
- promotion source PR #1262 completed all CI, CLI, Desktop, Broker Pack, and Docker gates

## Boundary touch
- release version authority only

## Non-goals
- no implementation or workflow changes
- no tag, GitHub Release, mirror, or package-manager publication in this PR