### PR TITLE
fix(railway): fence complete runtime lifecycle

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -138,9 +138,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: pnpm/action-setup@v6
+
       - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --filter @traderalice/openalice-cli
 
       - name: Exercise clean SSH host fixture
         run: node scripts/remote-ssh-smoke.mjs --skip-tui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,9 +400,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: pnpm/action-setup@v6
+
       - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --filter @traderalice/openalice-cli
 
       - name: Exercise candidate installer in a clean HTTP fixture
         run: node scripts/install-docker-smoke.mjs

--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -29,12 +29,14 @@ ENV OPENALICE_RAILWAY_VOLUME_ROOT=/data \
 COPY install /opt/openalice/install
 COPY scripts/railway/entrypoint.sh /usr/local/bin/openalice-railway-entrypoint
 COPY scripts/railway/command-wrapper.sh /usr/local/libexec/openalice-railway-command
+COPY scripts/railway/preflight-retained-locks.py /usr/local/libexec/openalice-railway-preflight
 COPY scripts/railway/shell-env.sh /etc/profile.d/openalice-railway.sh
 
 RUN chmod 0755 \
       /opt/openalice/install \
       /usr/local/bin/openalice-railway-entrypoint \
       /usr/local/libexec/openalice-railway-command \
+      /usr/local/libexec/openalice-railway-preflight \
       /etc/profile.d/openalice-railway.sh \
   && for command_name in openalice alice alice-workspace alice-uta traderhub; do \
        install -m 0755 /usr/local/libexec/openalice-railway-command "/usr/local/bin/$command_name"; \

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -109,7 +109,8 @@ the persistent `PATH` only after it has verified the native CLI.
 
 `OPENALICE_HOME` is the only layout selector and must resolve beneath `/data`;
 `AQ_LAUNCHER_ROOT` is always canonicalized from that selected Project as
-`<OPENALICE_HOME>/workspaces`. The entrypoint rejects a different Volume mount,
+`<OPENALICE_HOME>/workspaces`. The reserved `/data/quarantine` tree can never be
+selected as a Project Home. The entrypoint rejects a different Volume mount,
 ephemeral `HOME`, alternate install/npm/Bun root, or normalized/symlink escape;
 it does not honor an independent Workspace-root override. The image filesystem
 is replaceable; no install release, credential, Workspace, Agent login, or
@@ -137,15 +138,46 @@ its provenance environment, and rejects update/rollback/uninstall mutations;
 this keeps older published CLIs from bypassing Railway's release authority via
 the persistent command path.
 
+Before installer, current-pointer, or Project selection mutation, the
+entrypoint opens the mounted Railway Volume root itself read-only, takes an
+exclusive `flock` on that directory inode, and keeps the open file description
+for the complete foreground Runtime lifetime. Locking the mount inode avoids a
+replaceable Project-owned lock file and serializes every Runtime using that
+Volume. While holding that fence and before touching the install pointer,
+shims, or Project layout, the image discovers every Project Home on the Volume
+and inspects its four known Runtime lock directories, including nested legacy
+homes. It skips only the documented quarantine. Missing locks and
+same-service `railway-flock-v1` records may proceed; an initializing, malformed,
+foreign, or pre-fence owner anywhere on the Volume stops the deployment at this
+read-only boundary. The CLI independently checks that the actual canonical Project Home
+and install root are children of that real mount, that the inherited descriptor
+names its directory inode, and that Linux `/proc/self/fdinfo` reports an
+exclusive kernel lock; an environment flag or arbitrary locked directory is
+not authority.
+
+The CLI maps the locked descriptor explicitly to Guardian. Guardian retains
+its lifetime copy and maps a startup duplicate only to trusted Alice, UTA, and
+Connector processes. Each trusted writer validates and retains its duplicate for
+its own lifetime, but consumes the marker and descriptor number before connector
+adapters, broker helpers, Workspace Agents, or PTYs can start. Ordinary Node
+child-process and node-pty launch boundaries omit extra descriptors, which is
+verified with a positive-control Linux inheritance test. Consequently a Guardian
+crash cannot release the Volume fence while any old Project writer is still alive.
+This also makes a direct Railway `--internal-role connector` invocation without
+Guardian authority fail before it can open Project-backed queues. Agent and PTY environments also strip
+the descriptor number and entrypoint marker as defense in depth. Every Railway
+Runtime entry fails closed if the capability is missing or invalid; it never
+silently starts an unfenced writer.
+
 The entrypoint finally `exec`s `openalice server run`; it does not launch a
 detached Server and sleep. Railway therefore observes and restarts the actual
 Guardian service process. Railway places its platform init at PID 1, so the
 image runs `tini -s -g` as a child subreaper: it forwards signals to the
 complete process group and adopts/reaps orphaned descendants even though it is
-not PID 1. The shared installer serializes mutations
-with the platform kernel (`lockf` on macOS, `flock` on Linux); its persistent
-guard inode contains no Project or credential data, and hard process death
-releases ownership automatically.
+not PID 1. The shared installer has its own shorter transaction lock; both
+locks use the platform kernel and contain no Project or credential data. Hard
+process death releases ownership only after the complete trusted writer set has
+exited; one surviving Alice, UTA, or Connector keeps the replacement fenced.
 Alice stays on loopback port `47331` (or the explicit
 `OPENALICE_RAILWAY_PORT`), and this profile does not consume Railway's public
 `PORT` contract.
@@ -154,15 +186,35 @@ Every Railway shell and service process derives one exact machine identity
 from `RAILWAY_SERVICE_ID`; a conflicting configured identity fails startup.
 Within one container, Runtime ownership still uses PID and process-start-time
 identity. Across replacement-container PID namespaces on the same service
-Volume, it never probes or signals the recorded PID: a fresh, explicit
-heartbeat remains authoritative, while a stale explicit heartbeat may be
-reclaimed atomically. Missing, invalid, or foreign identity/heartbeat evidence
-fails closed. The image-owned entrypoint alone waits for this handoff before
-preparing or spawning Guardian; ordinary SSH commands do not inherit that
-privilege. Keep `OPENALICE_RAILWAY_WAIT_SECONDS` at 130 or higher (180 by
-default). The same value separately bounds owner release and Runtime readiness;
-for custom draining use at least `draining seconds + 100`, so the stale-heartbeat
-window retains a bounded margin.
+Volume, it never probes or signals the recorded PID. A Railway shell without
+the inherited locked descriptor is an observer: even a very old heartbeat is
+not reclaim authority. A fenced replacement may reclaim only an owner written
+under `fencingProtocol: railway-flock-v1`; the owner directory identity and
+complete owner evidence are checked again immediately before quarantine.
+Heartbeats remain diagnostic only. Missing or foreign identity, a forged or
+unlocked descriptor, and pre-fence legacy owners all fail closed. A retained
+legacy owner therefore requires a one-time operator cutover: first prove the
+old deployment has stopped, inspect the owner records, then move only these
+exact directories when present:
+
+```text
+<OPENALICE_HOME>/state/guardian.lock
+<OPENALICE_HOME>/state/runtime.lock
+<OPENALICE_HOME>/workspaces/state/runtime.lock
+<OPENALICE_HOME>/data/state/config-bootstrap.lock
+```
+
+Move them into a timestamped quarantine outside the Project, such as
+`/data/quarantine/<project>-<timestamp>/`, while preserving each relative
+path. If any owner still matches a running deployment, stop and do not move it.
+Never clear the Volume or relabel the Project to bypass the gate. Recovery is
+the reverse move while the service is stopped.
+
+The image-owned entrypoint alone waits to acquire the lifecycle fence before it
+installs or starts Guardian; ordinary SSH commands do not inherit that
+privilege. `OPENALICE_RAILWAY_WAIT_SECONDS` is 180 by default and separately
+bounds fence acquisition and Runtime readiness. Keep it comfortably above the
+configured deployment draining interval.
 
 Agent Runtime installation remains a user action performed through Railway
 SSH. Persistent locations `/data/home/.local/bin` and `/data/home/.bun/bin` are
@@ -204,11 +256,17 @@ self-contained repository connectivity, fail-closed linked/nested/submodule or
 external-object state, known Alice backup/session/install exclusions,
 credential omission and resealing, receipt validation, and safe handling of
 absolute or escaping symlinks.
-Runtime ownership tests must also cover same-container PID identity,
-legacy-to-stable Railway service identity handoff, fresh-versus-stale explicit
-heartbeats across container namespaces, missing/invalid evidence that remains
-blocked, entrypoint-only bounded waiting, and a proof that no cross-container
-PID receives a signal.
+Runtime ownership tests must also cover same-container PID identity, an
+observer that refuses both fresh and stale cross-container owners, a locked-FD
+entrypoint that reclaims only `railway-flock-v1` owners, legacy and forged-FD
+failure, owner-evidence races, bounded fence waiting, actual-home/mount
+containment, and a proof that no cross-container PID receives a signal. A
+Linux PTY regression must inspect `/proc/self/fd`, prove each trusted Project
+writer retains its own lifetime descriptor, and prove ordinary child processes
+and PTYs do not inherit one; an explicit mapped-descriptor positive control
+must still block a contender. Linux acceptance must suspend the old holder beyond the former heartbeat window and
+show that a replacement still cannot acquire the fence; only process/container
+death may release it, and simultaneous replacements must produce one winner.
 
 A real Railway acceptance is still required before treating the profile as a
 usable hosted product. Keep the clean-bootstrap and retained-data journeys

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -129,6 +129,28 @@ Set the service lifecycle explicitly in the Railway Dashboard:
 - set `RAILWAY_DEPLOYMENT_DRAINING_SECONDS=30` or higher so Railway gives
   Guardian at least 30 seconds between `SIGTERM` and forced termination.
 
