### PR TITLE
docs: record 0.91 beta release evidence

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -33,8 +33,9 @@ the durable truth after it changes. Git history is the archive.
   Runtime with a Bun-compiled, multi-process CLI distribution. Direct,
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set. The
   CLI package owns OpenAlice only: Agent Runtime installation and Electron
-  packaging stay outside this plan. Serial increments integrate on
-  `codex/usability-improvements` before coherent promotion to `dev`.
+  packaging stay outside this plan. The native CLI is public through the
+  separately dispatched `v0.91.0-beta.1`; native PowerShell and external
+  package-manager activation remain on focused branches from current `dev`.
 - [[plans/remote-project-fleet.md]] — Adds a machine-aware Supervisor fleet,
   remote AliceProject inventory/connection, and safe local-to-SSH project
   transfer for portable configuration and Workspaces while deliberately

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1,8 +1,8 @@
 # Bun-native CLI Distribution
 
-Status: Active — macOS/Linux native CLI is public in v0.90.2; v0.91.0-beta.1
-acceptance is next; native PowerShell and external package-manager activation
-remain deferred
+Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separately
+dispatched v0.91.0-beta.1 is externally verified; stable remains v0.90.2 while
+native PowerShell and external package-manager activation remain deferred
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`
@@ -549,19 +549,19 @@ artifacts.
 
 ### 10. Publish the 0.91 beta checkpoint
 
-- [ ] Capture the current stable manifest, updater feeds, aliases, and shared
+- [x] Capture the current stable manifest, updater feeds, aliases, and shared
   installer before beta publication.
-- [ ] Promote the exact accepted `dev` tip, including the GitHub-safe AUR
+- [x] Promote the exact accepted `dev` tip, including the GitHub-safe AUR
   metadata asset contract, to `master` through the full promotion gate.
-- [ ] Use a focused `master` branch and PR to set both product manifests to
+- [x] Use a focused `master` branch and PR to set both product manifests to
   `0.91.0-beta.1`; do not merge that version-only commit back to `dev`.
-- [ ] Dispatch one `beta` release for `v0.91.0-beta.1`. Do not produce or queue
+- [x] Dispatch one `beta` release for `v0.91.0-beta.1`. Do not produce or queue
   a stable release from the same run.
-- [ ] Externally verify the beta GitHub Release, updater feeds, CLI manifest,
+- [x] Externally verify the beta GitHub Release, updater feeds, CLI manifest,
   installer, native Runtime, and Broker Packs while proving every stable-owned
   mutable surface stayed byte-for-byte unchanged.
-- [ ] Leave later fixes on `dev`. A `beta.2` checkpoint is optional; stable is
-  a separate later decision after tomorrow's testing.
+- [x] Leave later fixes on `dev`. A `beta.2` checkpoint is optional; stable is
+  a separate later decision after beta testing and maintainer acceptance.
 
 ## Verification Matrix
 
@@ -942,3 +942,17 @@ This plan is complete only when:
   separate serial intents: fixes may accumulate on `dev` between them, another
   beta is optional, and unchanged-source stable promotion is the exception
   rather than an automatic second output.
+- 2026-08-31: Published only
+  [`v0.91.0-beta.1`](https://github.com/TraderAlice/OpenAlice/releases/tag/v0.91.0-beta.1)
+  from `009d3f466288bd69cf831e6bddccee501ca99c04` in
+  [release run 33329951354](https://github.com/TraderAlice/OpenAlice/actions/runs/33329951354).
+  The prerelease contains 49 uploaded assets: four native CLI archives and
+  sidecars, 20 Broker Pack archives plus catalogs, signed and notarized macOS
+  desktop packages, the intentionally unsigned Windows package, updater
+  metadata, and installers. Independent public verification downloaded and
+  hashed all CLI and Broker bytes with zero mismatches, then completed a clean
+  non-root Debian beta install, Runtime start/status/stop, uninstall, and data
+  preservation journey with no host Node, Bun, or Agent Runtime. The captured
+  stable manifest, feeds, aliases, and default installer route remained
+  unchanged at `v0.90.2`; npm, Homebrew Tap, and AUR publication stayed
+  disabled. No stable release was produced or queued.

--- a/plans/release-feedback-reliability.md
+++ b/plans/release-feedback-reliability.md
@@ -8,6 +8,10 @@ Related evidence:
 - [master CI run 31495757321](https://github.com/TraderAlice/OpenAlice/actions/runs/31495757321)
 - [promotion PR #1060](https://github.com/TraderAlice/OpenAlice/pull/1060)
 - [Batch 1 serial PR #1061](https://github.com/TraderAlice/OpenAlice/pull/1061) — merged to `dev` on 2026-08-11
+- [0.91 test-isolation PR #1272](https://github.com/TraderAlice/OpenAlice/pull/1272)
+- [0.91 source-promotion PR #1273](https://github.com/TraderAlice/OpenAlice/pull/1273)
+- [0.91 version-only PR #1271](https://github.com/TraderAlice/OpenAlice/pull/1271)
+- [0.91.0-beta.1 release run 33329951354](https://github.com/TraderAlice/OpenAlice/actions/runs/33329951354)
 
 Owner guides:
 
@@ -43,6 +47,11 @@ the versioned release lane.
   `dev`/`master` pull-request coverage remain available.
 - Defer DAG fan-in removal and accepted-tree provenance to a second batch. Both
   need explicit artifact/provenance contracts rather than YAML-only shortcuts.
+- Keep beta and stable as separate serial release intents. A changed source tree
+  invalidates prior candidate evidence and must be accepted again; unchanged
+  beta source may be selected only through a later explicit stable decision.
+  Even then, stable has independent version preparation and full release
+  acceptance.
 
 ## Acceptance Criteria
 
@@ -116,6 +125,21 @@ Silicon packaged Workspace journey. Its twelve receipt checks passed through
 Electron IPC, staged PTY login-shell readiness, all injected CLIs, scheduled
 managed Pi, and cleanup. Intel macOS, Windows, signing, and notarization remain
 native CI/release evidence.
+
+The 0.91 beta checkpoint supplied concrete Batch 2 evidence. The promotion and
+version-only PRs each tested a synthetic merge tree identical to their final
+merge tree, yet the resulting `master` pushes still started duplicate CI and
+Docker workflows. Those duplicate runs were cancelled only after tree identity
+was established. The tagged release then separately ran its candidate, signing,
+N-1 upgrade, installer, and publication gates. Two intermittent failures were
+test-environment defects rather than product regressions: a hard-coded port
+collided with a hosted runner, and Windows cleanup exceeded an implicit
+five-second test budget. PR #1272 replaced the port assumption with a reserved
+fixture window and gave the bounded Git cleanup path an explicit budget. The
+later promotion, version-only, and release gates all passed. This supports a
+future accepted-tree receipt that skips only identical post-merge CI; it does
+not justify reusing evidence after additional commits, weakening release gates,
+or combining beta and stable publication.
 
 ## Completion
 


### PR DESCRIPTION
## Summary
- record the completed v0.91.0-beta.1-only checkpoint and independent public-byte verification
- keep stable explicitly at v0.90.2 and document beta/stable as separate serial release intents
- attach the 0.91 hosted-run flake and duplicate-check evidence to the existing release feedback plan

## Verification
- git diff --check
- documentation-only; no product or workflow behavior changed

## Release boundary
This PR records evidence only. It does not publish, queue, or authorize a stable release.