### PR TITLE
fix(cli): respect runtime update authority

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -35,8 +35,11 @@ the durable truth after it changes. Git history is the archive.
   CLI package owns OpenAlice only: Agent Runtime installation and Electron
   packaging stay outside this plan. The native CLI is public through the
   separately dispatched `v0.91.0-beta.1`; stable/beta discovery now uses the
-  OpenAlice CDN manifests, while native PowerShell and external
-  package-manager activation remain on focused branches from current `dev`.
+  OpenAlice CDN manifests. The retained no-domain Railway profile has passed
+  real migration, OpenCode resume, normal restart, and hard-kill recovery;
+  disposable empty-Volume/failure fallback, native PowerShell, and external
+  package-manager activation remain open on focused branches from current
+  `dev`.
 - [[plans/remote-project-fleet.md]] — Adds a machine-aware Supervisor fleet,
   remote AliceProject inventory/connection, and safe local-to-SSH project
   transfer for portable configuration and Workspaces while deliberately

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -292,6 +292,34 @@ Direct installs write schema 3 metadata:
 identity. Invalid installed metadata is an error; the CLI does not silently
 change channels or trust boundaries.
 
+### Update authority in the Web surface
+
+Installed provenance and the runtime profile determine which surface may
+offer an update; package semver alone is not authority:
+
+- source checkouts use Git and may show source-update guidance;
+- packaged Electron uses the native desktop updater;
+- installed stable and beta releases use `openalice update` as the update entry
+  point; that command defers to npm, Bun, Homebrew, or AUR when provenance says
+  a package manager owns the files;
+- a direct dev CLI resolves updates in the native CLI by complete artifact
+  checksum and content identity, never by a Web semver comparison;
+- Railway and Docker are updated by their service/deployment owner, not by the
+  browser UI or a command run inside the service; and
+- pinned, custom, or invalid provenance is non-updating until the user repairs
+  it or explicitly selects another channel.
+
+`GET /api/version` and `POST /api/version/check` expose only the normalized
+channel and update authority. They never expose the provenance file path.
+Service-managed, dev, pinned, and custom contexts do not fetch a release
+manifest through these routes, so the Web UI cannot invent a second update
+path beside the native CLI or deployment workflow.
+
+The standalone launcher propagates the already-discovered `install-source.json`
+path into Guardian and Alice. This covers metadata beside the install prefix
+(npm/Bun and Homebrew) and under `share/openalice` (Homebrew and AUR) without
+teaching the Web layer a second package-layout discovery algorithm.
+
 ## Update and rollback
 
 `openalice update --check` reads the manifest owned by the installed stable,

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -136,12 +136,11 @@ unverified fallback.
 
 The Railway profile currently requires `railway-runtime-lock-v2`. Public
 stable `v0.90.2` and beta `v0.91.0-beta.1` predate that capability, so they are
-not eligible Railway fallbacks. The dev manifest current before this change is
-also v1-only. Do not deploy this profile until the change has merged and the
-matching completed dev manifest explicitly advertises v2; that later dev
-artifact may then be selected for candidate acceptance. A stable or beta host
-still requires a later explicit release. This repository change does not
-publish or promote one.
+not eligible Railway fallbacks. A completed dev artifact that explicitly
+advertises both Railway capabilities has passed retained-Volume acceptance; a
+stable or beta host still requires a later explicit release that carries the
+same capabilities. Do not infer eligibility from package version or branch
+name, and do not treat this guide as authority to publish or promote a channel.
 
 After selection, the image atomically replaces the persistent `openalice`,
 `alice`, `alice-workspace`, `alice-uta`, and `traderhub` shims with its Railway
@@ -149,6 +148,15 @@ wrapper. The wrapper resolves the active immutable release directly, rebuilds
 its provenance environment, and rejects update/rollback/uninstall mutations;
 this keeps older published CLIs from bypassing Railway's release authority via
 the persistent command path.
+
+Railway and the source-built Docker image are service-managed update surfaces.
+Their Web version route reports the normalized installed channel and
+`updateAuthority: service`, but does not fetch a stable/beta manifest or offer
+`git pull`, `openalice update`, rollback, or uninstall guidance. The deployment
+configuration selects and replaces the runtime; for dev that decision is bound
+to the completed artifact checksum and content identity rather than the reused
+package version. Missing or invalid installed provenance fails closed instead
+of handing update authority to the browser.
 
 Before installer, current-pointer, or Project selection mutation, the
 entrypoint opens the mounted Railway Volume root itself read-only, takes an
@@ -307,10 +315,11 @@ must still block a contender. Linux acceptance must suspend the old holder beyon
 show that a replacement still cannot acquire the fence; only process/container
 death may release it, and simultaneous replacements must produce one winner.
 
-A real Railway acceptance is still required before treating the profile as a
-usable hosted product. Keep the clean-bootstrap and retained-data journeys
-separate; never relabel or clear an existing user Volume merely to obtain an
-empty-host result:
+The retained-data Railway journey has passed through migration, a real Agent
+turn, normal restart, and hard-kill replacement. The disposable clean-bootstrap
+and forced installer-failure journeys remain separate required acceptance;
+never relabel or clear an existing user Volume merely to obtain an empty-host
+result:
 
 1. on a disposable service and empty `/data` Volume, bootstrap the image and
    prove that a failed initial install stops without an unverified fallback;

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -480,11 +480,26 @@ and warns before writing it.
 ### Version and update surface
 
 **Settings → General → About OpenAlice** is the user-facing source for the
-running version and update state on every distribution surface. The passive
-read uses `GET /api/version`, whose channel-specific OpenAlice CDN manifest
-lookup is cached. An explicit **Check for updates** uses the authenticated
-`POST /api/version/check` route to bypass that application cache. Stable and
-beta installations read their matching manifests; GitHub remains the immutable
+running version, normalized channel, and update owner on every distribution
+surface. The backend derives that state from installed provenance and the
+runtime profile rather than guessing from package semver. A source checkout
+uses Git, packaged Electron uses its native updater, a directly installed
+stable or beta CLI uses `openalice update` as its entry point (with that command
+handing package-manager installs back to their manager), and Railway or Docker
+remains owned by its service deployment. Pinned and custom installs have no
+implicit updater.
+Invalid installed provenance fails closed as custom/non-updating instead of
+silently falling back to a stable package version.
+
+The passive read uses `GET /api/version`. An explicit **Check for updates**
+uses the authenticated `POST /api/version/check` route to bypass the
+application cache, but neither route crosses the running surface's authority.
+Stable and beta source, desktop, or CLI contexts may read their matching
+OpenAlice CDN manifest. Dev identity is the complete native payload identity,
+not its reused package version, so the Web surface does not duplicate the
+native CLI or deployment selector. Service-managed, dev, pinned, and custom
+contexts therefore make no Web manifest request and never render a Git or CLI
+update instruction that their owner cannot apply. GitHub remains the immutable
 release-asset and release-notes host rather than the runtime discovery API.
 
 Packaged Electron also invokes the existing `electron-updater` check through
