### PR TITLE
fix(release): bound desktop upgrade smoke tags

### DIFF
--- a/plans/release-channels-0.90.2.md
+++ b/plans/release-channels-0.90.2.md
@@ -155,6 +155,12 @@ appropriate.
 - Stable N-1 acceptance and release notes must select the previous stable tag,
   not the latest tag of any kind; otherwise a beta immediately before stable
   would reduce the only stable upgrade proof to beta-to-stable.
+- The first stable version PR after publishing beta correctly used the newest
+  published app, `v0.90.2-beta.1`, for its ordinary package smoke, but the
+  derived temporary Workspace tag exceeded the product's 33-character limit.
+  Smoke Workspace tags are now bounded so both beta-to-stable PR acceptance and
+  future numbered-beta release acceptance can exercise the real product path.
+  The formal Release workflow still supplies its explicit same-channel N-1 tag.
 - The Windows failure observed on the earlier workflow PR predates the release
   change: three real `npm pack` subprocesses exceeded Vitest's default five
   seconds. That integration test now has an explicit 30-second timeout; the
@@ -229,19 +235,20 @@ appropriate.
 - [x] Merge the serial PR to `dev` and verify the post-merge dev-channel
   publication plus live installer path (PR #1257; `CLI Installer Smoke`
   run `33311979583`).
-- [ ] Promote the accepted `dev` source to `master` under the full promotion
-  gate. PR #1259 promoted the first accepted source, but subsequent release
-  rehearsal repairs on `dev` supersede it; repeat the promotion from the final
-  green preview SHA.
+- [x] Promote the accepted `dev` source to `master` under the full promotion
+  gate. PR #1262 promoted final preview SHA `7b730d6c` after the Guardian port
+  probe repair; all promotion lanes passed before the beta version-only PR.
 
 ### 5. Prove 0.90.2
 
-- [ ] Set both product package versions to `0.90.2-beta.1` on the release
-  source and dispatch `beta` + `v0.90.2-beta.1`.
-- [ ] Verify the GitHub prerelease, expected assets, beta updater feeds,
-  beta CLI manifest, shared installer, and unchanged stable product aliases.
-- [ ] Record any beta fix on `dev`, promote it normally, and repeat beta only if
-  the accepted source changes materially.
+- [x] Set both product package versions to `0.90.2-beta.1` on the release
+  source and dispatch `beta` + `v0.90.2-beta.1` (PR #1264; Release workflow
+  `33317533910`).
+- [x] Verify the GitHub prerelease and all 49 assets, beta updater feeds, beta
+  CLI manifest, shared installer, a clean external install/Runtime/uninstall,
+  and byte-for-byte unchanged stable feeds and download aliases.
+- [ ] Merge the bounded Workspace-tag repair to `dev`, promote it normally, and
+  refresh the stable version-only PR #1265 from the repaired `master` source.
 - [ ] Set both product package versions to `0.90.2`, dispatch `stable` +
   `v0.90.2`, and verify GitHub, updater, CDN, installer, Broker Pack, and opted-in
   package-manager publication evidence.

--- a/scripts/desktop-upgrade-smoke-lib.mjs
+++ b/scripts/desktop-upgrade-smoke-lib.mjs
@@ -10,6 +10,15 @@ export function selectPreviousDesktopTag(tags, candidateVersion) {
   return tags.find((tag) => versionFromTag(tag) !== candidateVersion) ?? null
 }
 
+export function desktopUpgradeWorkspaceTags(previousVersion) {
+  const slug = previousVersion
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase() || 'release'
+  const tag = `upgrade-${slug}`.slice(0, 28)
+  return { tag, postUpgradeTag: `${tag}-post` }
+}
+
 export function previousDesktopAssetName(version, platform, arch) {
   if (platform === 'darwin') {
     return arch === 'arm64'

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -8,6 +8,7 @@ import {
   buildUpgradeSeedExpression,
   buildUpgradeVerifyExpression,
   candidateDesktopAssetName,
+  desktopUpgradeWorkspaceTags,
   previousDesktopAssetName,
   selectPreviousDesktopTag,
   windowsInstallerArgs,
@@ -40,6 +41,16 @@ describe('desktop upgrade smoke planning', () => {
       '0.88.0-beta',
     )).toBe('v0.87.0-beta')
     expect(selectPreviousDesktopTag(['v0.88.0-beta'], '0.88.0-beta')).toBeNull()
+  })
+
+  it('keeps seeded Workspace tags valid for numbered beta releases', () => {
+    const tags = desktopUpgradeWorkspaceTags('0.90.2-beta.123456789')
+    expect(tags).toEqual({
+      tag: 'upgrade-0-90-2-beta-12345678',
+      postUpgradeTag: 'upgrade-0-90-2-beta-12345678-post',
+    })
+    expect(tags.tag).toMatch(/^[a-z0-9][a-z0-9_-]{0,32}$/)
+    expect(tags.postUpgradeTag).toMatch(/^[a-z0-9][a-z0-9_-]{0,32}$/)
   })
 
   it('maps native release artifacts by host architecture', () => {

--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -24,6 +24,7 @@ import {
   buildUpgradeVerifyExpression,
   candidateDesktopAssetName,
   DESKTOP_UPGRADE_RECEIPT_SCHEMA_VERSION,
+  desktopUpgradeWorkspaceTags,
   previousDesktopAssetName,
   selectPreviousDesktopTag,
   versionFromTag,
@@ -454,8 +455,7 @@ async function main() {
       OPENALICE_UTA_DISABLED: '1',
     }
     delete commonEnv.OPENALICE_TAKEOVER
-    const tag = `desktop-upgrade-${previousVersion.replace(/[^a-z0-9]+/gi, '-').toLowerCase()}`
-    const postUpgradeTag = `${tag}-post`
+    const { tag, postUpgradeTag } = desktopUpgradeWorkspaceTags(previousVersion)
     const sentinelKey = 'openalice-desktop-upgrade-smoke'
     const sentinelValue = `${fromTag}->${candidateVersion}`
 


### PR DESCRIPTION
## What changed

- derive desktop upgrade smoke Workspace tags through one bounded helper
- keep both the seeded and post-upgrade tags within the product 33-character contract
- record the beta completion and stable-PR discovery in the active 0.90.2 plan

## Why

Stable version PR #1265 packaged and launched successfully on both macOS runners, then deterministically failed when its beta-to-stable smoke generated `desktop-upgrade-0-90-2-beta-1-post`, which the real Workspace API correctly rejected as `invalid_tag`. This repairs the test fixture rather than weakening the product contract. Formal Release same-channel N-1 selection remains unchanged.

## Local verification

- `git diff --check`
- `node --check scripts/desktop-upgrade-smoke-lib.mjs`
- `node --check scripts/desktop-upgrade-smoke.mjs`
- `pnpm exec vitest run scripts/desktop-upgrade-smoke-lib.spec.ts scripts/release-workflow.spec.ts` — 21 passed
- `npx tsc --noEmit`
- `pnpm test` — 5189 passed, 9 skipped