+The image entrypoint holds an exclusive lifecycle `flock` on the mounted
+Railway Volume directory inode for the whole foreground Runtime. A replacement
+waits for that kernel lock before installing, selecting a Project, or starting;
+heartbeat age is not takeover authority. Before any install-pointer or Project
+mutation, the entrypoint also rejects retained legacy, malformed, or foreign
+owner records across every discovered Project Home on the Volume. Alice, UTA,
+and Connector validate and retain their own lifetime duplicates while removing
+the capability from descendant environments; ordinary child processes, adapters,
+Agents, and PTYs do not inherit them. Thus Guardian and every Project writer must
+be gone before a replacement can acquire the fence. Ordinary Railway SSH shells are observer-only and
+cannot start or reclaim a Runtime owner.
+
+For the first fenced deployment against a retained pre-fence Project, first
+verify the old deployment is stopped. Inspect and move only these directories
+when present: `state/guardian.lock`, `state/runtime.lock`,
+`workspaces/state/runtime.lock`, and `data/state/config-bootstrap.lock`, all
+relative to that exact Project Home. Preserve those relative paths beneath a
+timestamped `/data/quarantine/<project>-<timestamp>/` directory so the cutover
+is reversible. That quarantine tree is never a valid `OPENALICE_HOME`. Never
+clear the Project or Volume; if an owner still matches a
+running deployment, stop instead of quarantining it.
+
 The default service variables install the latest stable native release. Use
 only the selectors needed for the intended host:
 

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -53,6 +53,7 @@ export async function main(argv = process.argv.slice(2)) {
       installSource: await readInstallSource(),
       contentIdentity: installedContentIdentity(),
       managedRuntime: installedRuntimeInfo(version),
+      runtimeCapabilities: ['railway-flock-v1'],
     })}\n`)
     return 0
   }

--- a/packages/cli/src/internal-role-runtime.spec.ts
+++ b/packages/cli/src/internal-role-runtime.spec.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { describe, expect, it } from 'vitest'
+
+describe('private Runtime role fencing', () => {
+  it('refuses a direct Railway Connector writer without the Guardian fence', () => {
+    const home = join(tmpdir(), `openalice-connector-no-fence-${process.pid}`)
+    const result = spawnSync(process.execPath, [
+      '--import',
+      'tsx',
+      'packages/cli/bin/openalice-bun.ts',
+      '--internal-role',
+      'connector',
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NODE_OPTIONS: '--conditions=openalice-source',
+        OPENALICE_HOME: home,
+        AQ_LAUNCHER_ROOT: join(home, 'workspaces'),
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      encoding: 'utf8',
+      timeout: 10_000,
+    })
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1)
+    expect(result.stderr).toContain(
+      'invalid or missing inherited Railway lifecycle fence; refusing to start Connector',
+    )
+    expect(existsSync(home)).toBe(false)
+  })
+})

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { fstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { mkdir, open } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
@@ -53,17 +54,24 @@ export async function startRuntime(options, dependencies = {}) {
   })
   const readStatus = dependencies.readStatus ?? readRuntimeStatus
   const activation = await resolveActivationContext(env, dependencies)
+  const railwayFenceFd = (dependencies.resolveRailwayFenceFd ?? resolveRailwayFenceFd)(env, homeRoot)
+  const railwayFenceClaimed = Boolean(
+    env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER']
+    || env['OPENALICE_RAILWAY_FENCE_FD']
+    || env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway',
+  )
+  if (railwayFenceClaimed && railwayFenceFd === null) {
+    throw lifecycleError(
+      'ERAILWAYFENCE',
+      'Railway may start the Runtime only through its image entrypoint with the locked Volume capability',
+    )
+  }
   let status = await readStatus({ homeRoot, timeoutMs: 1_000 }, dependencies)
-  if (
-    isRailwayForegroundRuntime(env)
-    && status.class !== 'absent'
-    && !options.takeover
-  ) {
-    status = await waitForRuntimeRelease(homeRoot, options.waitMs, {
-      ...dependencies,
-      readStatus,
-      initialStatus: status,
-    })
+  if (railwayFenceFd !== null && status.class !== 'absent') {
+    throw lifecycleError(
+      'ERAILWAYCUTOVER',
+      `The Railway Volume fence is held, but retained Runtime ownership at ${homeRoot} is not eligible for automatic handoff. Verify the previous deployment is stopped, then quarantine only state/guardian.lock, state/runtime.lock, workspaces/state/runtime.lock, and data/state/config-bootstrap.lock from this exact Project Home; do not clear the Project or Volume.`,
+    )
   }
 
   if (status.owner?.surface === 'cli-server' && status.class === 'running') {
@@ -133,6 +141,8 @@ export async function startRuntime(options, dependencies = {}) {
     takeover: options.takeover,
   })
   delete runtimeEnv.OPENALICE_RAILWAY_ENTRYPOINT_OWNER
+  delete runtimeEnv.OPENALICE_RAILWAY_FENCE_FD
+  if (railwayFenceFd !== null) runtimeEnv.OPENALICE_RAILWAY_FENCE_FD = '3'
   runtimeEnv.OPENALICE_LAUNCHER = 'cli-server'
   runtimeEnv.OPENALICE_SERVER_MODE = detached ? 'detached' : 'foreground'
   runtimeEnv.OPENALICE_RUNTIME_PROVIDER = runtimeProvider.kind
@@ -165,7 +175,9 @@ export async function startRuntime(options, dependencies = {}) {
         cwd: appDir,
         env: runtimeEnv,
         detached: true,
-        stdio: ['ignore', logHandle.fd, logHandle.fd],
+        stdio: railwayFenceFd === null
+          ? ['ignore', logHandle.fd, logHandle.fd]
+          : ['ignore', logHandle.fd, logHandle.fd, railwayFenceFd],
         windowsHide: true,
       })
       runtime.unref()
@@ -176,7 +188,9 @@ export async function startRuntime(options, dependencies = {}) {
     runtime = spawnProcess(guardianSpec.cmd, guardianSpec.args, {
       cwd: appDir,
       env: runtimeEnv,
-      stdio: 'inherit',
+      stdio: railwayFenceFd === null
+        ? 'inherit'
+        : ['inherit', 'inherit', 'inherit', railwayFenceFd],
       windowsHide: true,
     })
   }
@@ -409,37 +423,90 @@ async function waitForRuntimeReady(homeRoot, timeoutMs, dependencies) {
   )
 }
 
-async function waitForRuntimeRelease(homeRoot, timeoutMs, dependencies) {
-  const readStatus = dependencies.readStatus ?? readRuntimeStatus
-  const sleep = dependencies.sleep ?? ((ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
-  const deadline = Date.now() + timeoutMs
-  let lastStatus = dependencies.initialStatus ?? null
-  while (true) {
-    if (lastStatus?.class === 'absent') return lastStatus
-    let remainingMs = deadline - Date.now()
-    if (remainingMs <= 0) break
-    await sleep(Math.min(500, remainingMs))
-    remainingMs = deadline - Date.now()
-    if (remainingMs <= 0) break
-    lastStatus = await readStatus({
-      homeRoot,
-      timeoutMs: Math.max(1, Math.min(1_000, remainingMs)),
-    }, dependencies)
-    if (lastStatus.class === 'absent') return lastStatus
+function resolveRailwayFenceFd(env, homeRoot) {
+  const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
+  const rawFd = env['OPENALICE_RAILWAY_FENCE_FD']?.trim()
+  const fd = Number(rawFd)
+  if (
+    env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER'] !== '1'
+    || env['OPENALICE_SERVICE_MANAGER']?.trim() !== 'railway'
+    || !env['RAILWAY_ENVIRONMENT_ID']?.trim()
+    || !/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
+    || env['OPENALICE_MACHINE_ID']?.trim() !== `railway-service-${serviceId}`
+    || !/^[0-9]{1,4}$/.test(rawFd ?? '')
+    || !Number.isInteger(fd)
+    || fd < 3
+  ) return null
+  const fencePath = railwayRuntimeFencePath(env, homeRoot)
+  if (!fencePath) return null
+  try {
+    const inherited = fstatSync(fd)
+    const expected = statSync(fencePath)
+    return inherited.isDirectory()
+      && expected.isDirectory()
+      && inherited.dev === expected.dev
+      && inherited.ino === expected.ino
+      && inheritedFdHoldsExclusiveFlock(fd)
+      ? fd
+      : null
+  } catch {
+    return null
   }
-  throw lifecycleError(
-    'ETIMEDOUT',
-    `Railway did not release the previous Runtime volume owner within ${Math.ceil(timeoutMs / 1_000)}s (${lastStatus?.class ?? 'no status'}). Keep one replica, Restart Policy Always, and at least 30 seconds of deployment draining.`,
-  )
 }
 
-function isRailwayForegroundRuntime(env) {
+function railwayRuntimeFencePath(env, homeRoot) {
   const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
-  return env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER'] === '1'
-    && env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway'
-    && Boolean(env['RAILWAY_ENVIRONMENT_ID']?.trim())
-    && /^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
-    && env['OPENALICE_MACHINE_ID']?.trim() === `railway-service-${serviceId}`
+  if (!/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')) return null
+  const configuredRoots = [
+    env['RAILWAY_VOLUME_MOUNT_PATH']?.trim(),
+    env['OPENALICE_RAILWAY_VOLUME_ROOT']?.trim(),
+  ].filter(Boolean).map((value) => resolve(value))
+  if (configuredRoots.length === 0 || new Set(configuredRoots).size !== 1) return null
+  const volumeRoot = configuredRoots[0]
+  const installDir = env['OPENALICE_INSTALL_DIR']?.trim()
+  if (!volumeRoot || volumeRoot === '/' || !homeRoot || !installDir) return null
+  if (!pathIsWithin(volumeRoot, homeRoot) || !pathIsWithin(volumeRoot, installDir)) return null
+  return isLinuxMountPoint(volumeRoot) ? volumeRoot : null
+}
+
+function pathIsWithin(root, candidate) {
+  try {
+    const canonicalRoot = realpathSync(root)
+    const canonicalCandidate = realpathSync(candidate)
+    return canonicalCandidate !== canonicalRoot
+      && canonicalCandidate.startsWith(`${canonicalRoot}/`)
+  } catch {
+    return false
+  }
+}
+
+function isLinuxMountPoint(path) {
+  if (process.platform !== 'linux') return false
+  try {
+    const canonical = realpathSync(path)
+    return readFileSync('/proc/self/mountinfo', 'utf8')
+      .split('\n')
+      .some((line) => decodeMountInfoPath(line.split(' ')[4] ?? '') === canonical)
+  } catch {
+    return false
+  }
+}
+
+function decodeMountInfoPath(value) {
+  return value.replace(/\\([0-7]{3})/g, (_match, octal) => (
+    String.fromCharCode(Number.parseInt(octal, 8))
+  ))
+}
+
+function inheritedFdHoldsExclusiveFlock(fd) {
+  if (process.platform !== 'linux') return false
+  try {
+    return /^lock:\s+\d+:\s+FLOCK\s+ADVISORY\s+WRITE\b/m.test(
+      readFileSync(`/proc/self/fdinfo/${fd}`, 'utf8'),
+    )
+  } catch {
+    return false
+  }
 }
 
 async function sleepOrAbort(ms, sleep, signal) {

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -492,13 +492,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
 
     await expect(startRuntime({ ...startOptions(), takeover: true }, {
       detached: true,
-      env: {
-        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
-        OPENALICE_SERVICE_MANAGER: 'railway',
-        OPENALICE_MACHINE_ID: 'railway-service-service-test',
-        RAILWAY_ENVIRONMENT_ID: 'environment-test',
-        RAILWAY_SERVICE_ID: 'service-test',
-      },
+      env: {},
       nodeBinary: '/test/node',
       resolveRoot: async (path) => path,
       prepareSource: async () => ({ prepared: false }),
@@ -510,7 +504,10 @@ describe('OpenAlice Runtime lifecycle core', () => {
     })).resolves.toEqual(expect.objectContaining({ outcome: 'started' }))
 
     expect(spawnProcess).toHaveBeenCalledWith('/test/node', ['scripts/guardian/prod.mjs'], expect.objectContaining({
-      env: expect.objectContaining({ OPENALICE_TAKEOVER: '1' }),
+      env: expect.objectContaining({
+        OPENALICE_TAKEOVER: '1',
+      }),
+      stdio: ['ignore', 9, 9],
     }))
     expect(child.kill).not.toHaveBeenCalled()
   })
@@ -529,16 +526,9 @@ describe('OpenAlice Runtime lifecycle core', () => {
     })
   })
 
-  it('waits for Railway entrypoint ownership handoff before spawning the foreground Runtime', async () => {
+  it('starts the foreground Runtime after the Volume fence and owner cleanup agree', async () => {
     const child = new FakeChild()
-    const previousOwner = {
-      ...runningStatus(),
-      class: 'owned_elsewhere',
-      endpoints: {},
-      capabilities: [],
-    }
     const readStatus = vi.fn()
-      .mockResolvedValueOnce(previousOwner)
       .mockResolvedValueOnce(absentStatus())
       .mockResolvedValue(runningStatus())
     const spawnProcess = vi.fn(() => child)
@@ -547,6 +537,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
       detached: false,
       env: {
         OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_RAILWAY_FENCE_FD: '9',
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
@@ -558,37 +549,48 @@ describe('OpenAlice Runtime lifecycle core', () => {
       spawnProcess,
       readStatus,
       sleep: async () => undefined,
+      resolveRailwayFenceFd: () => 9,
       emit(event) {
         if (event.type === 'ready') child.emit('exit', 0, null)
       },
     })).resolves.toEqual(expect.objectContaining({ outcome: 'exited', exitCode: 0 }))
 
-    expect(readStatus).toHaveBeenCalledTimes(3)
+    expect(readStatus).toHaveBeenCalledTimes(2)
     const spawnedEnvironment = spawnProcess.mock.calls[0][2].env
     expect(spawnedEnvironment).not.toHaveProperty('OPENALICE_RAILWAY_ENTRYPOINT_OWNER')
+    expect(spawnedEnvironment).toHaveProperty('OPENALICE_RAILWAY_FENCE_FD', '3')
+    expect(spawnProcess.mock.calls[0][2].stdio).toEqual(['inherit', 'inherit', 'inherit', 9])
   })
 
-  it('does not grant Railway entrypoint handoff behavior to ordinary SSH commands', async () => {
+  it('fails closed before inspection when Railway has no valid locked Volume FD', async () => {
     const sleep = vi.fn(async () => undefined)
+    const readStatus = vi.fn(async () => ({
+      ...runningStatus(),
+      class: 'owned_elsewhere',
+      owner: { ...runningStatus().owner, surface: 'cli-server' },
+    }))
     await expect(startRuntime(startOptions(), {
       detached: true,
       env: {
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_RAILWAY_FENCE_FD: '9',
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
         RAILWAY_SERVICE_ID: 'service-test',
       },
-      readStatus: async () => ({
-        ...runningStatus(),
-        class: 'owned_elsewhere',
-        owner: { ...runningStatus().owner, surface: 'cli-server' },
-      }),
+      readStatus,
       sleep,
-    })).rejects.toMatchObject({ code: 'EOWNED' })
+      resolveRailwayFenceFd: () => null,
+    })).rejects.toMatchObject({
+      code: 'ERAILWAYFENCE',
+      message: expect.stringContaining('image entrypoint'),
+    })
+    expect(readStatus).not.toHaveBeenCalled()
     expect(sleep).not.toHaveBeenCalled()
   })
 
-  it('times out Railway entrypoint handoff before preparation or spawn', async () => {
+  it('fails retained pre-fence ownership immediately with reversible cutover guidance', async () => {
     const previousOwner = {
       ...runningStatus(),
       class: 'owned_elsewhere',
@@ -600,24 +602,28 @@ describe('OpenAlice Runtime lifecycle core', () => {
     const spawnProcess = vi.fn(() => new FakeChild())
     const emit = vi.fn()
 
+    const readStatus = vi.fn(async () => previousOwner)
     await expect(startRuntime({ ...startOptions(), waitMs: 10 }, {
       detached: false,
       env: {
         OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_RAILWAY_FENCE_FD: '9',
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
         RAILWAY_SERVICE_ID: 'service-test',
       },
-      readStatus: async () => previousOwner,
+      readStatus,
       resolveRoot,
       prepareSource,
       spawnProcess,
       emit,
+      resolveRailwayFenceFd: () => 9,
     })).rejects.toMatchObject({
-      code: 'ETIMEDOUT',
-      message: expect.stringContaining('(owned_elsewhere)'),
+      code: 'ERAILWAYCUTOVER',
+      message: expect.stringContaining('state/guardian.lock'),
     })
+    expect(readStatus).toHaveBeenCalledOnce()
     expect(resolveRoot).not.toHaveBeenCalled()
     expect(prepareSource).not.toHaveBeenCalled()
     expect(spawnProcess).not.toHaveBeenCalled()

--- a/packages/cli/src/main.spec.ts
+++ b/packages/cli/src/main.spec.ts
@@ -3,6 +3,23 @@ import { describe, expect, it, vi } from 'vitest'
 import { main } from './main.ts'
 
 describe('OpenAlice TypeScript application entry', () => {
+  it('advertises Railway lifecycle-fence support in machine-readable version output', async () => {
+    let output = ''
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      output += String(chunk)
+      return true
+    })
+    try {
+      await expect(main(['version', '--json'])).resolves.toBe(0)
+    } finally {
+      write.mockRestore()
+    }
+
+    expect(JSON.parse(output)).toMatchObject({
+      runtimeCapabilities: expect.arrayContaining(['railway-flock-v1']),
+    })
+  })
+
   it('opens the Supervisor TUI for the bare command', async () => {
     const runTui = vi.fn(async () => 0)
 

--- a/packages/cli/src/server-control.mjs
+++ b/packages/cli/src/server-control.mjs
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
+import { fstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { homedir, hostname, tmpdir } from 'node:os'
 import { createConnection } from 'node:net'
@@ -14,7 +15,6 @@ export const GUARDIAN_CONTROL_PROTOCOL = 1
 export const GUARDIAN_CONTROL_API_VERSION = 1
 const MAX_RESPONSE_BYTES = 1024 * 1024
 const MAX_UPTIME_SECONDS = 10 * 365 * 24 * 60 * 60
-const RUNTIME_OWNER_STALE_HEARTBEAT_MS = 90_000
 
 export function resolveOpenAliceHome(homeRoot, options = {}) {
   const env = options.env ?? process.env
@@ -134,6 +134,7 @@ export async function readRuntimeStatus(options = {}, dependencies = {}) {
     platform: dependencies.platform,
     readMachineId: dependencies.readMachineId,
     readProcessStartedAt: dependencies.readProcessStartedAt,
+    railwayFenceValid: dependencies.railwayFenceValid,
   })
   if (owner?.active) {
     return {
@@ -349,14 +350,12 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
       }
     }
     const resolvedMachineId = await currentMachineId()
-    const railwayScope = railwayOwnerScope(owner, resolvedMachineId, localHostname, env)
+    const railwayScope = railwayOwnerScope(owner, resolvedMachineId, localHostname, env, homeRoot, options)
     let active
-    if (railwayScope === 'cross-container') {
-      const heartbeatAt = typeof owner.heartbeatAt === 'string'
-        ? Date.parse(owner.heartbeatAt)
-        : Number.NaN
-      active = !Number.isFinite(heartbeatAt)
-        || Math.max(0, Date.now() - heartbeatAt) <= RUNTIME_OWNER_STALE_HEARTBEAT_MS
+    if (railwayScope === 'cross-container-fenced') {
+      active = false
+    } else if (railwayScope === 'cross-container-observer') {
+      active = true
     } else if (railwayScope === 'foreign') {
       active = true
     } else {
@@ -390,7 +389,7 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
     : null
 }
 
-function railwayOwnerScope(owner, currentMachineId, localHostname, env) {
+function railwayOwnerScope(owner, currentMachineId, localHostname, env, homeRoot, options) {
   const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
   const environmentId = env['RAILWAY_ENVIRONMENT_ID']?.trim()
   const configuredMachineId = env['OPENALICE_MACHINE_ID']?.trim()
@@ -405,10 +404,91 @@ function railwayOwnerScope(owner, currentMachineId, localHostname, env) {
     return null
   }
   if (typeof owner.hostname !== 'string' || owner.hostname.length === 0) return 'foreign'
-  const belongsToService = owner.machineId === currentMachineId
-    || owner.machineId === `hostname:${owner.hostname}`
-  if (!belongsToService) return 'foreign'
-  return owner.hostname === localHostname ? 'same-container' : 'cross-container'
+  if (owner.machineId !== currentMachineId) return 'foreign'
+  if (owner.hostname === localHostname) return 'same-container'
+  if (owner.fencingProtocol !== 'railway-flock-v1') return 'foreign'
+  const fenceValid = options.railwayFenceValid
+    ?? hasValidRailwayFence(env, homeRoot)
+  return fenceValid ? 'cross-container-fenced' : 'cross-container-observer'
+}
+
+function hasValidRailwayFence(env, homeRoot) {
+  const rawFd = env['OPENALICE_RAILWAY_FENCE_FD']?.trim()
+  const fd = Number(rawFd)
+  if (
+    env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER'] !== '1'
+    || !/^[0-9]{1,4}$/.test(rawFd ?? '')
+    || !Number.isInteger(fd)
+    || fd < 3
+  ) return false
+  const fencePath = railwayRuntimeFencePath(env, homeRoot)
+  if (!fencePath) return false
+  try {
+    const inherited = fstatSync(fd)
+    const expected = statSync(fencePath)
+    return inherited.isDirectory()
+      && expected.isDirectory()
+      && inherited.dev === expected.dev
+      && inherited.ino === expected.ino
+      && inheritedFdHoldsExclusiveFlock(fd)
+  } catch {
+    return false
+  }
+}
+
+function railwayRuntimeFencePath(env, homeRoot) {
+  const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
+  if (!/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')) return null
+  const configuredRoots = [
+    env['RAILWAY_VOLUME_MOUNT_PATH']?.trim(),
+    env['OPENALICE_RAILWAY_VOLUME_ROOT']?.trim(),
+  ].filter(Boolean).map((value) => resolve(value))
+  if (configuredRoots.length === 0 || new Set(configuredRoots).size !== 1) return null
+  const volumeRoot = configuredRoots[0]
+  const installDir = env['OPENALICE_INSTALL_DIR']?.trim()
+  if (!volumeRoot || volumeRoot === '/' || !homeRoot || !installDir) return null
+  if (!pathIsWithin(volumeRoot, homeRoot) || !pathIsWithin(volumeRoot, installDir)) return null
+  return isLinuxMountPoint(volumeRoot) ? volumeRoot : null
+}
+
+function pathIsWithin(root, candidate) {
+  try {
+    const canonicalRoot = realpathSync(root)
+    const canonicalCandidate = realpathSync(candidate)
+    return canonicalCandidate !== canonicalRoot
+      && canonicalCandidate.startsWith(`${canonicalRoot}/`)
+  } catch {
+    return false
+  }
+}
+
+function isLinuxMountPoint(path) {
+  if (process.platform !== 'linux') return false
+  try {
+    const canonical = realpathSync(path)
+    return readFileSync('/proc/self/mountinfo', 'utf8')
+      .split('\n')
+      .some((line) => decodeMountInfoPath(line.split(' ')[4] ?? '') === canonical)
+  } catch {
+    return false
+  }
+}
+
+function decodeMountInfoPath(value) {
+  return value.replace(/\\([0-7]{3})/g, (_match, octal) => (
+    String.fromCharCode(Number.parseInt(octal, 8))
+  ))
+}
+
+function inheritedFdHoldsExclusiveFlock(fd) {
+  if (process.platform !== 'linux') return false
+  try {
+    return /^lock:\s+\d+:\s+FLOCK\s+ADVISORY\s+WRITE\b/m.test(
+      readFileSync(`/proc/self/fdinfo/${fd}`, 'utf8'),
+    )
+  } catch {
+    return false
+  }
 }
 
 async function isSameProcess(owner, dependencies) {

--- a/packages/cli/src/server-control.spec.mjs
+++ b/packages/cli/src/server-control.spec.mjs
@@ -258,53 +258,77 @@ describe('OpenAlice Guardian control protocol', () => {
     expect(readProcessStartedAt).not.toHaveBeenCalled()
   })
 
-  it('uses heartbeat authority across Railway container namespaces', async () => {
+  it('keeps cross-container Railway owners observer-only and lets a valid fence reclaim the cooperative protocol', async () => {
     const env = {
       OPENALICE_SERVICE_MANAGER: 'railway',
       OPENALICE_MACHINE_ID: 'railway-service-service-test',
       RAILWAY_ENVIRONMENT_ID: 'environment-test',
       RAILWAY_SERVICE_ID: 'service-test',
     }
-    for (const [index, machineId] of [
-      'hostname:prior-container',
-      'env:railway-service-service-test',
-    ].entries()) {
-      const home = await makeTempDir()
-      const lock = join(home, 'state', 'guardian.lock')
-      await mkdir(lock, { recursive: true })
-      const ownerPath = join(lock, 'owner.json')
-      const owner = {
-        pid: 4242,
-        hostname: 'prior-container',
-        machineId,
-        launcher: 'guardian-cli-server',
-        acquiredAt: new Date().toISOString(),
-        heartbeatAt: new Date().toISOString(),
-      }
-      await writeFile(ownerPath, JSON.stringify(owner))
-      const isProcessAlive = vi.fn(() => false)
-
-      const active = await readRuntimeStatus({ homeRoot: home }, {
-        env,
-        hostname: `current-container-${index}`,
-        isProcessAlive,
-      })
-      expect(active.class).toBe('owned_elsewhere')
-      expect(isProcessAlive).not.toHaveBeenCalled()
-
-      await writeFile(ownerPath, JSON.stringify({
-        ...owner,
-        heartbeatAt: new Date(0).toISOString(),
-      }))
-      const stale = await readRuntimeStatus({ homeRoot: home }, {
-        env,
-        hostname: `current-container-${index}`,
-        isProcessAlive,
-      })
-      expect(stale.class).toBe('absent')
-      expect(stale.detail).toContain('stale')
-      expect(isProcessAlive).not.toHaveBeenCalled()
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    const ownerPath = join(lock, 'owner.json')
+    const owner = {
+      pid: 4242,
+      hostname: 'prior-container',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
     }
+    await writeFile(ownerPath, JSON.stringify(owner))
+    const isProcessAlive = vi.fn(() => false)
+
+    for (const heartbeatAt of [new Date().toISOString(), new Date(0).toISOString()]) {
+      await writeFile(ownerPath, JSON.stringify({ ...owner, heartbeatAt }))
+      const observer = await readRuntimeStatus({ homeRoot: home }, {
+        env,
+        hostname: 'current-container',
+        isProcessAlive,
+      })
+      expect(observer.class).toBe('owned_elsewhere')
+
+      const fenced = await readRuntimeStatus({ homeRoot: home }, {
+        env,
+        hostname: 'current-container',
+        isProcessAlive,
+        railwayFenceValid: true,
+      })
+      expect(fenced.class).toBe('absent')
+      expect(fenced.detail).toContain('stale')
+    }
+    expect(isProcessAlive).not.toHaveBeenCalled()
+  })
+
+  it('keeps a legacy cross-container Railway owner blocked even for a fenced entrypoint', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: 4242,
+      hostname: 'prior-container',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date(0).toISOString(),
+      heartbeatAt: new Date(0).toISOString(),
+    }))
+    const isProcessAlive = vi.fn(() => false)
+    const status = await readRuntimeStatus({ homeRoot: home }, {
+      env: {
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      hostname: 'current-container',
+      isProcessAlive,
+      railwayFenceValid: true,
+    })
+
+    expect(status.class).toBe('owned_elsewhere')
+    expect(isProcessAlive).not.toHaveBeenCalled()
   })
 
   it('keeps same-container PID identity authoritative under Railway', async () => {
@@ -388,6 +412,7 @@ describe('OpenAlice Guardian control protocol', () => {
         machineId: 'env:railway-service-service-test',
         launcher: 'guardian-cli-server',
         acquiredAt: new Date(0).toISOString(),
+        fencingProtocol: 'railway-flock-v1',
         ...(heartbeatAt === undefined ? {} : { heartbeatAt }),
       }))
       const isProcessAlive = vi.fn(() => false)

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -1,3 +1,5 @@
+import { closeSync, existsSync, openSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { hostname, tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -23,6 +25,7 @@ class FakeProcesses implements ProcessController {
   readonly cascade = new Map<number, number[]>()
   ignoreTerm = new Set<number>()
   currentMachineId = 'machine-a'
+  machineIdHook: (() => Promise<void>) | undefined
 
   add(pid: number, startedAt = 1_000): void {
     this.alive.set(pid, true)
@@ -38,6 +41,7 @@ class FakeProcesses implements ProcessController {
   }
 
   async machineId(): Promise<string> {
+    await this.machineIdHook?.()
     return this.currentMachineId
   }
 
@@ -64,20 +68,63 @@ afterEach(async () => {
   await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 })
 })
 
+function railwayOwner(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    pid: 101,
+    hostname: 'prior-container',
+    machineId: 'env:railway-service-service-test',
+    token: 'prior-owner',
+    launcher: 'guardian-cli-server',
+    acquiredAt: new Date().toISOString(),
+    heartbeatAt: new Date().toISOString(),
+    fencingProtocol: 'railway-flock-v1',
+    processStartedAt: new Date(10_000).toISOString(),
+    ...overrides,
+  }
+}
+
 describe('runtime lock ownership', () => {
-  it('enables Railway volume authority only for the exact platform service identity', () => {
+  it('treats an exact Railway service identity without a locked fence as observer-only', () => {
     expect(resolveRuntimeLockOwnerAuthority({
       OPENALICE_SERVICE_MANAGER: 'railway',
       OPENALICE_MACHINE_ID: 'railway-service-service-test',
       RAILWAY_ENVIRONMENT_ID: 'environment-test',
       RAILWAY_SERVICE_ID: 'service-test',
-    })).toBe('railway-volume')
+    })).toBe('railway-observer')
     expect(resolveRuntimeLockOwnerAuthority({
       OPENALICE_SERVICE_MANAGER: 'railway',
       OPENALICE_MACHINE_ID: 'railway-service-other',
       RAILWAY_ENVIRONMENT_ID: 'environment-test',
       RAILWAY_SERVICE_ID: 'service-test',
     })).toBe('process')
+  })
+
+  it.runIf(process.platform === 'linux' && existsSync('/dev/shm'))('recognizes only an inherited FD that actually holds the Railway lifecycle flock', async () => {
+    const volumeRoot = '/dev/shm'
+    const railwayHome = join(volumeRoot, `openalice-fence-${process.pid}-${Math.random().toString(16).slice(2)}`)
+    const installDir = join(railwayHome, 'install')
+    await mkdir(installDir, { recursive: true })
+    const fd = openSync(volumeRoot, 'r')
+    try {
+      const locked = spawnSync('/usr/bin/flock', ['--exclusive', '3'], {
+        stdio: ['ignore', 'ignore', 'ignore', fd],
+      })
+      expect(locked.status).toBe(0)
+      expect(resolveRuntimeLockOwnerAuthority({
+        OPENALICE_HOME: railwayHome,
+        OPENALICE_INSTALL_DIR: installDir,
+        OPENALICE_RAILWAY_VOLUME_ROOT: volumeRoot,
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        OPENALICE_RAILWAY_FENCE_FD: String(fd),
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      })).toBe('railway-fenced-handoff')
+    } finally {
+      closeSync(fd)
+      await rm(railwayHome, { recursive: true, force: true })
+    }
   })
 
   it('publishes inspectable owner metadata and releases cleanly', async () => {
@@ -200,78 +247,83 @@ describe('runtime lock ownership', () => {
     expect(controller.signals).toEqual([])
   })
 
-  it('uses heartbeat authority for fresh and stale owners in another Railway container', async () => {
-    controller.currentMachineId = 'env:railway-service-service-test'
-    controller.add(202, 20_000)
-
-    for (const [index, machineId] of [
-      'hostname:legacy-container',
-      'env:railway-service-service-test',
-    ].entries()) {
-      const lockDir = join(home, `railway-runtime-${index}.lock`)
-      const owner = {
-        schemaVersion: 1,
-        pid: 101,
-        hostname: 'legacy-container',
-        machineId,
-        token: `owner-${index}`,
-        launcher: 'guardian-cli-server',
-        acquiredAt: new Date().toISOString(),
-        heartbeatAt: new Date().toISOString(),
-        processStartedAt: new Date(10_000).toISOString(),
-      }
-      await mkdir(lockDir)
-      await writeFile(join(lockDir, 'owner.json'), JSON.stringify(owner))
-
-      await expect(inspectRuntimeLock(lockDir, {
-        ownerAuthority: 'railway-volume',
-        processController: controller,
-      })).resolves.toMatchObject({
-        state: 'active',
-        reason: expect.stringContaining('another container namespace'),
-      })
-
-      await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
-        ...owner,
-        heartbeatAt: new Date(0).toISOString(),
-      }))
-      const fresh = await acquireRuntimeLock(lockDir, {
-        pid: 202,
-        processStartedAt: 20_000,
-        ownerAuthority: 'railway-volume',
-        heartbeatMs: 0,
-        processController: controller,
-      })
-      expect(fresh.owner.pid).toBe(202)
-      await fresh.release()
-    }
-  })
-
-  it('never signals a fresh owner in another Railway container during takeover', async () => {
+  it('keeps another Railway container active for an observer regardless of heartbeat age', async () => {
     controller.currentMachineId = 'env:railway-service-service-test'
     controller.add(202, 20_000)
     const lockDir = join(home, 'railway-runtime.lock')
+    const owner = railwayOwner({ heartbeatAt: new Date().toISOString() })
     await mkdir(lockDir)
-    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
-      schemaVersion: 1,
-      pid: 202,
-      hostname: 'prior-container',
-      machineId: 'env:railway-service-service-test',
-      token: 'prior-owner',
-      launcher: 'guardian-cli-server',
-      acquiredAt: new Date().toISOString(),
-      heartbeatAt: new Date().toISOString(),
-      processStartedAt: new Date(20_000).toISOString(),
-    }))
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify(owner))
+
+    for (const heartbeatAt of [new Date().toISOString(), new Date(0).toISOString()]) {
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify({ ...owner, heartbeatAt }))
+      await expect(inspectRuntimeLock(lockDir, {
+        ownerAuthority: 'railway-observer',
+        processController: controller,
+        staleHeartbeatMs: 1,
+      })).resolves.toMatchObject({
+        state: 'active',
+        reason: expect.stringContaining('observer refuses automatic recovery'),
+      })
+    }
 
     await expect(acquireRuntimeLock(lockDir, {
-      pid: 303,
-      processStartedAt: 30_000,
-      ownerAuthority: 'railway-volume',
+      pid: 202,
+      processStartedAt: 20_000,
+      ownerAuthority: 'railway-observer',
       takeover: true,
       heartbeatMs: 0,
       processController: controller,
     })).rejects.toThrow(/another Railway container/)
+    expect(controller.signals).toEqual([])
+  })
+
+  it('lets the fenced Railway handoff replace only a cooperative protocol owner', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    controller.add(303, 30_000)
+    const lockDir = join(home, 'railway-runtime.lock')
+    await mkdir(lockDir)
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify(railwayOwner()))
+
+    const fresh = await acquireRuntimeLock(lockDir, {
+      pid: 303,
+      processStartedAt: 30_000,
+      ownerAuthority: 'railway-fenced-handoff',
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    expect(fresh.owner).toMatchObject({
+      pid: 303,
+      fencingProtocol: 'railway-flock-v1',
+    })
+    expect(controller.signals).toEqual([])
+    await fresh.release()
+  })
+
+  it('fails closed on a legacy Railway owner even while holding the lifecycle fence', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    controller.add(303, 30_000)
+    const lockDir = join(home, 'railway-legacy.lock')
+    await mkdir(lockDir)
+    const legacyOwner = railwayOwner()
+    delete legacyOwner['fencingProtocol']
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify(legacyOwner))
+
+    await expect(inspectRuntimeLock(lockDir, {
+      ownerAuthority: 'railway-fenced-handoff',
+      processController: controller,
+    })).resolves.toMatchObject({
+      state: 'active',
+      reason: expect.stringContaining('does not belong to this Railway service'),
+    })
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 303,
+      processStartedAt: 30_000,
+      ownerAuthority: 'railway-fenced-handoff',
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toBeInstanceOf(RuntimeAlreadyRunningError)
     expect(controller.signals).toEqual([])
   })
 
@@ -293,7 +345,7 @@ describe('runtime lock ownership', () => {
     }))
 
     await expect(inspectRuntimeLock(lockDir, {
-      ownerAuthority: 'railway-volume',
+      ownerAuthority: 'railway-observer',
       processController: controller,
       staleHeartbeatMs: -1,
     })).resolves.toMatchObject({
@@ -319,7 +371,7 @@ describe('runtime lock ownership', () => {
       }))
 
       await expect(inspectRuntimeLock(lockDir, {
-        ownerAuthority: 'railway-volume',
+        ownerAuthority: 'railway-observer',
         processController: controller,
         staleHeartbeatMs: -1,
       })).resolves.toMatchObject({
@@ -329,7 +381,7 @@ describe('runtime lock ownership', () => {
     }
   })
 
-  it('keeps missing or invalid Railway heartbeats fail closed', async () => {
+  it('keeps missing or invalid Railway heartbeats observer-only', async () => {
     controller.currentMachineId = 'env:railway-service-service-test'
     for (const [index, heartbeatAt] of [undefined, 'not-a-date', 0].entries()) {
       const lockDir = join(home, `railway-heartbeat-${index}.lock`)
@@ -342,11 +394,12 @@ describe('runtime lock ownership', () => {
         token: `owner-${index}`,
         launcher: 'guardian-cli-server',
         acquiredAt: new Date(0).toISOString(),
+        fencingProtocol: 'railway-flock-v1',
         ...(heartbeatAt === undefined ? {} : { heartbeatAt }),
       }))
 
       await expect(inspectRuntimeLock(lockDir, {
-        ownerAuthority: 'railway-volume',
+        ownerAuthority: 'railway-observer',
         processController: controller,
         staleHeartbeatMs: -1,
       })).resolves.toMatchObject({
@@ -354,6 +407,34 @@ describe('runtime lock ownership', () => {
         reason: expect.stringContaining('missing or invalid'),
       })
     }
+  })
+
+  it('aborts reclamation when owner evidence changes after inspection', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    controller.add(202, 20_000)
+    const lockDir = join(home, 'railway-racing-owner.lock')
+    const ownerPath = join(lockDir, 'owner.json')
+    await mkdir(lockDir)
+    await writeFile(ownerPath, JSON.stringify(railwayOwner({ heartbeatAt: new Date(0).toISOString() })))
+    let machineIdReads = 0
+    controller.machineIdHook = async () => {
+      machineIdReads += 1
+      if (machineIdReads < 2) return
+      const latest = JSON.parse(await readFile(ownerPath, 'utf8')) as Record<string, unknown>
+      await writeFile(ownerPath, JSON.stringify({
+        ...latest,
+        heartbeatAt: new Date(machineIdReads * 1_000).toISOString(),
+      }))
+    }
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      ownerAuthority: 'railway-fenced-handoff',
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toBeInstanceOf(RuntimeAlreadyRunningError)
+    expect(JSON.parse(await readFile(ownerPath, 'utf8'))).toMatchObject({ token: 'prior-owner' })
   })
 
   it('performs a controlled takeover before acquiring the lock', async () => {

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { fstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
 import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { hostname } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -28,6 +29,7 @@ export interface RuntimeLockOwner {
   readonly launcher: string
   readonly acquiredAt: string
   readonly heartbeatAt: string
+  readonly fencingProtocol?: 'railway-flock-v1'
   readonly processStartedAt?: string
   readonly guardianPid?: number
   readonly guardianStartedAt?: string
@@ -64,7 +66,18 @@ export interface RuntimeLockOptions {
   readonly onOwnershipLost?: (error: Error) => void
 }
 
-export type RuntimeLockOwnerAuthority = 'process' | 'railway-volume'
+export type RuntimeLockOwnerAuthority =
+  | 'process'
+  | 'railway-observer'
+  | 'railway-fenced-owner'
+  | 'railway-fenced-handoff'
+
+export interface RailwayRuntimeFence {
+  readonly fd: number
+  readonly path: string
+}
+
+let adoptedRailwayFence: RailwayRuntimeFence | null = null
 
 export interface OpenAliceRuntimeOptions extends RuntimeLockOptions {
   readonly userDataHome: string
@@ -126,16 +139,120 @@ export function takeoverRequested(env: NodeJS.ProcessEnv = process.env, argv: re
 export function resolveRuntimeLockOwnerAuthority(
   env: NodeJS.ProcessEnv = process.env,
 ): RuntimeLockOwnerAuthority {
+  if (env === process.env && adoptedRailwayFence && railwayFenceMatches(adoptedRailwayFence)) {
+    return 'railway-fenced-owner'
+  }
   const serviceManager = env['OPENALICE_SERVICE_MANAGER']?.trim()
   const machineId = env['OPENALICE_MACHINE_ID']?.trim()
   const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
   const environmentId = env['RAILWAY_ENVIRONMENT_ID']?.trim()
-  return serviceManager === 'railway'
-    && Boolean(environmentId)
-    && /^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
-    && machineId === `railway-service-${serviceId}`
-    ? 'railway-volume'
-    : 'process'
+  if (
+    serviceManager !== 'railway'
+    || !environmentId
+    || !/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
+    || machineId !== `railway-service-${serviceId}`
+  ) return 'process'
+  return resolveRailwayRuntimeFence(env) ? 'railway-fenced-handoff' : 'railway-observer'
+}
+
+export function resolveRailwayRuntimeFence(
+  env: NodeJS.ProcessEnv = process.env,
+): RailwayRuntimeFence | null {
+  const rawFd = env['OPENALICE_RAILWAY_FENCE_FD']?.trim()
+  const fd = Number(rawFd)
+  const path = railwayRuntimeFencePath(env)
+  if (!path || !/^[0-9]{1,4}$/.test(rawFd ?? '') || !Number.isInteger(fd) || fd < 3) return null
+  try {
+    const fence = { fd, path }
+    return railwayFenceMatches(fence) ? fence : null
+  } catch {
+    return null
+  }
+}
+
+export function railwayRuntimeFencePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
+  if (!/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')) return null
+  const configuredRoots = [
+    env['RAILWAY_VOLUME_MOUNT_PATH']?.trim(),
+    env['OPENALICE_RAILWAY_VOLUME_ROOT']?.trim(),
+  ].filter((value): value is string => Boolean(value)).map((value) => resolve(value))
+  if (configuredRoots.length === 0 || new Set(configuredRoots).size !== 1) return null
+  const volumeRoot = configuredRoots[0]
+  const home = env['OPENALICE_HOME']?.trim()
+  const installDir = env['OPENALICE_INSTALL_DIR']?.trim()
+  if (!volumeRoot || volumeRoot === '/' || !home || !installDir) return null
+  if (!pathIsWithin(volumeRoot, home) || !pathIsWithin(volumeRoot, installDir)) return null
+  return isLinuxMountPoint(volumeRoot) ? volumeRoot : null
+}
+
+function pathIsWithin(root: string, candidate: string): boolean {
+  try {
+    const canonicalRoot = realpathSync(root)
+    const canonicalCandidate = realpathSync(candidate)
+    return canonicalCandidate !== canonicalRoot
+      && canonicalCandidate.startsWith(`${canonicalRoot}/`)
+  } catch {
+    return false
+  }
+}
+
+function isLinuxMountPoint(path: string): boolean {
+  if (process.platform !== 'linux') return false
+  try {
+    const canonical = realpathSync(path)
+    return readFileSync('/proc/self/mountinfo', 'utf8')
+      .split('\n')
+      .some((line) => decodeMountInfoPath(line.split(' ')[4] ?? '') === canonical)
+  } catch {
+    return false
+  }
+}
+
+function decodeMountInfoPath(value: string): string {
+  return value.replace(/\\([0-7]{3})/g, (_match, octal: string) => (
+    String.fromCharCode(Number.parseInt(octal, 8))
+  ))
+}
+
+/**
+ * Adopt the inherited Railway lifecycle capability inside a trusted writer.
+ *
+ * The returned authority may be passed explicitly to the child's initial lock
+ * acquisitions. The writer keeps its duplicate for its complete lifetime so a
+ * Guardian crash cannot release the Volume fence while Alice, UTA, or Connector
+ * is still alive. Node child-process and node-pty launch boundaries do not map
+ * this extra descriptor; the environment marker and descriptor number are also
+ * removed before any untrusted descendant can start.
+ */
+export function adoptRailwayRuntimeFence(
+  env: NodeJS.ProcessEnv = process.env,
+): RuntimeLockOwnerAuthority {
+  const ownerAuthority = resolveRuntimeLockOwnerAuthority(env)
+  const fence = resolveRailwayRuntimeFence(env)
+
+  delete env['OPENALICE_RAILWAY_FENCE_FD']
+  delete env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER']
+  if (fence && env === process.env && ownerAuthority === 'railway-fenced-handoff') {
+    adoptedRailwayFence = fence
+  }
+  return ownerAuthority
+}
+
+function railwayFenceMatches(fence: RailwayRuntimeFence): boolean {
+  try {
+    const openFile = fstatSync(fence.fd)
+    const fenceFile = statSync(fence.path)
+    return openFile.isDirectory()
+      && fenceFile.isDirectory()
+      && openFile.dev === fenceFile.dev
+      && openFile.ino === fenceFile.ino
+      && inheritedFdHoldsExclusiveFlock(fence.fd)
+  } catch {
+    return false
+  }
 }
 
 export async function inspectRuntimeLock(
@@ -173,18 +290,18 @@ export async function inspectRuntimeLock(
   const currentMachineId = await controller.machineId()
   const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
   const railwayScope = railwayOwnerScope(owner, currentMachineId, ownerAuthority)
-  if (railwayScope === 'cross-container') {
-    if (hasExplicitHeartbeat && heartbeatAgeMs !== null && heartbeatStale) {
-      return inspection(
-        lockDir,
-        'stale',
-        owner,
-        heartbeatAgeMs,
-        true,
-        directoryIdentity,
-        'Railway volume owner heartbeat is stale and eligible for orchestrator handoff',
-      )
-    }
+  if (railwayScope === 'cross-container-fenced') {
+    return inspection(
+      lockDir,
+      'stale',
+      owner,
+      heartbeatAgeMs,
+      heartbeatStale,
+      directoryIdentity,
+      'Railway lifecycle fence is held and the prior container owner is eligible for handoff',
+    )
+  }
+  if (railwayScope === 'cross-container-observer') {
     return inspection(
       lockDir,
       'active',
@@ -193,8 +310,8 @@ export async function inspectRuntimeLock(
       heartbeatStale,
       directoryIdentity,
       !hasExplicitHeartbeat || heartbeatAgeMs === null
-        ? 'Railway volume owner heartbeat is missing or invalid; refusing automatic recovery'
-        : 'Railway volume owner heartbeat is active in another container namespace',
+        ? 'Railway owner heartbeat is missing or invalid; observer refuses automatic recovery'
+        : 'Railway owner belongs to another container namespace; observer refuses automatic recovery',
     )
   }
   if (railwayScope === 'foreign') {
@@ -242,16 +359,21 @@ function railwayOwnerScope(
   owner: RuntimeLockOwner,
   currentMachineId: string,
   ownerAuthority: RuntimeLockOwnerAuthority | undefined,
-): 'same-container' | 'cross-container' | 'foreign' | null {
-  if (ownerAuthority !== 'railway-volume') return null
+): 'same-container' | 'cross-container-observer' | 'cross-container-fenced' | 'foreign' | null {
+  if (
+    ownerAuthority !== 'railway-observer'
+    && ownerAuthority !== 'railway-fenced-owner'
+    && ownerAuthority !== 'railway-fenced-handoff'
+  ) return null
   if (!/^env:railway-service-[A-Za-z0-9-]+$/.test(currentMachineId)) return 'foreign'
   if (owner.hostname.length === 0) return 'foreign'
   const sameContainer = owner.hostname === hostname()
-  const belongsToService = owner.machineId === currentMachineId
-    || owner.machineId === `hostname:${owner.hostname}`
-  if (sameContainer && belongsToService) return 'same-container'
-  if (belongsToService) return 'cross-container'
-  return 'foreign'
+  if (owner.machineId !== currentMachineId) return 'foreign'
+  if (sameContainer) return 'same-container'
+  if (owner.fencingProtocol !== 'railway-flock-v1') return 'foreign'
+  return ownerAuthority === 'railway-fenced-handoff'
+    ? 'cross-container-fenced'
+    : 'cross-container-observer'
 }
 
 export async function acquireRuntimeLock(
@@ -272,6 +394,9 @@ export async function acquireRuntimeLock(
     launcher: opts.launcher ?? process.env['OPENALICE_LAUNCHER'] ?? 'standalone',
     acquiredAt: now,
     heartbeatAt: now,
+    ...(ownerAuthority === 'railway-fenced-handoff' || ownerAuthority === 'railway-fenced-owner'
+      ? { fencingProtocol: 'railway-flock-v1' as const }
+      : {}),
     processStartedAt: new Date(processStartedAt).toISOString(),
     ...(opts.guardianPid ? { guardianPid: opts.guardianPid } : {}),
     ...(opts.guardianStartedAt ? { guardianStartedAt: new Date(opts.guardianStartedAt).toISOString() } : {}),
@@ -384,7 +509,7 @@ export async function recoverRuntimeOwner(
   const currentMachineId = await controller.machineId()
   const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
   const railwayScope = railwayOwnerScope(owner, currentMachineId, ownerAuthority)
-  if (railwayScope === 'cross-container') {
+  if (railwayScope === 'cross-container-observer' || railwayScope === 'cross-container-fenced') {
     throw new Error(`OpenAlice owner ${owner.pid} belongs to another Railway container; refusing to signal it`)
   }
   if (railwayScope === 'foreign') {
@@ -480,7 +605,7 @@ async function claimAndRemove(current: RuntimeLockInspection): Promise<boolean> 
     const identity = `${currentStat.dev}:${currentStat.ino}:${currentStat.birthtimeMs}`
     if (identity !== current.directoryIdentity) return false
     const latest = await readOwner(current.lockDir).catch(() => null)
-    if (current.owner && latest?.token !== current.owner.token) return false
+    if (current.owner && !sameReclaimEvidence(current.owner, latest)) return false
     if (!current.owner && latest) return false
     await rename(current.lockDir, quarantineDir)
     quarantined = true
@@ -550,6 +675,9 @@ async function readOwnerRecord(lockDir: string): Promise<ParsedRuntimeLockOwner>
       launcher: typeof parsed['launcher'] === 'string' ? parsed['launcher'] : 'legacy',
       acquiredAt,
       heartbeatAt: hasExplicitHeartbeat ? parsed['heartbeatAt'] as string : acquiredAt,
+      ...(parsed['fencingProtocol'] === 'railway-flock-v1'
+        ? { fencingProtocol: 'railway-flock-v1' as const }
+        : {}),
       ...(typeof parsed['processStartedAt'] === 'string' ? { processStartedAt: parsed['processStartedAt'] } : {}),
       ...(typeof parsed['guardianPid'] === 'number' ? { guardianPid: parsed['guardianPid'] } : {}),
       ...(typeof parsed['guardianStartedAt'] === 'string' ? { guardianStartedAt: parsed['guardianStartedAt'] } : {}),
@@ -559,6 +687,35 @@ async function readOwnerRecord(lockDir: string): Promise<ParsedRuntimeLockOwner>
 
 async function readOwner(lockDir: string): Promise<RuntimeLockOwner> {
   return (await readOwnerRecord(lockDir)).owner
+}
+
+function sameReclaimEvidence(
+  inspected: RuntimeLockOwner,
+  latest: RuntimeLockOwner | null,
+): boolean {
+  return latest !== null
+    && latest.schemaVersion === inspected.schemaVersion
+    && latest.token === inspected.token
+    && latest.pid === inspected.pid
+    && latest.hostname === inspected.hostname
+    && latest.machineId === inspected.machineId
+    && latest.launcher === inspected.launcher
+    && latest.acquiredAt === inspected.acquiredAt
+    && latest.heartbeatAt === inspected.heartbeatAt
+    && latest.fencingProtocol === inspected.fencingProtocol
+    && latest.processStartedAt === inspected.processStartedAt
+    && latest.guardianPid === inspected.guardianPid
+    && latest.guardianStartedAt === inspected.guardianStartedAt
+}
+
+function inheritedFdHoldsExclusiveFlock(fd: number): boolean {
+  if (process.platform !== 'linux') return false
+  try {
+    const fdInfo = readFileSync(`/proc/self/fdinfo/${fd}`, 'utf8')
+    return /^lock:\s+\d+:\s+FLOCK\s+ADVISORY\s+WRITE\b/m.test(fdInfo)
+  } catch {
+    return false
+  }
 }
 
 function inspection(

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -662,18 +662,26 @@ source-built Docker image.
 - [x] Diagnose the first retained-Volume Railway deployment failure. Its old
   beta lock used the legacy hostname-derived machine identity, while the new
   container correctly used the stable Railway service identity; ordinary
-  foreign-machine protection therefore left the stale owner blocked. Add the
-  Railway-volume authority needed for same-service container handoff: exact
-  service identity, explicit-heartbeat freshness, fail-closed missing/invalid
-  evidence, same-container PID authority, no cross-container signals, bounded
-  entrypoint-only waiting, and `tini` subreaper operation beneath Railway's
-  platform init. Live reacceptance remains pending a dev artifact containing
-  this repair.
-- [x] Pass the handoff-repair local gates: 83 focused ownership/CLI/entrypoint
-  tests, 5,281 full-suite tests, root/Guardian/CLI TypeScript, Guardian recovery,
-  Linux installer and SSH-remote Docker smokes, Bash syntax, and a rebuilt
-  Railway image whose `tini -s -g` entrypoint still contains no Node, Bun, or
-  Agent Runtime executable.
+  foreign-machine protection therefore left the stale owner blocked.
+- [x] Reject the first heartbeat-based handoff repair during review. It allowed
+  ordinary Railway SSH to gain cross-container reclaim authority and had a
+  stale-inspection/rename race. Cancel its dev artifact before publication;
+  keep the last accepted dev manifest unchanged.
+- [x] Replace heartbeat authority with a Volume-mount-inode kernel `flock`
+  taken before installer or Project mutation. Validate the real mount, its
+  canonical relationship to the actual Home/install roots, and the inherited
+  locked FD. Pass a startup duplicate only through CLI -> Guardian ->
+  Alice/UTA/Connector; those trusted writers validate and retain lifetime copies
+  while ordinary child processes, adapters, Agents, and PTYs receive none. Write `railway-flock-v1` owner
+  records, keep ordinary SSH observer-only, fail closed at every Runtime hop,
+  discover every Volume Project and reject legacy owners before release or
+  Project mutation, and recheck complete owner evidence before quarantine.
+- [x] Pass the fenced-handoff local gates: focused ownership/CLI/entrypoint and
+  capability-isolation specs, root/Guardian/CLI TypeScript, full suite,
+  Guardian recovery, Linux installer and SSH-remote Docker smokes, plus a
+  Linux shared-Volume drill for suspended holder, hard kill, and simultaneous
+  replacements. Rebuild the Railway image and reconfirm that it contains no
+  Node, Bun, or Agent Runtime executable.
 - [x] Pass the remaining local repository gates: root and CLI TypeScript,
   `git diff --check`, the 222-test focused run, the 5,266-test full suite,
   Linux installer and SSH-remote Docker smokes, Guardian recovery smoke, and a
@@ -690,8 +698,10 @@ source-built Docker image.
   `openalice remote` browser/tunnel journey. A beta candidate has now booted
   successfully against an isolated diagnostic Home on the retained Volume and
   exposed no public domain. Its first attempt against the existing Project Home
-  reproduced the legacy-machine-identity handoff failure above; redeployment
-  of the repaired dev artifact against that original Home is still required.
+  reproduced the legacy-machine-identity handoff failure above. Prove the new
+  lifecycle fence on the diagnostic Home first; then, after showing the old
+  deployment is stopped, quarantine only the exact retained legacy lock
+  directories before selecting that original Home.
 - [ ] Repeat `openalice project transfer --plan` through the deployed Railway
   candidate so SSH compatibility, destination absence, and free-space
   preflight are proven before apply.
@@ -705,7 +715,8 @@ source-built Docker image.
 - [ ] Restart and redeploy against the same Volume, verify install/Home/Agent
   persistence and foreground Guardian recovery, then exercise valid-release
   refresh fallback and the separately accepted hard-kill recovery path,
-  including legacy hostname identity and stable service identity across
+  including a holder suspended beyond the old heartbeat threshold, hard-kill
+  release of the kernel fence, and one-winner concurrent replacement across
   isolated container PID namespaces. The empty-Volume fail-closed case remains
   isolated to the disposable service.
 
@@ -1167,3 +1178,24 @@ This plan is complete only when:
   real Railway fixed-layout candidate deployment, Agent, restart/redeploy, and
   failure journeys remain pending. The inspected Railway service with
   `HOME=/root` is the old deployment, not candidate evidence.
+- 2026-09-01: Review of the first same-service handoff repair found two release
+  blockers: general Railway SSH inherited reclaim authority, and a heartbeat
+  could refresh between stale inspection and lock-directory rename. Dev build
+  run 33417079146 was cancelled before publication; the public dev manifest
+  stayed on `7a5fad58`. The replacement now locks the real Railway Volume mount
+  directory before creating mutable paths or installing. It validates canonical
+  actual Home/install containment plus the locked directory FD through Linux
+  fdinfo. A read-only Volume-wide retained-lock preflight now rejects legacy
+  ownership before release-pointer, shim, or Project mutation. Guardian keeps
+  the lifetime copy; Alice, UTA, and Connector retain lifetime duplicates that
+  ordinary children, adapters, Agents, and PTYs do not inherit. CLI, Guardian,
+  Alice, UTA, and Connector all fail
+  closed when the profile declares a missing or invalid fence. Cooperative owners declare `railway-flock-v1`;
+  legacy owners and changed owner evidence fail closed. The current macOS
+  focused review sets pass with the expected Linux-only skips; root, CLI,
+  and Guardian TypeScript, shell/Node syntax, Guardian recovery, and the full
+  5,292-test suite pass. A compiled Linux arm64 Bun chain independently proved
+  identical Volume/CLI/Guardian lock identity, trusted-writer descriptor adoption,
+  blocked contention, and fenced Guardian/Alice owner metadata. Linux installer,
+  remote-SSH, and full Docker Runtime smokes pass. PR/dev archive publication,
+  live Railway reacceptance, Project apply, and the Agent turn remain pending.

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -81,4 +81,18 @@ describe('CLI installer dev publication workflow', () => {
     expect(live.needs).toBe('publish-dev-cli')
     expect(live.if).toContain("needs.publish-dev-cli.result == 'success'")
   })
+
+  it('installs the remote smoke parser before running the checkout fixture', () => {
+    const steps = workflow.jobs['checkout-remote'].steps ?? []
+    const pnpm = steps.findIndex((candidate) => candidate.uses === 'pnpm/action-setup@v6')
+    const node = steps.findIndex((candidate) => candidate.uses === 'actions/setup-node@v7')
+    const install = steps.findIndex((candidate) => candidate.run === 'pnpm install --frozen-lockfile --filter @traderalice/openalice-cli')
+    const smoke = steps.findIndex((candidate) => candidate.name === 'Exercise clean SSH host fixture')
+
+    expect(pnpm).toBeGreaterThanOrEqual(0)
+    expect(node).toBeGreaterThan(pnpm)
+    expect(steps[node]?.with?.cache).toBe('pnpm')
+    expect(install).toBeGreaterThan(node)
+    expect(smoke).toBeGreaterThan(install)
+  })
 })

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -40,6 +40,8 @@ import {
   resolveAliceProjectIdentity,
   readAliceProjectProduct,
   normalizeProcessExitCode,
+  resolveRailwayRuntimeFence,
+  resolveRuntimeLockOwnerAuthority,
   RestartBackoff,
   takeoverRequested,
 } from '@traderalice/guardian-runtime'
@@ -53,6 +55,17 @@ import { runtimeProcessSpec } from './runtime-process-spec.mjs'
 const DATA_HOME = process.env.OPENALICE_HOME
   ?? process.env.OPENALICE_USER_DATA_HOME // deprecated alias, one-release courtesy
   ?? '/data'
+const RAILWAY_FENCE_CLAIMED = Boolean(
+  process.env.OPENALICE_RAILWAY_FENCE_FD
+  || process.env.OPENALICE_RAILWAY_ENTRYPOINT_OWNER,
+)
+const RAILWAY_RUNTIME_REQUIRED = process.env.OPENALICE_SERVICE_MANAGER?.trim() === 'railway'
+const RUNTIME_LOCK_OWNER_AUTHORITY = resolveRuntimeLockOwnerAuthority(process.env)
+const RAILWAY_RUNTIME_FENCE = RUNTIME_LOCK_OWNER_AUTHORITY === 'railway-fenced-handoff'
+  ? resolveRailwayRuntimeFence(process.env)
+  : null
+delete process.env.OPENALICE_RAILWAY_FENCE_FD
+delete process.env.OPENALICE_RAILWAY_ENTRYPOINT_OWNER
 const LAUNCHER_ROOT = process.env.AQ_LAUNCHER_ROOT ?? resolve(DATA_HOME, 'workspaces')
 const LAUNCHER = process.env.OPENALICE_LAUNCHER?.trim() || 'docker'
 const GUARDIAN_LAUNCHER = LAUNCHER.startsWith('guardian-') ? LAUNCHER : `guardian-${LAUNCHER}`
@@ -303,7 +316,7 @@ function makeUTASpec() {
 
 function spawnUTA() {
   const spec = makeUTASpec()
-  const child = spawn(spec.cmd, spec.args, { env: spec.env, stdio: 'inherit' })
+  const child = spawn(spec.cmd, spec.args, trustedRailwayChildOptions(spec.env))
   child.once('exit', (code, signal) => {
     if (utaChild === child) utaChild = null
     if (stopping || restartingUTA) return
@@ -322,7 +335,7 @@ function spawnConnector() {
     nodeBinary: NODE_BINARY,
   })
   const child = spawn(spec.cmd, spec.args, {
-    env: {
+    ...trustedRailwayChildOptions({
       ...process.env,
       ...ALICE_PROJECT_ENV,
       OPENALICE_CONNECTOR_PORT: String(CONNECTOR_PORT),
@@ -332,8 +345,7 @@ function spawnConnector() {
       OPENALICE_GUARDIAN_PID: String(process.pid),
       OPENALICE_GUARDIAN_STARTED_AT: String(GUARDIAN_STARTED_AT),
       ...(TAKEOVER ? { OPENALICE_TAKEOVER: '1' } : {}),
-    },
-    stdio: 'inherit',
+    }),
   })
   child.once('exit', (code, signal) => {
     if (connectorChild === child) connectorChild = null
@@ -354,7 +366,7 @@ function spawnAlice() {
     nodeBinary: NODE_BINARY,
   })
   const child = spawn(spec.cmd, spec.args, {
-    env: {
+    ...trustedRailwayChildOptions({
       ...process.env,
       ...ALICE_PROJECT_ENV,
       OPENALICE_WEB_PORT: String(WEB_PORT),
@@ -371,8 +383,7 @@ function spawnAlice() {
       ...(PROJECT_PRODUCT === 'nano'
         ? { OPENALICE_PROJECT_PRODUCT: 'nano', OPENALICE_UTA_DISABLED: '1' }
         : {}),
-    },
-    stdio: 'inherit',
+    }),
   })
   child.once('exit', (code, signal) => {
     if (stopping) return
@@ -381,6 +392,17 @@ function spawnAlice() {
     shutdown(typeof code === 'number' && code !== 0 ? code : 1)
   })
   return child
+}
+
+function trustedRailwayChildOptions(env) {
+  if (!RAILWAY_RUNTIME_FENCE) return { env, stdio: 'inherit' }
+  return {
+    env: {
+      ...env,
+      OPENALICE_RAILWAY_FENCE_FD: '3',
+    },
+    stdio: ['inherit', 'inherit', 'inherit', RAILWAY_RUNTIME_FENCE.fd],
+  }
 }
 
 async function waitForUTA() {
@@ -616,6 +638,9 @@ export async function startGuardianRuntime() {
   process.on('SIGTERM', () => shutdown())
   process.on('SIGHUP', () => shutdown())
 
+  if ((RAILWAY_FENCE_CLAIMED || RAILWAY_RUNTIME_REQUIRED) && !RAILWAY_RUNTIME_FENCE) {
+    throw new Error('invalid inherited Railway lifecycle fence; refusing to start Guardian')
+  }
   await initializeRuntimeState()
   if (!process.env.OPENALICE_HOME && process.env.OPENALICE_USER_DATA_HOME) {
     console.warn('[guardian/prod] OPENALICE_USER_DATA_HOME is deprecated — set OPENALICE_HOME instead')
@@ -638,6 +663,7 @@ export async function startGuardianRuntime() {
     launcher: GUARDIAN_LAUNCHER,
     takeover: TAKEOVER,
     processStartedAt: GUARDIAN_STARTED_AT,
+    ownerAuthority: RUNTIME_LOCK_OWNER_AUTHORITY,
     onOwnershipLost: (err) => {
       console.error('[guardian/prod] runtime ownership lost:', err)
       shutdown()

--- a/scripts/railway-entrypoint.spec.ts
+++ b/scripts/railway-entrypoint.spec.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { chmod, mkdir, mkdtemp, readFile, readlink, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -10,6 +11,7 @@ const execFileAsync = promisify(execFile)
 const temporaryPaths: string[] = []
 const entrypoint = resolve('scripts/railway/entrypoint.sh')
 const commandWrapper = resolve('scripts/railway/command-wrapper.sh')
+const retainedLockPreflight = resolve('scripts/railway/preflight-retained-locks.py')
 const shellEnvironment = resolve('scripts/railway/shell-env.sh')
 
 afterEach(async () => {
@@ -87,6 +89,36 @@ describe('Railway native CLI host entrypoint', () => {
     await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('rejects a Project Home inside the reserved reversible-quarantine tree', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_HOME: join(fixture.volume, 'quarantine', 'old-project'),
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining('cannot select the reserved Railway quarantine tree'),
+    })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects a Project Home reached through a symlinked quarantine alias', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+    await mkdir(join(fixture.volume, 'quarantine-target'))
+    await symlink('quarantine-target', join(fixture.volume, 'quarantine'))
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_HOME: join(fixture.volume, 'quarantine', 'old-project'),
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining('cannot select the reserved Railway quarantine tree'),
+    })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
   it('rejects the legacy Node-managed 0.90.1 release before invoking the installer', async () => {
     const fixture = await makeFixture({ installer: 'success' })
 
@@ -100,23 +132,149 @@ describe('Railway native CLI host entrypoint', () => {
     await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('uses the Railway mount and service identity as container-replacement authority', async () => {
+  it.runIf(process.platform === 'linux')('rejects a Railway fence rooted at an ordinary directory instead of a mounted Volume', async () => {
     const fixture = await makeFixture({ installer: 'success' })
 
-    await execFileAsync('bash', [entrypoint], {
+    await expect(execFileAsync('bash', [entrypoint], {
       env: {
         ...fixture.env,
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
         RAILWAY_SERVICE_ID: 'service-test',
       },
-    })
+    })).rejects.toMatchObject({ stderr: expect.stringContaining('must be an actual mount point') })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
 
-    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(
-      'OPENALICE_MACHINE_ID=railway-service-service-test',
-    )
-    expect(await readFile(fixture.runtimeCalled, 'utf8')).toContain(
-      'OPENALICE_RAILWAY_ENTRYPOINT_OWNER=1',
-    )
+  it.runIf(process.platform === 'linux' && existsSync('/dev/shm'))('blocks legacy retained ownership before installer or Project mutation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-legacy-preflight-'))
+    const fixtureRoot = join('/dev/shm', `openalice-legacy-preflight-${process.pid}-${Date.now()}`)
+    const legacyProject = join(fixtureRoot, 'projects', 'legacy-a')
+    const selectedProject = join(fixtureRoot, 'projects', 'empty-b')
+    temporaryPaths.push(root, fixtureRoot)
+    const lockDir = join(legacyProject, 'state', 'guardian.lock')
+    const installCalled = join(root, 'installer-called')
+    const installer = join(root, 'install')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'legacy-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'legacy-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    }))
+    await writeFile(installer, `#!/usr/bin/env bash\nprintf called >${JSON.stringify(installCalled)}\n`, { mode: 0o755 })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        PATH: process.env.PATH,
+        HOME: '/dev/shm/home',
+        OPENALICE_HOME: selectedProject,
+        OPENALICE_INSTALL_DIR: '/dev/shm/home/.openalice',
+        NPM_CONFIG_PREFIX: '/dev/shm/home/.local',
+        BUN_INSTALL: '/dev/shm/home/.bun',
+        RAILWAY_VOLUME_MOUNT_PATH: '/dev/shm',
+        OPENALICE_RAILWAY_VOLUME_ROOT: '/dev/shm',
+        OPENALICE_RAILWAY_INSTALLER_PATH: installer,
+        OPENALICE_RAILWAY_PREFLIGHT_PATH: retainedLockPreflight,
+        OPENALICE_RAILWAY_COMMAND_WRAPPER_PATH: commandWrapper,
+        OPENALICE_RAILWAY_LINK_DIR: join(root, 'links'),
+        OPENALICE_RAILWAY_CHANNEL: 'dev',
+        OPENALICE_RAILWAY_WAIT_SECONDS: '10',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        `${fixtureRoot.slice('/dev/shm/'.length)}/projects/legacy-a/state/guardian.lock`,
+      ),
+    })
+    await expect(readFile(installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(existsSync(selectedProject)).toBe(false)
+  })
+
+  it('accepts only retained lock owners written by the same fenced Railway service', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-retained-locks-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const owner = {
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'previous-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'fenced-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+    }
+    for (const lockDir of [
+      join(project, 'state', 'guardian.lock'),
+      join(project, 'state', 'runtime.lock'),
+      join(launcher, 'state', 'runtime.lock'),
+      join(project, 'data', 'state', 'config-bootstrap.lock'),
+    ]) {
+      await mkdir(lockDir, { recursive: true })
+      await writeFile(join(lockDir, 'owner.json'), JSON.stringify(owner))
+    }
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+
+    await writeFile(join(project, 'state', 'guardian.lock', 'owner.json'), JSON.stringify({
+      ...owner,
+      machineId: 'env:railway-service-other',
+    }))
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('state/guardian.lock'),
+    })
+  })
+
+  it('discovers a nested legacy owner beyond another Project marker before an A-to-B cutover', async () => {
+    const volume = await mkdtemp(join(tmpdir(), 'openalice-railway-volume-scan-'))
+    temporaryPaths.push(volume)
+    const outerProject = join(volume, 'projects', 'outer')
+    const legacyProject = join(outerProject, 'nested', 'legacy-a')
+    const selectedProject = join(volume, 'projects', 'empty-b')
+    const lockDir = join(legacyProject, 'state', 'guardian.lock')
+    await mkdir(lockDir, { recursive: true })
+    await mkdir(join(outerProject, 'data', 'config'), { recursive: true })
+    await writeFile(join(outerProject, 'data', 'config', 'alice-project.json'), '{}')
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'legacy-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'legacy-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    }))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      volume,
+      selectedProject,
+      join(selectedProject, 'workspaces'),
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('projects/outer/nested/legacy-a/state/guardian.lock'),
+    })
+    expect(existsSync(selectedProject)).toBe(false)
   })
 
   it('rejects a configured machine identity that does not match the Railway service', async () => {
@@ -135,18 +293,34 @@ describe('Railway native CLI host entrypoint', () => {
     await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('requires enough Railway startup time for hard-kill heartbeat recovery', async () => {
+  it('rejects a Dashboard override that disables Railway lifecycle authority', async () => {
     const fixture = await makeFixture({ installer: 'success' })
 
     await expect(execFileAsync('bash', [entrypoint], {
       env: {
         ...fixture.env,
-        OPENALICE_RAILWAY_WAIT_SECONDS: '90',
+        OPENALICE_SERVICE_MANAGER: 'docker',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
         RAILWAY_SERVICE_ID: 'service-test',
       },
     })).rejects.toMatchObject({
-      stderr: expect.stringContaining('must be at least 130 on Railway'),
+      stderr: expect.stringContaining('OPENALICE_SERVICE_MANAGER must be railway'),
+    })
+    await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects an invalid Railway lifecycle-fence wait bound', async () => {
+    const fixture = await makeFixture({ installer: 'success' })
+
+    await expect(execFileAsync('bash', [entrypoint], {
+      env: {
+        ...fixture.env,
+        OPENALICE_RAILWAY_WAIT_SECONDS: '0',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+    })).rejects.toMatchObject({
+      stderr: expect.stringContaining('must be between 1 and 600'),
     })
     await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
@@ -177,7 +351,9 @@ describe('Railway native CLI host entrypoint', () => {
       'PATH=/usr/local/sbin:/usr/local/bin:/data/home/.openalice/bin:/data/home/.local/bin:/data/home/.bun/bin:',
     )
     expect(dockerfile).toContain('scripts/railway/command-wrapper.sh')
+    expect(dockerfile).toContain('scripts/railway/preflight-retained-locks.py')
     expect(dockerfile).toContain('scripts/railway/shell-env.sh')
+    expect(await readFile(entrypoint, 'utf8')).toContain('/usr/bin/flock --exclusive --timeout "$wait_seconds" 9')
     expect(dockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--"')
   })
 
@@ -349,12 +525,25 @@ exit 1
       .rejects.toMatchObject({ stderr: expect.stringContaining('no previously verified OpenAlice release') })
   })
 
+  it('rejects a native release that cannot retain the Railway lifecycle fence', async () => {
+    const fixture = await makeFixture({
+      installer: 'failure',
+      existing: true,
+      existingFenceCapability: false,
+    })
+
+    await expect(execFileAsync('bash', [entrypoint], { env: fixture.env }))
+      .rejects.toMatchObject({ stderr: expect.stringContaining('no previously verified OpenAlice release') })
+    await expect(readFile(fixture.runtimeCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
 })
 
 async function makeFixture(options: {
   installer: 'success' | 'failure' | 'noop'
   existing?: boolean
   existingChannel?: 'beta' | 'dev'
+  existingFenceCapability?: boolean
 }) {
   const root = await mkdtemp(join(tmpdir(), 'openalice-railway-entrypoint-'))
   temporaryPaths.push(root)
@@ -368,9 +557,12 @@ async function makeFixture(options: {
   const installRoot = join(volume, 'home', '.openalice')
   await writeInstaller(installer, options.installer, installCalled, runtimeCalled)
   if (options.existing) {
-    await writeLauncher(join(installRoot, 'bin', 'openalice'), runtimeCalled, options.existingChannel === 'dev'
-      ? { version: '0.91.0-dev.1', channel: 'dev' }
-      : undefined)
+    await writeLauncher(join(installRoot, 'bin', 'openalice'), runtimeCalled, {
+      ...(options.existingChannel === 'dev'
+        ? { version: '0.91.0-dev.1', channel: 'dev' as const }
+        : {}),
+      ...(options.existingFenceCapability === false ? { runtimeCapabilities: [] } : {}),
+    })
   }
   return {
     volume,
@@ -465,12 +657,15 @@ cat >"$OPENALICE_INSTALL_DIR/cli/current/bin/openalice" <<'LAUNCHER'
 #!/usr/bin/env bash
 if [[ "\${1:-}" == --version ]]; then printf '0.91.0-beta.1\\n'; exit 0; fi
 if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then
-  printf '{"version":"0.91.0-beta.1","installSource":{"schemaVersion":3,"repository":"TraderAlice/OpenAlice","cliVersion":"0.91.0-beta.1","selector":{"kind":"version","value":"v0.91.0-beta.1"},"installerUrl":"https://openalice.ai/install","updateChannel":"beta","method":"direct","artifact":{"platform":"linux","arch":"x64","sha256":"%s"},"installedAt":"2026-08-31T00:00:00.000Z"},"contentIdentity":"aaaaaaaaaaaaaaaa","managedRuntime":{"productVersion":"0.91.0-beta.1","platform":"linux","arch":"x64","path":"%s","contentIdentity":"aaaaaaaaaaaaaaaa"}}\\n' \\
+  printf '{"version":"0.91.0-beta.1","installSource":{"schemaVersion":3,"repository":"TraderAlice/OpenAlice","cliVersion":"0.91.0-beta.1","selector":{"kind":"version","value":"v0.91.0-beta.1"},"installerUrl":"https://openalice.ai/install","updateChannel":"beta","method":"direct","artifact":{"platform":"linux","arch":"x64","sha256":"%s"},"installedAt":"2026-08-31T00:00:00.000Z"},"contentIdentity":"aaaaaaaaaaaaaaaa","managedRuntime":{"productVersion":"0.91.0-beta.1","platform":"linux","arch":"x64","path":"%s","contentIdentity":"aaaaaaaaaaaaaaaa"},"runtimeCapabilities":["railway-flock-v1"]}\\n' \\
     "$(printf '0%.0s' {1..64})" "$OPENALICE_INSTALL_DIR/cli/releases/0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa"
   exit 0
 fi
-printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\nOPENALICE_RAILWAY_ENTRYPOINT_OWNER=%s\\n' \\
-  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" "\${OPENALICE_RAILWAY_ENTRYPOINT_OWNER:-}" >'${runtimeCalled}'
+if [[ -n "\${OPENALICE_RAILWAY_FENCE_FD:-}" ]]; then
+  grep -Eq '^lock:[[:space:]]+[0-9]+:[[:space:]]+FLOCK[[:space:]]+ADVISORY[[:space:]]+WRITE' "/proc/self/fdinfo/\${OPENALICE_RAILWAY_FENCE_FD}" || exit 97
+fi
+printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\nOPENALICE_RAILWAY_ENTRYPOINT_OWNER=%s\\nOPENALICE_RAILWAY_FENCE_FD=%s\\n' \\
+  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" "\${OPENALICE_RAILWAY_ENTRYPOINT_OWNER:-}" "\${OPENALICE_RAILWAY_FENCE_FD:-}" >'${runtimeCalled}'
 printf '%s\\n' "$*" >>'${runtimeCalled}'
 LAUNCHER
 chmod 0755 "$OPENALICE_INSTALL_DIR/cli/current/bin/openalice"
@@ -482,7 +677,7 @@ ln -s ../cli/current/bin/openalice "$OPENALICE_INSTALL_DIR/bin/openalice"
 async function writeLauncher(
   path: string,
   runtimeCalled: string,
-  profile: { version?: string; channel?: 'beta' | 'dev'; identity?: string } = {},
+  profile: { version?: string; channel?: 'beta' | 'dev'; identity?: string; runtimeCapabilities?: string[] } = {},
 ) {
   const installRoot = resolve(path, '..', '..')
   const version = profile.version ?? '0.91.0-beta.1'
@@ -495,9 +690,12 @@ async function writeLauncher(
   await symlink(join('releases', releaseName), join(installRoot, 'cli', 'current'))
   await writeFile(join(runtimeRoot, 'bin', 'openalice'), `#!/usr/bin/env bash
 if [[ "\${1:-}" == --version ]]; then printf '${version}\\n'; exit 0; fi
-if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then printf '%s\\n' '${JSON.stringify(versionPayload(runtimeRoot, { version, channel, identity }))}'; exit 0; fi
-printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\nOPENALICE_RAILWAY_ENTRYPOINT_OWNER=%s\\n' \\
-  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" "\${OPENALICE_RAILWAY_ENTRYPOINT_OWNER:-}" >'${runtimeCalled}'
+if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then printf '%s\\n' '${JSON.stringify(versionPayload(runtimeRoot, { version, channel, identity, runtimeCapabilities: profile.runtimeCapabilities }))}'; exit 0; fi
+if [[ -n "\${OPENALICE_RAILWAY_FENCE_FD:-}" ]]; then
+  grep -Eq '^lock:[[:space:]]+[0-9]+:[[:space:]]+FLOCK[[:space:]]+ADVISORY[[:space:]]+WRITE' "/proc/self/fdinfo/\${OPENALICE_RAILWAY_FENCE_FD}" || exit 97
+fi
+printf 'HOME=%s\\nOPENALICE_HOME=%s\\nAQ_LAUNCHER_ROOT=%s\\nOPENALICE_INSTALL_DIR=%s\\nNPM_CONFIG_PREFIX=%s\\nBUN_INSTALL=%s\\nOPENALICE_MACHINE_ID=%s\\nOPENALICE_RAILWAY_ENTRYPOINT_OWNER=%s\\nOPENALICE_RAILWAY_FENCE_FD=%s\\n' \\
+  "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE_INSTALL_DIR" "$NPM_CONFIG_PREFIX" "$BUN_INSTALL" "\${OPENALICE_MACHINE_ID:-}" "\${OPENALICE_RAILWAY_ENTRYPOINT_OWNER:-}" "\${OPENALICE_RAILWAY_FENCE_FD:-}" >'${runtimeCalled}'
 printf '%s\\n' "$*" >>'${runtimeCalled}'
 `, { mode: 0o755 })
   await writeDynamicLauncher(path)
@@ -523,7 +721,7 @@ async function writeReleaseLauncher(
   runtimeRoot: string,
   runtimeCalled: string,
   releaseName: string,
-  profile: { version: string; channel: 'beta' | 'dev'; identity: string; installedAt?: string },
+  profile: { version: string; channel: 'beta' | 'dev'; identity: string; installedAt?: string; runtimeCapabilities?: string[] },
 ) {
   await mkdir(join(runtimeRoot, 'bin'), { recursive: true })
   const versionFile = join(runtimeRoot, 'version.json')
@@ -537,7 +735,7 @@ printf 'release=${releaseName}\\n%s\\n' "$*" >'${runtimeCalled}'
 
 function versionPayload(
   runtimeRoot: string,
-  profile: { version?: string; channel?: 'beta' | 'dev'; identity?: string; installedAt?: string } = {},
+  profile: { version?: string; channel?: 'beta' | 'dev'; identity?: string; installedAt?: string; runtimeCapabilities?: string[] } = {},
 ) {
   const version = profile.version ?? '0.91.0-beta.1'
   const channel = profile.channel ?? 'beta'
@@ -558,6 +756,7 @@ function versionPayload(
       installedAt: profile.installedAt ?? '2026-08-31T00:00:00.000Z',
     },
     contentIdentity: identity,
+    runtimeCapabilities: profile.runtimeCapabilities ?? ['railway-flock-v1'],
     managedRuntime: {
       productVersion: version,
       platform: 'linux',

--- a/scripts/railway-fence-pty-fixture.ts
+++ b/scripts/railway-fence-pty-fixture.ts
@@ -1,0 +1,98 @@
+import { statSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+import { adoptRailwayRuntimeFence } from '@traderalice/guardian-runtime'
+import * as pty from 'node-pty'
+
+const rawFenceFd = process.env['OPENALICE_RAILWAY_FENCE_FD']
+const fencePath = process.env['OPENALICE_TEST_FENCE_PATH']
+const fenceFd = Number(rawFenceFd)
+if (!fencePath || !Number.isInteger(fenceFd)) {
+  throw new Error('fixture requires an inherited Railway fence descriptor')
+}
+
+const authority = adoptRailwayRuntimeFence(process.env)
+if (authority !== 'railway-fenced-handoff') {
+  throw new Error(`fixture did not validate fenced handoff authority: ${authority}`)
+}
+if (
+  'OPENALICE_RAILWAY_FENCE_FD' in process.env
+  || 'OPENALICE_RAILWAY_ENTRYPOINT_OWNER' in process.env
+) {
+  throw new Error('fixture retained Railway fence environment markers after adoption')
+}
+
+const fenceIdentity = statIdentity(fencePath)
+if (statIdentity(`/proc/self/fd/${fenceFd}`) !== fenceIdentity) {
+  throw new Error(`trusted writer did not retain Railway fence fd ${fenceFd}`)
+}
+
+const descendantProbe = `
+target="$(stat -Lc '%d:%i' "$OPENALICE_TEST_FENCE_PATH")"
+for candidate in /proc/$$/fd/[0-9]*; do
+  current="$(stat -Lc '%d:%i' "$candidate" 2>/dev/null || true)"
+  if [ "$current" = "$target" ]; then
+    printf 'FENCE_LEAK:%s\\n' "$candidate"
+    exit 41
+  fi
+done
+printf '%s\\n' "$OPENALICE_TEST_SUCCESS"
+`
+const ordinary = spawnSync('/bin/sh', ['-lc', descendantProbe], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    OPENALICE_TEST_SUCCESS: 'ORDINARY_FENCE_ISOLATED',
+  },
+  encoding: 'utf8',
+})
+process.stdout.write(ordinary.stdout)
+if (ordinary.status !== 0 || ordinary.stdout.includes('FENCE_LEAK:')) {
+  throw new Error(`ordinary child inherited the Railway fence (exit ${ordinary.status})`)
+}
+
+const explicitControl = spawnSync('/bin/sh', ['-lc', descendantProbe], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    OPENALICE_TEST_SUCCESS: 'EXPLICIT_FENCE_MISSING',
+  },
+  stdio: ['ignore', 'pipe', 'pipe', fenceFd],
+  encoding: 'utf8',
+})
+if (explicitControl.status !== 41 || !explicitControl.stdout.includes('FENCE_LEAK:')) {
+  throw new Error(`explicit fence inheritance control failed (exit ${explicitControl.status})`)
+}
+process.stdout.write('EXPLICIT_FENCE_CONTROL\n')
+
+const child = pty.spawn('/bin/sh', ['-lc', `
+target="$(stat -Lc '%d:%i' "$OPENALICE_TEST_FENCE_PATH")"
+for candidate in /proc/$$/fd/[0-9]*; do
+  current="$(stat -Lc '%d:%i' "$candidate" 2>/dev/null || true)"
+  if [ "$current" = "$target" ]; then
+    printf 'FENCE_LEAK:%s\\n' "$candidate"
+    exit 41
+  fi
+done
+printf 'PTY_FENCE_ISOLATED\\n'
+`], {
+  cols: 80,
+  rows: 24,
+  cwd: process.cwd(),
+  env: process.env as Record<string, string>,
+})
+
+let output = ''
+child.onData((chunk) => { output += chunk })
+const exitCode = await new Promise<number>((resolve) => {
+  child.onExit(({ exitCode: code }) => resolve(code))
+})
+process.stdout.write(output)
+if (exitCode !== 0 || !output.includes('PTY_FENCE_ISOLATED') || output.includes('FENCE_LEAK:')) {
+  throw new Error(`PTY inherited the Railway fence (exit ${exitCode})`)
+}
+
+function statIdentity(path: string): string {
+  const row = statSync(path)
+  return `${row.dev}:${row.ino}`
+}

--- a/scripts/railway-fence-pty.spec.ts
+++ b/scripts/railway-fence-pty.spec.ts
@@ -1,0 +1,68 @@
+import { existsSync, rmSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+
+const linuxIt = process.platform === 'linux' && existsSync('/dev/shm') ? it : it.skip
+
+describe('Railway lifecycle fence PTY isolation', () => {
+  linuxIt('retains the validated writer fd without exposing it to child processes or node-pty', () => {
+    const volumeRoot = '/dev/shm'
+    const home = join(volumeRoot, `openalice-railway-fence-pty-${process.pid}`)
+    const fixture = resolve('scripts/railway-fence-pty-fixture.ts')
+    const result = spawnSync('/bin/bash', ['-lc', `
+set -euo pipefail
+mkdir -p "$OPENALICE_HOME" "$OPENALICE_INSTALL_DIR"
+exec 9<"$OPENALICE_RAILWAY_VOLUME_ROOT"
+flock --exclusive 9
+export OPENALICE_RAILWAY_FENCE_FD=3
+export OPENALICE_TEST_FENCE_PATH="$OPENALICE_RAILWAY_VOLUME_ROOT"
+"$OPENALICE_TEST_NODE" --import tsx "$OPENALICE_TEST_FIXTURE" 3<&9 9<&-
+if (exec 9<&-; flock --nonblock "$OPENALICE_RAILWAY_VOLUME_ROOT" /bin/true); then
+  printf 'PARENT_FENCE_LOST\\n'
+  exit 42
+fi
+printf 'GUARDIAN_COPY_HELD\\n'
+exec 9<&-
+# Another Vitest file also exercises the real /dev/shm mount fence. Wait for
+# that short-lived, legitimate contender instead of making this release probe
+# race whichever spec happens to acquire the shared mount inode next. A leaked
+# PTY descendant still keeps this blocked until the timeout and fails the test.
+flock --exclusive --timeout 10 "$OPENALICE_RAILWAY_VOLUME_ROOT" /bin/true
+printf 'FENCE_RELEASED\\n'
+`], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        OPENALICE_HOME: home,
+        OPENALICE_INSTALL_DIR: join(home, 'install'),
+        OPENALICE_RAILWAY_VOLUME_ROOT: volumeRoot,
+        RAILWAY_VOLUME_MOUNT_PATH: volumeRoot,
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-fence-pty-test',
+        RAILWAY_SERVICE_ID: 'fence-pty-test',
+        RAILWAY_ENVIRONMENT_ID: 'fence-pty-environment',
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_TEST_NODE: process.execPath,
+        OPENALICE_TEST_FIXTURE: fixture,
+        NODE_OPTIONS: '--conditions=openalice-source',
+      },
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+
+    try {
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+      expect(result.stdout).toContain('PTY_FENCE_ISOLATED')
+      expect(result.stdout).toContain('ORDINARY_FENCE_ISOLATED')
+      expect(result.stdout).toContain('EXPLICIT_FENCE_CONTROL')
+      expect(result.stdout).toContain('GUARDIAN_COPY_HELD')
+      expect(result.stdout).toContain('FENCE_RELEASED')
+      expect(result.stdout).not.toContain('FENCE_LEAK:')
+      expect(result.stdout).not.toContain('PARENT_FENCE_LOST')
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/scripts/railway/entrypoint.sh
+++ b/scripts/railway/entrypoint.sh
@@ -34,12 +34,16 @@ fi
 if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
   [[ -n "${RAILWAY_SERVICE_ID:-}" ]] \
     || fail 'Railway did not provide a stable service identity'
+  [[ -z "${OPENALICE_SERVICE_MANAGER:-}" || "$OPENALICE_SERVICE_MANAGER" == railway ]] \
+    || fail 'OPENALICE_SERVICE_MANAGER must be railway on a Railway host'
+  export OPENALICE_SERVICE_MANAGER=railway
+  [[ "$RAILWAY_SERVICE_ID" =~ ^[A-Za-z0-9-]{1,128}$ ]] \
+    || fail 'Railway service identity is invalid'
   expected_machine_id="railway-service-${RAILWAY_SERVICE_ID}"
   if [[ -n "${OPENALICE_MACHINE_ID:-}" && "$OPENALICE_MACHINE_ID" != "$expected_machine_id" ]]; then
     fail 'OPENALICE_MACHINE_ID must match the Railway service identity'
   fi
   export OPENALICE_MACHINE_ID="$expected_machine_id"
-  export OPENALICE_RAILWAY_ENTRYPOINT_OWNER=1
 fi
 
 fixed_home="$(canonical_path "$volume_root/home")"
@@ -79,7 +83,12 @@ for persistent_path in "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE
     *) fail "$persistent_path must stay beneath the persistent volume root $volume_root" ;;
   esac
 done
-mkdir -p "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$NPM_CONFIG_PREFIX/bin" "$BUN_INSTALL/bin"
+quarantine_root="$(canonical_path "$volume_root/quarantine")"
+case "$OPENALICE_HOME" in
+  "$quarantine_root"|"$quarantine_root/"*)
+    fail 'OPENALICE_HOME cannot select the reserved Railway quarantine tree'
+    ;;
+esac
 
 channel="${OPENALICE_RAILWAY_CHANNEL:-stable}"
 version="${OPENALICE_RAILWAY_VERSION:-}"
@@ -88,6 +97,7 @@ port="${OPENALICE_RAILWAY_PORT:-47331}"
 wait_seconds="${OPENALICE_RAILWAY_WAIT_SECONDS:-180}"
 installer="${OPENALICE_RAILWAY_INSTALLER_PATH:-/opt/openalice/install}"
 command_wrapper="${OPENALICE_RAILWAY_COMMAND_WRAPPER_PATH:-/usr/local/libexec/openalice-railway-command}"
+retained_lock_preflight="${OPENALICE_RAILWAY_PREFLIGHT_PATH:-/usr/local/libexec/openalice-railway-preflight}"
 launcher="$OPENALICE_INSTALL_DIR/bin/openalice"
 
 [[ "$channel" == stable || "$channel" == beta || "$channel" == dev ]] \
@@ -98,9 +108,6 @@ launcher="$OPENALICE_INSTALL_DIR/bin/openalice"
   || fail 'OPENALICE_RAILWAY_PORT must be between 1 and 65535'
 [[ "$wait_seconds" =~ ^[0-9]+$ && "$wait_seconds" -ge 1 && "$wait_seconds" -le 600 ]] \
   || fail 'OPENALICE_RAILWAY_WAIT_SECONDS must be between 1 and 600'
-if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" && "$wait_seconds" -lt 130 ]]; then
-  fail 'OPENALICE_RAILWAY_WAIT_SECONDS must be at least 130 on Railway so draining plus stale-heartbeat recovery retains a bounded margin'
-fi
 if [[ "$channel" == dev && -n "$version" ]]; then
   fail 'the rolling dev channel cannot be combined with OPENALICE_RAILWAY_VERSION'
 fi
@@ -115,6 +122,37 @@ if [[ -n "$version" ]]; then
   [[ "$version" != 0.90.1 ]] \
     || fail 'OpenAlice 0.90.1 uses the legacy Node-managed layout and cannot run as a Railway native CLI host'
 fi
+
+if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
+  [[ -x /usr/bin/flock ]] \
+    || fail 'the Railway image is missing /usr/bin/flock'
+  [[ -x /usr/bin/mountpoint ]] \
+    || fail 'the Railway image is missing /usr/bin/mountpoint'
+  /usr/bin/mountpoint --quiet "$volume_root" \
+    || fail 'the Railway Volume root must be an actual mount point'
+  railway_fence_path="$volume_root"
+  exec 9<"$railway_fence_path"
+  printf 'openalice railway: waiting for the Volume lifecycle fence at %s\n' "$railway_fence_path"
+  /usr/bin/flock --exclusive --timeout "$wait_seconds" 9 \
+    || fail "could not acquire the Volume lifecycle fence within ${wait_seconds}s"
+  [[ -d "$railway_fence_path" && -e /proc/self/fd/9 ]] \
+    || fail 'the Railway lifecycle fence did not preserve fd 9'
+  [[ "$(stat -Lc '%d:%i' /proc/self/fd/9)" == "$(stat -Lc '%d:%i' "$railway_fence_path")" ]] \
+    || fail 'the inherited Railway lifecycle fence names the wrong inode'
+  grep -Eq '^lock:[[:space:]]+[0-9]+:[[:space:]]+FLOCK[[:space:]]+ADVISORY[[:space:]]+WRITE' /proc/self/fdinfo/9 \
+    || fail 'the inherited Railway lifecycle fence is not exclusively locked'
+  export OPENALICE_RAILWAY_FENCE_FD=9
+  export OPENALICE_RAILWAY_ENTRYPOINT_OWNER=1
+  [[ -f "$retained_lock_preflight" && ! -L "$retained_lock_preflight" ]] \
+    || fail 'the Railway image is missing its retained-lock preflight'
+  python3 "$retained_lock_preflight" \
+    "$volume_root" \
+    "$OPENALICE_HOME" \
+    "$AQ_LAUNCHER_ROOT" \
+    "env:${OPENALICE_MACHINE_ID}"
+fi
+
+mkdir -p "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$NPM_CONFIG_PREFIX/bin" "$BUN_INSTALL/bin"
 
 validated_install_identity() {
   local expected_channel="${1:-}" expected_version="${2:-}"
@@ -136,6 +174,7 @@ except Exception:
 
 source = payload.get("installSource")
 runtime = payload.get("managedRuntime")
+capabilities = payload.get("runtimeCapabilities")
 artifact = source.get("artifact") if isinstance(source, dict) else None
 version = payload.get("version")
 identity = payload.get("contentIdentity")
@@ -156,6 +195,8 @@ if not (
     and isinstance(artifact.get("sha256"), str)
     and re.fullmatch(r"[a-f0-9]{64}", artifact["sha256"])
     and isinstance(runtime, dict)
+    and isinstance(capabilities, list)
+    and "railway-flock-v1" in capabilities
     and runtime.get("productVersion") == version
     and runtime.get("contentIdentity") == identity
     and runtime.get("platform") == artifact.get("platform")
@@ -188,6 +229,7 @@ if expected_channel:
 print(json.dumps({
     "version": version,
     "contentIdentity": identity,
+    "runtimeCapabilities": capabilities,
     "releaseRoot": runtime_root,
     "installSource": {
         "schemaVersion": source["schemaVersion"],

--- a/scripts/railway/preflight-retained-locks.py
+++ b/scripts/railway/preflight-retained-locks.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Fail before release mutation when any Railway Project retains legacy ownership."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+
+
+LOCK_PATHS = (
+    ("state/guardian.lock", lambda project, _launcher: os.path.join(project, "state", "guardian.lock")),
+    ("state/runtime.lock", lambda project, _launcher: os.path.join(project, "state", "runtime.lock")),
+    (
+        "workspaces/state/runtime.lock",
+        lambda _project, launcher: os.path.join(launcher, "state", "runtime.lock"),
+    ),
+    (
+        "data/state/config-bootstrap.lock",
+        lambda project, _launcher: os.path.join(project, "data", "state", "config-bootstrap.lock"),
+    ),
+)
+
+
+def read_fenced_owner(lock_dir: str, expected_machine_id: str) -> bool:
+    try:
+        lock_stat = os.lstat(lock_dir)
+    except FileNotFoundError:
+        return True
+    if not stat.S_ISDIR(lock_stat.st_mode) or stat.S_ISLNK(lock_stat.st_mode):
+        return False
+
+    owner_path = os.path.join(lock_dir, "owner.json")
+    try:
+        descriptor = os.open(owner_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except (FileNotFoundError, OSError):
+        return False
+    try:
+        owner_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(owner_stat.st_mode):
+            return False
+        with os.fdopen(descriptor, "r", encoding="utf-8", closefd=False) as stream:
+            owner = json.load(stream)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return False
+    finally:
+        os.close(descriptor)
+
+    return bool(
+        isinstance(owner, dict)
+        and owner.get("schemaVersion") == 1
+        and isinstance(owner.get("pid"), int)
+        and owner["pid"] > 0
+        and isinstance(owner.get("hostname"), str)
+        and owner["hostname"]
+        and owner.get("machineId") == expected_machine_id
+        and isinstance(owner.get("token"), str)
+        and owner["token"]
+        and isinstance(owner.get("launcher"), str)
+        and owner["launcher"]
+        and isinstance(owner.get("acquiredAt"), str)
+        and isinstance(owner.get("heartbeatAt"), str)
+        and owner.get("fencingProtocol") == "railway-flock-v1"
+    )
+
+
+def looks_like_project_home(path: str) -> bool:
+    if os.path.isfile(os.path.join(path, "data", "config", "alice-project.json")):
+        return True
+    return any(os.path.lexists(resolve_path(path, os.path.join(path, "workspaces"))) for _, resolve_path in LOCK_PATHS)
+
+
+def discover_project_homes(volume_root: str, selected_home: str) -> list[str]:
+    homes = {selected_home}
+    reserved = {os.path.realpath(os.path.join(volume_root, "quarantine"))}
+    for root, directories, _files in os.walk(volume_root, topdown=True, followlinks=False):
+        root = os.path.realpath(root)
+        if root in reserved:
+            directories[:] = []
+            continue
+        directories[:] = [
+            name
+            for name in directories
+            if not os.path.islink(os.path.join(root, name))
+            and os.path.realpath(os.path.join(root, name)) not in reserved
+        ]
+        if root != volume_root and looks_like_project_home(root):
+            homes.add(root)
+    return sorted(homes)
+
+
+def is_within(root: str, path: str) -> bool:
+    try:
+        return os.path.commonpath((root, path)) == root and path != root
+    except ValueError:
+        return False
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 5:
+        print(
+            "openalice railway: retained-lock preflight requires Volume root, Project Home, launcher root, and machine identity",
+            file=sys.stderr,
+        )
+        return 2
+
+    volume_root = os.path.realpath(os.path.abspath(argv[1]))
+    project_home = os.path.realpath(os.path.abspath(argv[2]))
+    launcher_root = os.path.realpath(os.path.abspath(argv[3]))
+    expected_machine_id = argv[4]
+    if not is_within(volume_root, project_home) or not is_within(volume_root, launcher_root):
+        print("openalice railway: retained-lock preflight paths escape the Volume", file=sys.stderr)
+        return 2
+
+    invalid: list[str] = []
+    for candidate_home in discover_project_homes(volume_root, project_home):
+        candidate_launcher = launcher_root if candidate_home == project_home else os.path.join(candidate_home, "workspaces")
+        for relative, resolve_path in LOCK_PATHS:
+            lock_path = resolve_path(candidate_home, candidate_launcher)
+            if read_fenced_owner(lock_path, expected_machine_id):
+                continue
+            invalid.append(os.path.relpath(lock_path, volume_root))
+    if not invalid:
+        return 0
+
+    print(
+        "openalice railway: retained pre-fence Runtime ownership blocks release mutation: "
+        + ", ".join(invalid)
+        + ". Verify the previous deployment is stopped, then move only these exact lock directories "
+        "to the documented reversible quarantine; do not clear the Project or Volume.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -183,6 +183,20 @@ describe('Release workflow critical path', () => {
     }
   })
 
+  it('installs the remote smoke parser before release installer acceptance', () => {
+    const steps = workflow.jobs['cli-installer-acceptance'].steps ?? []
+    const pnpm = steps.findIndex((candidate) => candidate.uses === 'pnpm/action-setup@v6')
+    const node = steps.findIndex((candidate) => candidate.uses === 'actions/setup-node@v7')
+    const install = steps.findIndex((candidate) => candidate.run === 'pnpm install --frozen-lockfile --filter @traderalice/openalice-cli')
+    const remote = steps.findIndex((candidate) => candidate.name === 'Exercise candidate installer through managed SSH remote')
+
+    expect(pnpm).toBeGreaterThanOrEqual(0)
+    expect(node).toBeGreaterThan(pnpm)
+    expect(steps[node]?.with?.cache).toBe('pnpm')
+    expect(install).toBeGreaterThan(node)
+    expect(remote).toBeGreaterThan(install)
+  })
+
   it('does not activate stable package-manager channels before CDN verification', () => {
     const verification = workflow.jobs['verify-public-cli-channels']
     expect(needs(verification)).toContain('mirror-release-assets')

--- a/services/connector/src/main.ts
+++ b/services/connector/src/main.ts
@@ -7,6 +7,7 @@
  */
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
+import { adoptRailwayRuntimeFence } from '@traderalice/guardian-runtime'
 import {
   connectorArtifactDeliverySchema,
   connectorArtifactFailureSchema,
@@ -28,8 +29,17 @@ import { dataPath } from '@/core/paths.js'
 import { installConnectorProxyTransport } from './core/proxy.js'
 
 const CONNECTOR_PORT = Number(process.env['OPENALICE_CONNECTOR_PORT'] ?? 47334)
+const RAILWAY_RUNTIME_REQUIRED = Boolean(
+  process.env['OPENALICE_RAILWAY_FENCE_FD']
+  || process.env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER']
+  || process.env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway'
+)
+const RUNTIME_LOCK_OWNER_AUTHORITY = adoptRailwayRuntimeFence(process.env)
 
 export async function startConnectorService(): Promise<void> {
+  if (RAILWAY_RUNTIME_REQUIRED && RUNTIME_LOCK_OWNER_AUTHORITY !== 'railway-fenced-handoff') {
+    throw new Error('invalid or missing inherited Railway lifecycle fence; refusing to start Connector')
+  }
   const startedAt = new Date().toISOString()
   console.log(`[connector] bootstrap @ ${startedAt}`)
 

--- a/services/uta/src/main.ts
+++ b/services/uta/src/main.ts
@@ -12,6 +12,7 @@
 
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
+import { adoptRailwayRuntimeFence } from '@traderalice/guardian-runtime'
 import { loadConfig, readUTAsConfig, purgeEphemeralUTAs, type UTAConfig } from '@/core/config.js'
 import { parseDuration } from '@/core/duration.js'
 import { createEventLog } from '@/core/event-log.js'
@@ -37,8 +38,17 @@ import type { UTAEngineContext } from './types.js'
 
 const UTA_PORT = Number(process.env['OPENALICE_UTA_PORT'] ?? 47333)
 const CATALOG_REFRESH_MS = 6 * 60 * 60 * 1000  // 6h
+const RAILWAY_RUNTIME_REQUIRED = Boolean(
+  process.env['OPENALICE_RAILWAY_FENCE_FD']
+  || process.env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER']
+  || process.env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway',
+)
+const RUNTIME_LOCK_OWNER_AUTHORITY = adoptRailwayRuntimeFence(process.env)
 
 export async function startUTAService(): Promise<void> {
+  if (RAILWAY_RUNTIME_REQUIRED && RUNTIME_LOCK_OWNER_AUTHORITY !== 'railway-fenced-handoff') {
+    throw new Error('invalid or missing inherited Railway lifecycle fence; refusing to start UTA')
+  }
   const startedAt = new Date().toISOString()
   console.log(`[uta] bootstrap @ ${startedAt}`)
 
@@ -53,7 +63,7 @@ export async function startUTAService(): Promise<void> {
     console.log(`[uta] outbound proxy detected (${outboundProxy.replace(/\/\/[^@/]*@/, '//***@')}) — bridging into CCXT exchanges`)
   }
 
-  const config = await loadConfig()
+  const config = await loadConfig({ ownerAuthority: RUNTIME_LOCK_OWNER_AUTHORITY })
 
   // ==================== Trading-only dependencies ====================
   // UTA needs eventLog (UTAManager journaling) + toolCenter (CCXT tool

--- a/src/core/config-bootstrap-lock.ts
+++ b/src/core/config-bootstrap-lock.ts
@@ -1,6 +1,7 @@
 import {
   RuntimeAlreadyRunningError,
   acquireRuntimeLock,
+  type RuntimeLockOwnerAuthority,
   type RuntimeProcessLock,
 } from '@traderalice/guardian-runtime'
 
@@ -15,6 +16,7 @@ export interface ConfigBootstrapLockOptions {
   readonly lockDir?: string
   readonly waitMs?: number
   readonly pollMs?: number
+  readonly ownerAuthority?: RuntimeLockOwnerAuthority
 }
 
 function positiveEnvNumber(name: string): number | undefined {
@@ -56,6 +58,7 @@ export async function withConfigBootstrapLock<T>(
         launcher: `${process.env['OPENALICE_LAUNCHER'] ?? 'standalone'}-config-bootstrap`,
         guardianPid: positiveEnvNumber('OPENALICE_GUARDIAN_PID'),
         guardianStartedAt: positiveEnvNumber('OPENALICE_GUARDIAN_STARTED_AT'),
+        ownerAuthority: opts.ownerAuthority,
       })
     } catch (err) {
       if (!(err instanceof RuntimeAlreadyRunningError)) throw err

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,6 +6,7 @@ import { newsCollectorSchema } from '../domain/news/config.js'
 import { runMigrations } from '../migrations/runner.js'
 import { dataPath } from '@/core/paths.js'
 import { withConfigBootstrapLock } from './config-bootstrap-lock.js'
+import type { RuntimeLockOwnerAuthority } from '@traderalice/guardian-runtime'
 import { parseDuration } from './duration.js'
 import { isSealedEnvelope, seal, unseal } from './sealing.js'
 
@@ -537,8 +538,12 @@ async function parseAndSeed<T>(
   return parsed
 }
 
-export async function loadConfig(): Promise<Config> {
-  return withConfigBootstrapLock(loadConfigUnlocked)
+export async function loadConfig(
+  options: { ownerAuthority?: RuntimeLockOwnerAuthority } = {},
+): Promise<Config> {
+  return withConfigBootstrapLock(loadConfigUnlocked, {
+    ownerAuthority: options.ownerAuthority,
+  })
 }
 
 async function loadConfigUnlocked(): Promise<Config> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import {
   acquireOpenAliceRuntimeLocks,
+  adoptRailwayRuntimeFence,
   takeoverRequested,
   type OpenAliceRuntimeLock,
 } from '@traderalice/guardian-runtime'
@@ -77,6 +78,12 @@ import { NewsCollectorStore, NewsCollector } from './domain/news/index.js'
 import { createNewsArchiveTools } from './tool/news.js'
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+const RAILWAY_RUNTIME_REQUIRED = Boolean(
+  process.env['OPENALICE_RAILWAY_FENCE_FD']
+  || process.env['OPENALICE_RAILWAY_ENTRYPOINT_OWNER']
+  || process.env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway',
+)
+const RUNTIME_LOCK_OWNER_AUTHORITY = adoptRailwayRuntimeFence(process.env)
 let runtimeLock: OpenAliceRuntimeLock | null = null
 
 async function releaseRuntimeLock(): Promise<void> {
@@ -91,7 +98,7 @@ async function main() {
   // `pnpm start`; guardian children get OPENALICE_HOME so this stays quiet).
   printLegacyDataNotice('[alice]')
 
-  const config = await loadConfig()
+  const config = await loadConfig({ ownerAuthority: RUNTIME_LOCK_OWNER_AUTHORITY })
 
   const toolCallLog = await createToolCallLog()
 
@@ -448,6 +455,9 @@ async function main() {
 }
 
 export async function startAliceRuntime(): Promise<void> {
+  if (RAILWAY_RUNTIME_REQUIRED && RUNTIME_LOCK_OWNER_AUTHORITY !== 'railway-fenced-handoff') {
+    throw new Error('invalid or missing inherited Railway lifecycle fence; refusing to start Alice')
+  }
   const guardianPid = positiveInteger(process.env['OPENALICE_GUARDIAN_PID'])
   const guardianStartedAt = positiveInteger(process.env['OPENALICE_GUARDIAN_STARTED_AT'])
   runtimeLock = await acquireOpenAliceRuntimeLocks({
@@ -455,6 +465,7 @@ export async function startAliceRuntime(): Promise<void> {
     launcherRoot: resolveLauncherRoot(),
     launcher: process.env['OPENALICE_LAUNCHER'] ?? 'standalone',
     takeover: takeoverRequested(),
+    ownerAuthority: RUNTIME_LOCK_OWNER_AUTHORITY,
     ...(guardianPid ? { guardianPid } : {}),
     ...(guardianStartedAt ? { guardianStartedAt } : {}),
     onOwnershipLost: (err) => {

--- a/src/workspaces/spawn-env.spec.ts
+++ b/src/workspaces/spawn-env.spec.ts
@@ -86,6 +86,22 @@ describe('buildSpawnEnv', () => {
     expect(out['COLORFGBG']).toBeUndefined()
   })
 
+  it('never exposes Railway handoff capabilities to a Workspace agent PTY', () => {
+    const out = buildSpawnEnv(
+      {
+        OPENALICE_RAILWAY_FENCE_FD: '3',
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+      },
+      {
+        OPENALICE_RAILWAY_FENCE_FD: '9',
+        OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+      },
+    )
+
+    expect(out).not.toHaveProperty('OPENALICE_RAILWAY_FENCE_FD')
+    expect(out).not.toHaveProperty('OPENALICE_RAILWAY_ENTRYPOINT_OWNER')
+  })
+
   it('defaults terminal locale to UTF-8 without overriding explicit locale', () => {
     expect(buildSpawnEnv({})['LANG']).toBe('en_US.UTF-8')
     expect(buildSpawnEnv({})['LC_CTYPE']).toBe('en_US.UTF-8')

--- a/src/workspaces/spawn-env.ts
+++ b/src/workspaces/spawn-env.ts
@@ -20,6 +20,11 @@ import { delimiter, dirname, join } from 'node:path';
 
 import { runtimeProfileFromEnv } from '@/core/runtime-profile.js';
 
+const PRIVILEGED_RUNTIME_ENV = [
+  'OPENALICE_RAILWAY_FENCE_FD',
+  'OPENALICE_RAILWAY_ENTRYPOINT_OWNER',
+] as const;
+
 const STRIP_EXACT = new Set<string>([
   'TERM_PROGRAM',
   'TERM_PROGRAM_VERSION',
@@ -30,6 +35,7 @@ const STRIP_EXACT = new Set<string>([
   'OPENALICE_WORKSPACE_CLI_BIN_PATH',
   'OPENCODE_CONFIG_CONTENT',
   'COLORFGBG',
+  ...PRIVILEGED_RUNTIME_ENV,
 ]);
 
 const STRIP_PREFIXES = [
@@ -102,6 +108,11 @@ export function buildSpawnEnv(
   for (const [k, v] of Object.entries(extras)) {
     out[k] = v;
   }
+  // The Railway fence is a launcher/Guardian capability, not session
+  // configuration. Never let a Workspace agent or its PTY inherit the marker
+  // or the descriptor number, even if a caller accidentally supplies either
+  // through per-session extras.
+  for (const name of PRIVILEGED_RUNTIME_ENV) delete out[name];
   const cliPath = buildCliPath(out);
   // Windows environment names are case-insensitive, but JavaScript objects are
   // not. A typical host contributes `Path`; adding a separate `PATH` leaves two


### PR DESCRIPTION
## Summary
- replace heartbeat-based Railway handoff authority with a kernel lifecycle fence on the mounted Volume inode
- keep the fence alive across Guardian, Alice, UTA, and Connector while preventing Agent and PTY inheritance
- reject retained legacy owners before installer or Project mutation and document reversible quarantine
- install CLI dependencies in remote smoke jobs so fixtures can load their YAML parser

## Verification
- `npx tsc --noEmit`
- `pnpm -F @traderalice/guardian-runtime typecheck`
- `pnpm -F @traderalice/openalice-cli typecheck`
- `pnpm test` (5,292 passed, 13 skipped)
- `pnpm test:guardian-recovery`
- `pnpm test:install:docker`
- `pnpm test:remote:docker`
- `pnpm docker:smoke`
- Linux named-Volume contention, nested legacy A -> B preflight, writer lifetime after Guardian SIGKILL, PTY/ordinary-child descriptor isolation, and one-winner replacement acceptance

Live Railway deployment of the resulting dev archive remains the final hosted acceptance gate.