### PR TITLE
fix(railway): make runtime lock handoff crash-safe

### DIFF
--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -110,7 +110,10 @@ the persistent `PATH` only after it has verified the native CLI.
 `OPENALICE_HOME` is the only layout selector and must resolve beneath `/data`;
 `AQ_LAUNCHER_ROOT` is always canonicalized from that selected Project as
 `<OPENALICE_HOME>/workspaces`. The reserved `/data/quarantine` tree can never be
-selected as a Project Home. The entrypoint rejects a different Volume mount,
+selected as a Project Home. That reserved path is lexical and must be absent or
+an actual directory directly under the Volume; a file, dangling link, or
+symlink to another Project fails startup instead of hiding its target from the
+Volume scan. The entrypoint rejects a different Volume mount,
 ephemeral `HOME`, alternate install/npm/Bun root, or normalized/symlink escape;
 it does not honor an independent Workspace-root override. The image filesystem
 is replaceable; no install release, credential, Workspace, Agent login, or
@@ -131,6 +134,15 @@ previous release still validates, the host starts the previous release. An
 empty or damaged install with a failed bootstrap stops instead of running an
 unverified fallback.
 
+The Railway profile currently requires `railway-runtime-lock-v2`. Public
+stable `v0.90.2` and beta `v0.91.0-beta.1` predate that capability, so they are
+not eligible Railway fallbacks. The dev manifest current before this change is
+also v1-only. Do not deploy this profile until the change has merged and the
+matching completed dev manifest explicitly advertises v2; that later dev
+artifact may then be selected for candidate acceptance. A stable or beta host
+still requires a later explicit release. This repository change does not
+publish or promote one.
+
 After selection, the image atomically replaces the persistent `openalice`,
 `alice`, `alice-workspace`, `alice-uta`, and `traderhub` shims with its Railway
 wrapper. The wrapper resolves the active immutable release directly, rebuilds
@@ -146,10 +158,22 @@ replaceable Project-owned lock file and serializes every Runtime using that
 Volume. While holding that fence and before touching the install pointer,
 shims, or Project layout, the image discovers every Project Home on the Volume
 and inspects its four known Runtime lock directories, including nested legacy
-homes. It skips only the documented quarantine. Missing locks and
-same-service `railway-flock-v1` records may proceed; an initializing, malformed,
-foreign, or pre-fence owner anywhere on the Volume stops the deployment at this
-read-only boundary. The CLI independently checks that the actual canonical Project Home
+homes and the historical Volume-root Project layout. It skips only the
+documented quarantine. Missing locks and
+same-service `railway-flock-v1` records may proceed; an initializing shape
+outside the bounded v2 intermediates, a malformed lock, foreign owner, or
+pre-fence owner anywhere on the Volume stops
+the deployment before release mutation. Recoverable v2 intermediate states are
+strictly shaped: an ownerless empty lock after the initialization grace, a
+single UUID-named mutation marker whose JSON token matches its filename, or the
+corresponding single write temp. A fully published fenced owner may retain the
+same validated claim or write temp after a hard kill. Cleanup begins only after
+the complete Volume scan has no blocker, reopens every path relative to the
+Volume descriptor without following symlinks, rechecks inode/mtime and owner
+evidence, and removes only those exact entries. Unknown entries, duplicate
+claim markers or write temps, symlinked/malformed nodes, and incomplete Volume
+traversal fail closed.
+The CLI independently checks that the actual canonical Project Home
 and install root are children of that real mount, that the inherited descriptor
 names its directory inode, and that Linux `/proc/self/fdinfo` reports an
 exclusive kernel lock; an environment flag or arbitrary locked directory is
@@ -163,6 +187,13 @@ adapters, broker helpers, Workspace Agents, or PTYs can start. Ordinary Node
 child-process and node-pty launch boundaries omit extra descriptors, which is
 verified with a positive-control Linux inheritance test. Consequently a Guardian
 crash cannot release the Volume fence while any old Project writer is still alive.
+Each fenced service start also creates a fresh opaque instance identity.
+Guardian and its trusted children record that identity in lock owners, while
+Agent and PTY environments omit it. This distinguishes replacement containers
+even when Railway reuses the same hostname and child PID layout.
+The installed Runtime must advertise both the retained-owner
+`railway-flock-v1` capability and `railway-runtime-lock-v2`; a fence-only older
+binary is not an eligible bootstrap fallback.
 This also makes a direct Railway `--internal-role connector` invocation without
 Guardian authority fail before it can open Project-backed queues. Agent and PTY environments also strip
 the descriptor number and entrypoint marker as defense in depth. Every Railway
