### PR TITLE
fix(release): publish GitHub-safe AUR metadata asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -957,6 +957,13 @@ jobs:
           name: cli-package-channels
           path: dist/release-cli-packages
 
+      - name: Stage GitHub-safe AUR metadata asset
+        if: needs.release.outputs.channel == 'stable'
+        run: >-
+          cp
+          dist/release-cli-packages/cli-package-channels/aur/.SRCINFO
+          dist/release-cli-packages/cli-package-channels/aur/openalice-bin.SRCINFO
+
       - name: Create beta tag and GitHub prerelease from accepted candidates
         if: needs.release.outputs.channel == 'beta'
         uses: softprops/action-gh-release@v2
@@ -1007,7 +1014,7 @@ jobs:
             dist/release-cli-packages/cli-package-channels/cli-package-channels.json
             dist/release-cli-packages/cli-package-channels/homebrew/openalice.rb
             dist/release-cli-packages/cli-package-channels/aur/PKGBUILD
-            dist/release-cli-packages/cli-package-channels/aur/.SRCINFO
+            dist/release-cli-packages/cli-package-channels/aur/openalice-bin.SRCINFO
             dist/release-cli-packages/cli-npm-tarballs/*.tgz
             dist/release-cli-packages/cli-npm-tarballs/npm-publish-order.json
 
@@ -1082,12 +1089,12 @@ jobs:
             --pattern cli-package-channels.json \
             --pattern openalice.rb \
             --pattern PKGBUILD \
-            --pattern .SRCINFO \
+            --pattern openalice-bin.SRCINFO \
             --pattern npm-publish-order.json
           cmp dist/cli-package-channels/cli-package-channels/cli-package-channels.json dist/public-cli-channels/cli-package-channels.json
           cmp dist/cli-package-channels/cli-package-channels/homebrew/openalice.rb dist/public-cli-channels/openalice.rb
           cmp dist/cli-package-channels/cli-package-channels/aur/PKGBUILD dist/public-cli-channels/PKGBUILD
-          cmp dist/cli-package-channels/cli-package-channels/aur/.SRCINFO dist/public-cli-channels/.SRCINFO
+          cmp dist/cli-package-channels/cli-package-channels/aur/.SRCINFO dist/public-cli-channels/openalice-bin.SRCINFO
           cmp dist/cli-package-channels/cli-npm-tarballs/npm-publish-order.json dist/public-cli-channels/npm-publish-order.json
 
       - name: Preserve public channel verification receipt

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -100,10 +100,13 @@ public.
 For every non-prerelease, the release workflow first downloads all four
 archives anonymously from their final public GitHub Release URLs and verifies
 their bytes plus public SHA-256 sidecars against the accepted channel manifest.
-It then downloads the public formula, `PKGBUILD`, `.SRCINFO`, and npm publish
-order and compares them byte-for-byte with the preserved publication inputs. A
-30-day verification receipt is retained. npm, Tap, and AUR publication all
-depend on that receipt; none can publish from a private Actions artifact alone.
+It then downloads the public formula, `PKGBUILD`, `openalice-bin.SRCINFO`, and
+npm publish order and compares them byte-for-byte with the preserved publication
+inputs. GitHub Release assets cannot retain a leading-dot filename, so the
+public `openalice-bin.SRCINFO` asset is the exact byte-for-byte copy that is
+installed as `.SRCINFO` in the AUR repository. A 30-day verification receipt is
+retained. npm, Tap, and AUR publication all depend on that receipt; none can
+publish from a private Actions artifact alone.
 
 External channels are explicit release switches:
 

--- a/plans/release-channels-0.90.2.md
+++ b/plans/release-channels-0.90.2.md
@@ -12,10 +12,12 @@ Related owner guides:
 ## Goal
 
 Separate source integration from product publication, then prove the new
-contract by releasing the same accepted 0.90.2 line first as beta and later as
-stable. Existing Bun/native CLI work already present in `dev` remains part of
-the candidate, but this plan does not introduce another Bun architecture or
-packaging redesign.
+contract by releasing a 0.90.2 beta checkpoint, continuing ordinary fixes on
+`dev`, and later releasing the accepted stable checkpoint. A beta may be
+promoted unchanged when it needs no repair, but beta and stable are independent
+release intents rather than two labels emitted from one build. Existing
+Bun/native CLI work already present in `dev` remains part of the candidate, but
+this plan does not introduce another Bun architecture or packaging redesign.
 
 ## Scope
 
@@ -48,6 +50,12 @@ this release line.
 human-promoted release source, but merging to `master` does not publish. A
 maintainer manually dispatches the workflow from the exact `master` commit and
 supplies both a channel and tag.
+
+Beta is a public test checkpoint, not the stable artifact produced early. After
+`beta.1`, fixes continue on `dev`, pass the normal promotion gate, and may become
+`beta.2` before a later stable intent. Stable therefore builds from the latest
+accepted `master`; it may have the same source as the last beta only when no
+intervening fix was needed.
 
 ### Channel and version are one contract
 
@@ -184,6 +192,12 @@ appropriate.
   that non-HTTP socket while closing. The probe now rejects accidental clients
   immediately; the repaired `dev` source must complete preview and promotion
   again before either 0.90.2 tag is attempted.
+- GitHub Release does not retain a leading-dot asset name: uploading the AUR
+  `.SRCINFO` exposed it as `default.SRCINFO`, so the final public metadata
+  receipt could not download the requested name even though the accepted and
+  public bytes matched. Release publication now stages an exact copy as
+  `openalice-bin.SRCINFO` for GitHub while AUR activation continues to install
+  the accepted source file as the standard repository-local `.SRCINFO`.
 
 ## Work Plan
 
@@ -247,11 +261,19 @@ appropriate.
 - [x] Verify the GitHub prerelease and all 49 assets, beta updater feeds, beta
   CLI manifest, shared installer, a clean external install/Runtime/uninstall,
   and byte-for-byte unchanged stable feeds and download aliases.
-- [ ] Merge the bounded Workspace-tag repair to `dev`, promote it normally, and
+- [x] Merge the bounded Workspace-tag repair to `dev`, promote it normally, and
   refresh the stable version-only PR #1265 from the repaired `master` source.
-- [ ] Set both product package versions to `0.90.2`, dispatch `stable` +
-  `v0.90.2`, and verify GitHub, updater, CDN, installer, Broker Pack, and opted-in
-  package-manager publication evidence.
+- [x] Set both product package versions to `0.90.2`, dispatch `stable` +
+  `v0.90.2`, and publish the accepted GitHub Release plus R2 mirrors from exact
+  source `cb199051` (Release workflow `33322819923`).
+- [x] Independently verify GitHub, updater, CDN, installer, and Broker Pack
+  surfaces, including a clean native install/Runtime/uninstall and unchanged
+  beta manifest/feeds. npm, Homebrew, and AUR activation remain intentionally
+  disabled until their external publication authority exists.
+- [ ] Merge the GitHub-safe `.SRCINFO` public asset-name repair. The original
+  workflow remains honestly red at its final metadata-name comparison; after
+  renaming that same public asset, a recovery check compared all five public
+  metadata files byte-for-byte with run `33322819923`'s accepted artifact.
 
 ## Completion Criteria
 

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -272,6 +272,7 @@ describe('Release workflow critical path', () => {
 
   it('verifies public release bytes before activating external package channels', () => {
     const verify = workflow.jobs['verify-public-cli-channels']
+    const publication = workflow.jobs['publish-release']
     expect(needs(verify)).toEqual([
       'release',
       'publish-release',
@@ -282,6 +283,36 @@ describe('Release workflow critical path', () => {
       .toContain('verify-public-cli-channels.mjs')
     expect(step(verify, 'Compare public metadata with the accepted publication inputs').run)
       .toContain('cmp dist/cli-package-channels/cli-package-channels/homebrew/openalice.rb')
+    const stageSrcinfo = step(publication, 'Stage GitHub-safe AUR metadata asset')
+    expect(stageSrcinfo.if).toBe("needs.release.outputs.channel == 'stable'")
+    expect(stageSrcinfo.run).toContain(
+      'aur/.SRCINFO dist/release-cli-packages/cli-package-channels/aur/openalice-bin.SRCINFO',
+    )
+    const stableFiles = step(
+      publication,
+      'Create stable tag and GitHub Release from accepted candidates',
+    ).with?.files
+    const betaFiles = step(
+      publication,
+      'Create beta tag and GitHub prerelease from accepted candidates',
+    ).with?.files
+    expect(stableFiles).toContain('aur/openalice-bin.SRCINFO')
+    expect(stableFiles).not.toContain('aur/.SRCINFO')
+    expect(betaFiles).not.toContain('openalice-bin.SRCINFO')
+    expect(betaFiles).not.toContain('aur/.SRCINFO')
+
+    const acceptedInputs = step(
+      workflow.jobs['build-cli-package-channels'],
+      'Preserve package-manager publication inputs',
+    )
+    expect(acceptedInputs.with?.path).toContain('aur/.SRCINFO')
+    expect(acceptedInputs.with?.path).not.toContain('openalice-bin.SRCINFO')
+    expect(acceptedInputs.with?.['include-hidden-files']).toBe(true)
+
+    const compare = step(verify, 'Compare public metadata with the accepted publication inputs').run ?? ''
+    expect(compare).toContain('--pattern openalice-bin.SRCINFO')
+    expect(compare).toContain('aur/.SRCINFO dist/public-cli-channels/openalice-bin.SRCINFO')
+    expect(compare).not.toContain('--pattern .SRCINFO')
 
     const homebrew = workflow.jobs['publish-cli-homebrew']
     expect(needs(homebrew)).toContain('verify-public-cli-channels')
@@ -299,8 +330,12 @@ describe('Release workflow critical path', () => {
     const aurCheckout = step(aur, 'Check out the AUR package repository').run ?? ''
     expect(aurCheckout).toContain('AUR_KNOWN_HOSTS')
     expect(aurCheckout).not.toContain('ssh-keyscan')
-    expect(step(aur, 'Activate the verified package metadata in AUR').run)
-      .toContain('git diff --cached --quiet')
+    const activateAur = step(aur, 'Activate the verified package metadata in AUR').run ?? ''
+    expect(activateAur).toContain(
+      'dist/cli-package-channels/cli-package-channels/aur/.SRCINFO aur/.SRCINFO',
+    )
+    expect(activateAur).not.toContain('openalice-bin.SRCINFO')
+    expect(activateAur).toContain('git diff --cached --quiet')
   })
 
   it('keeps beta mirrors away from stable aliases', () => {


### PR DESCRIPTION
## Summary
- stage the accepted AUR `.SRCINFO` under the explicit GitHub Release asset name `openalice-bin.SRCINFO`
- compare that public alias byte-for-byte with the accepted internal `.SRCINFO` while preserving the standard AUR repository filename
- record the 0.90.2 stable publication, external acceptance, and beta/stable checkpoint semantics

## Evidence
- `pnpm exec vitest run scripts/cli-release-fixture.spec.mjs scripts/build-cli-package-channels.spec.mjs scripts/pack-cli-npm-packages.spec.mjs scripts/release-workflow.spec.ts packages/cli/src/package-manager.spec.mjs` (27/27)
- `npx tsc --noEmit`
- `pnpm test` (5189 passed, 9 skipped)
- recovery compare: all five public metadata assets equal the accepted `cli-package-channels` artifact from release run 33322819923

The original 0.90.2 workflow remains red at its final old-name comparison; this repairs future stable publications rather than rewriting historical evidence.