### PR TITLE
ci(release): add a beta fast lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
   preflight-public-cli-authority:
     name: Preflight public CLI channel authority
     needs: release
-    if: needs.release.outputs.created == 'true'
+    if: needs.release.outputs.created == 'true' && needs.release.outputs.channel == 'stable'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -182,7 +182,6 @@ jobs:
           node-version: 22.19.0
 
       - name: Verify every opted-in public channel before release publication
-        if: needs.release.outputs.channel == 'stable'
         run: node scripts/preflight-public-cli-authority.mjs
         env:
           OPENALICE_PUBLISH_NPM: ${{ vars.OPENALICE_PUBLISH_NPM }}
@@ -193,14 +192,11 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
 
-  # Per-platform desktop installers are built before any tag or GitHub Release
-  # exists. Each runner builds only its own platform/arch, preserves the candidate
-  # immediately after fast package acceptance, and leaves the slower N-1 upgrade
-  # journey to a downstream job that can be retried without rebuilding it. macOS
-  # builds are signed and notarized through Developer ID secrets; Windows remains
-  # unsigned until a Windows code-signing certificate exists.
+  # Every beta still ships real signed/notarized desktop candidates and proves
+  # their current Workspace runtime. The slower N-1 journey is a stable-only
+  # confidence gate below rather than a tax on each beta iteration.
   build-desktop:
-    needs: [release, preflight-public-cli-authority]
+    needs: release
     if: needs.release.outputs.created == 'true'
     timeout-minutes: 45
     strategy:
@@ -328,15 +324,15 @@ jobs:
             dist/electron-app/*.exe
           if-no-files-found: error
           compression-level: 0
-          retention-days: 1
+          retention-days: 3
 
-  # The final-artifact upgrade journey is intentionally downstream from the
-  # build. A failed platform can be retried from its preserved installer without
-  # repeating Electron packaging, macOS signing, or notarization.
+  # Stable publication additionally proves each final candidate can upgrade
+  # the previous stable state. A failed platform remains retriable from the
+  # preserved candidate without rebuilding or re-signing it.
   accept-desktop-upgrade:
     name: Accept desktop upgrade (${{ matrix.os }}, ${{ matrix.arch }})
     needs: [release, build-desktop]
-    if: needs.release.outputs.created == 'true' && needs.build-desktop.result == 'success'
+    if: needs.release.outputs.created == 'true' && needs.release.outputs.channel == 'stable' && needs.build-desktop.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -390,7 +386,7 @@ jobs:
 
   cli-installer-acceptance:
     name: Accept CLI installer candidate
-    needs: [release, preflight-public-cli-authority]
+    needs: release
     if: needs.release.outputs.created == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35
@@ -413,6 +409,7 @@ jobs:
         run: node scripts/install-docker-smoke.mjs
 
       - name: Exercise candidate installer through managed SSH remote
+        if: needs.release.outputs.channel == 'stable'
         run: node scripts/remote-ssh-smoke.mjs --skip-tui
 
   build-cli-installer:
@@ -450,7 +447,7 @@ jobs:
 
   build-cli-release:
     name: Build native CLI (${{ matrix.platform }}-${{ matrix.arch }})
-    needs: [release, preflight-public-cli-authority]
+    needs: release
     if: needs.release.outputs.created == 'true'
     strategy:
       fail-fast: false
@@ -521,6 +518,7 @@ jobs:
             --json
 
       - name: Accept npm and Bun installs from the native candidate
+        if: needs.release.outputs.channel == 'stable'
         shell: bash
         run: |
           VERSION=$(node -p "require('./package.json').version")
@@ -811,7 +809,7 @@ jobs:
   accept-cli-legacy-cutover:
     name: Accept published v0.90.1 CLI cutover
     needs: [release, build-cli-release]
-    if: needs.release.outputs.created == 'true' && needs.build-cli-release.result == 'success'
+    if: needs.release.outputs.created == 'true' && needs.release.outputs.channel == 'stable' && needs.build-cli-release.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     permissions:
@@ -849,7 +847,7 @@ jobs:
   # native CLI candidates instead of serializing them in desktop jobs.
   build-broker-packs:
     name: Build Broker Packs (${{ matrix.os }}, ${{ matrix.arch }})
-    needs: [release, preflight-public-cli-authority]
+    needs: release
     if: needs.release.outputs.created == 'true'
     timeout-minutes: 30
     strategy:
@@ -885,6 +883,7 @@ jobs:
         run: pnpm broker-packs:build
 
       - name: Prove previous-release Broker Pack upgrade
+        if: needs.release.outputs.channel == 'stable'
         run: pnpm broker-packs:upgrade-smoke -- --from "${{ needs.release.outputs.previous_tag }}"
 
       - name: Preserve Broker Packs
@@ -904,22 +903,22 @@ jobs:
     if: >-
       always() &&
       needs.release.outputs.created == 'true' &&
-      needs.preflight-public-cli-authority.result == 'success' &&
       needs.build-desktop.result == 'success' &&
-      needs.accept-desktop-upgrade.result == 'success' &&
       needs.build-cli-installer.result == 'success' &&
       needs.build-cli-release.result == 'success' &&
-      needs.accept-cli-legacy-cutover.result == 'success' &&
       needs.build-broker-packs.result == 'success' &&
       needs.cli-installer-acceptance.result == 'success' &&
       (
         needs.release.outputs.channel == 'beta' ||
         (
           needs.release.outputs.channel == 'stable' &&
+          needs.preflight-public-cli-authority.result == 'success' &&
+          needs.accept-desktop-upgrade.result == 'success' &&
           needs.build-cli-package-channels.result == 'success' &&
           needs.accept-cli-homebrew.result == 'success' &&
           needs.accept-cli-linuxbrew.result == 'success' &&
-          needs.accept-cli-aur.result == 'success'
+          needs.accept-cli-aur.result == 'success' &&
+          needs.accept-cli-legacy-cutover.result == 'success'
         )
       )
     runs-on: ubuntu-latest

--- a/plans/release-feedback-reliability.md
+++ b/plans/release-feedback-reliability.md
@@ -23,13 +23,17 @@ Owner guides:
 Make release failures arrive earlier and carry enough evidence to diagnose
 without rerunning an hour-long pipeline. The first batch repairs deterministic
 feedback defects observed during the 0.89.3-beta release without changing any
-release gate. The second batch records the dependency and provenance redesign
-needed to shorten the successful release critical path.
+release gate. The second batch separates a fast beta candidate lane from the
+complete stable compatibility lane.
 
-This initiative does not weaken signing, notarization, N-1 upgrade, native
-platform, package-content, installer, or publication checks. Routine local and
-PR verification remains unsigned; release-only credentials stay confined to
-the versioned release lane.
+Beta still proves every published desktop, CLI, Broker Pack, installer,
+checksum, update-metadata, and channel-isolation artifact, including signed and
+notarized macOS bytes and current-candidate runtime startup. Cross-version and
+package-manager compatibility belong to stable: N-1 desktop upgrades, managed
+SSH deployment, legacy CLI cutover, Broker Pack upgrades, and npm/Bun/Homebrew/
+Linuxbrew/AUR acceptance remain full stable release gates. Routine local and PR
+verification remains unsigned; release-only credentials stay confined to the
+versioned release lane.
 
 ## Decisions
 
@@ -47,6 +51,17 @@ the versioned release lane.
   `dev`/`master` pull-request coverage remain available.
 - Defer DAG fan-in removal and accepted-tree provenance to a second batch. Both
   need explicit artifact/provenance contracts rather than YAML-only shortcuts.
+- Keep the existing desktop build and N-1 matrices. Beta stops after signed or
+  packaged candidate construction, current Workspace smoke, update-byte
+  verification, and artifact upload. The downstream N-1 matrix runs only for
+  stable. Preserve candidate artifacts for at least three days so delayed
+  diagnosis does not immediately lose the release bytes.
+- Treat a master-targeted release-preparation PR as a narrow semantic fast lane
+  only when its complete diff is exactly the matching top-level `version`
+  change in `package.json` and `packages/cli/package.json`. It still runs Linux
+  build/test plus workflow contracts, and the exact merged `master` SHA still
+  runs every release candidate/publication gate. Any extra path, JSON field,
+  mismatch, invalid version, or classifier failure keeps the full PR matrix.
 - Keep beta and stable as separate serial release intents. A changed source tree
   invalidates prior candidate evidence and must be accepted again; unchanged
   beta source may be selected only through a later explicit stable decision.
@@ -76,21 +91,26 @@ the versioned release lane.
   packaged Workspace smoke pass locally. Native Intel/Windows, signing, and
   notarization remain CI/release evidence and are not claimed locally.
 
-### Batch 2: critical-path and provenance redesign
+### Batch 2: beta fast lane and provenance redesign
 
-- [ ] Each platform's N-1 desktop acceptance begins as soon as its matching
-  candidate artifact is available; it does not wait for the entire desktop
-  build matrix. Per-platform artifact identity and retriable acceptance remain
-  explicit.
+- [x] Beta publication requires every current desktop, CLI, Broker Pack, and
+  installer candidate plus integrity/channel-isolation checks, but does not
+  wait for cross-version or package-manager compatibility suites.
+- [x] Stable publication still requires desktop N-1, managed SSH, legacy CLI
+  cutover, Broker Pack N-1, public-channel authority, and every supported
+  package-manager acceptance gate.
 - [ ] A trusted promotion receipt binds the accepted commit tree to the exact
   required PR checks. A `master` release may reuse it only for the identical
   tree; direct hotfixes or missing/stale receipts run the full master CI gates.
 - [ ] Release status presents one coherent view of publication and CI evidence,
   so a green release beside an unrelated red duplicate workflow is no longer
   the normal successful path.
-- [ ] Successful-path timing is measured before and after the DAG change, and
-  no signing, notarization, upgrade, cross-platform, installer, or publication
-  gate is removed to achieve the reduction.
+- [ ] An exact two-manifest release-preparation PR takes the bounded semantic
+  fast lane, while near misses demonstrably fall back to the ordinary full PR
+  matrix.
+- [ ] Successful beta timing is measured before and after the channel split;
+  signing, notarization, current-candidate startup, artifact integrity, and
+  stable-alias isolation are never removed from beta.
 
 ## Work
 
@@ -105,8 +125,12 @@ the versioned release lane.
 
 ### Batch 2
 
-- [ ] Choose and document either explicit per-platform build/accept pairs or a
-  reusable per-platform workflow; retain downloadable candidate artifacts.
+- [x] Define the minimal beta candidate contract and the complete stable
+  compatibility contract.
+- [x] Implement and validate the beta/stable release split while retaining
+  downloadable desktop candidates for three days.
+- [ ] Add the exact release-preparation semantic classifier and use it to skip
+  only redundant host/package PR jobs, never the final Release gates.
 - [ ] Define the signed accepted-tree receipt, trust boundary, invalidation
   rules, and hotfix fallback.
 - [ ] Implement the release DAG and master-CI provenance changes with timing
@@ -140,6 +164,21 @@ later promotion, version-only, and release gates all passed. This supports a
 future accepted-tree receipt that skips only identical post-merge CI; it does
 not justify reusing evidence after additional commits, weakening release gates,
 or combining beta and stable publication.
+
+The successful `v0.91.0-beta.1` Release run took 35:03 without a failed job or
+rerun. Its beta publication spent about 37 runner-minutes on compatibility
+checks that remain appropriate for stable but do not validate whether a beta
+candidate is installable now: desktop N-1, Broker Pack N-1, npm/Bun packaging,
+managed SSH, and legacy cutover. Keeping final candidate construction, signing,
+notarization, current-runtime smoke, installer fixture, integrity, and channel
+isolation makes the Intel signed desktop build the expected critical path. The
+new beta lane is therefore expected to finish in roughly 22-25 minutes, while
+stable retains the former full gate set. The same checkpoint's version-only PR
+changed only the two product manifest versions but waited about 15 minutes for
+Docker, unsigned desktop, and CLI host matrices; its independent Linux
+build/test completed in under four minutes. That evidence motivates the strict
+semantic release-preparation fast lane above rather than a title-, label-, or
+commit-message bypass.
 
 ## Completion
 

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -135,20 +135,22 @@ describe('Release workflow critical path', () => {
     )
   })
 
-  it('preserves desktop candidates before running retriable N-1 acceptance', () => {
+  it('keeps current desktop candidates on beta and N-1 acceptance on stable', () => {
     const desktop = workflow.jobs['build-desktop']
     const upgrade = workflow.jobs['accept-desktop-upgrade']
 
     expect(step(desktop, 'Preserve desktop release candidate').uses).toBe('actions/upload-artifact@v4')
+    expect(step(desktop, 'Preserve desktop release candidate').with?.['retention-days']).toBe(3)
     expect(desktop.steps?.map((candidate) => candidate.name)).not.toContain(
       'Prove final desktop artifact upgrades previous release state',
     )
     expect(needs(upgrade)).toEqual(['release', 'build-desktop'])
+    expect(upgrade.if).toContain("needs.release.outputs.channel == 'stable'")
     expect(step(upgrade, 'Restore desktop release candidate').uses).toBe('actions/download-artifact@v4')
     expect(step(upgrade, 'Prove final desktop artifact upgrades previous release state')).toBeDefined()
   })
 
-  it('keeps publication gated on both candidate builds and upgrade receipts', () => {
+  it('publishes beta from current candidates and stable from the complete compatibility gate set', () => {
     expect(needs(workflow.jobs['publish-release'])).toEqual(expect.arrayContaining([
       'preflight-public-cli-authority',
       'build-desktop',
@@ -161,17 +163,33 @@ describe('Release workflow critical path', () => {
       'accept-cli-legacy-cutover',
       'cli-installer-acceptance',
     ]))
-    expect(workflow.jobs['publish-release'].if).toContain(
+    const publication = workflow.jobs['publish-release'].if ?? ''
+    for (const common of [
+      "needs.build-desktop.result == 'success'",
+      "needs.build-cli-installer.result == 'success'",
+      "needs.build-cli-release.result == 'success'",
+      "needs.build-broker-packs.result == 'success'",
+      "needs.cli-installer-acceptance.result == 'success'",
+    ]) expect(publication).toContain(common)
+    for (const stable of [
       "needs.preflight-public-cli-authority.result == 'success'",
+      "needs.accept-desktop-upgrade.result == 'success'",
+      "needs.accept-cli-legacy-cutover.result == 'success'",
+      "needs.accept-cli-homebrew.result == 'success'",
+      "needs.accept-cli-linuxbrew.result == 'success'",
+      "needs.accept-cli-aur.result == 'success'",
+    ]) expect(publication).toContain(stable)
+    expect(publication.indexOf("needs.release.outputs.channel == 'beta'")).toBeLessThan(
+      publication.indexOf("needs.accept-desktop-upgrade.result == 'success'"),
     )
   })
 
-  it('preflights every enabled public CLI channel before creating the release', () => {
+  it('reserves public-channel authority checks for stable without delaying beta builders', () => {
     const preflight = workflow.jobs['preflight-public-cli-authority']
     expect(needs(preflight)).toEqual(['release'])
     expect(preflight['timeout-minutes']).toBe(5)
+    expect(preflight.if).toContain("needs.release.outputs.channel == 'stable'")
     const verify = step(preflight, 'Verify every opted-in public channel before release publication')
-    expect(verify.if).toContain("needs.release.outputs.channel == 'stable'")
     expect(verify.run).toBe('node scripts/preflight-public-cli-authority.mjs')
     for (const job of [
       'build-desktop',
@@ -179,7 +197,7 @@ describe('Release workflow critical path', () => {
       'build-cli-release',
       'build-broker-packs',
     ]) {
-      expect(needs(workflow.jobs[job])).toContain('preflight-public-cli-authority')
+      expect(needs(workflow.jobs[job])).not.toContain('preflight-public-cli-authority')
     }
   })
 
@@ -195,6 +213,27 @@ describe('Release workflow critical path', () => {
     expect(steps[node]?.with?.cache).toBe('pnpm')
     expect(install).toBeGreaterThan(node)
     expect(remote).toBeGreaterThan(install)
+    expect(steps[remote]?.if).toContain("needs.release.outputs.channel == 'stable'")
+  })
+
+  it('keeps beta behind real candidate build, startup, installer, and integrity checks', () => {
+    const desktop = workflow.jobs['build-desktop']
+    const nativeCli = workflow.jobs['build-cli-release']
+    const installer = workflow.jobs['cli-installer-acceptance']
+
+    expect(desktop.strategy?.matrix?.include).toEqual([
+      { os: 'macos-14', arch: 'arm64' },
+      { os: 'macos-15-intel', arch: 'x64' },
+      { os: 'windows-latest', arch: 'x64' },
+    ])
+    expect(step(desktop, 'Package macOS installer').if).toBe("runner.os == 'macOS'")
+    expect(step(desktop, 'Prove release candidate Workspace CLI acceptance').if).toBeUndefined()
+    expect(step(desktop, 'Verify candidate update metadata and referenced bytes').if).toBeUndefined()
+    const boot = step(nativeCli, 'Install and boot the native candidate outside the checkout').run ?? ''
+    expect(boot).toContain('openalice" up')
+    expect(boot).toContain('openalice" doctor')
+    expect(boot).toContain('openalice" down')
+    expect(step(installer, 'Exercise candidate installer in a clean HTTP fixture').if).toBeUndefined()
   })
 
   it('does not activate stable package-manager channels before CDN verification', () => {
@@ -234,6 +273,8 @@ describe('Release workflow critical path', () => {
     const aur = workflow.jobs['accept-cli-aur']
 
     const npmAndBun = step(nativeCli, 'Accept npm and Bun installs from the native candidate').run ?? ''
+    expect(step(nativeCli, 'Accept npm and Bun installs from the native candidate').if)
+      .toContain("needs.release.outputs.channel == 'stable'")
     expect(npmAndBun).toContain('--manager npm')
     expect(npmAndBun).toContain('--manager bun')
     expect(needs(channels)).toEqual(['release', 'build-cli-release'])
@@ -265,9 +306,19 @@ describe('Release workflow critical path', () => {
       .toContain('cli-aur-container-smoke.mjs')
     const cutover = workflow.jobs['accept-cli-legacy-cutover']
     expect(needs(cutover)).toEqual(['release', 'build-cli-release'])
+    expect(cutover.if).toContain("needs.release.outputs.channel == 'stable'")
     const cutoverRun = step(cutover, 'Replace the published legacy CLI with the accepted native candidate').run ?? ''
     expect(cutoverRun).toContain('cli-legacy-cutover-smoke.mjs')
     expect(cutoverRun).toContain('--channel "${{ needs.release.outputs.channel }}"')
+  })
+
+  it('builds beta Broker Packs but reserves previous-release upgrade proof for stable', () => {
+    const brokerPacks = workflow.jobs['build-broker-packs']
+    expect(needs(brokerPacks)).toEqual(['release'])
+    expect(step(brokerPacks, 'Build optional Broker Packs').if).toBeUndefined()
+    expect(step(brokerPacks, 'Prove previous-release Broker Pack upgrade').if)
+      .toContain("needs.release.outputs.channel == 'stable'")
+    expect(step(brokerPacks, 'Preserve Broker Packs').if).toBeUndefined()
   })
 
   it('publishes npm platform packages before the stable meta package', () => {


### PR DESCRIPTION
## Summary

- keep beta behind signed/notarized desktop candidates, current packaged Workspace smoke, native CLI install/boot checks, clean installer acceptance, Broker Pack builds, metadata/checksum verification, and beta/stable alias isolation
- reserve N-1 desktop/Broker Pack upgrades, managed SSH, legacy CLI cutover, public-channel authority, and package-manager compatibility for stable releases
- retain desktop candidates for three days and encode the beta/stable boundary in workflow contract tests and the active release plan

The successful `v0.91.0-beta.1` run took 35:03. Based on its job timings, this removes about 37 runner-minutes from each beta and should reduce the successful critical path to roughly 22–25 minutes; stable keeps the complete gate set.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `pnpm exec vitest run scripts/ci-workflow.spec.ts scripts/desktop-package-workflow.spec.ts scripts/release-workflow.spec.ts`
- `npx tsc --noEmit`
- `pnpm test` (623 files passed, 2 skipped; 5342 tests passed, 13 skipped)
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm electron:smoke:workspace` (12/12 packaged Workspace checks passed)