@@ -492,9 +507,9 @@ the narrow preload bridge. That check starts the native download path when an
 eligible release exists; download progress and the ready-to-restart action are
 projected into the same Settings card. Electron development and unsigned
 directory packages may not have updater metadata, so the native check reports
-that it is unsupported and the shared version route remains the non-installing
-fallback. The top-level update banner and downloaded-update prompt remain
-secondary notifications over the same backend and updater state.
+that it is unsupported without transferring authority to the Web route. The
+top-level update banner and downloaded-update prompt remain secondary
+notifications over the same backend and updater state.
 
 The update UI must distinguish determinate download progress from the native
 installer handoff. Before closing, the old app reports `preparing`,

--- a/packages/cli/src/bun-standalone.mjs
+++ b/packages/cli/src/bun-standalone.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { delimiter, dirname, join, resolve } from 'node:path'
 
 export function isBunStandalone() {
@@ -10,6 +10,30 @@ export function resolveBunResourceRoot(env = process.env, executable = process.e
     env.OPENALICE_APP_HOME?.trim()
       || resolve(dirname(executable), '..', 'share', 'openalice'),
   )
+}
+
+export function bunInstallSourceLocations(
+  env = process.env,
+  executable = process.execPath,
+  resourceRoot = resolveBunResourceRoot(env, executable),
+) {
+  const explicit = env.OPENALICE_INSTALL_SOURCE?.trim()
+  if (explicit) return [explicit]
+  return [
+    resolve(dirname(dirname(executable)), 'install-source.json'),
+    resolve(resourceRoot, 'install-source.json'),
+  ]
+}
+
+export function resolveBunInstallSourcePath(
+  env = process.env,
+  executable = process.execPath,
+  resourceRoot = resolveBunResourceRoot(env, executable),
+  exists = existsSync,
+) {
+  const locations = bunInstallSourceLocations(env, executable, resourceRoot)
+  if (env.OPENALICE_INSTALL_SOURCE?.trim()) return locations[0]
+  return locations.find((path) => exists(path)) ?? null
 }
 
 export function bunGuardianProcessSpec(executable = process.execPath) {
@@ -30,12 +54,20 @@ export function buildBunRuntimeEnvironment(
   env,
   resourceRoot,
   executable = process.execPath,
+  options = {},
 ) {
   const gitRoot = join(resourceRoot, 'runtime', 'git')
   const gitBin = join(gitRoot, 'bin')
   const runtimeEnv = buildExternalAgentRuntimeEnvironment(env)
+  const installSource = resolveBunInstallSourcePath(
+    runtimeEnv,
+    executable,
+    resourceRoot,
+    options.exists ?? existsSync,
+  )
   return {
     ...runtimeEnv,
+    ...(installSource ? { OPENALICE_INSTALL_SOURCE: installSource } : {}),
     OPENALICE_RUNTIME_EXECUTABLE: executable,
     LOCAL_GIT_DIRECTORY: gitRoot,
     GIT_EXEC_PATH: join(gitRoot, 'libexec', 'git-core'),

--- a/packages/cli/src/bun-standalone.spec.mjs
+++ b/packages/cli/src/bun-standalone.spec.mjs
@@ -5,7 +5,9 @@ import {
   buildBunRuntimeEnvironment,
   buildExternalAgentRuntimeEnvironment,
   bunGuardianProcessSpec,
+  bunInstallSourceLocations,
   resolveBunContentIdentity,
+  resolveBunInstallSourcePath,
   resolveBunResourceRoot,
 } from './bun-standalone.mjs'
 
@@ -22,6 +24,44 @@ describe('Bun standalone launch boundary', () => {
     )).toBe(resolve('/tmp/openalice-resources'))
   })
 
+  it('discovers package-manager provenance beside the install root or resources', () => {
+    const executable = resolve('/opt/openalice/bin/openalice')
+    const resourceRoot = resolve('/opt/openalice/share/openalice')
+    const locations = bunInstallSourceLocations({}, executable, resourceRoot)
+
+    expect(locations).toEqual([
+      resolve('/opt/openalice/install-source.json'),
+      resolve('/opt/openalice/share/openalice/install-source.json'),
+    ])
+    expect(resolveBunInstallSourcePath(
+      {},
+      executable,
+      resourceRoot,
+      (path) => path === locations[1],
+    )).toBe(locations[1])
+    expect(resolveBunInstallSourcePath(
+      {},
+      executable,
+      resourceRoot,
+      (path) => path === locations[0],
+    )).toBe(locations[0])
+    expect(resolveBunInstallSourcePath(
+      {},
+      executable,
+      resourceRoot,
+      () => false,
+    )).toBeNull()
+  })
+
+  it('preserves explicit provenance so malformed metadata fails closed downstream', () => {
+    expect(resolveBunInstallSourcePath(
+      { OPENALICE_INSTALL_SOURCE: '/managed/provenance.json' },
+      '/opt/openalice/bin/openalice',
+      '/opt/openalice/share/openalice',
+      () => false,
+    )).toBe('/managed/provenance.json')
+  })
+
   it('re-enters the executable as Guardian', () => {
     expect(bunGuardianProcessSpec('/opt/openalice/bin/openalice')).toEqual({
       cmd: '/opt/openalice/bin/openalice',
@@ -32,17 +72,43 @@ describe('Bun standalone launch boundary', () => {
   it('injects the release-owned Git without discarding the user PATH', () => {
     const resourceRoot = resolve('/opt/openalice/share/openalice')
     expect(buildBunRuntimeEnvironment(
-      { PATH: '/usr/local/bin', KEEP: 'yes' },
+      {
+        PATH: '/usr/local/bin',
+        KEEP: 'yes',
+        OPENALICE_INSTALL_SOURCE: '/opt/openalice/install-source.json',
+      },
       resourceRoot,
       '/opt/openalice/bin/openalice',
     )).toEqual(expect.objectContaining({
       KEEP: 'yes',
+      OPENALICE_INSTALL_SOURCE: '/opt/openalice/install-source.json',
       OPENALICE_RUNTIME_EXECUTABLE: '/opt/openalice/bin/openalice',
       LOCAL_GIT_DIRECTORY: resolve(resourceRoot, 'runtime/git'),
       GIT_EXEC_PATH: resolve(resourceRoot, 'runtime/git/libexec/git-core'),
       GIT_TEMPLATE_DIR: resolve(resourceRoot, 'runtime/git/share/git-core/templates'),
       PATH: `${resolve(resourceRoot, 'runtime/git/bin')}${process.platform === 'win32' ? ';' : ':'}/usr/local/bin`,
     }))
+  })
+
+  it('propagates discovered package-manager provenance into the Runtime', () => {
+    const executable = resolve('/opt/openalice/bin/openalice')
+    const resourceRoot = resolve('/opt/openalice/share/openalice')
+    const metadataPath = resolve(resourceRoot, 'install-source.json')
+
+    expect(buildBunRuntimeEnvironment(
+      { PATH: '/usr/local/bin' },
+      resourceRoot,
+      executable,
+      { exists: (path) => path === metadataPath },
+    )).toEqual(expect.objectContaining({
+      OPENALICE_INSTALL_SOURCE: metadataPath,
+    }))
+    expect(buildBunRuntimeEnvironment(
+      { PATH: '/usr/local/bin' },
+      resourceRoot,
+      executable,
+      { exists: () => false },
+    )).not.toHaveProperty('OPENALICE_INSTALL_SOURCE')
   })
 
   it('removes desktop-managed Pi selection without replacing native Pi state', () => {

--- a/packages/cli/src/install-source.mjs
+++ b/packages/cli/src/install-source.mjs
@@ -1,10 +1,11 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import {
+  bunInstallSourceLocations,
   isBunStandalone,
   resolveBunContentIdentity,
   resolveBunResourceRoot,
@@ -62,12 +63,12 @@ export function installedContentIdentity(moduleUrl = import.meta.url, options = 
 function nativeInstallSourceLocations(options, env) {
   const bunStandalone = options.bunStandalone ?? isBunStandalone()
   if (!bunStandalone) return [new URL('../install-source.json', import.meta.url)]
-  const executable = resolve(options.executable ?? process.execPath)
-  const resourceRoot = resolveBunResourceRoot(env, executable)
-  return [
-    join(dirname(dirname(executable)), 'install-source.json'),
-    join(resourceRoot, 'install-source.json'),
-  ]
+  const executable = options.executable ?? process.execPath
+  return bunInstallSourceLocations(
+    env,
+    executable,
+    resolveBunResourceRoot(env, executable),
+  )
 }
 
 export function normalizeInstallSource(value, fallback = DEFAULT_INSTALL_SOURCE) {

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -4,10 +4,10 @@ Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separatel
 dispatched v0.91.0-beta.1 is externally verified; stable remains v0.90.2 while
 stable/beta discovery authority is converged on the OpenAlice CDN;
 the Railway native CLI SSH host passes local empty-Volume, normal replacement,
-hard-kill recovery, real retained-Volume transfer, and one hosted Agent turn;
-the v2 crash-safe lock repair still needs live restart/hard-kill reacceptance;
-native PowerShell and external
-package-manager activation remain deferred
+hard-kill recovery, real retained-Volume transfer, hosted Agent turns, and live
+v2 normal-restart/hard-kill reacceptance; the disposable hosted empty-Volume
+and forced installer-failure fallback journeys remain open; native PowerShell
+and external package-manager activation remain deferred
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`
@@ -348,6 +348,14 @@ Package-manager channels initially publish stable releases only. Mutable `dev`
 and exact-ref testing stay on the direct installers until a real need justifies
 additional registry tags or formulas.
 
+The Web version surface follows the running topology rather than creating
+another updater. Source checkouts use Git; packaged Electron uses its native
+updater; direct stable/beta CLI installs use `openalice update`; and Railway or
+Docker stays owned by the service deployment. Direct dev changes are compared
+by the native CLI or deployment through checksum and content identity, not by
+package semver in the browser. Pinned, custom, and invalid provenance fail
+closed without an implicit update action.
+
 ## Alternatives Considered
 
 | Shape | Decision | Reason |
@@ -583,9 +591,11 @@ Runtime discovery must not depend on GitHub's anonymous API quota.
 - [x] Make the Bash installer resolve stable from `manifest.json` and beta from
   `beta/manifest.json`, with strict channel/version validation and no GitHub
   Releases API lookup.
-- [x] Make `GET /api/version` and its explicit refresh select and validate the
-  manifest matching the installed product channel while retaining per-channel
-  success and failure caches.
+- [x] Make `GET /api/version` and its explicit refresh derive the normalized
+  channel from installed provenance and expose the update authority. Read the
+  matching stable/beta manifest only for source, desktop, or CLI contexts;
+  service-managed, dev, pinned, and custom contexts do not create a duplicate
+  Web updater, and invalid provenance fails closed.
 - [x] Keep the v0.90.1 installer bridge only for an explicit 0.90.1 selector or
   a stable manifest that explicitly advertises 0.90.1; default stable discovery
   no longer uses that bridge now that stable has a native CLI release.
@@ -699,15 +709,14 @@ source-built Docker image.
 - [ ] On a disposable Railway service and empty `/data` Volume, pass clean
   bootstrap and empty-host install-failure/fail-closed acceptance without using
   or clearing the retained real Volume.
-- [ ] Deploy the profile non-destructively against the retained real Railway
+- [x] Deploy the profile non-destructively against the retained real Railway
   `/data` Volume with no public domain, no Dashboard Start Command override,
   Serverless disabled, Restart Policy set to Always, one replica, at least 30
   seconds of draining, fixed SSH `HOME=/data/home` plus persistent user `PATH`,
   an OpenSSH alias from `railway ssh config`, and a successful inspection-only
-  `openalice remote` browser/tunnel journey. The no-domain service, fixed Home,
-  one-replica/Always policy, tunnel, and retained Project have been exercised;
-  final completion remains blocked on redeploying the v2 crash-safe lock repair
-  and repeating restart/hard-kill recovery without manual lock deletion.
+  `openalice remote` browser/tunnel journey. The v2 deployment automatically
+  recovered the exact supported interrupted-lock shape without manual lock
+  deletion and retained the selected Project and native install.
 - [x] Repeat `openalice project transfer --plan` through the deployed Railway
   candidate so SSH compatibility, destination absence, and free-space
   preflight are proven before apply.
@@ -718,13 +727,15 @@ source-built Docker image.
 - [x] Install and authenticate one Agent Runtime through Railway SSH, then prove
   a real Workspace turn without treating those Agent bytes as an OpenAlice
   release artifact.
-- [ ] Restart and redeploy against the same Volume, verify install/Home/Agent
-  persistence and foreground Guardian recovery, then exercise valid-release
-  refresh fallback and the separately accepted hard-kill recovery path,
-  including a holder suspended beyond the old heartbeat threshold, hard-kill
-  release of the kernel fence, and one-winner concurrent replacement across
-  isolated container PID namespaces. The empty-Volume fail-closed case remains
-  isolated to the disposable service.
+- [x] Restart and redeploy against the same retained Volume, then hard-kill the
+  exact foreground Runtime child once. Verify automatic v2 recovery, distinct
+  per-start fence identities, persistent install/Home/OpenCode state, Runtime
+  readiness, and successful continuation of the same remote Session after both
+  replacements without deleting a lock.
+- [ ] Force one installer failure with a known-valid prior release on the
+  retained Volume and observe the bounded exact-release fallback. Keep the
+  empty-Volume install-failure/fail-closed journey isolated to the disposable
+  service above.
 
 ## Verification Matrix
 
@@ -1246,6 +1257,29 @@ This plan is complete only when:
   pass 133 tests with four platform skips; root, Guardian, and CLI TypeScript,
   diff checks, Guardian recovery, and the full 5,319-test suite with 13 skips
   are green. Linux installer, native SSH-remote, and full Docker Runtime smokes
-  also pass on OrbStack. A new dev archive, live automatic recovery, persisted
-  resume, and restart/hard-kill acceptance remain pending; no stable/beta
-  release or channel promotion was performed.
+  also pass on OrbStack. At that point a new dev archive, live automatic
+  recovery, persisted resume, and restart/hard-kill acceptance remained
+  pending; no stable/beta release or channel promotion was performed.
+- 2026-09-01: PR #1282 merged the v2 lock repair to `dev` at `5d58b259`;
+  workflow run 33448877068 published and accepted all four matching dev
+  archives plus the raw `dev/install` path. The retained no-domain Railway
+  service deployed candidate `9e423f82-3b24-4a8f-bb1e-efa8be770387` and
+  automatically recovered the supported interrupted
+  `config-bootstrap.lock` shape without manual deletion. Its Linux x64 Runtime
+  retained content identity `36bda5ecaa277a15`, selected
+  `/data/projects/main-cloud`, the migrated 10,702-file Default AliceProject,
+  and user-owned OpenCode 1.18.25. A normal restart and an exact hard kill of
+  the foreground Runtime child each produced a fresh fencing-instance id and
+  returned Alice, UTA, and Connector to ready state on the same Volume; the
+  fence changed from `a45ff33c` to `5866184a` and then `c3ca8fa8`. OpenCode
+  resume `resume-smooth-paper-bridge-ysivle` then completed
+  `OPENALICE_REMOTE_RESUME_OK`, `OPENALICE_REMOTE_RESTART_OK`, and
+  `OPENALICE_REMOTE_HARD_KILL_OK`; the inspection-only SSH tunnel also loaded
+  the migrated real UI without a public domain. That UI exposed a separate
+  authority defect: package semver made a service-managed dev Runtime suggest
+  a stable source update. The follow-up now derives channel from provenance and
+  keeps source, desktop, CLI, service, and non-updating ownership distinct;
+  service/dev/pinned/custom contexts do not create a duplicate Web updater.
+  The disposable hosted empty-Volume/bootstrap-failure drill and retained
+  valid-release forced-refresh fallback remain pending. No stable/beta release,
+  tag, or channel promotion was performed.

--- a/src/core/version.spec.ts
+++ b/src/core/version.spec.ts
@@ -24,6 +24,30 @@ function releaseManifest(
   }
 }
 
+function installSource(
+  updateChannel: 'stable' | 'beta' | 'pinned' | 'development' | 'custom',
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    schemaVersion: 3,
+    repository: 'TraderAlice/OpenAlice',
+    cliVersion: '0.90.1',
+    selector: updateChannel === 'pinned'
+      ? { kind: 'version', value: 'v0.90.1' }
+      : { kind: 'branch', value: updateChannel === 'development' ? 'dev' : 'master' },
+    installerUrl: 'https://openalice.ai/install',
+    updateChannel,
+    method: 'direct',
+    artifact: {
+      platform: 'linux',
+      arch: 'x64',
+      sha256: 'a'.repeat(64),
+    },
+    installedAt: '2026-08-31T23:11:19Z',
+    ...overrides,
+  }
+}
+
 function mockJsonResponse(value: unknown, response?: { status?: number; statusText?: string }) {
   const status = response?.status ?? 200
   const fetchMock = vi.fn().mockResolvedValue({
@@ -289,5 +313,131 @@ describe('getVersionInfo', () => {
     expect(info.latest).toBeNull()
     expect(info.hasUpdate).toBe(false)
     expect(info.error).toContain('boom')
+  })
+
+  it('keeps Railway release selection service-owned and does not fetch a manifest', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const info = await getVersionInfo({
+      env: {
+        OPENALICE_SERVICE_MANAGER: 'railway',
+        OPENALICE_INSTALL_SOURCE: '/runtime/install-source.json',
+      },
+      readTextFile: () => JSON.stringify(installSource('development')),
+    })
+
+    expect(info).toMatchObject({
+      channel: 'dev',
+      updateAuthority: 'service',
+      latest: null,
+      hasUpdate: false,
+      error: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps Docker release selection service-owned through the legacy launcher env', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const info = await getVersionInfo({
+      env: { OPENALICE_LAUNCHER: 'docker' },
+    })
+
+    expect(info).toMatchObject({
+      updateAuthority: 'service',
+      latest: null,
+      hasUpdate: false,
+      error: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('normalizes legacy non-master branch provenance to the development channel', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const info = await getVersionInfo({
+      env: { OPENALICE_INSTALL_SOURCE: '/runtime/install-source.json' },
+      readTextFile: () => JSON.stringify({
+        ...installSource('development'),
+        schemaVersion: 1,
+        selector: { kind: 'branch', value: 'feature/runtime' },
+        updateChannel: undefined,
+      }),
+    })
+
+    expect(info).toMatchObject({
+      channel: 'dev',
+      updateAuthority: 'cli',
+      latest: null,
+      hasUpdate: false,
+      error: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['development', 'dev', 'cli'],
+    ['pinned', 'pinned', 'none'],
+    ['custom', 'custom', 'none'],
+  ] as const)('does not duplicate %s update discovery in the web service', async (installed, channel, authority) => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const info = await getVersionInfo({
+      env: { OPENALICE_INSTALL_SOURCE: '/runtime/install-source.json' },
+      readTextFile: () => JSON.stringify(installSource(installed)),
+    })
+
+    expect(info).toMatchObject({
+      channel,
+      updateAuthority: authority,
+      latest: null,
+      hasUpdate: false,
+      error: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('uses installed beta provenance instead of inferring stable from the package version', async () => {
+    const fetchMock = mockJsonResponse(releaseManifest('beta', '999.999.999-beta.1'))
+
+    const info = await getVersionInfo({
+      env: { OPENALICE_INSTALL_SOURCE: '/runtime/install-source.json' },
+      readTextFile: () => JSON.stringify(installSource('beta')),
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(BETA_MANIFEST_URL, expect.any(Object))
+    expect(info).toMatchObject({
+      channel: 'beta',
+      updateAuthority: 'cli',
+      latest: '999.999.999-beta.1',
+      hasUpdate: true,
+      error: null,
+    })
+  })
+
+  it('fails closed when installed provenance is malformed', async () => {
+    const fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const info = await getVersionInfo({
+      env: { OPENALICE_INSTALL_SOURCE: '/runtime/install-source.json' },
+      readTextFile: () => JSON.stringify({
+        ...installSource('stable'),
+        selector: null,
+      }),
+    })
+
+    expect(info).toMatchObject({
+      channel: 'custom',
+      updateAuthority: 'none',
+      latest: null,
+      hasUpdate: false,
+      error: 'Installed OpenAlice update metadata is invalid',
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -4,6 +4,10 @@
  * The current version comes from package.json#version (read once at module
  * load). The latest stable or beta version comes from the matching OpenAlice
  * CDN manifest and is cached in memory with separate success/error TTLs.
+ * Installed provenance, rather than package semver, selects the channel and
+ * update authority. Dev discovery stays in the native CLI, pinned/custom
+ * installs do not discover updates, and service-managed runtimes defer to the
+ * service that deployed them.
  * GitHub Release assets remain the immutable payload source, but update
  * discovery does not depend on GitHub's anonymous API.
  */
@@ -133,6 +137,25 @@ interface FetchLatestReleaseOptions {
   channel?: ReleaseChannel
 }
 
+export type VersionChannel = 'stable' | 'beta' | 'dev' | 'pinned' | 'custom'
+export type UpdateAuthority = 'source' | 'desktop' | 'cli' | 'service' | 'none'
+
+type EnvLike = Readonly<Record<string, string | undefined>>
+type ReadTextFile = (path: string) => string
+
+interface UpdateContext {
+  channel: VersionChannel
+  authority: UpdateAuthority
+  error: string | null
+}
+
+interface GetVersionInfoOptions extends FetchLatestReleaseOptions {
+  /** Test seam for the running process environment. */
+  env?: EnvLike
+  /** Test seam for installed provenance reads. */
+  readTextFile?: ReadTextFile
+}
+
 const SUCCESS_TTL_MS = 60 * 60 * 1000 // 1h
 const ERROR_TTL_MS = 5 * 60 * 1000 // 5min
 
@@ -244,6 +267,8 @@ export function _resetCacheForTest(): void {
 
 export interface VersionInfo {
   current: string
+  channel: VersionChannel
+  updateAuthority: UpdateAuthority
   latest: string | null
   hasUpdate: boolean
   releaseUrl: string | null
@@ -252,12 +277,47 @@ export interface VersionInfo {
   error: string | null
 }
 
-export async function getVersionInfo(opts?: FetchLatestReleaseOptions): Promise<VersionInfo> {
+export async function getVersionInfo(opts?: GetVersionInfoOptions): Promise<VersionInfo> {
   const current = getCurrentVersion()
-  const { result, error } = await fetchLatestRelease(opts)
+  const context = opts?.channel
+    ? { channel: opts.channel, authority: 'source' as const, error: null }
+    : resolveUpdateContext(
+        opts?.env ?? process.env,
+        opts?.readTextFile ?? ((path) => readFileSync(path, 'utf8')),
+        current,
+      )
+
+  if (
+    context.error
+    || context.authority === 'service'
+    || context.authority === 'none'
+    || context.channel === 'dev'
+    || context.channel === 'pinned'
+    || context.channel === 'custom'
+  ) {
+    return {
+      current,
+      channel: context.channel,
+      updateAuthority: context.authority,
+      latest: null,
+      hasUpdate: false,
+      releaseUrl: null,
+      releaseNotes: null,
+      publishedAt: null,
+      error: context.error,
+    }
+  }
+
+  const { result, error } = await fetchLatestRelease({
+    force: opts?.force,
+    channel: context.channel,
+  })
   if (!result) {
     return {
-      current, latest: null, hasUpdate: false,
+      current,
+      channel: context.channel,
+      updateAuthority: context.authority,
+      latest: null, hasUpdate: false,
       releaseUrl: null, releaseNotes: null, publishedAt: null,
       error,
     }
@@ -265,6 +325,8 @@ export async function getVersionInfo(opts?: FetchLatestReleaseOptions): Promise<
   const hasUpdate = compareVersions(result.version, current) > 0
   return {
     current,
+    channel: context.channel,
+    updateAuthority: context.authority,
     latest: result.version,
     hasUpdate,
     releaseUrl: result.url,
@@ -272,4 +334,119 @@ export async function getVersionInfo(opts?: FetchLatestReleaseOptions): Promise<
     publishedAt: result.publishedAt,
     error: null,
   }
+}
+
+function resolveUpdateContext(
+  env: EnvLike,
+  readTextFile: ReadTextFile,
+  currentVersion: string,
+): UpdateContext {
+  const installedSourcePath = env['OPENALICE_INSTALL_SOURCE']?.trim()
+  const installedChannel = installedSourcePath
+    ? readInstalledChannel(installedSourcePath, readTextFile)
+    : null
+  const provenanceError = installedSourcePath && installedChannel === null
+    ? 'Installed OpenAlice update metadata is invalid'
+    : null
+  const channel = installedChannel ?? (
+    installedSourcePath
+      ? 'custom'
+      : releaseChannelForVersion(currentVersion)
+  )
+
+  if (env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway') {
+    return { channel, authority: 'service', error: provenanceError }
+  }
+
+  const runtimeProfile = env['OPENALICE_RUNTIME_PROFILE']?.trim()
+    || env['OPENALICE_LAUNCHER']?.trim()
+  if (runtimeProfile === 'electron-packaged') {
+    return { channel, authority: 'desktop', error: provenanceError }
+  }
+  if (runtimeProfile === 'docker') {
+    return { channel, authority: 'service', error: provenanceError }
+  }
+
+  if (installedSourcePath) {
+    const authority = channel === 'pinned' || channel === 'custom' ? 'none' : 'cli'
+    return { channel, authority, error: provenanceError }
+  }
+
+  return { channel, authority: 'source', error: null }
+}
+
+function readInstalledChannel(path: string, readTextFile: ReadTextFile): VersionChannel | null {
+  try {
+    const parsed = JSON.parse(readTextFile(path)) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    const source = parsed as Record<string, unknown>
+    if (!isValidInstalledSource(source)) return null
+
+    const schemaVersion = source['schemaVersion']
+    if (schemaVersion === 2 || schemaVersion === 3) {
+      return normalizeInstalledChannel(source['updateChannel'])
+    }
+    if (schemaVersion !== 1) return null
+
+    const selector = source['selector']
+    if (!selector || typeof selector !== 'object' || Array.isArray(selector)) return null
+    const kind = (selector as Record<string, unknown>)['kind']
+    const value = (selector as Record<string, unknown>)['value']
+    if (kind === 'version') return 'pinned'
+    if (kind !== 'branch' || typeof value !== 'string') return null
+    if (value === 'master') {
+      return source['installerUrl'] === 'https://openalice.ai/install' ? 'stable' : 'custom'
+    }
+    return 'dev'
+  } catch {
+    return null
+  }
+}
+
+function isValidInstalledSource(source: Record<string, unknown>): boolean {
+  const schemaVersion = source['schemaVersion']
+  const selector = source['selector']
+  if (!selector || typeof selector !== 'object' || Array.isArray(selector)) return false
+  const kind = (selector as Record<string, unknown>)['kind']
+  const value = (selector as Record<string, unknown>)['value']
+  if (
+    ![1, 2, 3].includes(schemaVersion as number)
+    || source['repository'] !== 'TraderAlice/OpenAlice'
+    || typeof source['cliVersion'] !== 'string'
+    || source['cliVersion'].length < 1
+    || (kind !== 'branch' && kind !== 'version')
+    || typeof value !== 'string'
+    || value.length < 1
+    || value.length > 128
+    || value.includes('..')
+    || !/^[A-Za-z0-9._/-]+$/.test(value)
+    || typeof source['installerUrl'] !== 'string'
+    || !isHttpUrl(source['installerUrl'])
+  ) {
+    return false
+  }
+  if (schemaVersion !== 3) return true
+
+  const artifact = source['artifact']
+  return (
+    typeof source['method'] === 'string'
+    && ['direct', 'npm', 'bun', 'brew', 'aur'].includes(source['method'])
+    && Boolean(artifact)
+    && typeof artifact === 'object'
+    && !Array.isArray(artifact)
+    && ['darwin', 'linux'].includes((artifact as Record<string, unknown>)['platform'] as string)
+    && ['arm64', 'x64'].includes((artifact as Record<string, unknown>)['arch'] as string)
+    && typeof (artifact as Record<string, unknown>)['sha256'] === 'string'
+    && /^[a-f0-9]{64}$/.test((artifact as Record<string, unknown>)['sha256'] as string)
+    && typeof source['installedAt'] === 'string'
+    && Number.isFinite(Date.parse(source['installedAt']))
+  )
+}
+
+function normalizeInstalledChannel(value: unknown): VersionChannel | null {
+  if (value === 'development') return 'dev'
+  if (value === 'stable' || value === 'beta' || value === 'pinned' || value === 'custom') {
+    return value
+  }
+  return null
 }

--- a/src/webui/routes/version.spec.ts
+++ b/src/webui/routes/version.spec.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   getVersionInfo: vi.fn(async (options?: { force?: boolean }) => ({
     current: '0.82.0-beta',
+    channel: 'beta',
+    updateAuthority: 'source',
     latest: '0.83.0-beta',
     hasUpdate: true,
     releaseUrl: 'https://example.test/v0.83.0-beta',

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,11 +1,18 @@
 // ==================== Version / Update awareness ====================
 
+export type UpdateChannel = 'stable' | 'beta' | 'dev' | 'pinned' | 'custom'
+export type UpdateAuthority = 'source' | 'desktop' | 'cli' | 'service' | 'none'
+
 export interface VersionInfo {
   /** App version from package.json. */
   current: string
+  /** Running installation's normalized update channel. */
+  channel: UpdateChannel
+  /** Surface that owns update discovery and application. */
+  updateAuthority: UpdateAuthority
   /** Latest version from the installed channel's release manifest. */
   latest: string | null
-  /** True when latest > current (semver). */
+  /** True when the update owner reports a newer release. */
   hasUpdate: boolean
   /** Release notes URL supplied by the channel manifest. */
   releaseUrl: string | null

--- a/ui/src/components/UpdateBanner.spec.tsx
+++ b/ui/src/components/UpdateBanner.spec.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { VersionInfo } from '../api/types'
+
+const mocks = vi.hoisted(() => ({
+  getVersion: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: {
+    version: {
+      get: mocks.getVersion,
+    },
+  },
+}))
+
+import { UpdateBanner } from './UpdateBanner'
+
+const availableUpdate: VersionInfo = {
+  current: '0.90.1',
+  channel: 'stable',
+  updateAuthority: 'source',
+  latest: '0.90.2',
+  hasUpdate: true,
+  releaseUrl: 'https://example.test/v0.90.2',
+  releaseNotes: null,
+  publishedAt: '2026-09-01T00:00:00Z',
+  error: null,
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  mocks.getVersion.mockResolvedValue(availableUpdate)
+})
+
+afterEach(() => {
+  cleanup()
+  Reflect.deleteProperty(window, 'openAlice')
+  vi.clearAllMocks()
+})
+
+describe('UpdateBanner', () => {
+  it('keeps source updates on the source-owned command', async () => {
+    render(<UpdateBanner />)
+
+    expect(await screen.findByText('git pull && pnpm build')).toBeTruthy()
+    expect(screen.queryByText('openalice update')).toBeNull()
+  })
+
+  it('delegates installed CLI updates to the CLI', async () => {
+    mocks.getVersion.mockResolvedValue({
+      ...availableUpdate,
+      updateAuthority: 'cli',
+    })
+
+    render(<UpdateBanner />)
+
+    expect(await screen.findByText('openalice update')).toBeTruthy()
+    expect(screen.queryByText('git pull && pnpm build')).toBeNull()
+  })
+
+  it('keeps desktop updates on the packaged updater', async () => {
+    mocks.getVersion.mockResolvedValue({
+      ...availableUpdate,
+      updateAuthority: 'desktop',
+    })
+
+    render(<UpdateBanner />)
+
+    expect(await screen.findByText('Desktop updater will prompt when the download is ready')).toBeTruthy()
+  })
+
+  it.each(['service', 'none'] as const)(
+    'does not render a defensive banner for %s-owned updates',
+    async (updateAuthority) => {
+      mocks.getVersion.mockResolvedValue({
+        ...availableUpdate,
+        updateAuthority,
+      })
+
+      render(<UpdateBanner />)
+
+      await waitFor(() => expect(mocks.getVersion).toHaveBeenCalledOnce())
+      expect(screen.queryByText('v0.90.2')).toBeNull()
+    },
+  )
+})

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -6,8 +6,8 @@ const SKIP_STORAGE_KEY = 'openalice.update.skipVersion'
 type RuntimeMode = 'browser' | 'electron-dev' | 'electron-packaged'
 
 /**
- * Top-of-app banner shown when GitHub Releases reports a version newer
- * than the running app's package.json.
+ * Top-of-app banner shown when the Runtime's update owner reports a newer
+ * version than the running app.
  *
  * Three actions for the user:
  *  - "Release notes" — opens the GitHub release page (changelog)
@@ -16,8 +16,9 @@ type RuntimeMode = 'browser' | 'electron-dev' | 'electron-packaged'
  *    when a newer version is released.
  *  - "×" close — session-only dismiss (until next page load).
  *
- * The action text is runtime-aware: source/Docker installs update from git,
- * while packaged Electron is handled by the native auto-updater.
+ * The action text follows the backend's update authority: source checkouts use
+ * Git, installed CLI releases use the CLI, and packaged Electron uses its
+ * native updater. Service-managed and non-updating installs do not render.
  */
 export function UpdateBanner() {
   const [info, setInfo] = useState<VersionInfo | null>(null)
@@ -31,7 +32,12 @@ export function UpdateBanner() {
       .catch(() => setRuntimeMode('browser'))
   }, [])
 
-  if (!info || !info.hasUpdate || !info.latest) return null
+  if (
+    !info
+    || !['source', 'desktop', 'cli'].includes(info.updateAuthority)
+    || !info.hasUpdate
+    || !info.latest
+  ) return null
   if (sessionDismissed) return null
 
   const skippedVersion = (() => {
@@ -63,9 +69,13 @@ export function UpdateBanner() {
           <span className="text-muted-foreground hidden lg:inline"> · released {info.publishedAt.slice(0, 10)}</span>
         )}
       </span>
-      {runtimeMode === 'electron-packaged' ? (
+      {runtimeMode === 'electron-packaged' || info.updateAuthority === 'desktop' ? (
         <span className="text-muted-foreground shrink-0 hidden md:inline">
           Desktop updater will prompt when the download is ready
+        </span>
+      ) : info.updateAuthority === 'cli' ? (
+        <span className="text-muted-foreground shrink-0 hidden md:inline">
+          Run <code className="text-primary bg-muted px-1 rounded">openalice update</code> to continue
         </span>
       ) : (
         <span className="text-muted-foreground shrink-0 hidden md:inline">

--- a/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
@@ -27,6 +27,8 @@ import { AboutOpenAliceSection } from './AboutOpenAliceSection'
 
 const currentVersion = {
   current: '0.82.0-beta',
+  channel: 'beta' as const,
+  updateAuthority: 'source' as const,
   latest: '0.82.0-beta',
   hasUpdate: false,
   releaseUrl: 'https://example.test/v0.82.0-beta',
@@ -77,6 +79,40 @@ describe('AboutOpenAliceSection', () => {
     await waitFor(() => expect(mocks.checkVersion).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.queryByText('Checking for updates…')).toBeNull())
     expect(screen.getByText('You’re up to date.')).toBeTruthy()
+  })
+
+  it('uses the backend channel instead of inferring it from the version', async () => {
+    mocks.getVersion.mockResolvedValue({
+      ...currentVersion,
+      current: '0.90.1',
+      channel: 'dev',
+    })
+
+    render(<AboutOpenAliceSection />)
+
+    expect(await screen.findByText('Development channel')).toBeTruthy()
+  })
+
+  it.each([
+    ['service', 'dev', 'Updates are managed by this deployment service.'],
+    ['cli', 'dev', 'Use the OpenAlice CLI to check this development build for updates.'],
+    ['none', 'pinned', 'This installation does not follow an automatic update channel.'],
+  ] as const)('shows %s update ownership without offering a no-op Web check', async (
+    updateAuthority,
+    channel,
+    expectedStatus,
+  ) => {
+    mocks.getVersion.mockResolvedValue({
+      ...currentVersion,
+      current: '0.90.1',
+      channel,
+      updateAuthority,
+    })
+
+    render(<AboutOpenAliceSection />)
+
+    expect(await screen.findByText(expectedStatus)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Check for updates' })).toBeNull()
   })
 
   it('uses the packaged updater and offers restart after a download completes', async () => {

--- a/ui/src/components/settings/AboutOpenAliceSection.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.tsx
@@ -81,7 +81,12 @@ export function AboutOpenAliceSection() {
   const releaseUrl = nativeStatus && 'releaseUrl' in nativeStatus && nativeStatus.releaseUrl
     ? nativeStatus.releaseUrl
     : versionInfo?.releaseUrl ?? RELEASES_URL
-  const channel = versionInfo?.current.includes('-') ? 'beta' : 'stable'
+  const channel = versionInfo?.channel ?? 'stable'
+  const webUpdateCheckOwned = versionInfo === null || (
+    versionInfo.updateAuthority === 'source'
+    || versionInfo.updateAuthority === 'desktop'
+    || (versionInfo.updateAuthority === 'cli' && versionInfo.channel !== 'dev')
+  )
 
   const status = useMemo(() => {
     if (checking) {
@@ -117,6 +122,15 @@ export function AboutOpenAliceSection() {
     }
     if (nativeStatus?.phase === 'error' || versionInfo?.error || error) {
       return { kind: 'error' as const, text: t('settings.about.status.error') }
+    }
+    if (versionInfo?.updateAuthority === 'service') {
+      return { kind: 'current' as const, text: t('settings.about.status.serviceManaged') }
+    }
+    if (versionInfo?.updateAuthority === 'none') {
+      return { kind: 'current' as const, text: t('settings.about.status.noUpdater') }
+    }
+    if (versionInfo?.updateAuthority === 'cli' && versionInfo.channel === 'dev') {
+      return { kind: 'current' as const, text: t('settings.about.status.cliManaged') }
     }
     if (versionInfo) {
       return { kind: 'current' as const, text: t('settings.about.status.current') }
@@ -256,7 +270,7 @@ export function AboutOpenAliceSection() {
                 ? t('settings.about.installing')
                 : t('settings.about.installAndRestart')}
             </button>
-          ) : (
+          ) : webUpdateCheckOwned ? (
             <button
               type="button"
               onClick={() => void checkForUpdates()}
@@ -266,7 +280,7 @@ export function AboutOpenAliceSection() {
               <RefreshCw className={`h-3.5 w-3.5 ${checking ? 'animate-spin motion-reduce:animate-none' : ''}`} />
               {checking ? t('settings.about.checking') : t('settings.about.check')}
             </button>
-          )}
+          ) : null}
           <button
             type="button"
             onClick={() => void openRelease()}

--- a/ui/src/demo/handlers/devMisc.spec.ts
+++ b/ui/src/demo/handlers/devMisc.spec.ts
@@ -23,5 +23,7 @@ describe('demo version handlers', () => {
 
     expect(response.status).toBe(200)
     expect(body.current).toBe(packageJson.version)
+    expect(body.channel).toBe('stable')
+    expect(body.updateAuthority).toBe('source')
   })
 })

--- a/ui/src/demo/handlers/devMisc.ts
+++ b/ui/src/demo/handlers/devMisc.ts
@@ -8,6 +8,8 @@ export const devMiscHandlers = [
   http.get('/api/version', () =>
     HttpResponse.json({
       current: currentVersion,
+      channel: 'stable',
+      updateAuthority: 'source',
       latest: null,
       hasUpdate: false,
       releaseUrl: null,
@@ -20,6 +22,8 @@ export const devMiscHandlers = [
   http.post('/api/version/check', () =>
     HttpResponse.json({
       current: currentVersion,
+      channel: 'stable',
+      updateAuthority: 'source',
       latest: null,
       hasUpdate: false,
       releaseUrl: null,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -425,11 +425,17 @@ export const en = {
       channel: {
         stable: 'Stable channel',
         beta: 'Beta channel',
+        dev: 'Development channel',
+        pinned: 'Pinned version',
+        custom: 'Custom source',
       },
       status: {
         loading: 'Reading version information…',
         checking: 'Checking for updates…',
         current: 'You’re up to date.',
+        serviceManaged: 'Updates are managed by this deployment service.',
+        cliManaged: 'Use the OpenAlice CLI to check this development build for updates.',
+        noUpdater: 'This installation does not follow an automatic update channel.',
         available: 'OpenAlice v{{version}} is available.',
         availableUnknown: 'A new OpenAlice version is available.',
         downloading: 'Downloading the update…',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -414,11 +414,17 @@ export const ja: Resources = {
       channel: {
         stable: '安定版チャンネル',
         beta: 'ベータチャンネル',
+        dev: '開発チャンネル',
+        pinned: '固定バージョン',
+        custom: 'カスタムソース',
       },
       status: {
         loading: 'バージョン情報を読み込み中…',
         checking: '更新を確認中…',
         current: '最新バージョンです。',
+        serviceManaged: '更新はこのデプロイサービスによって管理されています。',
+        cliManaged: 'この開発ビルドの更新確認には OpenAlice CLI を使用してください。',
+        noUpdater: 'このインストールは自動更新チャンネルを使用していません。',
         available: 'OpenAlice v{{version}} を利用できます。',
         availableUnknown: '新しい OpenAlice バージョンを利用できます。',
         downloading: '更新をダウンロード中…',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -421,11 +421,17 @@ export const zhHant: Resources = {
       channel: {
         stable: '穩定通道',
         beta: 'Beta 通道',
+        dev: '開發通道',
+        pinned: '固定版本',
+        custom: '自訂來源',
       },
       status: {
         loading: '正在讀取版本資訊…',
         checking: '正在檢查更新…',
         current: '目前已是最新版本。',
+        serviceManaged: '更新由此部署服務管理。',
+        cliManaged: '請使用 OpenAlice CLI 檢查此開發版本的更新。',
+        noUpdater: '此安裝不跟隨自動更新通道。',
         available: 'OpenAlice v{{version}} 已可更新。',
         availableUnknown: '已有新的 OpenAlice 版本可更新。',
         downloading: '正在下載更新…',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -413,11 +413,17 @@ export const zh: Resources = {
       channel: {
         stable: '稳定通道',
         beta: 'Beta 通道',
+        dev: '开发通道',
+        pinned: '固定版本',
+        custom: '自定义来源',
       },
       status: {
         loading: '正在读取版本信息…',
         checking: '正在检查更新…',
         current: '当前已是最新版本。',
+        serviceManaged: '更新由当前部署服务管理。',
+        cliManaged: '请使用 OpenAlice CLI 检查此开发版本的更新。',
+        noUpdater: '当前安装不跟随自动更新通道。',
         available: 'OpenAlice v{{version}} 已可更新。',
         availableUnknown: '已有新的 OpenAlice 版本可更新。',
         downloading: '正在下载更新…',

--- a/ui/src/pages/SettingsPage.loading.spec.tsx
+++ b/ui/src/pages/SettingsPage.loading.spec.tsx
@@ -44,6 +44,8 @@ beforeEach(async () => {
   await i18n.changeLanguage('en')
   mocks.getVersion.mockResolvedValue({
     current: '0.0.0',
+    channel: 'stable',
+    updateAuthority: 'source',
     latest: '0.0.0',
     hasUpdate: false,
     releaseUrl: '',


### PR DESCRIPTION
## Summary
- derive the Web update channel from installed provenance instead of package semver
- keep source, Electron, CLI, service-managed, and non-updating authority distinct
- propagate npm/Bun/Homebrew/AUR provenance into the standalone Runtime
- record retained Railway v2 restart, hard-kill, migration, and OpenCode resume acceptance

## Verification
- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm -F @traderalice/openalice-cli typecheck`
- `pnpm test` (5339 passed, 13 skipped)
- `pnpm build`
- `pnpm test:install:docker`
- `pnpm build:bun:release` (macOS arm64 native package smoke passed)
- focused version/UI/standalone tests (71 passed)

## Live evidence
- retained no-domain Railway dev service automatically recovered v2 locks
- normal restart and exact Runtime-child hard kill both recovered on the same Volume
- migrated Default AliceProject and user-owned OpenCode persisted; the same resume continued after both replacements

No tag, stable/beta release, or channel promotion is included.