### PR TITLE
Fix cross-platform release acceptance regressions

### DIFF
--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -11,9 +11,10 @@ dependencies, build tools, or an Agent Runtime.
 
 The direct installer expects Bash, `tar` with gzip support, `diff`, and either `sha256sum` or
 `shasum`; a network install also needs `curl`. Safe transaction ownership uses
-the platform kernel: macOS must provide `lockf`, while Linux must provide
-`flock` (normally from `util-linux`). These are host prerequisites, not packages
-that the installer silently adds. Minimal images and remote hosts should install
+the platform kernel: macOS uses `lockf` when available and falls back to the
+system `shlock` utility on older releases, while Linux must provide `flock`
+(normally from `util-linux`). These are host prerequisites, not packages that
+the installer silently adds. Minimal images and remote hosts should install
 them before running the shared installer.
 
 npm, Bun, Homebrew, and Arch/AUR installation consume the same accepted native

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -41,7 +41,7 @@ On the remote host:
 - Linux or macOS;
 - Bash, `tar` with gzip support, `diff`, and a SHA-256 utility;
 - `curl` for a network install;
-- `lockf` on macOS or `flock` on Linux (normally from `util-linux`);
+- `lockf` or the older system `shlock` on macOS, or `flock` on Linux (normally from `util-linux`);
 - enough disk and memory for the installed Runtime.
 
 The same shared-installer prerequisites apply on the laptop when it installs

--- a/install
+++ b/install
@@ -342,8 +342,8 @@ if [[ "$plan_only" == true ]]; then
 fi
 
 if [[ "$platform" == darwin ]]; then
-  command -v lockf >/dev/null 2>&1 \
-    || fail 'macOS lockf is required for safe concurrent installation'
+  { command -v lockf >/dev/null 2>&1 || command -v shlock >/dev/null 2>&1; } \
+    || fail 'macOS lockf or shlock is required for safe concurrent installation'
 else
   command -v flock >/dev/null 2>&1 \
     || fail 'Linux flock is required for safe concurrent installation'
@@ -370,6 +370,7 @@ bin_dir="$INSTALL_DIR/bin"
 lock_dir="$INSTALL_DIR/.cli-install.lock"
 lock_guard_path="$INSTALL_DIR/.cli-install.lock.guard"
 lock_guard_owned=false
+lock_guard_backend=""
 staging_dir=""
 lock_owned=false
 previous_release_name=""
