### PR TITLE
ci(release): fast-path exact beta version prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       cross_platform: ${{ steps.changes.outputs.cross_platform }}
+      beta_release_prep: ${{ steps.beta-release-prep.outcome == 'success' && steps.beta-release-prep.outputs.beta_release_prep || 'false' }}
 
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
+
+      - name: Detect exact beta release preparation
+        id: beta-release-prep
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git show "${BASE_SHA}:scripts/classify-beta-release-prep.mjs" > "$RUNNER_TEMP/classify-beta-release-prep.mjs"
+          node "$RUNNER_TEMP/classify-beta-release-prep.mjs" --github-output "$GITHUB_OUTPUT"
+
       - name: Classify changed paths
         id: changes
         uses: actions/github-script@v9
@@ -141,7 +157,16 @@ jobs:
   # green check from shipping regressions to macOS or Windows users.
   cross-platform-test:
     needs: change-scope
-    if: needs.change-scope.outputs.cross_platform == 'true'
+    if: >-
+      !cancelled() &&
+      (github.event_name != 'push' || github.ref == 'refs/heads/master') &&
+      (
+        needs.change-scope.result != 'success' ||
+        (
+          needs.change-scope.outputs.cross_platform == 'true' &&
+          needs.change-scope.outputs.beta_release_prep != 'true'
+        )
+      )
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -177,7 +202,16 @@ jobs:
   # diff, not a harness bug. See scripts/guardian/smoke.ts.
   dev-smoke:
     needs: change-scope
