### PR TITLE
fix(runtime): recover Railway volume owners across deploys

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -41,4 +41,4 @@ RUN chmod 0755 \
      done \
   && printf '\n. /etc/profile.d/openalice-railway.sh\n' >>/etc/bash.bashrc
 
-ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/openalice-railway-entrypoint"]
+ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--", "/usr/local/bin/openalice-railway-entrypoint"]

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -80,14 +80,15 @@ fallback, persistent `PATH`, and foreground Guardian startup in the image
 entrypoint.
 
 ```text
-tini (PID 1)
-└── scripts/railway/entrypoint.sh
-    └── /data/home/.openalice/bin/openalice server run
-        └── Guardian foreground tree
-            ├── Alice
-            ├── optional UTA
-            ├── optional Connector Service
-            └── user-launched external Agent Runtime processes
+Railway platform init (PID 1)
+└── tini -s -g
+    └── scripts/railway/entrypoint.sh
+        └── /data/home/.openalice/bin/openalice server run
+            └── Guardian foreground tree
+                ├── Alice
+                ├── optional UTA
+                ├── optional Connector Service
+                └── user-launched external Agent Runtime processes
 
 /opt/openalice/install       shared installer snapshot from the image source
 /data/home                   persistent user HOME
@@ -138,14 +139,30 @@ the persistent command path.
 
 The entrypoint finally `exec`s `openalice server run`; it does not launch a
 detached Server and sleep. Railway therefore observes and restarts the actual
-Guardian service process, while `tini -g` forwards signals to the complete
-process group and reaps children. The shared installer serializes mutations
+Guardian service process. Railway places its platform init at PID 1, so the
+image runs `tini -s -g` as a child subreaper: it forwards signals to the
+complete process group and adopts/reaps orphaned descendants even though it is
+not PID 1. The shared installer serializes mutations
 with the platform kernel (`lockf` on macOS, `flock` on Linux); its persistent
 guard inode contains no Project or credential data, and hard process death
 releases ownership automatically.
 Alice stays on loopback port `47331` (or the explicit
 `OPENALICE_RAILWAY_PORT`), and this profile does not consume Railway's public
 `PORT` contract.
+
+Every Railway shell and service process derives one exact machine identity
+from `RAILWAY_SERVICE_ID`; a conflicting configured identity fails startup.
+Within one container, Runtime ownership still uses PID and process-start-time
+identity. Across replacement-container PID namespaces on the same service
+Volume, it never probes or signals the recorded PID: a fresh, explicit
+heartbeat remains authoritative, while a stale explicit heartbeat may be
+reclaimed atomically. Missing, invalid, or foreign identity/heartbeat evidence
+fails closed. The image-owned entrypoint alone waits for this handoff before
+preparing or spawning Guardian; ordinary SSH commands do not inherit that
+privilege. Keep `OPENALICE_RAILWAY_WAIT_SECONDS` at 130 or higher (180 by
+default). The same value separately bounds owner release and Runtime readiness;
+for custom draining use at least `draining seconds + 100`, so the stale-heartbeat
+window retains a bounded margin.
 
 Agent Runtime installation remains a user action performed through Railway
 SSH. Persistent locations `/data/home/.local/bin` and `/data/home/.bun/bin` are
@@ -161,6 +178,9 @@ Local contract checks for this profile are:
 bash -n scripts/railway/*.sh
 pnpm exec vitest run \
   scripts/railway-entrypoint.spec.ts \
+  packages/guardian-runtime/src/runtime-lock.spec.ts \
+  packages/cli/src/lifecycle.spec.mjs \
+  packages/cli/src/server-control.spec.mjs \
   packages/cli/src/remote.spec.mjs \
   packages/cli/src/project-transfer.spec.ts \
   packages/cli/src/project-transfer-ssh.spec.ts \
@@ -184,6 +204,11 @@ self-contained repository connectivity, fail-closed linked/nested/submodule or
 external-object state, known Alice backup/session/install exclusions,
 credential omission and resealing, receipt validation, and safe handling of
 absolute or escaping symlinks.
+Runtime ownership tests must also cover same-container PID identity,
+legacy-to-stable Railway service identity handoff, fresh-versus-stale explicit
+heartbeats across container namespaces, missing/invalid evidence that remains
+blocked, entrypoint-only bounded waiting, and a proof that no cross-container
+PID receives a signal.
 
 A real Railway acceptance is still required before treating the profile as a
 usable hosted product. Keep the clean-bootstrap and retained-data journeys

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -54,6 +54,17 @@ export async function startRuntime(options, dependencies = {}) {
   const readStatus = dependencies.readStatus ?? readRuntimeStatus
   const activation = await resolveActivationContext(env, dependencies)
   let status = await readStatus({ homeRoot, timeoutMs: 1_000 }, dependencies)
+  if (
+    isRailwayForegroundRuntime(env)
+    && status.class !== 'absent'
+    && !options.takeover
+  ) {
+    status = await waitForRuntimeRelease(homeRoot, options.waitMs, {
+      ...dependencies,
+      readStatus,
+      initialStatus: status,
+    })
+  }
 
   if (status.owner?.surface === 'cli-server' && status.class === 'running') {
     status = await reconcileActivation(status, activation, dependencies)
@@ -121,6 +132,7 @@ export async function startRuntime(options, dependencies = {}) {
     port: options.port,
     takeover: options.takeover,
   })
+  delete runtimeEnv.OPENALICE_RAILWAY_ENTRYPOINT_OWNER
   runtimeEnv.OPENALICE_LAUNCHER = 'cli-server'
   runtimeEnv.OPENALICE_SERVER_MODE = detached ? 'detached' : 'foreground'
   runtimeEnv.OPENALICE_RUNTIME_PROVIDER = runtimeProvider.kind
@@ -395,6 +407,39 @@ async function waitForRuntimeReady(homeRoot, timeoutMs, dependencies) {
     'ETIMEDOUT',
     `OpenAlice Runtime did not become ready within ${Math.ceil(timeoutMs / 1_000)}s (${lastStatus?.class ?? 'no status'})`,
   )
+}
+
+async function waitForRuntimeRelease(homeRoot, timeoutMs, dependencies) {
+  const readStatus = dependencies.readStatus ?? readRuntimeStatus
+  const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
+  const deadline = Date.now() + timeoutMs
+  let lastStatus = dependencies.initialStatus ?? null
+  while (true) {
+    if (lastStatus?.class === 'absent') return lastStatus
+    let remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
+    await sleep(Math.min(500, remainingMs))
+    remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
+    lastStatus = await readStatus({
+      homeRoot,
+      timeoutMs: Math.max(1, Math.min(1_000, remainingMs)),
+    }, dependencies)
+    if (lastStatus.class === 'absent') return lastStatus
+  }
+  throw lifecycleError(
+    'ETIMEDOUT',
+    `Railway did not release the previous Runtime volume owner within ${Math.ceil(timeoutMs / 1_000)}s (${lastStatus?.class ?? 'no status'}). Keep one replica, Restart Policy Always, and at least 30 seconds of deployment draining.`,
+  )
+}
+
+function isRailwayForegroundRuntime(env) {
+  const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
+  return env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER'] === '1'
+    && env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway'
+    && Boolean(env['RAILWAY_ENVIRONMENT_ID']?.trim())
+    && /^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
+    && env['OPENALICE_MACHINE_ID']?.trim() === `railway-service-${serviceId}`
 }
 
 async function sleepOrAbort(ms, sleep, signal) {

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -492,7 +492,13 @@ describe('OpenAlice Runtime lifecycle core', () => {
 
     await expect(startRuntime({ ...startOptions(), takeover: true }, {
       detached: true,
-      env: {},
+      env: {
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
       nodeBinary: '/test/node',
       resolveRoot: async (path) => path,
       prepareSource: async () => ({ prepared: false }),
@@ -521,6 +527,101 @@ describe('OpenAlice Runtime lifecycle core', () => {
       code: 'EOWNED',
       message: expect.stringContaining('electron already owns'),
     })
+  })
+
+  it('waits for Railway entrypoint ownership handoff before spawning the foreground Runtime', async () => {
+    const child = new FakeChild()
+    const previousOwner = {
+      ...runningStatus(),
+      class: 'owned_elsewhere',
+      endpoints: {},
+      capabilities: [],
+    }
+    const readStatus = vi.fn()
+      .mockResolvedValueOnce(previousOwner)
+      .mockResolvedValueOnce(absentStatus())
+      .mockResolvedValue(runningStatus())
+    const spawnProcess = vi.fn(() => child)
+
+    await expect(startRuntime(startOptions(), {
+      detached: false,
+      env: {
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess,
+      readStatus,
+      sleep: async () => undefined,
+      emit(event) {
+        if (event.type === 'ready') child.emit('exit', 0, null)
+      },
+    })).resolves.toEqual(expect.objectContaining({ outcome: 'exited', exitCode: 0 }))
+
+    expect(readStatus).toHaveBeenCalledTimes(3)
+    const spawnedEnvironment = spawnProcess.mock.calls[0][2].env
+    expect(spawnedEnvironment).not.toHaveProperty('OPENALICE_RAILWAY_ENTRYPOINT_OWNER')
+  })
+
+  it('does not grant Railway entrypoint handoff behavior to ordinary SSH commands', async () => {
+    const sleep = vi.fn(async () => undefined)
+    await expect(startRuntime(startOptions(), {
+      detached: true,
+      env: {
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      readStatus: async () => ({
+        ...runningStatus(),
+        class: 'owned_elsewhere',
+        owner: { ...runningStatus().owner, surface: 'cli-server' },
+      }),
+      sleep,
+    })).rejects.toMatchObject({ code: 'EOWNED' })
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('times out Railway entrypoint handoff before preparation or spawn', async () => {
+    const previousOwner = {
+      ...runningStatus(),
+      class: 'owned_elsewhere',
+      endpoints: {},
+      capabilities: [],
+    }
+    const resolveRoot = vi.fn(async (path) => path)
+    const prepareSource = vi.fn(async () => ({ prepared: false }))
+    const spawnProcess = vi.fn(() => new FakeChild())
+    const emit = vi.fn()
+
+    await expect(startRuntime({ ...startOptions(), waitMs: 10 }, {
+      detached: false,
+      env: {
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      readStatus: async () => previousOwner,
+      resolveRoot,
+      prepareSource,
+      spawnProcess,
+      emit,
+    })).rejects.toMatchObject({
+      code: 'ETIMEDOUT',
+      message: expect.stringContaining('(owned_elsewhere)'),
+    })
+    expect(resolveRoot).not.toHaveBeenCalled()
+    expect(prepareSource).not.toHaveBeenCalled()
+    expect(spawnProcess).not.toHaveBeenCalled()
+    expect(emit).not.toHaveBeenCalled()
   })
 
   it('opens only a verified advertised Web endpoint, including Electron ownership', async () => {

--- a/packages/cli/src/server-control.mjs
+++ b/packages/cli/src/server-control.mjs
@@ -14,6 +14,7 @@ export const GUARDIAN_CONTROL_PROTOCOL = 1
 export const GUARDIAN_CONTROL_API_VERSION = 1
 const MAX_RESPONSE_BYTES = 1024 * 1024
 const MAX_UPTIME_SECONDS = 10 * 365 * 24 * 60 * 60
+const RUNTIME_OWNER_STALE_HEARTBEAT_MS = 90_000
 
 export function resolveOpenAliceHome(homeRoot, options = {}) {
   const env = options.env ?? process.env
@@ -312,10 +313,11 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
     resolve(homeRoot, 'state', 'runtime.lock', 'owner.json'),
     resolve(homeRoot, 'workspaces', 'state', 'runtime.lock', 'owner.json'),
   ]
+  const env = options.env ?? process.env
   const localHostname = options.hostname ?? hostname()
   const isAlive = options.isProcessAlive ?? isProcessAlive
   const machineId = options.readMachineId ?? (() => readMachineId({
-    env: options.env,
+    env,
     hostname: localHostname,
     platform: options.platform,
   }))
@@ -346,13 +348,27 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
         detail: `Runtime owner metadata is invalid at ${ownerPath}`,
       }
     }
-    const sameMachine = typeof owner.machineId === 'string' && owner.machineId
-      ? owner.machineId === await currentMachineId()
-      : typeof owner.hostname !== 'string' || owner.hostname === localHostname
-    const active = !sameMachine || await isSameProcess(owner, {
-      isAlive,
-      processStartedAt,
-    })
+    const resolvedMachineId = await currentMachineId()
+    const railwayScope = railwayOwnerScope(owner, resolvedMachineId, localHostname, env)
+    let active
+    if (railwayScope === 'cross-container') {
+      const heartbeatAt = typeof owner.heartbeatAt === 'string'
+        ? Date.parse(owner.heartbeatAt)
+        : Number.NaN
+      active = !Number.isFinite(heartbeatAt)
+        || Math.max(0, Date.now() - heartbeatAt) <= RUNTIME_OWNER_STALE_HEARTBEAT_MS
+    } else if (railwayScope === 'foreign') {
+      active = true
+    } else {
+      const sameMachine = railwayScope === 'same-container'
+        || (typeof owner.machineId === 'string' && owner.machineId
+          ? owner.machineId === resolvedMachineId
+          : typeof owner.hostname !== 'string' || owner.hostname === localHostname)
+      active = !sameMachine || await isSameProcess(owner, {
+        isAlive,
+        processStartedAt,
+      })
+    }
     const publicOwner = {
       surface: owner.launcher.startsWith('guardian-')
         ? owner.launcher.slice('guardian-'.length)
@@ -372,6 +388,27 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
         detail: 'A stale Runtime owner record is present; the next start may recover it',
       }
     : null
+}
+
+function railwayOwnerScope(owner, currentMachineId, localHostname, env) {
+  const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
+  const environmentId = env['RAILWAY_ENVIRONMENT_ID']?.trim()
+  const configuredMachineId = env['OPENALICE_MACHINE_ID']?.trim()
+  const expectedMachineId = `railway-service-${serviceId}`
+  if (
+    env['OPENALICE_SERVICE_MANAGER']?.trim() !== 'railway'
+    || !environmentId
+    || !/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
+    || configuredMachineId !== expectedMachineId
+    || currentMachineId !== `env:${expectedMachineId}`
+  ) {
+    return null
+  }
+  if (typeof owner.hostname !== 'string' || owner.hostname.length === 0) return 'foreign'
+  const belongsToService = owner.machineId === currentMachineId
+    || owner.machineId === `hostname:${owner.hostname}`
+  if (!belongsToService) return 'foreign'
+  return owner.hostname === localHostname ? 'same-container' : 'cross-container'
 }
 
 async function isSameProcess(owner, dependencies) {

--- a/packages/cli/src/server-control.spec.mjs
+++ b/packages/cli/src/server-control.spec.mjs
@@ -258,6 +258,150 @@ describe('OpenAlice Guardian control protocol', () => {
     expect(readProcessStartedAt).not.toHaveBeenCalled()
   })
 
+  it('uses heartbeat authority across Railway container namespaces', async () => {
+    const env = {
+      OPENALICE_SERVICE_MANAGER: 'railway',
+      OPENALICE_MACHINE_ID: 'railway-service-service-test',
+      RAILWAY_ENVIRONMENT_ID: 'environment-test',
+      RAILWAY_SERVICE_ID: 'service-test',
+    }
+    for (const [index, machineId] of [
+      'hostname:prior-container',
+      'env:railway-service-service-test',
+    ].entries()) {
+      const home = await makeTempDir()
+      const lock = join(home, 'state', 'guardian.lock')
+      await mkdir(lock, { recursive: true })
+      const ownerPath = join(lock, 'owner.json')
+      const owner = {
+        pid: 4242,
+        hostname: 'prior-container',
+        machineId,
+        launcher: 'guardian-cli-server',
+        acquiredAt: new Date().toISOString(),
+        heartbeatAt: new Date().toISOString(),
+      }
+      await writeFile(ownerPath, JSON.stringify(owner))
+      const isProcessAlive = vi.fn(() => false)
+
+      const active = await readRuntimeStatus({ homeRoot: home }, {
+        env,
+        hostname: `current-container-${index}`,
+        isProcessAlive,
+      })
+      expect(active.class).toBe('owned_elsewhere')
+      expect(isProcessAlive).not.toHaveBeenCalled()
+
+      await writeFile(ownerPath, JSON.stringify({
+        ...owner,
+        heartbeatAt: new Date(0).toISOString(),
+      }))
+      const stale = await readRuntimeStatus({ homeRoot: home }, {
+        env,
+        hostname: `current-container-${index}`,
+        isProcessAlive,
+      })
+      expect(stale.class).toBe('absent')
+      expect(stale.detail).toContain('stale')
+      expect(isProcessAlive).not.toHaveBeenCalled()
+    }
+  })
+
+  it('keeps same-container PID identity authoritative under Railway', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: 4242,
+      hostname: 'current-container',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date(0).toISOString(),
+      heartbeatAt: new Date(0).toISOString(),
+      processStartedAt: '2026-07-15T00:00:00.000Z',
+    }))
+    const isProcessAlive = vi.fn(() => true)
+    const readProcessStartedAt = vi.fn(async () => Date.parse('2026-07-15T00:00:00.000Z'))
+
+    const status = await readRuntimeStatus({ homeRoot: home }, {
+      env: {
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      hostname: 'current-container',
+      isProcessAlive,
+      readProcessStartedAt,
+    })
+
+    expect(status.class).toBe('owned_elsewhere')
+    expect(isProcessAlive).toHaveBeenCalledWith(4242)
+    expect(readProcessStartedAt).toHaveBeenCalledWith(4242)
+  })
+
+  it('keeps missing or foreign Railway owner identity fail closed', async () => {
+    const env = {
+      OPENALICE_SERVICE_MANAGER: 'railway',
+      OPENALICE_MACHINE_ID: 'railway-service-service-test',
+      RAILWAY_ENVIRONMENT_ID: 'environment-test',
+      RAILWAY_SERVICE_ID: 'service-test',
+    }
+    for (const [index, machineId] of [undefined, 'env:railway-service-other'].entries()) {
+      const home = await makeTempDir()
+      const lock = join(home, 'state', 'guardian.lock')
+      await mkdir(lock, { recursive: true })
+      await writeFile(join(lock, 'owner.json'), JSON.stringify({
+        pid: 4242,
+        hostname: `foreign-container-${index}`,
+        ...(machineId ? { machineId } : {}),
+        launcher: 'guardian-cli-server',
+        acquiredAt: new Date(0).toISOString(),
+        heartbeatAt: new Date(0).toISOString(),
+      }))
+      const isProcessAlive = vi.fn(() => false)
+
+      const status = await readRuntimeStatus({ homeRoot: home }, {
+        env,
+        hostname: 'current-container',
+        isProcessAlive,
+      })
+      expect(status.class).toBe('owned_elsewhere')
+      expect(isProcessAlive).not.toHaveBeenCalled()
+    }
+  })
+
+  it('keeps missing or invalid Railway heartbeats fail closed', async () => {
+    const env = {
+      OPENALICE_SERVICE_MANAGER: 'railway',
+      OPENALICE_MACHINE_ID: 'railway-service-service-test',
+      RAILWAY_ENVIRONMENT_ID: 'environment-test',
+      RAILWAY_SERVICE_ID: 'service-test',
+    }
+    for (const [index, heartbeatAt] of [undefined, 'not-a-date', 0].entries()) {
+      const home = await makeTempDir()
+      const lock = join(home, 'state', 'guardian.lock')
+      await mkdir(lock, { recursive: true })
+      await writeFile(join(lock, 'owner.json'), JSON.stringify({
+        pid: 4242,
+        hostname: `prior-container-${index}`,
+        machineId: 'env:railway-service-service-test',
+        launcher: 'guardian-cli-server',
+        acquiredAt: new Date(0).toISOString(),
+        ...(heartbeatAt === undefined ? {} : { heartbeatAt }),
+      }))
+      const isProcessAlive = vi.fn(() => false)
+
+      const status = await readRuntimeStatus({ homeRoot: home }, {
+        env,
+        hostname: 'current-container',
+        isProcessAlive,
+      })
+      expect(status.class).toBe('owned_elsewhere')
+      expect(isProcessAlive).not.toHaveBeenCalled()
+    }
+  })
+
   it('keeps the same process active but treats a reused PID as stale', async () => {
     const home = await makeTempDir()
     const lock = join(home, 'state', 'guardian.lock')

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { hostname, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -12,6 +12,7 @@ import {
   acquireRuntimeLock,
   inspectRuntimeLock,
   prepareOpenAliceRuntime,
+  resolveRuntimeLockOwnerAuthority,
   runtimeLockDir,
 } from './runtime-lock.js'
 
@@ -64,6 +65,21 @@ afterEach(async () => {
 })
 
 describe('runtime lock ownership', () => {
+  it('enables Railway volume authority only for the exact platform service identity', () => {
+    expect(resolveRuntimeLockOwnerAuthority({
+      OPENALICE_SERVICE_MANAGER: 'railway',
+      OPENALICE_MACHINE_ID: 'railway-service-service-test',
+      RAILWAY_ENVIRONMENT_ID: 'environment-test',
+      RAILWAY_SERVICE_ID: 'service-test',
+    })).toBe('railway-volume')
+    expect(resolveRuntimeLockOwnerAuthority({
+      OPENALICE_SERVICE_MANAGER: 'railway',
+      OPENALICE_MACHINE_ID: 'railway-service-other',
+      RAILWAY_ENVIRONMENT_ID: 'environment-test',
+      RAILWAY_SERVICE_ID: 'service-test',
+    })).toBe('process')
+  })
+
   it('publishes inspectable owner metadata and releases cleanly', async () => {
     controller.add(101, 10_000)
     const lockDir = join(home, 'runtime.lock')
@@ -182,6 +198,162 @@ describe('runtime lock ownership', () => {
       processController: controller,
     })).rejects.toThrow(/another machine/)
     expect(controller.signals).toEqual([])
+  })
+
+  it('uses heartbeat authority for fresh and stale owners in another Railway container', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    controller.add(202, 20_000)
+
+    for (const [index, machineId] of [
+      'hostname:legacy-container',
+      'env:railway-service-service-test',
+    ].entries()) {
+      const lockDir = join(home, `railway-runtime-${index}.lock`)
+      const owner = {
+        schemaVersion: 1,
+        pid: 101,
+        hostname: 'legacy-container',
+        machineId,
+        token: `owner-${index}`,
+        launcher: 'guardian-cli-server',
+        acquiredAt: new Date().toISOString(),
+        heartbeatAt: new Date().toISOString(),
+        processStartedAt: new Date(10_000).toISOString(),
+      }
+      await mkdir(lockDir)
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify(owner))
+
+      await expect(inspectRuntimeLock(lockDir, {
+        ownerAuthority: 'railway-volume',
+        processController: controller,
+      })).resolves.toMatchObject({
+        state: 'active',
+        reason: expect.stringContaining('another container namespace'),
+      })
+
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+        ...owner,
+        heartbeatAt: new Date(0).toISOString(),
+      }))
+      const fresh = await acquireRuntimeLock(lockDir, {
+        pid: 202,
+        processStartedAt: 20_000,
+        ownerAuthority: 'railway-volume',
+        heartbeatMs: 0,
+        processController: controller,
+      })
+      expect(fresh.owner.pid).toBe(202)
+      await fresh.release()
+    }
+  })
+
+  it('never signals a fresh owner in another Railway container during takeover', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    controller.add(202, 20_000)
+    const lockDir = join(home, 'railway-runtime.lock')
+    await mkdir(lockDir)
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 202,
+      hostname: 'prior-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'prior-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      processStartedAt: new Date(20_000).toISOString(),
+    }))
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 303,
+      processStartedAt: 30_000,
+      ownerAuthority: 'railway-volume',
+      takeover: true,
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toThrow(/another Railway container/)
+    expect(controller.signals).toEqual([])
+  })
+
+  it('keeps same-container PID identity authoritative on Railway', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'railway-same-container.lock')
+    await mkdir(lockDir)
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 101,
+      hostname: hostname(),
+      machineId: 'env:railway-service-service-test',
+      token: 'same-container-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date(0).toISOString(),
+      heartbeatAt: new Date(0).toISOString(),
+      processStartedAt: new Date(10_000).toISOString(),
+    }))
+
+    await expect(inspectRuntimeLock(lockDir, {
+      ownerAuthority: 'railway-volume',
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'active',
+      reason: 'owner process is alive but its heartbeat is stale',
+    })
+  })
+
+  it('keeps missing or foreign Railway identity fail closed', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    for (const [index, machineId] of [undefined, 'env:railway-service-other'].entries()) {
+      const lockDir = join(home, `railway-foreign-${index}.lock`)
+      await mkdir(lockDir)
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+        schemaVersion: 1,
+        pid: 101,
+        hostname: 'foreign-container',
+        ...(machineId ? { machineId } : {}),
+        token: `foreign-${index}`,
+        launcher: 'guardian-cli-server',
+        acquiredAt: new Date(0).toISOString(),
+        heartbeatAt: new Date(0).toISOString(),
+      }))
+
+      await expect(inspectRuntimeLock(lockDir, {
+        ownerAuthority: 'railway-volume',
+        processController: controller,
+        staleHeartbeatMs: -1,
+      })).resolves.toMatchObject({
+        state: 'active',
+        reason: expect.stringContaining('does not belong to this Railway service'),
+      })
+    }
+  })
+
+  it('keeps missing or invalid Railway heartbeats fail closed', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    for (const [index, heartbeatAt] of [undefined, 'not-a-date', 0].entries()) {
+      const lockDir = join(home, `railway-heartbeat-${index}.lock`)
+      await mkdir(lockDir)
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+        schemaVersion: 1,
+        pid: 101,
+        hostname: 'prior-container',
+        machineId: 'env:railway-service-service-test',
+        token: `owner-${index}`,
+        launcher: 'guardian-cli-server',
+        acquiredAt: new Date(0).toISOString(),
+        ...(heartbeatAt === undefined ? {} : { heartbeatAt }),
+      }))
+
+      await expect(inspectRuntimeLock(lockDir, {
+        ownerAuthority: 'railway-volume',
+        processController: controller,
+        staleHeartbeatMs: -1,
+      })).resolves.toMatchObject({
+        state: 'active',
+        reason: expect.stringContaining('missing or invalid'),
+      })
+    }
   })
 
   it('performs a controlled takeover before acquiring the lock', async () => {

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -59,9 +59,12 @@ export interface RuntimeLockOptions {
   readonly heartbeatMs?: number
   readonly staleHeartbeatMs?: number
   readonly initializationGraceMs?: number
+  readonly ownerAuthority?: RuntimeLockOwnerAuthority
   readonly processController?: ProcessController
   readonly onOwnershipLost?: (error: Error) => void
 }
+
+export type RuntimeLockOwnerAuthority = 'process' | 'railway-volume'
 
 export interface OpenAliceRuntimeOptions extends RuntimeLockOptions {
   readonly userDataHome: string
@@ -80,6 +83,7 @@ export interface PrepareOpenAliceRuntimeOptions {
   readonly userDataHome: string
   readonly launcherRoot: string
   readonly takeover?: boolean
+  readonly ownerAuthority?: RuntimeLockOwnerAuthority
   readonly processController?: ProcessController
   readonly staleHeartbeatMs?: number
   readonly initializationGraceMs?: number
@@ -119,9 +123,24 @@ export function takeoverRequested(env: NodeJS.ProcessEnv = process.env, argv: re
   return /^(1|true|yes|on)$/i.test(env['OPENALICE_TAKEOVER']?.trim() ?? '')
 }
 
+export function resolveRuntimeLockOwnerAuthority(
+  env: NodeJS.ProcessEnv = process.env,
+): RuntimeLockOwnerAuthority {
+  const serviceManager = env['OPENALICE_SERVICE_MANAGER']?.trim()
+  const machineId = env['OPENALICE_MACHINE_ID']?.trim()
+  const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
+  const environmentId = env['RAILWAY_ENVIRONMENT_ID']?.trim()
+  return serviceManager === 'railway'
+    && Boolean(environmentId)
+    && /^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
+    && machineId === `railway-service-${serviceId}`
+    ? 'railway-volume'
+    : 'process'
+}
+
 export async function inspectRuntimeLock(
   lockDir: string,
-  opts: Pick<RuntimeLockOptions, 'processController' | 'staleHeartbeatMs' | 'initializationGraceMs'> = {},
+  opts: Pick<RuntimeLockOptions, 'processController' | 'staleHeartbeatMs' | 'initializationGraceMs' | 'ownerAuthority'> = {},
 ): Promise<RuntimeLockInspection> {
   const controller = opts.processController ?? defaultProcessController
   const staleMs = opts.staleHeartbeatMs ?? DEFAULT_STALE_HEARTBEAT_MS
@@ -136,8 +155,11 @@ export async function inspectRuntimeLock(
   const directoryIdentity = `${lockStat.dev}:${lockStat.ino}:${lockStat.birthtimeMs}`
   const ageMs = Math.max(0, Date.now() - lockStat.mtimeMs)
   let owner: RuntimeLockOwner
+  let hasExplicitHeartbeat: boolean
   try {
-    owner = await readOwner(lockDir)
+    const parsedOwner = await readOwnerRecord(lockDir)
+    owner = parsedOwner.owner
+    hasExplicitHeartbeat = parsedOwner.hasExplicitHeartbeat
   } catch {
     if (ageMs < initGraceMs) {
       return inspection(lockDir, 'initializing', null, null, false, directoryIdentity, 'owner metadata is still being published')
@@ -148,7 +170,45 @@ export async function inspectRuntimeLock(
   const heartbeatAt = Date.parse(owner.heartbeatAt)
   const heartbeatAgeMs = Number.isFinite(heartbeatAt) ? Math.max(0, Date.now() - heartbeatAt) : null
   const heartbeatStale = heartbeatAgeMs === null || heartbeatAgeMs > staleMs
-  if (owner.machineId && owner.machineId !== await controller.machineId()) {
+  const currentMachineId = await controller.machineId()
+  const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
+  const railwayScope = railwayOwnerScope(owner, currentMachineId, ownerAuthority)
+  if (railwayScope === 'cross-container') {
+    if (hasExplicitHeartbeat && heartbeatAgeMs !== null && heartbeatStale) {
+      return inspection(
+        lockDir,
+        'stale',
+        owner,
+        heartbeatAgeMs,
+        true,
+        directoryIdentity,
+        'Railway volume owner heartbeat is stale and eligible for orchestrator handoff',
+      )
+    }
+    return inspection(
+      lockDir,
+      'active',
+      owner,
+      heartbeatAgeMs,
+      heartbeatStale,
+      directoryIdentity,
+      !hasExplicitHeartbeat || heartbeatAgeMs === null
+        ? 'Railway volume owner heartbeat is missing or invalid; refusing automatic recovery'
+        : 'Railway volume owner heartbeat is active in another container namespace',
+    )
+  }
+  if (railwayScope === 'foreign') {
+    return inspection(
+      lockDir,
+      'active',
+      owner,
+      heartbeatAgeMs,
+      heartbeatStale,
+      directoryIdentity,
+      'owner does not belong to this Railway service; refusing automatic recovery',
+    )
+  }
+  if (owner.machineId && owner.machineId !== currentMachineId && railwayScope !== 'same-container') {
     return inspection(
       lockDir,
       'active',
@@ -178,11 +238,28 @@ export async function inspectRuntimeLock(
   )
 }
 
+function railwayOwnerScope(
+  owner: RuntimeLockOwner,
+  currentMachineId: string,
+  ownerAuthority: RuntimeLockOwnerAuthority | undefined,
+): 'same-container' | 'cross-container' | 'foreign' | null {
+  if (ownerAuthority !== 'railway-volume') return null
+  if (!/^env:railway-service-[A-Za-z0-9-]+$/.test(currentMachineId)) return 'foreign'
+  if (owner.hostname.length === 0) return 'foreign'
+  const sameContainer = owner.hostname === hostname()
+  const belongsToService = owner.machineId === currentMachineId
+    || owner.machineId === `hostname:${owner.hostname}`
+  if (sameContainer && belongsToService) return 'same-container'
+  if (belongsToService) return 'cross-container'
+  return 'foreign'
+}
+
 export async function acquireRuntimeLock(
   lockDir: string,
   opts: RuntimeLockOptions = {},
 ): Promise<RuntimeProcessLock> {
   const controller = opts.processController ?? defaultProcessController
+  const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
   const processStartedAt = opts.processStartedAt ?? currentProcessStartedAt()
   const machineId = await controller.machineId()
   const now = new Date().toISOString()
@@ -205,19 +282,22 @@ export async function acquireRuntimeLock(
     try {
       await mkdir(lockDir)
       await writeOwnerAtomic(lockDir, owner, controller)
-      return makeLock(lockDir, owner, opts)
+      return makeLock(lockDir, owner, { ...opts, ownerAuthority })
     } catch (err) {
       if (!isErrno(err, 'EEXIST')) throw err
     }
 
-    const current = await inspectRuntimeLock(lockDir, opts)
+    const current = await inspectRuntimeLock(lockDir, { ...opts, ownerAuthority })
     if (current.state === 'missing' || current.state === 'initializing') {
       await controller.sleep(25)
       continue
     }
     if (current.state === 'active') {
       if (!opts.takeover || !current.owner) throw new RuntimeAlreadyRunningError(current)
-      await recoverRuntimeOwner(current.owner, { processController: controller })
+      await recoverRuntimeOwner(current.owner, {
+        processController: controller,
+        ownerAuthority,
+      })
       await controller.sleep(25)
       continue
     }
@@ -226,7 +306,7 @@ export async function acquireRuntimeLock(
     await controller.sleep(25)
   }
 
-  throw new RuntimeAlreadyRunningError(await inspectRuntimeLock(lockDir, opts))
+  throw new RuntimeAlreadyRunningError(await inspectRuntimeLock(lockDir, { ...opts, ownerAuthority }))
 }
 
 export async function acquireOpenAliceRuntimeLocks(opts: OpenAliceRuntimeOptions): Promise<OpenAliceRuntimeLock> {
@@ -285,17 +365,32 @@ export async function prepareOpenAliceRuntime(opts: PrepareOpenAliceRuntimeOptio
   const active = dedupeOwners(inspections.filter((row) => row.state === 'active' && row.owner !== null))
   if (active.length > 0 && !opts.takeover) throw new RuntimeAlreadyRunningError(active[0]!)
   for (const row of active) {
-    await recoverRuntimeOwner(row.owner!, { processController: opts.processController })
+    await recoverRuntimeOwner(row.owner!, {
+      processController: opts.processController,
+      ownerAuthority: opts.ownerAuthority,
+    })
   }
   return inspections
 }
 
 export async function recoverRuntimeOwner(
   owner: RuntimeLockOwner,
-  opts: { readonly processController?: ProcessController } = {},
+  opts: {
+    readonly processController?: ProcessController
+    readonly ownerAuthority?: RuntimeLockOwnerAuthority
+  } = {},
 ): Promise<void> {
   const controller = opts.processController ?? defaultProcessController
-  if (owner.machineId && owner.machineId !== await controller.machineId()) {
+  const currentMachineId = await controller.machineId()
+  const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
+  const railwayScope = railwayOwnerScope(owner, currentMachineId, ownerAuthority)
+  if (railwayScope === 'cross-container') {
+    throw new Error(`OpenAlice owner ${owner.pid} belongs to another Railway container; refusing to signal it`)
+  }
+  if (railwayScope === 'foreign') {
+    throw new Error(`OpenAlice owner ${owner.pid} does not belong to this Railway service; refusing to signal it`)
+  }
+  if (owner.machineId && owner.machineId !== currentMachineId && railwayScope !== 'same-container') {
     throw new Error(`OpenAlice owner ${owner.pid} belongs to another machine; refusing to signal it`)
   }
   if (!controller.isAlive(owner.pid)) return
@@ -428,7 +523,12 @@ function isTransientWindowsRenameError(error: unknown): boolean {
   return isErrno(error, 'EPERM') || isErrno(error, 'EACCES') || isErrno(error, 'EBUSY')
 }
 
-async function readOwner(lockDir: string): Promise<RuntimeLockOwner> {
+interface ParsedRuntimeLockOwner {
+  readonly owner: RuntimeLockOwner
+  readonly hasExplicitHeartbeat: boolean
+}
+
+async function readOwnerRecord(lockDir: string): Promise<ParsedRuntimeLockOwner> {
   const parsed = JSON.parse(await readFile(join(lockDir, OWNER_FILE), 'utf8')) as Record<string, unknown>
   if (
     typeof parsed['pid'] !== 'number' ||
@@ -438,19 +538,27 @@ async function readOwner(lockDir: string): Promise<RuntimeLockOwner> {
   ) throw new Error('invalid runtime lock owner')
 
   const acquiredAt = parsed['acquiredAt']
+  const hasExplicitHeartbeat = typeof parsed['heartbeatAt'] === 'string'
   return {
-    schemaVersion: 1,
-    pid: parsed['pid'],
-    hostname: parsed['hostname'],
-    ...(typeof parsed['machineId'] === 'string' ? { machineId: parsed['machineId'] } : {}),
-    token: parsed['token'],
-    launcher: typeof parsed['launcher'] === 'string' ? parsed['launcher'] : 'legacy',
-    acquiredAt,
-    heartbeatAt: typeof parsed['heartbeatAt'] === 'string' ? parsed['heartbeatAt'] : acquiredAt,
-    ...(typeof parsed['processStartedAt'] === 'string' ? { processStartedAt: parsed['processStartedAt'] } : {}),
-    ...(typeof parsed['guardianPid'] === 'number' ? { guardianPid: parsed['guardianPid'] } : {}),
-    ...(typeof parsed['guardianStartedAt'] === 'string' ? { guardianStartedAt: parsed['guardianStartedAt'] } : {}),
+    hasExplicitHeartbeat,
+    owner: {
+      schemaVersion: 1,
+      pid: parsed['pid'],
+      hostname: parsed['hostname'],
+      ...(typeof parsed['machineId'] === 'string' ? { machineId: parsed['machineId'] } : {}),
+      token: parsed['token'],
+      launcher: typeof parsed['launcher'] === 'string' ? parsed['launcher'] : 'legacy',
+      acquiredAt,
+      heartbeatAt: hasExplicitHeartbeat ? parsed['heartbeatAt'] as string : acquiredAt,
+      ...(typeof parsed['processStartedAt'] === 'string' ? { processStartedAt: parsed['processStartedAt'] } : {}),
+      ...(typeof parsed['guardianPid'] === 'number' ? { guardianPid: parsed['guardianPid'] } : {}),
+      ...(typeof parsed['guardianStartedAt'] === 'string' ? { guardianStartedAt: parsed['guardianStartedAt'] } : {}),
+    },
   }
+}
+
+async function readOwner(lockDir: string): Promise<RuntimeLockOwner> {
+  return (await readOwnerRecord(lockDir)).owner
 }
 
 function inspection(

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -654,10 +654,26 @@ source-built Docker image.
   remain excluded. Live source ownership/quiescence and remote capability,
   destination, and free-space preflight are not part of this offline evidence.
 - [x] Rerun the hard-kill container replacement after the stale-owner PID reuse
-  and CLI preflight repairs. The current dev Bun Runtime reclaimed the stale
-  lock on the same Volume, retained the Project marker, matched release content
-  without pending activation, restored the fixed SSH Home/PATH, and did not
-  acquire an Agent Runtime.
+  and CLI preflight repairs in the local Docker harness. The current dev Bun
+  Runtime reclaimed the stale lock on the same Volume, retained the Project
+  marker, matched release content without pending activation, restored the
+  fixed SSH Home/PATH, and did not acquire an Agent Runtime. This evidence did
+  not exercise Railway replacement containers with isolated PID namespaces.
+- [x] Diagnose the first retained-Volume Railway deployment failure. Its old
+  beta lock used the legacy hostname-derived machine identity, while the new
+  container correctly used the stable Railway service identity; ordinary
+  foreign-machine protection therefore left the stale owner blocked. Add the
+  Railway-volume authority needed for same-service container handoff: exact
+  service identity, explicit-heartbeat freshness, fail-closed missing/invalid
+  evidence, same-container PID authority, no cross-container signals, bounded
+  entrypoint-only waiting, and `tini` subreaper operation beneath Railway's
+  platform init. Live reacceptance remains pending a dev artifact containing
+  this repair.
+- [x] Pass the handoff-repair local gates: 83 focused ownership/CLI/entrypoint
+  tests, 5,281 full-suite tests, root/Guardian/CLI TypeScript, Guardian recovery,
+  Linux installer and SSH-remote Docker smokes, Bash syntax, and a rebuilt
+  Railway image whose `tini -s -g` entrypoint still contains no Node, Bun, or
+  Agent Runtime executable.
 - [x] Pass the remaining local repository gates: root and CLI TypeScript,
   `git diff --check`, the 222-test focused run, the 5,266-test full suite,
   Linux installer and SSH-remote Docker smokes, Guardian recovery smoke, and a
@@ -671,8 +687,11 @@ source-built Docker image.
   Serverless disabled, Restart Policy set to Always, one replica, at least 30
   seconds of draining, fixed SSH `HOME=/data/home` plus persistent user `PATH`,
   an OpenSSH alias from `railway ssh config`, and a successful inspection-only
-  `openalice remote` browser/tunnel journey. The inspected `HOME=/root` service
-  is an old deployment; the candidate has not been deployed.
+  `openalice remote` browser/tunnel journey. A beta candidate has now booted
+  successfully against an isolated diagnostic Home on the retained Volume and
+  exposed no public domain. Its first attempt against the existing Project Home
+  reproduced the legacy-machine-identity handoff failure above; redeployment
+  of the repaired dev artifact against that original Home is still required.
 - [ ] Repeat `openalice project transfer --plan` through the deployed Railway
   candidate so SSH compatibility, destination absence, and free-space
   preflight are proven before apply.
@@ -685,8 +704,10 @@ source-built Docker image.
   release artifact.
 - [ ] Restart and redeploy against the same Volume, verify install/Home/Agent
   persistence and foreground Guardian recovery, then exercise valid-release
-  refresh fallback and the separately accepted hard-kill recovery path. The
-  empty-Volume fail-closed case remains isolated to the disposable service.
+  refresh fallback and the separately accepted hard-kill recovery path,
+  including legacy hostname identity and stable service identity across
+  isolated container PID namespaces. The empty-Volume fail-closed case remains
+  isolated to the disposable service.
 
 ## Verification Matrix
 

--- a/scripts/railway-entrypoint.spec.ts
+++ b/scripts/railway-entrypoint.spec.ts
@@ -114,6 +114,41 @@ describe('Railway native CLI host entrypoint', () => {
     expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(
       'OPENALICE_MACHINE_ID=railway-service-service-test',
     )
+    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(
+      'OPENALICE_RAILWAY_ENTRYPOINT_OWNER=1',
+    )
+  })
+
+  it('rejects a configured machine identity that does not match the Railway service', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_MACHINE_ID: 'railway-service-other',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining('must match the Railway service identity'),
+    })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('requires enough Railway startup time for hard-kill heartbeat recovery', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_RAILWAY_WAIT_SECONDS: '90',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining('must be at least 130 on Railway'),
+    })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('rejects an ephemeral Railway shell home that would split SSH from the Runtime', async () => {
@@ -143,7 +178,7 @@ describe('Railway native CLI host entrypoint', () => {
     )
     expect(dockerfile).toContain('scripts/railway/command-wrapper.sh')
     expect(dockerfile).toContain('scripts/railway/shell-env.sh')
-    expect(dockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-g", "--"')
+    expect(dockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--"')
   })
 
   it('restores the persistent user environment in a Railway login shell', async () => {
@@ -157,6 +192,7 @@ describe('Railway native CLI host entrypoint', () => {
         PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         HOME: '/root',
         OPENALICE_HOME: '/data/projects/main-cloud',
+        OPENALICE_MACHINE_ID: 'railway-service-wrong',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
         RAILWAY_SERVICE_ID: 'service-test',
       },
@@ -433,8 +469,8 @@ if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then
     "$(printf '0%.0s' {1..64})" "$OPENALICE_INSTALL_DIR/cli/releases/0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa"
   exit 0
 fi
-printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\n' \\
-  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" >'${runtimeCalled}'
+printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\nOPENALICE_RAILWAY_ENTRYPOINT_OWNER=%s\\n' \\
+  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" "\${OPENALICE_RAILWAY_ENTRYPOINT_OWNER:-}" >'${runtimeCalled}'
 printf '%s\\n' "$*" >>'${runtimeCalled}'
 LAUNCHER
 chmod 0755 "$OPENALICE_INSTALL_DIR/cli/current/bin/openalice"
@@ -460,8 +496,8 @@ async function writeLauncher(
   await writeFile(join(runtimeRoot, 'bin', 'openalice'), `#!/usr/bin/env bash
 if [[ "\${1:-}" == --version ]]; then printf '${version}\\n'; exit 0; fi
 if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then printf '%s\\n' '${JSON.stringify(versionPayload(runtimeRoot, { version, channel, identity }))}'; exit 0; fi
-printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\n' \\
-  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" >'${runtimeCalled}'
+printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\nOPENALICE_RAILWAY_ENTRYPOINT_OWNER=%s\\n' \\
+  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" "\${OPENALICE_RAILWAY_ENTRYPOINT_OWNER:-}" >'${runtimeCalled}'
 printf '%s\\n' "$*" >>'${runtimeCalled}'
 `, { mode: 0o755 })
   await writeDynamicLauncher(path)

--- a/scripts/railway/command-wrapper.sh
+++ b/scripts/railway/command-wrapper.sh
@@ -27,7 +27,7 @@ if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
     printf 'openalice railway: Railway did not provide a stable service identity\n' >&2
     exit 1
   }
-  export OPENALICE_MACHINE_ID="${OPENALICE_MACHINE_ID:-railway-service-${RAILWAY_SERVICE_ID}}"
+  export OPENALICE_MACHINE_ID="railway-service-${RAILWAY_SERVICE_ID}"
 fi
 
 if [[ "${OPENALICE_SERVICE_MANAGER:-}" == railway && ( "$command_name" == openalice || "$command_name" == alice ) ]]; then

--- a/scripts/railway/entrypoint.sh
+++ b/scripts/railway/entrypoint.sh
@@ -34,7 +34,12 @@ fi
 if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
   [[ -n "${RAILWAY_SERVICE_ID:-}" ]] \
     || fail 'Railway did not provide a stable service identity'
-  export OPENALICE_MACHINE_ID="${OPENALICE_MACHINE_ID:-railway-service-${RAILWAY_SERVICE_ID}}"
+  expected_machine_id="railway-service-${RAILWAY_SERVICE_ID}"
+  if [[ -n "${OPENALICE_MACHINE_ID:-}" && "$OPENALICE_MACHINE_ID" != "$expected_machine_id" ]]; then
+    fail 'OPENALICE_MACHINE_ID must match the Railway service identity'
+  fi
+  export OPENALICE_MACHINE_ID="$expected_machine_id"
+  export OPENALICE_RAILWAY_ENTRYPOINT_OWNER=1
 fi
 
 fixed_home="$(canonical_path "$volume_root/home")"
@@ -93,6 +98,9 @@ launcher="$OPENALICE_INSTALL_DIR/bin/openalice"
   || fail 'OPENALICE_RAILWAY_PORT must be between 1 and 65535'
 [[ "$wait_seconds" =~ ^[0-9]+$ && "$wait_seconds" -ge 1 && "$wait_seconds" -le 600 ]] \
   || fail 'OPENALICE_RAILWAY_WAIT_SECONDS must be between 1 and 600'
+if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" && "$wait_seconds" -lt 130 ]]; then
+  fail 'OPENALICE_RAILWAY_WAIT_SECONDS must be at least 130 on Railway so draining plus stale-heartbeat recovery retains a bounded margin'
+fi
 if [[ "$channel" == dev && -n "$version" ]]; then
   fail 'the rolling dev channel cannot be combined with OPENALICE_RAILWAY_VERSION'
 fi

--- a/scripts/railway/shell-env.sh
+++ b/scripts/railway/shell-env.sh
@@ -13,5 +13,5 @@ export AQ_LAUNCHER_ROOT="$OPENALICE_HOME/workspaces"
 export PATH=/usr/local/sbin:/usr/local/bin:/data/home/.openalice/bin:/data/home/.local/bin:/data/home/.bun/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 if [ -n "${RAILWAY_ENVIRONMENT_ID:-}" ] && [ -n "${RAILWAY_SERVICE_ID:-}" ]; then
-  export OPENALICE_MACHINE_ID="${OPENALICE_MACHINE_ID:-railway-service-${RAILWAY_SERVICE_ID}}"
+  export OPENALICE_MACHINE_ID="railway-service-${RAILWAY_SERVICE_ID}"
 fi


### PR DESCRIPTION
## Summary

- preserve PID/start-time authority inside one container while using explicit heartbeats for same-service Railway Volume handoff across container namespaces
- fail closed on foreign, missing, or invalid ownership evidence and never signal a PID recorded by another container
- give only the Railway image entrypoint a bounded handoff wait, enforce the stable service identity, and run tini as a child subreaper
- record the retained-Volume failure and required live reacceptance in the owner guide and active plan

## Local verification

- `npx tsc --noEmit`
- `pnpm test` (5,281 passed, 9 skipped)
- focused ownership/lifecycle/entrypoint specs (83 passed)
- Guardian Runtime and CLI typechecks
- `pnpm test:guardian-recovery`
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- Railway image rebuild/entrypoint inspection; no Node, Bun, or Agent Runtime executable
- `bash -n scripts/railway/*.sh`
- `git diff --check`

## Live acceptance

Pending after merge: wait for the dev native artifact containing this commit, redeploy it against the retained Railway Volume, then verify legacy-lock recovery, normal replacement, hard-kill recovery, SSH/tunnel/UI, AliceProject transfer, and a user-owned Agent Runtime turn.