### PR TITLE
feat(cli): complete managed Railway remote flow

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -1,0 +1,44 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    diffutils \
+    git \
+    gzip \
+    openssh-client \
+    procps \
+    python3 \
+    tini \
+    util-linux \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV OPENALICE_RAILWAY_VOLUME_ROOT=/data \
+    OPENALICE_SERVICE_MANAGER=railway \
+    OPENALICE_RAILWAY_CHANNEL=stable \
+    HOME=/data/home \
+    OPENALICE_HOME=/data/projects/default \
+    OPENALICE_INSTALL_DIR=/data/home/.openalice \
+    NPM_CONFIG_PREFIX=/data/home/.local \
+    BUN_INSTALL=/data/home/.bun \
+    ENV=/etc/profile.d/openalice-railway.sh \
+    PATH=/usr/local/sbin:/usr/local/bin:/data/home/.openalice/bin:/data/home/.local/bin:/data/home/.bun/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+COPY install /opt/openalice/install
+COPY scripts/railway/entrypoint.sh /usr/local/bin/openalice-railway-entrypoint
+COPY scripts/railway/command-wrapper.sh /usr/local/libexec/openalice-railway-command
+COPY scripts/railway/shell-env.sh /etc/profile.d/openalice-railway.sh
+
+RUN chmod 0755 \
+      /opt/openalice/install \
+      /usr/local/bin/openalice-railway-entrypoint \
+      /usr/local/libexec/openalice-railway-command \
+      /etc/profile.d/openalice-railway.sh \
+  && for command_name in openalice alice alice-workspace alice-uta traderhub; do \
+       install -m 0755 /usr/local/libexec/openalice-railway-command "/usr/local/bin/$command_name"; \
+     done \
+  && printf '\n. /etc/profile.d/openalice-railway.sh\n' >>/etc/bash.bashrc
+
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/openalice-railway-entrypoint"]

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -9,6 +9,13 @@ The current CLI payload is one target-native Bun executable plus immutable
 OpenAlice resources. The installer does not install Node.js, Bun, npm, source
 dependencies, build tools, or an Agent Runtime.
 
+The direct installer expects Bash, `tar` with gzip support, `diff`, and either `sha256sum` or
+`shasum`; a network install also needs `curl`. Safe transaction ownership uses
+the platform kernel: macOS must provide `lockf`, while Linux must provide
+`flock` (normally from `util-linux`). These are host prerequisites, not packages
+that the installer silently adds. Minimal images and remote hosts should install
+them before running the shared installer.
+
 npm, Bun, Homebrew, and Arch/AUR installation consume the same accepted native
 archives but remain owned by their package manager. Their topology, commands,
 and update behavior live in [[docs/cli-package-managers.md]].
@@ -162,7 +169,8 @@ The default install root is `~/.openalice`, independent from any
 │   ├── releases/<version>-<platform>-<arch>-<content-id>/
 │   ├── provenance/<release-name>.json
 │   └── staging/
-├── .cli-install.lock/       # only while an installer owns the transaction
+├── .cli-install.lock/       # owner record while an installer owns the transaction
+├── .cli-install.lock.guard  # persistent kernel-lock inode; contains no user data
 ├── .cli-update-check.json   # optional bounded update cache
 ├── data/                    # preserved product state
 ├── workspaces/              # preserved user work
@@ -175,6 +183,48 @@ Launchers resolve `cli/current` on every invocation and export the canonical
 install root, release root, provenance path, content identity, and install
 method to the native executable. They never hard-code one release path, so an
 atomic pointer change is enough for update or rollback.
+
+### Volume-backed service hosts
+
+A persistent service host must keep the native install root separate from the
+AliceProject Home even when both live on one mounted volume. The Railway SSH
+profile uses:
+
+```text
+/data/home                  fixed persistent Railway SSH HOME
+/data/home/.openalice       OPENALICE_INSTALL_DIR
+/data/projects/default      OPENALICE_HOME
+```
+
+The image fixes and exports `/data/home`, `/data/home/.openalice`,
+`/data/home/.local`, `/data/home/.bun`, and their persistent executable `PATH`.
+That image environment is intentional: a Railway SSH process must see the same
+user and installed commands as Guardian. The entrypoint starts installer
+bootstrap with system-only `PATH`, validates those fixed roots, and restores
+the persistent `PATH` only after the native CLI passes provenance and Runtime
+checks. These user/install paths are not deployment options.
+
+Only `OPENALICE_HOME` may select another AliceProject beneath `/data`.
+`AQ_LAUNCHER_ROOT` is always derived as `<OPENALICE_HOME>/workspaces`; an
+independent Workspace-root override is not honored, while an alternate
+Volume/user/install/npm/Bun root or normalized path escape is rejected.
+
+The install root owns immutable native releases, activation, provenance, and
+the five OpenAlice launchers. The AliceProject root owns user configuration,
+credentials, Workspaces, and Runtime state. Machine-level convenience links
+under `/usr/local/bin` may be rebuilt on every container boot; they are not the
+durable install or data authority. AliceProject transfer likewise excludes
+top-level `bin/`, `cli/`, and machine-local or escaping symlinks rather than
+copying installation bytes to another machine.
+
+Service bootstrap may call the shared installer with `--yes`,
+`--no-modify-path`, the fixed install root, and a stable, beta, or dev selector.
+This is service configuration authority, not a relaxation of the interactive
+user consent contract. Installation still does not start a background service
+by itself; the Railway entrypoint separately validates the active launcher and
+`exec`s foreground `openalice server run`. Agent Runtime executables and their
+user-level install roots remain outside both the OpenAlice install root and
+AliceProject transfer.
 
 ## Consent and transaction
 
@@ -195,7 +245,8 @@ consent never starts OpenAlice.
 
 After consent, the transaction:
 
-1. rejects a live installer lock or removes a stale one;
+1. acquires the persistent kernel-lock inode, then rejects a verified live
+   transaction owner or removes only its stale owner record;
 2. stages on the same filesystem as the release store;
 3. downloads or copies the archive and verifies SHA-256;
 4. validates and smoke-runs the staged release;
@@ -267,6 +318,24 @@ human bootstrap entry only; an updater never combines that URL with the
 versioned checksum.
 `openalice status` and an idempotent `openalice up` report the pending product
 version while an older Guardian is still active.
+
+Managed SSH bootstrap compares stable, beta, and pinned installations by their
+logical release identity: repository, channel/selector, and product version.
+It must not require a macOS archive and Linux archive for that release to have
+the same SHA-256 or content identity. The remote host must instead report valid
+schema 3 provenance for its own platform and architecture, and its active
+native Runtime must match that remote artifact's product and content identity.
+When local and remote targets are the same, their checksum and content identity
+must still match exactly.
+
+Dev is stricter because the package version alone does not name one build. The
+latest CDN dev manifest is the completed-set authority. Before a managed remote
+install, the invoking CLI must match its own manifest target by version,
+archive SHA-256, and content identity; the remote platform target is then
+selected from that same manifest and passed to the installer as expected
+checksum and content identity. A stale local dev CLI, missing target, malformed
+manifest, or unavailable manifest blocks remote mutation rather than falling
+back to a branch label or version-only comparison.
 
 The first successful Guardian plus Alice HTTP readiness from the newly active
 content confirms `cli/activation.json`. If that first start exits early, times
@@ -395,6 +464,25 @@ pnpm test:install:docker
 npx tsc --noEmit
 pnpm test
 ```
+
+For a volume-backed Railway bootstrap or managed cross-target change, also run:
+
+```bash
+bash -n scripts/railway/*.sh
+pnpm exec vitest run \
+  scripts/railway-entrypoint.spec.ts \
+  packages/cli/src/remote.spec.mjs \
+  packages/cli/src/project-transfer.spec.ts \
+  packages/cli/src/project-transfer-ssh.spec.ts \
+  packages/cli/src/project-transfer-stream.spec.ts
+```
+
+These local checks replace neither hosted acceptance journey: a disposable
+empty-Volume bootstrap/fail-closed drill, nor a non-destructive deployment,
+AliceProject transfer, restart/redeploy, and SSH tunnel journey against the
+retained real Volume. The authoritative checklist is owned by
+[[docs/docker-deployment.md]]; run-specific progress and measurements live only
+in [[plans/bun-cli-distribution.md]].
 
 The Docker smoke uses a clean non-root Debian host with Node, npm, pnpm, Bun,
 and Agent Runtimes absent. It verifies plan, consent, native installation,

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -6,12 +6,14 @@ remote-host safety boundary, and container smoke requirements. It complements
 External notification setup is owned by [[docs/connector-service.md]].
 For private source-backed browser access over SSH, start with
 [[docs/remote-quickstart.md]]; its authoritative lifecycle and transport
-contract is owned by [[docs/remote-access.md]]. Docker and managed remote are
-parallel first-class deployment surfaces: Docker owns an image, volume,
-healthcheck, and container lifecycle, while managed remote prepares an existing
-SSH host without requiring it to adopt Docker.
+contract is owned by [[docs/remote-access.md]]. The source server image,
+Railway native CLI SSH host, and managed existing-host path are parallel
+deployment profiles. The first owns an image, volume, healthcheck, bundled
+Agent Runtimes, and optional HTTPS lifecycle. The Railway profile owns a small
+native-CLI bootstrap image and foreground SSH-only service. Managed remote can
+prepare an existing host without requiring either image.
 
-## Topology
+## Source Server Image Topology
 
 The image is the non-Electron production topology:
 
@@ -46,6 +48,180 @@ the build executes every runtime's `--version`, preventing a cached/rebuilt
 image from silently acquiring a different or broken runtime. Pi headless runs
 auto-approve project resources because the image owns its pinned Pi version;
 interactive Pi still leaves that trust decision visible to the user.
+
+## Railway Native CLI SSH Host
+
+`Dockerfile.railway` is a separate image contract. It does not replace the
+source server image above and must not inherit that image's bundled Agent
+Runtime or public-Web promises. Configure a Railway service to build it by
+setting `RAILWAY_DOCKERFILE_PATH=Dockerfile.railway`, attach a Volume at
+`/data`, and leave Public Networking without a generated domain or TCP proxy.
+Railway provides the SSH transport; the browser still reaches Alice only
+through `openalice remote` and a laptop-local loopback URL.
+
+The Railway service settings are part of the runtime contract:
+
+- leave the Dashboard **Start Command** empty so the Docker `ENTRYPOINT` stays
+  authoritative;
+- disable **Serverless**; SSH-only inactivity must not suspend a persistent
+  Guardian or Agent process;
+- select **Restart Policy: Always** so Railway restores the foreground service
+  after either clean or failed exit (a plan without `Always` does not satisfy
+  this always-on profile);
+- run exactly one replica against the Volume because Guardian and the
+  AliceProject filesystem are single-writer state; and
+- set `RAILWAY_DEPLOYMENT_DRAINING_SECONDS=30` or higher so `tini` and Guardian
+  receive at least 30 seconds to cascade `SIGTERM` before Railway sends
+  `SIGKILL`.
+
+Do not duplicate those settings in a legacy `railway.json`. In particular, a
+Dashboard Start Command override would bypass volume validation, installer
+fallback, persistent `PATH`, and foreground Guardian startup in the image
+entrypoint.
+
+```text
+tini (PID 1)
+└── scripts/railway/entrypoint.sh
+    └── /data/home/.openalice/bin/openalice server run
+        └── Guardian foreground tree
+            ├── Alice
+            ├── optional UTA
+            ├── optional Connector Service
+            └── user-launched external Agent Runtime processes
+
+/opt/openalice/install       shared installer snapshot from the image source
+/data/home                   persistent user HOME
+/data/home/.openalice        persistent native CLI install root
+/data/projects/default       persistent OPENALICE_HOME
+/data/projects/default/workspaces
+                             persistent AQ_LAUNCHER_ROOT
+```
+
+The Railway profile fixes the Volume at `/data`, persistent SSH `HOME` at
+`/data/home`, OpenAlice install root at `/data/home/.openalice`, npm prefix at
+`/data/home/.local`, and Bun root at `/data/home/.bun`. `Dockerfile.railway`
+exports those values and their executable directories on `PATH`, because a new
+Railway SSH process receives image/service environment rather than variables
+mutated only inside the entrypoint process. The entrypoint nevertheless starts
+bootstrap with system-only `PATH`, validates the fixed user layout, and restores
+the persistent `PATH` only after it has verified the native CLI.
+
+`OPENALICE_HOME` is the only layout selector and must resolve beneath `/data`;
+`AQ_LAUNCHER_ROOT` is always canonicalized from that selected Project as
+`<OPENALICE_HOME>/workspaces`. The entrypoint rejects a different Volume mount,
+ephemeral `HOME`, alternate install/npm/Bun root, or normalized/symlink escape;
+it does not honor an independent Workspace-root override. The image filesystem
+is replaceable; no install release, credential, Workspace, Agent login, or
+Project state may depend on it.
+
+The first boot runs the ordinary shared installer non-interactively without
+editing user-owned shell profiles. The image-owned global shell environment
+restores the same fixed Home, user PATH, Project Home, and Railway service
+identity for later interactive SSH login shells. `OPENALICE_RAILWAY_CHANNEL`
+accepts `stable` (the default),
+`beta`, or `dev`; `OPENALICE_RAILWAY_VERSION` may pin only an in-channel stable
+or beta version. Dev always resolves the latest completed dev manifest and
+rejects an exact version. Subsequent boots reuse a release only after both
+`openalice --version` and `openalice version --json` validate it. Set
+`OPENALICE_RAILWAY_FORCE_INSTALL=1` for a deliberate refresh deploy, then clear
+it after verifying the selected release. If that refresh cannot install but the
+previous release still validates, the host starts the previous release. An
+empty or damaged install with a failed bootstrap stops instead of running an
+unverified fallback.
+
+After selection, the image atomically replaces the persistent `openalice`,
+`alice`, `alice-workspace`, `alice-uta`, and `traderhub` shims with its Railway
+wrapper. The wrapper resolves the active immutable release directly, rebuilds
+its provenance environment, and rejects update/rollback/uninstall mutations;
+this keeps older published CLIs from bypassing Railway's release authority via
+the persistent command path.
+
+The entrypoint finally `exec`s `openalice server run`; it does not launch a
+detached Server and sleep. Railway therefore observes and restarts the actual
+Guardian service process, while `tini -g` forwards signals to the complete
+process group and reaps children. The shared installer serializes mutations
+with the platform kernel (`lockf` on macOS, `flock` on Linux); its persistent
+guard inode contains no Project or credential data, and hard process death
+releases ownership automatically.
+Alice stays on loopback port `47331` (or the explicit
+`OPENALICE_RAILWAY_PORT`), and this profile does not consume Railway's public
+`PORT` contract.
+
+Agent Runtime installation remains a user action performed through Railway
+SSH. Persistent locations `/data/home/.local/bin` and `/data/home/.bun/bin` are
+already on `PATH`, but the image and OpenAlice installer do not place Claude,
+Codex, OpenCode, Pi, or another Agent there. Their versions, credentials,
+plugins, and upgrades remain outside the OpenAlice release transaction.
+
+### Railway migration and restart acceptance
+
+Local contract checks for this profile are:
+
+```bash
+bash -n scripts/railway/*.sh
+pnpm exec vitest run \
+  scripts/railway-entrypoint.spec.ts \
+  packages/cli/src/remote.spec.mjs \
+  packages/cli/src/project-transfer.spec.ts \
+  packages/cli/src/project-transfer-ssh.spec.ts \
+  packages/cli/src/project-transfer-stream.spec.ts
+```
+
+The entrypoint fixture must cover empty-volume bootstrap, verified-install
+reuse without installer access, failed forced-refresh fallback, and fail-closed
+empty bootstrap. It must also prove the fixed `/data/home` SSH/install layout,
+system-only bootstrap `PATH`, Project-only `OPENALICE_HOME` selection, derived
+Workspace root, Railway service identity, and rejection of mount/layout
+mismatches or normalized escapes before installation. Ordinary SSH-managed
+remote tests must cover stable/beta/pinned logical release matching across
+different target artifacts, target-local checksum and content identity
+validation, stale/unverifiable dev-manifest blocking, and dev installer handoff
+bound to the remote target. Railway tests must instead prove that the laptop
+command is inspection-only, never selects or mutates the service release, and
+reports a verified fallback without confusing it with the configured selector.
+Transfer tests must cover Git-aware inclusion, ignored dependency exclusion,
+self-contained repository connectivity, fail-closed linked/nested/submodule or
+external-object state, known Alice backup/session/install exclusions,
+credential omission and resealing, receipt validation, and safe handling of
+absolute or escaping symlinks.
+
+A real Railway acceptance is still required before treating the profile as a
+usable hosted product. Keep the clean-bootstrap and retained-data journeys
+separate; never relabel or clear an existing user Volume merely to obtain an
+empty-host result:
+
+1. on a disposable service and empty `/data` Volume, bootstrap the image and
+   prove that a failed initial install stops without an unverified fallback;
+2. deploy the candidate non-destructively against the retained real `/data`
+   Volume with no public domain; confirm no existing install or Project data was
+   deleted, Start Command is empty, Serverless is off, Restart Policy is Always,
+   replica count is one, and draining is at least 30 seconds;
+3. use `railway ssh config` to create an OpenSSH alias, then verify
+   `HOME=/data/home`, the persistent OpenAlice/Agent paths on `PATH`,
+   `openalice version --json`, foreground Runtime logs, and an
+   inspection-only `openalice remote <alias>` browser/tunnel journey;
+4. stop a real source AliceProject and review/apply `openalice project transfer`
+   into a new `/data/projects/<name>` Home, confirming the Git/credential
+   boundary, destination absence/free space, and that the source data remains
+   unchanged;
+5. select the transferred Home with `OPENALICE_HOME`, redeploy, and verify its
+   Workspace/configuration marker through the real Runtime;
+6. install one chosen Agent Runtime through SSH into a persistent user path,
+   authenticate it, and exercise a real Workspace Session without attributing
+   that installation to OpenAlice;
+7. normally restart and redeploy the service with the same Volume, then verify
+   the CLI release, selected Home, Project files, Agent executable/login, SSH
+   tunnel, and Runtime readiness survived while old PIDs and PTYs did not;
+8. hard-kill the foreground service once and replace the container against the
+   same Volume; prove PID reuse or stale owner metadata cannot fool CLI
+   preflight or block safe recovery; and
+9. force one installer failure with a known-valid prior release on the retained
+   Volume and observe the bounded exact-release fallback.
+
+This guide owns the acceptance contract, not a snapshot of one worktree or
+service. Current pass/fail state, exact counts, and run-specific evidence live
+only in [[plans/bun-cli-distribution.md]]. Local Docker evidence never substitutes
+for the two hosted Volume journeys above.
 
 ## Start and Authenticate
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -39,6 +39,9 @@ source checkout support retained only as an explicit development override:
   AliceProject into a new complete home on a registered SSH Machine, preserving
   portable configuration and Workspace repositories while deliberately
   starting with zero resumable Sessions;
+- `Dockerfile.railway` provides a volume-backed native CLI SSH host whose
+  foreground `server run` process is supervised by Railway while the browser
+  still connects only through an SSH loopback tunnel;
 - Electron remains a complete local desktop distribution.
 
 The release-owned installer advances one checksum-bound native OpenAlice
@@ -109,12 +112,18 @@ protocol is deferred until the local/server boundary is stable.
    PID or delete a live lock.
 8. `--takeover` remains the only command-line authority to replace another
    recorded Guardian owner.
-9. Remote bootstrap reuses the invoking local CLI's recorded ordinary
-   installer source, selector, and installed content identity. It does not
-   carry a second SSH-only installer, upload Runtime bytes through SSH, install
-   Node/build tools, clone a checkout, or install an Agent Runtime. The ordinary
-   installer downloads the matching platform-native release directly on the
-   remote host. Only an explicit `--app-dir` opts into source preparation.
+9. On an ordinary SSH-managed host, remote bootstrap reuses the invoking local
+   CLI's recorded installer source and logical release identity. Stable, beta,
+   and pinned installs may use different target archives for different
+   operating systems or architectures; each host verifies its own archive
+   checksum and content identity. Dev additionally requires the invoking CLI to
+   match the latest completed dev manifest and selects the remote target from
+   that same manifest. Bootstrap does not carry a second SSH-only installer,
+   upload Runtime bytes through SSH, install Node/build tools, clone a checkout,
+   or install an Agent Runtime. Only an explicit `--app-dir` opts into source
+   preparation. A Railway host is platform-managed instead: its entrypoint and
+   service variables select the release, while the laptop only inspects the
+   resulting target-local CLI and Runtime identity.
 10. Shared Runtime facts use presentation-neutral names and versioned schemas.
     Browser layout, Electron chrome, modal state, and other client UI state do
     not become server truth.
@@ -152,19 +161,39 @@ A matching published receipt makes registration retry idempotent. Cancellation
 terminates the SSH receiver and leaves only that transaction's marked staging
 path eligible for a safe retry.
 
-Portable configuration, active and departed Workspace repositories, Git state,
-Workspace ids, and lifecycle records transfer. Absolute Workspace paths are
-rebased to the remote Home. Guardian state, Runtime payloads, ports, auth,
-headless/native conversation state, resume identities, and untracked Session
-dossiers do not. A deliberately Git-tracked `.alice/sessions` dossier remains
-as inert repository content but does not create a resumable remote Session.
+Portable configuration, active and departed Workspace repositories, Workspace
+ids, and lifecycle records transfer. Absolute Workspace paths are rebased to
+the remote Home. For an ordinary self-contained Git Workspace, the planner
+keeps portable object/ref/index state, tracked files (including deliberately
+tracked ignored files), and nonignored untracked user files; machine-local Git
+configuration plus ignored untracked dependencies and build outputs stay
+behind. Linked worktrees, alternate/promisor object stores, nested Git
+repositories, and initialized submodules block apply instead of being silently
+degraded. A non-Git Workspace remains portable subject to the same Session,
+symlink, and machine-local exclusions.
 
-Home-owned AI/provider credentials can travel only in the private SSH stream.
-Broker and Connector values are decrypted in source-process memory and sealed
-on the receiver with a newly created destination key; the source sealing key is
-never copied. `--without-credentials` retains secret-free configuration and
-requires those integrations to be configured again. Exact-Session scheduled
-Issue owners require an explicit `keep-blocked` or `new-then-resume` policy.
+Guardian state, Runtime payloads, ports, Web auth and sessions,
+headless/native conversation state, resume identities, native Agent login and
+configuration, and untracked Session dossiers do not transfer. A deliberately
+Git-tracked `.alice/sessions` dossier remains inert repository content and does
+not create a resumable remote Session. Top-level `bin/` and `cli/` trees,
+installer locks/caches, and Alice-owned backup families are excluded; an
+arbitrary backup file deliberately stored inside a user repository still
+follows that repository's Git rules. Absolute symlinks, symlinks containing
+control characters, and relative symlinks that resolve outside the source
+AliceProject Home are reported as machine-local exclusions. Portable relative
+symlinks contained by the Home remain part of the transfer.
+
+Only Alice-owned AI, market-data-provider, broker, and Connector credentials
+can travel in the private SSH stream. Broker and Connector values are decrypted
+in source-process memory and sealed on the receiver with a newly created
+destination key; the source sealing key is never copied. With
+`--without-credentials`, portable AI and market-data configuration remains
+after secret fields are stripped, while broker-account and Connector credential
+files are omitted and must be configured again. Web authentication and native
+Agent login remain separate destination setup in either mode. Exact-Session
+scheduled Issue owners require an explicit `keep-blocked` or `new-then-resume`
+policy.
 
 ## Layered Topology
 
@@ -257,6 +286,17 @@ does not advertise that control contract, status reports `owned_elsewhere` and
 stop refuses. The user may then close that surface normally or make a separate
 explicit takeover decision.
 
+On a service-managed host, `server run` stays in the foreground so Guardian is
+the service's observed process rather than a detached child hidden behind an
+idle container. The platform owns container restart and replacement. A
+Railway-identified target is therefore status/connect-only through
+`openalice remote`: `--stop`, `--takeover`, and `--app-dir` are rejected, and
+the operator changes lifecycle or release selection through Railway. Inside
+Railway SSH, the image-owned wrapper replaces every persistent command shim on
+startup and routes `update`, `rollback`, and `uninstall` back to service
+configuration before an installed release can change the persistent pointer
+beneath a running foreground Runtime.
+
 ### Managed remote command
 
 ```bash
@@ -271,8 +311,11 @@ openalice remote <target>
    or the explicit source checkout named by `--app-dir`;
 4. probe `openalice server status --json`, Runtime provider state, and protocol
    compatibility;
-5. compare the remote CLI version, installer source/selector, and immutable
-   installed content identity with the invoking local CLI;
+5. on an ordinary SSH-managed host, compare stable, beta, or pinned installs by
+   logical release, then validate the remote target's own platform,
+   architecture, archive checksum, content identity, and embedded Runtime
+   identity; for dev, first require the invoking CLI to match the latest
+   completed dev manifest and bind the remote target to that same manifest;
 6. if CLI install or update is required, show the exact matching plan and ask
    separately before calling the normal installer on the remote host;
 7. re-probe and re-plan after installation so a newly visible owner can block
@@ -287,20 +330,86 @@ openalice remote <target>
 12. open or print the local URL and stay in the foreground to own only the
     tunnel.
 
+Railway is the explicit exception to release-selection and mutation steps 5–9.
+Its service variables, entrypoint, deploy, and restart policy are the sole
+release/lifecycle authority. The laptop does not fetch a dev manifest or
+compare the service release to its own CLI. `openalice remote` verifies that the
+platform-managed installed CLI, target-local provenance, embedded Runtime,
+running provider, and configured selector are self-consistent; a verified
+previous-release fallback is reported distinctly. It then opens the same
+loopback tunnel without installing, updating, starting, taking over, or stopping
+the service.
+
 When reusing a healthy Server, `remote` takes the loopback web port from the
 versioned status response. An explicitly supplied `--remote-port` must match
 that owner; a mismatch is reported before opening a misleading tunnel.
 
-Closing `openalice remote` closes the tunnel but leaves the detached remote
-Server running. Status and stop remain explicit but do not require users to
-compose raw SSH commands:
+On an ordinary SSH-managed host, closing `openalice remote` closes the tunnel
+but leaves the detached remote Server running. Status and stop remain explicit
+and do not require users to compose raw SSH commands:
 
 ```bash
 openalice remote <target> --status
 openalice remote <target> --stop
 ```
 
-Neither command conflates “disconnect” with “stop my remote work.”
+Neither command conflates “disconnect” with “stop my remote work.” A Railway
+foreground Server also survives tunnel closure, but Railway owns its lifecycle
+and `openalice remote --stop` is rejected.
+
+### Railway native CLI SSH host
+
+Railway is a deployment profile of the same SSH/browser product, not a public
+Web deployment and not a second remote protocol. `Dockerfile.railway` builds a
+small service image with OpenSSH client utilities, the shared Bash installer,
+and `scripts/railway/entrypoint.sh`. The image does not contain an OpenAlice
+native release or an Agent Runtime. At boot the entrypoint installs or reuses a
+verified native release on the attached volume, then replaces itself with:
+
+```bash
+openalice server run --home /data/projects/default --port 47331 --wait 180
+```
+
+The required persistent layout keeps machine installation and AliceProject
+state distinct:
+
+```text
+/data/
+├── home/
+│   ├── .openalice/       # native CLI install root and immutable releases
+│   ├── .local/           # persistent user-owned package/bin prefix
+│   └── .bun/             # optional user-owned Bun installation
+└── projects/
+    └── default/          # OPENALICE_HOME
+        └── workspaces/   # AQ_LAUNCHER_ROOT
+```
+
+The Railway Volume is fixed at `/data`. The image exposes the persistent SSH
+`HOME=/data/home`, OpenAlice install root, npm prefix, Bun root, and their
+executable directories on `PATH`, so a fresh Railway SSH shell sees the same
+user installation as Guardian. Bootstrap temporarily replaces that `PATH` with
+system directories only, validates the fixed user layout, and restores the
+persistent paths only after the native CLI is verified. Operators may select
+only `OPENALICE_HOME`, which must resolve beneath `/data`; `AQ_LAUNCHER_ROOT` is
+always derived as `<OPENALICE_HOME>/workspaces`. `HOME`, install root, npm/Bun
+roots, Volume root, and `AQ_LAUNCHER_ROOT` are not independent profile options.
+A normalized `..` or symlink escape is refused, and a Railway environment
+without the `/data` Volume fails before installation.
+Stable is the default bootstrap channel; beta may be pinned to an accepted beta
+version, stable may be pinned to an accepted stable version, and rolling dev
+does not accept a version override. Stable and beta reuse a verified matching
+release unless refresh is explicitly requested. Rolling dev always asks the
+shared installer to resolve the latest completed dev manifest. If a requested
+refresh fails, the exact previously verified release remains the fallback; an
+empty or damaged install fails closed.
+
+The service must not publish Alice's port or attach a Railway public domain.
+The laptop reaches it through Railway's SSH target and the ordinary
+`openalice remote` loopback tunnel. Agent Runtime executables, credentials, and
+updates remain user-owned: install them through an SSH shell into persistent
+user paths such as `/data/home/.local/bin` or `/data/home/.bun/bin`, both of
+which the entrypoint includes on `PATH`. Missing Agent Runtimes do not make the
+OpenAlice host bootstrap incomplete.
 
 ### Registered Machines and aggregate inventory
 
@@ -649,6 +758,7 @@ Remote documentation must distinguish what survived:
 | Alice child restart under Guardian | Guardian survives | depends on current PTY ownership path | implementation-dependent | native Agent process/session dependent |
 | full Guardian/server restart | stops and restarts | does not automatically survive | only persisted history, if explicitly supported | only through native Agent resume/provenance |
 | machine reboot | stops | stops | only persisted history | only through native Agent resume/provenance |
+| Railway container replacement with the same Volume | foreground Guardian restarts | stops | only persisted history | only through native Agent resume/provenance |
 
 OpenAlice must not market server detach as crash-proof terminal persistence.
 Conversation provenance and native CLI resume remain governed by
@@ -662,13 +772,14 @@ incompatible. It must describe the effect before acting.
 
 ## Managed Remote Bootstrap and Compatibility
 
-Managed bootstrap uses a plan/apply split.
+Ordinary SSH-managed bootstrap uses a plan/apply split. Railway uses the same
+read-only facts but permits no laptop-owned apply phase.
 
 The read-only plan reports:
 
 - SSH target and resolved remote platform/architecture;
-- detected OpenAlice CLI path, version, and whether its install source and
-  content identity match the invoking local CLI;
+- detected OpenAlice CLI path, version, logical release identity, and whether
+  its target-local artifact identity is valid for the remote host;
 - control protocol compatibility;
 - Server state, Runtime provider, native content identity, and release/source
   root;
@@ -676,16 +787,18 @@ The read-only plan reports:
   platform, architecture, selector, and checksum-bound provenance;
 - for an explicit source override, whether its checkout already has complete
   Runtime artifacts;
-- proposed install/update/start actions;
+- proposed install/update/start actions, or an explicit no-mutation result for
+  Railway;
 - destination paths and whether PATH changes are required;
 - whether a running owner would be affected;
 - the final local and remote loopback ports.
 
-Apply rules:
+Apply rules for an ordinary SSH-managed host:
 
 1. no matching compatible CLI or Runtime: ask before invoking the normal
-   installer with the local CLI's recorded branch/version selector and expected
-   product version; the installer obtains the matching platform-native release;
+   installer with the local CLI's recorded logical release selector and
+   expected target-local artifact identity; the installer obtains the matching
+   platform-native release;
 2. native mode never installs source-build dependencies or Agent Runtime
    executables;
 3. explicit source mode validates its own prerequisites and remains separate
@@ -712,12 +825,24 @@ or Server is already present and compatible, otherwise it returns the original
 failure. Source preparation uses compact phase output and suppresses successful
 package/build chatter; a failed phase still includes a bounded diagnostic tail.
 
-The local orchestrator compares protocol ranges, CLI version, install source,
-and immutable content identity; human version strings alone are insufficient. It may tolerate a newer
-compatible Runtime, but its remote control CLI must match the invoking local
-CLI. The managed command exposes no independent branch/version selector. Test
-fixtures may replace the installer URL and payload base through test-only
-environment seams; those are not a release path.
+For an ordinary SSH-managed host, the local orchestrator compares protocol
+ranges and logical release identity; human version strings alone are
+insufficient. Stable, beta, and pinned releases may have different macOS and
+Linux archive/content identities, but the remote CLI provenance and embedded
+Runtime must agree with that remote host's target. For dev, the latest CDN dev
+manifest is the completed-set authority: the local CLI must match its own
+target, the remote target is selected from the same manifest, and installer
+handoff is bound to the remote checksum and content identity. If the manifest
+cannot be verified or the local CLI is stale, remote mutation is blocked.
+
+Railway performs no such laptop-to-service release selection. Its entrypoint
+resolves stable, beta, or rolling dev on the service and may start an exactly
+verified prior fallback. The local orchestrator only checks target-local
+provenance, embedded/running Runtime agreement, and configured selector versus
+running fallback before tunneling. Neither mode exposes an independent
+branch/version selector through `openalice remote`. Test fixtures may replace
+the installer URL and payload base through test-only environment seams; those
+are not a release path.
 
 ## Future Independent Studio Protocol
 
@@ -776,22 +901,11 @@ Runtime model.
 - remaining release observation: validate ordinary Agent TUI interaction under
   representative network shaping before deciding whether Stage 3 is useful.
 
-#### Bun-native Linux SSH observation — 2026-08-29
-
-The disposable OrbStack Docker SSH fixture exercised a Linux arm64 host with no
-Node, npm, Bun, source checkout, or Agent Runtime executable. The normal Bash
-installer downloaded and checksum-verified the native `dev` archive, activated
-it under `cli/releases/`, and reported `provider=bun`. The installed binary
-then re-executed Guardian, Alice, and optional UTA as distinct processes.
-
-The same journey verified default-no planning, detached readiness against the
-real `/api/auth/status` contract, tunnel disconnect persistence, same-origin
-and same-port reconnect, aggregate Machine/AliceProject inventory, structured
-stop, interrupted-transfer retry, secret resealing, a second transferred
-AliceProject home using the same immutable native release, and final clean
-shutdown. No managed source checkout or `bin/pi` launcher was created. This is
-the current native baseline; representative network shaping and authenticated
-third-party Agent turns remain separate observations.
+The Railway profile follows the contracts above, but implementation progress,
+exact transfer measurements, and service-specific acceptance evidence are
+tracked only in [[plans/bun-cli-distribution.md]]. An offline content plan does
+not prove source quiescence, remote capability, destination absence, free
+space, transfer apply, or hosted lifecycle recovery.
 
 ### Stage 3 — terminal transport optimization
 
@@ -840,24 +954,31 @@ third-party Agent turns remain separate observations.
 
 | Scenario | Required result |
 |---|---|
-| matching compatible remote CLI/Server | reuses both without mutation |
-| protocol-compatible CLI from a different branch/tag/commit | plan names a matching CLI update before connection |
-| missing remote CLI, interactive | shows plan; default no leaves host unchanged |
-| missing remote CLI, non-interactive | fails unless explicit approval is present |
-| incompatible running Server | explains process impact before update/restart |
+| ordinary SSH, matching compatible remote CLI/Server | reuses both without mutation |
+| ordinary SSH, matching release across different targets | compares the logical stable/beta/pinned release, then validates the remote archive and Runtime against its own platform/architecture provenance |
+| ordinary SSH, dev client behind latest manifest | blocks install/start mutation and asks the user to update the local dev CLI first |
+| ordinary SSH, protocol-compatible CLI from a different branch/tag/commit | plan names a matching CLI update before connection |
+| ordinary SSH, missing remote CLI, interactive | shows plan; default no leaves host unchanged |
+| ordinary SSH, missing remote CLI, non-interactive | fails unless explicit approval is present |
+| ordinary SSH, incompatible running Server | explains process impact before update/restart |
 | matching installed native Runtime | plan selects it without Node, Bun, checkout, build-tool, or Agent-install mutation |
 | missing remote CLI and Runtime | ordinary installer obtains matching native platform artifact; default no leaves the host unchanged |
 | unsupported native target | reports the unsupported platform/architecture without cloning source |
 | explicit source path | remains a deliberate development override and preserves existing Git state |
 | tunnel disconnect | local command exits; remote Server and work continue |
 | reconnect | same local port is preferred; same Runtime, browser origin, and live terminal are reachable; a busy port falls back visibly |
-| status and stop | user-facing commands require no raw SSH; status uses one bundled control probe and stop verifies structured shutdown |
-| transient SSH loss after apply | retry known transport faults; re-probe completed install/start state before deciding failure |
+| ordinary SSH, status and stop | user-facing commands require no raw SSH; status uses one bundled control probe and stop verifies structured shutdown |
+| ordinary SSH, transient SSH loss after apply | retry known transport faults; re-probe completed install/start state before deciding failure |
 | host-key failure | fails without disabling verification |
 | SSH agent/passphrase path | preserves normal OpenSSH interaction |
 | browser security | same-origin HTTP/WS works; public Origin remains rejected |
 | external Agent TUI matrix | each user-installed Shell/Agent executable retains its own version, config, and process |
 | Docker SSH fixture | no-Node host exercises install, start, tunnel, reconnect, transfer, and stop |
+| AliceProject containing install bytes or host links | transfer excludes top-level `bin/`, `cli/`, and escaping/absolute symlinks as machine-local content |
+| Railway inspection-only connect | local CLI proposes no release or lifecycle mutation; it validates the service selector, target-local provenance, and running Runtime before opening the tunnel |
+| Railway empty Volume | shared installer bootstraps the selected native channel, then Guardian remains the foreground service process |
+| Railway normal refresh or replacement | failed refresh reuses only a still-valid prior release; normal same-Volume replacement preserves install root and AliceProject data while restarting process state |
+| Railway hard-kill replacement | stale owner metadata cannot become active merely because the replacement reused a PID; CLI preflight reaches a valid start or an actionable failure without mutating Project data |
 
 ### Later protocols
 
@@ -885,12 +1006,17 @@ When this surface changes:
 5. exercise pure `ssh` and managed `remote` against a disposable SSH/Docker
    host with `pnpm test:remote:docker`, including default-no, installed payload
    equality, detach persistence, reconnect, and structured stop;
-6. follow [[docs/docker-deployment.md]] and run `pnpm docker:smoke` when
+6. for the Railway profile, run the entrypoint and cross-target/project-transfer
+   specs documented in [[docs/docker-deployment.md]], then exercise two hosted
+   journeys: bootstrap and fail-closed behavior on a disposable service with an
+   empty Volume, and non-destructive Project migration, SSH reconnect, restart,
+   and redeploy acceptance on the retained real Volume;
+7. follow [[docs/docker-deployment.md]] and run `pnpm docker:smoke` when
    `scripts/guardian/prod.mjs` or the server image path changes;
-7. follow [[docs/managed-workspace-runtime.md]] and run the matching Electron
+8. follow [[docs/managed-workspace-runtime.md]] and run the matching Electron
    and package smoke whenever shared Guardian, PTY, startup, or dependency
    behavior changes;
-8. run the repository-wide TypeScript and test gates required by `AGENTS.md`.
+9. run the repository-wide TypeScript and test gates required by `AGENTS.md`.
 
 Record any network-shaping gap explicitly. A localhost smoke does not verify
 remote TUI behavior, and an SSH tunnel smoke does not verify Electron package
@@ -899,6 +1025,7 @@ behavior.
 ## Non-Goals for the First Implementation
 
 - public TCP binding of Alice or the Guardian control endpoint;
+- a Railway public domain or public Web fallback for the SSH-host profile;
 - hosted-domain cookie forwarding;
 - cloud relay, NAT traversal, or device fleet management;
 - live migration of PTYs across Runtime upgrades;

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -7,8 +7,9 @@ optional trading services; the laptop owns only the browser and SSH tunnel.
 
 The lifecycle and security contract lives in [[docs/remote-access.md]]. For an
 always-on container exposed through HTTPS, Tailscale, or a private proxy, use
-[[docs/docker-deployment.md]]. Remote and Docker are parallel deployment
-choices: neither is a compatibility fallback for the other.
+the source-built server image in [[docs/docker-deployment.md]]. Railway also
+has a native CLI SSH-host profile described below. These are parallel
+deployment choices: none is a compatibility fallback for another.
 
 ## Choose a Deployment
 
@@ -17,6 +18,7 @@ choices: neither is a compatibility fallback for the other.
 | Complete packaged desktop app | Electron |
 | OpenAlice from a local source checkout | `openalice start` |
 | Existing private machine reached through SSH | `openalice remote` |
+| Railway service reached only through SSH | `Dockerfile.railway` + `openalice remote` |
 | Existing compatible Server; tunnel only | `openalice ssh` |
 | Container lifecycle, volume, healthcheck, and HTTPS | Docker |
 
@@ -37,8 +39,14 @@ On the laptop:
 On the remote host:
 
 - Linux or macOS;
-- `curl`, `tar`, and a SHA-256 utility;
+- Bash, `tar` with gzip support, `diff`, and a SHA-256 utility;
+- `curl` for a network install;
+- `lockf` on macOS or `flock` on Linux (normally from `util-linux`);
 - enough disk and memory for the installed Runtime.
+
+The same shared-installer prerequisites apply on the laptop when it installs
+its local CLI. The Railway image supplies them explicitly; OpenAlice does not
+silently add missing system packages on a generic host.
 
 The native release does not require Node.js, Bun, Git, an Agent Runtime, or
 source-build tools. If you explicitly select a source checkout, that separate
@@ -61,9 +69,14 @@ openalice version --json
 ```
 
 The installer records its channel/version, target, checksum, and immutable
-content identity. Managed remote reproduces that same native OpenAlice release
-on the target; it has no separate hidden release channel and does not install
-or change the target's Agent Runtime executables.
+content identity. On an ordinary SSH-managed host, managed remote selects the
+same logical OpenAlice release for the target, then verifies that target's own
+platform archive and content identity. Cross-platform archives are not expected
+to be byte-identical. Dev uses one completed latest manifest for both local and
+remote target selection and blocks mutation until the invoking dev CLI is
+current. Railway is different: its service variables and entrypoint select the
+release, while the laptop CLI only inspects the installed target-local Runtime
+before tunneling. Neither path installs or changes Agent Runtime executables.
 
 ## 2. Give the Host a Useful SSH Name
 
@@ -87,6 +100,99 @@ ssh openalice-box
 Exit that shell after it connects. OpenAlice will use the same host-key and
 authentication policy.
 
+### Railway host setup
+
+For a volume-backed Railway host, connect the OpenAlice repository as the
+service source and set `RAILWAY_DOCKERFILE_PATH` to:
+
+```text
+Dockerfile.railway
+```
+
+Attach a Railway Volume at `/data` before the first deploy. Do not configure a
+pre-deploy install step: Railway mounts the Volume only when the service starts,
+and the image entrypoint owns bootstrap on that mounted filesystem. Do not
+generate a public domain or TCP proxy for Alice. The only client path in this
+profile is Railway SSH plus OpenAlice's local loopback tunnel.
+
+Set the service lifecycle explicitly in the Railway Dashboard:
+
+- leave **Start Command** empty so Railway uses `Dockerfile.railway`'s
+  `ENTRYPOINT` rather than replacing it;
+- disable **Serverless** so an idle but persistent Agent Runtime is not put to
+  sleep;
+- set **Restart Policy** to **Always** so a foreground Guardian is restored
+  after either clean or failed exit (choose a Railway plan that exposes this
+  policy);
+- keep the volume-backed service at exactly one replica; Guardian and one
+  AliceProject Home are single-owner state, not a load-balanced workload; and
+- set `RAILWAY_DEPLOYMENT_DRAINING_SECONDS=30` or higher so Railway gives
+  Guardian at least 30 seconds between `SIGTERM` and forced termination.
+
+The default service variables install the latest stable native release. Use
+only the selectors needed for the intended host:
+
+```text
+OPENALICE_RAILWAY_CHANNEL=stable
+
+# Accepted beta checkpoint instead:
+OPENALICE_RAILWAY_CHANNEL=beta
+OPENALICE_RAILWAY_VERSION=<accepted-beta-version>
+
+# Rolling latest dev preview instead (no version variable):
+OPENALICE_RAILWAY_CHANNEL=dev
+
+# Optional Project selection; this is the only layout override:
+OPENALICE_HOME=/data/projects/research
+```
+
+On the first install or a forced refresh, stable and beta may omit the version
+to resolve the latest manifest or may pin an in-channel version. A later boot
+reuses an already valid install instead of treating every restart as an update.
+Dev always follows the completed latest dev manifest and refuses a version
+override. Installation and Project data survive service replacement under
+separate paths:
+
+```text
+/data/home                  fixed persistent Railway SSH HOME
+/data/home/.openalice       native OpenAlice install root
+/data/home/.local           persistent user-owned executable prefix
+/data/home/.bun             optional persistent user-owned Bun root
+/data/projects/default      OPENALICE_HOME
+```
+
+Those user paths and their persistent `PATH` are fixed by the image so Railway
+SSH and Guardian see the same installation. Do not override `HOME`,
+`OPENALICE_INSTALL_DIR`, `NPM_CONFIG_PREFIX`, `BUN_INSTALL`,
+`OPENALICE_RAILWAY_VOLUME_ROOT`, or `AQ_LAUNCHER_ROOT`. The only layout selector
+is `OPENALICE_HOME`; it must stay beneath `/data`, and the entrypoint always
+derives `<OPENALICE_HOME>/workspaces` as `AQ_LAUNCHER_ROOT`. During bootstrap
+the entrypoint uses system-only `PATH`, then restores the persistent user paths
+after validating the native CLI.
+
+Wait for the service log to report the foreground Runtime start, then add an
+OpenSSH alias on the laptop with the Railway CLI:
+
+```bash
+railway ssh config --service openalice --alias openalice-railway
+ssh openalice-railway 'openalice version --json'
+```
+
+Use the actual Railway service name in place of `openalice`. The generated
+OpenSSH block preserves Railway account and deployment routing, so
+`openalice-railway` can be used anywhere this guide shows `openalice-box`.
+OpenAlice never installs an Agent Runtime into the service. If one is needed,
+open a Railway SSH shell and install it into a persistent user location already
+on `PATH`, such as `/data/home/.local/bin` or `/data/home/.bun/bin`; its login,
+version, and updates remain yours.
+
+AliceProject transfer can reuse Alice-owned AI, market-data-provider, broker,
+and Connector credentials, but it does not copy Web authentication/sessions or
+native Agent login/configuration. Git-ignored dependencies and Alice-owned
+runtime, backup, Session, and install state are also excluded. Review the exact
+contract and run `--plan` before apply as described in
+[[docs/remote-access.md]].
+
 ## 3. Review the Plan
 
 ```bash
@@ -94,7 +200,8 @@ openalice remote openalice-box --plan
 ```
 
 The read-only plan reports the remote platform, CLI, Runtime owner/provider,
-ports, and every proposed change. On a new supported host it normally includes:
+ports, and every proposed change. On a new ordinary SSH-managed host it normally
+includes:
 
 1. install the matching native OpenAlice release;
 2. verify and start the detached OpenAlice Server from that immutable Runtime;
@@ -105,15 +212,22 @@ release directory. You do not need to SSH in, clone the repository, install a
 compiler, find an absolute source path, or repeat `--app-dir` on later
 connections. Nothing changes until you approve the plan.
 
+For a Railway target, the plan is inspection-only: it must not propose an
+install, update, start, takeover, or stop. If bootstrap or Runtime consistency
+is unhealthy, repair the service through Railway rather than approving a local
+mutation.
+
 ## 4. Connect
 
 ```bash
 openalice remote openalice-box
 ```
 
-Approve the displayed plan. The native archive downloads and activates as one
-bounded transaction; failures include a bounded diagnostic tail. When ready,
-OpenAlice opens a URL such as
+On an ordinary SSH-managed host, approve the displayed plan. The native archive
+downloads and activates as one bounded transaction; failures include a bounded
+diagnostic tail. On Railway there is no release or lifecycle approval at this
+step: `openalice remote` verifies the service-owned foreground Runtime and opens
+only the tunnel. When ready, OpenAlice opens a URL such as
 `http://127.0.0.1:49891` in the local browser.
 
 The browser, page APIs, and Workspace PTY WebSocket all cross the same SSH
@@ -131,7 +245,8 @@ OpenAlice prefers the last successful local port, so an existing browser tab
 can recover on the same localhost origin. If that port is genuinely occupied,
 the command chooses another one and tells you.
 
-Inspect or stop the remote Server without writing raw SSH commands:
+Inspect or stop a generic SSH-managed remote Server without writing raw SSH
+commands:
 
 ```bash
 openalice remote openalice-box --status
@@ -142,9 +257,21 @@ Status bundles the control lookup into one SSH round trip instead of repeating
 the full bootstrap prerequisite scan. Stop uses the same control-only probe
 before and after Guardian's structured shutdown.
 
-Closing the browser or pressing `Ctrl+C` closes only the local tunnel. The
-detached Server, Workspaces, PTYs, and Agent processes continue on the remote
-host until you run `--stop`, the host stops, or Guardian shuts them down.
+On an ordinary SSH-managed host, closing the browser or pressing `Ctrl+C`
+closes only the local tunnel. The detached Server, Workspaces, PTYs, and Agent
+processes continue until you run `--stop`, the host stops, or Guardian shuts
+them down.
+
+The Railway profile deliberately runs `server run` in the foreground rather
+than keeping a detached child. Closing the laptop tunnel still leaves it
+running, and Railway is the only release and lifecycle authority. For a
+Railway-identified target, `openalice remote` is status/connect-only and rejects
+`--stop`, `--takeover`, and `--app-dir`; stop, restart, or redeploy the service
+through Railway instead. On every start, the image-owned Railway wrapper
+replaces the persistent command shims and refuses `openalice update`,
+`rollback`, and `uninstall` before an installed release can mutate the
+persistent pointer; change the service channel/version variables and redeploy,
+or remove the service itself.
 
 Known transient SSH transport interruptions are retried with a short,
 platform-neutral message. Raw platform diagnostics are shown only when the
@@ -202,6 +329,10 @@ openalice remote openalice-box \
 - Use a least-privilege remote account and normal SSH host-key discipline.
 - Provider credentials, Workspace history, files, and Agent state live under
   the remote home; the browser is not a backup.
+- On Railway, the SSH Home and user install paths are fixed below `/data/home`.
+  Only `OPENALICE_HOME` may select a different Project beneath `/data`; the
+  entrypoint derives its Workspace root, rejects normalized escapes, and
+  rejects a Railway service that has no `/data` Volume.
 - For an ephemeral VM or container, place `--home` on persistent storage. The
   Runtime can be reinstalled; the home is the durable state that must survive.
 - A platform replacement can reattach a volume whose Guardian lock names the
@@ -224,3 +355,8 @@ expected to wrap their SSH host in Docker. Both surfaces run the same
 Guardian/Alice product with different operational ownership. Continue with
 [[docs/docker-deployment.md]] for authentication, backups, upgrades, and the
 full container acceptance contract.
+
+The Railway native CLI image is likewise not a replacement for this source
+server image. It intentionally omits bundled Agent Runtimes, public Web
+exposure, and the source-image health/auth deployment contract; its job is to
+keep one install root and AliceProject Home durable behind SSH.

--- a/install
+++ b/install
@@ -32,6 +32,24 @@ fail() {
   exit 1
 }
 
+process_identity() {
+  local identity_pid="$1" boot_id stat_line stat_tail start_ticks started_at
+  if [[ "${platform:-}" == linux && -r "/proc/$identity_pid/stat" ]]; then
+    boot_id="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || true)"
+    stat_line="$(cat "/proc/$identity_pid/stat" 2>/dev/null || true)"
+    stat_tail="${stat_line##*) }"
+    start_ticks="$(printf '%s\n' "$stat_tail" | awk 'NF >= 20 { print $20 }')"
+    if [[ -n "$boot_id" && "$start_ticks" =~ ^[0-9]+$ ]]; then
+      printf 'linux:%s:%s\n' "$boot_id" "$start_ticks"
+      return 0
+    fi
+  fi
+  started_at="$(LC_ALL=C ps -p "$identity_pid" -o lstart= 2>/dev/null \
+    | awk '{$1=$1; print}' || true)"
+  [[ -n "$started_at" ]] || return 1
+  printf 'ps:%s\n' "$started_at"
+}
+
 usage() {
   cat <<'EOF'
 OpenAlice CLI Installer
@@ -323,6 +341,16 @@ if [[ "$plan_only" == true ]]; then
   exit 0
 fi
 
+if [[ "$platform" == darwin ]]; then
+  command -v lockf >/dev/null 2>&1 \
+    || fail 'macOS lockf is required for safe concurrent installation'
+else
+  command -v flock >/dev/null 2>&1 \
+    || fail 'Linux flock is required for safe concurrent installation'
+fi
+command -v diff >/dev/null 2>&1 \
+  || fail "diff is required to verify the existing OpenAlice release"
+
 if [[ "$assume_yes" != true ]]; then
   if ! { exec 3<>/dev/tty; } 2>/dev/null; then
     printf 'No interactive terminal is available. Review --plan, then re-run with --yes.\n' >&2
@@ -340,6 +368,8 @@ provenance_dir="$cli_root/provenance"
 activation_path="$cli_root/activation.json"
 bin_dir="$INSTALL_DIR/bin"
 lock_dir="$INSTALL_DIR/.cli-install.lock"
+lock_guard_path="$INSTALL_DIR/.cli-install.lock.guard"
+lock_guard_owned=false
 staging_dir=""
 lock_owned=false
 previous_release_name=""
@@ -348,6 +378,56 @@ activation_switched=false
 install_complete=false
 legacy_launcher_backup=""
 legacy_launchers_backed_up=false
+
+acquire_install_lock() {
+  local lock_pid stored_identity actual_identity
+  if [[ -e "$lock_guard_path" || -L "$lock_guard_path" ]]; then
+    [[ -f "$lock_guard_path" && ! -L "$lock_guard_path" ]] \
+      || fail "CLI installer advisory lock is not a safe file: $lock_guard_path"
+  fi
+  exec 9>>"$lock_guard_path" \
+    || fail "Cannot open CLI installer advisory lock at $lock_guard_path"
+  if [[ "$platform" == darwin ]]; then
+    command -v lockf >/dev/null 2>&1 \
+      || fail 'macOS lockf is required for safe concurrent installation'
+    lockf -t 0 9 2>/dev/null \
+      || fail 'Another OpenAlice CLI installer is running'
+  else
+    command -v flock >/dev/null 2>&1 \
+      || fail 'Linux flock is required for safe concurrent installation'
+    flock -n 9 2>/dev/null \
+      || fail 'Another OpenAlice CLI installer is running'
+  fi
+  lock_guard_owned=true
+
+  if [[ -e "$lock_dir" || -L "$lock_dir" ]]; then
+    [[ -d "$lock_dir" && ! -L "$lock_dir" ]] \
+      || fail "CLI installer transaction lock is not a safe legacy directory: $lock_dir"
+    lock_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+    stored_identity="$(cat "$lock_dir/process-identity" 2>/dev/null || true)"
+    if [[ "$lock_pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
+      if [[ -z "$stored_identity" ]]; then
+        fail "Another OpenAlice CLI installer may be running (pid $lock_pid); the legacy lock cannot be verified"
+      fi
+      actual_identity="$(process_identity "$lock_pid" || true)"
+      [[ -n "$actual_identity" ]] \
+        || fail "Cannot verify OpenAlice CLI installer lock owner $lock_pid"
+      if [[ "$actual_identity" == "$stored_identity" ]]; then
+        fail "Another OpenAlice CLI installer is running (pid $lock_pid)"
+      fi
+    fi
+    printf 'Removing a stale CLI installer lock.\n'
+    rm -rf "$lock_dir"
+  fi
+
+  mkdir "$lock_dir"
+  lock_owned=true
+  printf '%s\n' "$$" >"$lock_dir/pid"
+  actual_identity="$(process_identity "$$" || true)"
+  [[ -n "$actual_identity" ]] \
+    || fail "Cannot record the CLI installer process identity"
+  printf '%s\n' "$actual_identity" >"$lock_dir/process-identity"
+}
 
 cleanup() {
   cleanup_status=$?
@@ -410,6 +490,7 @@ EOF
   fi
   [[ -z "$staging_dir" ]] || rm -rf "$staging_dir"
   if [[ "$lock_owned" == true ]]; then rm -rf "$lock_dir"; fi
+  if [[ "$lock_guard_owned" == true ]]; then exec 9>&-; fi
   exit "$cleanup_status"
 }
 trap cleanup EXIT
@@ -418,17 +499,7 @@ trap 'exit 143' TERM
 trap 'exit 129' HUP
 
 mkdir -p "$INSTALL_DIR"
-if [[ -d "$lock_dir" ]]; then
-  lock_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
-  if [[ "$lock_pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
-    fail "Another OpenAlice CLI installer is running (pid $lock_pid)"
-  fi
-  printf 'Removing a stale CLI installer lock.\n'
-  rm -rf "$lock_dir"
-fi
-mkdir "$lock_dir"
-printf '%s\n' "$$" >"$lock_dir/pid"
-lock_owned=true
+acquire_install_lock
 mkdir -p "$releases_dir" "$provenance_dir" "$bin_dir" "$cli_root/staging"
 releases_dir="$(CDPATH= cd -- "$releases_dir" && pwd -P)"
 staging_dir="$(mktemp -d "$cli_root/staging/install.XXXXXX")"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
     "directory": "packages/cli"
   },
   "dependencies": {
-    "@earendil-works/pi-tui": "0.83.0"
+    "@earendil-works/pi-tui": "0.83.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -11,10 +11,12 @@ import {
   realpath,
   readdir,
   rm,
+  symlink,
+  utimes,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { delimiter, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 
@@ -241,6 +243,28 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
     await expect(access(join(installRoot, 'cli', 'current'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('checks locking and release-comparison prerequisites before requesting consent', async () => {
+    const fixture = await makeReleaseArchive('0.91.0', '5'.repeat(16))
+    const lockCommand = platform === 'darwin' ? 'lockf' : 'flock'
+    const cases = [
+      {
+        missing: lockCommand,
+        message: platform === 'darwin'
+          ? 'macOS lockf is required for safe concurrent installation'
+          : 'Linux flock is required for safe concurrent installation',
+      },
+      { missing: 'diff', message: 'diff is required to verify the existing OpenAlice release' },
+    ]
+
+    for (const testCase of cases) {
+      const installRoot = join(fixture.root, `missing-${testCase.missing}`)
+      const path = await makeInstallerPathWithout(testCase.missing)
+      await expect(runInstaller(fixture, installRoot, [], { PATH: path }))
+        .rejects.toMatchObject({ stderr: expect.stringContaining(testCase.message) })
+      await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  })
+
   it('recovers a stale lock and refuses to race a live installer', async () => {
     const fixture = await makeReleaseArchive('0.91.0', '6'.repeat(16))
     const installRoot = join(fixture.root, 'installed')
@@ -253,7 +277,62 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
     await mkdir(lockDir)
     await writeFile(join(lockDir, 'pid'), `${process.pid}\n`)
     await expect(runInstaller(fixture, installRoot, ['--yes']))
-      .rejects.toMatchObject({ stderr: expect.stringContaining('installer is running') })
+      .rejects.toMatchObject({ stderr: expect.stringContaining('legacy lock cannot be verified') })
+  })
+
+  it('recovers an interrupted installer lock after its pid is reused by another process', async () => {
+    const fixture = await makeReleaseArchive('0.91.0', '6'.repeat(16))
+    const installRoot = join(fixture.root, 'installed')
+    const lockDir = join(installRoot, '.cli-install.lock')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'pid'), `${process.pid}\n`)
+    await writeFile(join(lockDir, 'process-identity'), 'linux:stale-boot:1\n')
+
+    const recovered = await runInstaller(fixture, installRoot, ['--yes'])
+
+    expect(recovered.stdout).toContain('Removing a stale CLI installer lock')
+  })
+
+  it('recovers an installer lock interrupted before its owner pid was published', async () => {
+    const fixture = await makeReleaseArchive('0.91.0', '6'.repeat(16))
+    const installRoot = join(fixture.root, 'installed')
+    const lockDir = join(installRoot, '.cli-install.lock')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'process-identity'), 'linux:interrupted:1\n')
+    const old = new Date(Date.now() - 5_000)
+    await utimes(lockDir, old, old)
+
+    const recovered = await runInstaller(fixture, installRoot, ['--yes'])
+
+    expect(recovered.stdout).toContain('Removing a stale CLI installer lock')
+  })
+
+  it('recovers a legacy stale lock even when an interrupted reclaimer left its marker', async () => {
+    const fixture = await makeReleaseArchive('0.91.0', '6'.repeat(16))
+    const installRoot = join(fixture.root, 'installed')
+    const lockDir = join(installRoot, '.cli-install.lock')
+    await mkdir(join(lockDir, 'reclaiming'), { recursive: true })
+    await writeFile(join(lockDir, 'pid'), '99999999\n')
+    await writeFile(join(lockDir, 'process-identity'), 'linux:interrupted:1\n')
+
+    const recovered = await runInstaller(fixture, installRoot, ['--yes'])
+
+    expect(recovered.stdout).toContain('Removing a stale CLI installer lock')
+  })
+
+  it('serializes two installers with a kernel lock while recovering transaction markers', async () => {
+    const fixture = await makeReleaseArchive('0.91.0', '6'.repeat(16), { versionDelaySeconds: 2 })
+    const installRoot = join(fixture.root, 'installed')
+    const lockDir = join(installRoot, '.cli-install.lock')
+    const guard = join(installRoot, '.cli-install.lock.guard')
+    const first = runInstaller(fixture, installRoot, ['--yes'])
+    await waitForPath(lockDir)
+
+    await expect(runInstaller(fixture, installRoot, ['--yes']))
+      .rejects.toMatchObject({ stderr: expect.stringContaining('Another OpenAlice CLI installer is running') })
+    await expect(first).resolves.toMatchObject({ stdout: expect.stringContaining('OpenAlice 0.91.0 is ready') })
+    await expect(access(lockDir)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(guard)).resolves.toBeUndefined()
   })
 
   it('uses the fixed dev-channel archive and records dev provenance', async () => {
@@ -697,9 +776,12 @@ async function makeReleaseArchive(version, contentIdentity, options = {}) {
   const installedLauncherFailure = options.failInstalledLauncher
     ? 'if [ "${OPENALICE_INSTALL_METHOD:-}" = "direct" ]; then exit 42; fi\n'
     : ''
+  const versionDelay = Number(options.versionDelaySeconds) > 0
+    ? `sleep ${Number(options.versionDelaySeconds)}\n`
+    : ''
   await writeFile(executable, `#!/bin/sh
 set -eu
-${installedLauncherFailure}if [ "\${1:-}" = "--version" ]; then printf '%s\\n' '${version}'; exit 0; fi
+${installedLauncherFailure}if [ "\${1:-}" = "--version" ]; then ${versionDelay}printf '%s\\n' '${version}'; exit 0; fi
 if [ "\${1:-}" = "debug-env" ]; then
   printf '%s|%s|%s|%s|%s\\n' "\$OPENALICE_INSTALL_ROOT" "\$OPENALICE_RELEASE_DIR" "\$OPENALICE_INSTALL_SOURCE" "\$OPENALICE_CONTENT_IDENTITY" "\$OPENALICE_INSTALL_METHOD"
   exit 0
@@ -723,4 +805,51 @@ printf 'fixture %s\\n' '${version}'
     archive,
     sha256: createHash('sha256').update(bytes).digest('hex'),
   }
+}
+
+async function waitForPath(path, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      await access(path)
+      return
+    } catch {}
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20))
+  }
+  throw new Error(`Timed out waiting for ${path}`)
+}
+
+async function makeInstallerPathWithout(missingCommand) {
+  const bin = await mkdtemp(join(tmpdir(), 'openalice-installer-path-'))
+  temporaryPaths.push(bin)
+  const commands = [
+    'bash',
+    'cat',
+    'diff',
+    'flock',
+    'lockf',
+    'sha256sum',
+    'shasum',
+    'sysctl',
+    'tar',
+    'uname',
+  ]
+  for (const command of commands) {
+    if (command === missingCommand) continue
+    const executable = await resolveExecutable(command)
+    if (executable) await symlink(executable, join(bin, command))
+  }
+  return bin
+}
+
+async function resolveExecutable(command) {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    if (!directory) continue
+    const candidate = join(directory, command)
+    try {
+      await access(candidate)
+      return candidate
+    } catch {}
+  }
+  return null
 }

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -98,7 +98,12 @@ export async function startRuntime(options, dependencies = {}) {
   const appDir = standalone
     ? resolveBunResourceRoot(env, dependencies.runtimeExecutable ?? process.execPath)
     : await resolveRoot(requestedAppDir)
-  const runtimeProvider = resolveRuntimeProvider(options.runtimeProvider, appDir, env)
+  const runtimeProvider = resolveRuntimeProvider(
+    options.runtimeProvider,
+    appDir,
+    env,
+    activation.contentIdentity,
+  )
   const prepareSource = dependencies.prepareSource ?? prepareSourceCheckout
   emit({ type: 'preparing', appDir, homeRoot })
   if (!standalone) {
@@ -166,7 +171,8 @@ export async function startRuntime(options, dependencies = {}) {
 
   let ready = false
   const readinessAbort = new AbortController()
-  const startupSignals = createStartupSignalGuard(runtime, 'OpenAlice Runtime start')
+  const signalSource = dependencies.signalSource ?? process
+  const startupSignals = createStartupSignalGuard(runtime, 'OpenAlice Runtime start', { signalSource })
   const earlyFailure = new Promise((_, reject) => {
     runtime.once('error', reject)
     const rejectExit = (code, signal) => {
@@ -209,11 +215,17 @@ export async function startRuntime(options, dependencies = {}) {
       logPath: detached ? logPath : null,
       status,
     }
-    startupSignals.release()
+    if (detached) {
+      startupSignals.release()
+      emit({ type: 'ready', result: launch })
+      return launch
+    }
+    const runtimeExit = holdRuntime(runtime, {
+      signalSource,
+      releaseStartupSignals: startupSignals.release,
+    })
     emit({ type: 'ready', result: launch })
-
-    if (detached) return launch
-    const exitCode = await holdRuntime(runtime)
+    const exitCode = await runtimeExit
     return {
       ...launch,
       outcome: 'exited',
@@ -250,13 +262,17 @@ export async function startRuntime(options, dependencies = {}) {
   }
 }
 
-function resolveRuntimeProvider(explicit, appDir, env) {
+function resolveRuntimeProvider(explicit, appDir, env, installedIdentity = null) {
   if (explicit?.kind === 'bun' || isBunStandalone()) {
+    const explicitIdentity = typeof explicit?.contentIdentity === 'string'
+      ? explicit.contentIdentity.trim()
+      : explicit?.contentIdentity
     return {
       kind: 'bun',
-      contentIdentity: explicit?.contentIdentity
-        ?? env['OPENALICE_RUNTIME_CONTENT_IDENTITY']?.trim()
-        ?? null,
+      contentIdentity: explicitIdentity
+        || env['OPENALICE_RUNTIME_CONTENT_IDENTITY']?.trim()
+        || installedIdentity
+        || null,
     }
   }
   if (explicit?.kind === 'bundle') {
@@ -420,25 +436,45 @@ function isLoopbackWebUrl(value) {
   }
 }
 
-function holdRuntime(runtime) {
+function holdRuntime(runtime, options = {}) {
+  const signalSource = options.signalSource ?? process
+  const releaseStartupSignals = options.releaseStartupSignals ?? (() => undefined)
+  const exitCodeFor = (code, signal, requestedStop) => (
+    requestedStop ? 0 : code ?? (signal ? 1 : 0)
+  )
   if (runtime.exitCode !== undefined && (
     runtime.exitCode !== null
     || (runtime.signalCode !== undefined && runtime.signalCode !== null)
   )) {
-    return Promise.resolve(runtime.exitCode ?? 0)
+    releaseStartupSignals()
+    return Promise.resolve(exitCodeFor(runtime.exitCode, runtime.signalCode, false))
   }
   return new Promise((resolvePromise) => {
     let requestedStop = false
+    let settled = false
+    const cleanup = () => {
+      signalSource.off('SIGINT', stop)
+      signalSource.off('SIGTERM', stop)
+      runtime.off('exit', onExit)
+    }
+    const onExit = (code, signal) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolvePromise(exitCodeFor(code, signal, requestedStop))
+    }
     const stop = () => {
+      if (requestedStop) return
       requestedStop = true
       runtime.kill('SIGTERM')
     }
-    process.once('SIGINT', stop)
-    process.once('SIGTERM', stop)
-    runtime.once('exit', (code) => {
-      process.off('SIGINT', stop)
-      process.off('SIGTERM', stop)
-      resolvePromise(requestedStop ? 0 : code ?? 0)
-    })
+    runtime.once('exit', onExit)
+    signalSource.once('SIGINT', stop)
+    signalSource.once('SIGTERM', stop)
+    releaseStartupSignals()
+    if (runtime.exitCode !== undefined && (
+      runtime.exitCode !== null
+      || (runtime.signalCode !== undefined && runtime.signalCode !== null)
+    )) onExit(runtime.exitCode, runtime.signalCode)
   })
 }

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -336,6 +336,111 @@ describe('OpenAlice Runtime lifecycle core', () => {
     }
   })
 
+  it('injects and confirms the installed Bun identity on a direct server start', async () => {
+    const fixture = await makeActivationLayout()
+    await recordPendingActivation(fixture.layout, {
+      activeRelease: fixture.currentName,
+      previousRelease: fixture.previousName,
+      productVersion: '0.92.0',
+    })
+    vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true)
+    try {
+      const child = new FakeChild()
+      const spawnProcess = vi.fn(() => child)
+      const readStatus = vi.fn()
+        .mockResolvedValueOnce(absentStatus())
+        .mockResolvedValue(runningStatus('bbbbbbbbbbbbbbbb'))
+
+      const result = await startRuntime({
+        ...startOptions(),
+        appDir: null,
+      }, {
+        activationLayout: fixture.layout,
+        installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+        cliVersion: '0.92.0',
+        detached: true,
+        env: {
+          OPENALICE_APP_HOME: '/opt/openalice/releases/v1/share/openalice',
+          OPENALICE_RUNTIME_CONTENT_IDENTITY: '   ',
+        },
+        runtimeExecutable: '/opt/openalice/releases/v1/bin/openalice',
+        spawnProcess,
+        openFile: async () => ({ fd: 9, close: async () => undefined }),
+        mkdirImpl: async () => undefined,
+        readStatus,
+        sleep: async () => undefined,
+      })
+
+      expect(spawnProcess.mock.calls[0][2].env).toEqual(expect.objectContaining({
+        OPENALICE_RUNTIME_PROVIDER: 'bun',
+        OPENALICE_RUNTIME_CONTENT_IDENTITY: 'bbbbbbbbbbbbbbbb',
+      }))
+      expect(result.status.pendingActivation).toBeNull()
+      expect((await readActivationReceipt(fixture.layout)).state).toBe('confirmed')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('returns a failure when the foreground Guardian exits from an unexpected signal', async () => {
+    const child = new FakeChild()
+    const signalSource = new EventEmitter()
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(absentStatus())
+      .mockResolvedValue(runningStatus())
+
+    const result = await startRuntime(startOptions(), {
+      detached: false,
+      env: {},
+      signalSource,
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess: () => child,
+      mkdirImpl: async () => undefined,
+      readStatus,
+      sleep: async () => undefined,
+      emit(event) {
+        if (event.type === 'ready') child.emit('exit', null, 'SIGKILL')
+      },
+    })
+
+    expect(result).toMatchObject({ outcome: 'exited', exitCode: 1 })
+  })
+
+  it('installs the steady signal relay before reporting foreground readiness', async () => {
+    const child = new FakeChild()
+    const signalSource = new EventEmitter()
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(absentStatus())
+      .mockResolvedValue(runningStatus())
+    child.kill.mockImplementation(() => {
+      child.signalCode = 'SIGTERM'
+      queueMicrotask(() => child.emit('exit', null, 'SIGTERM'))
+      return true
+    })
+
+    const result = await startRuntime(startOptions(), {
+      detached: false,
+      env: {},
+      signalSource,
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess: () => child,
+      mkdirImpl: async () => undefined,
+      readStatus,
+      sleep: async () => undefined,
+      emit(event) {
+        if (event.type === 'ready') signalSource.emit('SIGTERM')
+      },
+    })
+
+    expect(child.kill).toHaveBeenCalledOnce()
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(result).toMatchObject({ outcome: 'exited', exitCode: 0 })
+  })
+
   it('allows its spawned Guardian ownership transition but rejects a racing owner', async () => {
     const child = new FakeChild()
     child.pid = 321

--- a/packages/cli/src/project-command.spec.ts
+++ b/packages/cli/src/project-command.spec.ts
@@ -1,11 +1,15 @@
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Readable, Writable } from 'node:stream'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AI_PROVIDER_FILE_REL } from './ai-credential-copy.ts'
+import { writeAliceProjectProductStamp } from './alice-project-product.ts'
 import { formatProjectHelp, runProjectCommand } from './project-command.ts'
+import { planProjectTransfer } from './project-transfer.ts'
+import { writeProjectTransferStream } from './project-transfer-stream.ts'
 import {
   createSupervisorAliceProject,
   persistMachineLaunchConfig,
@@ -214,6 +218,73 @@ describe('openalice project', () => {
     expect(JSON.parse(stdout.join(''))).toMatchObject({ transferId: 'transfer-receive' })
   })
 
+  it('receives a real stream into the Supervisor registry without changing the default', async () => {
+    const env = await setupProjects()
+    await persistSelectedSupervisorAliceProject(env.context, 'office')
+    const transferRoot = await realpath(env.root)
+    const source = join(transferRoot, 'transfer-source')
+    const destination = join(transferRoot, 'received-home')
+    await mkdir(source)
+    await writeAliceProjectProductStamp(source, 'nano')
+    await writeFile(join(source, 'portable.txt'), 'portable project\n')
+    const sourceSummary = {
+      id: 'alice-project-transfer-source',
+      key: 'source',
+      displayName: 'Source',
+      home: source,
+      port: 47331,
+      portAutomatic: true,
+      isDefault: false,
+    }
+    const plan = await planProjectTransfer({
+      source: sourceSummary,
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'remote-copy',
+      destinationDisplayName: 'Remote Copy',
+      destinationHome: destination,
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+    })
+    const stream = await serializeTransfer(plan)
+    const receiveIo = {
+      supervisorRoot: env.context.supervisorRoot,
+      transferSource: Readable.from(stream),
+      stdout: { write: () => undefined },
+    }
+
+    await expect(runProjectCommand(['transfer-receive'], receiveIo)).resolves.toBe(0)
+    const registered = JSON.parse(await env.readConfig()) as {
+      defaultProject?: string
+      projects?: Record<string, { displayName?: string; home?: string; product?: string }>
+    }
+    expect(registered.defaultProject).toBe('office')
+    expect(registered.projects?.['remote-copy']).toMatchObject({
+      displayName: 'Remote Copy',
+      home: destination,
+      product: 'nano',
+    })
+    expect(await readFile(join(destination, 'portable.txt'), 'utf8')).toBe('portable project\n')
+
+    await expect(runProjectCommand(['transfer-receive'], {
+      ...receiveIo,
+      transferSource: Readable.from(stream),
+    })).resolves.toBe(0)
+
+    const conflictingPlan = await planProjectTransfer({
+      source: sourceSummary,
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'remote-copy',
+      destinationDisplayName: 'Conflicting Copy',
+      destinationHome: join(transferRoot, 'conflicting-home'),
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+    })
+    await expect(runProjectCommand(['transfer-receive'], {
+      ...receiveIo,
+      transferSource: Readable.from(await serializeTransfer(conflictingPlan)),
+    })).rejects.toThrow('already registered to another Home')
+  })
+
   it('documents the command surface', () => {
     expect(formatProjectHelp()).toContain('copy-ai-creds')
     expect(formatProjectHelp()).toContain('project use')
@@ -240,6 +311,7 @@ async function setupProjects() {
   await persistSelectedSupervisorAliceProject(withHome, 'default', options)
   const ready = await resolveStoredLaunchContext({}, options)
   return {
+    root,
     context: ready,
     defaultHome,
     officeHome,
@@ -252,6 +324,18 @@ async function setupProjects() {
       return readFile(join(officeHome, AI_PROVIDER_FILE_REL), 'utf8')
     },
   }
+}
+
+async function serializeTransfer(plan: Awaited<ReturnType<typeof planProjectTransfer>>): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  const output = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk))
+      callback()
+    },
+  })
+  await writeProjectTransferStream({ plan, output })
+  return Buffer.concat(chunks)
 }
 
 function transferIo(

--- a/packages/cli/src/project-command.ts
+++ b/packages/cli/src/project-command.ts
@@ -5,6 +5,7 @@
 import { createInterface } from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { posix, resolve } from 'node:path'
+import type { Readable } from 'node:stream'
 
 import {
   copyAiCredentials,
@@ -112,6 +113,7 @@ export interface ProjectCommandIo {
     stderr?: { write(chunk: string): void }
   }) => Promise<ProjectTransferReceipt>
   receiveTransfer?: () => Promise<ProjectTransferReceipt>
+  transferSource?: Readable
 }
 
 export async function runProjectCommand(
@@ -348,7 +350,7 @@ async function runProjectTransferReceive(argv: string[], io: ProjectCommandIo): 
   if (argv.length > 0) throw usageError('project transfer-receive does not accept arguments')
   const supervisorRoot = io.supervisorRoot ?? resolveSupervisorRootPath({ env: io.env })
   const receive = io.receiveTransfer ?? (() => receiveProjectTransferStream({
-    source: process.stdin,
+    source: io.transferSource ?? process.stdin,
     register: async (plan) => {
       const context = { supervisorRoot }
       const registry = await readSupervisorAliceProjectRegistry(context, { env: io.env })
@@ -424,6 +426,9 @@ export function formatProjectTransferPlan(plan: ProjectTransferPlan): string {
   const excludedSessions = plan.excluded
     .filter((entry) => entry.reason === 'session-plane' || entry.reason === 'untracked-session-dossier')
     .reduce((sum, entry) => sum + entry.files, 0)
+  const excludedMachineLocal = plan.excluded
+    .filter((entry) => entry.reason === 'machine-local')
+    .reduce((sum, entry) => sum + entry.files, 0)
   const credentials = plan.policy.credentials === 'omit'
     ? 'omitted by request'
     : `${plan.credentials.ai.count} AI, ${plan.credentials.broker.count} broker, ${plan.credentials.connector.count} Connector, ${plan.credentials.providerKeys.count} provider key(s)`
@@ -439,6 +444,7 @@ export function formatProjectTransferPlan(plan: ProjectTransferPlan): string {
     `  Free space   ${formatBytes(plan.destination.requiredFreeBytes)} required on destination`,
     `  Credentials  ${credentials}`,
     `  Sessions     0 imported; ${excludedSessions} runtime file(s) excluded`,
+    `  Machine      ${excludedMachineLocal} machine-local file(s) or link(s) excluded`,
     `  Issues       ${plan.scheduledIssues.length} exact-Session scheduled owner(s); policy ${plan.policy.scheduledIssues ?? 'required'}`,
   ]
   if (plan.blockers.length > 0) {

--- a/packages/cli/src/project-transfer-files.ts
+++ b/packages/cli/src/project-transfer-files.ts
@@ -1,5 +1,6 @@
 /** Deterministic transforms applied before portable bytes enter the SSH stream. */
-import { join } from 'node:path'
+import { posix } from 'node:path'
+import { parseDocument } from 'yaml'
 
 import type { ProjectTransferTransform } from './project-transfer.ts'
 
@@ -15,7 +16,11 @@ export function transformProjectTransferFile(input: {
     case 'workspace-catalog-paths':
       return transformJson(input.bytes, (value) => rewriteWorkspaceCatalog(value, input.destinationHome))
     case 'strip-ai-credentials':
-      return transformJson(input.bytes, (value) => ({ ...recordValue(value), credentials: {} }))
+      return transformJson(input.bytes, (value) => ({
+        ...recordValue(value),
+        apiKeys: {},
+        credentials: {},
+      }))
     case 'strip-market-provider-keys':
       return transformJson(input.bytes, (value) => ({ ...recordValue(value), providerKeys: {} }))
     case 'rewrite-issue-owner':
@@ -29,7 +34,7 @@ function rewriteWorkspaceRegistry(value: unknown, destinationHome: string): unkn
     ? root['workspaces'].map((entry) => {
         const workspace = recordValue(entry)
         const id = requireSafeId(workspace['id'], 'Workspace')
-        return { ...workspace, dir: join(destinationHome, 'workspaces', 'workspaces', id) }
+        return { ...workspace, dir: posix.join(destinationHome, 'workspaces', 'workspaces', id) }
       })
     : []
   return { ...root, workspaces }
@@ -38,16 +43,23 @@ function rewriteWorkspaceRegistry(value: unknown, destinationHome: string): unkn
 function rewriteWorkspaceCatalog(value: unknown, destinationHome: string): unknown {
   const root = recordValue(value)
   const workspaces = Array.isArray(root['workspaces'])
-    ? root['workspaces'].map((entry) => {
+    ? root['workspaces'].flatMap((entry) => {
         const workspace = recordValue(entry)
+        // Pre-#662 could import Pi's redirected agent home as a departed
+        // pseudo-Workspace. It is native runtime state, not a user Workspace.
+        if (
+          workspace['id'] === '.pi-agent'
+          && workspace['legacyImported'] === true
+          && workspace['lifecycle'] === 'departed'
+        ) return []
         const id = requireSafeId(workspace['id'], 'Workspace Catalog')
-        return {
+        return [{
           ...workspace,
-          activeDir: join(destinationHome, 'workspaces', 'workspaces', id),
+          activeDir: posix.join(destinationHome, 'workspaces', 'workspaces', id),
           ...(typeof workspace['departedDir'] === 'string'
-            ? { departedDir: join(destinationHome, 'workspaces', 'departed-workspaces', id) }
+            ? { departedDir: posix.join(destinationHome, 'workspaces', 'departed-workspaces', id) }
             : {}),
-        }
+        }]
       })
     : []
   return { ...root, workspaces }
@@ -58,13 +70,12 @@ function rewriteIssueOwner(value: string): string {
   if (!match?.[1] || match[2] === undefined || !match[3]) {
     throw transferTransformError('Scheduled Issue frontmatter changed after planning.')
   }
-  const rewritten = match[2].replace(
-    /^(assignee\s*:\s*)["']?@resume-[^\s"']+["']?(\s*)$/mu,
-    '$1"@new-then-resume"$2',
-  )
-  if (rewritten === match[2]) {
+  const document = parseDocument(match[2])
+  if (document.errors.length > 0 || document.get('assignee')?.toString().startsWith('@resume-') !== true) {
     throw transferTransformError('Scheduled Issue exact owner changed after planning.')
   }
+  document.set('assignee', '@new-then-resume')
+  const rewritten = document.toString().replace(/\n$/u, '')
   return `${match[1]}${rewritten}${match[3]}${value.slice(match[0].length)}`
 }
 

--- a/packages/cli/src/project-transfer-secrets.ts
+++ b/packages/cli/src/project-transfer-secrets.ts
@@ -29,10 +29,14 @@ const KEY_BYTES = 32
 const IV_BYTES = 12
 
 export interface ProjectTransferCredentialBundle {
-  ai: AiProviderVault
+  ai: ProjectTransferAiVault
   brokerAccounts: unknown[]
   connectors: Record<string, unknown>
   providerKeys: Record<string, string>
+}
+
+export interface ProjectTransferAiVault extends AiProviderVault {
+  apiKeys: Record<string, string>
 }
 
 export interface ProjectTransferCredentialSummary {
@@ -53,7 +57,7 @@ interface SealedEnvelope {
 export async function readProjectTransferCredentialBundle(
   home: string,
 ): Promise<ProjectTransferCredentialBundle> {
-  const [ai, brokerValue, connectorValue, globalProviderKeys, marketData] = await Promise.all([
+  const [aiVault, brokerValue, connectorValue, globalProviderKeys, marketData] = await Promise.all([
     readAiProviderVault(home),
     readOptionalSecretJson(home, join('data', 'config', 'accounts.json')),
     readOptionalSecretJson(home, join('data', 'config', 'connectors.json')),
@@ -61,7 +65,7 @@ export async function readProjectTransferCredentialBundle(
     readOptionalJson(join(home, 'data', 'config', 'market-data.json')),
   ])
   return {
-    ai,
+    ai: normalizeProjectTransferAiVault(aiVault),
     brokerAccounts: Array.isArray(brokerValue) ? brokerValue : [],
     connectors: recordValue(connectorValue),
     providerKeys: stringMap({
@@ -78,6 +82,7 @@ export function summarizeProjectTransferCredentials(
   for (const value of Object.values(bundle.ai.credentials)) {
     if (typeof value.vendor === 'string' && value.vendor.trim()) aiVendors.add(value.vendor)
   }
+  for (const vendor of Object.keys(bundle.ai.apiKeys)) aiVendors.add(vendor)
   const brokerPresets = new Set<string>()
   for (const value of bundle.brokerAccounts) {
     const record = recordValue(value)
@@ -87,7 +92,7 @@ export function summarizeProjectTransferCredentials(
   const connectorRoot = recordValue(bundle.connectors['adapters'])
   return {
     ai: {
-      count: Object.keys(bundle.ai.credentials).length,
+      count: Object.keys(bundle.ai.credentials).length + Object.keys(bundle.ai.apiKeys).length,
       vendors: [...aiVendors].sort(),
     },
     broker: {
@@ -102,6 +107,19 @@ export function summarizeProjectTransferCredentials(
       count: Object.keys(bundle.providerKeys).length,
       vendors: Object.keys(bundle.providerKeys).sort(),
     },
+  }
+}
+
+/**
+ * Legacy flat API keys are still a supported read shape. Normalize them into
+ * an explicit string-only map before they enter the private transfer bundle so
+ * they are counted, transported only on SSH stdin, and never left behind in
+ * the portable AI configuration file.
+ */
+export function normalizeProjectTransferAiVault(vault: AiProviderVault): ProjectTransferAiVault {
+  return {
+    ...vault,
+    apiKeys: stringMap(recordValue(vault['apiKeys'])),
   }
 }
 

--- a/packages/cli/src/project-transfer-ssh.spec.ts
+++ b/packages/cli/src/project-transfer-ssh.spec.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import type { ChildProcess, spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { PassThrough } from 'node:stream'
 
 import { describe, expect, it } from 'vitest'
@@ -47,11 +48,55 @@ describe('AliceProject SSH transfer transport', () => {
     }
   })
 
-  it('bounds and sanitizes remote failure diagnostics', async () => {
+  it('validates every receipt field and returns only the receipt schema', async () => {
+    const receipt = matchingReceipt()
+    const remoteReceipt = {
+      ...receipt,
+      secretCanary: 'top-level-secret',
+      unexpectedNested: {
+        secretCanary: 'nested-secret',
+      },
+    }
+    const spawnProcess = fakeSpawn((child) => {
+      child.stdin.once('finish', () => {
+        child.stdout.end(`${JSON.stringify(remoteReceipt)}\n`)
+        child.emit('exit', 0, null)
+      })
+    })
+    const returned = await transferProjectOverSsh({
+      machine: machine(),
+      plan: transferPlan(),
+      spawnProcess,
+    })
+    expect(returned).toEqual(receipt)
+    expect(JSON.stringify(returned)).not.toContain('secretCanary')
+
+    for (const invalid of [
+      { ...receipt, files: -1 },
+      { ...receipt, bytes: 1.5 },
+      { ...receipt, manifestSha256: 'not-a-sha256' },
+      { ...receipt, credentials: 'unknown' },
+      { ...receipt, publishedAt: 123 },
+    ]) {
+      const invalidSpawn = fakeSpawn((child) => {
+        child.stdin.once('finish', () => {
+          child.stdout.end(`${JSON.stringify(invalid)}\n`)
+          child.emit('exit', 0, null)
+        })
+      })
+      await expect(transferProjectOverSsh({
+        machine: machine(),
+        plan: transferPlan(),
+        spawnProcess: invalidSpawn,
+      })).rejects.toMatchObject({ code: 'ETRANSSSH' })
+    }
+  })
+
+  it('withholds untrusted remote diagnostics from the credential-bearing channel', async () => {
     const diagnostics: string[] = []
     const spawnProcess = fakeSpawn((child) => {
       child.stdin.once('finish', () => {
-        child.stderr.write('receiver\u0000 failed\n')
+        child.stderr.write('receiver\u0000 failed secret-canary\n')
         child.stderr.end()
         child.emit('exit', 23, null)
       })
@@ -61,8 +106,8 @@ describe('AliceProject SSH transfer transport', () => {
       plan: transferPlan(),
       spawnProcess,
       stderr: { write: (value) => diagnostics.push(value) },
-    })).rejects.toThrow('receiver failed')
-    expect(diagnostics).toEqual(['receiver\u0000 failed\n'])
+    })).rejects.toThrow('diagnostics were withheld')
+    expect(diagnostics).toEqual([])
   })
 })
 
@@ -142,7 +187,7 @@ function matchingReceipt() {
     destinationHome: '/home/alice/.openalice-copy',
     files: 0,
     bytes: 0,
-    manifestSha256: '0'.repeat(64),
+    manifestSha256: createHash('sha256').update('[]').digest('hex'),
     credentials: 'omitted' as const,
     sessionsImported: 0 as const,
     publishedAt: '2026-08-23T00:01:00.000Z',

--- a/packages/cli/src/project-transfer-ssh.ts
+++ b/packages/cli/src/project-transfer-ssh.ts
@@ -1,5 +1,6 @@
 /** SSH transport for the AliceProject transfer stream. */
 import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
 
 import type { RegisteredMachine } from './machine-registry.ts'
 import { buildRemoteSshArgs } from './remote.mjs'
@@ -35,7 +36,7 @@ export async function transferProjectOverSsh(input: {
   })
   const stdout: Buffer[] = []
   let stdoutBytes = 0
-  let stderrText = ''
+  let receiverReportedError = false
   ssh.stdout.on('data', (chunk: Buffer | string) => {
     const bytes = Buffer.from(chunk)
     stdoutBytes += bytes.byteLength
@@ -46,16 +47,14 @@ export async function transferProjectOverSsh(input: {
     stdout.push(bytes)
   })
   ssh.stderr.on('data', (chunk: Buffer | string) => {
-    const text = String(chunk)
-    stderrText = `${stderrText}${text}`.slice(-16_384)
-    input.stderr?.write(text)
+    if (Buffer.byteLength(chunk) > 0) receiverReportedError = true
   })
   const exited = new Promise<number>((resolvePromise, reject) => {
     ssh.once('error', reject)
     ssh.once('exit', (code, signal) => {
       if (code === 0) resolvePromise(0)
       else reject(transferSshError(
-        `Remote transfer receiver exited ${signal ? `with ${signal}` : `with code ${code ?? 'unknown'}`}${stderrText.trim() ? `: ${safeRemoteError(stderrText)}` : '.'}`,
+        `Remote transfer receiver exited ${signal ? `with ${signal}` : `with code ${code ?? 'unknown'}`}.${receiverReportedError ? ' Remote diagnostics were withheld from the credential-bearing transfer channel.' : ''}`,
       ))
     })
   })
@@ -90,11 +89,19 @@ export async function transferProjectOverSsh(input: {
   }
   if (stdoutBytes > MAX_RECEIPT_BYTES) throw transferSshError('Remote transfer receipt was too large.')
   const receipt = parseReceipt(Buffer.concat(stdout).toString('utf8'))
+  const expectedManifestSha256 = createHash('sha256')
+    .update(JSON.stringify(input.plan.portable.entries))
+    .digest('hex')
+  const expectedCredentials = input.plan.policy.credentials === 'include' ? 'included' : 'omitted'
   if (
     receipt.transferId !== input.plan.transferId
     || receipt.sourceProjectId !== input.plan.source.projectId
     || receipt.destinationProjectId !== input.plan.destination.projectId
     || receipt.destinationHome !== input.plan.destination.home
+    || receipt.files !== input.plan.portable.files
+    || receipt.bytes !== input.plan.portable.bytes
+    || receipt.manifestSha256 !== expectedManifestSha256
+    || receipt.credentials !== expectedCredentials
     || receipt.sessionsImported !== 0
   ) throw transferSshError('Remote transfer receiver returned a receipt for another transaction.')
   return receipt
@@ -111,24 +118,55 @@ function parseReceipt(value: string): ProjectTransferReceipt {
     parsed === null
     || typeof parsed !== 'object'
     || Array.isArray(parsed)
-    || (parsed as Record<string, unknown>)['schemaVersion'] !== 1
-    || typeof (parsed as Record<string, unknown>)['transferId'] !== 'string'
-    || typeof (parsed as Record<string, unknown>)['sourceProjectId'] !== 'string'
-    || typeof (parsed as Record<string, unknown>)['destinationProjectId'] !== 'string'
-    || typeof (parsed as Record<string, unknown>)['destinationHome'] !== 'string'
-    || (parsed as Record<string, unknown>)['sessionsImported'] !== 0
   ) {
     throw transferSshError('Remote transfer receiver returned an invalid receipt.')
   }
-  return parsed as ProjectTransferReceipt
-}
-
-function safeRemoteError(value: string): string {
-  return value
-    .replaceAll(/[\u0000-\u001f\u007f-\u009f]+/gu, ' ')
-    .replaceAll(/\s+/gu, ' ')
-    .trim()
-    .slice(-1_000)
+  const root = parsed as Record<string, unknown>
+  const transferId = root['transferId']
+  const sourceProjectId = root['sourceProjectId']
+  const destinationProjectId = root['destinationProjectId']
+  const destinationHome = root['destinationHome']
+  const files = root['files']
+  const bytes = root['bytes']
+  const manifestSha256 = root['manifestSha256']
+  const credentials = root['credentials']
+  const publishedAt = root['publishedAt']
+  if (
+    root['schemaVersion'] !== 1
+    || typeof transferId !== 'string'
+    || transferId.length < 1
+    || typeof sourceProjectId !== 'string'
+    || sourceProjectId.length < 1
+    || typeof destinationProjectId !== 'string'
+    || destinationProjectId.length < 1
+    || typeof destinationHome !== 'string'
+    || destinationHome.length < 1
+    || !Number.isSafeInteger(files)
+    || Number(files) < 0
+    || !Number.isSafeInteger(bytes)
+    || Number(bytes) < 0
+    || typeof manifestSha256 !== 'string'
+    || !/^[a-f0-9]{64}$/u.test(manifestSha256)
+    || (credentials !== 'included' && credentials !== 'omitted')
+    || root['sessionsImported'] !== 0
+    || typeof publishedAt !== 'string'
+    || !Number.isFinite(Date.parse(publishedAt))
+  ) {
+    throw transferSshError('Remote transfer receiver returned an invalid receipt.')
+  }
+  return {
+    schemaVersion: 1,
+    transferId,
+    sourceProjectId,
+    destinationProjectId,
+    destinationHome,
+    files: Number(files),
+    bytes: Number(bytes),
+    manifestSha256,
+    credentials,
+    sessionsImported: 0,
+    publishedAt,
+  }
 }
 
 function transferSshError(message: string, cause?: unknown): Error & { code: string; exitCode: number } {

--- a/packages/cli/src/project-transfer-stream.spec.ts
+++ b/packages/cli/src/project-transfer-stream.spec.ts
@@ -1,14 +1,18 @@
 import { Writable, Readable } from 'node:stream'
+import { execFile as execFileCallback } from 'node:child_process'
 import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   stat,
+  symlink,
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -24,6 +28,7 @@ import {
 } from './project-transfer-stream.ts'
 
 const roots: string[] = []
+const execFile = promisify(execFileCallback)
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((path) => rm(path, { recursive: true, force: true })))
@@ -51,9 +56,12 @@ describe('AliceProject transfer stream', () => {
     expect(await readFile(join(destination, 'portable.txt'), 'utf8')).toBe('PORTABLE-CONTENT\n')
     const registry = JSON.parse(await readFile(join(destination, 'workspaces', 'workspaces.json'), 'utf8'))
     expect(registry.workspaces[0].dir).toBe(join(plan.destination.home, 'workspaces', 'workspaces', 'ws-one'))
+    const catalog = JSON.parse(await readFile(join(destination, 'workspaces', 'state', 'workspace-catalog.json'), 'utf8'))
+    expect(catalog.workspaces.map((workspace: { id: string }) => workspace.id)).toEqual(['ws-one'])
     await expect(stat(join(destination, 'workspaces', 'state', 'resume-identities.json'))).rejects.toMatchObject({ code: 'ENOENT' })
     const destinationCredentials = await readProjectTransferCredentialBundle(destination)
     expect(destinationCredentials.ai.credentials['openai-1']?.apiKey).toBe('sk-stream-secret')
+    expect(destinationCredentials.ai.apiKeys['google']).toBe('legacy-stream-secret')
     expect(destinationCredentials.brokerAccounts).toEqual([
       expect.objectContaining({ presetId: 'alpaca-paper' }),
     ])
@@ -61,6 +69,29 @@ describe('AliceProject transfer stream', () => {
       adapters: expect.objectContaining({ telegram: expect.any(Object) }),
     }))
     expect(await readFile(join(destination, 'sealing.key'), 'utf8')).not.toBe(sourceKey)
+  })
+
+  it('omits every credential and derived-backup canary outside the private bundle', async () => {
+    const { destination, plan } = await fixture('omit')
+    const stream = await serialize(plan)
+    const streamText = stream.toString('utf8')
+
+    for (const canary of [
+      'sk-stream-secret',
+      'legacy-stream-secret',
+      'fmp-stream-secret',
+      'backup-only-secret-canary',
+      'web-session-secret-canary',
+    ]) expect(streamText).not.toContain(canary)
+
+    const receipt = await receiveProjectTransferStream({ source: Readable.from(stream) })
+    expect(receipt.credentials).toBe('omitted')
+    const portableAi = JSON.parse(await readFile(join(destination, 'data', 'config', 'ai-provider-manager.json'), 'utf8'))
+    expect(portableAi.credentials).toEqual({})
+    expect(portableAi.apiKeys).toEqual({})
+    await expect(stat(join(destination, 'data', '_backup'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(join(destination, 'data', 'config', 'sessions.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(join(destination, 'sealing.key'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('leaves only marked staging on checksum failure and safely retries the same transaction', async () => {
@@ -92,6 +123,19 @@ describe('AliceProject transfer stream', () => {
     const { source, plan } = await fixture()
     await writeFile(join(source, 'portable.txt'), 'CHANGED-AFTER-PLAN\n')
     await expect(serialize(plan)).rejects.toThrow('changed after planning')
+  })
+
+  it('sends the consented credential snapshot when source credentials change later', async () => {
+    const { source, destination, plan } = await fixture()
+    await sealProjectTransferJson(source, join('data', 'config', 'accounts.json'), [
+      { id: 'changed-after-consent', presetId: 'synthetic' },
+    ])
+    const stream = await serialize(plan)
+    await receiveProjectTransferStream({ source: Readable.from(stream) })
+    const received = await readProjectTransferCredentialBundle(destination)
+    expect(received.brokerAccounts).toEqual([
+      expect.objectContaining({ presetId: 'alpaca-paper' }),
+    ])
   })
 
   it('reports completed portable file and byte progress', async () => {
@@ -129,6 +173,74 @@ describe('AliceProject transfer stream', () => {
     await expect(stat(staging)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it.skipIf(process.platform === 'win32')('rejects a destination whose parent resolves through a symlink', async () => {
+    const { source } = await fixture('omit')
+    const destinationRoot = await mkdtemp(join(tmpdir(), 'oa-stream-canonical-destination-'))
+    roots.push(destinationRoot)
+    const canonicalParent = join(destinationRoot, 'canonical')
+    const aliasParent = join(destinationRoot, 'alias')
+    await mkdir(canonicalParent)
+    await symlink(canonicalParent, aliasParent)
+    const destination = join(aliasParent, 'remote-home')
+    const plan = await planProjectTransfer({
+      source: {
+        id: 'alice-project-source',
+        key: 'source',
+        displayName: 'Source',
+        home: source,
+        port: 47331,
+        portAutomatic: true,
+        isDefault: true,
+      },
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'remote-copy',
+      destinationHome: destination,
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+      isGitTracked: async () => false,
+    })
+    await expect(receiveProjectTransferStream({ source: Readable.from(await serialize(plan)) }))
+      .rejects.toThrow('resolves through a symlink')
+    await expect(stat(join(canonicalParent, 'remote-home'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('publishes a self-contained ordinary Git Workspace without local credentials', async () => {
+    const { source, destination } = await fixture('omit')
+    const workspace = join(source, 'workspaces', 'workspaces', 'ws-one')
+    await execFile('git', ['init', '-q'], { cwd: workspace })
+    await execFile('git', ['add', 'README.md'], { cwd: workspace })
+    await execFile('git', [
+      '-c', 'user.name=OpenAlice Test',
+      '-c', 'user.email=openalice@example.test',
+      'commit', '-qm', 'fixture',
+    ], { cwd: workspace })
+    await execFile('git', ['config', '--local', 'http.https://example.test/.extraHeader', 'Authorization: Bearer secret-canary'], { cwd: workspace })
+    const plan = await planProjectTransfer({
+      source: {
+        id: 'alice-project-source',
+        key: 'source',
+        displayName: 'Source',
+        home: source,
+        port: 47331,
+        portAutomatic: true,
+        isDefault: true,
+      },
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'remote-copy',
+      destinationHome: destination,
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+    })
+    expect(plan.readyToApply).toBe(true)
+    await receiveProjectTransferStream({ source: Readable.from(await serialize(plan)) })
+    const receivedWorkspace = join(destination, 'workspaces', 'workspaces', 'ws-one')
+    await expect(stat(join(receivedWorkspace, '.git', 'config'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(execFile('git', ['status', '--porcelain'], { cwd: receivedWorkspace }))
+      .resolves.toMatchObject({ stdout: '' })
+    await expect(execFile('git', ['fsck', '--connectivity-only', '--no-dangling'], { cwd: receivedWorkspace }))
+      .resolves.toMatchObject({ stderr: '' })
+  })
+
   it('retries registration idempotently after files were already published', async () => {
     const { destination, plan } = await fixture()
     const stream = await serialize(plan)
@@ -137,6 +249,32 @@ describe('AliceProject transfer stream', () => {
       register: async () => { throw new Error('synthetic registration failure') },
     })).rejects.toThrow('synthetic registration failure')
     expect(await readFile(join(destination, 'portable.txt'), 'utf8')).toBe('PORTABLE-CONTENT\n')
+    const receiptPath = join(destination, '.openalice-transfer-receipt.json')
+    const storedReceipt = JSON.parse(await readFile(receiptPath, 'utf8'))
+    await writeJson(receiptPath, { ...storedReceipt, secretCanary: 'must-not-return' })
+
+    let registrations = 0
+    const retried = await receiveProjectTransferStream({
+      source: Readable.from(stream),
+      register: async () => { registrations += 1 },
+    })
+    expect(retried).toMatchObject({ transferId: plan.transferId })
+    expect(JSON.stringify(retried)).not.toContain('secretCanary')
+    expect(registrations).toBe(1)
+  })
+
+  it('retries registration when credential import created a previously absent AI vault', async () => {
+    const { destination, plan } = await fixture('include', false, false)
+    expect(plan.portable.entries.some((entry) => (
+      entry.path === 'data/config/ai-provider-manager.json'
+    ))).toBe(false)
+    const stream = await serialize(plan)
+
+    await expect(receiveProjectTransferStream({
+      source: Readable.from(stream),
+      register: async () => { throw new Error('synthetic registration failure') },
+    })).rejects.toThrow('synthetic registration failure')
+    await expect(stat(join(destination, 'data', 'config', 'ai-provider-manager.json'))).resolves.toBeDefined()
 
     let registrations = 0
     await expect(receiveProjectTransferStream({
@@ -145,23 +283,102 @@ describe('AliceProject transfer stream', () => {
     })).resolves.toMatchObject({ transferId: plan.transferId })
     expect(registrations).toBe(1)
   })
+
+  it('re-plans the same transaction in a new process and repairs registration', async () => {
+    const { source, destination, plan } = await fixture('omit', true)
+    await expect(receiveProjectTransferStream({
+      source: Readable.from(await serialize(plan)),
+      register: async () => { throw new Error('synthetic registration failure') },
+    })).rejects.toThrow('synthetic registration failure')
+
+    const replanned = await planProjectTransfer({
+      source: {
+        id: 'alice-project-source',
+        key: 'source',
+        displayName: 'Source',
+        home: source,
+        port: 47331,
+        portAutomatic: true,
+        isDefault: true,
+      },
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'remote-copy',
+      destinationHome: destination,
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+      isGitTracked: async () => false,
+    })
+    expect(replanned.transferId).toBe(plan.transferId)
+    let registrations = 0
+    await expect(receiveProjectTransferStream({
+      source: Readable.from(await serialize(replanned)),
+      register: async () => { registrations += 1 },
+    })).resolves.toMatchObject({ transferId: plan.transferId })
+    expect(registrations).toBe(1)
+  })
+
+  it('refuses registration retry when published files changed after the receipt', async () => {
+    const { destination, plan } = await fixture()
+    const stream = await serialize(plan)
+    await expect(receiveProjectTransferStream({
+      source: Readable.from(stream),
+      register: async () => { throw new Error('synthetic registration failure') },
+    })).rejects.toThrow('synthetic registration failure')
+
+    await writeFile(join(destination, 'portable.txt'), 'TAMPERED-AFTER-PUBLISH\n')
+    let registrations = 0
+    await expect(receiveProjectTransferStream({
+      source: Readable.from(stream),
+      register: async () => { registrations += 1 },
+    })).rejects.toThrow('destination changed before registration retry')
+    expect(registrations).toBe(0)
+  })
+
+  it('refuses registration retry when an unexpected file was added after publish', async () => {
+    const { destination, plan } = await fixture('omit')
+    const stream = await serialize(plan)
+    await expect(receiveProjectTransferStream({
+      source: Readable.from(stream),
+      register: async () => { throw new Error('synthetic registration failure') },
+    })).rejects.toThrow('synthetic registration failure')
+
+    await writeJson(join(destination, 'data', 'config', 'auth.json'), { token: 'unexpected' })
+    await expect(receiveProjectTransferStream({ source: Readable.from(stream) }))
+      .rejects.toThrow('destination changed before registration retry')
+  })
 })
 
-async function fixture() {
+async function fixture(
+  credentials: 'include' | 'omit' = 'include',
+  deterministicTransferId = false,
+  includeAiVault = true,
+) {
   const source = await mkdtemp(join(tmpdir(), 'oa-stream-source-'))
-  const destinationParent = await mkdtemp(join(tmpdir(), 'oa-stream-destination-'))
+  const destinationParent = await realpath(await mkdtemp(join(tmpdir(), 'oa-stream-destination-')))
   roots.push(source, destinationParent)
   const destination = join(destinationParent, 'remote-home')
   await writeAliceProjectProductStamp(source, 'trader')
   await writeFile(join(source, 'portable.txt'), 'PORTABLE-CONTENT\n')
-  await writeJson(join(source, 'data', 'config', 'ai-provider-manager.json'), {
-    profiles: { default: { backend: 'native' } },
-    credentials: {
-      'openai-1': { vendor: 'openai', authType: 'api-key', apiKey: 'sk-stream-secret' },
-    },
-  })
+  if (includeAiVault) {
+    await writeJson(join(source, 'data', 'config', 'ai-provider-manager.json'), {
+      profiles: { default: { backend: 'native' } },
+      apiKeys: { google: 'legacy-stream-secret' },
+      credentials: {
+        'openai-1': { vendor: 'openai', authType: 'api-key', apiKey: 'sk-stream-secret' },
+      },
+    })
+  }
   await writeJson(join(source, 'data', 'config', 'market-data.json'), {
     providerKeys: { fmp: 'fmp-stream-secret' },
+  })
+  await writeJson(join(source, 'data', '_backup', 'before', 'config', 'ai-provider-manager.json'), {
+    apiKeys: { backup: 'backup-only-secret-canary' },
+  })
+  await writeJson(join(source, 'data', 'config', 'ai-provider-manager.json.backup'), {
+    apiKeys: { backup: 'backup-only-secret-canary' },
+  })
+  await writeJson(join(source, 'data', 'config', 'sessions.json'), {
+    sessions: [{ sid: 'web-session-secret-canary' }],
   })
   await sealProjectTransferJson(source, join('data', 'config', 'accounts.json'), [
     { id: 'paper', presetId: 'alpaca-paper', presetConfig: { apiKey: 'broker-stream-secret' } },
@@ -179,7 +396,17 @@ async function fixture() {
   })
   await writeJson(join(source, 'workspaces', 'state', 'workspace-catalog.json'), {
     version: 1,
-    workspaces: [{ id: 'ws-one', tag: 'One', activeDir: workspace, lifecycle: 'active' }],
+    workspaces: [
+      { id: 'ws-one', tag: 'One', activeDir: workspace, lifecycle: 'active' },
+      {
+        id: '.pi-agent',
+        tag: 'Pi Agent',
+        activeDir: join(source, 'workspaces', 'departed-workspaces', '.pi-agent'),
+        departedDir: join(source, 'workspaces', 'departed-workspaces', '.pi-agent'),
+        lifecycle: 'departed',
+        legacyImported: true,
+      },
+    ],
   })
   await writeJson(join(source, 'workspaces', 'state', 'resume-identities.json'), {
     version: 1,
@@ -199,7 +426,8 @@ async function fixture() {
     destinationProjectKey: 'remote-copy',
     destinationHome: destination,
     scheduledIssues: 'keep-blocked',
-    randomId: () => 'transfer-stream-test',
+    credentials,
+    ...(deterministicTransferId ? {} : { randomId: () => 'transfer-stream-test' }),
     now: () => new Date('2026-08-23T00:00:00Z'),
     isGitTracked: async () => false,
   })

--- a/packages/cli/src/project-transfer-stream.ts
+++ b/packages/cli/src/project-transfer-stream.ts
@@ -7,7 +7,9 @@ import {
   mkdir,
   open,
   readFile,
+  readdir,
   readlink,
+  realpath,
   rename,
   rm,
   stat,
@@ -22,12 +24,15 @@ import { once } from 'node:events'
 import { parseAiProviderVault, writeAiProviderVault } from './ai-credential-copy.ts'
 import { transformProjectTransferFile } from './project-transfer-files.ts'
 import {
+  normalizeProjectTransferAiVault,
   readProjectTransferCredentialBundle,
   sealProjectTransferJson,
   type ProjectTransferCredentialBundle,
 } from './project-transfer-secrets.ts'
 import {
+  PROJECT_TRANSFER_RECEIPT_FILE,
   PROJECT_TRANSFER_SCHEMA_VERSION,
+  readProjectTransferCredentialSnapshot,
   validateManifestPath,
   type ProjectTransferEntry,
   type ProjectTransferPlan,
@@ -40,7 +45,6 @@ const MAX_FILE_BYTES = 64 * 1024 * 1024 * 1024
 const MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024 * 1024
 const MAX_CREDENTIAL_BYTES = 16 * 1024 * 1024
 const MARKER_FILE = '.openalice-transfer-transaction.json'
-const RECEIPT_FILE = '.openalice-transfer-receipt.json'
 
 export interface ProjectTransferReceipt {
   schemaVersion: 1
@@ -59,7 +63,6 @@ export interface ProjectTransferReceipt {
 export async function writeProjectTransferStream(input: {
   plan: ProjectTransferPlan
   output: Writable
-  readCredentials?: (home: string) => Promise<ProjectTransferCredentialBundle>
   signal?: AbortSignal
   onProgress?: (progress: { files: number; bytes: number; totalFiles: number; totalBytes: number }) => void
 }): Promise<{ bytes: number }> {
@@ -126,8 +129,8 @@ export async function writeProjectTransferStream(input: {
   }
   if (input.plan.policy.credentials === 'include') {
     input.signal?.throwIfAborted()
-    const bundle = await (input.readCredentials ?? readProjectTransferCredentialBundle)(input.plan.source.home)
-    const bytes = Buffer.from(JSON.stringify(bundle), 'utf8')
+    const bytes = readProjectTransferCredentialSnapshot(input.plan)
+    if (!bytes) throw transferStreamError('Credential snapshot is unavailable; review a new transfer plan.')
     if (bytes.byteLength > MAX_CREDENTIAL_BYTES) throw transferStreamError('Credential payload is too large.')
     await writeChunk(input.output, Buffer.from(`${JSON.stringify({
       type: 'credentials',
@@ -152,18 +155,27 @@ export async function receiveProjectTransferStream(input: {
   assertTransferPlan(plan)
   if (!plan.readyToApply) throw transferStreamError('Transfer plan has unresolved blockers.')
   const destination = plan.destination.home
+  await assertCanonicalDestination(destination)
   const staging = join(dirname(destination), `.openalice-transfer-${plan.transferId}.staging`)
   const existingReceipt = await readPublishedReceipt(destination)
   if (existingReceipt) {
+    const expectedManifestSha256 = sha256(Buffer.from(JSON.stringify(plan.portable.entries), 'utf8'))
+    const expectedCredentials = plan.policy.credentials === 'include' ? 'included' : 'omitted'
     if (
       existingReceipt.transferId !== plan.transferId
       || existingReceipt.destinationHome !== destination
       || existingReceipt.destinationProjectId !== plan.destination.projectId
       || existingReceipt.sourceProjectId !== plan.source.projectId
+      || existingReceipt.files !== plan.portable.files
+      || existingReceipt.bytes !== plan.portable.bytes
+      || existingReceipt.manifestSha256 !== expectedManifestSha256
+      || existingReceipt.credentials !== expectedCredentials
+      || existingReceipt.sessionsImported !== 0
     ) {
       throw transferStreamError(`Destination already contains another AliceProject: ${destination}`)
     }
-    await verifyAndDiscardPayload(reader, plan)
+    const retryCredentialBytes = await verifyAndDiscardPayload(reader, plan)
+    await verifyPublishedDestination(destination, plan, retryCredentialBytes)
     await input.register?.(plan, existingReceipt)
     return existingReceipt
   }
@@ -239,7 +251,8 @@ export async function receiveProjectTransferStream(input: {
       sessionsImported: 0,
       publishedAt: (input.now ?? (() => new Date()))().toISOString(),
     }
-    await writePrivateJson(join(staging, RECEIPT_FILE), receipt)
+    await writePrivateJson(join(staging, PROJECT_TRANSFER_RECEIPT_FILE), receipt)
+    await rm(join(staging, MARKER_FILE), { force: true })
     await rename(staging, destination)
     await input.register?.(plan, receipt)
     return receipt
@@ -249,7 +262,24 @@ export async function receiveProjectTransferStream(input: {
   }
 }
 
-async function verifyAndDiscardPayload(reader: AsyncByteReader, plan: ProjectTransferPlan): Promise<void> {
+async function assertCanonicalDestination(destination: string): Promise<void> {
+  let existing = destination
+  const missing: string[] = []
+  while (!(await exists(existing))) {
+    const parent = dirname(existing)
+    if (parent === existing) break
+    missing.unshift(basename(existing))
+    existing = parent
+  }
+  const canonical = resolve(await realpath(existing), ...missing)
+  if (canonical !== resolve(destination)) {
+    throw transferStreamError(
+      'Destination Home resolves through a symlink; use its canonical path before planning the transfer.',
+    )
+  }
+}
+
+async function verifyAndDiscardPayload(reader: AsyncByteReader, plan: ProjectTransferPlan): Promise<Buffer | null> {
   for (let index = 0; index < plan.portable.entries.length; index += 1) {
     const entry = plan.portable.entries[index]!
     const header = parseRecord(await reader.readLine())
@@ -262,15 +292,21 @@ async function verifyAndDiscardPayload(reader: AsyncByteReader, plan: ProjectTra
     if (hash.digest('hex') !== entry.sha256) throw transferStreamError(`Checksum mismatch for ${entry.path}.`)
   }
   let final = parseRecord(await reader.readLine())
+  let credentialBytes: Buffer | null = null
   if (final['type'] === 'credentials') {
     if (plan.policy.credentials !== 'include') throw transferStreamError('Unexpected credential payload.')
     const size = requireBoundedInteger(final['size'], 0, MAX_CREDENTIAL_BYTES, 'credential size')
     const expected = requireSha(final['sha256'], 'credential checksum')
     const bytes = await reader.readBuffer(size)
     if (sha256(bytes) !== expected) throw transferStreamError('Credential payload checksum mismatch.')
+    credentialBytes = bytes
     final = parseRecord(await reader.readLine())
   }
   if (final['type'] !== 'end') throw transferStreamError('Transfer stream did not terminate cleanly.')
+  if (plan.policy.credentials === 'include' && !credentialBytes) {
+    throw transferStreamError('Credential payload is missing.')
+  }
+  return credentialBytes
 }
 
 function assertTransferPlan(plan: ProjectTransferPlan): void {
@@ -310,6 +346,95 @@ function assertTransferPlan(plan: ProjectTransferPlan): void {
     || directories !== plan.portable.directories
     || symlinkCount !== plan.portable.symlinks
   ) throw transferStreamError('Transfer manifest entry totals are inconsistent.')
+}
+
+async function verifyPublishedDestination(
+  destination: string,
+  plan: ProjectTransferPlan,
+  retryCredentialBytes: Buffer | null,
+): Promise<void> {
+  try {
+    for (const entry of plan.portable.entries) {
+      // Included credentials intentionally replace the stripped portable AI
+      // vault; the private bundle verification below owns its final bytes.
+      if (
+        plan.policy.credentials === 'include'
+        && entry.path === 'data/config/ai-provider-manager.json'
+      ) continue
+      const path = join(destination, ...entry.path.split('/'))
+      const info = await lstat(path)
+      if (entry.kind === 'directory') {
+        if (!info.isDirectory()) throw new Error(`${entry.path} changed type`)
+      } else if (entry.kind === 'symlink') {
+        if (!info.isSymbolicLink() || await readlink(path) !== entry.linkTarget) {
+          throw new Error(`${entry.path} changed symlink target`)
+        }
+      } else {
+        if (!info.isFile() || info.size !== entry.size) throw new Error(`${entry.path} changed size or type`)
+        const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
+        try {
+          const hash = createHash('sha256')
+          let size = 0
+          for await (const chunk of handle.createReadStream({ autoClose: false })) {
+            const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+            size += bytes.byteLength
+            hash.update(bytes)
+          }
+          if (size !== entry.size || hash.digest('hex') !== entry.sha256) {
+            throw new Error(`${entry.path} changed content`)
+          }
+        } finally {
+          await handle.close()
+        }
+      }
+    }
+    if (plan.policy.credentials === 'include') {
+      if (!retryCredentialBytes) throw new Error('credential payload is missing')
+      const expected = parseCredentialBundle(retryCredentialBytes)
+      const actual = await readProjectTransferCredentialBundle(destination)
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error('credential bundle changed')
+    }
+    await assertPublishedEntrySet(destination, plan)
+  } catch (error: unknown) {
+    throw transferStreamError(
+      'Published transfer destination changed before registration retry; choose a new destination Home.',
+      error,
+    )
+  }
+}
+
+async function assertPublishedEntrySet(destination: string, plan: ProjectTransferPlan): Promise<void> {
+  const allowed = new Set(plan.portable.entries.map((entry) => entry.path))
+  allowed.add(PROJECT_TRANSFER_RECEIPT_FILE)
+  if (plan.policy.credentials === 'include') {
+    for (const path of [
+      'sealing.key',
+      'provider-keys.json',
+      'data/config/ai-provider-manager.json',
+      'data/config/accounts.json',
+      'data/config/connectors.json',
+    ]) allowed.add(path)
+  }
+  for (const path of [...allowed]) {
+    const parts = path.split('/')
+    for (let index = 1; index < parts.length; index += 1) {
+      allowed.add(parts.slice(0, index).join('/'))
+    }
+  }
+
+  const pending = ['']
+  while (pending.length > 0) {
+    const parent = pending.pop()!
+    const absoluteParent = parent
+      ? join(destination, ...parent.split('/'))
+      : destination
+    for (const name of await readdir(absoluteParent)) {
+      const path = parent ? `${parent}/${name}` : name
+      if (!allowed.has(path)) throw new Error(`unexpected published path ${path}`)
+      const info = await lstat(join(destination, ...path.split('/')))
+      if (info.isDirectory()) pending.push(path)
+    }
+  }
 }
 
 async function readAvailableBytes(path: string): Promise<number> {
@@ -363,7 +488,7 @@ async function writeCredentialBundle(home: string, bundle: ProjectTransferCreden
 
 async function readPublishedReceipt(destination: string): Promise<ProjectTransferReceipt | null> {
   try {
-    return parseReceipt(JSON.parse(await readFile(join(destination, RECEIPT_FILE), 'utf8')) as unknown)
+    return parseReceipt(JSON.parse(await readFile(join(destination, PROJECT_TRANSFER_RECEIPT_FILE), 'utf8')) as unknown)
   } catch (error: unknown) {
     if (isNodeError(error, 'ENOENT')) return null
     throw error
@@ -402,7 +527,7 @@ function parseCredentialBundle(bytes: Buffer): ProjectTransferCredentialBundle {
   const value = JSON.parse(bytes.toString('utf8')) as unknown
   const root = requireRecord(value, 'credential payload')
   return {
-    ai: parseAiProviderVault(root['ai']),
+    ai: normalizeProjectTransferAiVault(parseAiProviderVault(root['ai'])),
     brokerAccounts: Array.isArray(root['brokerAccounts']) ? root['brokerAccounts'] : [],
     connectors: requireRecord(root['connectors'], 'Connector credential payload'),
     providerKeys: Object.fromEntries(
@@ -414,20 +539,49 @@ function parseCredentialBundle(bytes: Buffer): ProjectTransferCredentialBundle {
 
 function parseReceipt(value: unknown): ProjectTransferReceipt {
   const root = requireRecord(value, 'transfer receipt')
+  const transferId = root['transferId']
+  const sourceProjectId = root['sourceProjectId']
+  const destinationProjectId = root['destinationProjectId']
+  const destinationHome = root['destinationHome']
+  const files = root['files']
+  const bytes = root['bytes']
+  const manifestSha256 = root['manifestSha256']
+  const credentials = root['credentials']
+  const publishedAt = root['publishedAt']
   if (
     root['schemaVersion'] !== 1
-    || typeof root['transferId'] !== 'string'
-    || typeof root['sourceProjectId'] !== 'string'
-    || typeof root['destinationProjectId'] !== 'string'
-    || typeof root['destinationHome'] !== 'string'
-    || !Number.isSafeInteger(root['files'])
-    || !Number.isSafeInteger(root['bytes'])
-    || typeof root['manifestSha256'] !== 'string'
-    || !['included', 'omitted'].includes(String(root['credentials']))
+    || typeof transferId !== 'string'
+    || transferId.length < 1
+    || typeof sourceProjectId !== 'string'
+    || sourceProjectId.length < 1
+    || typeof destinationProjectId !== 'string'
+    || destinationProjectId.length < 1
+    || typeof destinationHome !== 'string'
+    || destinationHome.length < 1
+    || !Number.isSafeInteger(files)
+    || Number(files) < 0
+    || !Number.isSafeInteger(bytes)
+    || Number(bytes) < 0
+    || typeof manifestSha256 !== 'string'
+    || !/^[a-f0-9]{64}$/u.test(manifestSha256)
+    || (credentials !== 'included' && credentials !== 'omitted')
     || root['sessionsImported'] !== 0
-    || typeof root['publishedAt'] !== 'string'
+    || typeof publishedAt !== 'string'
+    || !Number.isFinite(Date.parse(publishedAt))
   ) throw transferStreamError('Invalid transfer receipt.')
-  return value as ProjectTransferReceipt
+  return {
+    schemaVersion: 1,
+    transferId,
+    sourceProjectId,
+    destinationProjectId,
+    destinationHome,
+    files: Number(files),
+    bytes: Number(bytes),
+    manifestSha256,
+    credentials,
+    sessionsImported: 0,
+    publishedAt,
+  }
 }
 
 function parseRecord(value: string): Record<string, unknown> {

--- a/packages/cli/src/project-transfer.spec.ts
+++ b/packages/cli/src/project-transfer.spec.ts
@@ -1,10 +1,13 @@
+import { execFile as execFileCallback } from 'node:child_process'
 import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { promisify } from 'node:util'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { writeAliceProjectProductStamp } from './alice-project-product.ts'
+import { transformProjectTransferFile } from './project-transfer-files.ts'
 import {
   planProjectTransfer,
   validateManifestPath,
@@ -12,6 +15,7 @@ import {
 import { sealProjectTransferJson } from './project-transfer-secrets.ts'
 
 const homes: string[] = []
+const execFile = promisify(execFileCallback)
 
 afterEach(async () => {
   await Promise.all(homes.splice(0).map((path) => rm(path, { recursive: true, force: true })))
@@ -39,6 +43,8 @@ describe('AliceProject transfer planner', () => {
     expect(plan.portable.entries.map((entry) => entry.path)).toEqual(expect.arrayContaining([
       'data/config/ai-provider-manager.json',
       'data/config/market-data.json',
+      'workspaces/workspaces/runtime-selection.json',
+      'workspaces/workspaces/ws-one/.claude/skills/portable/SKILL.md',
       'workspaces/workspaces/ws-one/.alice/sessions/tracked.json',
       'workspaces/workspaces/ws-one/research.txt',
     ]))
@@ -48,14 +54,49 @@ describe('AliceProject transfer planner', () => {
       'data/config/accounts.json',
       'data/config/connectors.json',
       'data/config/auth.json',
+      'data/config/auth.json.previous',
       'data/config/ports.json',
+      'data/config/ports.json.backup',
+      'data/config/sessions.json',
+      'data/config/sessions.json.tmp',
+      'data/config/accounts.json.backup-canary',
+      'data/config/connectors.json.tmp-canary',
+      'data/config/ai-provider-manager.json.backup-canary',
+      'data/config/.ai-provider-manager.123.tmp',
+      'data/config/market-data.json.previous',
+      'data/_backup/pre-migration/config/ai-provider-manager.json',
+      'demo-text-backups/provider-canary.json',
+      '.openalice-transfer-receipt.json',
+      '.cli-update-check.json',
+      '.cli-install.lock/pid',
+      '.cli-install.lock.guard',
+      'provider-keys.json.backup',
+      'sealing.key.previous',
+      'workspaces/workspaces.json.before-transfer',
+      'workspaces/state/workspace-catalog.json.backup',
       'workspaces/state/resume-identities.json',
+      'workspaces/state/runtime.lock/owner.json',
       'workspaces/workspaces/ws-one/.alice/sessions/untracked.json',
+      'workspaces/workspaces/opencode.json',
+      'workspaces/workspaces/ws-one/.claude/settings.local.json',
+      'workspaces/workspaces/ws-one/.claude/openalice-provider.json',
+      'workspaces/workspaces/ws-one/.codex/env.json',
+      'workspaces/workspaces/ws-one/.codex/openalice-home/auth.json',
+      'workspaces/workspaces/ws-one/.codex/sessions/rollout.jsonl',
+      'workspaces/workspaces/ws-one/opencode.json',
+      'workspaces/workspaces/ws-one/.opencode/openalice-provider.json',
+      'workspaces/workspaces/ws-one/.pi/settings.json',
+      'workspaces/workspaces/ws-one/.pi/openalice-provider.json',
+      'workspaces/workspaces/ws-one/.pi/extensions/openalice-provider.ts',
+      'workspaces/workspaces/ws-one/.pi-agent/auth.json',
+      'data/logs/connector-io.jsonl',
     ]))
     expect(plan.portable.entries.find((entry) => entry.path === 'data/config/ai-provider-manager.json')?.transform)
       .toBe('strip-ai-credentials')
+    const catalogEntry = plan.portable.entries.find((entry) => entry.path === 'workspaces/state/workspace-catalog.json')
+    expect(catalogEntry?.transform).toBe('workspace-catalog-paths')
     expect(plan.credentials).toEqual({
-      ai: { count: 1, vendors: ['openai'] },
+      ai: { count: 2, vendors: ['google', 'openai'] },
       broker: { count: 1, presets: ['alpaca-paper'] },
       connector: { count: 1, adapters: ['telegram'] },
       providerKeys: { count: 2, vendors: ['fmp', 'fred'] },
@@ -64,6 +105,9 @@ describe('AliceProject transfer planner', () => {
     expect(JSON.stringify(plan)).not.toContain('broker-transfer-secret')
     expect(JSON.stringify(plan)).not.toContain('connector-transfer-secret')
     expect(JSON.stringify(plan)).not.toContain('provider-transfer-secret')
+    expect(JSON.stringify(plan)).not.toContain('legacy-ai-transfer-secret')
+    expect(JSON.stringify(plan)).not.toContain('derived-secret-canary')
+    expect(JSON.stringify(plan)).not.toContain('native-agent-secret-canary')
   })
 
   it('blocks apply until exact-Session scheduled Issues have an explicit policy', async () => {
@@ -76,10 +120,12 @@ describe('AliceProject transfer planner', () => {
       destinationProjectKey: 'alice-cloud',
       destinationHome: join(destinationRoot, 'alice'),
       credentials: 'omit',
+      readCredentials: async () => { throw new Error('omit must not read credentials') },
       randomId: () => 'transfer-policy',
       isGitTracked: async () => false,
     })
     expect(plan.readyToApply).toBe(false)
+    expect(plan.credentials.ai.count).toBe(0)
     expect(plan.blockers).toContainEqual(expect.objectContaining({ code: 'EISSUEPOLICY' }))
     expect(plan.scheduledIssues).toEqual([expect.objectContaining({
       workspaceId: 'ws-one',
@@ -123,15 +169,64 @@ describe('AliceProject transfer planner', () => {
     expect(plan.destination.home).toBe('/home/alice/.openalice-copy')
   })
 
+  it('derives a stable transaction id so a new CLI process can retry registration', async () => {
+    const home = await fixtureHome()
+    const input = {
+      source: sourceProject(home),
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'alice-cloud',
+      destinationHome: '/srv/openalice/alice-cloud',
+      credentials: 'omit' as const,
+      scheduledIssues: 'keep-blocked' as const,
+      isGitTracked: async () => false,
+    }
+    const first = await planProjectTransfer({
+      ...input,
+      now: () => new Date('2026-08-23T00:00:00Z'),
+    })
+    const second = await planProjectTransfer({
+      ...input,
+      now: () => new Date('2026-08-24T00:00:00Z'),
+    })
+    expect(second.transferId).toBe(first.transferId)
+    expect(second.generatedAt).not.toBe(first.generatedAt)
+  })
+
   it.each(['../escape', '/absolute', 'safe\\windows-ambiguous', 'bad\u0000name'])(
     'rejects unsafe manifest path %j',
     (path) => expect(() => validateManifestPath(path)).toThrow('Unsafe transfer path'),
   )
 
-  it.skipIf(process.platform === 'win32')('rejects symlinks that escape the selected home', async () => {
+  it('rewrites remote Workspace paths with POSIX semantics on every sender OS', () => {
+    const transformed = transformProjectTransferFile({
+      path: 'workspaces/state/workspace-catalog.json',
+      transform: 'workspace-catalog-paths',
+      bytes: Buffer.from(JSON.stringify({
+        workspaces: [
+          { id: 'active-one', activeDir: 'C:\\source\\active-one', lifecycle: 'active' },
+          {
+            id: '.pi-agent',
+            activeDir: 'C:\\source\\.pi-agent',
+            departedDir: 'C:\\source\\.pi-agent',
+            lifecycle: 'departed',
+            legacyImported: true,
+          },
+        ],
+      })),
+      destinationHome: '/srv/openalice/main-cloud',
+    })
+    const catalog = JSON.parse(transformed.toString('utf8'))
+    expect(catalog.workspaces).toEqual([expect.objectContaining({
+      id: 'active-one',
+      activeDir: '/srv/openalice/main-cloud/workspaces/workspaces/active-one',
+    })])
+  })
+
+  it.skipIf(process.platform === 'win32')('excludes machine-local symlinks and keeps contained links portable', async () => {
     const home = await fixtureHome()
     await symlink('../../../../outside', join(home, 'workspaces', 'workspaces', 'ws-one', 'escape'))
-    await expect(planProjectTransfer({
+    await symlink('research.txt', join(home, 'workspaces', 'workspaces', 'ws-one', 'contained'))
+    const plan = await planProjectTransfer({
       source: sourceProject(home),
       destinationMachineKey: 'cloud',
       destinationProjectKey: 'alice-cloud',
@@ -139,7 +234,204 @@ describe('AliceProject transfer planner', () => {
       scheduledIssues: 'keep-blocked',
       randomId: () => 'transfer-symlink',
       isGitTracked: async () => false,
-    })).rejects.toThrow('escapes the AliceProject home')
+    })
+    expect(plan.portable.entries).toContainEqual(expect.objectContaining({
+      path: 'workspaces/workspaces/ws-one/contained',
+      kind: 'symlink',
+      linkTarget: 'research.txt',
+    }))
+    expect(plan.portable.entries.map((entry) => entry.path))
+      .not.toContain('workspaces/workspaces/ws-one/escape')
+    expect(plan.excluded.find((entry) => entry.reason === 'machine-local')?.files)
+      .toBeGreaterThanOrEqual(4)
+  })
+
+  it.skipIf(process.platform === 'win32')('blocks linked worktrees instead of silently dropping their Git state', async () => {
+    const home = await fixtureHome()
+    const repository = await mkdtemp(join(tmpdir(), 'oa-transfer-worktree-owner-'))
+    homes.push(repository)
+    await execFile('git', ['init', '-q'], { cwd: repository })
+    await writeFile(join(repository, 'README.md'), 'linked workspace\n')
+    await execFile('git', ['add', 'README.md'], { cwd: repository })
+    await execFile('git', [
+      '-c', 'user.name=OpenAlice Test',
+      '-c', 'user.email=openalice@example.test',
+      'commit', '-qm', 'fixture',
+    ], { cwd: repository })
+    const linked = join(home, 'workspaces', 'workspaces', 'linked')
+    await execFile('git', ['worktree', 'add', '--detach', linked, 'HEAD'], { cwd: repository })
+
+    const plan = await planProjectTransfer({
+      source: sourceProject(home),
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'alice-cloud',
+      destinationHome: join(tmpdir(), 'oa-transfer-linked-worktree'),
+      scheduledIssues: 'keep-blocked',
+      randomId: () => 'transfer-linked-worktree',
+    })
+    const paths = plan.portable.entries.map((entry) => entry.path)
+    expect(paths).toContain('workspaces/workspaces/linked/README.md')
+    expect(paths).not.toContain('workspaces/workspaces/linked/.git')
+    expect(plan.readyToApply).toBe(false)
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: 'ELINKEDWORKTREE' }))
+    expect(plan.excluded.find((entry) => entry.reason === 'machine-local')?.files)
+      .toBeGreaterThanOrEqual(4)
+  })
+
+  it('blocks Git Workspaces that depend on non-portable object or promisor state', async () => {
+    const home = await fixtureHome()
+    const workspace = join(home, 'workspaces', 'workspaces', 'ws-one')
+    const alternate = await mkdtemp(join(tmpdir(), 'oa-transfer-alternate-'))
+    homes.push(alternate)
+    await execFile('git', ['init', '-q'], { cwd: workspace })
+    await execFile('git', ['init', '-q'], { cwd: alternate })
+    await writeText(
+      join(workspace, '.git', 'objects', 'info', 'alternates'),
+      `${join(alternate, '.git', 'objects')}\n`,
+    )
+    await execFile('git', ['config', '--local', 'remote.origin.promisor', 'true'], { cwd: workspace })
+
+    const plan = await planProjectTransfer({
+      source: sourceProject(home),
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'alice-cloud',
+      destinationHome: '/srv/openalice/alice-cloud',
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+    })
+    expect(plan.readyToApply).toBe(false)
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: 'EGITPORTABILITY' }))
+    expect(plan.blockers.find((blocker) => blocker.code === 'EGITPORTABILITY')?.message)
+      .toContain('alternate object database')
+  })
+
+  it('blocks an independent nested Git repository instead of silently emptying it', async () => {
+    const home = await fixtureHome()
+    const workspace = join(home, 'workspaces', 'workspaces', 'ws-one')
+    await initCommittedRepository(workspace, 'research.txt')
+    const nested = join(workspace, 'nested-repository')
+    await mkdir(nested)
+    await writeFile(join(nested, 'nested.txt'), 'nested user work\n')
+    await initCommittedRepository(nested, 'nested.txt')
+
+    const plan = await planProjectTransfer({
+      source: sourceProject(home),
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'alice-cloud',
+      destinationHome: '/srv/openalice/alice-cloud',
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+    })
+
+    expect(plan.readyToApply).toBe(false)
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: 'ENESTEDGIT' }))
+    expect(plan.blockers.find((blocker) => blocker.code === 'ENESTEDGIT')?.message)
+      .toContain('nested-repository')
+  })
+
+  it.each([
+    ['clean', false],
+    ['dirty', true],
+  ])('blocks an initialized %s Git submodule instead of degrading it', async (_label, dirty) => {
+    const home = await fixtureHome()
+    const workspace = join(home, 'workspaces', 'workspaces', 'ws-one')
+    await initCommittedRepository(workspace, 'research.txt')
+    const submoduleSource = await mkdtemp(join(tmpdir(), 'oa-transfer-submodule-source-'))
+    homes.push(submoduleSource)
+    await writeFile(join(submoduleSource, 'module.txt'), 'submodule content\n')
+    await initCommittedRepository(submoduleSource, 'module.txt')
+    await execFile('git', [
+      '-c', 'protocol.file.allow=always',
+      'submodule', 'add', '-q', submoduleSource, 'vendor/module',
+    ], { cwd: workspace })
+    await execFile('git', ['add', '.gitmodules', 'vendor/module'], { cwd: workspace })
+    await execFile('git', [
+      '-c', 'user.name=OpenAlice Test',
+      '-c', 'user.email=openalice@example.test',
+      'commit', '-qm', 'add submodule',
+    ], { cwd: workspace })
+    if (dirty) await writeFile(join(workspace, 'vendor', 'module', 'module.txt'), 'dirty submodule work\n')
+
+    const plan = await planProjectTransfer({
+      source: sourceProject(home),
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'alice-cloud',
+      destinationHome: '/srv/openalice/alice-cloud',
+      scheduledIssues: 'keep-blocked',
+      credentials: 'omit',
+    })
+
+    expect(plan.readyToApply).toBe(false)
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: 'ENESTEDGIT' }))
+    expect(plan.blockers.find((blocker) => blocker.code === 'ENESTEDGIT')?.message)
+      .toContain('vendor/module')
+  })
+
+  it('uses one cached Git index per Workspace to skip ignored generated trees', async () => {
+    const home = await fixtureHome()
+    const workspace = join(home, 'workspaces', 'workspaces', 'ws-one')
+    await execFile('git', ['init', '-q'], { cwd: workspace })
+    await writeFile(join(workspace, '.gitignore'), [
+      'node_modules/',
+      '.venv/',
+      'dist/',
+      '',
+    ].join('\n'))
+    await writeFile(join(workspace, '.git', 'info', 'exclude'), '.pi-agent/\n')
+    await writeFile(join(workspace, 'draft.txt'), 'untracked user work\n')
+    await mkdir(join(workspace, 'node_modules', 'package'), { recursive: true })
+    await mkdir(join(workspace, '.venv', 'bin'), { recursive: true })
+    await mkdir(join(workspace, 'dist'), { recursive: true })
+    await writeFile(join(workspace, 'node_modules', 'package', 'tracked.js'), 'tracked dependency\n')
+    await writeFile(join(workspace, 'node_modules', 'package', 'ignored.js'), 'ignored dependency\n')
+    await writeFile(join(workspace, '.venv', 'bin', 'python'), 'ignored virtualenv\n')
+    await writeFile(join(workspace, 'dist', 'bundle.js'), 'ignored build output\n')
+    await writeJson(join(workspace, '.pi-agent', 'auth.json'), { token: 'ignored-agent-secret-canary' })
+    await writeText(join(workspace, '.codex', 'commands', 'tracked.md'), 'tracked native project command\n')
+    await writeText(join(workspace, '.codex', 'local-state.json'), 'untracked native runtime state\n')
+    await writeText(join(workspace, '.codex', 'state_5.sqlite'), 'untracked native session state\n')
+    await execFile('git', [
+      'add', '.gitignore', 'research.txt', '.alice/sessions/tracked.json', '.codex/commands/tracked.md',
+    ], { cwd: workspace })
+    await execFile('git', ['add', '-f', 'node_modules/package/tracked.js'], { cwd: workspace })
+
+    const plainWorkspace = join(home, 'workspaces', 'workspaces', 'plain')
+    await mkdir(join(plainWorkspace, 'node_modules'), { recursive: true })
+    await writeFile(join(plainWorkspace, 'node_modules', 'kept.js'), 'non-Git content\n')
+
+    const plan = await planProjectTransfer({
+      source: sourceProject(home),
+      destinationMachineKey: 'cloud',
+      destinationProjectKey: 'alice-cloud',
+      destinationHome: join(tmpdir(), 'oa-transfer-git-index'),
+      scheduledIssues: 'keep-blocked',
+      randomId: () => 'transfer-git-index',
+    })
+    const paths = plan.portable.entries.map((entry) => entry.path)
+    expect(paths).toEqual(expect.arrayContaining([
+      'workspaces/workspaces/ws-one/.git/HEAD',
+      'workspaces/workspaces/ws-one/.git/index',
+      'workspaces/workspaces/ws-one/.gitignore',
+      'workspaces/workspaces/ws-one/research.txt',
+      'workspaces/workspaces/ws-one/draft.txt',
+      'workspaces/workspaces/ws-one/node_modules/package/tracked.js',
+      'workspaces/workspaces/ws-one/.alice/sessions/tracked.json',
+      'workspaces/workspaces/ws-one/.codex/commands/tracked.md',
+      'workspaces/workspaces/plain/node_modules/kept.js',
+    ]))
+    expect(paths).not.toEqual(expect.arrayContaining([
+      'workspaces/workspaces/ws-one/node_modules/package/ignored.js',
+      'workspaces/workspaces/ws-one/.venv/bin/python',
+      'workspaces/workspaces/ws-one/dist/bundle.js',
+      'workspaces/workspaces/ws-one/.pi-agent/auth.json',
+      'workspaces/workspaces/ws-one/.alice/sessions/untracked.json',
+      'workspaces/workspaces/ws-one/.git/config',
+      'workspaces/workspaces/ws-one/.codex/local-state.json',
+      'workspaces/workspaces/ws-one/.codex/state_5.sqlite',
+    ]))
+    expect(plan.excluded.find((entry) => entry.reason === 'git-ignored')?.files)
+      .toBeGreaterThanOrEqual(3)
+    expect(JSON.stringify(plan)).not.toContain('ignored-agent-secret-canary')
   })
 })
 
@@ -149,6 +441,7 @@ async function fixtureHome(): Promise<string> {
   await writeAliceProjectProductStamp(home, 'nano')
   await writeJson(join(home, 'data', 'config', 'ai-provider-manager.json'), {
     activeProfile: 'default',
+    apiKeys: { google: 'legacy-ai-transfer-secret' },
     credentials: {
       'openai-1': { vendor: 'openai', authType: 'api-key', apiKey: 'sk-transfer-secret' },
     },
@@ -167,18 +460,56 @@ async function fixtureHome(): Promise<string> {
   })
   await writeJson(join(home, 'data', 'config', 'ports.json'), { web: 47331 })
   await writeJson(join(home, 'data', 'config', 'auth.json'), { tokenHash: 'machine-local' })
+  await writeJson(join(home, 'data', 'config', 'sessions.json'), { sessions: [{ sid: 'derived-secret-canary' }] })
+  await writeJson(join(home, 'data', 'config', 'sessions.json.tmp'), { sid: 'derived-secret-canary' })
+  await writeText(join(home, 'data', 'logs', 'connector-io.jsonl'), 'native-agent-secret-canary\n')
+  await writeJson(join(home, 'data', 'config', 'ports.json.backup'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', 'config', 'auth.json.previous'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', 'config', 'accounts.json.backup-canary'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', 'config', 'connectors.json.tmp-canary'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', 'config', 'ai-provider-manager.json.backup-canary'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', 'config', '.ai-provider-manager.123.tmp'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', 'config', 'market-data.json.previous'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'data', '_backup', 'pre-migration', 'config', 'ai-provider-manager.json'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, 'demo-text-backups', 'provider-canary.json'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, '.openalice-transfer-receipt.json'), { secret: 'derived-secret-canary' })
+  await writeJson(join(home, '.cli-update-check.json'), { secret: 'derived-secret-canary' })
+  await mkdir(join(home, '.cli-install.lock'), { recursive: true })
+  await writeFile(join(home, '.cli-install.lock', 'pid'), '99999999\n')
+  await writeFile(join(home, '.cli-install.lock.guard'), '')
+  await writeJson(join(home, 'provider-keys.json.backup'), { secret: 'derived-secret-canary' })
+  await writeFile(join(home, 'sealing.key.previous'), 'derived-secret-canary\n')
+  await writeJson(join(home, 'workspaces', 'workspaces.json.before-transfer'), { path: '/source-only' })
+  await writeJson(join(home, 'workspaces', 'state', 'workspace-catalog.json.backup'), { path: '/source-only' })
+  await writeJson(join(home, 'workspaces', 'state', 'runtime.lock', 'owner.json'), {
+    token: 'native-agent-secret-canary',
+  })
 
   const workspace = join(home, 'workspaces', 'workspaces', 'ws-one')
   await mkdir(join(workspace, '.alice', 'sessions'), { recursive: true })
   await mkdir(join(workspace, '.alice', 'issues'), { recursive: true })
   await writeFile(join(workspace, 'research.txt'), 'portable research\n')
+  await writeText(join(workspace, '.claude', 'skills', 'portable', 'SKILL.md'), '# Portable skill\n')
+  await writeJson(join(workspace, '.claude', 'settings.local.json'), { env: { API_KEY: 'native-agent-secret-canary' } })
+  await writeJson(join(workspace, '.claude', 'openalice-provider.json'), { key: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, '.codex', 'env.json'), { OPENALICE_WORKSPACE_KEY: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, '.codex', 'openalice-home', 'auth.json'), { token: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, '.codex', 'sessions', 'rollout.jsonl'), { token: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, 'opencode.json'), { key: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, '.opencode', 'openalice-provider.json'), { key: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, '.pi', 'settings.json'), { provider: 'native-agent-secret-canary' })
+  await writeJson(join(workspace, '.pi', 'openalice-provider.json'), { key: 'native-agent-secret-canary' })
+  await writeText(join(workspace, '.pi', 'extensions', 'openalice-provider.ts'), 'native-agent-secret-canary\n')
+  await writeJson(join(workspace, '.pi-agent', 'auth.json'), { token: 'native-agent-secret-canary' })
   await writeJson(join(workspace, '.alice', 'sessions', 'tracked.json'), { resumeId: 'tracked' })
   await writeJson(join(workspace, '.alice', 'sessions', 'untracked.json'), { resumeId: 'untracked' })
   await writeFile(join(workspace, '.alice', 'issues', 'scheduled-owner.md'), [
     '---',
     'title: Scheduled owner',
-    'assignee: "@resume-old-owner"',
-    'when: { kind: every, every: 1h }',
+    'assignee: "@resume-old-owner" # exact owner',
+    'when:',
+    '  kind: every',
+    '  every: 1h',
     '---',
     'Continue the work.',
     '',
@@ -195,9 +526,25 @@ async function fixtureHome(): Promise<string> {
     version: 1,
     workspaces: [{ id: 'ws-one', tag: 'one', dir: workspace, createdAt: '2026-08-23T00:00:00Z' }],
   })
+  await writeJson(join(home, 'workspaces', 'workspaces', 'runtime-selection.json'), {
+    selectedRuntime: 'opencode',
+  })
+  await writeJson(join(home, 'workspaces', 'workspaces', 'opencode.json'), {
+    provider: { key: 'native-agent-secret-canary' },
+  })
   await writeJson(join(home, 'workspaces', 'state', 'workspace-catalog.json'), {
     version: 1,
-    workspaces: [{ id: 'ws-one', tag: 'one', activeDir: workspace, lifecycle: 'active' }],
+    workspaces: [
+      { id: 'ws-one', tag: 'one', activeDir: workspace, lifecycle: 'active' },
+      {
+        id: '.pi-agent',
+        tag: 'pi-agent',
+        activeDir: join(home, 'workspaces', 'departed-workspaces', '.pi-agent'),
+        departedDir: join(home, 'workspaces', 'departed-workspaces', '.pi-agent'),
+        lifecycle: 'departed',
+        legacyImported: true,
+      },
+    ],
   })
   await writeJson(join(home, 'workspaces', 'state', 'resume-identities.json'), { version: 1, records: {} })
   return home
@@ -218,4 +565,19 @@ function sourceProject(home: string) {
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(join(path, '..'), { recursive: true })
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function initCommittedRepository(repository: string, file: string): Promise<void> {
+  await execFile('git', ['init', '-q'], { cwd: repository })
+  await execFile('git', ['add', file], { cwd: repository })
+  await execFile('git', [
+    '-c', 'user.name=OpenAlice Test',
+    '-c', 'user.email=openalice@example.test',
+    'commit', '-qm', 'fixture',
+  ], { cwd: repository })
+}
+
+async function writeText(path: string, value: string): Promise<void> {
+  await mkdir(join(path, '..'), { recursive: true })
+  await writeFile(path, value)
 }

--- a/packages/cli/src/project-transfer.ts
+++ b/packages/cli/src/project-transfer.ts
@@ -1,5 +1,5 @@
 /** Versioned local AliceProject → SSH Machine transfer planner. */
-import { createHash, randomUUID } from 'node:crypto'
+import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
 import {
   lstat,
@@ -10,6 +10,7 @@ import {
 } from 'node:fs/promises'
 import { execFile as execFileCallback } from 'node:child_process'
 import { promisify } from 'node:util'
+import { parse as parseYaml } from 'yaml'
 import {
   basename,
   dirname,
@@ -30,6 +31,7 @@ import { transformProjectTransferFile } from './project-transfer-files.ts'
 import {
   readProjectTransferCredentialBundle,
   summarizeProjectTransferCredentials,
+  type ProjectTransferCredentialBundle,
   type ProjectTransferCredentialSummary,
 } from './project-transfer-secrets.ts'
 import type { SupervisorAliceProjectSummary } from './supervisor-config.ts'
@@ -37,6 +39,12 @@ import type { SupervisorAliceProjectSummary } from './supervisor-config.ts'
 const execFile = promisify(execFileCallback)
 
 export const PROJECT_TRANSFER_SCHEMA_VERSION = 1
+export const PROJECT_TRANSFER_RECEIPT_FILE = '.openalice-transfer-receipt.json'
+
+const AI_PROVIDER_CONFIG_PATH = 'data/config/ai-provider-manager.json'
+const MARKET_DATA_CONFIG_PATH = 'data/config/market-data.json'
+const GIT_INDEX_MAX_BYTES = 64 * 1024 * 1024
+const credentialSnapshots = new WeakMap<ProjectTransferPlan, Buffer>()
 
 export type ProjectTransferIssuePolicy = 'keep-blocked' | 'new-then-resume'
 export type ProjectTransferCredentialMode = 'include' | 'omit'
@@ -66,6 +74,7 @@ export interface ProjectTransferExclusion {
     | 'runtime-state'
     | 'machine-local'
     | 'credential-plane'
+    | 'git-ignored'
     | 'untracked-session-dossier'
   files: number
   bytes: number
@@ -128,6 +137,7 @@ export interface PlanProjectTransferInput {
   now?: () => Date
   randomId?: () => string
   isGitTracked?: (workspaceRoot: string, relativePath: string) => Promise<boolean>
+  readCredentials?: (home: string) => Promise<ProjectTransferCredentialBundle>
 }
 
 export async function planProjectTransfer(
@@ -144,18 +154,31 @@ export async function planProjectTransfer(
     })
   }
   const credentialsMode = input.credentials ?? 'include'
-  const credentialBundle = await readProjectTransferCredentialBundle(sourceHome)
-  const credentialSummary = summarizeProjectTransferCredentials(credentialBundle)
-  const tracked = input.isGitTracked ?? defaultIsGitTracked
+  const credentialBundle = credentialsMode === 'include'
+    ? await (input.readCredentials ?? readProjectTransferCredentialBundle)(sourceHome)
+    : null
+  const credentialBytes = credentialBundle
+    ? Buffer.from(JSON.stringify(credentialBundle), 'utf8')
+    : null
+  const credentialSummary = credentialBundle
+    ? summarizeProjectTransferCredentials(credentialBundle)
+    : emptyCredentialSummary()
   const exclusions = new Map<ProjectTransferExclusion['reason'], ProjectTransferExclusion>()
   const entries: ProjectTransferEntry[] = []
   const scheduledIssues: ProjectTransferScheduledIssue[] = []
+  const linkedWorktrees: string[] = []
+  const nestedGitRepositories: string[] = []
+  const gitPortabilityIssues = new Map<string, string[]>()
   await walkPortableTree(sourceHome, '', {
     entries,
     exclusions,
     scheduledIssues,
     issuePolicy: input.scheduledIssues ?? null,
-    isGitTracked: tracked,
+    isGitTracked: input.isGitTracked,
+    workspaceGitIndexes: new Map(),
+    linkedWorktrees,
+    nestedGitRepositories,
+    gitPortabilityIssues,
     destinationHome,
   })
   entries.sort((left, right) => left.path.localeCompare(right.path))
@@ -164,6 +187,27 @@ export async function planProjectTransfer(
     blockers.push({
       code: 'EISSUEPOLICY',
       message: `${scheduledIssues.length} scheduled Issue(s) use an exact Session owner; choose keep-blocked or new-then-resume.`,
+    })
+  }
+  if (linkedWorktrees.length > 0) {
+    blockers.push({
+      code: 'ELINKEDWORKTREE',
+      message: `${linkedWorktrees.length} linked Git worktree(s) cannot be transferred faithfully; materialize each as an independent repository first.`,
+    })
+  }
+  if (nestedGitRepositories.length > 0) {
+    blockers.push({
+      code: 'ENESTEDGIT',
+      message: `${nestedGitRepositories.length} nested Git repository or initialized submodule path(s) cannot be transferred faithfully; materialize or remove them first: ${nestedGitRepositories.slice(0, 3).join(', ')}.`,
+    })
+  }
+  if (gitPortabilityIssues.size > 0) {
+    const examples = [...gitPortabilityIssues.entries()].slice(0, 3)
+      .map(([path, issues]) => `${path} (${issues.join(', ')})`)
+      .join('; ')
+    blockers.push({
+      code: 'EGITPORTABILITY',
+      message: `${gitPortabilityIssues.size} Git Workspace(s) depend on machine-local object/config state and must be materialized before transfer: ${examples}.`,
     })
   }
 
@@ -177,15 +221,21 @@ export async function planProjectTransfer(
     },
   })
   const portableBytes = entries.reduce((sum, entry) => sum + entry.size, 0)
-  const credentialBytes = credentialsMode === 'include'
-    ? Buffer.byteLength(JSON.stringify(credentialBundle))
-    : 0
   const requiredFreeBytes = portableBytes
-    + credentialBytes
+    + (credentialBytes?.byteLength ?? 0)
     + Math.max(64 * 1024 * 1024, Math.ceil(portableBytes * 0.05))
-  return {
+  const transferId = input.randomId?.() ?? deterministicTransferId({
+    sourceProjectId: input.source.id,
+    destinationMachineKey: input.destinationMachineKey,
+    destinationProjectId: destinationProject.id,
+    destinationHome,
+    credentials: credentialsMode,
+    scheduledIssues: input.scheduledIssues ?? null,
+    entries,
+  })
+  const plan: ProjectTransferPlan = {
     schemaVersion: PROJECT_TRANSFER_SCHEMA_VERSION,
-    transferId: (input.randomId ?? randomUUID)(),
+    transferId,
     generatedAt: (input.now ?? (() => new Date()))().toISOString(),
     source: {
       projectId: input.source.id,
@@ -219,6 +269,39 @@ export async function planProjectTransfer(
     blockers,
     readyToApply: blockers.length === 0,
   }
+  if (credentialBytes) credentialSnapshots.set(plan, Buffer.from(credentialBytes))
+  return plan
+}
+
+function deterministicTransferId(input: {
+  sourceProjectId: string
+  destinationMachineKey: string
+  destinationProjectId: string
+  destinationHome: string
+  credentials: ProjectTransferCredentialMode
+  scheduledIssues: ProjectTransferIssuePolicy | null
+  entries: ProjectTransferEntry[]
+}): string {
+  const digest = hashBuffer(Buffer.from(JSON.stringify(input), 'utf8'))
+  return `transfer-${digest.slice(0, 40)}`
+}
+
+/**
+ * The consented credential snapshot stays process-private: it is neither part
+ * of JSON plan output nor a reusable offline verifier for low-entropy secrets.
+ */
+export function readProjectTransferCredentialSnapshot(plan: ProjectTransferPlan): Buffer | null {
+  const snapshot = credentialSnapshots.get(plan)
+  return snapshot ? Buffer.from(snapshot) : null
+}
+
+function emptyCredentialSummary(): ProjectTransferCredentialSummary {
+  return {
+    ai: { count: 0, vendors: [] },
+    broker: { count: 0, presets: [] },
+    connector: { count: 0, adapters: [] },
+    providerKeys: { count: 0, vendors: [] },
+  }
 }
 
 interface WalkContext {
@@ -226,8 +309,20 @@ interface WalkContext {
   exclusions: Map<ProjectTransferExclusion['reason'], ProjectTransferExclusion>
   scheduledIssues: ProjectTransferScheduledIssue[]
   issuePolicy: ProjectTransferIssuePolicy | null
-  isGitTracked: (workspaceRoot: string, relativePath: string) => Promise<boolean>
+  isGitTracked?: (workspaceRoot: string, relativePath: string) => Promise<boolean>
+  workspaceGitIndexes: Map<string, Promise<WorkspaceGitIndex | null>>
+  linkedWorktrees: string[]
+  nestedGitRepositories: string[]
+  gitPortabilityIssues: Map<string, string[]>
   destinationHome: string
+}
+
+interface WorkspaceGitIndex {
+  portablePaths: Set<string>
+  portableDirectories: Set<string>
+  trackedPaths: Set<string>
+  trackedDirectories: Set<string>
+  portabilityIssues: string[]
 }
 
 async function walkPortableTree(
@@ -245,9 +340,21 @@ async function walkPortableTree(
     return
   }
 
+  const workspaceEntry = workspaceTreeEntry(relativePath)
+  const gitIndex = workspaceEntry
+    ? await readWorkspaceGitIndexOnce(
+        workspaceEntry.workspaceRoot(home),
+        context.workspaceGitIndexes,
+      )
+    : null
+  if (workspaceEntry && gitIndex?.portabilityIssues.length) {
+    context.gitPortabilityIssues.set(workspaceEntry.rootPath, gitIndex.portabilityIssues)
+  }
   const sessionDossier = workspaceSessionDossier(relativePath)
   if (sessionDossier) {
-    const tracked = await context.isGitTracked(sessionDossier.workspaceRoot(home), sessionDossier.gitPath)
+    const tracked = context.isGitTracked
+      ? await context.isGitTracked(sessionDossier.workspaceRoot(home), sessionDossier.gitPath)
+      : gitIndex?.trackedPaths.has(sessionDossier.gitPath) === true
     if (!tracked) {
       addExclusion(context.exclusions, 'untracked-session-dossier', relativePath, {
         files: info.isDirectory() ? 0 : 1,
@@ -257,9 +364,65 @@ async function walkPortableTree(
     }
   }
 
+  if (workspaceEntry?.gitPath === '.git' && !info.isDirectory()) {
+    context.linkedWorktrees.push(relativePath.slice(0, -'/.git'.length))
+    addExclusion(context.exclusions, 'machine-local', relativePath, {
+      files: 1,
+      bytes: info.isFile() ? info.size : 0,
+    })
+    return
+  }
+
+  if (
+    workspaceEntry
+    && workspaceEntry.gitPath.endsWith('/.git')
+    && !workspaceEntry.gitPath.startsWith('.git/')
+  ) {
+    context.nestedGitRepositories.push(posix.dirname(relativePath))
+    addExclusion(context.exclusions, 'machine-local', relativePath, await measureTree(absolutePath))
+    return
+  }
+
+  if (
+    workspaceEntry
+    && workspaceEntry.gitPath
+    && isNativeAgentProjectPath(workspaceEntry.gitPath)
+    && !isPortableNativeProjectAsset(workspaceEntry.gitPath)
+    && (
+      !gitIndex
+      || !isTrackedGitWorkspaceEntry(gitIndex, workspaceEntry.gitPath, info.isDirectory())
+    )
+  ) {
+    addExclusion(
+      context.exclusions,
+      'machine-local',
+      relativePath,
+      await measureTree(absolutePath),
+    )
+    return
+  }
+
+  if (
+    workspaceEntry
+    && gitIndex
+    && workspaceEntry.gitPath
+    && !isPortableGitWorkspaceEntry(gitIndex, workspaceEntry.gitPath, info.isDirectory())
+  ) {
+    addExclusion(
+      context.exclusions,
+      'git-ignored',
+      relativePath,
+      await measureTree(absolutePath),
+    )
+    return
+  }
+
   if (info.isSymbolicLink()) {
     const linkTarget = await readlink(absolutePath)
-    assertSafeSymlink(home, absolutePath, linkTarget)
+    if (!isPortableSymlink(home, absolutePath, linkTarget)) {
+      addExclusion(context.exclusions, 'machine-local', relativePath, { files: 1, bytes: 0 })
+      return
+    }
     context.entries.push({
       path: relativePath,
       kind: 'symlink',
@@ -322,20 +485,183 @@ async function walkPortableTree(
 
 function exclusionReason(path: string): ProjectTransferExclusion['reason'] | null {
   const parts = path.split('/')
+  const workspaceNativeState = workspaceNativeStateReason(path)
+  if (workspaceNativeState) return workspaceNativeState
+  const gitLocalState = gitLocalStateReason(path)
+  if (gitLocalState) return gitLocalState
+  if (parts[0] === 'bin' || parts[0] === 'cli') return 'machine-local'
   if (parts[0] === 'state' || parts[0] === 'runtime' || parts[0] === 'logs') return 'runtime-state'
-  if (path === 'sealing.key') return 'machine-local'
-  if (path === 'provider-keys.json') return 'credential-plane'
+  if (parts[0] === 'data' && parts[1] === 'logs') return 'runtime-state'
+  if (parts[0] === 'data' && ['sessions', 'tool-calls'].includes(parts[1] ?? '')) return 'session-plane'
+  if (parts[0] === 'demo-text-backups') return 'machine-local'
+  if (parts[0] === 'data' && parts[1] === '_backup') return 'credential-plane'
+  if (matchesFileFamily(path, '.cli-install.lock')) return 'machine-local'
+  if (matchesFileFamily(path, PROJECT_TRANSFER_RECEIPT_FILE)) return 'machine-local'
+  if (matchesFileFamily(path, '.cli-update-check.json')) return 'machine-local'
+  if (matchesFileFamily(path, '.cli-install.lock.guard')) return 'machine-local'
+  if (matchesFileFamily(path, 'sealing.key')) return 'machine-local'
+  if (matchesFileFamily(path, 'provider-keys.json')) return 'credential-plane'
   if (parts[0] === 'workspaces' && parts[1] === 'state') {
     if (['sessions', 'resume-identities.json', 'headless-tasks.json', 'headless-logs',
       'agent-conversations.jsonl', 'agent-runtime.jsonl', 'scrollback',
       'workspace-manager-sessions'].includes(parts[2] ?? '')) return 'session-plane'
+    if (
+      ['runtime.lock', 'runtime-readiness', 'schedule-markers.json'].includes(parts[2] ?? '')
+      || /(?:lock|lease)(?:\.|$)/u.test(parts[2] ?? '')
+    ) return 'runtime-state'
+    if (
+      path !== 'workspaces/state/workspace-catalog.json'
+      && matchesFileFamily(path, 'workspaces/state/workspace-catalog.json')
+    ) return 'machine-local'
   }
+  if (
+    path !== 'workspaces/workspaces.json'
+    && matchesFileFamily(path, 'workspaces/workspaces.json')
+  ) return 'machine-local'
   if (parts[0] === 'data' && parts[1] === 'config') {
-    if (['accounts.json', 'connectors.json'].includes(parts[2] ?? '')) return 'credential-plane'
-    if (['ports.json', 'auth.json'].includes(parts[2] ?? '')) return 'machine-local'
+    if (
+      matchesFileFamily(path, 'data/config/accounts.json')
+      || matchesFileFamily(path, 'data/config/connectors.json')
+      || (path !== AI_PROVIDER_CONFIG_PATH && matchesFileFamily(path, AI_PROVIDER_CONFIG_PATH))
+      || (path !== MARKET_DATA_CONFIG_PATH && matchesFileFamily(path, MARKET_DATA_CONFIG_PATH))
+    ) return 'credential-plane'
+    if (matchesFileFamily(path, 'data/config/sessions.json')) return 'session-plane'
+    if (
+      matchesFileFamily(path, 'data/config/ports.json')
+      || matchesFileFamily(path, 'data/config/auth.json')
+    ) return 'machine-local'
   }
   if (parts[0] === 'data' && parts[1] === 'control') return 'runtime-state'
   return null
+}
+
+/**
+ * Native Agent login/session/config files are deliberately not AliceProject
+ * credentials. They may contain plaintext API keys or host-bound login state,
+ * so the destination runtime must recreate them from the transferred Alice
+ * vault or its own login flow. Shared skills and ordinary dot-directory files
+ * remain portable.
+ */
+function workspaceNativeStateReason(path: string): ProjectTransferExclusion['reason'] | null {
+  if (!path.startsWith('workspaces/')) return null
+  const parts = path.split('/')
+  if (parts.includes('.pi-agent')) return 'machine-local'
+
+  if (
+    matchesNestedFileFamily(path, '.claude', 'settings.local.json')
+    || matchesNestedFileFamily(path, '.claude', 'openalice-provider.json')
+    || matchesNestedFileFamily(path, '.codex', 'auth.json')
+    || matchesNestedFileFamily(path, '.codex', 'env.json')
+    || matchesNestedFileFamily(path, '.codex', 'config.toml')
+    || matchesNestedFileFamily(path, '.codex', 'openalice-provider.json')
+    || matchesNestedTree(path, '.codex', 'openalice-home')
+    || matchesWorkspaceRootFileFamily(path, 'opencode.json')
+    || matchesWorkspaceRootFileFamily(path, 'tui.json')
+    || matchesNestedFileFamily(path, '.opencode', 'openalice-provider.json')
+    || matchesNestedFileFamily(path, '.pi', 'settings.json')
+    || matchesNestedFileFamily(path, '.pi', 'openalice-provider.json')
+    || matchesNestedPath(path, ['.pi', 'extensions', 'openalice-provider.ts'])
+  ) return 'credential-plane'
+
+  if (
+    matchesNestedTree(path, '.codex', 'sessions')
+    || matchesNestedFileFamily(path, '.codex', 'history.jsonl')
+    || matchesNestedFileFamily(path, '.codex', 'session_index.jsonl')
+    || matchesNestedTree(path, '.claude', 'projects')
+    || matchesNestedTree(path, '.claude', 'session-env')
+    || matchesNestedTree(path, '.claude', 'debug')
+    || matchesNestedTree(path, '.claude', 'todos')
+    || matchesNestedFileFamily(path, '.claude', 'history.jsonl')
+  ) return 'session-plane'
+  const codexPath = nestedPathParts(path, '.codex')
+  if (codexPath) {
+    if (
+      ['log', 'cache', 'tmp', '.tmp', 'shell_snapshots'].includes(codexPath[0] ?? '')
+      || /^(?:state|logs)_.*\.sqlite(?:-shm|-wal)?$/u.test(codexPath[0] ?? '')
+    ) return 'session-plane'
+    if (
+      ['installation_id', 'models_cache.json', 'version.json'].includes(codexPath[0] ?? '')
+    ) return 'machine-local'
+  }
+  return null
+}
+
+/** Git object/ref/index state is portable; host credentials and path pointers are not. */
+function gitLocalStateReason(path: string): ProjectTransferExclusion['reason'] | null {
+  if (!path.startsWith('workspaces/')) return null
+  const parts = path.split('/')
+  const gitIndex = parts.indexOf('.git')
+  if (gitIndex < 0) return null
+  const gitPath = parts.slice(gitIndex + 1)
+  if (gitPath.some((part) => part.endsWith('.lock'))) return 'runtime-state'
+  if (
+    matchesFileFamily(gitPath.join('/'), 'config')
+    || matchesFileFamily(gitPath.join('/'), 'config.worktree')
+    || gitPath.join('/') === 'objects/info/alternates'
+    || gitPath[0] === 'worktrees'
+    || (gitPath[0] === 'modules' && gitPath.at(-1) === 'config')
+  ) return 'machine-local'
+  return null
+}
+
+function matchesNestedFileFamily(path: string, directory: string, baseName: string): boolean {
+  const parts = path.split('/')
+  for (let index = 0; index < parts.length; index += 1) {
+    if (parts[index] !== directory) continue
+    if (matchesFileFamily(parts.slice(index + 1).join('/'), baseName)) return true
+  }
+  return false
+}
+
+function matchesNestedTree(path: string, directory: string, child: string): boolean {
+  return matchesNestedPath(path, [directory, child])
+}
+
+function matchesNestedPath(path: string, sequence: string[]): boolean {
+  const parts = path.split('/')
+  return parts.some((_, index) => sequence.every((part, offset) => parts[index + offset] === part))
+}
+
+function nestedPathParts(path: string, directory: string): string[] | null {
+  const parts = path.split('/')
+  const index = parts.indexOf(directory)
+  return index < 0 ? null : parts.slice(index + 1)
+}
+
+function isNativeAgentProjectPath(path: string): boolean {
+  return ['.claude', '.codex', '.opencode', '.pi']
+    .some((root) => path === root || path.startsWith(`${root}/`))
+}
+
+function isPortableNativeProjectAsset(path: string): boolean {
+  if (path === '.claude' || path === '.codex' || path === '.pi') return true
+  return ['.claude/skills', '.codex/skills', '.pi/skills']
+    .some((root) => path === root || path.startsWith(`${root}/`))
+}
+
+function matchesWorkspaceRootFileFamily(path: string, baseName: string): boolean {
+  const parts = path.split('/')
+  if (parts[0] !== 'workspaces') return false
+  let candidate: string | undefined
+  if (parts[1] === 'workspaces' || parts[1] === 'departed-workspaces') {
+    if (parts.length === 3) candidate = parts[2]
+    else if (parts.length === 4) candidate = parts[3]
+  } else if (parts[1]?.endsWith('-mirror') && parts.length === 3) {
+    candidate = parts[2]
+  }
+  return candidate !== undefined && matchesFileFamily(candidate, baseName)
+}
+
+function matchesFileFamily(path: string, basePath: string): boolean {
+  const pathDirectory = posix.dirname(path)
+  const baseDirectory = posix.dirname(basePath)
+  if (pathDirectory !== baseDirectory) return false
+  const name = posix.basename(path)
+  const baseName = posix.basename(basePath)
+  const stem = baseName.endsWith('.json') ? baseName.slice(0, -'.json'.length) : baseName
+  return name === baseName
+    || name.startsWith(`${baseName}.`)
+    || name.startsWith(`.${stem}.`)
 }
 
 function transferTransform(
@@ -344,8 +670,8 @@ function transferTransform(
 ): ProjectTransferTransform | undefined {
   if (path === 'workspaces/workspaces.json') return 'workspace-registry-paths'
   if (path === 'workspaces/state/workspace-catalog.json') return 'workspace-catalog-paths'
-  if (path === 'data/config/ai-provider-manager.json') return 'strip-ai-credentials'
-  if (path === 'data/config/market-data.json') return 'strip-market-provider-keys'
+  if (path === AI_PROVIDER_CONFIG_PATH) return 'strip-ai-credentials'
+  if (path === MARKET_DATA_CONFIG_PATH) return 'strip-market-provider-keys'
   if (rewriteIssueOwner) return 'rewrite-issue-owner'
   return undefined
 }
@@ -362,16 +688,142 @@ function workspaceSessionDossier(path: string): {
   }
 }
 
-async function defaultIsGitTracked(workspaceRoot: string, relativePath: string): Promise<boolean> {
-  try {
-    const { stdout } = await execFile('git', [
-      '-C', workspaceRoot,
-      'ls-files', '--error-unmatch', '--', relativePath,
-    ], { encoding: 'utf8', maxBuffer: 1024 * 1024 })
-    return stdout.trim().length > 0
-  } catch {
-    return false
+function workspaceTreeEntry(path: string): {
+  rootPath: string
+  workspaceRoot(home: string): string
+  gitPath: string
+} | null {
+  const match = /^(workspaces\/(?:workspaces|departed-workspaces)\/[^/]+)(?:\/(.*))?$/u.exec(path)
+    ?? /^(workspaces\/[^/]+-mirror)(?:\/(.*))?$/u.exec(path)
+  if (!match?.[1]) return null
+  return {
+    rootPath: match[1],
+    workspaceRoot: (home) => join(home, ...match[1]!.split('/')),
+    gitPath: match[2] ?? '',
   }
+}
+
+async function readWorkspaceGitIndexOnce(
+  workspaceRoot: string,
+  cache: Map<string, Promise<WorkspaceGitIndex | null>>,
+): Promise<WorkspaceGitIndex | null> {
+  let pending = cache.get(workspaceRoot)
+  if (!pending) {
+    pending = readWorkspaceGitIndex(workspaceRoot)
+    cache.set(workspaceRoot, pending)
+  }
+  return pending
+}
+
+async function readWorkspaceGitIndex(workspaceRoot: string): Promise<WorkspaceGitIndex | null> {
+  try {
+    await lstat(join(workspaceRoot, '.git'))
+  } catch (error: unknown) {
+    // The Workspace container may also hold top-level control files. Those
+    // paths match the structural prefix but are not Workspace directories, so
+    // `<file>/.git` reports ENOTDIR rather than ENOENT.
+    if (isNodeError(error, 'ENOENT') || isNodeError(error, 'ENOTDIR')) return null
+    throw transferPlanError(`Could not inspect Git metadata for Workspace ${workspaceRoot}.`, error)
+  }
+
+  const portabilityIssues = await inspectGitPortabilityIssues(workspaceRoot)
+  let stdout: string
+  try {
+    const result = await execFile('git', [
+      '-C', workspaceRoot,
+      'ls-files', '-z', '-t', '--cached', '--others', '--exclude-standard', '--full-name', '--', '.',
+    ], { encoding: 'utf8', maxBuffer: GIT_INDEX_MAX_BYTES })
+    stdout = String(result.stdout)
+  } catch (error: unknown) {
+    throw transferPlanError(`Could not read the Git index for Workspace ${workspaceRoot}.`, error)
+  }
+
+  const portablePaths = new Set<string>()
+  const portableDirectories = new Set<string>()
+  const trackedPaths = new Set<string>()
+  const trackedDirectories = new Set<string>()
+  for (const record of stdout.split('\0')) {
+    if (!record) continue
+    if (record.length < 3 || record[1] !== ' ') {
+      throw transferPlanError(`Git returned an invalid index record for Workspace ${workspaceRoot}.`)
+    }
+    const tag = record[0]
+    const hadTrailingSlash = record.endsWith('/')
+    const gitPath = record.slice(2).replace(/\/+$/u, '')
+    validateManifestPath(gitPath)
+    portablePaths.add(gitPath)
+    if (tag !== '?') trackedPaths.add(gitPath)
+    if (hadTrailingSlash) portableDirectories.add(gitPath)
+    const parts = gitPath.split('/')
+    for (let index = 1; index < parts.length; index += 1) {
+      portableDirectories.add(parts.slice(0, index).join('/'))
+      if (tag !== '?') trackedDirectories.add(parts.slice(0, index).join('/'))
+    }
+  }
+  return { portablePaths, portableDirectories, trackedPaths, trackedDirectories, portabilityIssues }
+}
+
+async function inspectGitPortabilityIssues(workspaceRoot: string): Promise<string[]> {
+  const issues: string[] = []
+  try {
+    await lstat(join(workspaceRoot, '.git', 'objects', 'info', 'alternates'))
+    issues.push('alternate object database')
+  } catch (error: unknown) {
+    if (!isNodeError(error, 'ENOENT') && !isNodeError(error, 'ENOTDIR')) throw error
+  }
+
+  let output = ''
+  try {
+    const result = await execFile('git', [
+      '-C', workspaceRoot,
+      'config', '--local', '--get-regexp',
+      '^(core\\.(repositoryformatversion|worktree)|extensions\\.(objectformat|refstorage|partialclone|worktreeconfig)|remote\\..*\\.promisor)$',
+    ], { encoding: 'utf8', maxBuffer: 1024 * 1024 })
+    output = String(result.stdout)
+  } catch (error: unknown) {
+    if (!isExitCode(error, 1)) {
+      throw transferPlanError(`Could not inspect Git portability for Workspace ${workspaceRoot}.`, error)
+    }
+  }
+  for (const line of output.split(/\r?\n/u)) {
+    const match = /^(\S+)\s+(.*)$/u.exec(line)
+    if (!match?.[1]) continue
+    const key = match[1].toLowerCase()
+    const value = (match[2] ?? '').trim().toLowerCase()
+    if (key === 'core.repositoryformatversion' && value !== '0') issues.push('non-default repository format')
+    else if (key === 'core.worktree') issues.push('external Git worktree path')
+    else if (key === 'extensions.objectformat' && value !== 'sha1') issues.push('non-default object format')
+    else if (key === 'extensions.refstorage' && value !== 'files') issues.push('non-default ref storage')
+    else if (key === 'extensions.partialclone' && value) issues.push('partial-clone object dependency')
+    else if (key === 'extensions.worktreeconfig' && value === 'true') issues.push('worktree-local Git config')
+    else if (key.startsWith('remote.') && key.endsWith('.promisor') && value === 'true') {
+      issues.push('promisor remote object dependency')
+    }
+  }
+  return [...new Set(issues)]
+}
+
+function isPortableGitWorkspaceEntry(
+  index: WorkspaceGitIndex,
+  gitPath: string,
+  directory: boolean,
+): boolean {
+  if (gitPath === '.git') return directory
+  if (gitPath.startsWith('.git/')) return true
+  if (directory) {
+    return index.portableDirectories.has(gitPath) || index.portablePaths.has(gitPath)
+  }
+  return index.portablePaths.has(gitPath)
+}
+
+function isTrackedGitWorkspaceEntry(
+  index: WorkspaceGitIndex,
+  gitPath: string,
+  directory: boolean,
+): boolean {
+  return directory
+    ? index.trackedDirectories.has(gitPath)
+    : index.trackedPaths.has(gitPath)
 }
 
 async function inspectScheduledIssue(
@@ -380,10 +832,19 @@ async function inspectScheduledIssue(
 ): Promise<ProjectTransferScheduledIssue | null> {
   const text = await readFile(absolutePath, 'utf8')
   if (Buffer.byteLength(text) > 64 * 1024) return null
-  const frontmatter = /^---\s*\n([\s\S]*?)\n---(?:\s*\n|$)/u.exec(text)?.[1]
-  if (!frontmatter || !/^when\s*:/mu.test(frontmatter)) return null
-  const assignee = /^assignee\s*:\s*["']?(@resume-[^\s"']+)["']?\s*$/mu.exec(frontmatter)?.[1]
-  if (!assignee) return null
+  const frontmatter = splitIssueFrontmatter(text)?.frontmatter
+  if (!frontmatter) return null
+  let value: unknown
+  try {
+    value = parseYaml(frontmatter)
+  } catch {
+    return null
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (record['when'] === undefined) return null
+  const assignee = record['assignee']
+  if (typeof assignee !== 'string' || !assignee.startsWith('@resume-')) return null
   const parts = relativePath.split('/')
   return {
     workspaceId: parts[2] ?? 'unknown',
@@ -391,6 +852,17 @@ async function inspectScheduledIssue(
     path: relativePath,
     assignee,
   }
+}
+
+function splitIssueFrontmatter(raw: string): { frontmatter: string } | null {
+  const lines = raw.replace(/^\uFEFF/u, '').split(/\r?\n/u)
+  if (lines[0]?.trim() !== '---') return null
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index]?.trim() === '---') {
+      return { frontmatter: lines.slice(1, index).join('\n') }
+    }
+  }
+  return null
 }
 
 function isIssuePath(path: string): boolean {
@@ -445,14 +917,12 @@ export function validateManifestPath(path: string): void {
   }
 }
 
-function assertSafeSymlink(home: string, path: string, target: string): void {
+function isPortableSymlink(home: string, path: string, target: string): boolean {
   if (isAbsolute(target) || /[\u0000-\u001f\u007f-\u009f]/u.test(target)) {
-    throw transferPlanError(`Symlink ${relative(home, path)} escapes the AliceProject home.`)
+    return false
   }
   const resolvedTarget = resolve(dirname(path), target)
-  if (resolvedTarget !== home && !resolvedTarget.startsWith(`${home}${sep}`)) {
-    throw transferPlanError(`Symlink ${relative(home, path)} escapes the AliceProject home.`)
-  }
+  return resolvedTarget === home || resolvedTarget.startsWith(`${home}${sep}`)
 }
 
 function pathContains(parent: string, child: string): boolean {
@@ -460,6 +930,20 @@ function pathContains(parent: string, child: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
 }
 
-function transferPlanError(message: string): Error & { code: string; exitCode: number } {
-  return Object.assign(new Error(message), { code: 'ETRANSFERPLAN', exitCode: 1 })
+function transferPlanError(message: string, cause?: unknown): Error & { code: string; exitCode: number } {
+  return Object.assign(new Error(message, cause === undefined ? undefined : { cause }), {
+    code: 'ETRANSFERPLAN',
+    exitCode: 1,
+  })
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code
+}
+
+function isExitCode(error: unknown, code: number): boolean {
+  return error !== null
+    && typeof error === 'object'
+    && 'code' in error
+    && (error as { code?: unknown }).code === code
 }

--- a/packages/cli/src/remote.mjs
+++ b/packages/cli/src/remote.mjs
@@ -17,12 +17,17 @@ import {
 } from './install-source.mjs'
 import { formatMissingRuntimeBuildTools } from './runtime-deps.mjs'
 import { connectSsh } from './ssh-connect.mjs'
+import {
+  fetchDevManifestDocument,
+  selectDevManifestTarget,
+} from './update.mjs'
 
 const MINIMUM_NODE_VERSION = '22.19.0'
 const MAX_SSH_OUTPUT_BYTES = 1024 * 1024
 const REMOTE_STATE_VERSION = 1
 const MAX_REMEMBERED_TARGETS = 32
 const DEFAULT_REPOSITORY_URL = 'https://github.com/TraderAlice/OpenAlice.git'
+const DEFAULT_DEV_MANIFEST_URL = 'https://download.openalice.ai/cli/dev/manifest.json'
 const TRANSIENT_SSH_PATTERNS = [
   /can't verify your ssh key right now/i,
   /temporary service issue/i,
@@ -143,9 +148,17 @@ export async function connectRemote(options, dependencies = {}) {
   if (options.mode === 'stop') {
     return stopManagedRemote(connectionOptions, remote, { ...dependencies, probe, stdout })
   }
+  const devExpectation = normalizeRemoteDeploymentAuthority(remote.deploymentAuthority)
+    ? {}
+    : await resolveDevInstallExpectation(
+      localInstall,
+      remote,
+      { ...dependencies, env },
+    )
   let plan = createRemotePlan(connectionOptions, remote, {
     installSource: localInstall.installSource,
     contentIdentity: localInstall.contentIdentity,
+    ...devExpectation,
     installBaseUrl: dependencies.installBaseUrl ?? env['OPENALICE_REMOTE_TEST_INSTALL_BASE_URL'] ?? '',
     repositoryUrl,
   })
@@ -173,6 +186,7 @@ export async function connectRemote(options, dependencies = {}) {
       const output = await runRemote(connectionOptions, buildRemoteInstallCommand(
         plan.installSource,
         plan.installBaseUrl,
+        plan.expectedRemoteTarget,
       ), dependencies)
       writeRemoteActionOutput(stdout, output)
     } catch (error) {
@@ -184,9 +198,12 @@ export async function connectRemote(options, dependencies = {}) {
     } catch (probeError) {
       throw installerError ?? probeError
     }
-    const matchingRemoteCli = remote.cliCompatible
-      && installSourcesMatch(remote.installSource, plan.installSource)
-      && contentIdentitiesMatch(plan.contentIdentity, remote.cliContentIdentity)
+    const matchingRemoteCli = remoteCliMatchesRelease(remote, {
+      installSource: plan.installSource,
+      contentIdentity: plan.contentIdentity,
+      expectedRemoteTarget: plan.expectedRemoteTarget,
+      nativeRuntimeRequired: !connectionOptions.appDir,
+    })
     if (installerError && matchingRemoteCli) {
       stdout.write('The remote install completed before the disconnect; continuing from detected state.\n')
     } else if (installerError) {
@@ -195,9 +212,20 @@ export async function connectRemote(options, dependencies = {}) {
     if (!remote.cliPath || !matchingRemoteCli) {
       throw new Error('The remote OpenAlice CLI install completed, but it does not match the invoking local CLI')
     }
+    if (plan.restartServer) {
+      remote = await stopNativeRuntimeAfterUpdate(
+        connectionOptions,
+        plan.restartOwner,
+        remote,
+        { ...dependencies, runRemote, probe, stdout },
+      )
+    }
     const refreshedPlan = createRemotePlan(connectionOptions, remote, {
       installSource: plan.installSource,
       contentIdentity: plan.contentIdentity,
+      expectedRemoteTarget: plan.expectedRemoteTarget,
+      devCommit: plan.devCommit,
+      devBlocker: plan.devBlocker,
       installBaseUrl: plan.installBaseUrl,
       repositoryUrl: plan.repositoryUrl,
     })
@@ -248,6 +276,9 @@ export async function connectRemote(options, dependencies = {}) {
     const refreshedPlan = createRemotePlan(connectionOptions, remote, {
       installSource: plan.installSource,
       contentIdentity: plan.contentIdentity,
+      expectedRemoteTarget: plan.expectedRemoteTarget,
+      devCommit: plan.devCommit,
+      devBlocker: plan.devBlocker,
       installBaseUrl: plan.installBaseUrl,
       repositoryUrl: plan.repositoryUrl,
     })
@@ -294,6 +325,9 @@ export async function connectRemote(options, dependencies = {}) {
   if (remote.status?.class !== 'running' || remote.status?.owner?.surface !== 'cli-server') {
     throw new Error(`Remote OpenAlice Server is not ready after apply (${remote.status?.class ?? 'no status'})`)
   }
+  if (!runningRuntimeMatchesPlan(connectionOptions, remote)) {
+    throw new Error(formatRunningRuntimeMismatch(connectionOptions, remote))
+  }
   const runtimePort = remoteRuntimePort(remote.status)
   if (runtimePort === null) {
     throw new Error('Remote OpenAlice Server reported an invalid non-loopback web endpoint')
@@ -328,6 +362,9 @@ async function stopManagedRemote(options, initialRemote, dependencies) {
   const stdout = dependencies.stdout
   const runRemote = dependencies.runRemote ?? runSshCommand
   const probe = dependencies.probe
+  if (normalizeRemoteDeploymentAuthority(initialRemote.deploymentAuthority)) {
+    throw new Error('This Railway service owns the foreground Runtime and will restart it. Stop or restart the service through Railway instead of openalice remote --stop.')
+  }
   if (!initialRemote.cliPath) {
     throw new Error(`No managed OpenAlice CLI was found on ${options.destination}; there is no CLI Server to stop`)
   }
@@ -360,6 +397,47 @@ async function stopManagedRemote(options, initialRemote, dependencies) {
   return 0
 }
 
+async function stopNativeRuntimeAfterUpdate(options, expectedOwner, remote, dependencies) {
+  const stdout = dependencies.stdout
+  if (remote.status?.class === 'absent') {
+    stdout.write('The previous remote Server stopped during the CLI update; starting the updated Runtime.\n')
+    return remote
+  }
+  if (!runningOwnerMatches(remote.status, expectedOwner)) {
+    throw new Error('The remote CLI Server owner changed during the CLI update. OpenAlice did not stop the new owner; inspect the remote Runtime before reconnecting.')
+  }
+
+  stdout.write(`Stopping the previous OpenAlice Server on ${options.destination} before starting the updated Runtime...\n`)
+  let stopError = null
+  const stopDependencies = { ...dependencies, retryTransientSsh: false }
+  try {
+    const output = await dependencies.runRemote(
+      options,
+      buildRemoteServerStopCommand(options, remote.cliPath),
+      stopDependencies,
+    )
+    writeRemoteActionOutput(stdout, output)
+  } catch (error) {
+    stopError = error
+    stdout.write('The connection ended unexpectedly; checking whether the previous remote Server stopped...\n')
+  }
+
+  let stoppedRemote
+  try {
+    stoppedRemote = await dependencies.probe(options, dependencies)
+  } catch (probeError) {
+    throw stopError ?? probeError
+  }
+  if (stoppedRemote.status?.class === 'absent') {
+    if (stopError) stdout.write('The previous remote Server stopped before the disconnect; continuing with the updated Runtime.\n')
+    return stoppedRemote
+  }
+  if (!runningOwnerMatches(stoppedRemote.status, expectedOwner)) {
+    throw new Error('The remote CLI Server owner changed while the previous Runtime was stopping. OpenAlice will not stop the new owner.')
+  }
+  throw stopError ?? new Error(`The previous remote OpenAlice Server did not stop cleanly (${stoppedRemote.status?.class ?? 'unknown'})`)
+}
+
 function formatManagedRemoteStatus(destination, remote) {
   const status = remote.status
   const lines = [
@@ -375,31 +453,69 @@ function formatManagedRemoteStatus(destination, remote) {
     lines.push(`${status.provider?.kind === 'source' ? 'Source' : 'Runtime'}:  ${status.owner.launchRoot}`)
   }
   if (status?.endpoints?.web) lines.push(`Web:     ${status.endpoints.web}`)
+  const deploymentAuthority = normalizeRemoteDeploymentAuthority(remote.deploymentAuthority)
+  if (deploymentAuthority) {
+    lines.push(`Lifecycle: Railway (${formatDeploymentAuthoritySelector(deploymentAuthority)})`)
+  }
   return `${lines.join('\n')}\n\n`
 }
 
 export function createRemotePlan(options, remote, install = {}) {
   const installSource = requireInstallSource(install.installSource ?? DEFAULT_INSTALL_SOURCE)
+  const deploymentAuthority = normalizeRemoteDeploymentAuthority(remote.deploymentAuthority)
   const contentIdentity = normalizeContentIdentity(install.contentIdentity)
+  const expectedRemoteTarget = normalizeExpectedRemoteTarget(install.expectedRemoteTarget)
+  const devCommit = typeof install.devCommit === 'string' ? install.devCommit : null
+  const devBlocker = typeof install.devBlocker === 'string' ? install.devBlocker : ''
+  const expectedTargetBlocker = !deploymentAuthority
+    && installSourceUpdateChannel(installSource) === 'development'
+    && !expectedRemoteTarget
+    ? 'The latest dev target for this remote host is missing or invalid. Refresh the dev manifest and try again.'
+    : ''
   const installBaseUrl = install.installBaseUrl ?? ''
   const repositoryUrl = install.repositoryUrl ?? DEFAULT_REPOSITORY_URL
   const mutations = []
-  let blocker = ''
+  let blocker = deploymentAuthority ? '' : devBlocker || expectedTargetBlocker
   let cloneSource = false
   let startServer = false
-  const cliMatchesLocal = remote.installSource != null
-    && installSourcesMatch(remote.installSource, installSource)
-    && contentIdentitiesMatch(contentIdentity, remote.cliContentIdentity)
+  let restartServer = false
+  let restartOwner = null
+  const cliMatchesLocal = remoteCliMatchesRelease(remote, {
+    installSource,
+    contentIdentity,
+    expectedRemoteTarget,
+    nativeRuntimeRequired: !options.appDir,
+  })
   const bundledRuntime = !options.appDir && remote.managedRuntime?.compatible === true
-  const installCli = !remote.cliPath
-    || !remote.cliCompatible
-    || !cliMatchesLocal
-    || (!options.appDir && !bundledRuntime)
-  const nativeRuntimeExpected = !options.appDir && (bundledRuntime || installCli)
+  const remoteRuntimeConsistent = remoteNativeRuntimeIsConsistent(remote)
+  const installCli = !deploymentAuthority && (
+    !remote.cliPath
+      || !remote.cliCompatible
+      || !cliMatchesLocal
+      || (!options.appDir && !bundledRuntime)
+  )
+  const nativeRuntimeExpected = !options.appDir && (bundledRuntime || installCli || Boolean(deploymentAuthority))
   let serverAppDir = options.appDir
     || (bundledRuntime ? remote.managedRuntime.path : '')
     || ''
   let remotePort = options.remotePort
+  let deploymentNotice = ''
+
+  if (!blocker && deploymentAuthority?.error) {
+    blocker = `The Railway-managed host has an invalid release profile: ${deploymentAuthority.error}`
+  } else if (!blocker && deploymentAuthority) {
+    if (options.appDir) {
+      blocker = 'This Railway-managed host owns its installed foreground Runtime; --app-dir source management is not available through openalice remote.'
+    } else if (options.takeover) {
+      blocker = 'This Railway-managed host owns foreground Runtime recovery; use Railway restart/redeploy instead of --takeover.'
+    } else if (!remote.cliPath || !remote.cliCompatible || !remoteRuntimeConsistent) {
+      blocker = 'The Railway-managed CLI, installed Runtime, and running provider are not self-consistent. Inspect or redeploy the Railway service; openalice remote will not repair platform-managed release state.'
+    } else if (remote.status?.class !== 'running' || remote.status?.owner?.surface !== 'cli-server') {
+      blocker = `The Railway-managed foreground Runtime is ${remote.status?.class ?? 'unavailable'}. Inspect or restart the Railway service instead of starting a detached Server over SSH.`
+    } else if (!remoteInstallMatchesDeploymentAuthority(remote, deploymentAuthority)) {
+      deploymentNotice = `Configured ${formatDeploymentAuthoritySelector(deploymentAuthority)}; running verified fallback ${formatRemoteInstallSelector(remote)}. Railway will retry the configured selector on its next restart.`
+    }
+  }
 
   if (!['linux', 'darwin'].includes(remote.platform?.os)) {
     blocker = `Unsupported remote platform: ${remote.platform?.label ?? 'unknown'}. Stage 2 supports Linux and macOS hosts.`
@@ -415,7 +531,12 @@ export function createRemotePlan(options, remote, install = {}) {
 
   const status = remote.status
   const detectedRuntimePort = remoteRuntimePort(status)
-  if (!blocker && status?.class === 'running' && status?.owner?.surface === 'cli-server') {
+  const runningRuntimeMismatch = status?.class === 'running'
+    && status?.owner?.surface === 'cli-server'
+    && !runningRuntimeMatchesPlan(options, remote)
+  if (!blocker && runningRuntimeMismatch) {
+    blocker = formatRunningRuntimeMismatch(options, remote)
+  } else if (!blocker && status?.class === 'running' && status?.owner?.surface === 'cli-server') {
     if (detectedRuntimePort === null) {
       blocker = 'The remote CLI Server reported an invalid non-loopback web endpoint.'
     } else if (options.remotePortExplicit && detectedRuntimePort !== options.remotePort) {
@@ -448,6 +569,26 @@ export function createRemotePlan(options, remote, install = {}) {
     else {
       startServer = true
       mutations.push('start remote OpenAlice Server')
+    }
+  }
+
+  if (
+    !blocker
+    && !options.appDir
+    && installCli
+    && status?.class === 'running'
+    && status?.owner?.surface === 'cli-server'
+  ) {
+    if (!Array.isArray(status.capabilities) || !status.capabilities.includes('runtime.stop')) {
+      blocker = 'The running remote CLI Server does not advertise structured stop support, so OpenAlice cannot restart it safely after the CLI update. Stop it explicitly before retrying.'
+    } else {
+      restartOwner = runningOwnerIdentity(status)
+    }
+    if (!blocker && !restartOwner) {
+      blocker = 'The running remote CLI Server does not expose a complete owner identity, so OpenAlice cannot restart it safely after the CLI update. Stop it explicitly before retrying.'
+    } else if (!blocker) {
+      restartServer = true
+      mutations.push('restart remote OpenAlice Server')
     }
   }
 
@@ -504,13 +645,21 @@ export function createRemotePlan(options, remote, install = {}) {
     cloneSource,
     runInstaller,
     startServer,
+    restartServer,
+    restartOwner,
     sourceCheckoutPresent: remote.sourceCheckoutPresent ?? null,
     sourceArtifactsReady: remote.sourceArtifactsReady ?? null,
     runtimeBuildToolsMissing,
     installSource,
     contentIdentity,
+    expectedRemoteTarget,
+    devCommit,
+    devBlocker,
     installBaseUrl,
     repositoryUrl,
+    deploymentAuthority,
+    deploymentNotice,
+    remoteRuntimeConsistent,
     mutations,
     blocker,
   }
@@ -529,16 +678,24 @@ export function formatRemotePlan(plan) {
       : plan.appDir === 'not selected'
         ? 'Not inspected'
         : 'Ready'
-  const cliState = plan.cliCompatible && plan.cliMatchesLocal
-    ? ', compatible and matches local CLI'
-    : ', install/update required'
+  const cliState = plan.deploymentAuthority
+    ? plan.remoteRuntimeConsistent
+      ? ', compatible; platform-managed'
+      : ', inconsistent platform state'
+    : plan.cliCompatible && plan.cliMatchesLocal
+      ? ', compatible and matches local CLI'
+      : ', install/update required'
   const runtimeState = plan.bundledRuntime
     ? `, content ${plan.runtimeContentIdentity}`
     : plan.cloneSource
     ? ', will clone'
     : plan.sourceCheckoutState === 'present' ? ', ready' : ''
   const runtimeLabel = plan.nativeRuntimeExpected ? 'Release' : 'Source'
-  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${cliState})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n  ${runtimeLabel.padEnd(14)} ${plan.appDir} (${plan.sourceMode}${runtimeState})\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installSource.installerUrl} (CLI ${plan.installSource.cliVersion}, ${formatInstallSelector(plan.installSource)}, selected by local CLI)\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
+  const lifecycle = plan.deploymentAuthority
+    ? `  Lifecycle      Railway (${formatDeploymentAuthoritySelector(plan.deploymentAuthority)})\n`
+    : ''
+  const notice = plan.deploymentNotice ? `  Notice         ${plan.deploymentNotice}\n` : ''
+  return `\nOpenAlice Remote\n\nRemote plan\n  Target         ${plan.target}\n  Platform       ${plan.platform}\n  CLI            ${plan.cliPath} (${plan.cliVersion}${cliState})\n  Runtime        ${plan.runtimeClass} (${plan.runtimeOwner})\n${lifecycle}${notice}  ${runtimeLabel.padEnd(14)} ${plan.appDir} (${plan.sourceMode}${runtimeState})\n  Build tools    ${buildTools}\n  Home           ${plan.remoteHome}\n  Tunnel         127.0.0.1:${plan.localPort} -> remote 127.0.0.1:${plan.remotePort}\n  Actions        ${actions.join('; ')}\n${plan.runInstaller ? `  Installer      ${plan.installSource.installerUrl} (CLI ${plan.installSource.cliVersion}, ${formatInstallSelector(plan.installSource)}, selected by local CLI)\n` : ''}${plan.blocker ? `\nBlocked: ${plan.blocker}\n` : '\nNothing has changed yet.\n'}\n`
 }
 
 async function resolveLocalInstallIdentity(dependencies, env) {
@@ -566,6 +723,59 @@ async function resolveLocalInstallIdentity(dependencies, env) {
   return { installSource: await readInstallSource(), contentIdentity }
 }
 
+async function resolveDevInstallExpectation(localInstall, remote, dependencies) {
+  const source = requireInstallSource(localInstall.installSource)
+  if (installSourceUpdateChannel(source) !== 'development') return {}
+  if (source.schemaVersion !== 3 || !source.artifact || !localInstall.contentIdentity) {
+    return {
+      devBlocker: 'The invoking OpenAlice CLI does not have target identity for the latest dev artifact. Run "openalice update --channel dev" first.',
+    }
+  }
+  const fetchManifest = dependencies.fetchDevManifestDocumentImpl ?? fetchDevManifestDocument
+  let manifest
+  try {
+    manifest = await fetchManifest({
+      manifestUrl: dependencies.devManifestUrl
+        ?? dependencies.env?.['OPENALICE_REMOTE_TEST_DEV_MANIFEST_URL']
+        ?? DEFAULT_DEV_MANIFEST_URL,
+      timeoutMs: dependencies.devManifestTimeoutMs ?? 10_000,
+    }, dependencies)
+  } catch (error) {
+    return {
+      devBlocker: `Could not verify the latest dev CLI artifact: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+  let localTarget
+  let remoteTarget
+  try {
+    localTarget = selectDevManifestTarget(manifest, {
+      platform: source.artifact.platform,
+      arch: source.artifact.arch,
+    })
+    remoteTarget = selectDevManifestTarget(manifest, {
+      platform: remote.platform?.os,
+      arch: normalizeRemoteArchitecture(remote.platform?.architecture),
+    })
+  } catch (error) {
+    return {
+      devBlocker: `Could not select the latest dev CLI artifact: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+  if (
+    source.cliVersion !== manifest.version
+    || source.artifact.sha256 !== localTarget.sha256
+    || localInstall.contentIdentity !== localTarget.contentIdentity
+  ) {
+    return {
+      devBlocker: `This OpenAlice CLI is not the latest dev build (${manifest.commit.slice(0, 12)}). Run "openalice update --channel dev" before managing another host.`,
+    }
+  }
+  return {
+    expectedRemoteTarget: remoteTarget,
+    devCommit: manifest.commit,
+  }
+}
+
 export async function probeRemoteHost(options, dependencies = {}) {
   const runRemote = dependencies.runRemote ?? runSshCommand
   if (options.mode === 'status' || options.mode === 'stop') {
@@ -574,7 +784,15 @@ export async function probeRemoteHost(options, dependencies = {}) {
   const platformRaw = await runRemote(options, 'uname -s; uname -m', dependencies)
   const [kernel = '', architecture = ''] = platformRaw.trim().split(/\r?\n/)
   const platform = normalizeRemotePlatform(kernel, architecture)
-  const shellHome = normalizeRemoteHome((await runRemote(options, 'printf "%s\\n" "$HOME"', dependencies)).trim())
+  const environmentOutput = await runRemote(options, `printf '%s\\n%s\\n%s\\n%s\\n%s\\n' "$HOME" "\${OPENALICE_SERVICE_MANAGER:-}" "\${RAILWAY_SERVICE_ID:-}" "\${OPENALICE_RAILWAY_CHANNEL:-}" "\${OPENALICE_RAILWAY_VERSION:-}"`, dependencies)
+  const [shellHomeValue = '', serviceManager = '', serviceId = '', managedChannel = '', managedVersion = ''] = environmentOutput.split(/\r?\n/)
+  const shellHome = normalizeRemoteHome(shellHomeValue.trim())
+  const deploymentAuthority = parseRemoteDeploymentAuthority({
+    serviceManager,
+    serviceId,
+    channel: managedChannel,
+    version: managedVersion,
+  })
   const sourceAppDir = options.appDir
   const nodeVersion = sourceAppDir
     ? (await runRemote(options, 'command -v node >/dev/null 2>&1 && node --version || true', dependencies)).trim() || null
@@ -599,7 +817,7 @@ export async function probeRemoteHost(options, dependencies = {}) {
   }
   const cliPath = normalizeRemoteCliPath((await runRemote(options, 'command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf "%s\\n" "$HOME/.openalice/bin/openalice"; }', dependencies)).trim())
   if (!cliPath) {
-    return { platform, shellHome, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, cliPath: null, cliVersion: null, cliContentIdentity: null, installSource: null, cliCompatible: false, status: null }
+    return { platform, shellHome, deploymentAuthority, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, cliPath: null, cliVersion: null, cliContentIdentity: null, installSource: null, cliCompatible: false, status: null }
   }
 
   let cliVersion = null
@@ -630,7 +848,7 @@ export async function probeRemoteHost(options, dependencies = {}) {
   } catch {
     cliCompatible = false
   }
-  return { platform, shellHome, managedRuntime, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, cliPath, cliVersion, cliContentIdentity, installSource: remoteInstallSource, cliCompatible, status }
+  return { platform, shellHome, deploymentAuthority, managedRuntime, nodeVersion, hasCurl, sourceCheckoutState, sourceCheckoutPresent, sourceArtifactsReady, runtimeBuildToolsMissing, cliPath, cliVersion, cliContentIdentity, installSource: remoteInstallSource, cliCompatible, status }
 }
 
 async function probeRemoteControl(options, dependencies) {
@@ -649,6 +867,12 @@ async function probeRemoteControl(options, dependencies) {
       .filter(Boolean),
   )
   const cliPath = normalizeRemoteCliPath(fields.get('cli') ?? '')
+  const deploymentAuthority = parseRemoteDeploymentAuthority({
+    serviceManager: fields.get('serviceManager') ?? '',
+    serviceId: fields.get('serviceId') ?? '',
+    channel: fields.get('managedChannel') ?? '',
+    version: fields.get('managedVersion') ?? '',
+  })
   if (!cliPath) {
     return {
       cliPath: null,
@@ -657,6 +881,7 @@ async function probeRemoteControl(options, dependencies) {
       installSource: null,
       cliCompatible: false,
       status: null,
+      deploymentAuthority,
     }
   }
 
@@ -670,12 +895,17 @@ async function probeRemoteControl(options, dependencies) {
     installSource: versionInfo.version === cliVersion ? versionInfo.installSource : null,
     cliCompatible: status.protocol === 1,
     status,
+    deploymentAuthority,
   }
 }
 
 export function buildRemoteControlProbeCommand(options) {
   const statusHome = options.remoteHome ? ` --home ${shellQuote(options.remoteHome)}` : ''
-  return `cli=$(command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf '%s\\n' "$HOME/.openalice/bin/openalice"; })
+  return `printf 'serviceManager=%s\\n' "\${OPENALICE_SERVICE_MANAGER:-}"
+printf 'serviceId=%s\\n' "\${RAILWAY_SERVICE_ID:-}"
+printf 'managedChannel=%s\\n' "\${OPENALICE_RAILWAY_CHANNEL:-}"
+printf 'managedVersion=%s\\n' "\${OPENALICE_RAILWAY_VERSION:-}"
+cli=$(command -v openalice 2>/dev/null || { [ ! -x "$HOME/.openalice/bin/openalice" ] || printf '%s\\n' "$HOME/.openalice/bin/openalice"; })
 printf 'cli=%s\\n' "$cli"
 if test -n "$cli"; then
   printf 'version='; "$cli" --version
@@ -739,10 +969,17 @@ export function buildRemoteServerStopCommand(options, cliPath) {
   return args.join(' ')
 }
 
-export function buildRemoteInstallCommand(installSource, installBaseUrl = '') {
+export function buildRemoteInstallCommand(installSource, installBaseUrl = '', expectedTarget = null) {
   const source = requireInstallSource(installSource)
-  const url = shellQuote(source.installerUrl)
+  const target = normalizeExpectedRemoteTarget(expectedTarget)
   const updateChannel = installSourceUpdateChannel(source)
+  if (expectedTarget !== null && expectedTarget !== undefined && !target) {
+    throw new Error('The expected remote CLI target is invalid')
+  }
+  if (updateChannel === 'development' && !target) {
+    throw new Error('A dev remote install requires an exact target checksum and content identity')
+  }
+  const url = shellQuote(source.installerUrl)
   const selectorArgs = updateChannel === 'stable' || updateChannel === 'beta'
     ? `--channel ${updateChannel} --version ${shellQuote(source.cliVersion)}`
     : updateChannel === 'development'
@@ -751,6 +988,8 @@ export function buildRemoteInstallCommand(installSource, installBaseUrl = '') {
   const installEnv = [
     `OPENALICE_INSTALL_URL=${url}`,
     `OPENALICE_EXPECTED_CLI_VERSION=${shellQuote(source.cliVersion)}`,
+    target ? `OPENALICE_EXPECTED_CLI_ARTIFACT_SHA256=${shellQuote(target.sha256)}` : '',
+    target ? `OPENALICE_EXPECTED_CLI_CONTENT_IDENTITY=${shellQuote(target.contentIdentity)}` : '',
     installBaseUrl ? `OPENALICE_DOWNLOAD_BASE_URL=${shellQuote(installBaseUrl)}` : '',
   ].filter(Boolean).join(' ')
   return `set -eu\ntmp=$(mktemp "${'${TMPDIR:-/tmp}'}/openalice-install.XXXXXX")\ntrap 'rm -f "$tmp"' EXIT HUP INT TERM\ncurl -fsSL ${url} -o "$tmp"\n${installEnv} bash "$tmp" --yes --no-modify-path ${selectorArgs}`
@@ -774,13 +1013,14 @@ export async function runSshCommand(options, remoteCommand, dependencies = {}) {
   const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
   const stdout = dependencies.stdout ?? process.stdout
   const stderrOutput = dependencies.stderr ?? process.stderr
+  const maximumAttempts = dependencies.retryTransientSsh === false ? 1 : 3
   let lastError
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
+  for (let attempt = 1; attempt <= maximumAttempts; attempt += 1) {
     try {
       return await runSshCommandOnce(options, remoteCommand, dependencies)
     } catch (error) {
       lastError = error
-      if (attempt >= 3 || !isTransientSshError(error)) {
+      if (attempt >= maximumAttempts || !isTransientSshError(error)) {
         if (error?.stderr) stderrOutput.write(error.stderr)
         throw error
       }
@@ -1027,9 +1267,11 @@ function remoteRuntimePort(status) {
 }
 
 function remainingMutationsAfterInstall(plan) {
-  return plan.mutations.filter((mutation) => (
-    !/^(install|update) remote OpenAlice CLI$/.test(mutation)
-  ))
+  return plan.mutations.flatMap((mutation) => {
+    if (/^(install|update) remote OpenAlice CLI$/.test(mutation)) return []
+    if (mutation === 'restart remote OpenAlice Server') return ['start remote OpenAlice Server']
+    return [mutation]
+  })
 }
 
 function remainingMutationsAfterClone(plan) {
@@ -1053,8 +1295,227 @@ function isTransientSshError(error) {
   return TRANSIENT_SSH_PATTERNS.some((pattern) => pattern.test(details))
 }
 
-function contentIdentitiesMatch(localIdentity, remoteIdentity) {
-  return localIdentity === null || localIdentity === normalizeContentIdentity(remoteIdentity)
+function parseRemoteDeploymentAuthority(value) {
+  const manager = typeof value?.serviceManager === 'string' ? value.serviceManager.trim() : ''
+  if (!manager) return null
+  if (manager !== 'railway') return { manager, error: `unsupported service manager ${manager}` }
+  const serviceId = typeof value?.serviceId === 'string' ? value.serviceId.trim() : ''
+  const channel = typeof value?.channel === 'string' ? value.channel.trim() : ''
+  const version = typeof value?.version === 'string' ? value.version.trim() : ''
+  if (!/^[A-Za-z0-9._-]{1,128}$/.test(serviceId)) {
+    return { manager, serviceId, channel, version, error: 'Railway service identity is missing or invalid' }
+  }
+  if (!['stable', 'beta', 'dev'].includes(channel)) {
+    return { manager, serviceId, channel, version, error: 'Railway channel must be stable, beta, or dev' }
+  }
+  if (channel === 'dev' && version) {
+    return { manager, serviceId, channel, version, error: 'Railway dev channel cannot be combined with an exact version' }
+  }
+  if (version) {
+    const valid = channel === 'stable'
+      ? /^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)
+      : /^[0-9]+\.[0-9]+\.[0-9]+-beta(?:\.[1-9][0-9]*)?$/.test(version)
+    if (!valid) return { manager, serviceId, channel, version, error: `Railway ${channel} version is invalid` }
+  }
+  return { manager, serviceId, channel, version, error: '' }
+}
+
+function normalizeRemoteDeploymentAuthority(value) {
+  if (!value || typeof value !== 'object') return null
+  return parseRemoteDeploymentAuthority({
+    serviceManager: value.manager ?? value.serviceManager,
+    serviceId: value.serviceId,
+    channel: value.channel,
+    version: value.version,
+  })
+}
+
+function remoteNativeRuntimeIsConsistent(remote) {
+  return installedNativeRuntimeMatches(remote)
+    && runningRuntimeMatchesPlan({ appDir: '' }, remote)
+}
+
+function installedNativeRuntimeMatches(remote) {
+  const source = parseInstallSource(remote.installSource)
+  const platform = remote.platform?.os
+  const arch = normalizeRemoteArchitecture(remote.platform?.architecture)
+  const identity = normalizeContentIdentity(remote.cliContentIdentity)
+  const artifact = source?.schemaVersion === 3 ? source.artifact : null
+  const runtime = remote.managedRuntime
+  return remote.cliCompatible === true
+    && source !== null
+    && remote.cliVersion === source.cliVersion
+    && identity !== null
+    && artifact?.platform === platform
+    && artifact?.arch === arch
+    && runtime?.compatible === true
+    && runtime.productVersion === remote.cliVersion
+    && runtime.platform === platform
+    && runtime.arch === arch
+    && normalizeContentIdentity(runtime.contentIdentity) === identity
+}
+
+function remoteInstallMatchesDeploymentAuthority(remote, authority) {
+  const source = parseInstallSource(remote.installSource)
+  if (!source || authority?.error) return false
+  const expectedChannel = authority.channel === 'dev' ? 'development' : authority.channel
+  return installSourceUpdateChannel(source) === expectedChannel
+    && (!authority.version || source.cliVersion === authority.version)
+}
+
+function formatDeploymentAuthoritySelector(authority) {
+  if (authority?.error) return 'invalid profile'
+  return authority.version ? `${authority.channel} ${authority.version}` : `${authority.channel} channel`
+}
+
+function formatRemoteInstallSelector(remote) {
+  const source = parseInstallSource(remote.installSource)
+  if (!source) return remote.cliVersion ?? 'unknown release'
+  const channel = installSourceUpdateChannel(source) === 'development'
+    ? 'dev'
+    : installSourceUpdateChannel(source)
+  return `${channel} ${source.cliVersion}`
+}
+
+function remoteCliMatchesRelease(remote, expected) {
+  const localSource = requireInstallSource(expected.installSource)
+  const remoteSource = parseInstallSource(remote.installSource)
+  if (
+    !remote.cliCompatible
+    || !remoteSource
+    || !installSourcesMatch(remoteSource, localSource)
+    || remote.cliVersion !== remoteSource.cliVersion
+  ) return false
+
+  const remotePlatform = remote.platform?.os
+  const remoteArch = normalizeRemoteArchitecture(remote.platform?.architecture)
+  const remoteIdentity = normalizeContentIdentity(remote.cliContentIdentity)
+  const remoteArtifact = remoteSource.schemaVersion === 3 ? remoteSource.artifact : null
+  if (
+    !remoteIdentity
+    || !remoteArtifact
+    || remoteArtifact.platform !== remotePlatform
+    || remoteArtifact.arch !== remoteArch
+  ) return false
+
+  const expectedTarget = normalizeExpectedRemoteTarget(expected.expectedRemoteTarget)
+  if (installSourceUpdateChannel(localSource) === 'development' && !expectedTarget) return false
+  if (expectedTarget && (
+    expectedTarget.platform !== remotePlatform
+    || expectedTarget.arch !== remoteArch
+    || expectedTarget.sha256 !== remoteArtifact.sha256
+    || expectedTarget.contentIdentity !== remoteIdentity
+  )) return false
+
+  const localArtifact = localSource.schemaVersion === 3 ? localSource.artifact : null
+  const localIdentity = normalizeContentIdentity(expected.contentIdentity)
+  if (
+    localArtifact
+    && localArtifact.platform === remoteArtifact.platform
+    && localArtifact.arch === remoteArtifact.arch
+    && (
+      localArtifact.sha256 !== remoteArtifact.sha256
+      || (localIdentity !== null && localIdentity !== remoteIdentity)
+    )
+  ) return false
+
+  if (!expected.nativeRuntimeRequired) return true
+  const managedRuntime = remote.managedRuntime
+  return managedRuntime?.compatible === true
+    && managedRuntime.productVersion === remote.cliVersion
+    && managedRuntime.platform === remotePlatform
+    && managedRuntime.arch === remoteArch
+    && normalizeContentIdentity(managedRuntime.contentIdentity) === remoteIdentity
+}
+
+function runningRuntimeMatchesPlan(options, remote) {
+  const status = remote.status
+  if (status?.class !== 'running' || status?.owner?.surface !== 'cli-server') return false
+  const provider = status.provider
+  const actualRoot = normalizeRemoteRuntimeRoot(provider?.root ?? status.owner?.launchRoot)
+  if (options.appDir) {
+    return provider?.kind === 'source'
+      && actualRoot === normalizeRemoteRuntimeRoot(options.appDir)
+  }
+  const expectedRoot = normalizeRemoteRuntimeRoot(
+    remote.managedRuntime?.path
+      ? posix.join(remote.managedRuntime.path, 'share', 'openalice')
+      : null,
+  )
+  const reportedProviderIdentity = provider?.contentIdentity
+  const providerIdentity = normalizeContentIdentity(reportedProviderIdentity)
+  const missingProviderIdentity = reportedProviderIdentity === undefined
+    || reportedProviderIdentity === null
+    || reportedProviderIdentity === ''
+  const providerIdentityMatches = missingProviderIdentity
+    ? installedNativeRuntimeMatches(remote)
+    : providerIdentity === normalizeContentIdentity(remote.cliContentIdentity)
+  return provider?.kind === 'bun'
+    && providerIdentityMatches
+    && actualRoot === expectedRoot
+}
+
+function runningOwnerIdentity(status) {
+  const owner = status?.class === 'running' && status?.owner?.surface === 'cli-server'
+    ? status.owner
+    : null
+  if (
+    !Number.isInteger(owner?.pid)
+    || owner.pid < 1
+    || typeof owner.instanceId !== 'string'
+    || owner.instanceId === 'unknown'
+    || owner.instanceId.length < 1
+    || typeof owner.startedAt !== 'string'
+    || !Number.isFinite(Date.parse(owner.startedAt))
+  ) return null
+  return {
+    pid: owner.pid,
+    instanceId: owner.instanceId,
+    startedAt: owner.startedAt,
+  }
+}
+
+function runningOwnerMatches(status, expectedOwner) {
+  const currentOwner = runningOwnerIdentity(status)
+  return currentOwner !== null
+    && expectedOwner !== null
+    && currentOwner.pid === expectedOwner.pid
+    && currentOwner.instanceId === expectedOwner.instanceId
+    && currentOwner.startedAt === expectedOwner.startedAt
+}
+
+function formatRunningRuntimeMismatch(options, remote) {
+  const expected = options.appDir
+    ? `source Runtime ${normalizeRemoteRuntimeRoot(options.appDir) ?? options.appDir}`
+    : 'installed native Runtime'
+  const provider = remote.status?.provider
+  const actualRoot = normalizeRemoteRuntimeRoot(provider?.root ?? remote.status?.owner?.launchRoot)
+  const actual = `${provider?.kind ?? 'unknown'} Runtime${actualRoot ? ` ${actualRoot}` : ''}`
+  return `The running remote CLI Server uses ${actual}, not the requested ${expected}. Stop it with "openalice remote ${options.destination} --stop" before reconnecting.`
+}
+
+function normalizeRemoteRuntimeRoot(value) {
+  if (typeof value !== 'string' || !value.startsWith('/')) return null
+  return posix.normalize(value).replace(/\/$/, '') || '/'
+}
+
+function normalizeExpectedRemoteTarget(value) {
+  if (value === null || value === undefined) return null
+  if (
+    !value
+    || !['darwin', 'linux'].includes(value.platform)
+    || !['arm64', 'x64'].includes(value.arch)
+    || typeof value.sha256 !== 'string'
+    || !/^[a-f0-9]{64}$/.test(value.sha256)
+    || typeof value.contentIdentity !== 'string'
+    || !/^[a-f0-9]{16}$/.test(value.contentIdentity)
+  ) return null
+  return {
+    platform: value.platform,
+    arch: value.arch,
+    sha256: value.sha256,
+    contentIdentity: value.contentIdentity,
+  }
 }
 
 function normalizeContentIdentity(value) {

--- a/packages/cli/src/remote.spec.mjs
+++ b/packages/cli/src/remote.spec.mjs
@@ -28,11 +28,15 @@ const CLI_VERSION = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 ).version
 const masterInstallSource = {
-  schemaVersion: 1,
+  schemaVersion: 3,
   repository: 'TraderAlice/OpenAlice',
   cliVersion: CLI_VERSION,
   selector: { kind: 'branch', value: 'master' },
   installerUrl: 'https://openalice.ai/install',
+  updateChannel: 'stable',
+  method: 'direct',
+  artifact: { platform: 'linux', arch: 'x64', sha256: 'a'.repeat(64) },
+  installedAt: '2026-08-31T00:00:00.000Z',
 }
 
 describe('OpenAlice managed remote connector', () => {
@@ -108,16 +112,31 @@ describe('OpenAlice managed remote connector', () => {
     })
     expect(beta).toContain("--channel beta --version '0.90.2-beta.1'")
 
-    const dev = buildRemoteInstallCommand({
+    const devSource = {
       schemaVersion: 2,
       repository: 'TraderAlice/OpenAlice',
       cliVersion: '0.90.2',
       selector: { kind: 'branch', value: 'dev' },
       installerUrl: 'https://openalice.ai/install',
       updateChannel: 'development',
+    }
+    expect(() => buildRemoteInstallCommand(devSource))
+      .toThrow('requires an exact target checksum and content identity')
+    expect(() => buildRemoteInstallCommand(devSource, '', {
+      platform: 'linux',
+      arch: 'x64',
+      sha256: 'not-a-checksum',
+      contentIdentity: 'c'.repeat(16),
+    })).toThrow('expected remote CLI target is invalid')
+
+    const verifiedDev = buildRemoteInstallCommand(devSource, '', {
+      platform: 'linux',
+      arch: 'x64',
+      sha256: 'b'.repeat(64),
+      contentIdentity: 'c'.repeat(16),
     })
-    expect(dev).toContain('--channel dev')
-    expect(dev).not.toContain('--version')
+    expect(verifiedDev).toContain(`OPENALICE_EXPECTED_CLI_ARTIFACT_SHA256='${'b'.repeat(64)}'`)
+    expect(verifiedDev).toContain(`OPENALICE_EXPECTED_CLI_CONTENT_IDENTITY='${'c'.repeat(16)}'`)
   })
 
   it('plans install and start separately, with no implicit takeover', () => {
@@ -156,6 +175,123 @@ describe('OpenAlice managed remote connector', () => {
     expect(plan.blocker).toBe('')
   })
 
+  it('treats Railway as the only release and lifecycle mutation authority', () => {
+    const remote = outdatedNativeRemote()
+    remote.deploymentAuthority = railwayAuthority()
+
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+
+    expect(plan.cliMatchesLocal).toBe(false)
+    expect(plan.remoteRuntimeConsistent).toBe(true)
+    expect(plan.installCli).toBe(false)
+    expect(plan.startServer).toBe(false)
+    expect(plan.restartServer).toBe(false)
+    expect(plan.mutations).toEqual([])
+    expect(plan.blocker).toBe('')
+    expect(formatRemotePlan(plan)).toContain('Lifecycle      Railway (stable channel)')
+  })
+
+  it('does not resolve a local dev manifest for a Railway tunnel-only plan', async () => {
+    const remote = compatibleRemote()
+    remote.deploymentAuthority = railwayAuthority()
+    const fetchDevManifestDocumentImpl = vi.fn()
+
+    await expect(connectRemote(parseRemoteArgs(['host', '--plan']), {
+      probeRemote: async () => remote,
+      installSource: devInstallSource({
+        platform: 'darwin',
+        arch: 'arm64',
+        sha256: '1'.repeat(64),
+      }),
+      contentIdentity: '1111111111111111',
+      fetchDevManifestDocumentImpl,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+    expect(fetchDevManifestDocumentImpl).not.toHaveBeenCalled()
+  })
+
+  it('keeps a verified Railway fallback connectable while showing selector drift', () => {
+    const remote = compatibleRemote()
+    remote.deploymentAuthority = railwayAuthority({
+      channel: 'beta',
+      version: '0.91.0-beta.1',
+    })
+
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+
+    expect(plan.blocker).toBe('')
+    expect(plan.mutations).toEqual([])
+    expect(plan.deploymentNotice).toContain('Configured beta 0.91.0-beta.1')
+    expect(plan.deploymentNotice).toContain('running verified fallback stable')
+  })
+
+  it('accepts a published native fallback whose provider predates content identity status', () => {
+    const remote = compatibleRemote()
+    remote.deploymentAuthority = railwayAuthority({
+      channel: 'beta',
+      version: '0.91.0-beta.1',
+    })
+    delete remote.status.provider.contentIdentity
+
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+
+    expect(plan.remoteRuntimeConsistent).toBe(true)
+    expect(plan.blocker).toBe('')
+    expect(plan.mutations).toEqual([])
+  })
+
+  it('fails closed instead of repairing inconsistent Railway release state over SSH', () => {
+    const remote = compatibleRemote()
+    remote.deploymentAuthority = railwayAuthority()
+    remote.status.provider = {
+      ...remote.status.provider,
+      contentIdentity: 'ffffffffffffffff',
+    }
+
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+
+    expect(plan.installCli).toBe(false)
+    expect(plan.startServer).toBe(false)
+    expect(plan.blocker).toContain('not self-consistent')
+  })
+
+  it('refuses source management and takeover on a Railway foreground service', () => {
+    const remote = compatibleRemote()
+    remote.deploymentAuthority = railwayAuthority()
+
+    expect(createRemotePlan(
+      parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice']),
+      remote,
+    ).blocker).toContain('--app-dir')
+    expect(createRemotePlan(
+      parseRemoteArgs(['host', '--takeover']),
+      remote,
+    ).blocker).toContain('Railway restart/redeploy')
+  })
+
+  it('does not reuse a running source Runtime when native mode was requested', () => {
+    const remote = compatibleRemote({
+      owner: { surface: 'cli-server', pid: 99, launchRoot: '/srv/source-runtime' },
+      provider: { kind: 'source', root: '/srv/source-runtime' },
+    })
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
+    expect(plan.startServer).toBe(false)
+    expect(plan.blocker).toContain('not the requested installed native Runtime')
+  })
+
+  it('does not reuse a running source Runtime from another checkout', () => {
+    const remote = compatibleRemote({
+      owner: { surface: 'cli-server', pid: 99, launchRoot: '/srv/other-source' },
+      provider: { kind: 'source', root: '/srv/other-source' },
+    })
+    const plan = createRemotePlan(
+      parseRemoteArgs(['host', '--app-dir', '/srv/requested-source']),
+      remote,
+    )
+    expect(plan.startServer).toBe(false)
+    expect(plan.blocker).toContain('not the requested source Runtime /srv/requested-source')
+  })
+
   it('updates a protocol-compatible remote CLI when its install source differs from local', () => {
     const remote = compatibleRemote()
     remote.installSource = {
@@ -165,7 +301,17 @@ describe('OpenAlice managed remote connector', () => {
     }
     const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
     expect(plan.installCli).toBe(true)
-    expect(plan.mutations).toEqual(['update remote OpenAlice CLI'])
+    expect(plan.restartServer).toBe(true)
+    expect(plan.restartOwner).toEqual({
+      pid: 99,
+      instanceId: 'runtime-99',
+      startedAt: '2026-08-31T00:00:00.000Z',
+    })
+    expect(plan.mutations).toEqual([
+      'update remote OpenAlice CLI',
+      'restart remote OpenAlice Server',
+    ])
+    expect(formatRemotePlan(plan)).toContain('update remote OpenAlice CLI; restart remote OpenAlice Server')
   })
 
   it('updates a protocol-compatible remote CLI when only its CLI version differs', () => {
@@ -175,6 +321,35 @@ describe('OpenAlice managed remote connector', () => {
     const plan = createRemotePlan(parseRemoteArgs(['host']), remote)
     expect(plan.cliCompatible).toBe(true)
     expect(plan.cliMatchesLocal).toBe(false)
+    expect(plan.mutations).toEqual([
+      'update remote OpenAlice CLI',
+      'restart remote OpenAlice Server',
+    ])
+  })
+
+  it('does not restart an explicit source Runtime when only its CLI is updated', () => {
+    const remote = compatibleRemote({
+      owner: {
+        surface: 'cli-server',
+        pid: 99,
+        instanceId: 'runtime-99',
+        startedAt: '2026-08-31T00:00:00.000Z',
+        launchRoot: '/srv/OpenAlice',
+      },
+      provider: { kind: 'source', root: '/srv/OpenAlice' },
+    })
+    remote.installSource = {
+      ...masterInstallSource,
+      cliVersion: '0.1.0',
+    }
+    remote.cliVersion = '0.1.0'
+
+    const plan = createRemotePlan(
+      parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice']),
+      remote,
+    )
+
+    expect(plan.restartServer).toBe(false)
     expect(plan.mutations).toEqual(['update remote OpenAlice CLI'])
   })
 
@@ -298,13 +473,73 @@ describe('OpenAlice managed remote connector', () => {
   it('updates a matching-version remote CLI when its installed payload differs', () => {
     const remote = compatibleRemote()
     remote.cliContentIdentity = '1111111111111111'
+    remote.managedRuntime = {
+      ...remote.managedRuntime,
+      contentIdentity: '1111111111111111',
+    }
+    remote.status.provider = {
+      ...remote.status.provider,
+      contentIdentity: '1111111111111111',
+    }
     const plan = createRemotePlan(parseRemoteArgs(['host']), remote, {
+      installSource: masterInstallSource,
       contentIdentity: '2222222222222222',
     })
     expect(plan.cliMatchesLocal).toBe(false)
     expect(plan.mutations).toEqual([
       'update remote OpenAlice CLI',
+      'restart remote OpenAlice Server',
     ])
+  })
+
+  it('reuses one immutable beta release across target-specific payload identities', () => {
+    const localSource = {
+      ...masterInstallSource,
+      cliVersion: '0.91.0-beta.1',
+      selector: { kind: 'version', value: 'v0.91.0-beta.1' },
+      updateChannel: 'beta',
+      artifact: { platform: 'darwin', arch: 'arm64', sha256: 'd'.repeat(64) },
+    }
+    const remote = compatibleRemote()
+    remote.cliVersion = '0.91.0-beta.1'
+    remote.installSource = {
+      ...localSource,
+      artifact: { platform: 'linux', arch: 'x64', sha256: 'e'.repeat(64) },
+    }
+    remote.cliContentIdentity = 'bbbbbbbbbbbbbbbb'
+    remote.managedRuntime = {
+      ...remote.managedRuntime,
+      path: '/home/alice/.openalice/cli/releases/0.91.0-beta.1-linux-x64-bbbbbbbbbbbbbbbb',
+      productVersion: '0.91.0-beta.1',
+      contentIdentity: 'bbbbbbbbbbbbbbbb',
+    }
+    remote.status.owner = {
+      ...remote.status.owner,
+      launchRoot: `${remote.managedRuntime.path}/share/openalice`,
+    }
+    remote.status.provider = {
+      kind: 'bun',
+      root: `${remote.managedRuntime.path}/share/openalice`,
+      contentIdentity: 'bbbbbbbbbbbbbbbb',
+    }
+
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote, {
+      installSource: localSource,
+      contentIdentity: 'aaaaaaaaaaaaaaaa',
+    })
+
+    expect(plan.cliMatchesLocal).toBe(true)
+    expect(plan.installCli).toBe(false)
+  })
+
+  it('rejects a remote CLI whose target payload and managed Runtime disagree', () => {
+    const remote = compatibleRemote()
+    remote.cliContentIdentity = '1111111111111111'
+    const plan = createRemotePlan(parseRemoteArgs(['host']), remote, {
+      installSource: masterInstallSource,
+    })
+    expect(plan.cliMatchesLocal).toBe(false)
+    expect(plan.installCli).toBe(true)
   })
 
   it('blocks unsupported native architectures instead of falling back to source', () => {
@@ -362,6 +597,87 @@ describe('OpenAlice managed remote connector', () => {
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('No remote files or processes were changed'))
   })
 
+  it('matches only the latest dev manifest targets across platforms', async () => {
+    const localSource = devInstallSource({
+      platform: 'darwin',
+      arch: 'arm64',
+      sha256: '1'.repeat(64),
+    })
+    const remote = compatibleRemote()
+    remote.installSource = devInstallSource({
+      platform: 'linux',
+      arch: 'x64',
+      sha256: '2'.repeat(64),
+    })
+    remote.cliContentIdentity = '2222222222222222'
+    remote.managedRuntime = {
+      ...remote.managedRuntime,
+      contentIdentity: '2222222222222222',
+    }
+    remote.status.provider = {
+      ...remote.status.provider,
+      contentIdentity: '2222222222222222',
+    }
+    const runRemote = vi.fn()
+    const connectTunnel = vi.fn()
+
+    await expect(connectRemote(parseRemoteArgs(['host', '--plan']), {
+      installSource: localSource,
+      contentIdentity: '1111111111111111',
+      fetchDevManifestDocumentImpl: async () => devManifestDocument(),
+      probeRemote: async () => remote,
+      runRemote,
+      connectTunnel,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+    expect(runRemote).not.toHaveBeenCalled()
+    expect(connectTunnel).not.toHaveBeenCalled()
+  })
+
+  it('blocks a stale local dev build before mutating the remote host', async () => {
+    const localSource = devInstallSource({
+      platform: 'darwin',
+      arch: 'arm64',
+      sha256: 'f'.repeat(64),
+    })
+    const runRemote = vi.fn()
+
+    await expect(connectRemote(parseRemoteArgs(['host', '--yes']), {
+      installSource: localSource,
+      contentIdentity: '1111111111111111',
+      fetchDevManifestDocumentImpl: async () => devManifestDocument(),
+      probeRemote: async () => compatibleRemote(),
+      runRemote,
+      stdout: { write: vi.fn() },
+    })).rejects.toThrow('not the latest dev build')
+    expect(runRemote).not.toHaveBeenCalled()
+  })
+
+  it('blocks a dev plan whose exact remote target is missing or malformed', () => {
+    const source = devInstallSource({
+      platform: 'darwin',
+      arch: 'arm64',
+      sha256: '1'.repeat(64),
+    })
+    const missing = createRemotePlan(parseRemoteArgs(['host']), missingRemote(), {
+      installSource: source,
+      contentIdentity: '1111111111111111',
+    })
+    expect(missing.blocker).toContain('latest dev target')
+
+    const malformed = createRemotePlan(parseRemoteArgs(['host']), missingRemote(), {
+      installSource: source,
+      contentIdentity: '1111111111111111',
+      expectedRemoteTarget: {
+        platform: 'linux',
+        arch: 'x64',
+        sha256: 'bad',
+        contentIdentity: '2222222222222222',
+      },
+    })
+    expect(malformed.blocker).toContain('latest dev target')
+  })
+
   it('reports managed remote status without opening a tunnel or changing the host', async () => {
     const runRemote = vi.fn()
     const connectTunnel = vi.fn()
@@ -382,6 +698,10 @@ describe('OpenAlice managed remote connector', () => {
       expect(command).toContain('server status --json')
       expect(command).toContain("--home '/data/openalice'")
       return [
+        'serviceManager=railway',
+        'serviceId=service-test',
+        'managedChannel=beta',
+        'managedVersion=0.91.0-beta.1',
         'cli=/home/alice/.openalice/bin/openalice',
         `version=${CLI_VERSION}`,
         'identity=' + JSON.stringify({
@@ -406,6 +726,11 @@ describe('OpenAlice managed remote connector', () => {
       cliContentIdentity: '1234567890abcdef',
       cliCompatible: true,
       status: expect.objectContaining({ class: 'running' }),
+      deploymentAuthority: expect.objectContaining({
+        manager: 'railway',
+        channel: 'beta',
+        version: '0.91.0-beta.1',
+      }),
     }))
     expect(buildRemoteControlProbeCommand(parseRemoteArgs(['host', '--stop'])))
       .toContain('server status --json')
@@ -414,7 +739,7 @@ describe('OpenAlice managed remote connector', () => {
   it('does not probe Node, build tools, or source in native remote mode', async () => {
     const runRemote = vi.fn(async (_options, command) => {
       if (command === 'uname -s; uname -m') return 'Linux\nx86_64\n'
-      if (command.includes('printf "%s\\n" "$HOME"')) return '/home/alice\n'
+      if (command.includes('OPENALICE_SERVICE_MANAGER')) return '/home/alice\n\n\n\n\n'
       if (command.includes('command -v curl')) return 'yes'
       if (command.includes('command -v openalice')) return ''
       throw new Error(`Unexpected native probe: ${command}`)
@@ -451,6 +776,19 @@ describe('OpenAlice managed remote connector', () => {
     expect(stdout.write).toHaveBeenCalledWith('OpenAlice Server is stopped on host.\n')
   })
 
+  it('refuses remote stop for a Railway foreground Runtime', async () => {
+    const remote = compatibleRemote()
+    remote.deploymentAuthority = railwayAuthority()
+    const runRemote = vi.fn()
+
+    await expect(connectRemote(parseRemoteArgs(['host', '--stop']), {
+      probeRemote: async () => remote,
+      runRemote,
+      stdout: { write: vi.fn() },
+    })).rejects.toThrow('Stop or restart the service through Railway')
+    expect(runRemote).not.toHaveBeenCalled()
+  })
+
   it('default-no leaves a missing remote Runtime unchanged', async () => {
     const runRemote = vi.fn()
     const connectTunnel = vi.fn()
@@ -476,7 +814,10 @@ describe('OpenAlice managed remote connector', () => {
     }
     const installedRemote = compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} })
     installedRemote.installSource = installSource
-    const runningRemote = compatibleRemote()
+    const runningRemote = compatibleRemote({
+      owner: { surface: 'cli-server', pid: 99, launchRoot: '/srv/OpenAlice' },
+      provider: { kind: 'source', root: '/srv/OpenAlice' },
+    })
     runningRemote.installSource = installSource
     const probeRemote = vi.fn()
       .mockResolvedValueOnce(missingRemote())
@@ -499,7 +840,6 @@ describe('OpenAlice managed remote connector', () => {
     expect(runRemote.mock.calls[0][1]).toBe(buildRemoteInstallCommand(
       installSource,
       'https://example.test/packages/cli/',
-      true,
     ))
     expect(runRemote.mock.calls[1][1]).toContain('server start')
     expect(connectTunnel).toHaveBeenCalledWith(expect.objectContaining({
@@ -547,12 +887,163 @@ describe('OpenAlice managed remote connector', () => {
     expect(connectTunnel).toHaveBeenCalledOnce()
   })
 
+  it('updates and restarts one continuous running native Runtime under the original plan consent', async () => {
+    const options = parseRemoteArgs(['host', '--no-open'])
+    const beforeUpdate = outdatedNativeRemote()
+    const afterInstall = compatibleRemote({
+      owner: { ...beforeUpdate.status.owner },
+      provider: { ...beforeUpdate.status.provider },
+      pendingActivation: {
+        productVersion: CLI_VERSION,
+        restartRequired: true,
+        reason: 'A newly installed OpenAlice release is waiting for this Runtime to restart',
+      },
+    })
+    const stopped = compatibleRemote({
+      class: 'absent',
+      state: 'absent',
+      owner: null,
+      endpoints: {},
+      provider: { kind: 'unknown' },
+    })
+    const running = compatibleRemote({
+      owner: {
+        ...compatibleRemote().status.owner,
+        pid: 101,
+        instanceId: 'runtime-101',
+        startedAt: '2026-08-31T00:01:00.000Z',
+      },
+    })
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(beforeUpdate)
+      .mockResolvedValueOnce(afterInstall)
+      .mockResolvedValueOnce(stopped)
+      .mockResolvedValueOnce(running)
+    const runRemote = vi.fn(async () => '')
+    const confirmPlan = vi.fn(async () => true)
+    const connectTunnel = vi.fn(async () => 0)
+    const stdout = { write: vi.fn() }
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      confirmPlan,
+      connectTunnel,
+      installSource: masterInstallSource,
+      stdout,
+    })).resolves.toBe(0)
+
+    expect(confirmPlan).toHaveBeenCalledOnce()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining(
+      'update remote OpenAlice CLI; restart remote OpenAlice Server',
+    ))
+    expect(runRemote).toHaveBeenCalledTimes(3)
+    expect(runRemote.mock.calls[0][1]).toContain('openalice-install')
+    expect(runRemote.mock.calls[1][1]).toContain('server stop')
+    expect(runRemote.mock.calls[1][2]).toEqual(expect.objectContaining({ retryTransientSsh: false }))
+    expect(runRemote.mock.calls[2][1]).toContain('server start')
+    expect(connectTunnel).toHaveBeenCalledOnce()
+  })
+
+  it('starts the updated native Runtime when the previous owner stopped during install', async () => {
+    const options = parseRemoteArgs(['host', '--yes', '--no-open'])
+    const stopped = compatibleRemote({
+      class: 'absent',
+      state: 'absent',
+      owner: null,
+      endpoints: {},
+      provider: { kind: 'unknown' },
+    })
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(outdatedNativeRemote())
+      .mockResolvedValueOnce(stopped)
+      .mockResolvedValueOnce(compatibleRemote())
+    const runRemote = vi.fn(async () => '')
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel: vi.fn(async () => 0),
+      installSource: masterInstallSource,
+      stdout: { write: vi.fn() },
+    })).resolves.toBe(0)
+
+    expect(runRemote).toHaveBeenCalledTimes(2)
+    expect(runRemote.mock.calls[0][1]).toContain('openalice-install')
+    expect(runRemote.mock.calls[1][1]).toContain('server start')
+    expect(runRemote.mock.calls.some(([, command]) => command.includes('server stop'))).toBe(false)
+  })
+
+  it.each([
+    ['pid', 100],
+    ['instanceId', 'runtime-replaced'],
+    ['startedAt', '2026-08-31T00:00:01.000Z'],
+  ])('fails closed when the running native owner changes %s during install', async (field, value) => {
+    const options = parseRemoteArgs(['host', '--yes', '--no-open'])
+    const beforeUpdate = outdatedNativeRemote()
+    const changedOwner = {
+      ...beforeUpdate.status.owner,
+      [field]: value,
+    }
+    const afterInstall = compatibleRemote({
+      owner: changedOwner,
+      provider: { ...beforeUpdate.status.provider },
+    })
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(beforeUpdate)
+      .mockResolvedValueOnce(afterInstall)
+    const runRemote = vi.fn(async () => '')
+    const connectTunnel = vi.fn(async () => 0)
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      installSource: masterInstallSource,
+      stdout: { write: vi.fn() },
+    })).rejects.toThrow('owner changed during the CLI update')
+
+    expect(runRemote).toHaveBeenCalledOnce()
+    expect(runRemote.mock.calls[0][1]).toContain('openalice-install')
+    expect(runRemote.mock.calls.some(([, command]) => command.includes('server stop'))).toBe(false)
+    expect(connectTunnel).not.toHaveBeenCalled()
+  })
+
+  it('refuses to tunnel when the started Runtime does not match the native plan', async () => {
+    const options = parseRemoteArgs(['host', '--yes', '--no-open'])
+    const installed = compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} })
+    const wrongRuntime = compatibleRemote({
+      owner: { surface: 'cli-server', pid: 99, launchRoot: '/srv/OpenAlice' },
+      provider: { kind: 'source', root: '/srv/OpenAlice' },
+    })
+    const probeRemote = vi.fn()
+      .mockResolvedValueOnce(missingRemote())
+      .mockResolvedValueOnce(installed)
+      .mockResolvedValueOnce(wrongRuntime)
+    const runRemote = vi.fn(async () => '')
+    const connectTunnel = vi.fn(async () => 0)
+
+    await expect(connectRemote(options, {
+      probeRemote,
+      runRemote,
+      connectTunnel,
+      installSource: masterInstallSource,
+      stdout: { write: vi.fn() },
+    })).rejects.toThrow('not the requested installed native Runtime')
+
+    expect(runRemote).toHaveBeenCalledTimes(2)
+    expect(connectTunnel).not.toHaveBeenCalled()
+  })
+
   it('continues when an interrupted installer or Server start actually completed remotely', async () => {
     const options = parseRemoteArgs(['host', '--app-dir', '/srv/OpenAlice', '--yes', '--no-open'])
     const probeRemote = vi.fn()
       .mockResolvedValueOnce(missingRemote())
       .mockResolvedValueOnce(compatibleRemote({ class: 'absent', state: 'absent', owner: null, endpoints: {} }))
-      .mockResolvedValueOnce(compatibleRemote())
+      .mockResolvedValueOnce(compatibleRemote({
+        owner: { surface: 'cli-server', pid: 99, launchRoot: '/srv/OpenAlice' },
+        provider: { kind: 'source', root: '/srv/OpenAlice' },
+      }))
     const runRemote = vi.fn()
       .mockRejectedValueOnce(new Error('connection closed'))
       .mockRejectedValueOnce(new Error('connection reset'))
@@ -635,6 +1126,20 @@ describe('OpenAlice managed remote connector', () => {
     expect(sleep).toHaveBeenNthCalledWith(2, 1500)
     expect(stdout.write).toHaveBeenCalledWith('Connection interrupted; retrying (1 of 2)...\n')
     expect(stderr.write).not.toHaveBeenCalled()
+  })
+
+  it('does not replay an owner-scoped SSH mutation after a transient disconnect', async () => {
+    const spawnProcess = vi.fn(() => commandChild({ code: 255, stderr: 'Connection reset by peer\n' }))
+
+    await expect(runSshCommand(parseRemoteArgs(['host']), 'openalice server stop', {
+      retryTransientSsh: false,
+      spawnProcess,
+      sleep: vi.fn(async () => undefined),
+      stdout: { write: vi.fn() },
+      stderr: { write: vi.fn() },
+    })).rejects.toThrow('Remote SSH command failed')
+
+    expect(spawnProcess).toHaveBeenCalledOnce()
   })
 
   it('does not retry an ordinary remote command failure', async () => {
@@ -721,12 +1226,14 @@ function missingRemote() {
 }
 
 function compatibleRemote(statusOverrides = {}) {
+  const managedRuntimePath = `/home/alice/.openalice/cli/releases/${CLI_VERSION}-linux-x64-0123456789abcdef`
+  const managedRuntimeRoot = `${managedRuntimePath}/share/openalice`
   return {
     platform: { os: 'linux', architecture: 'x86_64', label: 'Linux x86_64' },
     nodeVersion: 'v22.23.1',
     hasCurl: true,
     managedRuntime: {
-      path: `/home/alice/.openalice/cli/releases/${CLI_VERSION}-linux-x64-0123456789abcdef`,
+      path: managedRuntimePath,
       contentIdentity: '0123456789abcdef',
       productVersion: CLI_VERSION,
       platform: 'linux',
@@ -740,17 +1247,124 @@ function compatibleRemote(statusOverrides = {}) {
     cliPath: '/home/alice/.openalice/bin/openalice',
     cliVersion: CLI_VERSION,
     installSource: masterInstallSource,
+    cliContentIdentity: '0123456789abcdef',
     cliCompatible: true,
     status: {
       protocol: 1,
       class: 'running',
       state: 'running',
       home: '/home/alice/.openalice',
-      owner: { surface: 'cli-server', pid: 99, launchRoot: '/srv/OpenAlice' },
+      owner: {
+        surface: 'cli-server',
+        pid: 99,
+        instanceId: 'runtime-99',
+        startedAt: '2026-08-31T00:00:00.000Z',
+        launchRoot: managedRuntimeRoot,
+      },
       endpoints: { web: 'http://127.0.0.1:47331' },
+      provider: { kind: 'bun', root: managedRuntimeRoot, contentIdentity: '0123456789abcdef' },
       components: { alice: 'ready', uta: 'disabled', connector: 'disabled' },
       capabilities: ['runtime.stop'],
       ...statusOverrides,
     },
+  }
+}
+
+function outdatedNativeRemote(statusOverrides = {}) {
+  const version = '0.1.0'
+  const contentIdentity = 'aaaaaaaaaaaaaaaa'
+  const managedRuntimePath = `/home/alice/.openalice/cli/releases/${version}-linux-x64-${contentIdentity}`
+  const managedRuntimeRoot = `${managedRuntimePath}/share/openalice`
+  const remote = compatibleRemote({
+    owner: {
+      surface: 'cli-server',
+      pid: 99,
+      instanceId: 'runtime-99',
+      startedAt: '2026-08-31T00:00:00.000Z',
+      launchRoot: managedRuntimeRoot,
+    },
+    provider: { kind: 'bun', root: managedRuntimeRoot, contentIdentity },
+    ...statusOverrides,
+  })
+  remote.cliVersion = version
+  remote.installSource = {
+    ...masterInstallSource,
+    cliVersion: version,
+    artifact: {
+      ...masterInstallSource.artifact,
+      sha256: 'b'.repeat(64),
+    },
+  }
+  remote.cliContentIdentity = contentIdentity
+  remote.managedRuntime = {
+    path: managedRuntimePath,
+    contentIdentity,
+    productVersion: version,
+    platform: 'linux',
+    arch: 'x64',
+    compatible: true,
+  }
+  return remote
+}
+
+function devInstallSource({ platform, arch, sha256 }) {
+  return {
+    ...masterInstallSource,
+    selector: { kind: 'branch', value: 'dev' },
+    updateChannel: 'development',
+    artifact: { platform, arch, sha256 },
+  }
+}
+
+function devManifestDocument() {
+  return {
+    version: CLI_VERSION,
+    commit: '1234567890abcdef1234567890abcdef12345678',
+    installer: {
+      url: 'https://download.openalice.ai/install',
+      versionedUrl: 'https://download.openalice.ai/cli/dev/releases/1234567890abcdef1234567890abcdef12345678/install',
+      sha256: '3'.repeat(64),
+    },
+    targets: [
+      {
+        platform: 'darwin',
+        arch: 'arm64',
+        archive: 'openalice-cli-dev-darwin-arm64.tar.gz',
+        sha256: '1'.repeat(64),
+        contentIdentity: '1111111111111111',
+      },
+      {
+        platform: 'darwin',
+        arch: 'x64',
+        archive: 'openalice-cli-dev-darwin-x64.tar.gz',
+        sha256: '4'.repeat(64),
+        contentIdentity: '4444444444444444',
+      },
+      {
+        platform: 'linux',
+        arch: 'arm64',
+        archive: 'openalice-cli-dev-linux-arm64.tar.gz',
+        sha256: '5'.repeat(64),
+        contentIdentity: '5555555555555555',
+      },
+      {
+        platform: 'linux',
+        arch: 'x64',
+        archive: 'openalice-cli-dev-linux-x64.tar.gz',
+        sha256: '2'.repeat(64),
+        contentIdentity: '2222222222222222',
+      },
+    ],
+  }
+}
+
+function railwayAuthority(overrides = {}) {
+  return {
+    manager: 'railway',
+    serviceId: 'service-test',
+    channel: 'stable',
+    version: '',
+    error: '',
+    ...overrides,
   }
 }

--- a/packages/cli/src/rollback.mjs
+++ b/packages/cli/src/rollback.mjs
@@ -38,6 +38,11 @@ export async function runRollbackCommand(argv, dependencies = {}) {
   const stdout = dependencies.stdout ?? process.stdout
   const stdin = dependencies.stdin ?? process.stdin
   const env = dependencies.env ?? process.env
+  if (env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway') {
+    stdout.write('Railway service variables own this OpenAlice installation. Set OPENALICE_RAILWAY_CHANNEL and optional OPENALICE_RAILWAY_VERSION, then restart or redeploy the service.\n')
+    stdout.write('OpenAlice did not modify the persistent release pointer.\n')
+    return 0
+  }
   const layout = Object.hasOwn(dependencies, 'layout')
     ? dependencies.layout
     : resolveInstalledLayout(import.meta.url, { env })

--- a/packages/cli/src/rollback.spec.mjs
+++ b/packages/cli/src/rollback.spec.mjs
@@ -74,6 +74,23 @@ describe.skipIf(process.platform === 'win32')('OpenAlice CLI rollback transactio
     expect(await readlink(layout.currentPath)).toBe(before)
   })
 
+  it('does not switch the persistent release pointer inside Railway', async () => {
+    const layout = await makeInstalledLayout()
+    const before = await readlink(layout.currentPath)
+    const output = []
+
+    await expect(runRollbackCommand(['--yes'], {
+      layout,
+      env: { OPENALICE_SERVICE_MANAGER: 'railway' },
+      stdout: { write: (value) => output.push(value) },
+      stdin: { isTTY: false },
+    })).resolves.toBe(0)
+
+    expect(await readlink(layout.currentPath)).toBe(before)
+    expect(output.join('')).toContain('OPENALICE_RAILWAY_CHANNEL')
+    expect(output.join('')).toContain('did not modify')
+  })
+
   it('refuses rollback when no previous release is retained', async () => {
     const layout = await makeInstalledLayout({ previous: false })
     await expect(inspectRollback(layout)).rejects.toThrow('No previous')

--- a/packages/cli/src/runtime-client.mjs
+++ b/packages/cli/src/runtime-client.mjs
@@ -60,7 +60,8 @@ export async function waitForOpenAlice(baseUrl, options = {}) {
   throw new Error(`OpenAlice did not become ready at ${baseUrl} within ${Math.ceil(timeoutMs / 1_000)}s (${lastError})`)
 }
 
-export function createStartupSignalGuard(runtime, label) {
+export function createStartupSignalGuard(runtime, label, options = {}) {
+  const signalSource = options.signalSource ?? process
   let interrupted = false
   let rejectSignal
   const promise = new Promise((_, rejectPromise) => {
@@ -74,13 +75,13 @@ export function createStartupSignalGuard(runtime, label) {
   }
   const onSigint = () => interrupt('SIGINT')
   const onSigterm = () => interrupt('SIGTERM')
-  process.once('SIGINT', onSigint)
-  process.once('SIGTERM', onSigterm)
+  signalSource.once('SIGINT', onSigint)
+  signalSource.once('SIGTERM', onSigterm)
   return {
     promise,
     release() {
-      process.off('SIGINT', onSigint)
-      process.off('SIGTERM', onSigterm)
+      signalSource.off('SIGINT', onSigint)
+      signalSource.off('SIGTERM', onSigterm)
     },
   }
 }

--- a/packages/cli/src/server-control.mjs
+++ b/packages/cli/src/server-control.mjs
@@ -1,10 +1,14 @@
+import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { homedir, hostname, tmpdir } from 'node:os'
 import { createConnection } from 'node:net'
 import { resolve } from 'node:path'
+import { promisify } from 'node:util'
 
 import { resolveAliceProjectIdentity } from './alice-project.ts'
+
+const execFileAsync = promisify(execFile)
 
 export const GUARDIAN_CONTROL_PROTOCOL = 1
 export const GUARDIAN_CONTROL_API_VERSION = 1
@@ -123,8 +127,12 @@ export async function readRuntimeStatus(options = {}, dependencies = {}) {
 
   const inspectOwner = dependencies.inspectOwner ?? inspectGuardianOwner
   const owner = await inspectOwner(homeRoot, {
+    env: dependencies.env,
     hostname: dependencies.hostname,
     isProcessAlive: dependencies.isProcessAlive,
+    platform: dependencies.platform,
+    readMachineId: dependencies.readMachineId,
+    readProcessStartedAt: dependencies.readProcessStartedAt,
   })
   if (owner?.active) {
     return {
@@ -306,6 +314,18 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
   ]
   const localHostname = options.hostname ?? hostname()
   const isAlive = options.isProcessAlive ?? isProcessAlive
+  const machineId = options.readMachineId ?? (() => readMachineId({
+    env: options.env,
+    hostname: localHostname,
+    platform: options.platform,
+  }))
+  let machineIdPromise
+  const currentMachineId = () => {
+    machineIdPromise ??= Promise.resolve().then(() => machineId())
+    return machineIdPromise
+  }
+  const processStartedAt = options.readProcessStartedAt
+    ?? ((pid) => readProcessStartedAt(pid, { platform: options.platform }))
   let staleOwner = null
   for (const ownerPath of ownerPaths) {
     let owner
@@ -326,9 +346,13 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
         detail: `Runtime owner metadata is invalid at ${ownerPath}`,
       }
     }
-    const sameHost = typeof owner.hostname !== 'string'
-      || owner.hostname === localHostname
-    const active = !sameHost || isAlive(owner.pid)
+    const sameMachine = typeof owner.machineId === 'string' && owner.machineId
+      ? owner.machineId === await currentMachineId()
+      : typeof owner.hostname !== 'string' || owner.hostname === localHostname
+    const active = !sameMachine || await isSameProcess(owner, {
+      isAlive,
+      processStartedAt,
+    })
     const publicOwner = {
       surface: owner.launcher.startsWith('guardian-')
         ? owner.launcher.slice('guardian-'.length)
@@ -348,6 +372,70 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
         detail: 'A stale Runtime owner record is present; the next start may recover it',
       }
     : null
+}
+
+async function isSameProcess(owner, dependencies) {
+  if (!dependencies.isAlive(owner.pid)) return false
+  if (typeof owner.processStartedAt !== 'string') return true
+  const expected = Date.parse(owner.processStartedAt)
+  if (!Number.isFinite(expected)) return true
+  const actual = await dependencies.processStartedAt(owner.pid)
+  if (actual === null) return true
+  return Math.abs(actual - expected) <= 2_000
+}
+
+async function readProcessStartedAt(pid, options = {}) {
+  try {
+    if ((options.platform ?? process.platform) === 'win32') {
+      const script = `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')`
+      const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+        windowsHide: true,
+        timeout: 2_000,
+      })
+      const parsed = Date.parse(stdout.trim())
+      return Number.isFinite(parsed) ? parsed : null
+    }
+
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'lstart='], { timeout: 2_000 })
+    const parsed = Date.parse(stdout.trim())
+    return Number.isFinite(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+// Installed CLI payloads do not include @traderalice/guardian-runtime. Keep
+// these machine/process identity readers aligned with its process-control.ts.
+async function readMachineId(options = {}) {
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  const localHostname = options.hostname ?? hostname()
+  const override = env['OPENALICE_MACHINE_ID']?.trim()
+  if (override) return `env:${override}`
+  try {
+    if (platform === 'linux') {
+      const value = (await readFile('/etc/machine-id', 'utf8')).trim()
+      if (value) return `linux:${value}`
+    }
+    if (platform === 'darwin') {
+      const { stdout } = await execFileAsync('ioreg', ['-rd1', '-c', 'IOPlatformExpertDevice'], { timeout: 2_000 })
+      const value = /"IOPlatformUUID"\s*=\s*"([^"]+)"/.exec(stdout)?.[1]
+      if (value) return `darwin:${value}`
+    }
+    if (platform === 'win32') {
+      const { stdout } = await execFileAsync('reg.exe', [
+        'query',
+        'HKLM\\SOFTWARE\\Microsoft\\Cryptography',
+        '/v',
+        'MachineGuid',
+      ], { windowsHide: true, timeout: 2_000 })
+      const value = /MachineGuid\s+REG_\w+\s+([^\r\n]+)/i.exec(stdout)?.[1]?.trim()
+      if (value) return `win32:${value}`
+    }
+  } catch {
+    // Match Guardian's weaker fallback when a platform identity is unavailable.
+  }
+  return `hostname:${localHostname}`
 }
 
 function sanitizeControlOwner(owner) {

--- a/packages/cli/src/server-control.spec.mjs
+++ b/packages/cli/src/server-control.spec.mjs
@@ -220,6 +220,107 @@ describe('OpenAlice Guardian control protocol', () => {
     })
     expect(stale.class).toBe('absent')
     expect(stale.detail).toContain('stale')
+
+    const legacyPidProbe = vi.fn(() => false)
+    const legacyForeignHost = await readRuntimeStatus({ homeRoot: home }, {
+      hostname: 'another-fixture-host',
+      isProcessAlive: legacyPidProbe,
+    })
+    expect(legacyForeignHost.class).toBe('owned_elsewhere')
+    expect(legacyPidProbe).not.toHaveBeenCalled()
+  })
+
+  it('reclaims a dead same-machine owner after its hostname changes', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: 4242,
+      hostname: 'old-container-host',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: '2026-07-15T00:00:00.000Z',
+      processStartedAt: '2026-07-15T00:00:00.000Z',
+    }))
+    const isProcessAlive = vi.fn(() => false)
+    const readProcessStartedAt = vi.fn(async () => Date.parse('2026-07-15T00:00:00.000Z'))
+
+    const status = await readRuntimeStatus({ homeRoot: home }, {
+      env: { OPENALICE_MACHINE_ID: 'railway-service-service-test' },
+      hostname: 'new-container-host',
+      isProcessAlive,
+      readProcessStartedAt,
+    })
+
+    expect(status.class).toBe('absent')
+    expect(status.detail).toContain('stale')
+    expect(isProcessAlive).toHaveBeenCalledWith(4242)
+    expect(readProcessStartedAt).not.toHaveBeenCalled()
+  })
+
+  it('keeps the same process active but treats a reused PID as stale', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: 4242,
+      hostname: 'fixture-host',
+      machineId: 'env:fixture-machine',
+      launcher: 'guardian-cli-server',
+      acquiredAt: '2026-07-15T00:00:00.000Z',
+      processStartedAt: '2026-07-15T00:00:00.000Z',
+    }))
+    const readProcessStartedAt = vi.fn()
+      .mockResolvedValueOnce(Date.parse('2026-07-15T00:00:01.000Z'))
+      .mockResolvedValueOnce(Date.parse('2026-07-15T00:00:10.000Z'))
+
+    const dependencies = {
+      hostname: 'fixture-host',
+      isProcessAlive: () => true,
+      readMachineId: async () => 'env:fixture-machine',
+      readProcessStartedAt,
+    }
+
+    const sameProcess = await readRuntimeStatus({ homeRoot: home }, dependencies)
+    expect(sameProcess.class).toBe('owned_elsewhere')
+
+    const reusedPid = await readRuntimeStatus({ homeRoot: home }, dependencies)
+
+    expect(reusedPid.class).toBe('absent')
+    expect(reusedPid.detail).toContain('stale')
+    expect(readProcessStartedAt).toHaveBeenCalledTimes(2)
+    expect(readProcessStartedAt).toHaveBeenNthCalledWith(1, 4242)
+    expect(readProcessStartedAt).toHaveBeenNthCalledWith(2, 4242)
+  })
+
+  it('keeps a foreign-machine owner active without probing its PID', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: 4242,
+      hostname: 'same-hostname-is-not-authoritative',
+      machineId: 'env:foreign-machine',
+      launcher: 'guardian-cli-server',
+      acquiredAt: '2026-07-15T00:00:00.000Z',
+      processStartedAt: '2026-07-15T00:00:00.000Z',
+    }))
+    const isProcessAlive = vi.fn(() => false)
+    const readProcessStartedAt = vi.fn(async () => null)
+
+    const status = await readRuntimeStatus({ homeRoot: home }, {
+      hostname: 'same-hostname-is-not-authoritative',
+      isProcessAlive,
+      readMachineId: async () => 'env:local-machine',
+      readProcessStartedAt,
+    })
+
+    expect(status).toEqual(expect.objectContaining({
+      class: 'owned_elsewhere',
+      owner: expect.objectContaining({ surface: 'cli-server', pid: 4242 }),
+    }))
+    expect(isProcessAlive).not.toHaveBeenCalled()
+    expect(readProcessStartedAt).not.toHaveBeenCalled()
   })
 
   it('keeps shutdown non-absent while an Alice runtime lock is still active', async () => {

--- a/packages/cli/src/uninstall.mjs
+++ b/packages/cli/src/uninstall.mjs
@@ -26,13 +26,19 @@ export async function runUninstallCommand(argv, dependencies = {}) {
   const options = parseUninstallArgs(argv)
   const stdout = dependencies.stdout ?? process.stdout
   const stdin = dependencies.stdin ?? process.stdin
+  const env = dependencies.env ?? process.env
+  if (env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway') {
+    stdout.write('Railway owns this OpenAlice installation and its retained fallback releases. Remove or reconfigure the Railway service instead of uninstalling from SSH.\n')
+    stdout.write('OpenAlice did not modify the persistent install root.\n')
+    return 0
+  }
   const layout = Object.hasOwn(dependencies, 'layout')
     ? dependencies.layout
-    : resolveInstalledLayout(import.meta.url, { env: dependencies.env ?? process.env })
+    : resolveInstalledLayout(import.meta.url, { env })
   if (!layout) {
     const installSource = await (
       dependencies.readInstallSourceImpl ?? readInstallSource
-    )({ env: dependencies.env ?? process.env })
+    )({ env })
     const managerMessage = packageManagerUninstallMessage(installSource)
     if (managerMessage) {
       stdout.write(`${managerMessage}\n`)

--- a/packages/cli/src/uninstall.spec.mjs
+++ b/packages/cli/src/uninstall.spec.mjs
@@ -86,6 +86,24 @@ after
     await expect(access(layout.versionsDir)).resolves.toBeUndefined()
   })
 
+  it('preserves fallback releases when Railway owns the install root', async () => {
+    const root = await makeTempDir()
+    const layout = await makeInstalledLayout(root)
+    const output = []
+
+    await expect(runUninstallCommand(['--yes'], {
+      layout,
+      env: { OPENALICE_SERVICE_MANAGER: 'railway' },
+      profiles: [],
+      stdout: { write: (value) => output.push(value) },
+      stdin: { isTTY: false },
+    })).resolves.toBe(0)
+
+    await expect(access(layout.versionsDir)).resolves.toBeUndefined()
+    expect(output.join('')).toContain('retained fallback releases')
+    expect(output.join('')).toContain('did not modify')
+  })
+
   it('routes package-managed removal back to the owning manager', async () => {
     const output = []
     await expect(runUninstallCommand(['--yes'], {

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -26,6 +26,7 @@ const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1_000
 const CHECK_TIMEOUT_MS = 1_500
 const EXPLICIT_CHECK_TIMEOUT_MS = 10_000
 const INSTALLER_DOWNLOAD_TIMEOUT_MS = 30_000
+const DEV_MANIFEST_TARGET_COUNT = 4
 
 export function parseUpdateArgs(argv) {
   const options = { checkOnly: false, yes: false, json: false }
@@ -142,9 +143,15 @@ export async function checkForUpdate(options = {}, dependencies = {}) {
 export async function runUpdateCommand(argv, dependencies = {}) {
   const options = parseUpdateArgs(argv)
   const stdout = dependencies.stdout ?? process.stdout
+  const env = dependencies.env ?? process.env
+  if (env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway' && !options.checkOnly) {
+    stdout.write('Railway service variables own this OpenAlice installation. Set OPENALICE_RAILWAY_CHANNEL and optional OPENALICE_RAILWAY_VERSION, then restart or redeploy the service.\n')
+    stdout.write('OpenAlice did not modify the persistent release pointer.\n')
+    return 0
+  }
   const installSource = await (
     dependencies.readInstallSourceImpl ?? readInstallSource
-  )({ env: dependencies.env ?? process.env })
+  )({ env })
   const manager = packageManagerForSource(installSource)
   if (manager && !options.checkOnly) {
     if (options.channel && options.channel !== 'stable') {
@@ -193,7 +200,7 @@ export async function runUpdateCommand(argv, dependencies = {}) {
   }
   const layout = Object.hasOwn(dependencies, 'layout')
     ? dependencies.layout
-    : resolveInstalledLayout(import.meta.url, { env: dependencies.env ?? process.env })
+    : resolveInstalledLayout(import.meta.url, { env })
   if (!layout) {
     throw new Error('This OpenAlice CLI is running from source, not an installed release. Re-run the public installer to update the installed command.')
   }
@@ -201,7 +208,7 @@ export async function runUpdateCommand(argv, dependencies = {}) {
   return await applyUpdate(result, {
     layout,
     yes: options.yes,
-    env: dependencies.env ?? process.env,
+    env,
     fetchImpl: dependencies.fetchImpl,
     spawnImpl: dependencies.spawnImpl,
   })
@@ -367,6 +374,14 @@ function requireReleaseManifest(value) {
 }
 
 async function fetchDevManifest(options, dependencies) {
+  const manifest = await fetchDevManifestDocument(options, dependencies)
+  return {
+    ...manifest,
+    target: selectDevManifestTarget(manifest, options),
+  }
+}
+
+export async function fetchDevManifestDocument(options, dependencies = {}) {
   const fetchImpl = dependencies.fetchImpl ?? fetch
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs)
@@ -377,13 +392,13 @@ async function fetchDevManifest(options, dependencies) {
       headers: { accept: 'application/json' },
     })
     if (!response.ok) throw new Error(`dev manifest returned HTTP ${response.status}`)
-    return requireDevManifest(await response.json(), options)
+    return requireDevManifestDocument(await response.json())
   } finally {
     clearTimeout(timeout)
   }
 }
 
-function requireDevManifest(value, options) {
+function requireDevManifestDocument(value) {
   if (
     value?.schemaVersion !== 1
     || value.channel !== 'dev'
@@ -393,36 +408,59 @@ function requireDevManifest(value, options) {
     || typeof value.commit !== 'string'
     || !/^[a-f0-9]{7,64}$/.test(value.commit)
     || !Array.isArray(value.targets)
+    || value.targets.length !== DEV_MANIFEST_TARGET_COUNT
   ) {
     throw new Error('dev manifest is invalid')
   }
-  const matchingTargets = value.targets.filter((target) => (
-    target?.platform === options.platform && target?.arch === options.arch
-  ))
-  if (matchingTargets.length !== 1) {
-    throw new Error(`dev manifest does not contain exactly one ${options.platform}-${options.arch} target`)
-  }
-  const target = matchingTargets[0]
-  const expectedArchive = `openalice-cli-dev-${options.platform}-${options.arch}.tar.gz`
-  if (
-    typeof target.archive !== 'string'
-    || target.archive !== expectedArchive
-    || typeof target.sha256 !== 'string'
-    || !/^[a-f0-9]{64}$/.test(target.sha256)
-    || typeof target.contentIdentity !== 'string'
-    || !/^[a-f0-9]{16}$/.test(target.contentIdentity)
-  ) {
-    throw new Error(`dev manifest contains an invalid ${options.platform}-${options.arch} target`)
+  const targets = []
+  const seen = new Set()
+  for (const target of value.targets) {
+    const key = `${String(target?.platform)}-${String(target?.arch)}`
+    const expectedArchive = `openalice-cli-dev-${key}.tar.gz`
+    if (
+      !['darwin', 'linux'].includes(target?.platform)
+      || !['arm64', 'x64'].includes(target?.arch)
+      || seen.has(key)
+      || typeof target.archive !== 'string'
+      || target.archive !== expectedArchive
+      || typeof target.sha256 !== 'string'
+      || !/^[a-f0-9]{64}$/.test(target.sha256)
+      || typeof target.contentIdentity !== 'string'
+      || !/^[a-f0-9]{16}$/.test(target.contentIdentity)
+    ) {
+      throw new Error(`dev manifest contains an invalid ${key} target`)
+    }
+    seen.add(key)
+    targets.push({
+      platform: target.platform,
+      arch: target.arch,
+      archive: target.archive,
+      sha256: target.sha256,
+      contentIdentity: target.contentIdentity,
+    })
   }
   return {
     version: value.version,
     commit: value.commit,
     installer: requireInstaller(value.installer, 'dev'),
-    target: {
-      archive: target.archive,
-      sha256: target.sha256,
-      contentIdentity: target.contentIdentity,
-    },
+    targets,
+  }
+}
+
+export function selectDevManifestTarget(manifest, options) {
+  const matchingTargets = manifest.targets.filter((target) => (
+    target.platform === options.platform && target.arch === options.arch
+  ))
+  if (matchingTargets.length !== 1) {
+    throw new Error(`dev manifest does not contain exactly one ${options.platform}-${options.arch} target`)
+  }
+  const target = matchingTargets[0]
+  return {
+    platform: target.platform,
+    arch: target.arch,
+    archive: target.archive,
+    sha256: target.sha256,
+    contentIdentity: target.contentIdentity,
   }
 }
 

--- a/packages/cli/src/update.spec.mjs
+++ b/packages/cli/src/update.spec.mjs
@@ -190,6 +190,23 @@ describe('OpenAlice CLI updates', () => {
     })).rejects.toThrow('invalid linux-x64 target')
   })
 
+  it('rejects a dev manifest that is not the complete four-target receipt', async () => {
+    await expect(checkForUpdate({
+      installSource: devSource,
+      platform: 'linux',
+      arch: 'x64',
+    }, {
+      fetchImpl: devManifestFetch({
+        version: currentCliVersion,
+        commit: '0123456789abcdef0123456789abcdef01234567',
+        sha256: 'e'.repeat(64),
+        contentIdentity: '1'.repeat(16),
+        missingTarget: 'darwin-x64',
+      }),
+      env: {},
+    })).rejects.toThrow('dev manifest is invalid')
+  })
+
   it('treats an explicit cross-channel selection as an installable switch', async () => {
     await expect(checkForUpdate({
       currentVersion: newerStableVersion,
@@ -246,6 +263,24 @@ describe('OpenAlice CLI updates', () => {
         yes: true,
       }),
     )
+  })
+
+  it('leaves Railway release selection to service variables', async () => {
+    const applyUpdate = vi.fn(async () => 0)
+    const readInstallSourceImpl = vi.fn(async () => stableSource)
+    const stdout = { write: vi.fn() }
+
+    await expect(runUpdateCommand(['--channel', 'stable', '--yes'], {
+      applyUpdate,
+      readInstallSourceImpl,
+      stdout,
+      env: { OPENALICE_SERVICE_MANAGER: 'railway' },
+    })).resolves.toBe(0)
+
+    expect(readInstallSourceImpl).not.toHaveBeenCalled()
+    expect(applyUpdate).not.toHaveBeenCalled()
+    expect(stdout.write.mock.calls.flat().join('')).toContain('OPENALICE_RAILWAY_CHANNEL')
+    expect(stdout.write.mock.calls.flat().join('')).toContain('did not modify')
   })
 
   it('routes package-managed updates back to the owner without invoking the installer', async () => {
@@ -499,8 +534,39 @@ function devManifestFetch({
   sha256,
   contentIdentity,
   archive = 'openalice-cli-dev-linux-x64.tar.gz',
+  missingTarget = '',
 }) {
   const installer = '#!/usr/bin/env bash\n'
+  const targets = [
+    {
+      platform: 'darwin',
+      arch: 'arm64',
+      archive: 'openalice-cli-dev-darwin-arm64.tar.gz',
+      sha256: 'a'.repeat(64),
+      contentIdentity: 'aaaaaaaaaaaaaaaa',
+    },
+    {
+      platform: 'darwin',
+      arch: 'x64',
+      archive: 'openalice-cli-dev-darwin-x64.tar.gz',
+      sha256: 'b'.repeat(64),
+      contentIdentity: 'bbbbbbbbbbbbbbbb',
+    },
+    {
+      platform: 'linux',
+      arch: 'arm64',
+      archive: 'openalice-cli-dev-linux-arm64.tar.gz',
+      sha256: 'c'.repeat(64),
+      contentIdentity: 'cccccccccccccccc',
+    },
+    {
+      platform: 'linux',
+      arch: 'x64',
+      archive,
+      sha256,
+      contentIdentity,
+    },
+  ].filter((target) => `${target.platform}-${target.arch}` !== missingTarget)
   return vi.fn(async () => ({
     ok: true,
     status: 200,
@@ -515,13 +581,7 @@ function devManifestFetch({
         versionedUrl: `https://download.openalice.ai/cli/dev/releases/${commit}/install`,
         sha256: createHash('sha256').update(installer).digest('hex'),
       },
-      targets: [{
-        platform: 'linux',
-        arch: 'x64',
-        archive,
-        sha256,
-        contentIdentity,
-      }],
+      targets,
     }),
   }))
 }

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -3,7 +3,10 @@
 Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separately
 dispatched v0.91.0-beta.1 is externally verified; stable remains v0.90.2 while
 stable/beta discovery authority is converged on the OpenAlice CDN;
-native PowerShell and external package-manager activation remain deferred
+the Railway native CLI SSH host passes local empty-Volume, normal replacement,
+hard-kill recovery, and real Project offline planning while hosted deploy/apply
+acceptance remains pending; native PowerShell and external
+package-manager activation remain deferred
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`
@@ -27,6 +30,8 @@ Owner guides:
 - [[docs/managed-workspace-runtime.md]]
 - [[docs/broker-packs.md]]
 - [[docs/development-workflow.md]]
+- [[docs/remote-access.md]]
+- [[docs/docker-deployment.md]]
 
 Research references:
 
@@ -511,8 +516,9 @@ artifacts.
   remote content/provenance comparison.
 - [x] Define an explicit unsupported-host result for targets outside the
   accepted Bun build matrix.
-- [x] Keep Docker on its current server image until a separately justified
-  change proves that consuming the Bun artifact improves that distribution.
+- [x] Keep the existing source-built Docker server image on its current
+  bundled-Agent/public-Web contract; add the separately justified Railway
+  native CLI SSH-host profile instead of reshaping that image.
 
 ### 8. Retire the expanded CLI Runtime
 
@@ -589,6 +595,99 @@ Runtime discovery must not depend on GitHub's anonymous API quota.
   tests, the public stable install plan, clean Linux installer acceptance, and
   the real Settings route without GitHub API access.
 
+### 12. Railway native CLI SSH host
+
+This is a small deployment profile of the Stage 2 SSH product. It is not a
+hosted Studio, public Web server, new installer, or replacement for the
+source-built Docker image.
+
+- [x] Add a repo-owned `Dockerfile.railway` and entrypoint that keep the native
+  OpenAlice release out of the image, validate or install it on the mounted
+  volume, and `exec` foreground `openalice server run` under `tini`.
+- [x] Fix the Volume at `/data`, Railway SSH `HOME` at `/data/home`, and native
+  install/npm/Bun user roots beneath it. Export those paths and persistent
+  `PATH` from the image for Railway SSH, use system-only `PATH` during
+  bootstrap, and keep machine launch links rebuildable outside the durable
+  authority.
+- [x] Allow only `OPENALICE_HOME` to select a Project beneath `/data`; always
+  derive `AQ_LAUNCHER_ROOT` from it and reject alternate Volume/user/install/
+  package roots or normalized escapes.
+- [x] Reuse the shared stable/beta/dev installer. Stable and beta may select an
+  in-channel pinned version; dev follows its completed latest manifest and
+  rejects a version override. A failed refresh may reuse only a still-valid
+  prior release; an empty failed bootstrap stops.
+- [x] On ordinary SSH-managed hosts, compare stable, beta, and pinned targets by
+  logical release while validating each target's schema 3 platform,
+  architecture, checksum, content identity, and embedded Runtime locally. For
+  dev, require the invoking CLI to match the latest manifest and bind installer
+  handoff to the remote target from that same completed set.
+- [x] Keep Railway inspection-only from the laptop: the service entrypoint and
+  variables own release selection and lifecycle, while `openalice remote`
+  verifies target-local provenance/Runtime consistency, distinguishes a
+  configured selector from a verified fallback, and opens only the tunnel.
+  Replace persistent command shims with the image-owned wrapper after every
+  selection and route SSH `update`, `rollback`, and `uninstall` back to Railway
+  configuration so neither a current release nor a published fallback can
+  split the persistent pointer from the foreground Runtime.
+- [x] Keep Agent Runtime installation, authentication, version, plugins, and
+  updates user-owned through Railway SSH and persistent user `PATH` locations.
+- [x] Make AliceProject transfer Git-aware: retain tracked and nonignored
+  untracked Workspace content, exclude ignored untracked dependencies, native
+  install/runtime/session/known-backup state, and reject or classify unsafe
+  symlinks. Prove ordinary repositories remain connected after transfer and
+  fail closed on linked worktrees, alternate/promisor object state, nested Git
+  repositories, and initialized submodules. Transfer only Alice-owned
+  credential families through the private stream; Web auth/sessions and native
+  Agent login/config remain destination setup.
+- [x] Pass Bash syntax plus the focused entrypoint, managed-remote, and
+  Project-transfer specs (222 tests).
+- [x] Build `Dockerfile.railway`, bootstrap the native CLI and foreground
+  Runtime from an empty local Docker Volume, then perform a normal
+  stop/recreate replacement against that Volume and retain CLI and Project
+  markers. Verify the image has no Agent Runtime.
+- [x] Run the content planner locally against the real Default AliceProject,
+  using the intended Railway destination metadata but no SSH or mutation:
+  10,693 portable files, 5,612 directories, 222,215,071 portable bytes,
+  289,328,517 required destination bytes, 21 credential entries, six
+  exact-Session scheduled Issues, and no content-policy blockers. Git-ignored
+  dependencies plus runtime, backup, session, install, and machine-local state
+  remain excluded. Live source ownership/quiescence and remote capability,
+  destination, and free-space preflight are not part of this offline evidence.
+- [x] Rerun the hard-kill container replacement after the stale-owner PID reuse
+  and CLI preflight repairs. The current dev Bun Runtime reclaimed the stale
+  lock on the same Volume, retained the Project marker, matched release content
+  without pending activation, restored the fixed SSH Home/PATH, and did not
+  acquire an Agent Runtime.
+- [x] Pass the remaining local repository gates: root and CLI TypeScript,
+  `git diff --check`, the 222-test focused run, the 5,266-test full suite,
+  Linux installer and SSH-remote Docker smokes, Guardian recovery smoke, and a
+  rebuilt Railway image with the required tools but no Node, Bun, or Agent
+  Runtime.
+- [ ] On a disposable Railway service and empty `/data` Volume, pass clean
+  bootstrap and empty-host install-failure/fail-closed acceptance without using
+  or clearing the retained real Volume.
+- [ ] Deploy the profile non-destructively against the retained real Railway
+  `/data` Volume with no public domain, no Dashboard Start Command override,
+  Serverless disabled, Restart Policy set to Always, one replica, at least 30
+  seconds of draining, fixed SSH `HOME=/data/home` plus persistent user `PATH`,
+  an OpenSSH alias from `railway ssh config`, and a successful inspection-only
+  `openalice remote` browser/tunnel journey. The inspected `HOME=/root` service
+  is an old deployment; the candidate has not been deployed.
+- [ ] Repeat `openalice project transfer --plan` through the deployed Railway
+  candidate so SSH compatibility, destination absence, and free-space
+  preflight are proven before apply.
+- [ ] Apply the reviewed real AliceProject transfer into a new
+  `/data/projects/<name>` Home, select that Home for the service, and verify its
+  portable Workspace/configuration state after redeploy without copied install
+  bytes or machine-local symlinks.
+- [ ] Install and authenticate one Agent Runtime through Railway SSH, then prove
+  a real Workspace turn without treating those Agent bytes as an OpenAlice
+  release artifact.
+- [ ] Restart and redeploy against the same Volume, verify install/Home/Agent
+  persistence and foreground Guardian recovery, then exercise valid-release
+  refresh fallback and the separately accepted hard-kill recovery path. The
+  empty-Volume fail-closed case remains isolated to the disposable service.
+
 ## Verification Matrix
 
 Every code increment runs:
@@ -609,6 +708,19 @@ pnpm test:install:dev-channel
 pnpm test:remote:docker
 pnpm electron:smoke:pty
 pnpm electron:smoke:workspace
+bash -n scripts/railway/*.sh
+pnpm exec vitest run scripts/railway-entrypoint.spec.ts \
+  packages/cli/src/install.spec.mjs \
+  packages/cli/src/lifecycle.spec.mjs \
+  packages/cli/src/project-command.spec.ts \
+  packages/cli/src/remote.spec.mjs \
+  packages/cli/src/server-control.spec.mjs \
+  packages/cli/src/update.spec.mjs \
+  packages/cli/src/rollback.spec.mjs \
+  packages/cli/src/uninstall.spec.mjs \
+  packages/cli/src/project-transfer.spec.ts \
+  packages/cli/src/project-transfer-ssh.spec.ts \
+  packages/cli/src/project-transfer-stream.spec.ts
 ```
 
 Use the local OrbStack Docker engine as the default clean Linux harness for
@@ -689,7 +801,12 @@ This plan is complete only when:
    pass; and
 9. the old expanded headless Runtime and managed-Pi CLI distribution paths are
    deleted from current source and the durable owner guides describe the Bun
-   architecture.
+   architecture; and
+10. the Railway SSH-host profile completes both a disposable empty-Volume
+    bootstrap/fail-closed journey and a non-destructive retained-Volume journey
+    with fixed persistent SSH Home, AliceProject migration, a user-owned Agent
+    turn, same-Volume normal and hard-kill restart/redeploy, and exact-release
+    fallback without a public Web route.
 
 ## Progress Log
 
@@ -994,3 +1111,38 @@ This plan is complete only when:
   GitHub API seam, and the real Settings card plus forced refresh. A direct
   public beta manifest read resolved v0.91.0-beta.1. No release or channel
   promotion was performed.
+- 2026-08-31: Added the focused Railway native CLI SSH-host increment in the
+  working tree. The repo-owned image fixes `/data`, persistent Railway SSH
+  `HOME=/data/home`, OpenAlice install/npm/Bun user paths, and persistent `PATH`;
+  bootstrap first uses system-only `PATH`. Only `OPENALICE_HOME` selects a
+  Project and its Workspace root is always derived. Ordinary SSH-managed remote
+  treats stable/beta/pinned as logical releases with target-local artifact
+  integrity, while dev is bound to both local and remote targets from the latest
+  completed manifest. Railway remains platform-owned and inspection-only from
+  the laptop. Project transfer is Git-aware and excludes native install,
+  runtime, Session, known-backup, and machine-local state. Focused Bash,
+  entrypoint, managed-remote, and Project-transfer checks passed 222 tests; the
+  full suite passed 5,266 tests. Root and CLI TypeScript, diff checks, Linux
+  installer and SSH-remote Docker smokes, Guardian recovery smoke, and the
+  Railway image prerequisite/no-runtime check also passed. A local empty-Volume
+  build and normal stop/recreate retained CLI and Project markers while
+  confirming the image has no Agent Runtime. A later hard-kill exposed
+  stale-owner PID reuse and CLI preflight defects; after the owner check adopted
+  stable machine and process-start identity, the current dev Bun Runtime passed
+  the same-Volume hard-kill/recreate journey with its Project marker and
+  persistent login-shell environment intact. The real Default AliceProject
+  offline content-planner pass, using destination metadata but no SSH, reduced
+  the portable boundary to 10,693 files, 5,612 directories, and 222,215,071
+  bytes; it requires 289,328,517 destination bytes and found 21 credential
+  entries plus six exact-Session scheduled Issues, with no content-policy
+  blockers. Git-ignored dependencies, runtime state, backups, sessions, native
+  install trees, and machine-local state stay outside the stream. Live source
+  ownership and remote destination preflight remain separate apply gates. A
+  real public `v0.91.0-beta.1` run in the final Railway image proved the legacy
+  provider-without-content-identity compatibility fallback, and the
+  image-owned persistent wrappers blocked direct update, rollback, and
+  uninstall without changing the active pointer, release store, or install
+  manifest. The disposable hosted empty-Volume drill, Project apply, the
+  real Railway fixed-layout candidate deployment, Agent, restart/redeploy, and
+  failure journeys remain pending. The inspected Railway service with
+  `HOME=/root` is the old deployment, not candidate evidence.

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -28,6 +28,9 @@ Related active plan:
   lifecycle core, installer-managed Runtime, update model, and terminal
   acceptance. This plan owns the new machine fleet, remote AliceProject
   inventory, transfer transaction, and the TUI flows built on those services.
+- [[plans/bun-cli-distribution.md]] owns the Railway native host profile,
+  release authority, and hosted deployment acceptance. This plan continues to
+  own the AliceProject content/credential transaction used against that host.
 
 ## Objective
 
@@ -232,9 +235,13 @@ The default transfer includes:
 - AliceProject product birth (`trader` or `nano`);
 - portable product configuration and preferences under `data/`, subject to the
   exclusions and credential rules below;
-- active Workspace repositories, departed Workspace repositories, Git
-  metadata, uncommitted files, `.alice/settings.json`, Issues, comments,
-  Harness receipts, handoff artifacts, and other Workspace-owned files;
+- active Workspace repositories, departed Workspace repositories, portable Git
+  object/ref/index state, tracked files, and nonignored untracked files.
+  Ignored generated dependencies are omitted; linked worktrees, initialized
+  submodules/nested repositories, alternates, and promisor/partial-clone state
+  block transfer until the Workspace is materialized independently;
+- `.alice/settings.json`, Issues, comments, Harness receipts, handoff artifacts,
+  and other portable Workspace-owned files;
 - active Workspace registry and lifecycle Catalog semantics, reconstructed
   with remote absolute paths;
 - Inbox, trading history/snapshots, schedules, UI layout, and other portable
@@ -300,14 +307,16 @@ SSH encrypts transport, but that does not make every secret portable.
 
 - AI provider credentials owned by the selected complete home may transfer
   after the plan reports only their count/vendors and obtains confirmation.
-  Values travel only over the SSH process pipe and are never printed.
+  This includes the current credential records and supported legacy flat API
+  keys. Values are read once into the consented process-private snapshot,
+  travel only over the SSH process pipe, and are never printed.
 - An `OPENALICE_GLOBAL_DIR` outside the complete home remains user-global and
   is never traversed implicitly. The plan reports that those credentials stay
   on the source machine.
 - Broker account and Connector credentials are decrypted in source-process
   memory, sent through the authenticated SSH stdin channel, and sealed on the
   remote machine with a newly generated destination `sealing.key`.
-- Plaintext credential material never enters the archive, argv, environment,
+- Plaintext credential material never enters the portable file frames, argv, environment,
   logs, progress events, plan JSON, staging files, or test snapshots.
 - The source `sealing.key` is never copied. The destination key is mode `0600`
   and is created only by the remote importer.
@@ -327,6 +336,8 @@ Do not transfer:
 - local Supervisor registry/default selection or source `appDir`;
 - local machine logs, migration scratch files, update state, or installer
   content;
+- user-owned Agent Runtime executables, login/session stores, native config,
+  caches, and plugin state; shared portable Workspace skills remain eligible;
 - web/admin login sessions;
 - symlinks or archive entries that escape the declared source roots;
 - an externally overridden `AQ_LAUNCHER_ROOT` without a future explicit
@@ -354,12 +365,12 @@ are regenerated from destination configuration before first launch.
 7. Obtain consent for the exact manifest and any credential/session-owner
    policy. Re-probe before mutation so stale plans cannot overwrite new state.
 8. Create an owner-private sibling staging directory on the remote host and a
-   durable transaction receipt containing no secrets.
-9. Stream a versioned archive through SSH stdin. Use a Node archive library in
-   the standalone CLI rather than depending on GNU/BSD `tar` flag parity.
-   Validate entry type, normalized relative path, declared root, size bounds,
-   and symlink containment during receive.
-10. Stream credential frames separately from the archive and re-seal directly
+  durable transaction receipt containing no secrets.
+9. Stream a versioned, bounded file protocol through SSH stdin without a host
+   `tar` dependency. Validate entry order/type, normalized relative path,
+   declared root, size bounds, per-file checksum, and symlink containment
+   during receive.
+10. Stream credential frames separately from portable file frames and re-seal directly
     into destination files without plaintext staging.
 11. Verify file count, byte count, per-entry or content-tree SHA-256, product
     stamp, Workspace registry/catalog reconstruction, permissions, and the
@@ -371,9 +382,11 @@ are regenerated from destination configuration before first launch.
 13. Run read-only destination Doctor/inventory checks. Runtime start and tunnel
     open are separate post-transfer actions offered by CLI/TUI.
 14. On interruption, leave a bounded staging receipt. A retry with the same
-    manifest resumes verified chunks when supported or safely replaces only
-    that transaction's staging directory. Cleanup never targets an unresolved
-    path or another transaction.
+    manifest safely replaces only that transaction's staging directory. If
+    publish succeeded but registry registration failed, retry verifies the
+    exact published tree and credential bundle before idempotently repairing
+    registration. Cleanup never targets an unresolved path or another
+    transaction.
 
 The local source remains byte-for-byte untouched except for an explicitly
 approved graceful stop. A successful transfer report includes the remote
@@ -389,7 +402,7 @@ Keep the implementation split into presentation-neutral modules under
 - machine config parser/store;
 - fleet inventory types and local/SSH probes;
 - transfer inventory and policy planner;
-- versioned manifest and archive filter;
+- versioned manifest and framed-stream filter;
 - source exporter and secret-frame producer;
 - remote staging/import transaction and secret re-sealer;
 - connection/tunnel service that reuses existing `remote.mjs` behavior;
@@ -467,8 +480,8 @@ signals a guessed PID, exposes the Guardian socket, or performs trading writes.
 - [x] Add source/destination quiescence and ownership checks with isolated
   consent for source stop; refuse foreign owners and occupied destinations.
 - [x] Stream configuration and Workspace trees into owner-private remote
-  staging with bounded input, safe archive extraction, checksums, and durable
-  receipts.
+  staging with bounded framed input, normalized paths, checksums, safe
+  symlinks, and durable receipts.
 - [x] Rebase active/departed Workspace registry and Catalog paths while
   preserving Workspace ids, tags, lifecycle, Git state, and files.
 - [x] Exclude the complete Session/runtime/auth plane and verify the destination
@@ -479,7 +492,8 @@ signals a guessed PID, exposes the Guardian socket, or performs trading writes.
   with a new destination key; prove plaintext never reaches archive, argv,
   env, logs, progress, or fixture snapshots.
 - [x] Atomically publish and register the destination project; implement safe
-  retry/cancel/cleanup for only the resolved transaction staging path.
+  retry/cancel/cleanup for only the resolved transaction staging path, plus
+  exact-tree verification before repairing a post-publish registration retry.
 - [x] Add `openalice project transfer ... --plan|--yes`, concise human progress,
   and a stable machine-readable result.
 - [x] Extend the disposable Docker SSH acceptance through plan, default-no,
@@ -527,6 +541,20 @@ signals a guessed PID, exposes the Guardian socket, or performs trading writes.
 - [ ] Delete this plan and its [[PLANS.md]] bullet only after every acceptance
   criterion is repository truth and the maintainer accepts the completed
   product behavior.
+
+### Increment 6 — Railway-backed transfer hardening
+
+- [x] Make Workspace inclusion Git-aware: preserve tracked and nonignored
+  untracked content plus self-contained Git state, exclude ignored generated
+  dependencies, and fail closed on linked/nested/alternate/promisor layouts.
+- [x] Freeze Alice-owned AI/broker/Connector/provider credentials once at plan
+  consent, keep them out of plan JSON and portable file frames, and re-seal
+  them under a new destination key.
+- [x] Validate the complete receipt and exact published entry set before an
+  idempotent registration retry, including receiver-created credential files.
+- [ ] Apply the reviewed transfer to the retained Railway Volume, select the
+  imported Project, and verify portable Workspace/configuration state plus a
+  new user-owned Agent Runtime turn without importing native Session state.
 
 ## Verification Matrix
 
@@ -603,6 +631,17 @@ retry after transfer failure, and proves Escape cancellation aborts the active
 sender. README already links the remote quickstart, so no public positioning
 rewrite is needed.
 
+Increment 6 local progress (2026-08-31): the planner now preserves tracked and
+nonignored untracked Workspace content while rejecting Git layouts that depend
+on machine-local worktree, nested repository, alternate-object, or promisor
+state. Alice-owned credentials are frozen in a process-private consent
+snapshot, streamed separately from portable files, and re-sealed at the
+destination; native Agent login/config/session state remains excluded. Receipt
+validation covers the exact manifest, credentials policy, and published entry
+set, including idempotent recovery when the receiver created an AI vault before
+registry registration failed. Hosted Railway apply and real Project selection
+remain the acceptance step shared with the Bun CLI distribution plan.
+
 Always:
 
 ```bash
@@ -642,15 +681,15 @@ Targeted security/transaction tests cover:
 - malformed/unknown/newer machine registry schemas and atomic-write failure;
 - SSH host-key/auth/timeout/connection-loss classes without disabling
   verification;
-- hostile machine keys, targets, remote homes, archive paths, control bytes,
+- hostile machine keys, targets, remote homes, manifest paths, control bytes,
   oversized entries, symlink escapes, and destination collisions;
 - source/destination Runtime races between plan and apply;
 - dirty Git repositories, submodules, executable files, Unicode names, empty
   files, large files, and interrupted streams;
-- Session paths and global Agent homes absent from the archive/destination;
+- Session paths and global Agent homes absent from the stream/destination;
 - exact-Session Issues under both explicit policies;
 - synthetic AI/broker/Connector secrets absent from every stdout/stderr/log,
-  manifest, archive, receipt, error, and snapshot while destination unsealing
+  manifest, portable file frames, receipt, error, and snapshot while destination unsealing
   succeeds with a distinct key;
 - checksum mismatch, publish/register failure, retry, cancellation, bounded
   cleanup, and source byte-for-byte preservation.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: 0.83.0
         version: 0.83.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   packages/connector-protocol:
     dependencies:

--- a/scripts/railway-entrypoint.spec.ts
+++ b/scripts/railway-entrypoint.spec.ts
@@ -1,0 +1,533 @@
+import { execFile } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, readFile, readlink, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const temporaryPaths: string[] = []
+const entrypoint = resolve('scripts/railway/entrypoint.sh')
+const commandWrapper = resolve('scripts/railway/command-wrapper.sh')
+const shellEnvironment = resolve('scripts/railway/shell-env.sh')
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('Railway native CLI host entrypoint', () => {
+  it('bootstraps an empty persistent volume and runs the Guardian in foreground mode', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await execFileAsync('bash', [entrypoint], { env: fixture.env })
+
+    expect(await readFile(fixture.installCalled, 'utf8')).toContain('--channel beta')
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(
+      `server run --home ${join(fixture.volume, 'projects', 'default')} --port 47331 --wait 180`,
+    )
+  })
+
+  it('starts an existing verified release without contacting the installer', async () => {
+    const fixture = await makeFixture({ installer: 'failure', existing: true })
+
+    await execFileAsync('bash', [entrypoint], { env: fixture.env })
+
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain('server run')
+  })
+
+  it('falls back to the existing release when an explicit refresh fails', async () => {
+    const fixture = await makeFixture({ installer: 'failure', existing: true })
+
+    const result = await execFileAsync('bash', [entrypoint], {
+      env: { ...fixture.env, OPENALICE_RAILWAY_FORCE_INSTALL: '1' },
+    })
+
+    expect(result.stderr).toContain('starting previously verified OpenAlice 0.91.0-beta.1')
+    expect(await readFile(fixture.installCalled, 'utf8')).toContain('--channel beta')
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain('server run')
+  })
+
+  it('fails closed when an empty volume cannot be bootstrapped', async () => {
+    const fixture = await makeFixture({ installer: 'failure' })
+
+    await expect(execFileAsync('bash', [entrypoint], { env: fixture.env }))
+      .rejects.toMatchObject({ stderr: expect.stringContaining('no previously verified OpenAlice release') })
+    await expect(readFile(fixture.runtimeCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('keeps the user install layout fixed while selecting an overridden Project home', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+    const projectHome = join(fixture.volume, 'projects', 'main-cloud')
+
+    await execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_HOME: projectHome,
+      },
+    })
+
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain([
+      `HOME=${join(fixture.volume, 'home')}`,
+      `OPENALICE_HOME=${projectHome}`,
+      `AQ_LAUNCHER_ROOT=${join(projectHome, 'workspaces')}`,
+      `OPENALICE_INSTALL_DIR=${join(fixture.volume, 'home', '.openalice')}`,
+      `NPM_CONFIG_PREFIX=${join(fixture.volume, 'home', '.local')}`,
+      `BUN_INSTALL=${join(fixture.volume, 'home', '.bun')}`,
+    ].join('\n'))
+  })
+
+  it('rejects a persistent path that escapes the mounted volume after normalization', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: { ...fixture.env, OPENALICE_HOME: join(fixture.volume, '..', 'outside') },
+    })).rejects.toMatchObject({ stderr: expect.stringContaining('must stay beneath the persistent volume root') })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects the legacy Node-managed 0.90.1 release before invoking the installer', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_RAILWAY_CHANNEL: 'stable',
+        OPENALICE_RAILWAY_VERSION: '0.90.1',
+      },
+    })).rejects.toMatchObject({ stderr: expect.stringContaining('legacy Node-managed layout') })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('uses the Railway mount and service identity as container-replacement authority', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })
+
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(
+      'OPENALICE_MACHINE_ID=railway-service-service-test',
+    )
+  })
+
+  it('rejects an ephemeral Railway shell home that would split SSH from the Runtime', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        HOME: '/root',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })).rejects.toMatchObject({ stderr: expect.stringContaining('HOME must use the persistent Railway user layout') })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('bakes the persistent SSH home and user executable paths into the Railway image', async () => {
+    const dockerfile = await readFile(resolve('Dockerfile.railway'), 'utf8')
+
+    expect(dockerfile).toMatch(/^FROM debian:bookworm-slim$/m)
+    expect(dockerfile).not.toMatch(/^FROM node:/m)
+    expect(dockerfile).toContain('util-linux')
+    expect(dockerfile).toContain('HOME=/data/home')
+    expect(dockerfile).toContain('OPENALICE_INSTALL_DIR=/data/home/.openalice')
+    expect(dockerfile).toContain(
+      'PATH=/usr/local/sbin:/usr/local/bin:/data/home/.openalice/bin:/data/home/.local/bin:/data/home/.bun/bin:',
+    )
+    expect(dockerfile).toContain('scripts/railway/command-wrapper.sh')
+    expect(dockerfile).toContain('scripts/railway/shell-env.sh')
+    expect(dockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-g", "--"')
+  })
+
+  it('restores the persistent user environment in a Railway login shell', async () => {
+    const result = await execFileAsync('sh', [
+      '-c',
+      '. "$1"; printf "%s|%s|%s|%s\n" "$HOME" "$PATH" "$AQ_LAUNCHER_ROOT" "$OPENALICE_MACHINE_ID"',
+      'openalice-shell-test',
+      shellEnvironment,
+    ], {
+      env: {
+        PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        HOME: '/root',
+        OPENALICE_HOME: '/data/projects/main-cloud',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })
+
+    expect(result.stdout.trim()).toBe([
+      '/data/home',
+      '/usr/local/sbin:/usr/local/bin:/data/home/.openalice/bin:/data/home/.local/bin:/data/home/.bun/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      '/data/projects/main-cloud/workspaces',
+      'railway-service-service-test',
+    ].join('|'))
+  })
+
+  it('gives Railway SSH commands the same stable machine identity as the foreground Runtime', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-wrapper-'))
+    temporaryPaths.push(root)
+    const installRoot = join(root, 'install')
+    const wrapper = join(root, 'openalice')
+    await writeActiveRelease(installRoot, `#!/usr/bin/env bash
+printf '%s|%s|%s\n' "\${OPENALICE_MACHINE_ID:-}" "$HOME" "$*"
+`)
+    await writeFile(wrapper, await readFile(commandWrapper), { mode: 0o755 })
+
+    const result = await execFileAsync('bash', [wrapper, 'server', 'status'], {
+      env: {
+        PATH: process.env.PATH,
+        HOME: '/data/home',
+        OPENALICE_INSTALL_DIR: installRoot,
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })
+
+    expect(result.stdout.trim()).toBe(
+      'railway-service-service-test|/data/home|server status',
+    )
+  })
+
+  it.each(['update', 'rollback', 'uninstall'])('keeps Railway %s mutations out of the persistent release', async (action) => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-wrapper-authority-'))
+    temporaryPaths.push(root)
+    const installRoot = join(root, 'install')
+    const wrapper = join(root, 'openalice')
+    const invoked = join(root, 'invoked')
+    await writeActiveRelease(
+      installRoot,
+      `#!/usr/bin/env bash\nprintf 'invoked' >${JSON.stringify(invoked)}\n`,
+    )
+    await writeFile(wrapper, await readFile(commandWrapper), { mode: 0o755 })
+
+    const result = await execFileAsync('bash', [wrapper, action, '--yes'], {
+      env: {
+        PATH: process.env.PATH,
+        HOME: '/data/home',
+        OPENALICE_INSTALL_DIR: installRoot,
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })
+
+    expect(result.stdout).toContain('openalice railway:')
+    await expect(readFile(invoked, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('replaces the persistent installer launcher so old releases cannot bypass Railway authority', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await execFileAsync('bash', [entrypoint], { env: fixture.env })
+    const before = await readFile(fixture.runtimeCalled, 'utf8')
+    const result = await execFileAsync('bash', [fixture.launcher, 'update', '--channel', 'stable', '--yes'], {
+      env: {
+        ...fixture.env,
+        OPENALICE_INSTALL_DIR: join(fixture.volume, 'home', '.openalice'),
+        OPENALICE_SERVICE_MANAGER: 'railway',
+      },
+    })
+
+    expect(result.stdout).toContain('service variables own release selection')
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toBe(before)
+  })
+
+  it('rejects a configured volume root that disagrees with the Railway mount', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_RAILWAY_VOLUME_ROOT: join(fixture.volume, 'other'),
+      },
+    })).rejects.toMatchObject({ stderr: expect.stringContaining('must match the Railway Volume mount path') })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refreshes an exact pin mismatch and names the verified fallback when refresh fails', async () => {
+    const fixture = await makeFixture({ installer: 'failure', existing: true })
+
+    const result = await execFileAsync('bash', [entrypoint], {
+      env: { ...fixture.env, OPENALICE_RAILWAY_VERSION: '0.91.0-beta.2' },
+    })
+
+    expect(await readFile(fixture.installCalled, 'utf8')).toContain('--version 0.91.0-beta.2')
+    expect(result.stderr).toContain('starting previously verified OpenAlice 0.91.0-beta.1')
+  })
+
+  it('falls back when the installer exits successfully without producing the selected release', async () => {
+    const fixture = await makeFixture({ installer: 'noop', existing: true })
+
+    const result = await execFileAsync('bash', [entrypoint], {
+      env: { ...fixture.env, OPENALICE_RAILWAY_VERSION: '0.91.0-beta.2' },
+    })
+
+    expect(result.stderr).toContain('installer returned without the selected verified release')
+    expect(result.stderr).toContain('starting previously verified OpenAlice 0.91.0-beta.1')
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain('server run')
+  })
+
+  it('restores the exact previous pointer when a successful installer activates another valid release', async () => {
+    const fixture = await makeSwitchingFixture()
+
+    const result = await execFileAsync('bash', [entrypoint], { env: fixture.env })
+
+    expect(result.stderr).toContain('installer returned without the selected verified release')
+    expect(result.stderr).toContain('starting previously verified OpenAlice 0.91.0-beta.1')
+    expect(await readlink(fixture.current)).toBe(`releases/${fixture.previousReleaseName}`)
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(`release=${fixture.previousReleaseName}`)
+  })
+
+  it('resolves the rolling dev selector on every container start and keeps the exact fallback', async () => {
+    const fixture = await makeFixture({ installer: 'failure', existing: true, existingChannel: 'dev' })
+
+    const result = await execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_RAILWAY_CHANNEL: 'dev',
+        OPENALICE_RAILWAY_VERSION: '',
+      },
+    })
+
+    expect(await readFile(fixture.installCalled, 'utf8')).toContain('--channel dev')
+    expect(result.stderr).toContain('starting previously verified OpenAlice 0.91.0-dev.1')
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain('server run')
+  })
+
+  it('does not treat a launcher with incomplete provenance as a verified fallback', async () => {
+    const fixture = await makeFixture({ installer: 'failure', existing: true })
+    await writeFile(fixture.launcher, `#!/usr/bin/env bash
+if [[ "\${1:-}" == --version ]]; then printf '0.91.0-beta.1\\n'; exit 0; fi
+if [[ "\${1:-}" == version ]]; then printf '{"version":"0.91.0-beta.1"}\\n'; exit 0; fi
+exit 1
+`, { mode: 0o755 })
+
+    await expect(execFileAsync('bash', [entrypoint], { env: fixture.env }))
+      .rejects.toMatchObject({ stderr: expect.stringContaining('no previously verified OpenAlice release') })
+  })
+
+})
+
+async function makeFixture(options: {
+  installer: 'success' | 'failure' | 'noop'
+  existing?: boolean
+  existingChannel?: 'beta' | 'dev'
+}) {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-railway-entrypoint-'))
+  temporaryPaths.push(root)
+  const volumePath = join(root, 'volume')
+  const installer = join(root, 'install')
+  const installCalled = join(root, 'installer-called')
+  const runtimeCalled = join(root, 'runtime-called')
+  const linkDir = join(root, 'links')
+  await mkdir(volumePath, { recursive: true })
+  const volume = await realpath(volumePath)
+  const installRoot = join(volume, 'home', '.openalice')
+  await writeInstaller(installer, options.installer, installCalled, runtimeCalled)
+  if (options.existing) {
+    await writeLauncher(join(installRoot, 'bin', 'openalice'), runtimeCalled, options.existingChannel === 'dev'
+      ? { version: '0.91.0-dev.1', channel: 'dev' }
+      : undefined)
+  }
+  return {
+    volume,
+    launcher: join(installRoot, 'bin', 'openalice'),
+    installCalled,
+    runtimeCalled,
+    env: {
+      PATH: process.env.PATH,
+      RAILWAY_VOLUME_MOUNT_PATH: volume,
+      OPENALICE_RAILWAY_VOLUME_ROOT: volume,
+      OPENALICE_RAILWAY_INSTALLER_PATH: installer,
+      OPENALICE_RAILWAY_COMMAND_WRAPPER_PATH: commandWrapper,
+      OPENALICE_RAILWAY_LINK_DIR: linkDir,
+      OPENALICE_RAILWAY_CHANNEL: 'beta',
+      OPENALICE_RAILWAY_VERSION: '0.91.0-beta.1',
+    },
+  }
+}
+
+async function makeSwitchingFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'openalice-railway-switch-'))
+  temporaryPaths.push(root)
+  const volumePath = join(root, 'volume')
+  const volume = await realpath(await mkdir(volumePath, { recursive: true }).then(() => volumePath))
+  const installRoot = join(volume, 'home', '.openalice')
+  const cliRoot = join(installRoot, 'cli')
+  const previousReleaseName = '0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa'
+  const otherReleaseName = '0.91.0-beta.3-linux-x64-bbbbbbbbbbbbbbbb'
+  const runtimeCalled = join(root, 'runtime-called')
+  const installCalled = join(root, 'installer-called')
+  const installer = join(root, 'install')
+  const current = join(cliRoot, 'current')
+  const previousRuntimeRoot = join(cliRoot, 'releases', previousReleaseName)
+  const previousProfile = { version: '0.91.0-beta.1', channel: 'beta' as const, identity: 'aaaaaaaaaaaaaaaa' }
+  await mkdir(join(installRoot, 'bin'), { recursive: true })
+  await writeDynamicLauncher(join(installRoot, 'bin', 'openalice'))
+  await writeReleaseLauncher(
+    previousRuntimeRoot,
+    runtimeCalled,
+    previousReleaseName,
+    previousProfile,
+  )
+  await writeReleaseLauncher(
+    join(cliRoot, 'releases', otherReleaseName),
+    runtimeCalled,
+    otherReleaseName,
+    { version: '0.91.0-beta.3', channel: 'beta', identity: 'bbbbbbbbbbbbbbbb' },
+  )
+  await symlink(`releases/${previousReleaseName}`, current)
+  await writeFile(installer, `#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >'${installCalled}'
+printf '%s\n' '${JSON.stringify(versionPayload(previousRuntimeRoot, {
+    ...previousProfile,
+    installedAt: '2026-08-31T02:00:00.000Z',
+  }))}' >'${join(previousRuntimeRoot, 'version.json')}'
+rm -f "$OPENALICE_INSTALL_DIR/cli/current"
+ln -s 'releases/${otherReleaseName}' "$OPENALICE_INSTALL_DIR/cli/current"
+`, { mode: 0o755 })
+  return {
+    current,
+    previousReleaseName,
+    runtimeCalled,
+    env: {
+      PATH: process.env.PATH,
+      RAILWAY_VOLUME_MOUNT_PATH: volume,
+      OPENALICE_RAILWAY_VOLUME_ROOT: volume,
+      OPENALICE_RAILWAY_INSTALLER_PATH: installer,
+      OPENALICE_RAILWAY_COMMAND_WRAPPER_PATH: commandWrapper,
+      OPENALICE_RAILWAY_LINK_DIR: join(root, 'links'),
+      OPENALICE_RAILWAY_CHANNEL: 'beta',
+      OPENALICE_RAILWAY_VERSION: '0.91.0-beta.2',
+    },
+  }
+}
+
+async function writeInstaller(
+  path: string,
+  outcome: 'success' | 'failure' | 'noop',
+  installCalled: string,
+  runtimeCalled: string,
+) {
+  await writeFile(path, outcome !== 'success'
+    ? `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >'${installCalled}'\n${outcome === 'failure' ? 'exit 23' : 'exit 0'}\n`
+    : `#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >'${installCalled}'
+mkdir -p "$OPENALICE_INSTALL_DIR/bin"
+mkdir -p "$OPENALICE_INSTALL_DIR/cli/releases/0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa/bin"
+ln -sfn 'releases/0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa' "$OPENALICE_INSTALL_DIR/cli/current"
+cat >"$OPENALICE_INSTALL_DIR/cli/current/bin/openalice" <<'LAUNCHER'
+#!/usr/bin/env bash
+if [[ "\${1:-}" == --version ]]; then printf '0.91.0-beta.1\\n'; exit 0; fi
+if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then
+  printf '{"version":"0.91.0-beta.1","installSource":{"schemaVersion":3,"repository":"TraderAlice/OpenAlice","cliVersion":"0.91.0-beta.1","selector":{"kind":"version","value":"v0.91.0-beta.1"},"installerUrl":"https://openalice.ai/install","updateChannel":"beta","method":"direct","artifact":{"platform":"linux","arch":"x64","sha256":"%s"},"installedAt":"2026-08-31T00:00:00.000Z"},"contentIdentity":"aaaaaaaaaaaaaaaa","managedRuntime":{"productVersion":"0.91.0-beta.1","platform":"linux","arch":"x64","path":"%s","contentIdentity":"aaaaaaaaaaaaaaaa"}}\\n' \\
+    "$(printf '0%.0s' {1..64})" "$OPENALICE_INSTALL_DIR/cli/releases/0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa"
+  exit 0
+fi
+printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\n' \\
+  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" >'${runtimeCalled}'
+printf '%s\\n' "$*" >>'${runtimeCalled}'
+LAUNCHER
+chmod 0755 "$OPENALICE_INSTALL_DIR/cli/current/bin/openalice"
+ln -s ../cli/current/bin/openalice "$OPENALICE_INSTALL_DIR/bin/openalice"
+`, { mode: 0o755 })
+  await chmod(path, 0o755)
+}
+
+async function writeLauncher(
+  path: string,
+  runtimeCalled: string,
+  profile: { version?: string; channel?: 'beta' | 'dev'; identity?: string } = {},
+) {
+  const installRoot = resolve(path, '..', '..')
+  const version = profile.version ?? '0.91.0-beta.1'
+  const channel = profile.channel ?? 'beta'
+  const identity = profile.identity ?? 'aaaaaaaaaaaaaaaa'
+  const releaseName = `${version}-linux-x64-${identity}`
+  const runtimeRoot = join(installRoot, 'cli', 'releases', releaseName)
+  await mkdir(join(runtimeRoot, 'bin'), { recursive: true })
+  await mkdir(join(path, '..'), { recursive: true })
+  await symlink(join('releases', releaseName), join(installRoot, 'cli', 'current'))
+  await writeFile(join(runtimeRoot, 'bin', 'openalice'), `#!/usr/bin/env bash
+if [[ "\${1:-}" == --version ]]; then printf '${version}\\n'; exit 0; fi
+if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then printf '%s\\n' '${JSON.stringify(versionPayload(runtimeRoot, { version, channel, identity }))}'; exit 0; fi
+printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\n' \\
+  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" >'${runtimeCalled}'
+printf '%s\\n' "$*" >>'${runtimeCalled}'
+`, { mode: 0o755 })
+  await writeDynamicLauncher(path)
+}
+
+async function writeDynamicLauncher(path: string) {
+  await writeFile(path, `#!/usr/bin/env bash
+set -eu
+release_root="$(CDPATH= cd -- "$OPENALICE_INSTALL_DIR/cli/current" && pwd -P)"
+exec "$release_root/bin/openalice" "$@"
+`, { mode: 0o755 })
+}
+
+async function writeActiveRelease(installRoot: string, executable: string) {
+  const releaseName = '0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa'
+  const releaseRoot = join(installRoot, 'cli', 'releases', releaseName)
+  await mkdir(join(releaseRoot, 'bin'), { recursive: true })
+  await writeFile(join(releaseRoot, 'bin', 'openalice'), executable, { mode: 0o755 })
+  await symlink(join('releases', releaseName), join(installRoot, 'cli', 'current'))
+}
+
+async function writeReleaseLauncher(
+  runtimeRoot: string,
+  runtimeCalled: string,
+  releaseName: string,
+  profile: { version: string; channel: 'beta' | 'dev'; identity: string; installedAt?: string },
+) {
+  await mkdir(join(runtimeRoot, 'bin'), { recursive: true })
+  const versionFile = join(runtimeRoot, 'version.json')
+  await writeFile(versionFile, `${JSON.stringify(versionPayload(runtimeRoot, profile))}\n`)
+  await writeFile(join(runtimeRoot, 'bin', 'openalice'), `#!/usr/bin/env bash
+if [[ "\${1:-}" == --version ]]; then printf '${profile.version}\\n'; exit 0; fi
+if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then cat '${versionFile}'; exit 0; fi
+printf 'release=${releaseName}\\n%s\\n' "$*" >'${runtimeCalled}'
+`, { mode: 0o755 })
+}
+
+function versionPayload(
+  runtimeRoot: string,
+  profile: { version?: string; channel?: 'beta' | 'dev'; identity?: string; installedAt?: string } = {},
+) {
+  const version = profile.version ?? '0.91.0-beta.1'
+  const channel = profile.channel ?? 'beta'
+  const identity = profile.identity ?? 'aaaaaaaaaaaaaaaa'
+  return {
+    version,
+    installSource: {
+      schemaVersion: 3,
+      repository: 'TraderAlice/OpenAlice',
+      cliVersion: version,
+      selector: channel === 'dev'
+        ? { kind: 'branch', value: 'dev' }
+        : { kind: 'version', value: `v${version}` },
+      installerUrl: 'https://openalice.ai/install',
+      updateChannel: channel === 'dev' ? 'development' : channel,
+      method: 'direct',
+      artifact: { platform: 'linux', arch: 'x64', sha256: '0'.repeat(64) },
+      installedAt: profile.installedAt ?? '2026-08-31T00:00:00.000Z',
+    },
+    contentIdentity: identity,
+    managedRuntime: {
+      productVersion: version,
+      platform: 'linux',
+      arch: 'x64',
+      path: runtimeRoot,
+      contentIdentity: identity,
+    },
+  }
+}

--- a/scripts/railway/command-wrapper.sh
+++ b/scripts/railway/command-wrapper.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${0##*/}"
+install_dir="${OPENALICE_INSTALL_DIR:-/data/home/.openalice}"
+release_dir="$(CDPATH= cd -- "$install_dir/cli/current" 2>/dev/null && pwd -P)" || {
+  printf 'openalice railway: the active release pointer is unavailable at %s\n' "$install_dir/cli/current" >&2
+  exit 1
+}
+releases_dir="$(CDPATH= cd -- "$install_dir/cli/releases" 2>/dev/null && pwd -P)" || {
+  printf 'openalice railway: the release store is unavailable at %s\n' "$install_dir/cli/releases" >&2
+  exit 1
+}
+case "$release_dir" in
+  "$releases_dir"/*) ;;
+  *)
+    printf 'openalice railway: the active release escaped the managed release store\n' >&2
+    exit 1
+    ;;
+esac
+release_name="${release_dir##*/}"
+content_identity="${release_name##*-}"
+target="$release_dir/bin/openalice"
+
+if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
+  [[ -n "${RAILWAY_SERVICE_ID:-}" ]] || {
+    printf 'openalice railway: Railway did not provide a stable service identity\n' >&2
+    exit 1
+  }
+  export OPENALICE_MACHINE_ID="${OPENALICE_MACHINE_ID:-railway-service-${RAILWAY_SERVICE_ID}}"
+fi
+
+if [[ "${OPENALICE_SERVICE_MANAGER:-}" == railway && ( "$command_name" == openalice || "$command_name" == alice ) ]]; then
+  case "${1:-}" in
+    update|rollback)
+      printf 'openalice railway: service variables own release selection; set OPENALICE_RAILWAY_CHANNEL and optional OPENALICE_RAILWAY_VERSION, then restart or redeploy\n'
+      exit 0
+      ;;
+    uninstall)
+      printf 'openalice railway: the service owns this install and its fallback releases; remove or reconfigure the Railway service instead\n'
+      exit 0
+      ;;
+  esac
+fi
+
+[[ -x "$target" ]] || {
+  printf 'openalice railway: the active OpenAlice executable is unavailable at %s\n' "$target" >&2
+  exit 1
+}
+
+export OPENALICE_INSTALL_ROOT="$install_dir"
+export OPENALICE_RELEASE_DIR="$release_dir"
+export OPENALICE_INSTALL_SOURCE="$install_dir/cli/provenance/$release_name.json"
+export OPENALICE_CONTENT_IDENTITY="$content_identity"
+export OPENALICE_INSTALL_METHOD=direct
+
+case "$command_name" in
+  alice|alice-workspace|alice-uta|traderhub)
+    exec "$target" --workspace-cli "$command_name" "$@"
+    ;;
+  *)
+    exec "$target" "$@"
+    ;;
+esac

--- a/scripts/railway/entrypoint.sh
+++ b/scripts/railway/entrypoint.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'openalice railway: %s\n' "$*" >&2
+  exit 1
+}
+
+canonical_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(os.path.abspath(sys.argv[1])))
+PY
+}
+
+system_path='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+export PATH="$system_path"
+
+requested_volume_root="${RAILWAY_VOLUME_MOUNT_PATH:-${OPENALICE_RAILWAY_VOLUME_ROOT:-/data}}"
+requested_volume_root="${requested_volume_root%/}"
+[[ "$requested_volume_root" == /* && "$requested_volume_root" != / ]] \
+  || fail 'the persistent volume root must be an absolute path other than /'
+if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" && -z "${RAILWAY_VOLUME_MOUNT_PATH:-}" ]]; then
+  fail 'attach a Railway Volume before starting this service'
+fi
+volume_root="$(canonical_path "$requested_volume_root")"
+if [[ -n "${RAILWAY_VOLUME_MOUNT_PATH:-}" && -n "${OPENALICE_RAILWAY_VOLUME_ROOT:-}" ]]; then
+  configured_volume_root="$(canonical_path "$OPENALICE_RAILWAY_VOLUME_ROOT")"
+  [[ "$configured_volume_root" == "$volume_root" ]] \
+    || fail 'OPENALICE_RAILWAY_VOLUME_ROOT must match the Railway Volume mount path'
+fi
+if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
+  [[ -n "${RAILWAY_SERVICE_ID:-}" ]] \
+    || fail 'Railway did not provide a stable service identity'
+  export OPENALICE_MACHINE_ID="${OPENALICE_MACHINE_ID:-railway-service-${RAILWAY_SERVICE_ID}}"
+fi
+
+fixed_home="$(canonical_path "$volume_root/home")"
+fixed_install_dir="$(canonical_path "$fixed_home/.openalice")"
+fixed_npm_prefix="$(canonical_path "$fixed_home/.local")"
+fixed_bun_install="$(canonical_path "$fixed_home/.bun")"
+if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
+  for configured_pair in \
+    "HOME=${HOME:-}" \
+    "OPENALICE_INSTALL_DIR=${OPENALICE_INSTALL_DIR:-}" \
+    "NPM_CONFIG_PREFIX=${NPM_CONFIG_PREFIX:-}" \
+    "BUN_INSTALL=${BUN_INSTALL:-}"; do
+    configured_name="${configured_pair%%=*}"
+    configured_value="${configured_pair#*=}"
+    [[ -z "$configured_value" ]] && continue
+    case "$configured_name" in
+      HOME) expected_value="$fixed_home" ;;
+      OPENALICE_INSTALL_DIR) expected_value="$fixed_install_dir" ;;
+      NPM_CONFIG_PREFIX) expected_value="$fixed_npm_prefix" ;;
+      BUN_INSTALL) expected_value="$fixed_bun_install" ;;
+    esac
+    [[ "$(canonical_path "$configured_value")" == "$expected_value" ]] \
+      || fail "$configured_name must use the persistent Railway user layout beneath $volume_root/home"
+  done
+fi
+
+export HOME="$fixed_home"
+export OPENALICE_HOME="$(canonical_path "${OPENALICE_HOME:-$volume_root/projects/default}")"
+export AQ_LAUNCHER_ROOT="$(canonical_path "$OPENALICE_HOME/workspaces")"
+export OPENALICE_INSTALL_DIR="$fixed_install_dir"
+export NPM_CONFIG_PREFIX="$fixed_npm_prefix"
+export BUN_INSTALL="$fixed_bun_install"
+
+for persistent_path in "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL"; do
+  case "$persistent_path" in
+    "$volume_root"/*) ;;
+    *) fail "$persistent_path must stay beneath the persistent volume root $volume_root" ;;
+  esac
+done
+mkdir -p "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$NPM_CONFIG_PREFIX/bin" "$BUN_INSTALL/bin"
+
+channel="${OPENALICE_RAILWAY_CHANNEL:-stable}"
+version="${OPENALICE_RAILWAY_VERSION:-}"
+force_install="${OPENALICE_RAILWAY_FORCE_INSTALL:-0}"
+port="${OPENALICE_RAILWAY_PORT:-47331}"
+wait_seconds="${OPENALICE_RAILWAY_WAIT_SECONDS:-180}"
+installer="${OPENALICE_RAILWAY_INSTALLER_PATH:-/opt/openalice/install}"
+command_wrapper="${OPENALICE_RAILWAY_COMMAND_WRAPPER_PATH:-/usr/local/libexec/openalice-railway-command}"
+launcher="$OPENALICE_INSTALL_DIR/bin/openalice"
+
+[[ "$channel" == stable || "$channel" == beta || "$channel" == dev ]] \
+  || fail 'OPENALICE_RAILWAY_CHANNEL must be stable, beta, or dev'
+[[ "$force_install" == 0 || "$force_install" == 1 ]] \
+  || fail 'OPENALICE_RAILWAY_FORCE_INSTALL must be 0 or 1'
+[[ "$port" =~ ^[0-9]+$ && "$port" -ge 1 && "$port" -le 65535 ]] \
+  || fail 'OPENALICE_RAILWAY_PORT must be between 1 and 65535'
+[[ "$wait_seconds" =~ ^[0-9]+$ && "$wait_seconds" -ge 1 && "$wait_seconds" -le 600 ]] \
+  || fail 'OPENALICE_RAILWAY_WAIT_SECONDS must be between 1 and 600'
+if [[ "$channel" == dev && -n "$version" ]]; then
+  fail 'the rolling dev channel cannot be combined with OPENALICE_RAILWAY_VERSION'
+fi
+if [[ -n "$version" ]]; then
+  if [[ "$channel" == stable ]]; then
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+      || fail 'stable OPENALICE_RAILWAY_VERSION must be x.y.z'
+  else
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta(\.[1-9][0-9]*)?$ ]] \
+      || fail 'beta OPENALICE_RAILWAY_VERSION must be x.y.z-beta or x.y.z-beta.N'
+  fi
+  [[ "$version" != 0.90.1 ]] \
+    || fail 'OpenAlice 0.90.1 uses the legacy Node-managed layout and cannot run as a Railway native CLI host'
+fi
+
+validated_install_identity() {
+  local expected_channel="${1:-}" expected_version="${2:-}"
+  local reported_version version_json
+  [[ -x "$launcher" ]] || return 1
+  reported_version="$("$launcher" --version 2>/dev/null)" || return 1
+  version_json="$("$launcher" version --json 2>/dev/null)" || return 1
+  python3 -c '
+import json
+import os
+import re
+import sys
+
+expected_channel, expected_version, reported_version, install_root = sys.argv[1:]
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(1)
+
+source = payload.get("installSource")
+runtime = payload.get("managedRuntime")
+artifact = source.get("artifact") if isinstance(source, dict) else None
+version = payload.get("version")
+identity = payload.get("contentIdentity")
+if not (
+    isinstance(version, str)
+    and version == reported_version
+    and re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", version)
+    and isinstance(identity, str)
+    and re.fullmatch(r"[a-f0-9]{16}", identity)
+    and isinstance(source, dict)
+    and source.get("schemaVersion") == 3
+    and source.get("repository") == "TraderAlice/OpenAlice"
+    and source.get("cliVersion") == version
+    and source.get("updateChannel") in {"stable", "beta", "development"}
+    and isinstance(artifact, dict)
+    and artifact.get("platform") in {"darwin", "linux"}
+    and artifact.get("arch") in {"arm64", "x64"}
+    and isinstance(artifact.get("sha256"), str)
+    and re.fullmatch(r"[a-f0-9]{64}", artifact["sha256"])
+    and isinstance(runtime, dict)
+    and runtime.get("productVersion") == version
+    and runtime.get("contentIdentity") == identity
+    and runtime.get("platform") == artifact.get("platform")
+    and runtime.get("arch") == artifact.get("arch")
+    and isinstance(runtime.get("path"), str)
+):
+    raise SystemExit(1)
+
+release_root = os.path.realpath(os.path.join(install_root, "cli", "releases"))
+runtime_root = os.path.realpath(runtime["path"])
+try:
+    contained = os.path.commonpath([release_root, runtime_root]) == release_root
+except ValueError:
+    contained = False
+if not contained or runtime_root == release_root or not os.path.isdir(runtime_root):
+    raise SystemExit(1)
+
+if expected_channel:
+    desired_channel = "development" if expected_channel == "dev" else expected_channel
+    if source.get("updateChannel") != desired_channel:
+        raise SystemExit(1)
+    if expected_version and version != expected_version:
+        raise SystemExit(1)
+    selector = source.get("selector")
+    if expected_channel == "dev":
+        if selector != {"kind": "branch", "value": "dev"}:
+            raise SystemExit(1)
+    elif selector != {"kind": "version", "value": f"v{version}"}:
+        raise SystemExit(1)
+print(json.dumps({
+    "version": version,
+    "contentIdentity": identity,
+    "releaseRoot": runtime_root,
+    "installSource": {
+        "schemaVersion": source["schemaVersion"],
+        "repository": source["repository"],
+        "cliVersion": source["cliVersion"],
+        "selector": source.get("selector"),
+        "updateChannel": source["updateChannel"],
+        "method": source.get("method"),
+        "artifact": {
+            "platform": artifact["platform"],
+            "arch": artifact["arch"],
+            "sha256": artifact["sha256"],
+        },
+    },
+    "managedRuntime": {
+        "productVersion": runtime["productVersion"],
+        "platform": runtime["platform"],
+        "arch": runtime["arch"],
+        "path": runtime_root,
+        "contentIdentity": runtime["contentIdentity"],
+    },
+}, sort_keys=True, separators=(",", ":")))
+' "$expected_channel" "$expected_version" "$reported_version" "$OPENALICE_INSTALL_DIR" \
+    <<<"$version_json" 2>/dev/null
+}
+
+validate_install() {
+  validated_install_identity "${1:-}" "${2:-}" >/dev/null
+}
+
+valid_install() {
+  validate_install '' ''
+}
+
+install_matches_selection() {
+  validate_install "$channel" "$version"
+}
+
+previous_release_name=''
+previous_release_version=''
+previous_release_identity=''
+
+capture_previous_install() {
+  local current_release releases_root
+  current_release="$(canonical_path "$OPENALICE_INSTALL_DIR/cli/current")"
+  releases_root="$(canonical_path "$OPENALICE_INSTALL_DIR/cli/releases")"
+  [[ "$(dirname "$current_release")" == "$releases_root" ]] || return 1
+  previous_release_name="$(basename "$current_release")"
+  [[ "$previous_release_name" =~ ^[A-Za-z0-9._+-]+$ ]] || return 1
+  previous_release_version="$("$launcher" --version 2>/dev/null)" || return 1
+  previous_release_identity="$(validated_install_identity '' '')" || return 1
+  [[ -n "$previous_release_identity" ]] || return 1
+}
+
+restore_previous_install() {
+  local previous_release previous_link current_release
+  [[ "$previous_install_valid" == 1 && -n "$previous_release_name" && -n "$previous_release_version" && -n "$previous_release_identity" ]] \
+    || return 1
+  previous_release="$OPENALICE_INSTALL_DIR/cli/releases/$previous_release_name"
+  [[ -d "$previous_release" && ! -L "$previous_release" ]] || return 1
+  current_release="$(canonical_path "$OPENALICE_INSTALL_DIR/cli/current" 2>/dev/null || true)"
+  if [[ "$current_release" != "$(canonical_path "$previous_release")" ]]; then
+    previous_link="$OPENALICE_INSTALL_DIR/cli/current.railway-rollback.$$"
+    rm -f "$previous_link"
+    ln -s "releases/$previous_release_name" "$previous_link" || return 1
+    if [[ "$(uname -s)" == Darwin* ]]; then
+      mv -fh "$previous_link" "$OPENALICE_INSTALL_DIR/cli/current" || return 1
+    else
+      mv -Tf "$previous_link" "$OPENALICE_INSTALL_DIR/cli/current" || return 1
+    fi
+  fi
+  valid_install \
+    && [[ "$("$launcher" --version 2>/dev/null)" == "$previous_release_version" ]] \
+    && [[ "$(validated_install_identity '' '')" == "$previous_release_identity" ]]
+}
+
+previous_install_valid=0
+if valid_install; then
+  previous_install_valid=1
+  capture_previous_install || fail 'the current verified OpenAlice release pointer is invalid'
+fi
+if [[ "$force_install" == 1 || "$previous_install_valid" == 0 || "$channel" == dev ]] || ! install_matches_selection; then
+  [[ -f "$installer" ]] || fail "installer not found at $installer"
+  install_args=(
+    --yes
+    --no-modify-path
+    --install-dir "$OPENALICE_INSTALL_DIR"
+    --channel "$channel"
+  )
+  if [[ -n "$version" ]]; then install_args+=(--version "$version"); fi
+  printf 'openalice railway: installing %s%s into the persistent user home\n' \
+    "$channel" "${version:+ $version}"
+  selected_install_ready=0
+  if bash "$installer" "${install_args[@]}"; then
+    if install_matches_selection; then
+      selected_install_ready=1
+    else
+      printf 'openalice railway: installer returned without the selected verified release\n' >&2
+    fi
+  fi
+  if [[ "$selected_install_ready" != 1 ]] && restore_previous_install; then
+    fallback_version="$previous_release_version"
+    printf 'openalice railway: bootstrap failed; starting previously verified OpenAlice %s\n' \
+      "$fallback_version" >&2
+  elif [[ "$selected_install_ready" != 1 ]]; then
+    fail 'bootstrap failed and no previously verified OpenAlice release is available'
+  fi
+fi
+
+[[ -f "$command_wrapper" && ! -L "$command_wrapper" ]] \
+  || fail "Railway command wrapper not found at $command_wrapper"
+for command_name in openalice alice alice-workspace alice-uta traderhub; do
+  target="$OPENALICE_INSTALL_DIR/bin/$command_name"
+  temporary_target="$OPENALICE_INSTALL_DIR/bin/.$command_name.railway-next.$$"
+  rm -f "$temporary_target"
+  install -m 0755 "$command_wrapper" "$temporary_target"
+  mv -f "$temporary_target" "$target"
+done
+
+link_dir="${OPENALICE_RAILWAY_LINK_DIR:-/usr/local/bin}"
+mkdir -p "$link_dir"
+for command_name in openalice alice alice-workspace alice-uta traderhub; do
+  target="$OPENALICE_INSTALL_DIR/bin/$command_name"
+  link="$link_dir/$command_name"
+  if [[ -e "$target" || -L "$target" ]]; then
+    if [[ ! -e "$link" || -L "$link" ]]; then
+      ln -sfn "$target" "$link"
+    fi
+  fi
+done
+
+export PATH="$OPENALICE_INSTALL_DIR/bin:$NPM_CONFIG_PREFIX/bin:$BUN_INSTALL/bin:$system_path"
+printf 'openalice railway: starting foreground Runtime at %s on loopback port %s\n' \
+  "$OPENALICE_HOME" "$port"
+exec "$launcher" server run \
+  --home "$OPENALICE_HOME" \
+  --port "$port" \
+  --wait "$wait_seconds"

--- a/scripts/railway/shell-env.sh
+++ b/scripts/railway/shell-env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+export HOME=/data/home
+export OPENALICE_INSTALL_DIR=/data/home/.openalice
+export NPM_CONFIG_PREFIX=/data/home/.local
+export BUN_INSTALL=/data/home/.bun
+export OPENALICE_HOME="${OPENALICE_HOME:-/data/projects/default}"
+export AQ_LAUNCHER_ROOT="$OPENALICE_HOME/workspaces"
+
+# Image-owned command wrappers must win over the persistent release launchers.
+# They inject the stable Railway machine identity for non-interactive SSH execs,
+# whose environment is not a child of the foreground entrypoint process.
+export PATH=/usr/local/sbin:/usr/local/bin:/data/home/.openalice/bin:/data/home/.local/bin:/data/home/.bun/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+if [ -n "${RAILWAY_ENVIRONMENT_ID:-}" ] && [ -n "${RAILWAY_SERVICE_ID:-}" ]; then
+  export OPENALICE_MACHINE_ID="${OPENALICE_MACHINE_ID:-railway-service-${RAILWAY_SERVICE_ID}}"
+fi

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -97,17 +97,18 @@ try {
   await chmod(sshWrapper, 0o700)
 
   const remoteTarget = 'openalice-remote-smoke'
-  const smokeEnv = {
+  let smokeEnv = {
     ...process.env,
     HOME: localHome,
     PATH: `${fixtureBin}:${process.env.PATH ?? ''}`,
     OPENALICE_REMOTE_SMOKE_SSH_CONFIG: join(sshDir, 'config'),
-    OPENALICE_REMOTE_TEST_INSTALL_URL: 'http://127.0.0.1:18080/install',
-    OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_KIND: 'branch',
-    OPENALICE_REMOTE_TEST_INSTALL_SELECTOR_VALUE: 'dev',
     OPENALICE_REMOTE_TEST_INSTALL_BASE_URL: 'http://127.0.0.1:18080',
   }
   await waitForSsh(remoteTarget, smokeEnv)
+  smokeEnv = {
+    ...smokeEnv,
+    ...await prepareLocalDevIdentityFixture(container, scratch),
+  }
 
   console.log('[remote-ssh-smoke] checking read-only missing-host plan')
   const initialPlan = run(process.execPath, [
@@ -378,6 +379,104 @@ async function prepareTransferSource(home) {
   }, null, 2)}\n`)
   await writeFile(join(home, 'workspaces', 'state', 'resume-identities.json'), '{"version":1,"records":{}}\n')
   return workspace
+}
+
+async function prepareLocalDevIdentityFixture(containerId, scratchRoot) {
+  const remoteArch = normalizeSmokeArchitecture(
+    run('docker', ['exec', containerId, 'uname', '-m']).trim(),
+  )
+  const remoteArchive = `/fixture/www/cli/dev/openalice-cli-dev-linux-${remoteArch}.tar.gz`
+  const remoteSha256 = run('docker', [
+    'exec', containerId, 'sh', '-c',
+    `awk 'NR == 1 { print $1 }' ${shellQuote(`${remoteArchive}.sha256`)}`,
+  ]).trim()
+  const metadata = JSON.parse(run('docker', [
+    'exec', containerId, 'sh', '-c',
+    `archive=${shellQuote(remoteArchive)}; root="$(tar -tzf "$archive" | sed -n '1{s#/.*##;p}')"; tar -xOzf "$archive" "$root/release.json"`,
+  ]))
+  if (
+    !/^[a-f0-9]{64}$/.test(remoteSha256)
+    || metadata?.platform !== 'linux'
+    || metadata?.arch !== remoteArch
+    || !/^[a-f0-9]{16}$/.test(metadata?.contentIdentity ?? '')
+    || typeof metadata?.version !== 'string'
+  ) {
+    throw new Error('Remote smoke artifact did not expose valid dev identity metadata')
+  }
+
+  const localPlatform = process.platform
+  const localArch = process.arch
+  if (!['darwin', 'linux'].includes(localPlatform) || !['arm64', 'x64'].includes(localArch)) {
+    throw new Error(`Remote smoke does not support local target ${localPlatform}-${localArch}`)
+  }
+  const remoteTarget = {
+    platform: 'linux',
+    arch: remoteArch,
+    archive: `openalice-cli-dev-linux-${remoteArch}.tar.gz`,
+    sha256: remoteSha256,
+    contentIdentity: metadata.contentIdentity,
+  }
+  const targetMatrix = [
+    ['darwin', 'arm64'],
+    ['darwin', 'x64'],
+    ['linux', 'arm64'],
+    ['linux', 'x64'],
+  ]
+  const targets = targetMatrix.map(([platform, arch], index) => {
+    if (platform === remoteTarget.platform && arch === remoteTarget.arch) return remoteTarget
+    const marker = (index + 4).toString(16)
+    return {
+      platform,
+      arch,
+      archive: `openalice-cli-dev-${platform}-${arch}.tar.gz`,
+      sha256: marker.repeat(64),
+      contentIdentity: marker.repeat(16),
+    }
+  })
+  const localTarget = targets.find((target) => (
+    target.platform === localPlatform && target.arch === localArch
+  ))
+  if (!localTarget) throw new Error(`Remote smoke did not synthesize local target ${localPlatform}-${localArch}`)
+  const manifest = {
+    schemaVersion: 1,
+    channel: 'dev',
+    repository: 'TraderAlice/OpenAlice',
+    version: metadata.version,
+    commit: run('git', ['rev-parse', 'HEAD'], { cwd: repoRoot }).trim(),
+    installer: {
+      url: 'http://127.0.0.1:18080/install',
+      versionedUrl: 'http://127.0.0.1:18080/install',
+      sha256: '3'.repeat(64),
+    },
+    targets,
+  }
+  const installSourcePath = join(scratchRoot, 'local-dev-install-source.json')
+  await writeFile(installSourcePath, `${JSON.stringify({
+    schemaVersion: 3,
+    repository: 'TraderAlice/OpenAlice',
+    cliVersion: metadata.version,
+    selector: { kind: 'branch', value: 'dev' },
+    installerUrl: 'http://127.0.0.1:18080/install',
+    updateChannel: 'development',
+    method: 'direct',
+    artifact: {
+      platform: localTarget.platform,
+      arch: localTarget.arch,
+      sha256: localTarget.sha256,
+    },
+    installedAt: '2026-08-31T00:00:00.000Z',
+  }, null, 2)}\n`)
+  return {
+    OPENALICE_INSTALL_SOURCE: installSourcePath,
+    OPENALICE_CONTENT_IDENTITY: localTarget.contentIdentity,
+    OPENALICE_REMOTE_TEST_DEV_MANIFEST_URL: `data:application/json;base64,${Buffer.from(JSON.stringify(manifest)).toString('base64')}`,
+  }
+}
+
+function normalizeSmokeArchitecture(value) {
+  if (value === 'aarch64' || value === 'arm64') return 'arm64'
+  if (value === 'x86_64' || value === 'amd64') return 'x64'
+  throw new Error(`Remote smoke does not support Docker architecture ${value}`)
 }
 
 async function waitForSsh(target, env) {


### PR DESCRIPTION
## Summary

- add a volume-backed Railway native CLI host with foreground Guardian supervision, fixed SSH Home/PATH, platform-owned release selection, and loopback-only remote inspection
- bind dev remote installs to the complete four-platform manifest and keep stable/beta fallback compatibility without allowing SSH lifecycle commands to mutate Railway release state
- harden AliceProject SSH transfer with Git-aware inclusion, process-private credential snapshots, destination re-sealing, exact receipts, and idempotent registration recovery

## Verification

- `bash -n install scripts/railway/*.sh`
- focused Railway/remote/transfer suite: 12 files, 222 tests
- `pnpm -F @traderalice/openalice-cli typecheck`
- `npx tsc --noEmit`
- `pnpm test`: 5,266 passed, 9 skipped
- `pnpm test:install:docker`
- `pnpm test:remote:docker --skip-tui`
- `pnpm test:guardian-recovery`
- final Railway image build and no-Node/Bun/Agent-runtime prerequisite check
- real public `v0.91.0-beta.1` bootstrap: persistent update/rollback/uninstall leave pointer, release store, and install manifest unchanged
- real Default AliceProject offline planner: 10,693 files, 222,215,071 portable bytes, 21 credential entries, 6 exact-Session Issues

No release, tag, channel promotion, public domain, or retained Railway Volume mutation is part of this PR.