### PR TITLE
Promote repaired dev to master for v0.91.0-beta.1

### DIFF
--- a/apps/desktop/src/probe-port.spec.ts
+++ b/apps/desktop/src/probe-port.spec.ts
@@ -1,48 +1,75 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { createServer, type Server } from 'node:net'
+import { createServer, type AddressInfo, type Server } from 'node:net'
 import { probeFreePort } from './probe-port.js'
 
-async function holdPort(port: number): Promise<Server> {
+async function listen(port: number = 0): Promise<Server> {
   return new Promise((resolve, reject) => {
     const srv = createServer()
     srv.once('error', reject)
     srv.once('listening', () => resolve(srv))
-    srv.listen(port, '127.0.0.1')
+    srv.listen(port)
   })
+}
+
+function boundPort(server: Server): number {
+  return (server.address() as AddressInfo).port
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
+
+async function reserveConsecutivePorts(count: number): Promise<{ start: number; servers: Server[] }> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const servers: Server[] = []
+    try {
+      const first = await listen()
+      servers.push(first)
+      const start = boundPort(first)
+      if (start + count - 1 > 65_535) throw new Error('dynamic range crosses port limit')
+      for (let offset = 1; offset < count; offset++) {
+        servers.push(await listen(start + offset))
+      }
+      return { start, servers }
+    } catch {
+      await Promise.all(servers.map(close))
+    }
+  }
+  throw new Error(`could not reserve ${count} consecutive dynamic ports`)
 }
 
 describe('probeFreePort', () => {
   const held: Server[] = []
 
   afterEach(async () => {
-    await Promise.all(held.splice(0).map((s) => new Promise<void>((r) => s.close(() => r()))))
+    await Promise.all(held.splice(0).map(close))
   })
 
-  it('returns the starting port when it is free', async () => {
-    // Use a high random port unlikely to collide on CI / dev machines.
-    const port = await probeFreePort(48732, 48732 + 10)
-    expect(port).toBe(48732)
+  it('returns a dynamically allocated starting port when it is free', async () => {
+    const { start, servers } = await reserveConsecutivePorts(1)
+    await close(servers[0]!)
+    expect(await probeFreePort(start, start)).toBe(start)
   })
 
   it('falls back to the next port when the starting port is taken', async () => {
-    const srv = await holdPort(48800)
-    held.push(srv)
-    const port = await probeFreePort(48800, 48800 + 10)
-    expect(port).toBe(48801)
+    const { start, servers } = await reserveConsecutivePorts(2)
+    held.push(servers[0]!)
+    await close(servers[1]!)
+    expect(await probeFreePort(start, start + 1)).toBe(start + 1)
   })
 
   it('skips consecutive occupied ports', async () => {
-    held.push(await holdPort(48810))
-    held.push(await holdPort(48811))
-    held.push(await holdPort(48812))
-    const port = await probeFreePort(48810, 48810 + 10)
-    expect(port).toBe(48813)
+    const { start, servers } = await reserveConsecutivePorts(4)
+    held.push(...servers.slice(0, 3))
+    await close(servers[3]!)
+    expect(await probeFreePort(start, start + 3)).toBe(start + 3)
   })
 
   it('throws when no port in range is available', async () => {
-    held.push(await holdPort(48820))
-    held.push(await holdPort(48821))
-    held.push(await holdPort(48822))
-    await expect(probeFreePort(48820, 48822)).rejects.toThrow(/no free port/)
+    const { start, servers } = await reserveConsecutivePorts(3)
+    held.push(...servers)
+    await expect(probeFreePort(start, start + 2)).rejects.toThrow(/no free port/)
   })
 })

--- a/scripts/probe-port.spec.ts
+++ b/scripts/probe-port.spec.ts
@@ -1,20 +1,16 @@
-import { createServer, type Server } from 'node:net'
+import { createServer, type AddressInfo, type Server } from 'node:net'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { probeFreePort } from './probe-port.js'
 
-// High, unlikely-to-collide base; each test offsets to stay independent.
-const BASE = 28460
-
 let held: Server[] = []
 
-function hold(port: number, host?: string): Promise<Server> {
+function listen(port: number = 0, host?: string): Promise<Server> {
   return new Promise((res, rej) => {
     const srv = createServer()
     srv.once('error', rej)
     srv.once('listening', () => {
-      held.push(srv)
       res(srv)
     })
     if (host === undefined) srv.listen(port) // node default — wildcard, dual-stack
@@ -22,19 +18,55 @@ function hold(port: number, host?: string): Promise<Server> {
   })
 }
 
+function boundPort(server: Server): number {
+  return (server.address() as AddressInfo).port
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
+
+async function reserveConsecutivePorts(
+  count: number,
+  firstHost?: string,
+): Promise<{ start: number; servers: Server[] }> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const servers: Server[] = []
+    try {
+      const first = await listen(0, firstHost)
+      servers.push(first)
+      const start = boundPort(first)
+      if (start + count - 1 > 65_535) throw new Error('dynamic range crosses port limit')
+      for (let offset = 1; offset < count; offset++) {
+        servers.push(await listen(start + offset))
+      }
+      return { start, servers }
+    } catch {
+      await Promise.all(servers.map(close))
+    }
+  }
+  throw new Error(`could not reserve ${count} consecutive dynamic ports`)
+}
+
 afterEach(async () => {
-  await Promise.all(held.map((s) => new Promise((r) => s.close(r))))
+  await Promise.all(held.map(close))
   held = []
 })
 
 describe('probeFreePort', () => {
   it('returns the start port when it is genuinely free', async () => {
-    expect(await probeFreePort(BASE)).toBe(BASE)
+    const { start, servers } = await reserveConsecutivePorts(1)
+    await close(servers[0]!)
+    expect(await probeFreePort(start, start)).toBe(start)
   })
 
   it('skips a port held on the loopback address', async () => {
-    await hold(BASE + 10, '127.0.0.1')
-    expect(await probeFreePort(BASE + 10)).toBe(BASE + 11)
+    const { start, servers } = await reserveConsecutivePorts(2, '127.0.0.1')
+    held.push(servers[0]!)
+    await close(servers[1]!)
+    expect(await probeFreePort(start, start + 1)).toBe(start + 1)
   })
 
   it('skips a port held by a default (wildcard) listener — the MCP-shaped regression', async () => {
@@ -42,18 +74,22 @@ describe('probeFreePort', () => {
     // 127.0.0.1-only probe reports this port as free (SO_REUSEADDR lets the
     // specific bind coexist), which handed instance B a port instance A was
     // actively serving on.
-    await hold(BASE + 20)
-    expect(await probeFreePort(BASE + 20)).toBe(BASE + 21)
+    const { start, servers } = await reserveConsecutivePorts(2)
+    held.push(servers[0]!)
+    await close(servers[1]!)
+    expect(await probeFreePort(start, start + 1)).toBe(start + 1)
   })
 
   it('skips a port held on the v4 wildcard 0.0.0.0', async () => {
-    await hold(BASE + 30, '0.0.0.0')
-    expect(await probeFreePort(BASE + 30)).toBe(BASE + 31)
+    const { start, servers } = await reserveConsecutivePorts(2, '0.0.0.0')
+    held.push(servers[0]!)
+    await close(servers[1]!)
+    expect(await probeFreePort(start, start + 1)).toBe(start + 1)
   })
 
   it('fails loud when the whole window is held', async () => {
-    await hold(BASE + 40, '127.0.0.1')
-    await hold(BASE + 41, '127.0.0.1')
-    await expect(probeFreePort(BASE + 40, BASE + 41)).rejects.toThrow(/no free port/)
+    const { start, servers } = await reserveConsecutivePorts(2, '127.0.0.1')
+    held.push(...servers)
+    await expect(probeFreePort(start, start + 1)).rejects.toThrow(/no free port/)
   })
 })

--- a/src/workspaces/harness-source-upgrade.spec.ts
+++ b/src/workspaces/harness-source-upgrade.spec.ts
@@ -12,12 +12,18 @@ import { WorkspaceOperationGuard } from './workspace-operation-guard.js'
 import { WorkspaceRegistry } from './workspace-registry.js'
 
 const roots: string[] = []
+const GIT_FIXTURE_TIMEOUT_MS = 30_000
 const logger = {
   debug() {}, info() {}, warn() {}, error() {}, event() {}, child() { return this },
 } as unknown as Logger
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  await Promise.all(roots.splice(0).map((root) => rm(root, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  })))
 })
 
 describe('HarnessSourceUpgradeManager', () => {
@@ -51,7 +57,7 @@ describe('HarnessSourceUpgradeManager', () => {
       version: 'v1.1.0',
       commit: fixture.v2,
     })
-  })
+  }, GIT_FIXTURE_TIMEOUT_MS)
 
   it('keeps unverified stable releases behind the opt-in policy', async () => {
     const fixture = await createFixture({ catalogV2: false })
@@ -70,7 +76,7 @@ describe('HarnessSourceUpgradeManager', () => {
       toVersion: 'v1.1.0',
       verified: false,
     })
-  })
+  }, GIT_FIXTURE_TIMEOUT_MS)
 
   it('blocks a dirty Workspace before any merge is applied', async () => {
     const fixture = await createFixture()
@@ -87,7 +93,7 @@ describe('HarnessSourceUpgradeManager', () => {
       planDigest: plan.planDigest,
       targetVersion: plan.toVersion,
     })).rejects.toMatchObject({ code: 'working_tree_changes' })
-  })
+  }, GIT_FIXTURE_TIMEOUT_MS)
 })
 
 function normalizeLineEndings(value: string): string {


### PR DESCRIPTION
## Intent

Promote the repaired `dev` source to `master` as the source checkpoint for a later **beta-only** `v0.91.0-beta.1` release. This PR does not publish any release and must not produce stable output.

## Delta since the previously accepted promotion

- isolate both native port-probe suites from host-global fixed ports
- give real-Git Harness source-upgrade tests a Windows-appropriate timeout and bounded fixture cleanup retries

No product runtime behavior or version field changes are included.

## Local evidence

- `npx tsc --noEmit`
- `pnpm -F @traderalice/desktop typecheck`
- targeted 12/12
- port suites repeated 50/50
- Harness suite repeated 20/20
- `pnpm test`: 5189 passed, 9 skipped

## Windows evidence from #1272

- cross-platform job 99300754819 passed
- Harness source-upgrade: 3/3 in 6996ms, no timeout or EBUSY
- script port probe: 5/5
- desktop port probe: 4/4
- full Windows suite: 5135 passed, 61 skipped

After this promotion is accepted, the separate version-only PR remains a distinct checkpoint; beta publication is a later explicit workflow dispatch. Stable is out of scope.