### PR TITLE
chore(release): prepare v0.90.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.90.2-beta.1",
+  "version": "0.90.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.90.2-beta.1",
+  "version": "0.90.2",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- promote the accepted 0.90.2 beta candidate to the stable version identity
- synchronize the root and native CLI package versions at 0.90.2
- leave source code and the lockfile unchanged

## Accepted beta evidence

- v0.90.2-beta.1 targets master SHA 73bacc737856a17fb45edde32026c3c3eafbaaa0
- GitHub prerelease contains the expected 49 desktop, CLI, installer, and Broker Pack assets
- signed desktop candidates, macOS notarization, three-platform N-1 upgrades, four native CLI candidates, installer cutover, and four-platform Broker Pack upgrades passed
- R2 beta manifest and updater feeds were verified; six stable feed files and five stable aliases remained unchanged
- a fresh external beta install reported 0.90.2-beta.1, update status current, started the Bun Runtime to Alice ready, stopped, and uninstalled cleanly

## Local stable verification

- release/channel contract specs: 52 passed
- npx tsc --noEmit
- pnpm test: 5188 passed, 9 skipped
- pnpm build:server
- pnpm build:bun:release: 0.90.2 darwin-arm64 archive passed external Runtime, UI, PTY, Git, and agent-process smoke

After all synchronous master gates pass, merge this version-only PR and dispatch the manual stable release for tag v0.90.2. External npm, Homebrew, and AUR publication switches remain disabled.