@@ -184,18 +215,26 @@ Alice stays on loopback port `47331` (or the explicit
 
 Every Railway shell and service process derives one exact machine identity
 from `RAILWAY_SERVICE_ID`; a conflicting configured identity fails startup.
-Within one container, Runtime ownership still uses PID and process-start-time
-identity. Across replacement-container PID namespaces on the same service
-Volume, it never probes or signals the recorded PID. A Railway shell without
-the inherited locked descriptor is an observer: even a very old heartbeat is
-not reclaim authority. A fenced replacement may reclaim only an owner written
-under `fencingProtocol: railway-flock-v1`; the owner directory identity and
-complete owner evidence are checked again immediately before quarantine.
-Heartbeats remain diagnostic only. Missing or foreign identity, a forged or
-unlocked descriptor, and pre-fence legacy owners all fail closed. A retained
-legacy owner therefore requires a one-time operator cutover: first prove the
-old deployment has stopped, inspect the owner records, then move only these
-exact directories when present:
+Within one fenced service start, Runtime ownership first matches the opaque
+fencing-instance identity, then PID and process-start-time identity. Across
+replacement containers on the same service Volume, it never probes or signals
+the recorded PID, even when Railway reuses the hostname and PID layout. A
+Railway shell without the inherited locked descriptor is an observer: even a
+very old heartbeat is not reclaim authority. A fenced replacement may reclaim
+only an owner written under `fencingProtocol: railway-flock-v1`; the owner
+directory identity and complete owner evidence are checked again while holding
+one recoverable mutation claim shared by owner publication, release, and stale
+reaping. The claim owner uses a UUID-bearing filename; release or recovery can
+atomically move only the exact generation it inspected, verifies the moved
+record, and rechecks that same marker immediately before canonical mutation.
+Release and stale reaping then rename the complete canonical lock before
+best-effort tombstone cleanup, so a hard kill leaves either the full owner, a
+strictly recoverable publication/claim intermediate, or no canonical lock. Heartbeats remain
+diagnostic only. Missing or foreign identity, a forged or unlocked descriptor,
+non-empty malformed locks, and pre-fence legacy owners all fail closed. A
+retained legacy owner therefore requires a one-time operator cutover: first
+prove the old deployment has stopped, inspect the owner records, then move only
+these exact directories when present:
 
 ```text
 <OPENALICE_HOME>/state/guardian.lock

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -139,7 +139,20 @@ and Connector validate and retain their own lifetime duplicates while removing
 the capability from descendant environments; ordinary child processes, adapters,
 Agents, and PTYs do not inherit them. Thus Guardian and every Project writer must
 be gone before a replacement can acquire the fence. Ordinary Railway SSH shells are observer-only and
-cannot start or reclaim a Runtime owner.
+cannot start or reclaim a Runtime owner. Each service start gives the trusted
+writer tree a fresh fencing-instance identity, so a replacement stays distinct
+even when Railway reuses its hostname and PIDs. Lock release atomically retires
+the canonical directory under the shared recoverable lock-mutation claim before
+cleanup. Claim ownership is generation-specific: the UUID in its filename must
+match its JSON token, and a recoverer can atomically retire only that exact
+generation before canonical mutation. The Runtime must advertise `railway-runtime-lock-v2` in addition to
+the retained-owner `railway-flock-v1` capability, so bootstrap cannot fall back
+to an older binary that does not understand instance fencing. If a hard kill from older code left a
+known ownerless directory, or v2 dies while publishing/releasing a claim,
+preflight recovers only the exact empty/UUID-marker/write-temp shape after the
+full Volume scan has no other blocker and descriptor-relative identity checks
+still match. Unknown entries, duplicate claim markers or write temps, and
+symlinked/malformed nodes fail closed.
 
 For the first fenced deployment against a retained pre-fence Project, first
 verify the old deployment is stopped. Inspect and move only these directories
@@ -148,11 +161,19 @@ when present: `state/guardian.lock`, `state/runtime.lock`,
 relative to that exact Project Home. Preserve those relative paths beneath a
 timestamped `/data/quarantine/<project>-<timestamp>/` directory so the cutover
 is reversible. That quarantine tree is never a valid `OPENALICE_HOME`. Never
+make `/data/quarantine` a symlink or file: it must be absent or a real directory
+at that exact Volume-root path, and startup fails closed otherwise. Never
 clear the Project or Volume; if an owner still matches a
 running deployment, stop instead of quarantining it.
 
-The default service variables install the latest stable native release. Use
-only the selectors needed for the intended host:
+The default service variables select the latest stable native release, but the
+currently public stable `v0.90.2` and beta `v0.91.0-beta.1` do not advertise the
+required `railway-runtime-lock-v2` capability and are therefore rejected by
+this profile. The dev manifest current before this change is also v1-only. Do
+not deploy until this change has merged and its matching completed dev manifest
+advertises v2; that later artifact may be used for candidate acceptance. Stable
+or beta still requires a later explicit release, which this guide does not
+authorize or perform. Use only the selectors needed for the intended host:
 
 ```text
 OPENALICE_RAILWAY_CHANNEL=stable

--- a/packages/cli/bin/openalice.mjs
+++ b/packages/cli/bin/openalice.mjs
@@ -53,7 +53,7 @@ export async function main(argv = process.argv.slice(2)) {
       installSource: await readInstallSource(),
       contentIdentity: installedContentIdentity(),
       managedRuntime: installedRuntimeInfo(version),
-      runtimeCapabilities: ['railway-flock-v1'],
+      runtimeCapabilities: ['railway-flock-v1', 'railway-runtime-lock-v2'],
     })}\n`)
     return 0
   }

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -538,6 +538,7 @@ describe('OpenAlice Runtime lifecycle core', () => {
       env: {
         OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
         OPENALICE_RAILWAY_FENCE_FD: '9',
+        OPENALICE_RAILWAY_INSTANCE_ID: '22222222-2222-4222-8222-222222222222',
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
@@ -559,6 +560,10 @@ describe('OpenAlice Runtime lifecycle core', () => {
     const spawnedEnvironment = spawnProcess.mock.calls[0][2].env
     expect(spawnedEnvironment).not.toHaveProperty('OPENALICE_RAILWAY_ENTRYPOINT_OWNER')
     expect(spawnedEnvironment).toHaveProperty('OPENALICE_RAILWAY_FENCE_FD', '3')
+    expect(spawnedEnvironment).toHaveProperty(
+      'OPENALICE_RAILWAY_INSTANCE_ID',
+      '22222222-2222-4222-8222-222222222222',
+    )
     expect(spawnProcess.mock.calls[0][2].stdio).toEqual(['inherit', 'inherit', 'inherit', 9])
   })
 

--- a/packages/cli/src/main.spec.ts
+++ b/packages/cli/src/main.spec.ts
@@ -16,7 +16,7 @@ describe('OpenAlice TypeScript application entry', () => {
     }
 
     expect(JSON.parse(output)).toMatchObject({
-      runtimeCapabilities: expect.arrayContaining(['railway-flock-v1']),
+      runtimeCapabilities: expect.arrayContaining(['railway-flock-v1', 'railway-runtime-lock-v2']),
     })
   })
 

--- a/packages/cli/src/server-control.mjs
+++ b/packages/cli/src/server-control.mjs
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { fstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { homedir, hostname, tmpdir } from 'node:os'
 import { createConnection } from 'node:net'
 import { resolve } from 'node:path'
@@ -335,7 +335,24 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
     try {
       owner = JSON.parse(await readFile(ownerPath, 'utf8'))
     } catch (error) {
-      if (error?.code === 'ENOENT') continue
+      if (error?.code === 'ENOENT') {
+        const lockPath = resolve(ownerPath, '..')
+        try {
+          await stat(lockPath)
+          return {
+            active: true,
+            publicOwner: null,
+            detail: `Runtime lock exists without published owner metadata at ${lockPath}`,
+          }
+        } catch (lockError) {
+          if (lockError?.code === 'ENOENT') continue
+          return {
+            active: true,
+            publicOwner: null,
+            detail: `Runtime lock metadata is unreadable at ${lockPath}`,
+          }
+        }
+      }
       return {
         active: true,
         publicOwner: null,
@@ -350,7 +367,7 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
       }
     }
     const resolvedMachineId = await currentMachineId()
-    const railwayScope = railwayOwnerScope(owner, resolvedMachineId, localHostname, env, homeRoot, options)
+    const railwayScope = railwayOwnerScope(owner, resolvedMachineId, env, homeRoot, options)
     let active
     if (railwayScope === 'cross-container-fenced') {
       active = false
@@ -389,7 +406,7 @@ async function inspectGuardianOwner(homeRoot, options = {}) {
     : null
 }
 
-function railwayOwnerScope(owner, currentMachineId, localHostname, env, homeRoot, options) {
+function railwayOwnerScope(owner, currentMachineId, env, homeRoot, options) {
   const serviceId = env['RAILWAY_SERVICE_ID']?.trim()
   const environmentId = env['RAILWAY_ENVIRONMENT_ID']?.trim()
   const configuredMachineId = env['OPENALICE_MACHINE_ID']?.trim()
@@ -403,10 +420,15 @@ function railwayOwnerScope(owner, currentMachineId, localHostname, env, homeRoot
   ) {
     return null
   }
-  if (typeof owner.hostname !== 'string' || owner.hostname.length === 0) return 'foreign'
   if (owner.machineId !== currentMachineId) return 'foreign'
-  if (owner.hostname === localHostname) return 'same-container'
   if (owner.fencingProtocol !== 'railway-flock-v1') return 'foreign'
+  if (
+    owner.fencingInstanceId !== undefined
+    && !/^[A-Za-z0-9-]{16,128}$/.test(owner.fencingInstanceId)
+  ) return 'foreign'
+  const currentInstanceId = env['OPENALICE_RAILWAY_INSTANCE_ID']?.trim()
+  if (!/^[A-Za-z0-9-]{16,128}$/.test(currentInstanceId ?? '')) return 'foreign'
+  if (owner.fencingInstanceId === currentInstanceId) return 'same-container'
   const fenceValid = options.railwayFenceValid
     ?? hasValidRailwayFence(env, homeRoot)
   return fenceValid ? 'cross-container-fenced' : 'cross-container-observer'

--- a/packages/cli/src/server-control.spec.mjs
+++ b/packages/cli/src/server-control.spec.mjs
@@ -14,6 +14,8 @@ import {
 } from './server-control.mjs'
 
 const temporaryPaths = []
+const PRIOR_RAILWAY_INSTANCE_ID = '11111111-1111-4111-8111-111111111111'
+const CURRENT_RAILWAY_INSTANCE_ID = '22222222-2222-4222-8222-222222222222'
 
 afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
@@ -230,6 +232,18 @@ describe('OpenAlice Guardian control protocol', () => {
     expect(legacyPidProbe).not.toHaveBeenCalled()
   })
 
+  it('does not report a claim-only Runtime lock as absent', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(join(lock, 'reclaiming'), { recursive: true })
+
+    const status = await readRuntimeStatus({ homeRoot: home })
+
+    expect(status.class).toBe('owned_elsewhere')
+    expect(status.owner).toBeNull()
+    expect(status.detail).toContain('ownership is active')
+  })
+
   it('reclaims a dead same-machine owner after its hostname changes', async () => {
     const home = await makeTempDir()
     const lock = join(home, 'state', 'guardian.lock')
@@ -258,8 +272,9 @@ describe('OpenAlice Guardian control protocol', () => {
     expect(readProcessStartedAt).not.toHaveBeenCalled()
   })
 
-  it('keeps cross-container Railway owners observer-only and lets a valid fence reclaim the cooperative protocol', async () => {
+  it('uses the Railway instance identity even when hostname, PID, and start time are reused', async () => {
     const env = {
+      OPENALICE_RAILWAY_INSTANCE_ID: CURRENT_RAILWAY_INSTANCE_ID,
       OPENALICE_SERVICE_MANAGER: 'railway',
       OPENALICE_MACHINE_ID: 'railway-service-service-test',
       RAILWAY_ENVIRONMENT_ID: 'environment-test',
@@ -271,15 +286,18 @@ describe('OpenAlice Guardian control protocol', () => {
     const ownerPath = join(lock, 'owner.json')
     const owner = {
       pid: 4242,
-      hostname: 'prior-container',
+      hostname: 'current-container',
       machineId: 'env:railway-service-service-test',
       launcher: 'guardian-cli-server',
       acquiredAt: new Date().toISOString(),
       heartbeatAt: new Date().toISOString(),
       fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: PRIOR_RAILWAY_INSTANCE_ID,
+      processStartedAt: '2026-07-15T00:00:00.000Z',
     }
     await writeFile(ownerPath, JSON.stringify(owner))
-    const isProcessAlive = vi.fn(() => false)
+    const isProcessAlive = vi.fn(() => true)
+    const readProcessStartedAt = vi.fn(async () => Date.parse('2026-07-15T00:00:00.000Z'))
 
     for (const heartbeatAt of [new Date().toISOString(), new Date(0).toISOString()]) {
       await writeFile(ownerPath, JSON.stringify({ ...owner, heartbeatAt }))
@@ -287,6 +305,7 @@ describe('OpenAlice Guardian control protocol', () => {
         env,
         hostname: 'current-container',
         isProcessAlive,
+        readProcessStartedAt,
       })
       expect(observer.class).toBe('owned_elsewhere')
 
@@ -294,12 +313,14 @@ describe('OpenAlice Guardian control protocol', () => {
         env,
         hostname: 'current-container',
         isProcessAlive,
+        readProcessStartedAt,
         railwayFenceValid: true,
       })
       expect(fenced.class).toBe('absent')
       expect(fenced.detail).toContain('stale')
     }
     expect(isProcessAlive).not.toHaveBeenCalled()
+    expect(readProcessStartedAt).not.toHaveBeenCalled()
   })
 
   it('keeps a legacy cross-container Railway owner blocked even for a fenced entrypoint', async () => {
@@ -317,6 +338,7 @@ describe('OpenAlice Guardian control protocol', () => {
     const isProcessAlive = vi.fn(() => false)
     const status = await readRuntimeStatus({ homeRoot: home }, {
       env: {
+        OPENALICE_RAILWAY_INSTANCE_ID: CURRENT_RAILWAY_INSTANCE_ID,
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
@@ -331,6 +353,37 @@ describe('OpenAlice Guardian control protocol', () => {
     expect(isProcessAlive).not.toHaveBeenCalled()
   })
 
+  it('keeps a malformed Railway fencing instance blocked', async () => {
+    const home = await makeTempDir()
+    const lock = join(home, 'state', 'guardian.lock')
+    await mkdir(lock, { recursive: true })
+    await writeFile(join(lock, 'owner.json'), JSON.stringify({
+      pid: 4242,
+      hostname: 'current-container',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date(0).toISOString(),
+      heartbeatAt: new Date(0).toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: 'not valid',
+    }))
+
+    const status = await readRuntimeStatus({ homeRoot: home }, {
+      env: {
+        OPENALICE_RAILWAY_INSTANCE_ID: CURRENT_RAILWAY_INSTANCE_ID,
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      },
+      hostname: 'current-container',
+      isProcessAlive: vi.fn(() => false),
+      railwayFenceValid: true,
+    })
+
+    expect(status.class).toBe('owned_elsewhere')
+  })
+
   it('keeps same-container PID identity authoritative under Railway', async () => {
     const home = await makeTempDir()
     const lock = join(home, 'state', 'guardian.lock')
@@ -342,6 +395,8 @@ describe('OpenAlice Guardian control protocol', () => {
       launcher: 'guardian-cli-server',
       acquiredAt: new Date(0).toISOString(),
       heartbeatAt: new Date(0).toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: CURRENT_RAILWAY_INSTANCE_ID,
       processStartedAt: '2026-07-15T00:00:00.000Z',
     }))
     const isProcessAlive = vi.fn(() => true)
@@ -349,6 +404,7 @@ describe('OpenAlice Guardian control protocol', () => {
 
     const status = await readRuntimeStatus({ homeRoot: home }, {
       env: {
+        OPENALICE_RAILWAY_INSTANCE_ID: CURRENT_RAILWAY_INSTANCE_ID,
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         RAILWAY_ENVIRONMENT_ID: 'environment-test',

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -1,6 +1,6 @@
 import { closeSync, existsSync, openSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, rmdir, writeFile } from 'node:fs/promises'
 import { hostname, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -26,6 +26,7 @@ class FakeProcesses implements ProcessController {
   ignoreTerm = new Set<number>()
   currentMachineId = 'machine-a'
   machineIdHook: (() => Promise<void>) | undefined
+  sleepHook: ((ms: number) => Promise<void>) | undefined
 
   add(pid: number, startedAt = 1_000): void {
     this.alive.set(pid, true)
@@ -52,11 +53,15 @@ class FakeProcesses implements ProcessController {
     for (const child of this.cascade.get(pid) ?? []) this.alive.set(child, false)
   }
 
-  async sleep(): Promise<void> {}
+  async sleep(ms: number): Promise<void> {
+    await this.sleepHook?.(ms)
+  }
 }
 
 let home: string
 let controller: FakeProcesses
+const PRIOR_FENCING_INSTANCE_ID = '11111111-1111-4111-8111-111111111111'
+const CURRENT_FENCING_INSTANCE_ID = '22222222-2222-4222-8222-222222222222'
 
 beforeEach(async () => {
   home = join(tmpdir(), `guardian-runtime-${process.pid}-${Math.random().toString(16).slice(2)}`)
@@ -79,6 +84,7 @@ function railwayOwner(overrides: Record<string, unknown> = {}): Record<string, u
     acquiredAt: new Date().toISOString(),
     heartbeatAt: new Date().toISOString(),
     fencingProtocol: 'railway-flock-v1',
+    fencingInstanceId: PRIOR_FENCING_INSTANCE_ID,
     processStartedAt: new Date(10_000).toISOString(),
     ...overrides,
   }
@@ -118,9 +124,20 @@ describe('runtime lock ownership', () => {
         OPENALICE_SERVICE_MANAGER: 'railway',
         OPENALICE_MACHINE_ID: 'railway-service-service-test',
         OPENALICE_RAILWAY_FENCE_FD: String(fd),
+        OPENALICE_RAILWAY_INSTANCE_ID: CURRENT_FENCING_INSTANCE_ID,
         RAILWAY_ENVIRONMENT_ID: 'environment-test',
         RAILWAY_SERVICE_ID: 'service-test',
       })).toBe('railway-fenced-handoff')
+      expect(resolveRuntimeLockOwnerAuthority({
+        OPENALICE_HOME: railwayHome,
+        OPENALICE_INSTALL_DIR: installDir,
+        OPENALICE_RAILWAY_VOLUME_ROOT: volumeRoot,
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_MACHINE_ID: 'railway-service-service-test',
+        OPENALICE_RAILWAY_FENCE_FD: String(fd),
+        RAILWAY_ENVIRONMENT_ID: 'environment-test',
+        RAILWAY_SERVICE_ID: 'service-test',
+      })).toBe('railway-observer')
     } finally {
       closeSync(fd)
       await rm(railwayHome, { recursive: true, force: true })
@@ -145,6 +162,56 @@ describe('runtime lock ownership', () => {
     })
     await lock.release()
     await expect(inspectRuntimeLock(lockDir, { processController: controller })).resolves.toMatchObject({ state: 'missing' })
+  })
+
+  it('never restores a retired marker into a newer claim-directory generation', async () => {
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime-with-claim-directory-reuse.lock')
+    const claimDir = join(lockDir, 'reclaiming')
+    const newToken = '55555555-5555-4555-8555-555555555555'
+    let markerRetired: (() => void) | undefined
+    let resumeCleanup: (() => void) | undefined
+    let paused = false
+    const markerWasRetired = new Promise<void>((resolvePromise) => { markerRetired = resolvePromise })
+    const cleanupResume = new Promise<void>((resolvePromise) => { resumeCleanup = resolvePromise })
+    controller.sleepHook = async (ms) => {
+      if (ms !== 0 || paused) return
+      paused = true
+      markerRetired?.()
+      await cleanupResume
+    }
+
+    const acquisition = acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    await markerWasRetired
+    await rmdir(claimDir)
+    await mkdir(claimDir)
+    const newMarker = join(claimDir, `owner.${newToken}.json`)
+    await writeFile(newMarker, JSON.stringify({
+      schemaVersion: 1,
+      pid: 505,
+      hostname: hostname(),
+      machineId: 'machine-a',
+      token: newToken,
+      launcher: 'runtime-lock-reaper',
+      acquiredAt: new Date(50_000).toISOString(),
+      heartbeatAt: new Date(50_000).toISOString(),
+      processStartedAt: new Date(50_000).toISOString(),
+    }))
+    resumeCleanup?.()
+
+    const lock = await acquisition
+    expect(await readdir(claimDir)).toEqual([`owner.${newToken}.json`])
+    expect(JSON.parse(await readFile(newMarker, 'utf8'))).toMatchObject({ token: newToken })
+
+    controller.sleepHook = undefined
+    await rm(newMarker)
+    await rmdir(claimDir)
+    await lock.release()
   })
 
   it('refuses a second live owner without takeover', async () => {
@@ -199,6 +266,202 @@ describe('runtime lock ownership', () => {
     await fresh.release()
   })
 
+  it('reclaims a stale lock even when an older reaper left its marker behind', async () => {
+    controller.add(101, 10_000)
+    controller.add(202, 20_000)
+    const lockDir = join(home, 'runtime-with-abandoned-reclaimer.lock')
+    const stale = await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    await mkdir(join(lockDir, 'reclaiming'))
+    controller.alive.set(101, false)
+
+    const fresh = await acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      initializationGraceMs: 0,
+      processController: controller,
+    })
+
+    await stale.release()
+    await expect(inspectRuntimeLock(lockDir, { processController: controller })).resolves.toMatchObject({
+      state: 'active',
+      owner: { pid: 202 },
+    })
+    await fresh.release()
+  })
+
+  it('recovers a complete mutation claim whose claimant process died', async () => {
+    controller.add(101, 10_000)
+    controller.add(202, 20_000)
+    const lockDir = join(home, 'runtime-with-dead-claimant.lock')
+    const stale = await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    const claimDir = join(lockDir, 'reclaiming')
+    const deadClaimToken = '44444444-4444-4444-8444-444444444444'
+    await mkdir(claimDir)
+    await writeFile(join(claimDir, `owner.${deadClaimToken}.json`), JSON.stringify({
+      schemaVersion: 1,
+      pid: 404,
+      hostname: hostname(),
+      machineId: 'machine-a',
+      token: deadClaimToken,
+      launcher: 'runtime-lock-reaper',
+      acquiredAt: new Date(40_000).toISOString(),
+      heartbeatAt: new Date(40_000).toISOString(),
+      processStartedAt: new Date(40_000).toISOString(),
+    }))
+    controller.alive.set(101, false)
+
+    const fresh = await acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    await expect(inspectRuntimeLock(lockDir, { processController: controller })).resolves.toMatchObject({
+      state: 'active',
+      owner: { pid: 202 },
+    })
+
+    await stale.release()
+    await fresh.release()
+  })
+
+  it('cannot retire a newer mutation-claim generation after inspecting an abandoned one', async () => {
+    controller.add(101, 10_000)
+    controller.add(202, 20_000)
+    controller.add(505, 50_000)
+    const lockDir = join(home, 'runtime-with-replaced-claim.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, false)
+    const claimDir = join(lockDir, 'reclaiming')
+    const oldToken = '44444444-4444-4444-8444-444444444444'
+    const newToken = '55555555-5555-4555-8555-555555555555'
+    await mkdir(claimDir)
+    await writeFile(join(claimDir, `owner.${oldToken}.json`), JSON.stringify({
+      schemaVersion: 1,
+      pid: 404,
+      hostname: hostname(),
+      machineId: 'machine-a',
+      token: oldToken,
+      launcher: 'runtime-lock-reaper',
+      acquiredAt: new Date(40_000).toISOString(),
+      heartbeatAt: new Date(40_000).toISOString(),
+      processStartedAt: new Date(40_000).toISOString(),
+    }))
+
+    let machineIdReads = 0
+    let inspectedOldClaim: (() => void) | undefined
+    let resumeRecovery: (() => void) | undefined
+    const oldClaimInspected = new Promise<void>((resolvePromise) => { inspectedOldClaim = resolvePromise })
+    const recoveryResume = new Promise<void>((resolvePromise) => { resumeRecovery = resolvePromise })
+    controller.machineIdHook = async () => {
+      machineIdReads += 1
+      if (machineIdReads === 3) {
+        inspectedOldClaim?.()
+        await recoveryResume
+      }
+    }
+
+    const acquisition = acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    await oldClaimInspected
+    await rm(join(claimDir, `owner.${oldToken}.json`))
+    await rmdir(claimDir)
+    await mkdir(claimDir)
+    const newClaimPath = join(claimDir, `owner.${newToken}.json`)
+    await writeFile(newClaimPath, JSON.stringify({
+      schemaVersion: 1,
+      pid: 505,
+      hostname: hostname(),
+      machineId: 'machine-a',
+      token: newToken,
+      launcher: 'runtime-lock-reaper',
+      acquiredAt: new Date(50_000).toISOString(),
+      heartbeatAt: new Date(50_000).toISOString(),
+      processStartedAt: new Date(50_000).toISOString(),
+    }))
+    resumeRecovery?.()
+
+    await expect(acquisition).rejects.toBeInstanceOf(RuntimeAlreadyRunningError)
+    controller.machineIdHook = undefined
+    expect(JSON.parse(await readFile(newClaimPath, 'utf8'))).toMatchObject({ token: newToken, pid: 505 })
+  })
+
+  it('serializes two reapers that inspected the same stale lock generation', async () => {
+    controller.add(101, 10_000)
+    controller.add(202, 20_000)
+    controller.add(303, 30_000)
+    const lockDir = join(home, 'runtime-with-concurrent-reapers.lock')
+    const stale = await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, false)
+
+    let machineIdReads = 0
+    let releaseInspectionBarrier: (() => void) | undefined
+    const inspectionBarrier = new Promise<void>((resolvePromise) => {
+      releaseInspectionBarrier = resolvePromise
+    })
+    controller.machineIdHook = async () => {
+      machineIdReads += 1
+      if (machineIdReads === 4) releaseInspectionBarrier?.()
+      if (machineIdReads === 3 || machineIdReads === 4) await inspectionBarrier
+    }
+
+    const results = await Promise.allSettled([
+      acquireRuntimeLock(lockDir, {
+        pid: 202,
+        processStartedAt: 20_000,
+        heartbeatMs: 0,
+        processController: controller,
+      }),
+      acquireRuntimeLock(lockDir, {
+        pid: 303,
+        processStartedAt: 30_000,
+        heartbeatMs: 0,
+        processController: controller,
+      }),
+    ])
+    controller.machineIdHook = undefined
+
+    const acquired = results.filter((result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof acquireRuntimeLock>>> => (
+      result.status === 'fulfilled'
+    ))
+    const blocked = results.filter((result) => result.status === 'rejected')
+    expect(acquired).toHaveLength(1)
+    expect(blocked).toHaveLength(1)
+    expect(blocked[0]).toMatchObject({ reason: expect.any(RuntimeAlreadyRunningError) })
+    await expect(inspectRuntimeLock(lockDir, { processController: controller })).resolves.toMatchObject({
+      state: 'active',
+      owner: { pid: acquired[0]!.value.owner.pid },
+    })
+
+    await stale.release()
+    await acquired[0]!.value.release()
+  })
+
   it('keeps a live owner authoritative even when its heartbeat is stale', async () => {
     controller.add(101, 10_000)
     const lockDir = join(home, 'runtime.lock')
@@ -251,7 +514,12 @@ describe('runtime lock ownership', () => {
     controller.currentMachineId = 'env:railway-service-service-test'
     controller.add(202, 20_000)
     const lockDir = join(home, 'railway-runtime.lock')
-    const owner = railwayOwner({ heartbeatAt: new Date().toISOString() })
+    const owner = railwayOwner({
+      pid: 202,
+      hostname: hostname(),
+      heartbeatAt: new Date().toISOString(),
+      processStartedAt: new Date(20_000).toISOString(),
+    })
     await mkdir(lockDir)
     await writeFile(join(lockDir, 'owner.json'), JSON.stringify(owner))
 
@@ -278,26 +546,45 @@ describe('runtime lock ownership', () => {
     expect(controller.signals).toEqual([])
   })
 
-  it('lets the fenced Railway handoff replace only a cooperative protocol owner', async () => {
+  it('uses the fencing instance to replace a prior Railway container with the same hostname and PID', async () => {
     controller.currentMachineId = 'env:railway-service-service-test'
     controller.add(303, 30_000)
     const lockDir = join(home, 'railway-runtime.lock')
     await mkdir(lockDir)
-    await writeFile(join(lockDir, 'owner.json'), JSON.stringify(railwayOwner()))
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify(railwayOwner({
+      pid: 303,
+      hostname: hostname(),
+      processStartedAt: new Date(30_000).toISOString(),
+    })))
 
     const fresh = await acquireRuntimeLock(lockDir, {
       pid: 303,
       processStartedAt: 30_000,
       ownerAuthority: 'railway-fenced-handoff',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
       heartbeatMs: 0,
       processController: controller,
     })
     expect(fresh.owner).toMatchObject({
       pid: 303,
       fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
     })
     expect(controller.signals).toEqual([])
     await fresh.release()
+  })
+
+  it('fails closed when a fenced writer lacks its per-start instance identity', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    const lockDir = join(home, 'railway-missing-instance.lock')
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 303,
+      processStartedAt: 30_000,
+      ownerAuthority: 'railway-fenced-handoff',
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toThrow('missing or invalid Railway fencing instance identity')
   })
 
   it('fails closed on a legacy Railway owner even while holding the lifecycle fence', async () => {
@@ -311,6 +598,7 @@ describe('runtime lock ownership', () => {
 
     await expect(inspectRuntimeLock(lockDir, {
       ownerAuthority: 'railway-fenced-handoff',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
       processController: controller,
     })).resolves.toMatchObject({
       state: 'active',
@@ -321,13 +609,32 @@ describe('runtime lock ownership', () => {
       pid: 303,
       processStartedAt: 30_000,
       ownerAuthority: 'railway-fenced-handoff',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
       heartbeatMs: 0,
       processController: controller,
     })).rejects.toBeInstanceOf(RuntimeAlreadyRunningError)
     expect(controller.signals).toEqual([])
   })
 
-  it('keeps same-container PID identity authoritative on Railway', async () => {
+  it('fails closed when a Railway owner publishes a malformed fencing instance', async () => {
+    controller.currentMachineId = 'env:railway-service-service-test'
+    const lockDir = join(home, 'railway-invalid-instance.lock')
+    await mkdir(lockDir)
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify(railwayOwner({
+      fencingInstanceId: 'not valid',
+    })))
+
+    await expect(inspectRuntimeLock(lockDir, {
+      ownerAuthority: 'railway-fenced-handoff',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
+      processController: controller,
+    })).resolves.toMatchObject({
+      state: 'active',
+      reason: expect.stringContaining('does not belong to this Railway service'),
+    })
+  })
+
+  it('keeps a live Railway sibling with the same fencing instance authoritative', async () => {
     controller.currentMachineId = 'env:railway-service-service-test'
     controller.add(101, 10_000)
     const lockDir = join(home, 'railway-same-container.lock')
@@ -341,11 +648,14 @@ describe('runtime lock ownership', () => {
       launcher: 'guardian-cli-server',
       acquiredAt: new Date(0).toISOString(),
       heartbeatAt: new Date(0).toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
       processStartedAt: new Date(10_000).toISOString(),
     }))
 
     await expect(inspectRuntimeLock(lockDir, {
-      ownerAuthority: 'railway-observer',
+      ownerAuthority: 'railway-fenced-handoff',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
       processController: controller,
       staleHeartbeatMs: -1,
     })).resolves.toMatchObject({
@@ -431,6 +741,7 @@ describe('runtime lock ownership', () => {
       pid: 202,
       processStartedAt: 20_000,
       ownerAuthority: 'railway-fenced-handoff',
+      fencingInstanceId: CURRENT_FENCING_INSTANCE_ID,
       heartbeatMs: 0,
       processController: controller,
     })).rejects.toBeInstanceOf(RuntimeAlreadyRunningError)

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { fstatSync, readFileSync, realpathSync, statSync } from 'node:fs'
-import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, rm, rmdir, stat, writeFile } from 'node:fs/promises'
 import { hostname } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -14,7 +14,12 @@ import {
 
 const OWNER_FILE = 'owner.json'
 const RECLAIM_DIR = 'reclaiming'
+const MUTATION_CLAIM_OWNER_PATTERN = /^owner\.([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.json$/i
+const UUID_PATTERN_SOURCE = '[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+const MUTATION_CLAIM_TEMP_PATTERN = new RegExp(`^\\.owner\\.(${UUID_PATTERN_SOURCE})\\.(${UUID_PATTERN_SOURCE})\\.tmp$`, 'i')
+const ACQUIRE_RETRY_DELAY_MS = 25
 const WINDOWS_RENAME_RETRY_DELAYS_MS = [10, 25, 50, 100] as const
+const RAILWAY_FENCING_INSTANCE_PATTERN = /^[A-Za-z0-9-]{16,128}$/
 
 export const DEFAULT_HEARTBEAT_MS = 30_000
 export const DEFAULT_STALE_HEARTBEAT_MS = 90_000
@@ -30,6 +35,7 @@ export interface RuntimeLockOwner {
   readonly acquiredAt: string
   readonly heartbeatAt: string
   readonly fencingProtocol?: 'railway-flock-v1'
+  readonly fencingInstanceId?: string
   readonly processStartedAt?: string
   readonly guardianPid?: number
   readonly guardianStartedAt?: string
@@ -62,6 +68,7 @@ export interface RuntimeLockOptions {
   readonly staleHeartbeatMs?: number
   readonly initializationGraceMs?: number
   readonly ownerAuthority?: RuntimeLockOwnerAuthority
+  readonly fencingInstanceId?: string
   readonly processController?: ProcessController
   readonly onOwnershipLost?: (error: Error) => void
 }
@@ -97,6 +104,7 @@ export interface PrepareOpenAliceRuntimeOptions {
   readonly launcherRoot: string
   readonly takeover?: boolean
   readonly ownerAuthority?: RuntimeLockOwnerAuthority
+  readonly fencingInstanceId?: string
   readonly processController?: ProcessController
   readonly staleHeartbeatMs?: number
   readonly initializationGraceMs?: number
@@ -152,7 +160,16 @@ export function resolveRuntimeLockOwnerAuthority(
     || !/^[A-Za-z0-9-]{1,128}$/.test(serviceId ?? '')
     || machineId !== `railway-service-${serviceId}`
   ) return 'process'
-  return resolveRailwayRuntimeFence(env) ? 'railway-fenced-handoff' : 'railway-observer'
+  return resolveRailwayRuntimeFence(env) && resolveRailwayFencingInstanceId(env)
+    ? 'railway-fenced-handoff'
+    : 'railway-observer'
+}
+
+function resolveRailwayFencingInstanceId(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const value = env['OPENALICE_RAILWAY_INSTANCE_ID']?.trim()
+  return value && RAILWAY_FENCING_INSTANCE_PATTERN.test(value) ? value : undefined
 }
 
 export function resolveRailwayRuntimeFence(
@@ -257,7 +274,7 @@ function railwayFenceMatches(fence: RailwayRuntimeFence): boolean {
 
 export async function inspectRuntimeLock(
   lockDir: string,
-  opts: Pick<RuntimeLockOptions, 'processController' | 'staleHeartbeatMs' | 'initializationGraceMs' | 'ownerAuthority'> = {},
+  opts: Pick<RuntimeLockOptions, 'processController' | 'staleHeartbeatMs' | 'initializationGraceMs' | 'ownerAuthority' | 'fencingInstanceId'> = {},
 ): Promise<RuntimeLockInspection> {
   const controller = opts.processController ?? defaultProcessController
   const staleMs = opts.staleHeartbeatMs ?? DEFAULT_STALE_HEARTBEAT_MS
@@ -289,7 +306,12 @@ export async function inspectRuntimeLock(
   const heartbeatStale = heartbeatAgeMs === null || heartbeatAgeMs > staleMs
   const currentMachineId = await controller.machineId()
   const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
-  const railwayScope = railwayOwnerScope(owner, currentMachineId, ownerAuthority)
+  const railwayScope = railwayOwnerScope(
+    owner,
+    currentMachineId,
+    ownerAuthority,
+    opts.fencingInstanceId ?? resolveRailwayFencingInstanceId(),
+  )
   if (railwayScope === 'cross-container-fenced') {
     return inspection(
       lockDir,
@@ -359,6 +381,7 @@ function railwayOwnerScope(
   owner: RuntimeLockOwner,
   currentMachineId: string,
   ownerAuthority: RuntimeLockOwnerAuthority | undefined,
+  currentFencingInstanceId: string | undefined,
 ): 'same-container' | 'cross-container-observer' | 'cross-container-fenced' | 'foreign' | null {
   if (
     ownerAuthority !== 'railway-observer'
@@ -366,11 +389,15 @@ function railwayOwnerScope(
     && ownerAuthority !== 'railway-fenced-handoff'
   ) return null
   if (!/^env:railway-service-[A-Za-z0-9-]+$/.test(currentMachineId)) return 'foreign'
-  if (owner.hostname.length === 0) return 'foreign'
-  const sameContainer = owner.hostname === hostname()
   if (owner.machineId !== currentMachineId) return 'foreign'
-  if (sameContainer) return 'same-container'
   if (owner.fencingProtocol !== 'railway-flock-v1') return 'foreign'
+  if (
+    owner.fencingInstanceId !== undefined
+    && !RAILWAY_FENCING_INSTANCE_PATTERN.test(owner.fencingInstanceId)
+  ) return 'foreign'
+  if (ownerAuthority === 'railway-observer') return 'cross-container-observer'
+  if (!currentFencingInstanceId) return 'foreign'
+  if (owner.fencingInstanceId === currentFencingInstanceId) return 'same-container'
   return ownerAuthority === 'railway-fenced-handoff'
     ? 'cross-container-fenced'
     : 'cross-container-observer'
@@ -382,6 +409,13 @@ export async function acquireRuntimeLock(
 ): Promise<RuntimeProcessLock> {
   const controller = opts.processController ?? defaultProcessController
   const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
+  const fencingInstanceId = opts.fencingInstanceId ?? resolveRailwayFencingInstanceId()
+  if (
+    (ownerAuthority === 'railway-fenced-handoff' || ownerAuthority === 'railway-fenced-owner')
+    && !fencingInstanceId
+  ) {
+    throw new Error('missing or invalid Railway fencing instance identity')
+  }
   const processStartedAt = opts.processStartedAt ?? currentProcessStartedAt()
   const machineId = await controller.machineId()
   const now = new Date().toISOString()
@@ -397,24 +431,62 @@ export async function acquireRuntimeLock(
     ...(ownerAuthority === 'railway-fenced-handoff' || ownerAuthority === 'railway-fenced-owner'
       ? { fencingProtocol: 'railway-flock-v1' as const }
       : {}),
+    ...(fencingInstanceId ? { fencingInstanceId } : {}),
     processStartedAt: new Date(processStartedAt).toISOString(),
     ...(opts.guardianPid ? { guardianPid: opts.guardianPid } : {}),
     ...(opts.guardianStartedAt ? { guardianStartedAt: new Date(opts.guardianStartedAt).toISOString() } : {}),
   }
 
   await mkdir(dirname(lockDir), { recursive: true })
-  for (let attempt = 0; attempt < 40; attempt++) {
+  const acquireAttempts = Math.max(
+    40,
+    Math.ceil(((opts.initializationGraceMs ?? DEFAULT_INITIALIZATION_GRACE_MS) + 2_000) / ACQUIRE_RETRY_DELAY_MS),
+  )
+  for (let attempt = 0; attempt < acquireAttempts; attempt++) {
+    let created = false
     try {
       await mkdir(lockDir)
-      await writeOwnerAtomic(lockDir, owner, controller)
-      return makeLock(lockDir, owner, { ...opts, ownerAuthority })
+      created = true
     } catch (err) {
       if (!isErrno(err, 'EEXIST')) throw err
     }
 
+    if (created) {
+      const directoryIdentity = await readLockDirectoryIdentity(lockDir)
+      const claim = await acquireLockMutationClaim(lockDir, owner, {
+        ...opts,
+        ownerAuthority,
+        fencingInstanceId,
+      })
+      if (!directoryIdentity || !claim) {
+        await controller.sleep(ACQUIRE_RETRY_DELAY_MS)
+        continue
+      }
+      let published = false
+      let claimReleased = false
+      try {
+        const latestIdentity = await readLockDirectoryIdentity(lockDir)
+        const latestOwner = await readOwner(lockDir).catch(() => null)
+        if (latestIdentity === directoryIdentity && !latestOwner && await claim.isCurrent()) {
+          await writeOwnerAtomic(lockDir, owner, controller)
+          const verifiedIdentity = await readLockDirectoryIdentity(lockDir)
+          const verifiedOwner = await readOwner(lockDir).catch(() => null)
+          published = verifiedIdentity === directoryIdentity
+            && verifiedOwner?.token === owner.token
+            && await claim.isCurrent()
+        }
+      } finally {
+        claimReleased = await claim.release()
+      }
+      if (!claimReleased) throw new Error(`runtime mutation claim could not be released at ${lockDir}`)
+      if (published) return makeLock(lockDir, owner, { ...opts, ownerAuthority, fencingInstanceId })
+      await controller.sleep(ACQUIRE_RETRY_DELAY_MS)
+      continue
+    }
+
     const current = await inspectRuntimeLock(lockDir, { ...opts, ownerAuthority })
     if (current.state === 'missing' || current.state === 'initializing') {
-      await controller.sleep(25)
+      await controller.sleep(ACQUIRE_RETRY_DELAY_MS)
       continue
     }
     if (current.state === 'active') {
@@ -422,13 +494,14 @@ export async function acquireRuntimeLock(
       await recoverRuntimeOwner(current.owner, {
         processController: controller,
         ownerAuthority,
+        fencingInstanceId,
       })
-      await controller.sleep(25)
+      await controller.sleep(ACQUIRE_RETRY_DELAY_MS)
       continue
     }
 
-    if (await claimAndRemove(current)) continue
-    await controller.sleep(25)
+    if (await claimAndRemove(current, owner, { ...opts, ownerAuthority, fencingInstanceId })) continue
+    await controller.sleep(ACQUIRE_RETRY_DELAY_MS)
   }
 
   throw new RuntimeAlreadyRunningError(await inspectRuntimeLock(lockDir, { ...opts, ownerAuthority }))
@@ -493,6 +566,7 @@ export async function prepareOpenAliceRuntime(opts: PrepareOpenAliceRuntimeOptio
     await recoverRuntimeOwner(row.owner!, {
       processController: opts.processController,
       ownerAuthority: opts.ownerAuthority,
+      fencingInstanceId: opts.fencingInstanceId,
     })
   }
   return inspections
@@ -503,12 +577,18 @@ export async function recoverRuntimeOwner(
   opts: {
     readonly processController?: ProcessController
     readonly ownerAuthority?: RuntimeLockOwnerAuthority
+    readonly fencingInstanceId?: string
   } = {},
 ): Promise<void> {
   const controller = opts.processController ?? defaultProcessController
   const currentMachineId = await controller.machineId()
   const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
-  const railwayScope = railwayOwnerScope(owner, currentMachineId, ownerAuthority)
+  const railwayScope = railwayOwnerScope(
+    owner,
+    currentMachineId,
+    ownerAuthority,
+    opts.fencingInstanceId ?? resolveRailwayFencingInstanceId(),
+  )
   if (railwayScope === 'cross-container-observer' || railwayScope === 'cross-container-fenced') {
     throw new Error(`OpenAlice owner ${owner.pid} belongs to another Railway container; refusing to signal it`)
   }
@@ -583,37 +663,272 @@ function makeLock(lockDir: string, initialOwner: RuntimeLockOwner, opts: Runtime
       while (updating) await (opts.processController ?? defaultProcessController).sleep(5)
       const current = await readOwner(lockDir).catch(() => null)
       if (current?.token !== owner.token) return
-      await rm(lockDir, { recursive: true, force: true })
+      const directoryIdentity = await readLockDirectoryIdentity(lockDir)
+      if (!directoryIdentity) return
+      let retiredDir: string | null = null
+      for (let attempt = 0; attempt < 40 && !retiredDir; attempt++) {
+        retiredDir = await retireLockDirectory(
+          lockDir,
+          directoryIdentity,
+          current,
+          owner,
+          opts,
+          'released',
+        )
+        if (retiredDir) break
+        const latest = await readOwner(lockDir).catch(() => null)
+        if (latest?.token !== owner.token) return
+        await (opts.processController ?? defaultProcessController).sleep(25)
+      }
+      if (!retiredDir) return
+      await rm(retiredDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 10 }).catch(() => undefined)
     },
   }
 }
 
-async function claimAndRemove(current: RuntimeLockInspection): Promise<boolean> {
+async function claimAndRemove(
+  current: RuntimeLockInspection,
+  claimant: RuntimeLockOwner,
+  opts: RuntimeLockOptions,
+): Promise<boolean> {
   if (!current.directoryIdentity) return current.state === 'missing'
-  const claimDir = join(current.lockDir, RECLAIM_DIR)
-  const quarantineDir = `${current.lockDir}.reaped-${randomUUID()}`
-  let quarantined = false
+  const retiredDir = await retireLockDirectory(
+    current.lockDir,
+    current.directoryIdentity,
+    current.owner,
+    claimant,
+    opts,
+    'reaped',
+  )
+  if (!retiredDir) return false
+  await rm(retiredDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 10 }).catch(() => undefined)
+  return true
+}
+
+async function readLockDirectoryIdentity(lockDir: string): Promise<string | null> {
+  try {
+    const lockStat = await stat(lockDir)
+    return lockDirectoryIdentity(lockStat)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return null
+    throw err
+  }
+}
+
+function lockDirectoryIdentity(lockStat: { dev: number; ino: number; birthtimeMs: number }): string {
+  return `${lockStat.dev}:${lockStat.ino}:${lockStat.birthtimeMs}`
+}
+
+async function retireLockDirectory(
+  lockDir: string,
+  expectedIdentity: string,
+  expectedOwner: RuntimeLockOwner | null,
+  claimant: RuntimeLockOwner,
+  opts: RuntimeLockOptions,
+  reason: 'released' | 'reaped',
+): Promise<string | null> {
+  const claim = await acquireLockMutationClaim(lockDir, claimant, opts)
+  if (!claim) return null
+  const retiredDir = `${lockDir}.${reason}-${randomUUID()}`
+  let retired = false
+  try {
+    const latestIdentity = await readLockDirectoryIdentity(lockDir)
+    if (latestIdentity !== expectedIdentity) return null
+    const latestOwner = await readOwner(lockDir).catch(() => null)
+    if (expectedOwner && !sameReclaimEvidence(expectedOwner, latestOwner)) return null
+    if (!expectedOwner && latestOwner) return null
+    if (!(await claim.isCurrent())) return null
+    await renameAtomic(lockDir, retiredDir, opts.processController ?? defaultProcessController)
+    retired = true
+    return retiredDir
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return null
+    throw err
+  } finally {
+    if (!retired && !(await claim.release())) {
+      throw new Error(`runtime mutation claim could not be released at ${lockDir}`)
+    }
+  }
+}
+
+interface LockMutationClaim {
+  isCurrent(): Promise<boolean>
+  release(): Promise<boolean>
+}
+
+async function acquireLockMutationClaim(
+  lockDir: string,
+  claimant: RuntimeLockOwner,
+  opts: RuntimeLockOptions,
+): Promise<LockMutationClaim | null> {
+  const claimDir = join(lockDir, RECLAIM_DIR)
+  const ownerFileName = mutationClaimOwnerFileName(claimant.token)
   try {
     await mkdir(claimDir)
   } catch (err) {
-    if (isErrno(err, 'ENOENT') || isErrno(err, 'EEXIST')) return false
+    if (isErrno(err, 'ENOENT')) return null
+    if (isErrno(err, 'EEXIST')) {
+      await recoverAbandonedMutationClaim(lockDir, opts)
+      return null
+    }
+    throw err
+  }
+  const claimDirectoryIdentity = await readLockDirectoryIdentity(claimDir)
+  if (!claimDirectoryIdentity) return null
+
+  const tempPath = join(claimDir, `.owner.${claimant.token}.${randomUUID()}.tmp`)
+  const ownerPath = join(claimDir, ownerFileName)
+  try {
+    await writeFile(tempPath, JSON.stringify(claimant, null, 2) + '\n', 'utf8')
+    await renameAtomic(tempPath, ownerPath, opts.processController ?? defaultProcessController)
+  } catch (err) {
+    await rm(tempPath, { force: true }).catch(() => undefined)
+    await rmdir(claimDir).catch(() => undefined)
+    if (isErrno(err, 'ENOENT')) return null
     throw err
   }
 
-  try {
-    const currentStat = await stat(current.lockDir)
-    const identity = `${currentStat.dev}:${currentStat.ino}:${currentStat.birthtimeMs}`
-    if (identity !== current.directoryIdentity) return false
-    const latest = await readOwner(current.lockDir).catch(() => null)
-    if (current.owner && !sameReclaimEvidence(current.owner, latest)) return false
-    if (!current.owner && latest) return false
-    await rename(current.lockDir, quarantineDir)
-    quarantined = true
-    await rm(quarantineDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 10 }).catch(() => undefined)
-    return true
-  } finally {
-    if (!quarantined) await rm(claimDir, { recursive: true, force: true }).catch(() => undefined)
+  const claim: LockMutationClaim = {
+    isCurrent: async () => {
+      if (await readLockDirectoryIdentity(claimDir) !== claimDirectoryIdentity) return false
+      const entries = await readdir(claimDir).catch(() => null)
+      if (entries === null || entries.length !== 1 || entries[0] !== ownerFileName) return false
+      const latest = await readOwnerFile(ownerPath).catch(() => null)
+      return sameReclaimEvidence(claimant, latest)
+    },
+    release: async () => {
+      return retireMutationClaimMarker(lockDir, claimDirectoryIdentity, claimant, opts).catch(() => false)
+    },
   }
+  if (!(await claim.isCurrent())) {
+    await claim.release()
+    return null
+  }
+  return claim
+}
+
+async function recoverAbandonedMutationClaim(
+  lockDir: string,
+  opts: RuntimeLockOptions,
+): Promise<boolean> {
+  const controller = opts.processController ?? defaultProcessController
+  const claimDir = join(lockDir, RECLAIM_DIR)
+  let claimStat
+  try {
+    claimStat = await stat(claimDir)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return true
+    throw err
+  }
+
+  const entries = await readdir(claimDir).catch(() => null)
+  if (entries === null) return false
+  const ownerEntry = entries.length === 1 && MUTATION_CLAIM_OWNER_PATTERN.test(entries[0]!)
+    ? entries[0]!
+    : null
+  if (!ownerEntry) {
+    const ageMs = Math.max(0, Date.now() - claimStat.mtimeMs)
+    const initializationGraceMs = opts.initializationGraceMs ?? DEFAULT_INITIALIZATION_GRACE_MS
+    const incompleteTemp = entries.length === 1 && MUTATION_CLAIM_TEMP_PATTERN.test(entries[0]!)
+      ? entries[0]!
+      : null
+    if ((entries.length > 0 && !incompleteTemp) || ageMs < initializationGraceMs) return false
+    try {
+      if (incompleteTemp) await rm(join(claimDir, incompleteTemp), { force: true })
+      await rmdir(claimDir)
+      return true
+    } catch (err) {
+      if (isErrno(err, 'ENOENT')) return true
+      if (isErrno(err, 'ENOTEMPTY') || isErrno(err, 'EEXIST')) return false
+      throw err
+    }
+  }
+
+  let claimant: RuntimeLockOwner
+  try {
+    claimant = await readOwnerFile(join(claimDir, ownerEntry))
+  } catch {
+    return false
+  }
+  const fileToken = MUTATION_CLAIM_OWNER_PATTERN.exec(ownerEntry)?.[1]
+  if (!fileToken || fileToken.toLowerCase() !== claimant.token.toLowerCase()) return false
+
+  const currentMachineId = await controller.machineId()
+  const ownerAuthority = opts.ownerAuthority ?? resolveRuntimeLockOwnerAuthority()
+  const railwayScope = railwayOwnerScope(
+    claimant,
+    currentMachineId,
+    ownerAuthority,
+    opts.fencingInstanceId ?? resolveRailwayFencingInstanceId(),
+  )
+  if (railwayScope === 'cross-container-observer' || railwayScope === 'foreign') return false
+  let abandoned = railwayScope === 'cross-container-fenced'
+  if (!abandoned) {
+    if (claimant.machineId && claimant.machineId !== currentMachineId && railwayScope !== 'same-container') return false
+    abandoned = !controller.isAlive(claimant.pid)
+      || !(await isSameProcess(claimant.pid, claimant.processStartedAt, controller))
+  }
+  if (!abandoned) return false
+
+  return retireMutationClaimMarker(lockDir, lockDirectoryIdentity(claimStat), claimant, opts)
+}
+
+function mutationClaimOwnerFileName(token: string): string {
+  const ownerFileName = `owner.${token}.json`
+  if (!MUTATION_CLAIM_OWNER_PATTERN.test(ownerFileName)) {
+    throw new Error('runtime mutation claim token is not a UUID')
+  }
+  return ownerFileName
+}
+
+async function retireMutationClaimMarker(
+  lockDir: string,
+  expectedClaimDirectoryIdentity: string,
+  claimant: RuntimeLockOwner,
+  opts: RuntimeLockOptions,
+): Promise<boolean> {
+  const controller = opts.processController ?? defaultProcessController
+  const claimDir = join(lockDir, RECLAIM_DIR)
+  const ownerPath = join(claimDir, mutationClaimOwnerFileName(claimant.token))
+  const retiredOwnerPath = `${lockDir}.mutation-${claimant.token}-${randomUUID()}.retired`
+  if (await readLockDirectoryIdentity(claimDir) !== expectedClaimDirectoryIdentity) return false
+  const entries = await readdir(claimDir).catch(() => null)
+  if (entries === null || entries.length !== 1 || entries[0] !== mutationClaimOwnerFileName(claimant.token)) {
+    return false
+  }
+  try {
+    await renameAtomic(ownerPath, retiredOwnerPath, controller)
+  } catch (err) {
+    if (isErrno(err, 'ENOENT')) return false
+    throw err
+  }
+
+  const movedOwner = await readOwnerFile(retiredOwnerPath).catch(() => null)
+  if (!sameReclaimEvidence(claimant, movedOwner)) {
+    return false
+  }
+
+  // The marker move fences this exact claim generation. Correctness must not
+  // depend on uninterrupted cleanup: another contender may remove the now-empty
+  // directory after its grace and create a new generation at the same path.
+  await controller.sleep(0)
+  try {
+    await rmdir(claimDir)
+  } catch (err) {
+    if (!isErrno(err, 'ENOENT')) {
+      if (isErrno(err, 'ENOTEMPTY') || isErrno(err, 'EEXIST')) {
+        const latestIdentity = await readLockDirectoryIdentity(claimDir)
+        if (latestIdentity !== expectedClaimDirectoryIdentity) {
+          await rm(retiredOwnerPath, { force: true }).catch(() => undefined)
+          return true
+        }
+        return false
+      }
+      throw err
+    }
+  }
+  await rm(retiredOwnerPath, { force: true }).catch(() => undefined)
+  return true
 }
 
 async function writeOwnerAtomic(
@@ -625,22 +940,30 @@ async function writeOwnerAtomic(
   const tempPath = join(lockDir, `.${OWNER_FILE}.${owner.token}.${randomUUID()}.tmp`)
   try {
     await writeFile(tempPath, JSON.stringify(owner, null, 2) + '\n', 'utf8')
-    for (let attempt = 0; ; attempt++) {
-      try {
-        await rename(tempPath, ownerPath)
-        break
-      } catch (error) {
-        const retryDelay = WINDOWS_RENAME_RETRY_DELAYS_MS[attempt]
-        if (
-          process.platform !== 'win32' ||
-          retryDelay === undefined ||
-          !isTransientWindowsRenameError(error)
-        ) throw error
-        await controller.sleep(retryDelay)
-      }
-    }
+    await renameAtomic(tempPath, ownerPath, controller)
   } finally {
     await rm(tempPath, { force: true }).catch(() => undefined)
+  }
+}
+
+async function renameAtomic(
+  source: string,
+  destination: string,
+  controller: ProcessController,
+): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await rename(source, destination)
+      return
+    } catch (error) {
+      const retryDelay = WINDOWS_RENAME_RETRY_DELAYS_MS[attempt]
+      if (
+        process.platform !== 'win32'
+        || retryDelay === undefined
+        || !isTransientWindowsRenameError(error)
+      ) throw error
+      await controller.sleep(retryDelay)
+    }
   }
 }
 
@@ -654,7 +977,11 @@ interface ParsedRuntimeLockOwner {
 }
 
 async function readOwnerRecord(lockDir: string): Promise<ParsedRuntimeLockOwner> {
-  const parsed = JSON.parse(await readFile(join(lockDir, OWNER_FILE), 'utf8')) as Record<string, unknown>
+  return readOwnerFileRecord(join(lockDir, OWNER_FILE))
+}
+
+async function readOwnerFileRecord(ownerPath: string): Promise<ParsedRuntimeLockOwner> {
+  const parsed = JSON.parse(await readFile(ownerPath, 'utf8')) as Record<string, unknown>
   if (
     typeof parsed['pid'] !== 'number' ||
     typeof parsed['hostname'] !== 'string' ||
@@ -678,6 +1005,9 @@ async function readOwnerRecord(lockDir: string): Promise<ParsedRuntimeLockOwner>
       ...(parsed['fencingProtocol'] === 'railway-flock-v1'
         ? { fencingProtocol: 'railway-flock-v1' as const }
         : {}),
+      ...(typeof parsed['fencingInstanceId'] === 'string'
+        ? { fencingInstanceId: parsed['fencingInstanceId'] }
+        : {}),
       ...(typeof parsed['processStartedAt'] === 'string' ? { processStartedAt: parsed['processStartedAt'] } : {}),
       ...(typeof parsed['guardianPid'] === 'number' ? { guardianPid: parsed['guardianPid'] } : {}),
       ...(typeof parsed['guardianStartedAt'] === 'string' ? { guardianStartedAt: parsed['guardianStartedAt'] } : {}),
@@ -687,6 +1017,10 @@ async function readOwnerRecord(lockDir: string): Promise<ParsedRuntimeLockOwner>
 
 async function readOwner(lockDir: string): Promise<RuntimeLockOwner> {
   return (await readOwnerRecord(lockDir)).owner
+}
+
+async function readOwnerFile(ownerPath: string): Promise<RuntimeLockOwner> {
+  return (await readOwnerFileRecord(ownerPath)).owner
 }
 
 function sameReclaimEvidence(
@@ -703,6 +1037,7 @@ function sameReclaimEvidence(
     && latest.acquiredAt === inspected.acquiredAt
     && latest.heartbeatAt === inspected.heartbeatAt
     && latest.fencingProtocol === inspected.fencingProtocol
+    && latest.fencingInstanceId === inspected.fencingInstanceId
     && latest.processStartedAt === inspected.processStartedAt
     && latest.guardianPid === inspected.guardianPid
     && latest.guardianStartedAt === inspected.guardianStartedAt

--- a/packages/guardian-runtime/src/runtime-lock.windows-retry.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.windows-retry.spec.ts
@@ -77,7 +77,7 @@ describe('Windows owner replacement retry', () => {
     await waitFor(() => renameFault.calls >= callsAfterAcquire + 3)
 
     expect(ownershipError).toBeNull()
-    expect(retryDelays).toEqual([10, 25])
+    expect(retryDelays).toEqual([0, 10, 25])
     await expect(readFile(join(lockDir, 'owner.json'), 'utf8')).resolves.toContain(lock.owner.token)
     await lock.release()
   })

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -4,8 +4,9 @@ Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separatel
 dispatched v0.91.0-beta.1 is externally verified; stable remains v0.90.2 while
 stable/beta discovery authority is converged on the OpenAlice CDN;
 the Railway native CLI SSH host passes local empty-Volume, normal replacement,
-hard-kill recovery, and real Project offline planning while hosted deploy/apply
-acceptance remains pending; native PowerShell and external
+hard-kill recovery, real retained-Volume transfer, and one hosted Agent turn;
+the v2 crash-safe lock repair still needs live restart/hard-kill reacceptance;
+native PowerShell and external
 package-manager activation remain deferred
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
@@ -687,6 +688,14 @@ source-built Docker image.
   Linux installer and SSH-remote Docker smokes, Guardian recovery smoke, and a
   rebuilt Railway image with the required tools but no Node, Bun, or Agent
   Runtime.
+- [x] Replace recursive mutation-claim cleanup with a UUID generation marker
+  shared by publication, release, and stale reaping. Atomically retire only the
+  exact marker generation, recheck it before canonical mutation, distinguish
+  Railway replacements with a per-start instance id, require the
+  `railway-runtime-lock-v2` capability, and let the Volume-fenced preflight
+  recover only exact claim-only/published-owner intermediate shapes after a
+  blocker-free full scan. Unknown entries, duplicate claim markers/write temps,
+  and malformed or symlinked nodes remain fail-closed.
 - [ ] On a disposable Railway service and empty `/data` Volume, pass clean
   bootstrap and empty-host install-failure/fail-closed acceptance without using
   or clearing the retained real Volume.
@@ -695,21 +704,18 @@ source-built Docker image.
   Serverless disabled, Restart Policy set to Always, one replica, at least 30
   seconds of draining, fixed SSH `HOME=/data/home` plus persistent user `PATH`,
   an OpenSSH alias from `railway ssh config`, and a successful inspection-only
-  `openalice remote` browser/tunnel journey. A beta candidate has now booted
-  successfully against an isolated diagnostic Home on the retained Volume and
-  exposed no public domain. Its first attempt against the existing Project Home
-  reproduced the legacy-machine-identity handoff failure above. Prove the new
-  lifecycle fence on the diagnostic Home first; then, after showing the old
-  deployment is stopped, quarantine only the exact retained legacy lock
-  directories before selecting that original Home.
-- [ ] Repeat `openalice project transfer --plan` through the deployed Railway
+  `openalice remote` browser/tunnel journey. The no-domain service, fixed Home,
+  one-replica/Always policy, tunnel, and retained Project have been exercised;
+  final completion remains blocked on redeploying the v2 crash-safe lock repair
+  and repeating restart/hard-kill recovery without manual lock deletion.
+- [x] Repeat `openalice project transfer --plan` through the deployed Railway
   candidate so SSH compatibility, destination absence, and free-space
   preflight are proven before apply.
-- [ ] Apply the reviewed real AliceProject transfer into a new
+- [x] Apply the reviewed real AliceProject transfer into a new
   `/data/projects/<name>` Home, select that Home for the service, and verify its
   portable Workspace/configuration state after redeploy without copied install
   bytes or machine-local symlinks.
-- [ ] Install and authenticate one Agent Runtime through Railway SSH, then prove
+- [x] Install and authenticate one Agent Runtime through Railway SSH, then prove
   a real Workspace turn without treating those Agent bytes as an OpenAlice
   release artifact.
 - [ ] Restart and redeploy against the same Volume, verify install/Home/Agent
@@ -1219,3 +1225,27 @@ This plan is complete only when:
   full build, and the local native Bun release smoke pass. A fresh dev archive
   and Railway restart/redeploy acceptance remain required before Project
   transfer.
+- 2026-09-01: PR #1281 merged the immutable Workspace-log repair to `dev` at
+  `50f3d49f`, and run 33435309446 published the matching native archives. The
+  retained no-domain Railway service then installed that dev archive under the
+  persistent SSH Home, selected `/data/projects/main-cloud`, and received the
+  stopped local Default AliceProject through the production transfer path:
+  10,702 files and 222,635,304 bytes, with zero native Sessions copied. OpenCode
+  1.18.25 was installed separately under `/data/home`, and Workspace
+  `chat-solid-coral-ridge` completed a real headless turn with
+  `OPENALICE_REMOTE_OK`. A following service restart exposed two crash-recovery
+  defects not covered by the earlier container drill: recursive release could
+  strand an empty canonical directory, and reused Railway hostname/PID identity
+  could misclassify the prior container. The current v2 repair adds a fresh
+  per-start instance id, requires both Railway Runtime capabilities, and uses a
+  UUID generation marker for publication/release/reaping. Exact-marker atomic
+  retirement prevents an old recoverer from deleting a new claim; the
+  Volume-fenced preflight validates every Project before cleaning only known
+  claim-only, owner-write-temp, or published-owner intermediates. Claim-only
+  status is no longer reported as absent. Focused Runtime/CLI/entrypoint tests
+  pass 133 tests with four platform skips; root, Guardian, and CLI TypeScript,
+  diff checks, Guardian recovery, and the full 5,319-test suite with 13 skips
+  are green. Linux installer, native SSH-remote, and full Docker Runtime smokes
+  also pass on OrbStack. A new dev archive, live automatic recovery, persisted
+  resume, and restart/hard-kill acceptance remain pending; no stable/beta
+  release or channel promotion was performed.

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -552,7 +552,7 @@ signals a guessed PID, exposes the Guardian socket, or performs trading writes.
   them under a new destination key.
 - [x] Validate the complete receipt and exact published entry set before an
   idempotent registration retry, including receiver-created credential files.
-- [ ] Apply the reviewed transfer to the retained Railway Volume, select the
+- [x] Apply the reviewed transfer to the retained Railway Volume, select the
   imported Project, and verify portable Workspace/configuration state plus a
   new user-owned Agent Runtime turn without importing native Session state.
 
@@ -640,7 +640,20 @@ destination; native Agent login/config/session state remains excluded. Receipt
 validation covers the exact manifest, credentials policy, and published entry
 set, including idempotent recovery when the receiver created an AI vault before
 registry registration failed. Hosted Railway apply and real Project selection
-remain the acceptance step shared with the Bun CLI distribution plan.
+were the acceptance step shared with the Bun CLI distribution plan.
+
+Increment 6 hosted acceptance (2026-09-01): the stopped local Default
+AliceProject transferred through the production SSH path into
+`/data/projects/main-cloud` on the retained Railway Volume. The destination
+published 10,702 files and 222,635,304 bytes, registered and selected its new
+AliceProject identity, retained portable Workspace/configuration state, copied
+no native Sessions, and left transfer staging clean. OpenCode 1.18.25 was then
+installed as user-owned persistent state outside the OpenAlice release, and
+Workspace `chat-solid-coral-ridge` completed a real headless turn returning
+`OPENALICE_REMOTE_OK`. The local source remains stopped to avoid divergent
+writes. Restart/resume and hard-kill persistence are owned by the Bun CLI
+distribution plan's still-open Railway acceptance, not by this transfer
+increment.
 
 Always:
 

--- a/scripts/railway-entrypoint.spec.ts
+++ b/scripts/railway-entrypoint.spec.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { chmod, mkdir, mkdtemp, readFile, readlink, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, readlink, realpath, rm, symlink, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { promisify } from 'node:util'
@@ -114,7 +114,7 @@ describe('Railway native CLI host entrypoint', () => {
         OPENALICE_HOME: join(fixture.volume, 'quarantine', 'old-project'),
       },
     })).rejects.toMatchObject({
-      stderr: expect.stringContaining('cannot select the reserved Railway quarantine tree'),
+      stderr: expect.stringContaining('quarantine path must be an actual directory'),
     })
     await expect(readFile(fixture.installCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
@@ -244,6 +244,482 @@ describe('Railway native CLI host entrypoint', () => {
     })
   })
 
+  it('accepts a missing legacy fencing instance id but rejects a malformed present value', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-retained-instance-id-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const ownerPath = join(project, 'state', 'guardian.lock', 'owner.json')
+    const owner = {
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'previous-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'fenced-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+    }
+    await mkdir(join(project, 'state', 'guardian.lock'), { recursive: true })
+    await writeFile(ownerPath, JSON.stringify(owner))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+
+    await writeFile(ownerPath, JSON.stringify({
+      ...owner,
+      fencingInstanceId: 'bad/id',
+    }))
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('project/state/guardian.lock'),
+    })
+
+    await writeFile(ownerPath, JSON.stringify({
+      ...owner,
+      fencingInstanceId: 'railway-fence-1234',
+    }))
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+  })
+
+  it('rejects boolean schema and pid values instead of treating them as valid integers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-retained-bool-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const lockDir = join(project, 'state', 'guardian.lock')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: true,
+      pid: true,
+      hostname: 'previous-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'malformed-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+    }))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      join(project, 'workspaces'),
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('project/state/guardian.lock'),
+    })
+  })
+
+  it('checks the historical Volume-root Project before switching to a nested Project', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-root-project-'))
+    temporaryPaths.push(root)
+    const selectedProject = join(root, 'projects', 'selected')
+    const lockDir = join(root, 'state', 'guardian.lock')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'legacy-root-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'legacy-root-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    }))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      selectedProject,
+      join(selectedProject, 'workspaces'),
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('state/guardian.lock'),
+    })
+    expect(existsSync(selectedProject)).toBe(false)
+  })
+
+  it.runIf(process.platform !== 'win32')('rejects symlinked lock parents without deleting outside the Volume', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-lock-symlink-'))
+    const outside = await mkdtemp(join(tmpdir(), 'openalice-railway-lock-outside-'))
+    temporaryPaths.push(root, outside)
+    const project = join(root, 'project')
+    const outsideLock = join(outside, 'state', 'config-bootstrap.lock')
+    await mkdir(project, { recursive: true })
+    await mkdir(outsideLock, { recursive: true })
+    await symlink(outside, join(project, 'data'))
+    const old = new Date(Date.now() - 5_000)
+    await utimes(outsideLock, old, old)
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      join(project, 'workspaces'),
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('project/data/state/config-bootstrap.lock'),
+    })
+    expect(existsSync(outsideLock)).toBe(true)
+  })
+
+  it.runIf(
+    process.platform !== 'win32'
+      && typeof process.getuid === 'function'
+      && process.getuid() !== 0,
+  )('fails closed when a Volume subtree cannot be traversed', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-walk-error-'))
+    temporaryPaths.push(root)
+    const hidden = join(root, 'hidden')
+    const legacyLock = join(hidden, 'project', 'state', 'guardian.lock')
+    const selectedProject = join(root, 'projects', 'selected')
+    await mkdir(legacyLock, { recursive: true })
+    await writeFile(join(legacyLock, 'owner.json'), '{}')
+    await chmod(hidden, 0o000)
+    try {
+      await expect(execFileAsync('python3', [
+        retainedLockPreflight,
+        root,
+        selectedProject,
+        join(selectedProject, 'workspaces'),
+        'env:railway-service-service-test',
+      ])).rejects.toMatchObject({
+        stderr: expect.stringContaining('could not inspect the complete Volume'),
+      })
+    } finally {
+      await chmod(hidden, 0o700)
+    }
+  })
+
+  it('reports a directory-shaped owner as malformed without a Python traceback', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-owner-directory-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const lockDir = join(project, 'state', 'guardian.lock')
+    await mkdir(join(lockDir, 'owner.json'), { recursive: true })
+
+    const result = execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      join(project, 'workspaces'),
+      'env:railway-service-service-test',
+    ])
+    await expect(result).rejects.toMatchObject({
+      stderr: expect.stringContaining('project/state/guardian.lock'),
+    })
+    await expect(result).rejects.not.toMatchObject({
+      stderr: expect.stringContaining('Traceback'),
+    })
+  })
+
+  it.runIf(process.platform !== 'win32')('opens a FIFO owner nonblocking and rejects it as malformed', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-owner-fifo-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const lockDir = join(project, 'state', 'guardian.lock')
+    const ownerPath = join(lockDir, 'owner.json')
+    await mkdir(lockDir, { recursive: true })
+    await execFileAsync('mkfifo', [ownerPath])
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      join(project, 'workspaces'),
+      'env:railway-service-service-test',
+    ], { timeout: 2_000 })).rejects.toMatchObject({
+      stderr: expect.stringContaining('project/state/guardian.lock'),
+      killed: false,
+    })
+  })
+
+  it('recovers an aged empty lock only after every retained owner passes validation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-empty-lock-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const validLock = join(project, 'state', 'guardian.lock')
+    const emptyLock = join(project, 'data', 'state', 'config-bootstrap.lock')
+    const owner = {
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'previous-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'fenced-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+    }
+    await mkdir(validLock, { recursive: true })
+    await writeFile(join(validLock, 'owner.json'), JSON.stringify(owner))
+    await mkdir(emptyLock, { recursive: true })
+    const old = new Date(Date.now() - 5_000)
+    await utimes(emptyLock, old, old)
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+    expect(existsSync(emptyLock)).toBe(false)
+    expect(existsSync(join(validLock, 'owner.json'))).toBe(true)
+
+    await mkdir(emptyLock, { recursive: true })
+    await utimes(emptyLock, old, old)
+    const malformedLock = join(project, 'state', 'runtime.lock')
+    await mkdir(malformedLock, { recursive: true })
+    await writeFile(join(malformedLock, 'owner.json'), '{}')
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('state/runtime.lock'),
+    })
+    expect(existsSync(emptyLock)).toBe(true)
+  })
+
+  it('recovers a hard-killed v2 claim-only publication window', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-claim-only-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const lockDir = join(project, 'state', 'guardian.lock')
+    const claimDir = join(lockDir, 'reclaiming')
+    const token = '44444444-4444-4444-8444-444444444444'
+    const writeId = '55555555-5555-4555-8555-555555555555'
+    const owner = {
+      schemaVersion: 1,
+      pid: 404,
+      hostname: 'hard-killed-container',
+      machineId: 'env:railway-service-service-test',
+      token,
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: '11111111-1111-4111-8111-111111111111',
+    }
+    await mkdir(claimDir, { recursive: true })
+    await writeFile(join(claimDir, `owner.${token}.json`), JSON.stringify(owner))
+    await writeFile(join(lockDir, `.owner.json.${token}.${writeId}.tmp`), JSON.stringify(owner))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+    expect(existsSync(lockDir)).toBe(false)
+  })
+
+  it('cleans a valid residual v2 claim after owner publication without removing the owner', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-published-claim-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const lockDir = join(project, 'state', 'guardian.lock')
+    const claimDir = join(lockDir, 'reclaiming')
+    const ownerToken = '66666666-6666-4666-8666-666666666666'
+    const claimToken = '77777777-7777-4777-8777-777777777777'
+    const baseOwner = {
+      schemaVersion: 1,
+      pid: 606,
+      hostname: 'published-container',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: '11111111-1111-4111-8111-111111111111',
+    }
+    await mkdir(claimDir, { recursive: true })
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({ ...baseOwner, token: ownerToken }))
+    await writeFile(join(claimDir, `owner.${claimToken}.json`), JSON.stringify({
+      ...baseOwner,
+      pid: 707,
+      token: claimToken,
+    }))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+    expect(JSON.parse(await readFile(join(lockDir, 'owner.json'), 'utf8'))).toMatchObject({ token: ownerToken })
+    expect(existsSync(claimDir)).toBe(false)
+  })
+
+  it('cleans a selected Project Workspace lock only once when discovery also sees its launcher root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-workspace-lock-dedup-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const lockDir = join(launcher, 'state', 'runtime.lock')
+    const claimDir = join(lockDir, 'reclaiming')
+    const ownerToken = '66666666-6666-4666-8666-666666666666'
+    const claimToken = '77777777-7777-4777-8777-777777777777'
+    const baseOwner = {
+      schemaVersion: 1,
+      pid: 606,
+      hostname: 'published-container',
+      machineId: 'env:railway-service-service-test',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: '11111111-1111-4111-8111-111111111111',
+    }
+    await mkdir(claimDir, { recursive: true })
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({ ...baseOwner, token: ownerToken }))
+    await writeFile(join(claimDir, `owner.${claimToken}.json`), JSON.stringify({
+      ...baseOwner,
+      pid: 707,
+      token: claimToken,
+    }))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).resolves.toMatchObject({ stderr: '' })
+    expect(JSON.parse(await readFile(join(lockDir, 'owner.json'), 'utf8'))).toMatchObject({ token: ownerToken })
+    expect(existsSync(claimDir)).toBe(false)
+  })
+
+  it.runIf(process.platform !== 'win32')('fails closed when quarantine is a symlink to a live legacy Project', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-quarantine-symlink-'))
+    temporaryPaths.push(root)
+    const legacyProject = join(root, 'projects', 'legacy-live')
+    const selectedProject = join(root, 'projects', 'selected')
+    const lockDir = join(legacyProject, 'state', 'guardian.lock')
+    await mkdir(lockDir, { recursive: true })
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'legacy-live-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'legacy-live-owner',
+      launcher: 'guardian-cli-server',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+    }))
+    await symlink(join('projects', 'legacy-live'), join(root, 'quarantine'))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      selectedProject,
+      join(selectedProject, 'workspaces'),
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringMatching(/could not inspect the complete Volume.*quarantine path/s),
+    })
+    expect(existsSync(join(lockDir, 'owner.json'))).toBe(true)
+  })
+
+  it('fails closed on an unknown v2 claim entry before cleaning another retained lock', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-claim-invalid-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const invalidLock = join(project, 'state', 'guardian.lock')
+    const recoverableLock = join(project, 'data', 'state', 'config-bootstrap.lock')
+    const recoverableClaim = join(recoverableLock, 'reclaiming')
+    const token = '88888888-8888-4888-8888-888888888888'
+    const owner = {
+      schemaVersion: 1,
+      pid: 808,
+      hostname: 'hard-killed-container',
+      machineId: 'env:railway-service-service-test',
+      token,
+      launcher: 'alice-config-bootstrap',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+      fencingInstanceId: '11111111-1111-4111-8111-111111111111',
+    }
+    await mkdir(join(invalidLock, 'reclaiming'), { recursive: true })
+    await writeFile(join(invalidLock, 'reclaiming', 'unexpected'), 'do not remove')
+    await mkdir(recoverableClaim, { recursive: true })
+    await writeFile(join(recoverableClaim, `owner.${token}.json`), JSON.stringify(owner))
+
+    await expect(execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining('state/guardian.lock'),
+    })
+    expect(existsSync(recoverableLock)).toBe(true)
+    expect(existsSync(join(recoverableClaim, `owner.${token}.json`))).toBe(true)
+  })
+
+  it('does not remove an initializing lock that publishes its owner during the grace window', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'openalice-railway-lock-race-'))
+    temporaryPaths.push(root)
+    const project = join(root, 'project')
+    const launcher = join(project, 'workspaces')
+    const lockDir = join(project, 'data', 'state', 'config-bootstrap.lock')
+    await mkdir(lockDir, { recursive: true })
+
+    const preflight = execFileAsync('python3', [
+      retainedLockPreflight,
+      root,
+      project,
+      launcher,
+      'env:railway-service-service-test',
+    ])
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    await writeFile(join(lockDir, 'owner.json'), JSON.stringify({
+      schemaVersion: 1,
+      pid: 101,
+      hostname: 'initializing-container',
+      machineId: 'env:railway-service-service-test',
+      token: 'initializing-owner',
+      launcher: 'alice-config-bootstrap',
+      acquiredAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      fencingProtocol: 'railway-flock-v1',
+    }))
+
+    await expect(preflight).rejects.toMatchObject({
+      stderr: expect.stringContaining('data/state/config-bootstrap.lock'),
+    })
+    expect(existsSync(join(lockDir, 'owner.json'))).toBe(true)
+  })
+
   it('discovers a nested legacy owner beyond another Project marker before an A-to-B cutover', async () => {
     const volume = await mkdtemp(join(tmpdir(), 'openalice-railway-volume-scan-'))
     temporaryPaths.push(volume)
@@ -353,7 +829,9 @@ describe('Railway native CLI host entrypoint', () => {
     expect(dockerfile).toContain('scripts/railway/command-wrapper.sh')
     expect(dockerfile).toContain('scripts/railway/preflight-retained-locks.py')
     expect(dockerfile).toContain('scripts/railway/shell-env.sh')
-    expect(await readFile(entrypoint, 'utf8')).toContain('/usr/bin/flock --exclusive --timeout "$wait_seconds" 9')
+    const entrypointSource = await readFile(entrypoint, 'utf8')
+    expect(entrypointSource).toContain('/usr/bin/flock --exclusive --timeout "$wait_seconds" 9')
+    expect(entrypointSource).toContain('export OPENALICE_RAILWAY_INSTANCE_ID')
     expect(dockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-s", "-g", "--"')
   })
 
@@ -537,6 +1015,18 @@ exit 1
     await expect(readFile(fixture.runtimeCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('rejects the old fence-only capability as a fallback for the v2 lock protocol', async () => {
+    const fixture = await makeFixture({
+      installer: 'failure',
+      existing: true,
+      existingRuntimeCapabilities: ['railway-flock-v1'],
+    })
+
+    await expect(execFileAsync('bash', [entrypoint], { env: fixture.env }))
+      .rejects.toMatchObject({ stderr: expect.stringContaining('no previously verified OpenAlice release') })
+    await expect(readFile(fixture.runtimeCalled, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
 })
 
 async function makeFixture(options: {
@@ -544,6 +1034,7 @@ async function makeFixture(options: {
   existing?: boolean
   existingChannel?: 'beta' | 'dev'
   existingFenceCapability?: boolean
+  existingRuntimeCapabilities?: string[]
 }) {
   const root = await mkdtemp(join(tmpdir(), 'openalice-railway-entrypoint-'))
   temporaryPaths.push(root)
@@ -562,6 +1053,7 @@ async function makeFixture(options: {
         ? { version: '0.91.0-dev.1', channel: 'dev' as const }
         : {}),
       ...(options.existingFenceCapability === false ? { runtimeCapabilities: [] } : {}),
+      ...(options.existingRuntimeCapabilities ? { runtimeCapabilities: options.existingRuntimeCapabilities } : {}),
     })
   }
   return {
@@ -657,7 +1149,7 @@ cat >"$OPENALICE_INSTALL_DIR/cli/current/bin/openalice" <<'LAUNCHER'
 #!/usr/bin/env bash
 if [[ "\${1:-}" == --version ]]; then printf '0.91.0-beta.1\\n'; exit 0; fi
 if [[ "\${1:-}" == version && "\${2:-}" == --json ]]; then
-  printf '{"version":"0.91.0-beta.1","installSource":{"schemaVersion":3,"repository":"TraderAlice/OpenAlice","cliVersion":"0.91.0-beta.1","selector":{"kind":"version","value":"v0.91.0-beta.1"},"installerUrl":"https://openalice.ai/install","updateChannel":"beta","method":"direct","artifact":{"platform":"linux","arch":"x64","sha256":"%s"},"installedAt":"2026-08-31T00:00:00.000Z"},"contentIdentity":"aaaaaaaaaaaaaaaa","managedRuntime":{"productVersion":"0.91.0-beta.1","platform":"linux","arch":"x64","path":"%s","contentIdentity":"aaaaaaaaaaaaaaaa"},"runtimeCapabilities":["railway-flock-v1"]}\\n' \\
+  printf '{"version":"0.91.0-beta.1","installSource":{"schemaVersion":3,"repository":"TraderAlice/OpenAlice","cliVersion":"0.91.0-beta.1","selector":{"kind":"version","value":"v0.91.0-beta.1"},"installerUrl":"https://openalice.ai/install","updateChannel":"beta","method":"direct","artifact":{"platform":"linux","arch":"x64","sha256":"%s"},"installedAt":"2026-08-31T00:00:00.000Z"},"contentIdentity":"aaaaaaaaaaaaaaaa","managedRuntime":{"productVersion":"0.91.0-beta.1","platform":"linux","arch":"x64","path":"%s","contentIdentity":"aaaaaaaaaaaaaaaa"},"runtimeCapabilities":["railway-flock-v1","railway-runtime-lock-v2"]}\\n' \\
     "$(printf '0%.0s' {1..64})" "$OPENALICE_INSTALL_DIR/cli/releases/0.91.0-beta.1-linux-x64-aaaaaaaaaaaaaaaa"
   exit 0
 fi
@@ -756,7 +1248,7 @@ function versionPayload(
       installedAt: profile.installedAt ?? '2026-08-31T00:00:00.000Z',
     },
     contentIdentity: identity,
-    runtimeCapabilities: profile.runtimeCapabilities ?? ['railway-flock-v1'],
+    runtimeCapabilities: profile.runtimeCapabilities ?? ['railway-flock-v1', 'railway-runtime-lock-v2'],
     managedRuntime: {
       productVersion: version,
       platform: 'linux',

--- a/scripts/railway-fence-pty.spec.ts
+++ b/scripts/railway-fence-pty.spec.ts
@@ -44,6 +44,7 @@ printf 'FENCE_RELEASED\\n'
         RAILWAY_SERVICE_ID: 'fence-pty-test',
         RAILWAY_ENVIRONMENT_ID: 'fence-pty-environment',
         OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_RAILWAY_INSTANCE_ID: '22222222-2222-4222-8222-222222222222',
         OPENALICE_TEST_NODE: process.execPath,
         OPENALICE_TEST_FIXTURE: fixture,
         NODE_OPTIONS: '--conditions=openalice-source',

--- a/scripts/railway/entrypoint.sh
+++ b/scripts/railway/entrypoint.sh
@@ -83,7 +83,11 @@ for persistent_path in "$HOME" "$OPENALICE_HOME" "$AQ_LAUNCHER_ROOT" "$OPENALICE
     *) fail "$persistent_path must stay beneath the persistent volume root $volume_root" ;;
   esac
 done
-quarantine_root="$(canonical_path "$volume_root/quarantine")"
+quarantine_root="$volume_root/quarantine"
+if [[ -e "$quarantine_root" || -L "$quarantine_root" ]]; then
+  [[ -d "$quarantine_root" && ! -L "$quarantine_root" ]] \
+    || fail 'the reserved Railway quarantine path must be an actual directory, not a symlink or file'
+fi
 case "$OPENALICE_HOME" in
   "$quarantine_root"|"$quarantine_root/"*)
     fail 'OPENALICE_HOME cannot select the reserved Railway quarantine tree'
@@ -141,6 +145,10 @@ if [[ -n "${RAILWAY_ENVIRONMENT_ID:-}" ]]; then
     || fail 'the inherited Railway lifecycle fence names the wrong inode'
   grep -Eq '^lock:[[:space:]]+[0-9]+:[[:space:]]+FLOCK[[:space:]]+ADVISORY[[:space:]]+WRITE' /proc/self/fdinfo/9 \
     || fail 'the inherited Railway lifecycle fence is not exclusively locked'
+  OPENALICE_RAILWAY_INSTANCE_ID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+  [[ "$OPENALICE_RAILWAY_INSTANCE_ID" =~ ^[A-Za-z0-9-]{16,128}$ ]] \
+    || fail 'could not create the Railway fencing instance identity'
+  export OPENALICE_RAILWAY_INSTANCE_ID
   export OPENALICE_RAILWAY_FENCE_FD=9
   export OPENALICE_RAILWAY_ENTRYPOINT_OWNER=1
   [[ -f "$retained_lock_preflight" && ! -L "$retained_lock_preflight" ]] \
@@ -197,6 +205,7 @@ if not (
     and isinstance(runtime, dict)
     and isinstance(capabilities, list)
     and "railway-flock-v1" in capabilities
+    and "railway-runtime-lock-v2" in capabilities
     and runtime.get("productVersion") == version
     and runtime.get("contentIdentity") == identity
     and runtime.get("platform") == artifact.get("platform")

--- a/scripts/railway/preflight-retained-locks.py
+++ b/scripts/railway/preflight-retained-locks.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import sys
+import time
+from dataclasses import dataclass
 
 
 LOCK_PATHS = (
@@ -23,34 +26,122 @@ LOCK_PATHS = (
 )
 
 
-def read_fenced_owner(lock_dir: str, expected_machine_id: str) -> bool:
-    try:
-        lock_stat = os.lstat(lock_dir)
-    except FileNotFoundError:
-        return True
-    if not stat.S_ISDIR(lock_stat.st_mode) or stat.S_ISLNK(lock_stat.st_mode):
-        return False
+EMPTY_LOCK_GRACE_SECONDS = 2.0
+FENCING_INSTANCE_ID_PATTERN = re.compile(r"[A-Za-z0-9-]{16,128}")
+UUID_PATTERN_TEXT = r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+MUTATION_OWNER_PATTERN = re.compile(rf"owner\.({UUID_PATTERN_TEXT})\.json", re.IGNORECASE)
+MUTATION_TEMP_PATTERN = re.compile(rf"\.owner\.({UUID_PATTERN_TEXT})\.({UUID_PATTERN_TEXT})\.tmp", re.IGNORECASE)
+CANONICAL_OWNER_TEMP_PATTERN = re.compile(
+    rf"\.owner\.json\.({UUID_PATTERN_TEXT})\.({UUID_PATTERN_TEXT})\.tmp",
+    re.IGNORECASE,
+)
+DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+OWNER_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NONBLOCK", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+LockIdentity = tuple[int, int, int]
 
-    owner_path = os.path.join(lock_dir, "owner.json")
+
+@dataclass(frozen=True)
+class MutationClaimCleanup:
+    identity: LockIdentity
+    entry_name: str | None
+    entry_identity: LockIdentity | None
+    entry_kind: str
+    token: str | None
+    needs_grace: bool
+
+
+@dataclass(frozen=True)
+class RetainedLockCleanup:
+    lock_identity: LockIdentity
+    canonical_temp_name: str | None
+    canonical_temp_identity: LockIdentity | None
+    claim: MutationClaimCleanup | None
+    remove_lock: bool
+
+
+def relative_components(volume_root: str, path: str) -> tuple[str, ...] | None:
     try:
-        descriptor = os.open(owner_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-    except (FileNotFoundError, OSError):
-        return False
+        relative = os.path.relpath(os.path.abspath(path), volume_root)
+    except ValueError:
+        return None
+    components = tuple(part for part in relative.split(os.sep) if part not in ("", "."))
+    if relative == os.pardir or relative.startswith(os.pardir + os.sep) or os.pardir in components:
+        return None
+    return components
+
+
+def open_directory_beneath(
+    volume_fd: int,
+    volume_root: str,
+    path: str,
+) -> tuple[str, int | None]:
+    components = relative_components(volume_root, path)
+    if components is None:
+        return ("invalid", None)
+
+    descriptor = os.dup(volume_fd)
+    for component in components:
+        try:
+            child = os.open(component, DIRECTORY_OPEN_FLAGS, dir_fd=descriptor)
+        except FileNotFoundError:
+            os.close(descriptor)
+            return ("missing", None)
+        except OSError:
+            os.close(descriptor)
+            return ("invalid", None)
+        os.close(descriptor)
+        descriptor = child
+    return ("directory", descriptor)
+
+
+def lock_identity(lock_stat: os.stat_result) -> LockIdentity:
+    return (lock_stat.st_dev, lock_stat.st_ino, lock_stat.st_mtime_ns)
+
+
+def read_regular_json(
+    directory_fd: int,
+    name: str,
+) -> tuple[dict[str, object], LockIdentity] | None:
+    try:
+        descriptor = os.open(name, OWNER_OPEN_FLAGS, dir_fd=directory_fd)
+    except OSError:
+        return None
     try:
         owner_stat = os.fstat(descriptor)
         if not stat.S_ISREG(owner_stat.st_mode):
-            return False
+            return None
         with os.fdopen(descriptor, "r", encoding="utf-8", closefd=False) as stream:
             owner = json.load(stream)
+        if not isinstance(owner, dict):
+            return None
+        return (owner, lock_identity(owner_stat))
     except (OSError, UnicodeError, json.JSONDecodeError):
-        return False
+        return None
     finally:
         os.close(descriptor)
 
+
+def valid_fenced_owner(
+    owner: dict[str, object],
+    expected_machine_id: str,
+    *,
+    require_instance_id: bool,
+) -> bool:
+    instance_id = owner.get("fencingInstanceId")
     return bool(
-        isinstance(owner, dict)
-        and owner.get("schemaVersion") == 1
-        and isinstance(owner.get("pid"), int)
+        type(owner.get("schemaVersion")) is int
+        and owner["schemaVersion"] == 1
+        and type(owner.get("pid")) is int
         and owner["pid"] > 0
         and isinstance(owner.get("hostname"), str)
         and owner["hostname"]
@@ -62,30 +153,412 @@ def read_fenced_owner(lock_dir: str, expected_machine_id: str) -> bool:
         and isinstance(owner.get("acquiredAt"), str)
         and isinstance(owner.get("heartbeatAt"), str)
         and owner.get("fencingProtocol") == "railway-flock-v1"
+        and (
+            (
+                not require_instance_id
+                and "fencingInstanceId" not in owner
+            )
+            or (
+                isinstance(instance_id, str)
+                and FENCING_INSTANCE_ID_PATTERN.fullmatch(instance_id) is not None
+            )
+        )
     )
 
 
-def looks_like_project_home(path: str) -> bool:
-    if os.path.isfile(os.path.join(path, "data", "config", "alice-project.json")):
+def inspect_mutation_claim(
+    lock_fd: int,
+    expected_machine_id: str,
+) -> MutationClaimCleanup | None:
+    try:
+        claim_fd = os.open("reclaiming", DIRECTORY_OPEN_FLAGS, dir_fd=lock_fd)
+    except OSError:
+        return None
+    try:
+        claim_stat = os.fstat(claim_fd)
+        try:
+            with os.scandir(claim_fd) as iterator:
+                entries = [entry.name for entry in iterator]
+        except OSError:
+            return None
+        if not entries:
+            return MutationClaimCleanup(
+                identity=lock_identity(claim_stat),
+                entry_name=None,
+                entry_identity=None,
+                entry_kind="empty",
+                token=None,
+                needs_grace=True,
+            )
+        if len(entries) != 1:
+            return None
+
+        entry_name = entries[0]
+        owner_match = MUTATION_OWNER_PATTERN.fullmatch(entry_name)
+        if owner_match is not None:
+            record = read_regular_json(claim_fd, entry_name)
+            if record is None:
+                return None
+            owner, owner_identity = record
+            token = owner_match.group(1)
+            if (
+                not valid_fenced_owner(owner, expected_machine_id, require_instance_id=True)
+                or not isinstance(owner.get("token"), str)
+                or owner["token"].lower() != token.lower()
+            ):
+                return None
+            return MutationClaimCleanup(
+                identity=lock_identity(claim_stat),
+                entry_name=entry_name,
+                entry_identity=owner_identity,
+                entry_kind="owner",
+                token=token,
+                needs_grace=False,
+            )
+
+        temp_match = MUTATION_TEMP_PATTERN.fullmatch(entry_name)
+        if temp_match is None:
+            return None
+        try:
+            descriptor = os.open(entry_name, OWNER_OPEN_FLAGS, dir_fd=claim_fd)
+        except OSError:
+            return None
+        try:
+            entry_stat = os.fstat(descriptor)
+            if not stat.S_ISREG(entry_stat.st_mode):
+                return None
+            return MutationClaimCleanup(
+                identity=lock_identity(claim_stat),
+                entry_name=entry_name,
+                entry_identity=lock_identity(entry_stat),
+                entry_kind="temp",
+                token=temp_match.group(1),
+                needs_grace=True,
+            )
+        finally:
+            os.close(descriptor)
+    finally:
+        os.close(claim_fd)
+
+
+def inspect_retained_lock(
+    volume_fd: int,
+    volume_root: str,
+    lock_dir: str,
+    expected_machine_id: str,
+) -> tuple[str, LockIdentity | RetainedLockCleanup | None]:
+    directory_state, lock_fd = open_directory_beneath(volume_fd, volume_root, lock_dir)
+    if directory_state != "directory" or lock_fd is None:
+        return (directory_state, None)
+
+    try:
+        lock_stat = os.fstat(lock_fd)
+        try:
+            with os.scandir(lock_fd) as iterator:
+                entries = [entry.name for entry in iterator]
+        except OSError:
+            return ("invalid", None)
+        if not entries:
+            return ("empty", lock_identity(lock_stat))
+
+        owner_record = read_regular_json(lock_fd, "owner.json") if "owner.json" in entries else None
+        if "owner.json" in entries and owner_record is None:
+            return ("invalid", None)
+        owner = owner_record[0] if owner_record is not None else None
+        if owner is not None and not valid_fenced_owner(owner, expected_machine_id, require_instance_id=False):
+            return ("invalid", None)
+
+        claim = inspect_mutation_claim(lock_fd, expected_machine_id) if "reclaiming" in entries else None
+        if "reclaiming" in entries and claim is None:
+            return ("invalid", None)
+
+        canonical_temps = [name for name in entries if CANONICAL_OWNER_TEMP_PATTERN.fullmatch(name)]
+        known = {"owner.json", "reclaiming", *canonical_temps}
+        if len(canonical_temps) > 1 or any(name not in known for name in entries):
+            return ("invalid", None)
+        if owner is None and claim is None:
+            return ("invalid", None)
+
+        canonical_temp_name = canonical_temps[0] if canonical_temps else None
+        canonical_temp_identity = None
+        if canonical_temp_name is not None:
+            match = CANONICAL_OWNER_TEMP_PATTERN.fullmatch(canonical_temp_name)
+            expected_token = owner.get("token") if owner is not None else claim.token if claim is not None else None
+            if match is None or not isinstance(expected_token, str) or match.group(1).lower() != expected_token.lower():
+                return ("invalid", None)
+            try:
+                descriptor = os.open(canonical_temp_name, OWNER_OPEN_FLAGS, dir_fd=lock_fd)
+            except OSError:
+                return ("invalid", None)
+            try:
+                temp_stat = os.fstat(descriptor)
+                if not stat.S_ISREG(temp_stat.st_mode):
+                    return ("invalid", None)
+                canonical_temp_identity = lock_identity(temp_stat)
+            finally:
+                os.close(descriptor)
+
+        if claim is None and canonical_temp_name is None:
+            return ("fenced", None)
+        return (
+            "recoverable",
+            RetainedLockCleanup(
+                lock_identity=lock_identity(lock_stat),
+                canonical_temp_name=canonical_temp_name,
+                canonical_temp_identity=canonical_temp_identity,
+                claim=claim,
+                remove_lock=owner is None,
+            ),
+        )
+    finally:
+        os.close(lock_fd)
+
+
+def reclaim_empty_lock(
+    volume_fd: int,
+    volume_root: str,
+    lock_dir: str,
+    identity: LockIdentity,
+) -> bool:
+    dev, ino, mtime_ns = identity
+    remaining_grace = EMPTY_LOCK_GRACE_SECONDS - max(0.0, time.time() - (mtime_ns / 1_000_000_000))
+    if remaining_grace > 0:
+        time.sleep(remaining_grace)
+
+    components = relative_components(volume_root, lock_dir)
+    if not components:
+        return False
+    parent_path = os.path.join(volume_root, *components[:-1])
+    parent_state, parent_fd = open_directory_beneath(volume_fd, volume_root, parent_path)
+    if parent_state == "missing":
         return True
-    return any(os.path.lexists(resolve_path(path, os.path.join(path, "workspaces"))) for _, resolve_path in LOCK_PATHS)
+    if parent_state != "directory" or parent_fd is None:
+        return False
+    try:
+        lock_name = components[-1]
+        try:
+            lock_fd = os.open(lock_name, DIRECTORY_OPEN_FLAGS, dir_fd=parent_fd)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        try:
+            latest = os.fstat(lock_fd)
+            if lock_identity(latest) != (dev, ino, mtime_ns):
+                return False
+            try:
+                with os.scandir(lock_fd) as entries:
+                    if next(entries, None) is not None:
+                        return False
+            except OSError:
+                return False
+            try:
+                os.rmdir(lock_name, dir_fd=parent_fd)
+                return True
+            except FileNotFoundError:
+                return True
+            except OSError:
+                return False
+        finally:
+            os.close(lock_fd)
+    finally:
+        os.close(parent_fd)
+
+
+def reclaim_recoverable_lock(
+    volume_fd: int,
+    volume_root: str,
+    lock_dir: str,
+    cleanup: RetainedLockCleanup,
+    expected_machine_id: str,
+) -> bool:
+    claim = cleanup.claim
+    if claim is not None and claim.needs_grace:
+        remaining_grace = EMPTY_LOCK_GRACE_SECONDS - max(
+            0.0,
+            time.time() - (claim.identity[2] / 1_000_000_000),
+        )
+        if remaining_grace > 0:
+            time.sleep(remaining_grace)
+
+    components = relative_components(volume_root, lock_dir)
+    if not components:
+        return False
+    parent_path = os.path.join(volume_root, *components[:-1])
+    parent_state, parent_fd = open_directory_beneath(volume_fd, volume_root, parent_path)
+    if parent_state == "missing":
+        return True
+    if parent_state != "directory" or parent_fd is None:
+        return False
+
+    try:
+        lock_name = components[-1]
+        try:
+            lock_fd = os.open(lock_name, DIRECTORY_OPEN_FLAGS, dir_fd=parent_fd)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        try:
+            if lock_identity(os.fstat(lock_fd)) != cleanup.lock_identity:
+                return False
+
+            if cleanup.canonical_temp_name is not None:
+                try:
+                    descriptor = os.open(cleanup.canonical_temp_name, OWNER_OPEN_FLAGS, dir_fd=lock_fd)
+                except OSError:
+                    return False
+                try:
+                    temp_stat = os.fstat(descriptor)
+                    if (
+                        not stat.S_ISREG(temp_stat.st_mode)
+                        or lock_identity(temp_stat) != cleanup.canonical_temp_identity
+                    ):
+                        return False
+                finally:
+                    os.close(descriptor)
+                try:
+                    os.unlink(cleanup.canonical_temp_name, dir_fd=lock_fd)
+                except OSError:
+                    return False
+
+            if claim is not None:
+                try:
+                    claim_fd = os.open("reclaiming", DIRECTORY_OPEN_FLAGS, dir_fd=lock_fd)
+                except OSError:
+                    return False
+                try:
+                    if lock_identity(os.fstat(claim_fd)) != claim.identity:
+                        return False
+                    if claim.entry_name is not None:
+                        try:
+                            descriptor = os.open(claim.entry_name, OWNER_OPEN_FLAGS, dir_fd=claim_fd)
+                        except OSError:
+                            return False
+                        try:
+                            entry_stat = os.fstat(descriptor)
+                            if (
+                                not stat.S_ISREG(entry_stat.st_mode)
+                                or lock_identity(entry_stat) != claim.entry_identity
+                            ):
+                                return False
+                        finally:
+                            os.close(descriptor)
+
+                        if claim.entry_kind == "owner":
+                            record = read_regular_json(claim_fd, claim.entry_name)
+                            if record is None:
+                                return False
+                            owner, owner_identity = record
+                            if (
+                                owner_identity != claim.entry_identity
+                                or not valid_fenced_owner(owner, expected_machine_id, require_instance_id=True)
+                                or not isinstance(owner.get("token"), str)
+                                or claim.token is None
+                                or owner["token"].lower() != claim.token.lower()
+                            ):
+                                return False
+                        elif claim.entry_kind == "temp":
+                            record = read_regular_json(claim_fd, claim.entry_name)
+                            if record is not None:
+                                owner, owner_identity = record
+                                if (
+                                    owner_identity != claim.entry_identity
+                                    or not isinstance(owner.get("token"), str)
+                                    or claim.token is None
+                                    or owner["token"].lower() != claim.token.lower()
+                                ):
+                                    return False
+                        try:
+                            os.unlink(claim.entry_name, dir_fd=claim_fd)
+                        except OSError:
+                            return False
+                    try:
+                        with os.scandir(claim_fd) as iterator:
+                            if next(iterator, None) is not None:
+                                return False
+                    except OSError:
+                        return False
+                finally:
+                    os.close(claim_fd)
+                try:
+                    os.rmdir("reclaiming", dir_fd=lock_fd)
+                except OSError:
+                    return False
+
+            if cleanup.remove_lock:
+                try:
+                    with os.scandir(lock_fd) as iterator:
+                        if next(iterator, None) is not None:
+                            return False
+                except OSError:
+                    return False
+                try:
+                    os.rmdir(lock_name, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    return True
+                except OSError:
+                    return False
+            return True
+        finally:
+            os.close(lock_fd)
+    finally:
+        os.close(parent_fd)
+
+
+def looks_like_project_home(path: str) -> bool:
+    try:
+        marker = os.lstat(os.path.join(path, "data", "config", "alice-project.json"))
+    except FileNotFoundError:
+        marker = None
+    if marker is not None and stat.S_ISREG(marker.st_mode):
+        return True
+    for _, resolve_path in LOCK_PATHS:
+        try:
+            os.lstat(resolve_path(path, os.path.join(path, "workspaces")))
+            return True
+        except FileNotFoundError:
+            continue
+    return False
+
+
+def raise_walk_error(error: OSError) -> None:
+    raise error
 
 
 def discover_project_homes(volume_root: str, selected_home: str) -> list[str]:
-    homes = {selected_home}
-    reserved = {os.path.realpath(os.path.join(volume_root, "quarantine"))}
-    for root, directories, _files in os.walk(volume_root, topdown=True, followlinks=False):
-        root = os.path.realpath(root)
-        if root in reserved:
+    homes = {volume_root, selected_home}
+    quarantine_root = os.path.abspath(os.path.join(volume_root, "quarantine"))
+    try:
+        quarantine_stat = os.lstat(quarantine_root)
+    except FileNotFoundError:
+        quarantine_stat = None
+    if quarantine_stat is not None and (
+        stat.S_ISLNK(quarantine_stat.st_mode)
+        or not stat.S_ISDIR(quarantine_stat.st_mode)
+    ):
+        raise OSError("the reserved Railway quarantine path is not an actual directory")
+    for root, directories, _files in os.walk(
+        volume_root,
+        topdown=True,
+        onerror=raise_walk_error,
+        followlinks=False,
+    ):
+        root = os.path.abspath(root)
+        if root == quarantine_root:
             directories[:] = []
             continue
-        directories[:] = [
-            name
-            for name in directories
-            if not os.path.islink(os.path.join(root, name))
-            and os.path.realpath(os.path.join(root, name)) not in reserved
-        ]
-        if root != volume_root and looks_like_project_home(root):
+        traversable: list[str] = []
+        for name in directories:
+            directory_path = os.path.join(root, name)
+            directory_stat = os.lstat(directory_path)
+            if stat.S_ISLNK(directory_stat.st_mode):
+                continue
+            if os.path.abspath(directory_path) == quarantine_root:
+                continue
+            traversable.append(name)
+        directories[:] = traversable
+        if looks_like_project_home(root):
             homes.add(root)
     return sorted(homes)
 
@@ -112,15 +585,72 @@ def main(argv: list[str]) -> int:
     if not is_within(volume_root, project_home) or not is_within(volume_root, launcher_root):
         print("openalice railway: retained-lock preflight paths escape the Volume", file=sys.stderr)
         return 2
+    quarantine_root = os.path.join(volume_root, "quarantine")
+    if project_home == quarantine_root or is_within(quarantine_root, project_home):
+        print("openalice railway: Project Home cannot select the reserved quarantine tree", file=sys.stderr)
+        return 2
+
+    try:
+        volume_fd = os.open(volume_root, DIRECTORY_OPEN_FLAGS)
+    except OSError as error:
+        print(f"openalice railway: retained-lock preflight cannot open the Volume: {error}", file=sys.stderr)
+        return 1
 
     invalid: list[str] = []
-    for candidate_home in discover_project_homes(volume_root, project_home):
-        candidate_launcher = launcher_root if candidate_home == project_home else os.path.join(candidate_home, "workspaces")
-        for relative, resolve_path in LOCK_PATHS:
-            lock_path = resolve_path(candidate_home, candidate_launcher)
-            if read_fenced_owner(lock_path, expected_machine_id):
-                continue
-            invalid.append(os.path.relpath(lock_path, volume_root))
+    empty: list[tuple[str, LockIdentity]] = []
+    recoverable: list[tuple[str, RetainedLockCleanup]] = []
+    seen_lock_paths: set[str] = set()
+    try:
+        try:
+            candidate_homes = discover_project_homes(volume_root, project_home)
+        except OSError as error:
+            print(
+                f"openalice railway: retained-lock preflight could not inspect the complete Volume: {error}",
+                file=sys.stderr,
+            )
+            return 1
+
+        for candidate_home in candidate_homes:
+            candidate_launcher = launcher_root if candidate_home == project_home else os.path.join(candidate_home, "workspaces")
+            for relative, resolve_path in LOCK_PATHS:
+                lock_path = os.path.normpath(os.path.abspath(resolve_path(candidate_home, candidate_launcher)))
+                if lock_path in seen_lock_paths:
+                    continue
+                seen_lock_paths.add(lock_path)
+                state, identity = inspect_retained_lock(
+                    volume_fd,
+                    volume_root,
+                    lock_path,
+                    expected_machine_id,
+                )
+                if state in ("missing", "fenced"):
+                    continue
+                if state == "empty" and identity is not None:
+                    if isinstance(identity, tuple):
+                        empty.append((lock_path, identity))
+                    else:
+                        invalid.append(os.path.relpath(lock_path, volume_root))
+                    continue
+                if state == "recoverable" and isinstance(identity, RetainedLockCleanup):
+                    recoverable.append((lock_path, identity))
+                    continue
+                invalid.append(os.path.relpath(lock_path, volume_root))
+        if not invalid:
+            for lock_path, cleanup in recoverable:
+                if not reclaim_recoverable_lock(
+                    volume_fd,
+                    volume_root,
+                    lock_path,
+                    cleanup,
+                    expected_machine_id,
+                ):
+                    invalid.append(os.path.relpath(lock_path, volume_root))
+            if not invalid:
+                for lock_path, identity in empty:
+                    if not reclaim_empty_lock(volume_fd, volume_root, lock_path, identity):
+                        invalid.append(os.path.relpath(lock_path, volume_root))
+    finally:
+        os.close(volume_fd)
     if not invalid:
         return 0
 

--- a/src/workspaces/spawn-env.spec.ts
+++ b/src/workspaces/spawn-env.spec.ts
@@ -91,15 +91,18 @@ describe('buildSpawnEnv', () => {
       {
         OPENALICE_RAILWAY_FENCE_FD: '3',
         OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_RAILWAY_INSTANCE_ID: 'runtime-instance-parent',
       },
       {
         OPENALICE_RAILWAY_FENCE_FD: '9',
         OPENALICE_RAILWAY_ENTRYPOINT_OWNER: '1',
+        OPENALICE_RAILWAY_INSTANCE_ID: 'runtime-instance-override',
       },
     )
 
     expect(out).not.toHaveProperty('OPENALICE_RAILWAY_FENCE_FD')
     expect(out).not.toHaveProperty('OPENALICE_RAILWAY_ENTRYPOINT_OWNER')
+    expect(out).not.toHaveProperty('OPENALICE_RAILWAY_INSTANCE_ID')
   })
 
   it('defaults terminal locale to UTF-8 without overriding explicit locale', () => {

--- a/src/workspaces/spawn-env.ts
+++ b/src/workspaces/spawn-env.ts
@@ -23,6 +23,7 @@ import { runtimeProfileFromEnv } from '@/core/runtime-profile.js';
 const PRIVILEGED_RUNTIME_ENV = [
   'OPENALICE_RAILWAY_FENCE_FD',
   'OPENALICE_RAILWAY_ENTRYPOINT_OWNER',
+  'OPENALICE_RAILWAY_INSTANCE_ID',
 ] as const;
 
 const STRIP_EXACT = new Set<string>([


### PR DESCRIPTION
## Outcome

Makes Railway Volume-fenced Runtime handoff crash-safe across container replacement, including claim-only publication windows and reused hostname/PID layouts. Adds per-start instance fencing, generation-bound mutation claims, strict whole-Volume preflight recovery, v2 capability gating, and fail-closed quarantine handling. Updates the active distribution and transfer plans with the live migration evidence.

## Verification

- focused Railway/Guardian/CLI: 133 passed, 4 skipped
- full suite: 5319 passed, 13 skipped
- root, Guardian, and CLI TypeScript
- Guardian recovery smoke
- Linux installer Docker smoke
- native SSH remote/transfer Docker smoke
- full Docker Runtime smoke
- independent final race/security review: no blocker

No stable/beta release or channel promotion is included. Live Railway restart, resume, and hard-kill acceptance follows the new dev artifact.