-    if: needs.change-scope.outputs.cross_platform == 'true'
+    if: >-
+      !cancelled() &&
+      (github.event_name != 'push' || github.ref == 'refs/heads/master') &&
+      (
+        needs.change-scope.result != 'success' ||
+        (
+          needs.change-scope.outputs.cross_platform == 'true' &&
+          needs.change-scope.outputs.beta_release_prep != 'true'
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -55,8 +55,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bun-cli-feasibility:
+  release-prep-scope:
     if: github.event_name != 'push'
+    name: release-prep scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      beta_release_prep: ${{ steps.beta-release-prep.outcome == 'success' && steps.beta-release-prep.outputs.beta_release_prep || 'false' }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect exact beta release preparation
+        id: beta-release-prep
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git show "${BASE_SHA}:scripts/classify-beta-release-prep.mjs" > "$RUNNER_TEMP/classify-beta-release-prep.mjs"
+          node "$RUNNER_TEMP/classify-beta-release-prep.mjs" --github-output "$GITHUB_OUTPUT"
+
+  bun-cli-feasibility:
+    needs: release-prep-scope
+    if: >-
+      !cancelled() &&
+      github.event_name != 'push' &&
+      (
+        needs.release-prep-scope.result != 'success' ||
+        needs.release-prep-scope.outputs.beta_release_prep != 'true'
+      )
     name: Bun feasibility (${{ matrix.os }})
     strategy:
       fail-fast: false
@@ -114,7 +144,14 @@ jobs:
             --expected-content-identity "$CONTENT_IDENTITY"
 
   checkout-install:
-    if: github.event_name != 'push'
+    needs: release-prep-scope
+    if: >-
+      !cancelled() &&
+      github.event_name != 'push' &&
+      (
+        needs.release-prep-scope.result != 'success' ||
+        needs.release-prep-scope.outputs.beta_release_prep != 'true'
+      )
     name: Current checkout install
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -130,7 +167,14 @@ jobs:
         run: node scripts/install-docker-smoke.mjs
 
   checkout-remote:
-    if: github.event_name != 'push'
+    needs: release-prep-scope
+    if: >-
+      !cancelled() &&
+      github.event_name != 'push' &&
+      (
+        needs.release-prep-scope.result != 'success' ||
+        needs.release-prep-scope.outputs.beta_release_prep != 'true'
+      )
     name: Current checkout managed remote
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -55,9 +55,23 @@ jobs:
     name: fast preflight
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      beta_release_prep: ${{ steps.beta-release-prep.outcome == 'success' && steps.beta-release-prep.outputs.beta_release_prep || 'false' }}
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect exact beta release preparation
+        id: beta-release-prep
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git show "${BASE_SHA}:scripts/classify-beta-release-prep.mjs" > "$RUNNER_TEMP/classify-beta-release-prep.mjs"
+          node "$RUNNER_TEMP/classify-beta-release-prep.mjs" --github-output "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v6
 
@@ -83,6 +97,7 @@ jobs:
   broker-packs-windows:
     name: broker-packs windows-latest
     needs: preflight
+    if: needs.preflight.outputs.beta_release_prep != 'true'
     runs-on: windows-latest
     timeout-minutes: 25
 
@@ -112,6 +127,7 @@ jobs:
   package:
     name: package ${{ matrix.os }}
     needs: preflight
+    if: needs.preflight.outputs.beta_release_prep != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -66,14 +66,29 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect exact beta release preparation
+        id: beta-release-prep
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git show "${BASE_SHA}:scripts/classify-beta-release-prep.mjs" > "$RUNNER_TEMP/classify-beta-release-prep.mjs"
+          node "$RUNNER_TEMP/classify-beta-release-prep.mjs" --github-output "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v7
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
         with:
           node-version: 22
 
       - uses: docker/setup-buildx-action@v3
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
 
       - name: Build server image
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -83,12 +98,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=openalice-docker
 
       - name: Exercise Guardian, Workspace PTY, and CLI gateway
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
         env:
           OPENALICE_DOCKER_SMOKE_LOG_FILE: artifacts/docker-smoke.log
         run: node scripts/docker-runtime-smoke.mjs --skip-build --image openalice:ci
 
       - name: Upload failure diagnostics
-        if: failure()
+        if: >-
+          failure() &&
+          (steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true')
         uses: actions/upload-artifact@v4
         with:
           name: docker-smoke-logs

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -234,6 +234,17 @@ delivery lane:
   `build-and-test` aggregate check requires both lanes to pass.
 - PRs whose complete diff is limited to `ui/`, `docs/`, or root documentation
   skip the macOS/Windows runtime matrix. Any other path keeps the full matrix.
+- A `master`-targeted PR whose complete diff is exactly the synchronized,
+  forward beta `version` value in `package.json` and
+  `packages/cli/package.json` takes the release-preparation fast lane. It keeps
+  Ubuntu build/test, workflow contracts, and root typecheck, while skipping the
+  Docker, CLI installer, Broker Pack, and desktop/cross-platform PR matrices
+  because no runtime implementation changed. The beta Release workflow then
+  rebuilds and accepts every final version-bearing candidate from the exact
+  `master` SHA.
+  The classifier is read from the trusted base commit and fails closed: stable
+  versions, extra bytes or paths, mismatches, invalid versions, and classifier
+  errors all retain the full PR suite.
 - Superseded runs for the same PR are cancelled. Only the latest-head result is
   actionable evidence.
 - Desktop Package Smoke runs its workflow-contract and root-typecheck preflight
@@ -254,7 +265,9 @@ delivery lane:
   `dev` push separately downloads `raw/.../dev/install` into a clean container,
   installs `--channel dev`, and verifies the live preview channel's provenance,
   commands, server control surface, and idempotent reuse.
-- A push to `master` always runs the complete matrix.
+- A push to `master` always runs the complete matrix. Reusing PR evidence after
+  merge remains a separate accepted-tree provenance problem; the semantic beta
+  PR fast lane does not silently solve it by trusting a commit message or diff.
 - Once this workflow version reaches the default `master` branch, the scheduled
   validation checks out current `dev` and runs the complete matrix, providing a
   daily cross-platform backstop for lightweight PRs.
@@ -370,6 +383,12 @@ the channel and tag:
 `vX.Y.Z`. The workflow rejects an existing tag, a channel/tag mismatch, or a
 version that disagrees with either the root or `packages/cli` package. It binds
 the accepted candidates and eventual tag to the dispatch commit SHA.
+
+An exact forward beta version-only PR uses the bounded CI fast lane described
+above. Stable version preparation deliberately does not: it retains the full
+PR matrix. The subsequent `master` push also remains complete for both
+channels, and the manually dispatched Release always rebuilds and accepts its
+own final candidates; the fast lane never supplies release artifacts.
 
 Beta and stable are serial public checkpoints, not paired outputs from one
 release run. After a beta, fixes may continue on `dev`, pass the ordinary

--- a/plans/release-feedback-reliability.md
+++ b/plans/release-feedback-reliability.md
@@ -105,7 +105,7 @@ versioned release lane.
 - [ ] Release status presents one coherent view of publication and CI evidence,
   so a green release beside an unrelated red duplicate workflow is no longer
   the normal successful path.
-- [ ] An exact two-manifest release-preparation PR takes the bounded semantic
+- [x] An exact two-manifest release-preparation PR takes the bounded semantic
   fast lane, while near misses demonstrably fall back to the ordinary full PR
   matrix.
 - [ ] Successful beta timing is measured before and after the channel split;
@@ -129,7 +129,7 @@ versioned release lane.
   compatibility contract.
 - [x] Implement and validate the beta/stable release split while retaining
   downloadable desktop candidates for three days.
-- [ ] Add the exact release-preparation semantic classifier and use it to skip
+- [x] Add the exact release-preparation semantic classifier and use it to skip
   only redundant host/package PR jobs, never the final Release gates.
 - [ ] Define the signed accepted-tree receipt, trust boundary, invalidation
   rules, and hotfix fallback.
@@ -179,6 +179,17 @@ Docker, unsigned desktop, and CLI host matrices; its independent Linux
 build/test completed in under four minutes. That evidence motivates the strict
 semantic release-preparation fast lane above rather than a title-, label-, or
 commit-message bypass.
+
+PR #1271's exact two-manifest bump consumed about 72 runner-minutes across 18
+Actions checks, with the Windows desktop package lane setting a roughly
+15-minute wall-clock path. The semantic fast lane keeps Linux build/test plus
+the desktop workflow-contract/typecheck preflight and removes roughly 65 of
+those runner-minutes; its expected PR wall time is about four minutes. The
+classifier executes from the trusted base commit and accepts only a byte-exact,
+synchronized, forward beta version change. Stable bumps, near misses, and
+classifier failures run the complete suite. `master` push reuse remains out of
+scope until the accepted-tree receipt can prove the associated PR, tree, and
+successful checks without adding an ad hoc trust tower.
 
 ## Completion
 

--- a/scripts/beta-release-prep-workflow.spec.ts
+++ b/scripts/beta-release-prep-workflow.spec.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+interface WorkflowStep {
+  name?: string
+  if?: string
+  run?: string
+  uses?: string
+  'continue-on-error'?: boolean
+  env?: Record<string, string>
+}
+
+interface WorkflowJob {
+  if?: string
+  needs?: string | string[]
+  outputs?: Record<string, string>
+  steps?: WorkflowStep[]
+}
+
+interface Workflow {
+  jobs: Record<string, WorkflowJob>
+}
+
+const root = resolve(import.meta.dirname, '..')
+
+function workflow(name: string): Workflow {
+  return YAML.parse(readFileSync(resolve(root, `.github/workflows/${name}`), 'utf8')) as Workflow
+}
+
+function step(job: WorkflowJob, name: string): WorkflowStep {
+  const found = job.steps?.find((candidate) => candidate.name === name)
+  if (!found) throw new Error(`Workflow step is missing: ${name}`)
+  return found
+}
+
+function expectTrustedClassifier(job: WorkflowJob): void {
+  const classifier = step(job, 'Detect exact beta release preparation')
+  expect(classifier['continue-on-error']).toBe(true)
+  expect(classifier.if).toBe("github.event_name == 'pull_request'")
+  expect(classifier.env?.BASE_SHA).toBe('${{ github.event.pull_request.base.sha }}')
+  expect(classifier.run).toContain('git show "${BASE_SHA}:scripts/classify-beta-release-prep.mjs"')
+  expect(classifier.run).toContain('--github-output "$GITHUB_OUTPUT"')
+}
+
+function expectOutcomeGatedOutput(job: WorkflowJob): void {
+  expect(job.outputs?.beta_release_prep).toContain("steps.beta-release-prep.outcome == 'success'")
+  expect(job.outputs?.beta_release_prep).toContain("|| 'false'")
+}
+
+describe('exact beta release-preparation workflow lane', () => {
+  it('keeps Linux build/test while skipping only CI host matrices', () => {
+    const jobs = workflow('ci.yml').jobs
+    expectTrustedClassifier(jobs['change-scope'])
+    expectOutcomeGatedOutput(jobs['change-scope'])
+    expect(jobs.build.needs).toBeUndefined()
+    expect(jobs.test.needs).toBeUndefined()
+    expect(jobs['build-and-test'].needs).toEqual(['build', 'test'])
+    for (const name of ['cross-platform-test', 'dev-smoke']) {
+      expect(jobs[name].if).toContain('!cancelled()')
+      expect(jobs[name].if).toContain("needs.change-scope.result != 'success'")
+      expect(jobs[name].if).toContain("beta_release_prep != 'true'")
+      expect(jobs[name].if).toContain("github.ref == 'refs/heads/master'")
+    }
+  })
+
+  it('keeps desktop contracts and typecheck while skipping package matrices', () => {
+    const jobs = workflow('desktop-package-smoke.yml').jobs
+    expectTrustedClassifier(jobs.preflight)
+    expectOutcomeGatedOutput(jobs.preflight)
+    expect(step(jobs.preflight, 'Verify CI workflow contracts')).toBeDefined()
+    expect(step(jobs.preflight, 'Typecheck root workspace')).toBeDefined()
+    expect(jobs['broker-packs-windows'].if).toContain("beta_release_prep != 'true'")
+    expect(jobs.package.if).toContain("beta_release_prep != 'true'")
+  })
+
+  it('skips CLI PR acceptance without changing the dev publication chain', () => {
+    const jobs = workflow('cli-installer-smoke.yml').jobs
+    const scope = jobs['release-prep-scope']
+    expectTrustedClassifier(scope)
+    expectOutcomeGatedOutput(scope)
+    expect(scope.if).toBe("github.event_name != 'push'")
+    for (const name of ['bun-cli-feasibility', 'checkout-install', 'checkout-remote']) {
+      expect(jobs[name].needs).toBe('release-prep-scope')
+      expect(jobs[name].if).toContain('!cancelled()')
+      expect(jobs[name].if).toContain("needs.release-prep-scope.result != 'success'")
+      expect(jobs[name].if).toContain("beta_release_prep != 'true'")
+    }
+    expect(jobs['build-dev-cli'].if).toBe("github.event_name == 'push'")
+    expect(jobs['build-dev-cli'].needs).toBeUndefined()
+    expect(jobs['publish-dev-cli'].needs).toBe('build-dev-cli')
+  })
+
+  it('keeps the Docker check green but omits setup, build, and smoke on an exact match', () => {
+    const smoke = workflow('docker-smoke.yml').jobs.smoke
+    expectTrustedClassifier(smoke)
+    const expensive = smoke.steps?.filter((candidate) => [
+      'actions/setup-node@v7',
+      'docker/setup-buildx-action@v3',
+      'docker/build-push-action@v6',
+    ].includes(candidate.uses ?? '') || candidate.name === 'Exercise Guardian, Workspace PTY, and CLI gateway') ?? []
+    expect(expensive).toHaveLength(4)
+    for (const candidate of expensive) {
+      expect(candidate.if).toContain("steps.beta-release-prep.outcome != 'success'")
+      expect(candidate.if).toContain("beta_release_prep != 'true'")
+    }
+    expect(step(smoke, 'Build server image').if).toContain("beta_release_prep != 'true'")
+    expect(step(smoke, 'Exercise Guardian, Workspace PTY, and CLI gateway').if)
+      .toContain("beta_release_prep != 'true'")
+  })
+
+  it('never lets the classifier bypass final release candidates or publication', () => {
+    const releaseSource = readFileSync(resolve(root, '.github/workflows/release.yml'), 'utf8')
+    expect(releaseSource).not.toContain('classify-beta-release-prep')
+    expect(releaseSource).not.toContain('beta_release_prep')
+  })
+})

--- a/scripts/classify-beta-release-prep.mjs
+++ b/scripts/classify-beta-release-prep.mjs
@@ -1,0 +1,246 @@
+import { appendFile, readFile } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const REQUIRED_MANIFESTS = ['package.json', 'packages/cli/package.json']
+const VERSION_LINE = /^  "version": "([^"]+)",\r?$/gm
+const RELEASE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-beta(?:\.([1-9]\d*))?)?$/
+const BETA_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta(?:\.([1-9]\d*))?$/
+
+function result(betaReleasePrep, reason) {
+  return { betaReleasePrep, reason }
+}
+
+export function parseChangedFiles(output) {
+  const fields = output.split('\0')
+  if (fields.at(-1) === '') fields.pop()
+  if (fields.length % 2 !== 0) {
+    throw new Error('git diff returned an incomplete name-status record')
+  }
+
+  const changes = []
+  for (let index = 0; index < fields.length; index += 2) {
+    changes.push({ status: fields[index], path: fields[index + 1] })
+  }
+  return changes
+}
+
+function versionToken(source) {
+  const matches = [...source.matchAll(VERSION_LINE)]
+  if (matches.length !== 1) return undefined
+
+  const match = matches[0]
+  const value = match[1]
+  const valueOffset = match[0].indexOf(value)
+  if (match.index === undefined || valueOffset < 0) return undefined
+
+  let parsed
+  try {
+    parsed = JSON.parse(source)
+  } catch {
+    return undefined
+  }
+  if (parsed?.version !== value) return undefined
+
+  return {
+    value,
+    start: match.index + valueOffset,
+    end: match.index + valueOffset + value.length,
+  }
+}
+
+function replaceVersion(source, token, value) {
+  return `${source.slice(0, token.start)}${value}${source.slice(token.end)}`
+}
+
+function parseReleaseVersion(value) {
+  const match = RELEASE_VERSION.exec(value)
+  if (!match) return undefined
+  return {
+    core: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
+    beta: value.includes('-beta'),
+    betaNumber: match[4] === undefined ? undefined : BigInt(match[4]),
+  }
+}
+
+function isNewerBeta(baseValue, nextValue) {
+  if (!BETA_VERSION.test(nextValue)) return false
+  const base = parseReleaseVersion(baseValue)
+  const next = parseReleaseVersion(nextValue)
+  if (!base || !next?.beta) return false
+
+  for (let index = 0; index < base.core.length; index += 1) {
+    if (next.core[index] !== base.core[index]) {
+      return next.core[index] > base.core[index]
+    }
+  }
+
+  if (!base.beta) return false
+  if (base.betaNumber === undefined) return next.betaNumber !== undefined
+  if (next.betaNumber === undefined) return false
+  return next.betaNumber > base.betaNumber
+}
+
+export function classifyBetaReleasePrep({
+  eventName,
+  ref,
+  baseRef,
+  changes,
+  baseManifests,
+  headManifests,
+}) {
+  const isMasterPullRequest = eventName === 'pull_request' && baseRef === 'master'
+  if (!isMasterPullRequest) {
+    return result(false, 'only master pull requests can use the beta release-preparation fast lane')
+  }
+
+  if (
+    changes.length !== REQUIRED_MANIFESTS.length ||
+    changes.some((change) => change.status !== 'M') ||
+    !REQUIRED_MANIFESTS.every((path) => changes.some((change) => change.path === path))
+  ) {
+    return result(false, 'the complete diff is not exactly the two modified product manifests')
+  }
+
+  const baseTokens = {}
+  const headTokens = {}
+  for (const path of REQUIRED_MANIFESTS) {
+    const baseSource = baseManifests[path]
+    const headSource = headManifests[path]
+    if (typeof baseSource !== 'string' || typeof headSource !== 'string') {
+      return result(false, `could not read both revisions of ${path}`)
+    }
+
+    const baseToken = versionToken(baseSource)
+    const headToken = versionToken(headSource)
+    if (!baseToken || !headToken) {
+      return result(false, `${path} does not have the expected single top-level version line`)
+    }
+    if (replaceVersion(headSource, headToken, baseToken.value) !== baseSource) {
+      return result(false, `${path} changes bytes outside the top-level version value`)
+    }
+    baseTokens[path] = baseToken
+    headTokens[path] = headToken
+  }
+
+  const baseVersion = baseTokens[REQUIRED_MANIFESTS[0]].value
+  const nextVersion = headTokens[REQUIRED_MANIFESTS[0]].value
+  if (baseTokens[REQUIRED_MANIFESTS[1]].value !== baseVersion) {
+    return result(false, 'the base product manifest versions disagree')
+  }
+  if (headTokens[REQUIRED_MANIFESTS[1]].value !== nextVersion) {
+    return result(false, 'the candidate product manifest versions disagree')
+  }
+  if (!isNewerBeta(baseVersion, nextVersion)) {
+    return result(false, `${nextVersion} is not a forward beta version from ${baseVersion}`)
+  }
+
+  return result(true, `exact beta release preparation ${baseVersion} -> ${nextVersion}`)
+}
+
+function git(args) {
+  const completed = spawnSync('git', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  })
+  if (completed.status !== 0) {
+    throw new Error(completed.stderr.trim() || `git ${args.join(' ')} failed`)
+  }
+  return completed.stdout
+}
+
+export function classifyBetaReleasePrepFromGit({ eventName, ref, baseRef, baseSha, headSha }) {
+  if (!/^[a-f0-9]{40}$/i.test(baseSha ?? '') || !/^[a-f0-9]{40}$/i.test(headSha ?? '')) {
+    return result(false, 'event did not provide two commit SHAs')
+  }
+  if (/^0{40}$/.test(baseSha)) {
+    return result(false, 'event base SHA is the null revision')
+  }
+
+  try {
+    git(['merge-base', '--is-ancestor', baseSha, headSha])
+    const changes = parseChangedFiles(git([
+      'diff', '--name-status', '-z', '--no-renames', baseSha, headSha, '--',
+    ]))
+    for (const path of REQUIRED_MANIFESTS) {
+      for (const revision of [baseSha, headSha]) {
+        const treeEntry = git(['ls-tree', revision, '--', path])
+        if (!treeEntry.startsWith(`100644 blob `) || !treeEntry.endsWith(`\t${path}\n`)) {
+          return result(false, `${path} is not a regular 100644 blob in both revisions`)
+        }
+      }
+    }
+    const baseManifests = Object.fromEntries(
+      REQUIRED_MANIFESTS.map((path) => [path, git(['show', `${baseSha}:${path}`])]),
+    )
+    const headManifests = Object.fromEntries(
+      REQUIRED_MANIFESTS.map((path) => [path, git(['show', `${headSha}:${path}`])]),
+    )
+    return classifyBetaReleasePrep({
+      eventName,
+      ref,
+      baseRef,
+      changes,
+      baseManifests,
+      headManifests,
+    })
+  } catch (error) {
+    return result(false, `classifier failed closed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+async function eventInputs() {
+  let event = {}
+  if (process.env.GITHUB_EVENT_PATH) {
+    try {
+      event = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, 'utf8'))
+    } catch (error) {
+      return {
+        error: `could not read GitHub event payload: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+  }
+
+  const eventName = process.env.GITHUB_EVENT_NAME ?? ''
+  if (eventName === 'pull_request') {
+    return {
+      eventName,
+      ref: process.env.GITHUB_REF ?? '',
+      baseRef: event.pull_request?.base?.ref ?? process.env.GITHUB_BASE_REF ?? '',
+      baseSha: event.pull_request?.base?.sha ?? '',
+      headSha: process.env.GITHUB_SHA ?? event.pull_request?.merge_commit_sha ?? '',
+    }
+  }
+  return {
+    eventName,
+    ref: process.env.GITHUB_REF ?? '',
+    baseRef: process.env.GITHUB_BASE_REF ?? '',
+    baseSha: '',
+    headSha: process.env.GITHUB_SHA ?? '',
+  }
+}
+
+async function main() {
+  const githubOutputIndex = process.argv.indexOf('--github-output')
+  const githubOutput = githubOutputIndex >= 0 ? process.argv[githubOutputIndex + 1] : undefined
+  const inputs = await eventInputs()
+  const classification = inputs.error
+    ? result(false, inputs.error)
+    : classifyBetaReleasePrepFromGit(inputs)
+
+  console.log(`beta release preparation: ${classification.betaReleasePrep}`)
+  console.log(`reason: ${classification.reason}`)
+  if (githubOutput) {
+    await appendFile(
+      githubOutput,
+      `beta_release_prep=${classification.betaReleasePrep}\nreason=${classification.reason.replace(/[\r\n]/g, ' ')}\n`,
+    )
+  } else {
+    console.log(JSON.stringify(classification))
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/scripts/classify-beta-release-prep.spec.mjs
+++ b/scripts/classify-beta-release-prep.spec.mjs
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyBetaReleasePrep,
+  parseChangedFiles,
+} from './classify-beta-release-prep.mjs'
+
+const manifests = ['package.json', 'packages/cli/package.json']
+
+function manifest(name, version, extra = '') {
+  return `{
+  "name": "${name}",
+  "version": "${version}",
+  "description": "fixture"${extra}
+}
+`
+}
+
+function candidate(overrides = {}) {
+  const baseVersion = overrides.baseVersion ?? '0.91.0-beta.1'
+  const nextVersion = overrides.nextVersion ?? '0.91.0-beta.2'
+  return classifyBetaReleasePrep({
+    eventName: 'pull_request',
+    ref: 'refs/pull/42/merge',
+    baseRef: 'master',
+    changes: manifests.map((path) => ({ status: 'M', path })),
+    baseManifests: {
+      'package.json': manifest('open-alice', baseVersion),
+      'packages/cli/package.json': manifest('@traderalice/openalice-cli', baseVersion),
+    },
+    headManifests: {
+      'package.json': manifest('open-alice', nextVersion),
+      'packages/cli/package.json': manifest('@traderalice/openalice-cli', nextVersion),
+    },
+    ...overrides,
+  })
+}
+
+describe('beta release-preparation classifier', () => {
+  it('accepts only an exact forward beta version change on a master PR', () => {
+    expect(candidate()).toEqual({
+      betaReleasePrep: true,
+      reason: 'exact beta release preparation 0.91.0-beta.1 -> 0.91.0-beta.2',
+    })
+    expect(candidate({ baseVersion: '0.90.2', nextVersion: '0.91.0-beta.1' }).betaReleasePrep).toBe(true)
+    expect(candidate({ baseVersion: '0.90.2', nextVersion: '0.91.0-beta' }).betaReleasePrep).toBe(true)
+  })
+
+  it('fails closed on a master push so post-merge validation stays complete', () => {
+    expect(candidate({
+      eventName: 'push',
+      ref: 'refs/heads/master',
+      baseRef: '',
+    }).betaReleasePrep).toBe(false)
+  })
+
+  it('fails closed for stable, stale, mismatched, and non-master versions', () => {
+    expect(candidate({ nextVersion: '0.91.0' }).betaReleasePrep).toBe(false)
+    expect(candidate({ nextVersion: '0.91.0-beta.1' }).betaReleasePrep).toBe(false)
+    expect(candidate({ nextVersion: '0.91.0-beta' }).betaReleasePrep).toBe(false)
+    expect(candidate({ nextVersion: '0.92.0-beta.0' }).betaReleasePrep).toBe(false)
+    expect(candidate({ nextVersion: '0.92.0-beta.01' }).betaReleasePrep).toBe(false)
+    expect(candidate({ baseRef: 'dev' }).betaReleasePrep).toBe(false)
+    expect(candidate({ eventName: 'workflow_dispatch', baseRef: '' }).betaReleasePrep).toBe(false)
+
+    const mismatch = candidate({
+      headManifests: {
+        'package.json': manifest('open-alice', '0.91.0-beta.2'),
+        'packages/cli/package.json': manifest('@traderalice/openalice-cli', '0.91.0-beta.3'),
+      },
+    })
+    expect(mismatch.betaReleasePrep).toBe(false)
+  })
+
+  it('rejects extra files, non-modification statuses, and bytes outside version', () => {
+    expect(candidate({
+      changes: [...manifests.map((path) => ({ status: 'M', path })), { status: 'M', path: 'README.md' }],
+    }).betaReleasePrep).toBe(false)
+    expect(candidate({
+      changes: [{ status: 'M', path: 'package.json' }, { status: 'A', path: 'packages/cli/package.json' }],
+    }).betaReleasePrep).toBe(false)
+
+    const extraBytes = candidate({
+      headManifests: {
+        'package.json': manifest('open-alice', '0.91.0-beta.2', ',\n  "private": true'),
+        'packages/cli/package.json': manifest('@traderalice/openalice-cli', '0.91.0-beta.2'),
+      },
+    })
+    expect(extraBytes.betaReleasePrep).toBe(false)
+  })
+
+  it('parses the null-delimited no-renames git diff contract', () => {
+    expect(parseChangedFiles('M\0package.json\0M\0packages/cli/package.json\0')).toEqual([
+      { status: 'M', path: 'package.json' },
+      { status: 'M', path: 'packages/cli/package.json' },
+    ])
+    expect(() => parseChangedFiles('M\0package.json\0M')).toThrow('incomplete name-status')
+  })
+})


### PR DESCRIPTION
## Summary

- classify only a byte-exact, synchronized, forward beta version change in the two product manifests on a `master` PR
- keep Linux build/test plus workflow-contract/typecheck preflight, while skipping redundant Docker, cross-platform, desktop/Broker Pack, and CLI installer matrices
- execute the classifier from the trusted base commit against GitHub's synthetic merge SHA and fail closed on any mismatch, missing output, failed scope, or near miss
- keep superseded runs cancelled; leave stable preparation, `master` push, dev publication, and the entire Release workflow unchanged

PR #1271 spent about 72 runner-minutes across 18 Actions checks and about 15 minutes wall time for this exact two-line change. The retained lanes are expected to finish in roughly four minutes and save about 65 runner-minutes.

## Verification

- historical replay: PR #1271 base → merge classified as `0.90.2 -> 0.91.0-beta.1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `pnpm exec vitest run scripts/classify-beta-release-prep.spec.mjs scripts/beta-release-prep-workflow.spec.ts scripts/ci-workflow.spec.ts scripts/desktop-package-workflow.spec.ts scripts/cli-installer-workflow.spec.ts scripts/release-workflow.spec.ts` (40 passed)
- `npx tsc --noEmit`
- `pnpm test` (625 files passed, 2 skipped; 5352 tests passed, 13 skipped)
