### PR TITLE
ci: focus routine release feedback lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [master, dev]
+    branches: [master]
   pull_request:
     branches: [dev, master, codex/usability-improvements]
   # Keep a full cross-platform safety net for lightweight PRs that intentionally
-  # skip the expensive host matrix. Scheduled workflows run from the default
+  # skip the focused host matrix. Scheduled workflows run from the default
   # branch, while checkout below points the jobs at the current dev branch.
   schedule:
     - cron: "0 19 * * *"
@@ -17,11 +17,11 @@ permissions:
   pull-requests: read
 
 # Agent-driven iterations often supersede an earlier commit before its Windows
-# job finishes. Keep only the latest PR/dev run while never cancelling a master
-# or scheduled validation.
+# job finishes. Keep only the latest PR run while never cancelling a master or
+# scheduled validation.
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # UI and prose changes are built and tested on Ubuntu, but do not need to
@@ -82,15 +82,14 @@ jobs:
 
             core.info(`Changed paths: ${paths.join(", ") || "none reported"}`);
             if (platformSensitive.length > 0) {
-              core.info(`Full matrix required by: ${platformSensitive.join(", ")}`);
+              core.info(`Native host contracts required by: ${platformSensitive.join(", ")}`);
             } else {
               core.info("Only UI/docs paths changed; Ubuntu remains the PR gate.");
             }
             core.setOutput("cross_platform", String(runCrossPlatform));
 
   build:
-    # A dev push is the already-tested result of merging a PR. It gets the
-    # focused post-merge smoke below instead of repeating the whole PR suite.
+    # Dev pushes belong exclusively to the rolling CLI publication workflow.
     if: github.event_name != 'push' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
@@ -151,10 +150,12 @@ jobs:
             exit 1
           fi
 
-  # The full Vitest suite includes path, port-binding, process-launch, and
-  # packaged-toolchain behavior whose semantics differ materially by host OS.
-  # Ubuntu remains the build gate above; this matrix prevents a Linux-only
-  # green check from shipping regressions to macOS or Windows users.
+  # Routine dev PRs run the complete build and test suite once on Ubuntu, then
+  # exercise only native CLI/Guardian/path/process contracts on macOS and
+  # Windows. Repeating all 5,000+ platform-neutral tests on constrained hosted
+  # runners amplified resource starvation into false serial blockers. Stable
+  # promotion, master, scheduled, and manual validation still run the complete
+  # build and test suite on both hosts.
   cross-platform-test:
     needs: change-scope
     if: >-
@@ -188,10 +189,19 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm build
+      - name: Build complete workspace for stable and scheduled validation
+        if: github.event_name != 'pull_request' || github.base_ref == 'master'
+        run: pnpm build
         timeout-minutes: 15
 
-      - run: pnpm test
+      - name: Run native platform contracts for routine integration PRs
+        if: github.event_name == 'pull_request' && github.base_ref != 'master'
+        run: pnpm test:platform-contracts
+        timeout-minutes: 8
+
+      - name: Run complete suite for stable and scheduled validation
+        if: github.event_name != 'pull_request' || github.base_ref == 'master'
+        run: pnpm test
         timeout-minutes: 15
 
   # Boots the real `pnpm dev` stack and asserts UTA/Alice/Vite all spawn.
@@ -237,31 +247,6 @@ jobs:
       # Exercises duplicate-start rejection, graceful takeover, crash-stale
       # reclamation, heartbeat renewal, and forced recovery with real child
       # processes before the heavier full-stack boot smoke.
-      - run: pnpm test:guardian-recovery
-        timeout-minutes: 3
-
-      - run: pnpm test:smoke
-        timeout-minutes: 8
-
-  # Merging a green PR changes the commit SHA but normally not its tested tree.
-  # Keep a cheap real-process integration check on dev without paying for a
-  # second complete Linux/macOS/Windows pass.
-  post-merge-dev-smoke:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
-
       - run: pnpm test:guardian-recovery
         timeout-minutes: 3
 

--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -232,11 +232,15 @@ jobs:
 
       - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
 
-      - name: Build Alice and native CLI
-        run: |
-          pnpm build:server
-          pnpm build:bun-runtime:feasibility
-          pnpm build:bun:release
+      - name: Build Alice server
+        run: pnpm build:server
+
+      - name: Accept multiprocess recovery once per dev commit
+        if: matrix.platform == 'linux' && matrix.arch == 'x64'
+        run: pnpm build:bun-runtime:feasibility
+
+      - name: Build native CLI
+        run: pnpm build:bun:release
 
       - name: Name the native acceptance report
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,10 +141,14 @@ credentials, destructive actions, security boundaries, or substantial
 cross-surface structure. A later interactive message does not retroactively
 authorize merging an autonomous topic PR. Related work may continue while its
 latest CI is pending, but a known failure must be repaired before adding more
