### PR TITLE
Prepare OpenAlice 0.91.0 beta 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.90.2",
+  "version": "0.91.0-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.90.2",
+  "version": "0.91.0-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- set the root product version to `0.91.0-beta.1`
- set the native CLI package version to the same release authority
- prepare exact promoted master source `e49a57c3` for a later manual **beta-only** `v0.91.0-beta.1` dispatch

## Verification

- release/channel targeted tests: 48 passed
- `npx tsc --noEmit`
- `pnpm test`: 5189 passed, 9 skipped
- prior local `pnpm build:bun:release`: version `0.91.0-beta.1`, Runtime/UI/PTY smoke passed, content identity `f6967eab9c38eee9`; the intervening promotion changed test files only
- source promotion PR #1273 completed CI, CLI Installer, Desktop, Docker, and Windows cross-platform gates
- exact dev preview `f4843a8a` published four native targets and passed the live raw `dev/install` path

## Boundary

- diff remains exactly `package.json#/version` and `packages/cli/package.json#/version`
- no implementation or workflow changes
- no tag, GitHub Release, mirror, stable publication, or package-manager activation in this PR

## Channel intent

This prepares beta only. It does not emit stable in the same run. Stable remains a separate later release intent after beta testing; intervening `dev` fixes may be promoted before that decision.