@@ -385,18 +386,28 @@ acquire_install_lock() {
     [[ -f "$lock_guard_path" && ! -L "$lock_guard_path" ]] \
       || fail "CLI installer advisory lock is not a safe file: $lock_guard_path"
   fi
-  exec 9>>"$lock_guard_path" \
-    || fail "Cannot open CLI installer advisory lock at $lock_guard_path"
   if [[ "$platform" == darwin ]]; then
-    command -v lockf >/dev/null 2>&1 \
-      || fail 'macOS lockf is required for safe concurrent installation'
-    lockf -t 0 9 2>/dev/null \
-      || fail 'Another OpenAlice CLI installer is running'
+    if command -v lockf >/dev/null 2>&1; then
+      exec 9>>"$lock_guard_path" \
+        || fail "Cannot open CLI installer advisory lock at $lock_guard_path"
+      lockf -t 0 9 2>/dev/null \
+        || fail 'Another OpenAlice CLI installer is running'
+      lock_guard_backend=lockf
+    else
+      command -v shlock >/dev/null 2>&1 \
+        || fail 'macOS lockf or shlock is required for safe concurrent installation'
+      shlock -p "$$" -f "$lock_guard_path" 2>/dev/null \
+        || fail 'Another OpenAlice CLI installer is running'
+      lock_guard_backend=shlock
+    fi
   else
+    exec 9>>"$lock_guard_path" \
+      || fail "Cannot open CLI installer advisory lock at $lock_guard_path"
     command -v flock >/dev/null 2>&1 \
       || fail 'Linux flock is required for safe concurrent installation'
     flock -n 9 2>/dev/null \
       || fail 'Another OpenAlice CLI installer is running'
+    lock_guard_backend=flock
   fi
   lock_guard_owned=true
 
@@ -490,7 +501,13 @@ EOF
   fi
   [[ -z "$staging_dir" ]] || rm -rf "$staging_dir"
   if [[ "$lock_owned" == true ]]; then rm -rf "$lock_dir"; fi
-  if [[ "$lock_guard_owned" == true ]]; then exec 9>&-; fi
+  if [[ "$lock_guard_owned" == true ]]; then
+    if [[ "$lock_guard_backend" == shlock ]]; then
+      rm -f "$lock_guard_path"
+    else
+      exec 9>&-
+    fi
+  fi
   exit "$cleanup_status"
 }
 trap cleanup EXIT

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -245,24 +245,33 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
 
   it('checks locking and release-comparison prerequisites before requesting consent', async () => {
     const fixture = await makeReleaseArchive('0.91.0', '5'.repeat(16))
-    const lockCommand = platform === 'darwin' ? 'lockf' : 'flock'
+    const lockCommands = platform === 'darwin' ? ['lockf', 'shlock'] : ['flock']
     const cases = [
       {
-        missing: lockCommand,
+        missing: lockCommands,
         message: platform === 'darwin'
-          ? 'macOS lockf is required for safe concurrent installation'
+          ? 'macOS lockf or shlock is required for safe concurrent installation'
           : 'Linux flock is required for safe concurrent installation',
       },
-      { missing: 'diff', message: 'diff is required to verify the existing OpenAlice release' },
+      { missing: ['diff'], message: 'diff is required to verify the existing OpenAlice release' },
     ]
 
     for (const testCase of cases) {
-      const installRoot = join(fixture.root, `missing-${testCase.missing}`)
+      const installRoot = join(fixture.root, `missing-${testCase.missing.join('-')}`)
       const path = await makeInstallerPathWithout(testCase.missing)
       await expect(runInstaller(fixture, installRoot, [], { PATH: path }))
         .rejects.toMatchObject({ stderr: expect.stringContaining(testCase.message) })
       await expect(access(installRoot)).rejects.toMatchObject({ code: 'ENOENT' })
     }
+  })
+
+  it.skipIf(platform !== 'darwin')('falls back to shlock on macOS versions without lockf', async () => {
+    const fixture = await makeReleaseArchive('0.91.0', 'e'.repeat(16))
+    const installRoot = join(fixture.root, 'shlock-fallback')
+    const path = await makeInstallerPathWithout(['lockf'])
+
+    await expect(runInstaller(fixture, installRoot, ['--yes'], { PATH: path }))
+      .resolves.toMatchObject({ stdout: expect.stringContaining('OpenAlice 0.91.0 is ready') })
   })
 
   it('recovers a stale lock and refuses to race a live installer', async () => {
@@ -819,23 +828,45 @@ async function waitForPath(path, timeoutMs = 5_000) {
   throw new Error(`Timed out waiting for ${path}`)
 }
 
-async function makeInstallerPathWithout(missingCommand) {
+async function makeInstallerPathWithout(missingCommands) {
   const bin = await mkdtemp(join(tmpdir(), 'openalice-installer-path-'))
   temporaryPaths.push(bin)
+  const missing = new Set(missingCommands)
   const commands = [
+    'awk',
+    'basename',
     'bash',
     'cat',
+    'chmod',
+    'cp',
+    'date',
     'diff',
+    'dirname',
+    'find',
     'flock',
+    'head',
+    'ln',
     'lockf',
+    'mkdir',
+    'mktemp',
+    'mv',
+    'ps',
+    'readlink',
+    'rm',
+    'sed',
+    'shlock',
     'sha256sum',
     'shasum',
+    'sort',
+    'stat',
     'sysctl',
     'tar',
+    'tr',
     'uname',
+    'wc',
   ]
   for (const command of commands) {
-    if (command === missingCommand) continue
+    if (missing.has(command)) continue
     const executable = await resolveExecutable(command)
     if (executable) await symlink(executable, join(bin, command))
   }

--- a/packages/cli/src/project-transfer-stream.spec.ts
+++ b/packages/cli/src/project-transfer-stream.spec.ts
@@ -11,7 +11,7 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, posix } from 'node:path'
 import { promisify } from 'node:util'
 
 import { afterEach, describe, expect, it } from 'vitest'
@@ -55,7 +55,7 @@ describe('AliceProject transfer stream', () => {
     expect(registered).toEqual(['remote-copy'])
     expect(await readFile(join(destination, 'portable.txt'), 'utf8')).toBe('PORTABLE-CONTENT\n')
     const registry = JSON.parse(await readFile(join(destination, 'workspaces', 'workspaces.json'), 'utf8'))
-    expect(registry.workspaces[0].dir).toBe(join(plan.destination.home, 'workspaces', 'workspaces', 'ws-one'))
+    expect(registry.workspaces[0].dir).toBe(posix.join(plan.destination.home, 'workspaces', 'workspaces', 'ws-one'))
     const catalog = JSON.parse(await readFile(join(destination, 'workspaces', 'state', 'workspace-catalog.json'), 'utf8'))
     expect(catalog.workspaces.map((workspace: { id: string }) => workspace.id)).toEqual(['ws-one'])
     await expect(stat(join(destination, 'workspaces', 'state', 'resume-identities.json'))).rejects.toMatchObject({ code: 'ENOENT' })

--- a/scripts/railway-entrypoint.spec.ts
+++ b/scripts/railway-entrypoint.spec.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
 })
 
-describe('Railway native CLI host entrypoint', () => {
+describe.skipIf(process.platform === 'win32')('Railway native CLI host entrypoint', () => {
   it('bootstraps an empty persistent volume and runs the Guardian in foreground mode', async () => {
     const fixture = await makeFixture({ installer: 'success' })
 


### PR DESCRIPTION
## Summary
- support the system `shlock` fallback on macOS releases that do not ship the newer `lockf` utility
- keep the Linux-only Railway entrypoint contract out of Windows host tests
- assert AliceProject remote registry paths with their intentional POSIX semantics

## Verification
- `bash -n install`
- `npx tsc --noEmit`
- `pnpm exec vitest run packages/cli/src/install.spec.mjs scripts/railway-entrypoint.spec.ts packages/cli/src/project-transfer-stream.spec.ts` (88 tests passed, 2 platform skips)
- full `pnpm test`: all 622 unrelated files passed; only the intentionally in-progress release workflow contract failed against separate uncommitted DAG edits not included in this PR

Fixes the deterministic macOS and Windows failures from post-merge run 33464664537.