-scope. In serial work, pending CI likewise must not become a synchronous lock;
-inspect the previous PR checks and post-merge `dev` run before publishing the
-next increment. `master` promotions, releases, explicit review pauses, and
-untrusted contributions keep their full synchronous gates. Detailed topic,
+scope. A hosted-runner or resource-starvation failure may be classified as
+infrastructure only when its log is captured, the affected contract passes in
+the proportional local/native lane, and no product assertion failed; it should
+be repaired or removed from the routine lane instead of retried blindly. In
+serial work, pending CI likewise must not become a synchronous lock; inspect the
+previous PR checks and post-merge `dev` run before publishing the next
+increment. `master` promotions, releases, explicit review pauses, and untrusted
+contributions keep their full synchronous gates. Detailed topic,
 branch, PR, promotion, hotfix, and external-contribution procedures live in
 [[docs/development-workflow.md]]
 ([Development workflow](docs/development-workflow.md)).

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -195,12 +195,15 @@ npx tsc --noEmit
 cd ui && npx tsc -b
 ```
 
-The Bun CLI lane additionally runs `pnpm build:bun-runtime:feasibility`. Its
-isolated fixture uses the production active-release layout, imports a private
-SDK from Pack-local `node_modules`, requires a real platform N-API binary, and
-proves the compiled UTA role loads it again after a forced UTA restart. This is
-the external-loading gate; it does not replace building and verifying the real
-release Packs above.
+The Bun CLI PR and release lanes additionally run
+`pnpm build:bun-runtime:feasibility` on their native hosts. Rolling `dev`
+publication samples this heavier multiprocess recovery on Linux x64 once per
+commit, while every platform still runs the packaged native-candidate smoke.
+The isolated feasibility fixture uses the production active-release layout,
+imports a private SDK from Pack-local `node_modules`, requires a real platform
+N-API binary, and proves the compiled UTA role loads it again after a forced UTA
+restart. This is the external-loading gate; it does not replace building and
+verifying the real release Packs above.
 
 For desktop changes, follow [[docs/managed-workspace-runtime.md]] and require
 `pnpm electron:assert-package` plus the packaged Workspace smoke. For a broker

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -225,15 +225,20 @@ the issue/PR that shaped the work.
 
 ## CI Feedback Lanes
 
-CI provides both change-level confidence and post-merge integration feedback.
-Its execution stays the same, but its blocking authority depends on the
+Pull-request CI and the rolling dev CLI publication provide change-level and
+post-merge integration feedback. Their blocking authority depends on the
 delivery lane:
 
 - Every PR to `dev` or `master` runs independent Ubuntu build and unit-test
   lanes so either failure is visible without waiting for the other. The stable
   `build-and-test` aggregate check requires both lanes to pass.
 - PRs whose complete diff is limited to `ui/`, `docs/`, or root documentation
-  skip the macOS/Windows runtime matrix. Any other path keeps the full matrix.
+  skip the macOS/Windows runtime matrix. Other routine PRs to `dev` run the
+  focused native CLI, Guardian, filesystem, shell, and process contract suite
+  on macOS and Windows instead of repeating every platform-neutral Vitest file
+  already accepted on Ubuntu. PRs to `master`, `master` pushes, scheduled runs,
+  and manual full validation still build and test the complete tree on both
+  hosts.
 - A `master`-targeted PR whose complete diff is exactly the synchronized,
   forward beta `version` value in `package.json` and
   `packages/cli/package.json` takes the release-preparation fast lane. It keeps
@@ -253,13 +258,23 @@ delivery lane:
 - In serial mode, a `dev` PR may merge after proportional local verification
   while its remote checks are pending. Before the next serial PR is published,
   inspect both that PR's checks and the resulting `dev` push run. A completed
-  failure blocks further stacking until it is understood and repaired; pending
-  status alone does not block progress.
+  product or contract failure blocks further stacking until it is understood
+  and repaired; pending status alone does not block progress. A hosted-runner
+  resource failure is not converted into product risk by repetition: capture
+  the log, reproduce the affected contract locally or in the smallest native
+  lane, then repair or remove the noisy routine check rather than blindly
+  retrying the whole matrix.
 - Autonomous topic PRs remain open for later acceptance. Pending runs do not
   block related commits, but only the latest head is evidence and a completed
   failure blocks further scope until repaired. CI never grants merge authority.
-- A push to `dev` runs the focused Ubuntu Guardian/full-stack smoke instead of
-  repeating the PR's complete build, test, and cross-platform jobs.
+- A push to `dev` is a CLI-only rolling publication lane. It does not run the
+  generic CI workflow, build Electron, or build Docker. Four native macOS/Linux
+  CLI candidates are assembled and each candidate runs its packaged
+  Guardian/Alice, Web, Workspace, PTY, and release-owned Git acceptance before
+  one atomic dev manifest is activated. The heavier UTA/Connector recovery and
+  external Broker Pack fixture run once on Linux x64; PR and release lanes keep
+  their broader native-host coverage. The scheduled CI run remains the daily
+  full cross-platform backstop for current `dev`.
 - Installer or distributed-CLI PRs run deterministic clean-container install
   and managed-SSH acceptance against the checked-out tree. After merge, the
   `dev` push separately downloads `raw/.../dev/install` into a clean container,
@@ -274,9 +289,13 @@ delivery lane:
 
 Keep the lightweight-path allowlist narrow. Changes to dependencies, runtime,
 Guardian, Electron, packaging, scripts, workflows, or any unclassified path
-must still produce Windows and macOS evidence. In serial `dev` work that
-evidence may arrive after merge, but a known failure stops the next increment;
-it must be green before promotion to `master` or release.
+must still produce Windows and macOS evidence, but routine PR evidence is the
+focused native contract suite plus the relevant real-runtime/package smoke, not
+three copies of all platform-neutral tests. Serial development uses the local
+Mac for the complete `npx tsc --noEmit` and `pnpm test` contract, adding the
+unsigned Electron/package smoke when that surface changes. A product failure
+must be green before promotion to `master` or release; stable keeps the full
+remote matrix even when routine integration used focused host checks.
 
 ### Package signing boundary
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "vendor:runtime": "node scripts/vendor-managed-runtime.mjs",
     "test": "vitest run",
     "test:cli": "pnpm -F @traderalice/openalice-cli test",
+    "test:platform-contracts": "vitest run --project node packages/cli/src packages/guardian-runtime/src scripts/guardian/shared.spec.ts scripts/pnpm-command.spec.ts scripts/railway-entrypoint.spec.ts services/connector/src/core/io-journal.spec.ts services/uta/src/uta-startup-resilience.spec.ts src/core/windows-workspace-shell.spec.ts src/services/auth/session-store.spec.ts src/services/auth/token-store.spec.ts src/workspaces/adapters/ai-config.spec.ts src/workspaces/adapters/shell.spec.ts src/workspaces/agent-conversation-log.spec.ts src/workspaces/agent-detect.spec.ts src/workspaces/cli/shim.spec.ts src/workspaces/headless-task-win-shim.spec.ts src/workspaces/spawn-env.spec.ts src/workspaces/win-command.spec.ts src/workspaces/workspace-creator.spec.ts",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:uta:live-paper": "vitest run --config vitest.uta-live.config.ts",

--- a/packages/cli/src/install.spec.mjs
+++ b/packages/cli/src/install.spec.mjs
@@ -272,6 +272,8 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
 
     await expect(runInstaller(fixture, installRoot, ['--yes'], { PATH: path }))
       .resolves.toMatchObject({ stdout: expect.stringContaining('OpenAlice 0.91.0 is ready') })
+    await expect(access(join(installRoot, '.cli-install.lock.guard')))
+      .rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('recovers a stale lock and refuses to race a live installer', async () => {
@@ -333,7 +335,6 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
     const fixture = await makeReleaseArchive('0.91.0', '6'.repeat(16), { versionDelaySeconds: 2 })
     const installRoot = join(fixture.root, 'installed')
     const lockDir = join(installRoot, '.cli-install.lock')
-    const guard = join(installRoot, '.cli-install.lock.guard')
     const first = runInstaller(fixture, installRoot, ['--yes'])
     await waitForPath(lockDir)
 
@@ -341,7 +342,13 @@ describe.skipIf(process.platform === 'win32')('OpenAlice native CLI installer', 
       .rejects.toMatchObject({ stderr: expect.stringContaining('Another OpenAlice CLI installer is running') })
     await expect(first).resolves.toMatchObject({ stdout: expect.stringContaining('OpenAlice 0.91.0 is ready') })
     await expect(access(lockDir)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(access(guard)).resolves.toBeUndefined()
+
+    // lockf/flock keep a harmless inode after releasing their advisory lock;
+    // shlock represents the lock by the file itself and removes it. A third
+    // successful install is the backend-independent proof that no live guard
+    // remains after the first owner exits.
+    await expect(runInstaller(fixture, installRoot, ['--yes']))
+      .resolves.toMatchObject({ stdout: expect.stringContaining('OpenAlice 0.91.0 is ready') })
   })
 
   it('uses the fixed dev-channel archive and records dev provenance', async () => {

--- a/packages/cli/src/internal-role-runtime.spec.ts
+++ b/packages/cli/src/internal-role-runtime.spec.ts
@@ -6,7 +6,11 @@ import { tmpdir } from 'node:os'
 
 import { describe, expect, it } from 'vitest'
 
-describe('private Runtime role fencing', () => {
+// Each case starts a real TypeScript child process with its own 10-second
+// process ceiling. Windows hosted runners can need more than Vitest's default
+// five seconds merely to load tsx under full-suite contention, so the enclosing
+// assertion budget must remain larger than the subprocess budget.
+describe('private Runtime role fencing', { timeout: 15_000 }, () => {
   it('refuses a direct Railway Connector writer without the Guardian fence', () => {
     const home = join(tmpdir(), `openalice-connector-no-fence-${process.pid}-${randomUUID()}`)
     const result = spawnSync(process.execPath, [

--- a/plans/release-feedback-reliability.md
+++ b/plans/release-feedback-reliability.md
@@ -49,8 +49,11 @@ versioned release lane.
   source tree is already exercised on the promotion PR, while the release
   workflow builds and accepts the signed candidate bytes. Manual dispatch and
   `dev`/`master` pull-request coverage remain available.
-- Defer DAG fan-in removal and accepted-tree provenance to a second batch. Both
-  need explicit artifact/provenance contracts rather than YAML-only shortcuts.
+- Do not add an accepted-tree receipt or a second release-provenance trust path
+  in this iteration. The strict version-only classifier removes the expensive
+  preparation duplicate, while the tagged release still rebuilds and accepts
+  its own bytes. Revisit provenance reuse only if measured master duplication
+  remains material after the simpler lane split.
 - Keep the existing desktop build and N-1 matrices. Beta stops after signed or
   packaged candidate construction, current Workspace smoke, update-byte
   verification, and artifact upload. The downstream N-1 matrix runs only for
@@ -65,6 +68,20 @@ versioned release lane.
 - Keep beta and stable as separate serial release intents. A changed source tree
   invalidates prior candidate evidence and must be accepted again; unchanged
   beta source may be selected only through a later explicit stable decision.
+- Keep rolling `dev` publication CLI-only. The four native candidates already
+  exercise packaged Guardian/Alice, Web, Workspace, PTY, and Git behavior; do
+  not add Electron or Docker to the commit path, and do not repeat the separate
+  source-mode post-merge smoke. Sample the heavier multiprocess/Broker Pack
+  recovery once on Linux x64 rather than four times. Preserve all four targets
+  and activate their checksummed manifest atomically rather than publishing
+  partial platform state.
+- Run platform-neutral build and unit coverage once on Ubuntu for routine
+  integration PRs. macOS and Windows run the focused native CLI, Guardian,
+  filesystem, shell, and process contracts plus their real runtime/package
+  smokes. The full cross-platform build/test matrix belongs to `master`, stable
+  promotion, scheduled validation, and explicit manual rehearsal. Classify a
+  hosted-runner failure from captured evidence and a proportional local/native
+  rerun; do not make blind whole-matrix retries part of the contract.
   Even then, stable has independent version preparation and full release
   acceptance.
 
@@ -91,7 +108,7 @@ versioned release lane.
   packaged Workspace smoke pass locally. Native Intel/Windows, signing, and
   notarization remain CI/release evidence and are not claimed locally.
 
-### Batch 2: beta fast lane and provenance redesign
+### Batch 2: beta fast lane and CI lane redesign
 
 - [x] Beta publication requires every current desktop, CLI, Broker Pack, and
   installer candidate plus integrity/channel-isolation checks, but does not
@@ -99,18 +116,18 @@ versioned release lane.
 - [x] Stable publication still requires desktop N-1, managed SSH, legacy CLI
   cutover, Broker Pack N-1, public-channel authority, and every supported
   package-manager acceptance gate.
-- [ ] A trusted promotion receipt binds the accepted commit tree to the exact
-  required PR checks. A `master` release may reuse it only for the identical
-  tree; direct hotfixes or missing/stale receipts run the full master CI gates.
-- [ ] Release status presents one coherent view of publication and CI evidence,
-  so a green release beside an unrelated red duplicate workflow is no longer
-  the normal successful path.
 - [x] An exact two-manifest release-preparation PR takes the bounded semantic
   fast lane, while near misses demonstrably fall back to the ordinary full PR
   matrix.
 - [ ] Successful beta timing is measured before and after the channel split;
   signing, notarization, current-candidate startup, artifact integrity, and
   stable-alias isolation are never removed from beta.
+- [x] Each `dev` commit publishes only the four accepted native CLI candidates
+  plus the live installer check; Electron, Docker, generic CI, package-manager,
+  legacy, and cross-version lanes are absent.
+- [x] Routine integration PRs run the full suite once on Ubuntu and a focused
+  native contract suite on macOS/Windows; `master`, stable, scheduled, and
+  manual validation retain the complete cross-platform matrix.
 
 ## Work
 
@@ -131,10 +148,16 @@ versioned release lane.
   downloadable desktop candidates for three days.
 - [x] Add the exact release-preparation semantic classifier and use it to skip
   only redundant host/package PR jobs, never the final Release gates.
-- [ ] Define the signed accepted-tree receipt, trust boundary, invalidation
-  rules, and hotfix fallback.
-- [ ] Implement the release DAG and master-CI provenance changes with timing
-  telemetry and native release rehearsal evidence.
+- [x] Remove the redundant generic CI `dev` push smoke after proving that the
+  native CLI candidate smoke covers the real packaged runtime on every target.
+- [x] Keep one Linux x64 multiprocess/Broker Pack recovery acceptance per dev
+  commit instead of repeating that identical semantic gate on four candidates.
+- [x] Replace routine macOS/Windows copies of the complete Vitest suite with
+  the focused platform contract command, while retaining full host coverage in
+  stable and scheduled lanes.
+- [ ] Record the first authorized beta run's actual wall and runner timing; this
+  is observational follow-up, not a publication blocker or a reason to add a
+  second provenance system.
 
 ## Verification
 
@@ -160,10 +183,10 @@ test-environment defects rather than product regressions: a hard-coded port
 collided with a hosted runner, and Windows cleanup exceeded an implicit
 five-second test budget. PR #1272 replaced the port assumption with a reserved
 fixture window and gave the bounded Git cleanup path an explicit budget. The
-later promotion, version-only, and release gates all passed. This supports a
-future accepted-tree receipt that skips only identical post-merge CI; it does
-not justify reusing evidence after additional commits, weakening release gates,
-or combining beta and stable publication.
+later promotion, version-only, and release gates all passed. The strict
+version-only fast lane captures the useful part of that evidence without
+making ordinary development depend on a new signed receipt or another release
+trust boundary.
 
 The successful `v0.91.0-beta.1` Release run took 35:03 without a failed job or
 rerun. Its beta publication spent about 37 runner-minutes on compatibility
@@ -188,11 +211,35 @@ those runner-minutes; its expected PR wall time is about four minutes. The
 classifier executes from the trusted base commit and accepts only a byte-exact,
 synchronized, forward beta version change. Stable bumps, near misses, and
 classifier failures run the complete suite. `master` push reuse remains out of
-scope until the accepted-tree receipt can prove the associated PR, tree, and
-successful checks without adding an ad hoc trust tower.
+scope because its modest savings do not currently justify another release
+trust path.
+
+Recent successful `dev` pushes confirmed that rolling publication already had
+no Electron, Docker, release, or full-test job. Four native CLI candidates,
+atomic R2 activation, and the live network installer took a median of about
+8.25 minutes wall time and 14.9 runner-minutes; Intel macOS was consistently the
+critical native leg. The removed source-mode smoke cost about one runner-minute
+in parallel and duplicated packaged runtime evidence. Sampling the heavier
+multiprocess/Broker Pack recovery only on Linux x64 saves roughly another
+minute of aggregate runner time and tens of seconds on the Intel critical path.
+All four final candidate smokes, checksums/content identities, manifest-last
+activation, cancellation of superseded builds, and the public dev install stay
+intact.
+
+The CI lane redesign passed root TypeScript, the complete local suite (5,359
+passing, 13 skipped), 44 focused workflow/desktop contracts, current
+`actionlint`, the 67-file platform contract command (774 passing, 6 skipped),
+and the real `build:server -> build:bun-runtime:feasibility ->
+build:bun:release` sequence on Apple Silicon. A local unpacked Electron journey
+also launched the latest published beta profile, launched the current dev
+candidate, and immediately restarted that candidate with all eleven persistence
+checks passing. Because the dev manifest still declares `0.90.1`, that journey
+is evidence for the macOS profile-release/restart repair, not a forward beta.2
+upgrade claim.
 
 ## Completion
 
 Batch 1 is complete: criteria, local verification, and serial PR #1061 are
-merged to `dev`. The overall plan remains active until the second-batch DAG
-and provenance criteria are implemented and measured.
+merged to `dev`. Batch 2 implementation is complete. The plan remains active
+only to record the first authorized beta fast-lane timing; publication itself
+still requires a separate maintainer decision.

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 
 interface WorkflowStep {
+  if?: string
   name?: string
   run?: string
+  'timeout-minutes'?: number
 }
 
 interface WorkflowJob {
@@ -13,18 +15,38 @@ interface WorkflowJob {
   needs?: string | string[]
   'timeout-minutes'?: number
   steps?: WorkflowStep[]
+  strategy?: {
+    matrix?: { os?: string[] }
+  }
+}
+
+interface Workflow {
+  on?: {
+    push?: { branches?: string[] }
+    pull_request?: { branches?: string[] }
+  }
+  jobs: Record<string, WorkflowJob>
 }
 
 const root = resolve(import.meta.dirname, '..')
 const workflow = YAML.parse(
   readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8'),
-) as { jobs: Record<string, WorkflowJob> }
+) as Workflow
+const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+  scripts: Record<string, string>
+}
 
 function commands(job: WorkflowJob): string[] {
   return job.steps?.flatMap((step) => step.run ? [step.run] : []) ?? []
 }
 
 describe('CI workflow fast failure lanes', () => {
+  it('leaves dev pushes to the CLI-only rolling publication workflow', () => {
+    expect(workflow.on?.push?.branches).toEqual(['master'])
+    expect(workflow.on?.pull_request?.branches).toEqual(expect.arrayContaining(['dev', 'master']))
+    expect(workflow.jobs['post-merge-dev-smoke']).toBeUndefined()
+  })
+
   it('runs build and unit tests independently', () => {
     const build = workflow.jobs.build
     const test = workflow.jobs.test
@@ -49,5 +71,33 @@ describe('CI workflow fast failure lanes', () => {
 
   it('bounds cross-platform runners even when a step never reports completion', () => {
     expect(workflow.jobs['cross-platform-test']['timeout-minutes']).toBe(30)
+  })
+
+  it('keeps routine PR hosts focused while stable and scheduled lanes stay complete', () => {
+    const crossPlatform = workflow.jobs['cross-platform-test']
+    expect(crossPlatform.strategy?.matrix?.os).toEqual(['macos-14', 'windows-latest'])
+    const platformContracts = crossPlatform.steps?.find(
+      (step) => step.name === 'Run native platform contracts for routine integration PRs',
+    )
+    const fullBuild = crossPlatform.steps?.find(
+      (step) => step.name === 'Build complete workspace for stable and scheduled validation',
+    )
+    const fullTest = crossPlatform.steps?.find(
+      (step) => step.name === 'Run complete suite for stable and scheduled validation',
+    )
+
+    expect(platformContracts).toMatchObject({
+      if: "github.event_name == 'pull_request' && github.base_ref != 'master'",
+      run: 'pnpm test:platform-contracts',
+      'timeout-minutes': 8,
+    })
+    for (const step of [fullBuild, fullTest]) {
+      expect(step?.if).toBe("github.event_name != 'pull_request' || github.base_ref == 'master'")
+    }
+    expect(fullBuild?.run).toBe('pnpm build')
+    expect(fullTest?.run).toBe('pnpm test')
+    expect(packageJson.scripts['test:platform-contracts']).toContain('--project node')
+    expect(packageJson.scripts['test:platform-contracts']).toContain('packages/cli/src')
+    expect(packageJson.scripts['test:platform-contracts']).toContain('packages/guardian-runtime/src')
   })
 })

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -5,6 +5,7 @@ import YAML from 'yaml'
 
 interface WorkflowStep {
   name?: string
+  if?: string
   run?: string
   uses?: string
   with?: Record<string, unknown>
@@ -24,7 +25,13 @@ interface WorkflowJob {
 const root = resolve(import.meta.dirname, '..')
 const workflow = YAML.parse(
   readFileSync(resolve(root, '.github/workflows/cli-installer-smoke.yml'), 'utf8'),
-) as { jobs: Record<string, WorkflowJob> }
+) as {
+  on?: {
+    push?: { branches?: string[] }
+    pull_request?: { branches?: string[] }
+  }
+  jobs: Record<string, WorkflowJob>
+}
 
 function step(job: WorkflowJob, name: string): WorkflowStep {
   const found = job.steps?.find((candidate) => candidate.name === name)
@@ -33,6 +40,11 @@ function step(job: WorkflowJob, name: string): WorkflowStep {
 }
 
 describe('CLI installer dev publication workflow', () => {
+  it('owns every dev push as the only rolling publication lane', () => {
+    expect(workflow.on?.push?.branches).toEqual(['dev'])
+    expect(workflow.on?.pull_request?.branches).toEqual(expect.arrayContaining(['dev', 'master']))
+  })
+
   it('builds all four supported native targets with the pinned Bun version', () => {
     const build = workflow.jobs['build-dev-cli']
     expect(build.strategy?.matrix?.include).toEqual([
@@ -42,7 +54,19 @@ describe('CLI installer dev publication workflow', () => {
       { os: 'ubuntu-24.04-arm', platform: 'linux', arch: 'arm64' },
     ])
     expect(build.steps?.some((candidate) => candidate.uses === 'oven-sh/setup-bun@v2')).toBe(true)
-    expect(step(build, 'Build Alice and native CLI').run).toContain('build:bun-runtime:feasibility')
+    expect(step(build, 'Accept multiprocess recovery once per dev commit')).toMatchObject({
+      if: "matrix.platform == 'linux' && matrix.arch == 'x64'",
+      run: 'pnpm build:bun-runtime:feasibility',
+    })
+    expect(step(build, 'Build Alice server').run).toBe('pnpm build:server')
+    expect(step(build, 'Build native CLI').run).toBe('pnpm build:bun:release')
+    const stepNames = build.steps?.map((candidate) => candidate.name)
+    expect(stepNames?.indexOf('Build Alice server')).toBeLessThan(
+      stepNames?.indexOf('Accept multiprocess recovery once per dev commit') ?? -1,
+    )
+    expect(stepNames?.indexOf('Accept multiprocess recovery once per dev commit')).toBeLessThan(
+      stepNames?.indexOf('Build native CLI') ?? -1,
+    )
     expect(step(build, 'Preserve accepted dev candidate').with?.name).toBe(
       'dev-cli-${{ matrix.platform }}-${{ matrix.arch }}',
     )

--- a/scripts/desktop-upgrade-smoke-lib.mjs
+++ b/scripts/desktop-upgrade-smoke-lib.mjs
@@ -1,6 +1,106 @@
-import { resolve } from 'node:path'
+import { existsSync, lstatSync, readlinkSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
 export const DESKTOP_UPGRADE_RECEIPT_SCHEMA_VERSION = 1
+export const CHROMIUM_PROFILE_SINGLETON_NAMES = Object.freeze([
+  'SingletonLock',
+  'SingletonSocket',
+  'SingletonCookie',
+])
+
+export function chromiumProfileReleaseState(entries) {
+  const pending = entries
+    .filter((entry) => entry.present)
+    .map((entry) => {
+      const kind = entry.kind ? ` [${entry.kind}]` : ''
+      const target = entry.target ? ` -> ${entry.target}` : ''
+      const detail = entry.detail ? ` (${entry.detail})` : ''
+      return `${entry.name}${kind}${target}${detail}`
+    })
+  return { released: pending.length === 0, pending }
+}
+
+// Chromium's macOS singleton entries are symlinks. Their targets can disappear
+// before Chromium removes the profile entry itself, so existsSync() alone
+// would mistake the exact dangling-link restart race for a released profile.
+export function inspectChromiumProfileSingleton(profileRoot, name) {
+  const path = join(profileRoot, name)
+  try {
+    const stat = lstatSync(path)
+    if (stat.isSymbolicLink()) {
+      let target
+      try {
+        target = readlinkSync(path)
+      } catch (error) {
+        if (error?.code === 'ENOENT') return { name, present: false }
+        return {
+          name,
+          present: true,
+          kind: 'symlink',
+          detail: `readlink failed: ${error instanceof Error ? error.message : String(error)}`,
+        }
+      }
+      return {
+        name,
+        present: true,
+        kind: 'symlink',
+        target,
+        ...(!existsSync(path) ? { detail: 'dangling target' } : {}),
+      }
+    }
+    return {
+      name,
+      present: true,
+      kind: stat.isSocket() ? 'socket' : stat.isFile() ? 'file' : 'other',
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { name, present: false }
+    return {
+      name,
+      present: true,
+      kind: 'inspection-error',
+      detail: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export async function waitForChromiumProfileRelease(profileRoot, options = {}) {
+  const {
+    label = 'OpenAlice',
+    childExitCode = 'unknown',
+    childPid = '<unknown>',
+    timeoutMs = 10_000,
+    pollIntervalMs = 100,
+    inspect = inspectChromiumProfileSingleton,
+    now = Date.now,
+    sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms)),
+    log = console.log,
+  } = options
+  const startedAt = now()
+  const deadline = startedAt + timeoutMs
+  let lastState = { released: false, pending: [] }
+  let observedPending = false
+  while (true) {
+    lastState = chromiumProfileReleaseState(
+      CHROMIUM_PROFILE_SINGLETON_NAMES.map((name) => inspect(profileRoot, name)),
+    )
+    if (lastState.released) {
+      if (observedPending) {
+        log(`[desktop-upgrade] ${label} Chromium profile released after ${now() - startedAt}ms`)
+      }
+      return
+    }
+    observedPending = true
+    const remainingMs = deadline - now()
+    if (remainingMs <= 0) break
+    await sleep(Math.min(pollIntervalMs, remainingMs))
+  }
+  throw new Error(
+    `${label} exited ${childExitCode ?? 'unknown'} but Chromium profile remained claimed ` +
+    `after ${timeoutMs}ms (pid=${childPid ?? '<unknown>'}, profile=${profileRoot}): ` +
+    lastState.pending.join(', '),
+  )
+}
 
 export function versionFromTag(tag) {
   return typeof tag === 'string' ? tag.replace(/^v/, '') : ''

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -1,5 +1,6 @@
-import { resolve } from 'node:path'
-import { readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -8,9 +9,13 @@ import {
   buildUpgradeSeedExpression,
   buildUpgradeVerifyExpression,
   candidateDesktopAssetName,
+  CHROMIUM_PROFILE_SINGLETON_NAMES,
+  chromiumProfileReleaseState,
   desktopUpgradeWorkspaceTags,
+  inspectChromiumProfileSingleton,
   previousDesktopAssetName,
   selectPreviousDesktopTag,
+  waitForChromiumProfileRelease,
   windowsInstallerArgs,
 } from './desktop-upgrade-smoke-lib.mjs'
 
@@ -51,6 +56,113 @@ describe('desktop upgrade smoke planning', () => {
     })
     expect(tags.tag).toMatch(/^[a-z0-9][a-z0-9_-]{0,32}$/)
     expect(tags.postUpgradeTag).toMatch(/^[a-z0-9][a-z0-9_-]{0,32}$/)
+  })
+
+  it('requires every Chromium profile singleton entry to be absent', () => {
+    expect(CHROMIUM_PROFILE_SINGLETON_NAMES).toEqual([
+      'SingletonLock',
+      'SingletonSocket',
+      'SingletonCookie',
+    ])
+    expect(chromiumProfileReleaseState(
+      CHROMIUM_PROFILE_SINGLETON_NAMES.map((name) => ({ name, present: false })),
+    )).toEqual({ released: true, pending: [] })
+
+    expect(chromiumProfileReleaseState([
+      {
+        name: 'SingletonLock',
+        present: true,
+        kind: 'symlink',
+        target: 'runner.local-1234',
+        detail: 'dangling target',
+      },
+      { name: 'SingletonSocket', present: false },
+      { name: 'SingletonCookie', present: false },
+    ])).toEqual({
+      released: false,
+      pending: ['SingletonLock [symlink] -> runner.local-1234 (dangling target)'],
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'treats a real dangling singleton symlink as claimed until it is unlinked',
+    () => {
+      const profileRoot = mkdtempSync(join(tmpdir(), 'openalice-chromium-singleton-'))
+      const lockPath = join(profileRoot, 'SingletonLock')
+      try {
+        symlinkSync('runner.local-1234', lockPath)
+        expect(inspectChromiumProfileSingleton(profileRoot, 'SingletonLock')).toEqual({
+          name: 'SingletonLock',
+          present: true,
+          kind: 'symlink',
+          target: 'runner.local-1234',
+          detail: 'dangling target',
+        })
+
+        unlinkSync(lockPath)
+        expect(inspectChromiumProfileSingleton(profileRoot, 'SingletonLock')).toEqual({
+          name: 'SingletonLock',
+          present: false,
+        })
+      } finally {
+        rmSync(profileRoot, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it('polls until Chromium removes the profile claim', async () => {
+    let nowMs = 0
+    let lockPresent = true
+    const logs: string[] = []
+
+    await waitForChromiumProfileRelease('/tmp/released-profile', {
+      label: 'candidate restart 0.91.0',
+      timeoutMs: 500,
+      pollIntervalMs: 100,
+      now: () => nowMs,
+      sleep: async (ms: number) => {
+        nowMs += ms
+        lockPresent = false
+      },
+      inspect: (_profileRoot: string, name: string) => ({
+        name,
+        present: name === 'SingletonLock' && lockPresent,
+      }),
+      log: (message: string) => logs.push(message),
+    })
+
+    expect(nowMs).toBe(100)
+    expect(logs).toEqual([
+      '[desktop-upgrade] candidate restart 0.91.0 Chromium profile released after 100ms',
+    ])
+  })
+
+  it('fails at the bounded deadline with the remaining singleton details', async () => {
+    let nowMs = 0
+
+    await expect(waitForChromiumProfileRelease('/tmp/stuck-profile', {
+      label: 'candidate 0.91.0',
+      childExitCode: 0,
+      childPid: 4321,
+      timeoutMs: 250,
+      pollIntervalMs: 100,
+      now: () => nowMs,
+      sleep: async (ms: number) => { nowMs += ms },
+      inspect: (_profileRoot: string, name: string) => name === 'SingletonLock'
+        ? {
+            name,
+            present: true,
+            kind: 'symlink',
+            target: 'runner.local-4321',
+            detail: 'dangling target',
+          }
+        : { name, present: false },
+    })).rejects.toThrow(
+      'candidate 0.91.0 exited 0 but Chromium profile remained claimed after 250ms ' +
+      '(pid=4321, profile=/tmp/stuck-profile): ' +
+      'SingletonLock [symlink] -> runner.local-4321 (dangling target)',
+    )
+    expect(nowMs).toBe(250)
   })
 
   it('maps native release artifacts by host architecture', () => {

--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -28,6 +28,7 @@ import {
   previousDesktopAssetName,
   selectPreviousDesktopTag,
   versionFromTag,
+  waitForChromiumProfileRelease,
   windowsInstallerArgs,
 } from './desktop-upgrade-smoke-lib.mjs'
 import { packagedElectronExecutable } from './smoke-packaged-toolchain.mjs'
@@ -369,6 +370,13 @@ async function runRendererJourney({ executable, env, electronUserData, expressio
     client = null
     const exitCode = await waitForExit(child)
     if (exitCode !== 0) throw new Error(`${label} exited ${exitCode}`)
+    if (process.platform === 'darwin') {
+      await waitForChromiumProfileRelease(electronUserData, {
+        label,
+        childExitCode: child.exitCode,
+        childPid: child.pid,
+      })
+    }
     return result
   } catch (error) {
     client?.close()

--- a/scripts/pack-cli-npm-packages.spec.mjs
+++ b/scripts/pack-cli-npm-packages.spec.mjs
@@ -7,7 +7,13 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { packCliNpmPackages } from './pack-cli-npm-packages.mjs'
 
 const temporaryPaths = []
-const npmPackTimeoutMs = 30_000
+// This is an integration check around three real `npm pack` subprocesses. On
+// the two-core hosted Linux runner those subprocesses can be starved while the
+// rest of the 600+ file Vitest suite is active; the observed slow run still
+// completed successfully in about 69 seconds. Keep a test-local ceiling rather
+// than weakening the suite-wide timeout or misclassifying runner contention as
+// a packaging failure.
+const npmPackTimeoutMs = 90_000
 
 afterEach(async () => {
   await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))


### PR DESCRIPTION
## Summary

- leave dev pushes to the four-platform native CLI publication lane and sample the heavier multiprocess recovery once on Linux x64
- run the complete routine PR suite once on Ubuntu while macOS and Windows exercise focused native platform contracts; keep master, scheduled, manual, and stable lanes complete
- harden three observed hosted-runner flakes with local bounded contracts, including macOS Chromium profile release before Electron candidate restart
- document the local-Mac acceptance boundary and avoid adding another release provenance trust system

## Local verification

- npx tsc --noEmit
- pnpm test: 5,359 passed, 13 skipped
- pnpm test:platform-contracts: 774 passed, 6 skipped
- 44 focused workflow and desktop tests
- actionlint latest on both changed workflows
- build:server, build:bun-runtime:feasibility, build:bun:release
- unsigned local Electron cross-version and immediate-restart journey: all 11 receipt checks passed
