### PR TITLE
Prepare v0.91.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0-beta.1",
+  "version": "0.91.0-beta.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0-beta.1",
+  "version": "0.91.0-beta.2",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- set the root product version to `0.91.0-beta.2`
- set the native CLI product version to `0.91.0-beta.2`
- keep the complete diff limited to those two synchronized top-level version values

## Verification
- trusted-base classifier result: `exact beta release preparation 0.91.0-beta.1 -> 0.91.0-beta.2`
- `git diff --name-status origin/master...HEAD` contains only `package.json` and `packages/cli/package.json`
- `git diff --check origin/master...HEAD`
- exact release source was accepted through promotion PR #1291 and local packaged Workspace smoke before this metadata-only change

## Boundary touch
- release metadata only

## Non-goals
- no runtime, installer, packaging, dependency, lockfile, or workflow bytes change
- no tag or GitHub Release is created by this PR
- this version commit remains master-only and is not merged back into dev
