### PR TITLE
fix(cli): keep runtime logs out of releases

### DIFF
--- a/packages/cli/src/internal-role-runtime.spec.ts
+++ b/packages/cli/src/internal-role-runtime.spec.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -7,7 +8,7 @@ import { describe, expect, it } from 'vitest'
 
 describe('private Runtime role fencing', () => {
   it('refuses a direct Railway Connector writer without the Guardian fence', () => {
-    const home = join(tmpdir(), `openalice-connector-no-fence-${process.pid}`)
+    const home = join(tmpdir(), `openalice-connector-no-fence-${process.pid}-${randomUUID()}`)
     const result = spawnSync(process.execPath, [
       '--import',
       'tsx',
@@ -33,6 +34,37 @@ describe('private Runtime role fencing', () => {
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1)
     expect(result.stderr).toContain(
       'invalid or missing inherited Railway lifecycle fence; refusing to start Connector',
+    )
+    expect(existsSync(home)).toBe(false)
+  })
+
+  it('refuses a direct Railway Alice writer without creating Project state', () => {
+    const home = join(tmpdir(), `openalice-alice-no-fence-${process.pid}-${randomUUID()}`)
+    const result = spawnSync(process.execPath, [
+      '--import',
+      'tsx',
+      'packages/cli/bin/openalice-bun.ts',
+      '--internal-role',
+      'alice',
+    ], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NODE_OPTIONS: '--conditions=openalice-source',
+        OPENALICE_HOME: home,
+        AQ_LAUNCHER_ROOT: join(home, 'workspaces'),
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      encoding: 'utf8',
+      timeout: 10_000,
+    })
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1)
+    expect(result.stderr).toContain(
+      'invalid or missing inherited Railway lifecycle fence; refusing to start Alice',
     )
     expect(existsSync(home)).toBe(false)
   })

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1199,3 +1199,20 @@ This plan is complete only when:
   blocked contention, and fenced Guardian/Alice owner metadata. Linux installer,
   remote-SSH, and full Docker Runtime smokes pass. PR/dev archive publication,
   live Railway reacceptance, Project apply, and the Agent turn remain pending.
+- 2026-09-01: PR #1280 merged the kernel-fence repair to `dev` at
+  `a0f17e40`; run 33431851058 published all four native aliases and passed the
+  public raw/dev install. The retained Railway Volume then failed before
+  release mutation on eight legacy lock directories as designed. After proving
+  the old deployment had stopped and no installed writer remained, those exact
+  directories and owner records moved reversibly to
+  `/data/quarantine/legacy-cutover-a0f17e40-1/`; the new Linux x64 archive
+  started with Guardian and Alice holding the Volume inode fence. Its first
+  restart exposed a separate immutability defect: the Workspace logger used
+  `process.cwd()` and appended to the release-owned
+  `share/openalice/logs/workspace-sessions.log`, so reinstall verification
+  rejected the changed tree and safely fell back. The current fix routes that
+  sink to `<OPENALICE_HOME>/logs/workspace-sessions.log`, makes the real Bun
+  Workspace smoke require the Project-owned log, and rejects any before/after
+  release-tree mutation. Root TypeScript, the 5,294-test suite, full build, and
+  the local native Bun release smoke pass. A fresh dev archive and Railway
+  restart/redeploy acceptance remain required before Project transfer.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1211,8 +1211,11 @@ This plan is complete only when:
   `process.cwd()` and appended to the release-owned
   `share/openalice/logs/workspace-sessions.log`, so reinstall verification
   rejected the changed tree and safely fell back. The current fix routes that
-  sink to `<OPENALICE_HOME>/logs/workspace-sessions.log`, makes the real Bun
-  Workspace smoke require the Project-owned log, and rejects any before/after
-  release-tree mutation. Root TypeScript, the 5,294-test suite, full build, and
-  the local native Bun release smoke pass. A fresh dev archive and Railway
-  restart/redeploy acceptance remain required before Project transfer.
+  sink to `<OPENALICE_HOME>/logs/workspace-sessions.log` and opens it lazily so
+  a rejected pre-fence Alice process cannot create Project state. A direct
+  no-fence Alice regression now requires the whole Project Home to stay absent;
+  the real Bun Workspace smoke requires the Project-owned log and rejects any
+  before/after release-tree mutation. Root TypeScript, the 5,295-test suite,
+  full build, and the local native Bun release smoke pass. A fresh dev archive
+  and Railway restart/redeploy acceptance remain required before Project
+  transfer.

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -126,7 +126,9 @@ const releaseMetadata = {
   ...unsignedReleaseMetadata,
   contentIdentity,
 }
-await writeFile(join(releaseRoot, 'release.json'), `${JSON.stringify(releaseMetadata, null, 2)}\n`)
+const releaseMetadataPath = join(releaseRoot, 'release.json')
+await writeFile(releaseMetadataPath, `${JSON.stringify(releaseMetadata, null, 2)}\n`)
+const releaseMetadataHash = await sha256File(releaseMetadataPath)
 const assemblyDurationMs = Math.round(performance.now() - releaseStartedAt)
 
 const smokeStartedAt = performance.now()
@@ -138,6 +140,20 @@ const smoke = await smokeRelease({
   contentIdentity,
 })
 const smokeDurationMs = Math.round(performance.now() - smokeStartedAt)
+const filesAfterSmoke = await releaseFiles(releaseRoot, new Set(['release.json']))
+const beforeByPath = new Map(files.map((entry) => [entry.path, JSON.stringify(entry)]))
+const afterByPath = new Map(filesAfterSmoke.map((entry) => [entry.path, JSON.stringify(entry)]))
+const mutatedReleasePaths = [...new Set([...beforeByPath.keys(), ...afterByPath.keys()])]
+  .filter((path) => beforeByPath.get(path) !== afterByPath.get(path))
+  .sort()
+if (await sha256File(releaseMetadataPath) !== releaseMetadataHash) {
+  mutatedReleasePaths.push('release.json')
+}
+if (mutatedReleasePaths.length > 0) {
+  throw new Error(
+    `Bun release smoke mutated the immutable release tree: ${mutatedReleasePaths.join(', ')}`,
+  )
+}
 
 const archiveStartedAt = performance.now()
 const archive = Bun.spawnSync([
@@ -670,6 +686,13 @@ printf '%s\\n' "${'$'}1" > "${'$'}OPENALICE_SMOKE_OPEN_RECEIPT"
   if (runtimeError || exitCode !== 0) {
     throw new Error(`installed release Runtime failed: ${String(runtimeError)}\n${stdout}\n${stderr}`)
   }
+  const workspaceSessionLog = await readFile(
+    join(runtimeHome, 'logs', 'workspace-sessions.log'),
+    'utf8',
+  ).catch(() => '')
+  if (!workspaceSessionLog.includes('"msg":"workspace.session_spawned"')) {
+    throw new Error('installed release did not persist Workspace session logs under the selected Project Home')
+  }
   return {
     nodeOrBunOnPath: false,
     gitInitCommitClone: true,
@@ -682,6 +705,7 @@ printf '%s\\n' "${'$'}1" > "${'$'}OPENALICE_SMOKE_OPEN_RECEIPT"
     externalAgentRuntimeManagedPi: false,
     browserOpenUrl,
     agentPtys: agentPtyReport,
+    workspaceSessionLog: 'logs/workspace-sessions.log',
     realExternalAgentRuntime: realOpenCodeReport,
     defaultResources: true,
     materializedPiAdapter: true,

--- a/src/workspaces/logger.ts
+++ b/src/workspaces/logger.ts
@@ -21,7 +21,7 @@ const envLevel = (process.env['WEB_TERMINAL_LOG_LEVEL'] ?? 'info').toLowerCase()
 const minLevel: number = LEVELS[envLevel as Level] ?? LEVELS.info;
 
 const FILE_PATH = resolve(userDataHome, 'logs', 'workspace-sessions.log');
-const fileStream = openFileSink(FILE_PATH);
+let fileStream: WriteStream | null | undefined;
 
 function openFileSink(path: string): WriteStream | null {
   try {
@@ -32,6 +32,14 @@ function openFileSink(path: string): WriteStream | null {
   } catch {
     return null;
   }
+}
+
+function getFileSink(): WriteStream | null {
+  // Importing Alice modules must stay read-only until the Runtime lifecycle
+  // fence has been validated and acquired. Defer the first filesystem write
+  // until Alice actually emits a Workspace log record after that gate.
+  if (fileStream === undefined) fileStream = openFileSink(FILE_PATH);
+  return fileStream;
 }
 
 function write(level: Level, msg: string, fields: Record<string, unknown>, toConsole: boolean): void {
@@ -49,8 +57,9 @@ function write(level: Level, msg: string, fields: Record<string, unknown>, toCon
       process.stdout.write(line);
     }
   }
-  if (fileStream) {
-    try { fileStream.write(line); } catch { /* swallow */ }
+  const sink = getFileSink();
+  if (sink) {
+    try { sink.write(line); } catch { /* swallow */ }
   }
 }
 

--- a/src/workspaces/logger.ts
+++ b/src/workspaces/logger.ts
@@ -1,8 +1,9 @@
 /**
  * Tiny structured logger. One JSON line per log record on stdout (errors on
  * stderr), with an additional append-only file sink at
- * `logs/workspace-sessions.log` so every spawn / resume / transcript event is
- * grep-able in isolation without scrolling past every other backend log line.
+ * `<OPENALICE_HOME>/logs/workspace-sessions.log` so every spawn / resume /
+ * transcript event is grep-able in isolation without scrolling past every
+ * other backend log line.
  *
  * Hand-rolled — keep the dep surface zero. The file sink failure must never
  * take down session lifecycle, so all fs errors are swallowed.
@@ -10,6 +11,7 @@
 
 import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { userDataHome } from '@/core/paths.js';
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
@@ -18,7 +20,7 @@ const LEVELS: Record<Level, number> = { debug: 10, info: 20, warn: 30, error: 40
 const envLevel = (process.env['WEB_TERMINAL_LOG_LEVEL'] ?? 'info').toLowerCase();
 const minLevel: number = LEVELS[envLevel as Level] ?? LEVELS.info;
 
-const FILE_PATH = resolve(process.cwd(), 'logs', 'workspace-sessions.log');
+const FILE_PATH = resolve(userDataHome, 'logs', 'workspace-sessions.log');
 const fileStream = openFileSink(FILE_PATH);
 
 function openFileSink(path: string): WriteStream | null {
@@ -60,7 +62,7 @@ function emit(level: Level, msg: string, fields: Record<string, unknown>): void 
 /**
  * Routine connection-lifecycle events (attach / detach / upgrade) — high
  * frequency, useful for forensics but pure noise on the console. Always written
- * to `logs/workspace-sessions.log`; surfaced on the console ONLY when
+ * to `<OPENALICE_HOME>/logs/workspace-sessions.log`; surfaced on the console ONLY when
  * WEB_TERMINAL_LOG_LEVEL=debug. Keeps `pnpm dev` readable without losing the trail.
  */
 function emitEvent(msg: string, fields: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary
- persist Workspace session logs under the selected AliceProject instead of the immutable Bun resource tree
- defer the log sink until the first real post-fence write so rejected Railway Alice startup cannot create Project state
- make the native release smoke require that Project-owned log
- fail native packaging if any release file changes during the real Runtime and Workspace smoke

## Live diagnosis
The first Railway restart of dev `a0f17e40` downloaded the same verified archive, then rejected its existing release because Runtime startup had appended to `share/openalice/logs/workspace-sessions.log`. The entrypoint safely fell back, but repeated dev restart was not acceptable.

Independent review also found that an eager Project-owned sink would still write before Railway fence validation. The sink is now lazy, and a direct no-fence Alice regression requires the entire Project Home to remain absent.

## Verification
- `npx tsc --noEmit`
- `pnpm build`
- `pnpm build:bun:release` with real Runtime, Web UI, two independent Agent PTYs, Project log present, and immutable release tree
- `pnpm test` with 5,295 passed and 13 skipped
- direct no-fence Alice regression, 2/2 targeted fencing tests
- `git diff --check`
- independent final diff review: no merge blocker

A fresh dev archive and a live Railway restart remain the final acceptance gate.