### PR TITLE
fix: make remote runtime state truthful

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -43,9 +43,12 @@ the durable truth after it changes. Git history is the archive.
 - [[plans/remote-project-fleet.md]] — Adds a machine-aware Supervisor fleet,
   remote AliceProject inventory/connection, and safe local-to-SSH project
   transfer for portable configuration and Workspaces while deliberately
-  excluding native/OpenAlice Session continuation state. The next increment
-  unifies controller/remote release negotiation and adds a consented Railway
-  redeploy adapter without background polling or SSH-owned installation.
+  excluding native/OpenAlice Session continuation state. The current
+  beta-blocking increment makes the attached browser truthful about remote
+  identity, Agent and Broker Pack capability, scheduled-work blockers,
+  reconnect recovery, and public Session titles. Controller/remote release
+  negotiation and a consented Railway redeploy adapter remain a separate
+  authority increment without background polling or SSH-owned installation.
 - [[plans/auto-prediction-harness.md]] — Auto Prediction Beta conversation
   Harness is in `dev`; managed AP/AQ Studio supervision, opaque routing, and
   embedded product surfaces are implemented. Shared verified/unverified source

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -166,6 +166,27 @@ release matrix as appropriate.
 
 ## UI Contract
 
+Alice is the readiness authority for every UI surface. `GET
+/api/trading/config/broker-packs` joins the persisted UTA configuration with
+the Broker Packs installed on the current Runtime and returns both engine-level
+`packs` and one exact `accounts` readiness row per configured UTA. A configured
+account and a loadable account are deliberately different states:
+
+- `ready` means the account's engine can be loaded on this Runtime;
+- `needs-install` and `needs-repair` keep the account visible but non-operational;
+- `unsupported-preset` preserves a legacy configuration without guessing an
+  engine;
+- a frontend that cannot read this contract fails closed as status unavailable
+  and offers Retry.
+
+This join is machine-local. AliceProject transfer preserves account
+configuration and historical snapshots, but it does not transfer replaceable
+`runtime/broker-packs/` payloads. A transferred account is therefore shown as
+"configured, support needed" until the destination Runtime installs or repairs
+its Pack. Discovery on mount, focus, visibility, or explicit Retry is cheap and
+read-only; it must never install a Pack, contact a broker, reconnect an account,
+or submit a trade.
+
 The Trading page owns three installation entry points:
 
 - broker creation stops before credentials and offers Install/Repair when the
@@ -177,6 +198,20 @@ The Trading page owns three installation entry points:
 
 Pack errors must be explicit and recoverable. Alice/Chat remains usable, UTA
 continues starting, and other installed broker engines remain independent.
+
+Trading, Portfolio, and UTA Detail consume the same account-readiness selector
+and interaction policy. When support is missing or broken they must not show a
+Live indicator, wait forever in a loading skeleton, poll account/sub-account/
+position/order/market-clock endpoints, or present Reconnect, Place Order, Close,
+or order deep links as usable actions. They instead offer Install, Repair, or
+Retry against the current Runtime. Installed Packs with an available update
+remain operational while Update is offered non-blockingly.
+
+`canTrade` is stricter than Pack readiness: the account must also be configured
+on, writable, running under `pro` trading mode, and report healthy, readable,
+trading-tier UTA health. A missing health row is not permission to trade.
+Historical snapshots may remain visible while live support is unavailable, but
+the UI must label them explicitly as stale/non-live.
 
 The v0.85.0-beta regression that established this contract is recorded in
 [[docs/incidents/2026-07-28-broker-pack-upgrade-gap.md]].

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -440,6 +440,18 @@ observable CLI round trip rather than only asserting that files exist. Docker
 build cache is shared infrastructure and is retained; only resources owned by
 the smoke are deleted. Use `--keep` or `--keep-image` for investigation.
 
+`pnpm test:remote:docker` is the corresponding disposable existing-host SSH
+journey. In addition to install, Server lifecycle, tunnel, TUI, and Project
+transfer acceptance, it exercises the layered-readiness contract without
+starting an Agent or contacting a broker: a temporary inert CLI shim must
+appear and disappear through cheap discovery while cached readiness follows
+the exact executable identity, and a transferred configured account whose
+machine-local Broker Pack is absent must remain visible as `needs-install` and
+non-operational. The fixture asserts that the shim was never executed and that
+no Pack installation or trading path ran. `--keep-container` preserves only
+the disposable fixture and prints its scratch SSH credentials for explicit
+investigation; the default path removes the container, owned image, and keys.
+
 Before a release, an operator can add a real multi-turn agent check with a
 credential already stored in the local Alice vault:
 

--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -441,6 +441,14 @@ Manager, Session spawn, and Session resume proceed through the selected native
 runtime without waiting for a probe. Onboarding, explicit Retry, and background
 health surfaces may probe and cache the result without becoming a launch gate.
 
+Readiness results are scoped to the executable identity that was probed. Every
+cheap runtime discovery compares installed state, resolved path, and a file
+fingerprint with that cached identity. Installing, removing, replacing, or
+rerouting a CLI invalidates the old probe result back to `unknown` (or
+`not_installed`). Returning focus to the UI refreshes inventory and the cached
+readiness snapshot with GET requests only; an explicit user action remains the
+only path that starts a headless readiness probe.
+
 Choosing an OpenAlice credential is an explicit override. A fresh Session may
 bind that vault reference without writing it into the Workspace or changing the
 runtime's global state. An absent choice means

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -486,8 +486,14 @@ containing only the validated SSH destination, SSH port, and remote loopback
 Runtime port. The Web UI consumes that fragment into tab-scoped session storage
 before rendering and immediately removes it from the address bar. Fragments are
 not sent in HTTP requests, so this context never becomes remote Runtime state or
-server log data. The global offline screen may use it to distinguish a broken
-SSH route from a local Runtime outage and show the exact endpoints to retry.
+server log data. The full client URL emitted by the CLI is the bootstrap
+authority; a same-tab reload retains that client-owned identity. A copied bare
+origin or unrelated tab has no authority to acquire it, and cross-tab
+persistence is not part of this phase. Both the healthy Settings/About surface
+and the global offline screen use the retained identity to show the SSH target,
+local tunnel endpoint, and remote Runtime endpoint. A remote/service-owned data
+home is described as belonging to that Runtime; the browser must not suggest
+local `openalice` or `pnpm` launch commands for it.
 
 ## Server Lifecycle
 
@@ -680,6 +686,15 @@ remote PTY and Agent TUI remain authoritative; the local xterm-compatible
 surface renders received terminal bytes. Shell, Claude Code, Codex, opencode,
 and Pi retain the same terminal semantics. WebPi remains an optional structured
 Pi surface, not a prerequisite or replacement for shell/TUI workflows.
+
+The browser's core health probe publishes a monotonic recovery generation only
+when Alice transitions from unavailable back to available. PTY views use that
+signal to re-attach the same Session after a recoverable tunnel/backend outage,
+including after their bounded exponential retry budget has expired. A stopped
+retry loop remains visibly closed with an explicit **Retry** action.
+Authentication failures, another controller's ownership, and a missing Session
+remain fatal to that attachment: recovery never implies takeover, Session
+recreation, or a new Agent Runtime.
 
 This path should be measured before adding a second terminal protocol. Relevant
 tests use controlled network conditions such as 20 ms, 80 ms, and 150 ms RTT,

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -295,7 +295,8 @@ by that Workspace; otherwise dispatch fails with an actionable message instead
 of mutating provider registration during a concurrent run.
 
 The Issue API also derives an `automationHealth` projection from these markers,
-the latest scheduled run, and the assignee's resume availability. It is not
+the latest scheduled run, the assignee's resume availability, and the effective
+Agent runtime installed on the current host. It is not
 persisted in markdown and does not create another Issue workflow status:
 
 - `not_started`, `due`, `running`, and `healthy` describe normal progress;
@@ -304,8 +305,11 @@ persisted in markdown and does not create another Issue workflow status:
   launcher suspension); this is operational interruption, not an agent-work failure;
 - `failed` retains a real timeout, launch error, runtime error, or non-zero
   process exit until a later success;
-- `blocked` means the schedule has no future fire, or an exact Session owner is
-  missing, retired, or not resumable;
+- `blocked` means the schedule has no future fire, an exact Session owner is
+  missing, retired, deleted, or not resumable, or the effective Agent runtime
+  is not installed. Runtime absence is exposed as the structured blocker
+  `agent_runtime_missing`; this read path performs only cheap executable
+  discovery and never starts a readiness probe or Agent;
 - `inactive` means Issue status `done`/`canceled` has stopped the schedule.
 
 Health measures scheduler fulfillment, not human attention. A successful run

--- a/packages/cli/src/internal-role-runtime.spec.ts
+++ b/packages/cli/src/internal-role-runtime.spec.ts
@@ -3,8 +3,11 @@ import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
+
+const cliBinPath = fileURLToPath(new URL('../bin/openalice-bun.ts', import.meta.url))
 
 // Each case starts a real TypeScript child process with its own 10-second
 // process ceiling. Windows hosted runners can need more than Vitest's default
@@ -16,7 +19,7 @@ describe('private Runtime role fencing', { timeout: 15_000 }, () => {
     const result = spawnSync(process.execPath, [
       '--import',
       'tsx',
-      'packages/cli/bin/openalice-bun.ts',
+      cliBinPath,
       '--internal-role',
       'connector',
     ], {
@@ -47,7 +50,7 @@ describe('private Runtime role fencing', { timeout: 15_000 }, () => {
     const result = spawnSync(process.execPath, [
       '--import',
       'tsx',
-      'packages/cli/bin/openalice-bun.ts',
+      cliBinPath,
       '--internal-role',
       'alice',
     ], {

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -876,6 +876,17 @@ with its Pack missing. The remaining Increment 8 acceptance item is a retained
 Railway long-outage journey on the released candidate; it intentionally stays
 open until beta3 replaces beta2 on that service.
 
+Increment 8 review follow-up (2026-09-01): a read-only recovery-state review
+found six races that isolated happy-path tests had missed. Broker readiness now
+invalidates old operational data on refresh failure or backend loss and reloads
+on backend recovery; Trading status/equity polling starts and stops with the
+same readable-account gate. Terminal retry history resets only after the
+authoritative `attached` frame, Agent inventory rediscovers on backend recovery,
+scheduled health reuses the assignee Session projection so a missing Workspace
+cannot appear ready, and in-flight Agent probes are shared only for the same
+executable path and fingerprint. Combined focused tests cover all six cases;
+the full repository/package and retained Railway gates remain below.
+
 Always:
 
 ```bash

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -19,6 +19,9 @@ Owner guides:
 - [[docs/data-locations.md]]
 - [[docs/workspace-lifecycle.md]]
 - [[docs/conversation-provenance.md]]
+- [[docs/model-semantics-and-runtime-injection.md]]
+- [[docs/workspace-issues-and-scheduling.md]]
+- [[docs/broker-packs.md]]
 - [[docs/managed-workspace-runtime.md]]
 - [[docs/development-workflow.md]]
 
@@ -50,6 +53,9 @@ machines:
   and remote Runtimes, so a current controller may deliberately advance an
   older remote while an older controller can never downgrade or mutate a newer
   remote;
+- keep the browser truthful after attaching to a remote Runtime: connection,
+  AliceProject authority, Agent availability, Broker Pack availability, and
+  recovery state remain distinct instead of collapsing into one green status;
 - deliberately exclude native Agent conversations and OpenAlice Session
   continuation state, so the remote AliceProject starts with zero resumable
   Sessions while retaining its Workspace repositories and Workspace ids.
@@ -478,6 +484,54 @@ correctly recognized `Lifecycle: Railway (dev channel)` and planned a tunnel
 only. The unified relation must make the former `controller-behind` or
 `channel-conflict`, never an update plan.
 
+## Browser Remote Readiness and Recovery
+
+Remote readiness is a layered projection, not one `remoteReady` boolean:
+
+| Layer | Authority | User-visible meaning |
+|---|---|---|
+| Connection | Browser connection context plus backend auth probe | The local page can currently reach this remote OpenAlice Runtime. |
+| Environment | Version info, AliceProject identity, and deployment authority | Which Project and release are running, and whether CLI, desktop, or a deployment service owns lifecycle and updates. |
+| Agent capability | Fresh executable discovery plus an optional explicit readiness probe | A particular native Agent Runtime is installed; separately, whether the user chose to run a potentially credentialed probe. |
+| Broker capability | Alice-owned account configuration joined with machine-local Broker Pack status | A configured account has the local integration required to become operational on this server. |
+
+Rules:
+
+- A missing Agent Runtime or Broker Pack does not make the SSH tunnel or core
+  OpenAlice Runtime unhealthy. It blocks only the schedule, Session launch,
+  account read, reconnect, or trading action that depends on that capability.
+- Cheap rediscovery may run on focus, visibility restoration, and backend
+  recovery. It must never silently run a native Agent, test credentials,
+  install software, contact a broker, or submit an order.
+- Fresh executable presence and path always outrank a cached probe row. When an
+  executable appears, disappears, or moves, the active-probe result becomes
+  `unknown` until the user explicitly checks it.
+- Scheduled Issue health resolves the effective Agent first. A missing exact
+  Session Runtime or fresh-run override is `blocked` with a stable reason code,
+  not `healthy` or `not_started`; installation makes the read-side projection
+  recover without rewriting the Issue.
+- A transferred account whose Pack is absent is "configured, support needed",
+  never "no account" and never Live. Historical snapshots may remain visible
+  only when clearly marked stale. Reconnect, order entry, position close, and
+  deep-linked order forms stay gated until Pack, account reachability,
+  permissions, and trading mode all allow the action.
+- Healthy browser chrome shows the SSH target, local tunnel, remote Runtime
+  endpoint, current AliceProject, and lifecycle/update owner. A Railway-owned
+  Data Home must not recommend local `openalice start` or `pnpm dev` commands.
+- The full CLI-issued client URL is the authority for establishing browser-side
+  SSH identity; same-tab reload must retain it. A scrubbed bare origin cannot
+  be asserted as a particular SSH target unless a bounded, backend-validated
+  origin context exists. Stale target labels are worse than generic recovery
+  guidance.
+- Recoverable transport loss keeps the page mounted. Backend recovery advances
+  a shared generation and causes stale domain reads and recoverable terminal
+  sockets to retry. Authentication, ownership conflict, and terminal-not-found
+  close codes remain explicit and never auto-take over or create a replacement.
+- Public Session and Automation titles use business provenance already present
+  in Issue/conversation/headless metadata. Delivered reconstruction wrappers,
+  raw target JSON, and scheduled instructions remain diagnostic detail and are
+  never the collapsed-row or Session display name.
+
 ## Ordered Delivery
 
 ### Increment 0 — contract and plan
@@ -643,6 +697,42 @@ only. The unified relation must make the former `controller-behind` or
 - [ ] Update `docs/remote-access.md`, `docs/docker-deployment.md`, CLI help, and
   Supervisor wording with the shipped apply authority and downgrade rules.
 
+### Increment 8 — remote readiness and browser truth
+
+This is the current beta-blocking increment and may land before the remaining
+Increment 7 release-apply work. It does not grant the SSH path deployment
+authority or broaden Agent/broker ownership.
+
+- [ ] Reconcile Agent readiness from fresh PATH discovery, expose a cheap
+  rediscovery action distinct from active probing, and refresh on focus,
+  visibility restoration, and backend recovery without spawning an Agent.
+- [ ] Project effective Agent availability into scheduled Issue health with a
+  stable `agent_runtime_missing` blocker and recover it after installation.
+- [ ] Join configured trading accounts to Broker Pack readiness in one
+  Alice-owned contract and one UI domain hook. Propagate the result through
+  Trading, Portfolio, account detail, reconnect, order entry, and position-close
+  actions; preserve configured disabled state and never contact a real broker in
+  acceptance.
+- [ ] Add healthy remote identity and deployment-owned Data Home guidance.
+  Preserve full-client-URL and same-tab reload identity, and make any cross-tab
+  reuse bounded and backend-validated before presenting it as current truth.
+- [ ] Make recoverable terminal reconnect survive outages beyond the current
+  retry budget, add an explicit retry for closed terminals, and retain fatal
+  auth/ownership/not-found behavior.
+- [ ] Reuse the existing Issue/Headless Session presentation projection across
+  Workspaces and Automation, including historical read-side presentation and
+  "Open as session". Unify sidebar/card timestamps on latest activity rather
+  than unlabeled Workspace creation time.
+- [ ] Add an authoritative Issue assignee-Session projection so a newly claimed
+  or cross-Workspace owner cannot coexist with a stale "Session is no longer
+  available" warning.
+- [ ] Extend the Docker SSH journey with dynamic free Runtime discovery,
+  missing-Pack account projection, complete client URL retention, and a real
+  shell PTY tunnel reconnect. Cover the longer logical retry window with fake
+  timers and run one retained Railway long-outage journey before beta release.
+- [ ] Update the remote access, Agent/runtime, scheduling, Broker Pack, and
+  Docker owner guides with the shipped layered-readiness contract.
+
 ## Verification Matrix
 
 Increment 1 progress (2026-08-23): the focused Machine specs (16 tests), CLI
@@ -755,6 +845,24 @@ and its post-redeploy evidence, but does not complete Increment 7: the typed
 release relation, consented Railway adapter, controller-behind guard, and TUI
 presentation remain implementation work.
 
+Increment 8 discovery evidence (2026-09-01): a real retained-Railway browser
+journey proved that the core SSH/backend recovery path survives a short outage,
+but optional capability and presentation state is not yet truthful. Pi appeared
+only after an explicit probe because cached `not_installed` overrode fresh PATH
+discovery; four Grok schedules said their schedule was valid while Grok was
+missing; six configured trading accounts collapsed to "No trading accounts
+connected", while Alpaca still showed a green indicator, stale equity, enabled
+Reconnect, and an order-entry dialog despite its missing Pack. Healthy Settings
+omitted the SSH target and advised local start commands for a Railway-owned
+Data Home. A copied scrubbed URL lost remote recovery identity, while the full
+CLI-issued URL retained exact target and port guidance. Workspaces and
+Automation exposed reconstruction wrappers/raw target JSON as public titles,
+and one polled Issue owner briefly coexisted with a stale unavailable-Session
+directory. A deliberate tunnel cut restored both open pages automatically;
+the remaining terminal retry budget beyond roughly 85 seconds is a separate
+component recovery gap. No Agent was started, no Connector message was sent,
+and no broker call or order submission occurred.
+
 Always:
 
 ```bash
@@ -831,6 +939,16 @@ normal `~/.openalice`.
   machine-bound data with a distinct remote key.
 - Exact-Session scheduled Issues are never silently reassigned; the chosen
   policy is visible in plan and result.
+- Missing Agent Runtimes and Broker Packs block only their dependent features,
+  recover through cheap rediscovery, and never appear as a healthy schedule,
+  absent configured account, Live broker, or available trading action.
+- Healthy and offline browser states identify a CLI-issued SSH attachment
+  truthfully; deployment-owned homes never receive local lifecycle guidance.
+- Recoverable SSH outages restore domain reads and terminal sockets without
+  starting a replacement Agent, taking ownership, or losing the current page.
+- Workspaces, Sessions, and Automation use business-facing provenance for
+  public titles and latest activity; internal reconstruction prompts and raw
+  target JSON remain diagnostic-only.
 - Interrupted or failed transfer never publishes a partial home, overwrites an
   existing project, mutates an unrelated path, or changes source project data.
 - TUI narrow/wide layouts, scrolling, cancellation, disconnect, resize, and

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -703,34 +703,34 @@ This is the current beta-blocking increment and may land before the remaining
 Increment 7 release-apply work. It does not grant the SSH path deployment
 authority or broaden Agent/broker ownership.
 
-- [ ] Reconcile Agent readiness from fresh PATH discovery, expose a cheap
+- [x] Reconcile Agent readiness from fresh PATH discovery, expose a cheap
   rediscovery action distinct from active probing, and refresh on focus,
   visibility restoration, and backend recovery without spawning an Agent.
-- [ ] Project effective Agent availability into scheduled Issue health with a
+- [x] Project effective Agent availability into scheduled Issue health with a
   stable `agent_runtime_missing` blocker and recover it after installation.
-- [ ] Join configured trading accounts to Broker Pack readiness in one
+- [x] Join configured trading accounts to Broker Pack readiness in one
   Alice-owned contract and one UI domain hook. Propagate the result through
   Trading, Portfolio, account detail, reconnect, order entry, and position-close
   actions; preserve configured disabled state and never contact a real broker in
   acceptance.
-- [ ] Add healthy remote identity and deployment-owned Data Home guidance.
+- [x] Add healthy remote identity and deployment-owned Data Home guidance.
   Preserve full-client-URL and same-tab reload identity, and make any cross-tab
   reuse bounded and backend-validated before presenting it as current truth.
-- [ ] Make recoverable terminal reconnect survive outages beyond the current
+- [x] Make recoverable terminal reconnect survive outages beyond the current
   retry budget, add an explicit retry for closed terminals, and retain fatal
   auth/ownership/not-found behavior.
-- [ ] Reuse the existing Issue/Headless Session presentation projection across
+- [x] Reuse the existing Issue/Headless Session presentation projection across
   Workspaces and Automation, including historical read-side presentation and
   "Open as session". Unify sidebar/card timestamps on latest activity rather
   than unlabeled Workspace creation time.
-- [ ] Add an authoritative Issue assignee-Session projection so a newly claimed
+- [x] Add an authoritative Issue assignee-Session projection so a newly claimed
   or cross-Workspace owner cannot coexist with a stale "Session is no longer
   available" warning.
 - [ ] Extend the Docker SSH journey with dynamic free Runtime discovery,
   missing-Pack account projection, complete client URL retention, and a real
   shell PTY tunnel reconnect. Cover the longer logical retry window with fake
   timers and run one retained Railway long-outage journey before beta release.
-- [ ] Update the remote access, Agent/runtime, scheduling, Broker Pack, and
+- [x] Update the remote access, Agent/runtime, scheduling, Broker Pack, and
   Docker owner guides with the shipped layered-readiness contract.
 
 ## Verification Matrix
@@ -862,6 +862,19 @@ directory. A deliberate tunnel cut restored both open pages automatically;
 the remaining terminal retry budget beyond roughly 85 seconds is a separate
 component recovery gap. No Agent was started, no Connector message was sent,
 and no broker call or order submission occurred.
+
+Increment 8 implementation evidence (2026-09-01): layered Agent, Issue,
+Session, connection, Terminal, and per-account Broker Pack projections now use
+their owning authorities and fail closed only on dependent actions. Targeted
+tests cover binary-identity cache invalidation, GET-only rediscovery,
+structured schedule blockers, authoritative cross-Workspace owners, public
+title projection, long terminal retry exhaustion, and trading-mode/health/write
+gates. The disposable OrbStack Linux arm64 SSH journey passed both its ordinary
+and full TUI paths: an inert Pi shim was discovered and removed without ever
+executing, and a migrated Alpaca account stayed configured but non-operational
+with its Pack missing. The remaining Increment 8 acceptance item is a retained
+Railway long-outage journey on the released candidate; it intentionally stays
+open until beta3 replaces beta2 on that service.
 
 Always:
 

--- a/scripts/remote-ssh-smoke-options.mjs
+++ b/scripts/remote-ssh-smoke-options.mjs
@@ -1,0 +1,51 @@
+export function parseRemoteSshSmokeOptions(argv) {
+  const options = {
+    help: false,
+    image: undefined,
+    keepContainer: false,
+    keepImage: false,
+    skipBuild: false,
+    skipTui: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') continue
+    if (arg === '--help' || arg === '-h') {
+      options.help = true
+      continue
+    }
+    if (arg === '--keep-image') {
+      options.keepImage = true
+      continue
+    }
+    if (arg === '--keep-container') {
+      options.keepContainer = true
+      continue
+    }
+    if (arg === '--skip-tui') {
+      options.skipTui = true
+      continue
+    }
+    if (arg === '--skip-build') {
+      options.skipBuild = true
+      continue
+    }
+    if (arg === '--image') {
+      const value = argv[index + 1]
+      if (!value || value === '--' || value.startsWith('-')) {
+        throw new Error('--image requires a Docker image name')
+      }
+      options.image = value
+      index += 1
+      continue
+    }
+    throw new Error(`unknown option: ${arg}`)
+  }
+
+  if (options.skipBuild && !options.image) {
+    throw new Error('--skip-build requires --image <name>')
+  }
+
+  return options
+}

--- a/scripts/remote-ssh-smoke-options.spec.mjs
+++ b/scripts/remote-ssh-smoke-options.spec.mjs
@@ -31,6 +31,11 @@ describe('parseRemoteSshSmokeOptions', () => {
       .toThrow('--skip-build requires --image <name>')
   })
 
+  it('rejects a missing image value before consuming the next option', () => {
+    expect(() => parseRemoteSshSmokeOptions(['--image', '--skip-tui']))
+      .toThrow('--image requires a Docker image name')
+  })
+
   it('rejects unknown options', () => {
     expect(() => parseRemoteSshSmokeOptions(['--wat']))
       .toThrow('unknown option: --wat')

--- a/scripts/remote-ssh-smoke-options.spec.mjs
+++ b/scripts/remote-ssh-smoke-options.spec.mjs
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseRemoteSshSmokeOptions } from './remote-ssh-smoke-options.mjs'
+
+describe('parseRemoteSshSmokeOptions', () => {
+  it('accepts pnpm argument separators', () => {
+    expect(parseRemoteSshSmokeOptions(['--', '--skip-tui'])).toEqual({
+      help: false,
+      image: undefined,
+      keepContainer: false,
+      keepImage: false,
+      skipBuild: false,
+      skipTui: true,
+    })
+  })
+
+  it('supports building and reusing a named image', () => {
+    expect(parseRemoteSshSmokeOptions([
+      '--image', 'openalice-remote-smoke:dev',
+      '--skip-build',
+      '--keep-container',
+    ])).toEqual(expect.objectContaining({
+      image: 'openalice-remote-smoke:dev',
+      skipBuild: true,
+      keepContainer: true,
+    }))
+  })
+
+  it('rejects skip-build without an explicit image', () => {
+    expect(() => parseRemoteSshSmokeOptions(['--skip-build']))
+      .toThrow('--skip-build requires --image <name>')
+  })
+
+  it('rejects unknown options', () => {
+    expect(() => parseRemoteSshSmokeOptions(['--wat']))
+      .toThrow('unknown option: --wat')
+  })
+})

--- a/scripts/remote-ssh-smoke-targets.mjs
+++ b/scripts/remote-ssh-smoke-targets.mjs
@@ -1,0 +1,78 @@
+function runtimeRow(snapshot, agent) {
+  const row = snapshot?.agents?.[agent]
+  if (!row || typeof row !== 'object') {
+    throw new Error(`Remote Runtime readiness did not include ${agent}: ${JSON.stringify(snapshot)}`)
+  }
+  return row
+}
+
+function catalogRow(catalog, agent) {
+  const row = catalog?.agents?.find?.((candidate) => candidate?.id === agent)
+  if (!row || typeof row !== 'object') {
+    throw new Error(`Remote Agent catalog did not include ${agent}: ${JSON.stringify(catalog)}`)
+  }
+  return row
+}
+
+export function requireMissingAgentRuntime({ readiness, catalog }, agent) {
+  const readinessRow = runtimeRow(readiness, agent)
+  const detected = catalogRow(catalog, agent)
+  if (
+    readinessRow.installed !== false
+    || readinessRow.status !== 'not_installed'
+    || readinessRow.ready !== false
+    || detected.installed !== false
+  ) {
+    throw new Error(`Remote ${agent} Runtime was not reported missing: ${JSON.stringify({ readinessRow, detected })}`)
+  }
+  return { readinessRow, detected }
+}
+
+export function requireDiscoveredAgentRuntime({ readiness, catalog }, agent, expectedPath) {
+  const readinessRow = runtimeRow(readiness, agent)
+  const detected = catalogRow(catalog, agent)
+  if (
+    readinessRow.installed !== true
+    || readinessRow.status !== 'unknown'
+    || readinessRow.ready !== false
+    || readinessRow.checkedAt !== null
+    || detected.installed !== true
+    || detected.binPath !== expectedPath
+    || typeof detected.fingerprint !== 'string'
+    || detected.fingerprint.length === 0
+    || readinessRow.fingerprint !== detected.fingerprint
+  ) {
+    throw new Error(`Remote ${agent} Runtime discovery did not retire its cached missing state: ${JSON.stringify({ readinessRow, detected })}`)
+  }
+  return { readinessRow, detected }
+}
+
+export function requireBrokerAccountNeedsInstall(payload, expected) {
+  const account = payload?.accounts?.find?.((candidate) => candidate?.accountId === expected.accountId)
+  if (!account || typeof account !== 'object') {
+    throw new Error(`Broker Pack readiness did not include account ${expected.accountId}: ${JSON.stringify(payload)}`)
+  }
+  if (
+    account.presetId !== expected.presetId
+    || account.engine !== expected.engine
+    || account.configuredEnabled !== true
+    || account.state !== 'needs-install'
+    || account.operational !== false
+    || account.action !== 'install'
+  ) {
+    throw new Error(`Broker account ${expected.accountId} did not fail closed on its missing Pack: ${JSON.stringify(account)}`)
+  }
+
+  const pack = payload?.packs?.find?.((candidate) => candidate?.engine === expected.engine)
+  if (
+    !pack
+    || typeof pack !== 'object'
+    || pack.installed !== false
+    || pack.source !== 'missing'
+    || !Array.isArray(pack.requiredBy)
+    || !pack.requiredBy.includes(account.label)
+  ) {
+    throw new Error(`Missing ${expected.engine} Pack did not name its dependent account: ${JSON.stringify(pack)}`)
+  }
+  return { account, pack }
+}

--- a/scripts/remote-ssh-smoke-targets.spec.mjs
+++ b/scripts/remote-ssh-smoke-targets.spec.mjs
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  requireBrokerAccountNeedsInstall,
+  requireDiscoveredAgentRuntime,
+  requireMissingAgentRuntime,
+} from './remote-ssh-smoke-targets.mjs'
+
+describe('remote SSH smoke target assertions', () => {
+  const missingRuntime = {
+    readiness: {
+      agents: {
+        pi: { installed: false, status: 'not_installed', ready: false, fingerprint: null },
+      },
+    },
+    catalog: {
+      agents: [{ id: 'pi', installed: false, binPath: null, fingerprint: null }],
+    },
+  }
+
+  it('accepts a missing Runtime without probing it', () => {
+    expect(requireMissingAgentRuntime(missingRuntime, 'pi').readinessRow.status)
+      .toBe('not_installed')
+  })
+
+  it('requires fresh discovery to replace a cached missing Runtime', () => {
+    const discovered = {
+      readiness: {
+        agents: {
+          pi: {
+            installed: true,
+            status: 'unknown',
+            ready: false,
+            checkedAt: null,
+            fingerprint: 'shim-v1',
+          },
+        },
+      },
+      catalog: {
+        agents: [{
+          id: 'pi',
+          installed: true,
+          binPath: '/usr/local/bin/pi',
+          fingerprint: 'shim-v1',
+        }],
+      },
+    }
+    expect(requireDiscoveredAgentRuntime(discovered, 'pi', '/usr/local/bin/pi').detected.fingerprint)
+      .toBe('shim-v1')
+    expect(() => requireDiscoveredAgentRuntime({
+      ...discovered,
+      readiness: { agents: { pi: { ...discovered.readiness.agents.pi, status: 'not_installed' } } },
+    }, 'pi', '/usr/local/bin/pi')).toThrow('cached missing state')
+  })
+
+  it('requires missing Broker Packs to block each configured account', () => {
+    const payload = {
+      packs: [{
+        engine: 'alpaca',
+        installed: false,
+        source: 'missing',
+        requiredBy: ['Paper'],
+      }],
+      accounts: [{
+        accountId: 'paper',
+        label: 'Paper',
+        presetId: 'alpaca',
+        configuredEnabled: true,
+        engine: 'alpaca',
+        state: 'needs-install',
+        operational: false,
+        action: 'install',
+      }],
+    }
+    expect(requireBrokerAccountNeedsInstall(payload, {
+      accountId: 'paper',
+      presetId: 'alpaca',
+      engine: 'alpaca',
+    }).account.operational).toBe(false)
+    expect(() => requireBrokerAccountNeedsInstall({
+      ...payload,
+      accounts: [{ ...payload.accounts[0], operational: true }],
+    }, {
+      accountId: 'paper',
+      presetId: 'alpaca',
+      engine: 'alpaca',
+    })).toThrow('fail closed')
+  })
+})

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -11,6 +11,11 @@ import { planProjectTransfer } from '../packages/cli/src/project-transfer.ts'
 import { sealProjectTransferJson } from '../packages/cli/src/project-transfer-secrets.ts'
 import { writeProjectTransferStream } from '../packages/cli/src/project-transfer-stream.ts'
 import { parseRemoteSshSmokeOptions } from './remote-ssh-smoke-options.mjs'
+import {
+  requireBrokerAccountNeedsInstall,
+  requireDiscoveredAgentRuntime,
+  requireMissingAgentRuntime,
+} from './remote-ssh-smoke-targets.mjs'
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url))
 const cliEntry = join(repoRoot, 'packages/cli/bin/openalice.ts')
@@ -34,8 +39,9 @@ if (options.help) {
 
 Builds a clean local SSH host, serves the real OpenAlice installer inside that
 host, and exercises plan, install, detached Server start, browser tunnel,
-disconnect persistence, reconnect, structured stop, and absent status. This is
-the clean Linux acceptance gate used by the CLI installer workflow.
+dynamic Agent discovery, disconnect persistence, reconnect, structured stop,
+AliceProject transfer, and missing Broker Pack readiness. This is the clean
+Linux acceptance gate used by the CLI installer workflow.
 
 Options:
   --keep-image      Preserve the temporary Docker image
@@ -140,6 +146,9 @@ try {
   if (running.provider?.kind !== 'bun') {
     throw new Error(`Remote Server did not report the Bun provider: ${JSON.stringify(running.provider)}`)
   }
+
+  console.log('[remote-ssh-smoke] checking dynamic Agent Runtime discovery without a probe')
+  await verifyDynamicAgentRuntimeDiscovery(container, remoteTarget, smokeEnv)
 
   console.log('[remote-ssh-smoke] registering the host and reading aggregate AliceProject inventory')
   run('ssh', [remoteTarget,
@@ -303,6 +312,17 @@ try {
   if (migratedRuntimeClass !== 'running') {
     throw new Error(`Transferred AliceProject did not start: ${JSON.stringify(migratedStatus)}`)
   }
+  console.log('[remote-ssh-smoke] checking migrated account readiness without loading a Broker Pack')
+  const migratedWebEndpoint = webEndpointFromStatus(migratedStatus)
+  const brokerPackReadiness = remoteJson(remoteTarget, smokeEnv, [
+    'curl --fail --silent --show-error',
+    shellQuote(`${migratedWebEndpoint}/api/trading/config/broker-packs`),
+  ].join(' '))
+  requireBrokerAccountNeedsInstall(brokerPackReadiness, {
+    accountId: 'paper',
+    presetId: 'alpaca',
+    engine: 'alpaca',
+  })
   run('ssh', [remoteTarget,
     '"$HOME/.openalice/bin/openalice" down --project migrated --wait 15 >/tmp/migrated-down.log',
   ], { env: smokeEnv })
@@ -341,7 +361,15 @@ async function prepareTransferSource(home) {
     providerKeys: { fmp: 'synthetic-provider-transfer-secret' },
   }, null, 2)}\n`)
   await sealProjectTransferJson(home, join('data', 'config', 'accounts.json'), [
-    { id: 'paper', presetId: 'alpaca-paper', presetConfig: { apiKey: 'synthetic-broker-transfer-secret' } },
+    {
+      id: 'paper',
+      presetId: 'alpaca',
+      presetConfig: {
+        mode: 'paper',
+        apiKey: 'synthetic-broker-transfer-key',
+        apiSecret: 'synthetic-broker-transfer-secret',
+      },
+    },
   ])
   await sealProjectTransferJson(home, join('data', 'config', 'connectors.json'), {
     version: 1,
@@ -510,6 +538,51 @@ async function attachAndProbe(target, env, remoteArgs) {
   }
 }
 
+async function verifyDynamicAgentRuntimeDiscovery(containerId, target, env) {
+  const agent = 'pi'
+  const shimPath = '/usr/local/bin/pi'
+  const executionMarker = '/tmp/openalice-remote-smoke-agent-shim-executed'
+  const tunnel = await startTunnel(target, env, ['--no-open', '--wait', '30'])
+  try {
+    const missingReadiness = await fetchRemoteJson(tunnel.origin, '/api/workspaces/agent-runtime-readiness')
+    const missingCatalog = await fetchRemoteJson(tunnel.origin, '/api/workspaces/agents')
+    requireMissingAgentRuntime({ readiness: missingReadiness, catalog: missingCatalog }, agent)
+
+    run('docker', ['exec', containerId, 'sh', '-c', [
+      'set -eu',
+      `rm -f ${executionMarker}`,
+      `printf '%s\\n' '#!/bin/sh' 'touch ${executionMarker}' 'exit 97' > ${shimPath}`,
+      `chmod 0755 ${shimPath}`,
+    ].join('; ')])
+
+    const discoveredCatalog = await fetchRemoteJson(tunnel.origin, '/api/workspaces/agents')
+    const discoveredReadiness = await fetchRemoteJson(tunnel.origin, '/api/workspaces/agent-runtime-readiness')
+    requireDiscoveredAgentRuntime({
+      readiness: discoveredReadiness,
+      catalog: discoveredCatalog,
+    }, agent, shimPath)
+    run('docker', ['exec', containerId, 'test', '!', '-e', executionMarker])
+
+    run('docker', ['exec', containerId, 'rm', '-f', shimPath])
+    const removedReadiness = await fetchRemoteJson(tunnel.origin, '/api/workspaces/agent-runtime-readiness')
+    const removedCatalog = await fetchRemoteJson(tunnel.origin, '/api/workspaces/agents')
+    requireMissingAgentRuntime({ readiness: removedReadiness, catalog: removedCatalog }, agent)
+    run('docker', ['exec', containerId, 'test', '!', '-e', executionMarker])
+  } finally {
+    run('docker', ['exec', containerId, 'rm', '-f', shimPath, executionMarker], { allowFailure: true })
+    await tunnel.close()
+  }
+}
+
+async function fetchRemoteJson(origin, path) {
+  const response = await fetch(`${origin}${path}`, { signal: AbortSignal.timeout(5_000) })
+  const body = await response.json()
+  if (!response.ok) {
+    throw new Error(`Remote Runtime ${path} returned ${response.status}: ${JSON.stringify(body)}`)
+  }
+  return body
+}
+
 async function startTunnel(target, env, remoteArgs) {
   const child = spawn(process.execPath, [cliEntry, 'remote', target, ...remoteArgs], {
     cwd: repoRoot,
@@ -577,6 +650,27 @@ function requireRemoteClientUrl(value, target) {
   ) {
     throw new Error(`Remote smoke client URL lost its connection identity: ${value}`)
   }
+}
+
+function webEndpointFromStatus(status) {
+  const candidates = [
+    status?.result?.status?.endpoints?.web,
+    status?.runtime?.endpoints?.web,
+    status?.status?.endpoints?.web,
+    status?.endpoints?.web,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const parsed = new URL(candidate)
+    if (
+      parsed.protocol === 'http:'
+      && parsed.hostname === '127.0.0.1'
+      && /^\d+$/.test(parsed.port)
+    ) {
+      return parsed.origin
+    }
+  }
+  throw new Error(`Remote Runtime status did not expose a safe loopback Web endpoint: ${JSON.stringify(status)}`)
 }
 
 function waitForExit(child, timeoutMs) {

--- a/scripts/remote-ssh-smoke.mjs
+++ b/scripts/remote-ssh-smoke.mjs
@@ -10,21 +10,27 @@ import { writeAliceProjectProductStamp } from '../packages/cli/src/alice-project
 import { planProjectTransfer } from '../packages/cli/src/project-transfer.ts'
 import { sealProjectTransferJson } from '../packages/cli/src/project-transfer-secrets.ts'
 import { writeProjectTransferStream } from '../packages/cli/src/project-transfer-stream.ts'
+import { parseRemoteSshSmokeOptions } from './remote-ssh-smoke-options.mjs'
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url))
 const cliEntry = join(repoRoot, 'packages/cli/bin/openalice.ts')
 const suffix = `${process.pid}-${Date.now().toString(36)}`
-const image = `openalice-remote-smoke:${suffix}`
-const args = process.argv.slice(2)
-const keepImage = args.includes('--keep-image')
-const keepContainer = args.includes('--keep-container')
-const skipTui = args.includes('--skip-tui')
+let options
+try {
+  options = parseRemoteSshSmokeOptions(process.argv.slice(2))
+} catch (error) {
+  console.error(`remote docker smoke: ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+}
+const image = options.image ?? `openalice-remote-smoke:${suffix}`
+const { keepImage, keepContainer, skipBuild, skipTui } = options
 let imageBuilt = false
 let container = ''
 let scratch = ''
 
-if (args.includes('--help') || args.includes('-h')) {
+if (options.help) {
   console.log(`Usage: pnpm test:remote:docker [--keep-image] [--keep-container]
+  [--image <name> [--skip-build]] [--skip-tui]
 
 Builds a clean local SSH host, serves the real OpenAlice installer inside that
 host, and exercises plan, install, detached Server start, browser tunnel,
@@ -34,20 +40,12 @@ the clean Linux acceptance gate used by the CLI installer workflow.
 Options:
   --keep-image      Preserve the temporary Docker image
   --keep-container  Preserve the running fixture container (also keeps image)
+  --image <name>    Build with this image name, or select it with --skip-build
+  --skip-build      Reuse --image instead of rebuilding the fixture
   --skip-tui        Skip the dependency-backed interactive TUI journey
   -h, --help        Show this help
 `)
   process.exit(0)
-}
-
-const unknownArgs = args.filter((arg) => ![
-  '--keep-image',
-  '--keep-container',
-  '--skip-tui',
-].includes(arg))
-if (unknownArgs.length > 0) {
-  console.error(`remote docker smoke: unknown option: ${unknownArgs[0]}`)
-  process.exit(1)
 }
 
 try {
@@ -55,14 +53,19 @@ try {
   const keyPath = join(scratch, 'id_ed25519')
   run('ssh-keygen', ['-q', '-t', 'ed25519', '-N', '', '-f', keyPath])
 
-  console.log(`[remote-ssh-smoke] building ${image}`)
-  run('docker', [
-    'build',
-    '--file', 'scripts/remote-smoke/Dockerfile',
-    '--tag', image,
-    '.',
-  ], { cwd: repoRoot, inherit: true })
-  imageBuilt = true
+  if (skipBuild) {
+    console.log(`[remote-ssh-smoke] reusing ${image}`)
+    run('docker', ['image', 'inspect', image])
+  } else {
+    console.log(`[remote-ssh-smoke] building ${image}`)
+    run('docker', [
+      'build',
+      '--file', 'scripts/remote-smoke/Dockerfile',
+      '--tag', image,
+      '.',
+    ], { cwd: repoRoot, inherit: true })
+    imageBuilt = true
+  }
 
   container = run('docker', [
     'run', '--detach', '--rm',
@@ -124,6 +127,7 @@ try {
   const firstTunnelUrl = await attachAndProbe(remoteTarget, smokeEnv, [
     '--yes', '--no-open', '--wait', '30',
   ])
+  requireRemoteClientUrl(firstTunnelUrl, remoteTarget)
   const running = remoteJson(remoteTarget, smokeEnv, '"$HOME/.openalice/bin/openalice" server status --json')
   if (running.class !== 'running' || running.owner?.surface !== 'cli-server') {
     throw new Error(`Remote Server did not survive tunnel disconnect: ${JSON.stringify(running)}`)
@@ -318,7 +322,11 @@ try {
   } else if (imageBuilt) {
     run('docker', ['image', 'rm', '--force', image], { allowFailure: true, inherit: true })
   }
-  if (scratch) await rm(scratch, { recursive: true, force: true })
+  if (scratch && keepContainer) {
+    console.log(`[remote-ssh-smoke] kept SSH fixture credentials ${scratch}`)
+  } else if (scratch) {
+    await rm(scratch, { recursive: true, force: true })
+  }
 }
 
 async function prepareTransferSource(home) {
@@ -489,6 +497,20 @@ async function waitForSsh(target, env) {
 }
 
 async function attachAndProbe(target, env, remoteArgs) {
+  const tunnel = await startTunnel(target, env, remoteArgs)
+  try {
+    const response = await fetch(`${tunnel.origin}/api/auth/status`, { signal: AbortSignal.timeout(5_000) })
+    const body = await response.json()
+    if (!response.ok || body.authed !== true || body.tokenConfigured !== true || body.passthrough !== 'localhost') {
+      throw new Error(`Tunnel returned the wrong Runtime response: ${JSON.stringify(body)}`)
+    }
+    return tunnel.clientUrl
+  } finally {
+    await tunnel.close()
+  }
+}
+
+async function startTunnel(target, env, remoteArgs) {
   const child = spawn(process.execPath, [cliEntry, 'remote', target, ...remoteArgs], {
     cwd: repoRoot,
     env,
@@ -505,7 +527,7 @@ async function attachAndProbe(target, env, remoteArgs) {
   child.stdout.on('data', (chunk) => {
     process.stdout.write(chunk)
     output += chunk
-    const match = /Local OpenAlice UI: (http:\/\/127\.0\.0\.1:\d+)/.exec(output)
+    const match = /Local OpenAlice UI: (http:\/\/127\.0\.0\.1:\d+\/[^\r\n]*)\r?\n/.exec(output)
     if (match) resolveUrl(match[1])
   })
   child.once('error', rejectUrl)
@@ -519,19 +541,42 @@ async function attachAndProbe(target, env, remoteArgs) {
   let url
   try {
     url = await urlReady
+  } catch (error) {
+    child.kill('SIGTERM')
+    await waitForExit(child, 10_000).catch(() => undefined)
+    throw error
   } finally {
     clearTimeout(timeout)
   }
-  const response = await fetch(`${url}/api/auth/status`, { signal: AbortSignal.timeout(5_000) })
-  const body = await response.json()
-  if (!response.ok || body.authed !== true || body.tokenConfigured !== true || body.passthrough !== 'localhost') {
-    child.kill('SIGTERM')
-    throw new Error(`Tunnel returned the wrong Runtime response: ${JSON.stringify(body)}`)
+  const parsed = new URL(url)
+  let closed = false
+  return {
+    child,
+    clientUrl: url,
+    origin: parsed.origin,
+    async close() {
+      if (closed) return
+      closed = true
+      child.kill('SIGTERM')
+      const exit = await waitForExit(child, 10_000)
+      if (exit.code !== 0) {
+        throw new Error(`remote CLI did not close cleanly after tunnel disconnect (${JSON.stringify(exit)})`)
+      }
+    },
   }
-  child.kill('SIGTERM')
-  const exit = await waitForExit(child, 10_000)
-  if (exit.code !== 0) throw new Error(`remote CLI did not close cleanly after tunnel disconnect (${JSON.stringify(exit)})`)
-  return url
+}
+
+function requireRemoteClientUrl(value, target) {
+  const parsed = new URL(value)
+  const fragment = new URLSearchParams(parsed.hash.slice(1))
+  if (
+    fragment.get('openalice-remote') !== '1'
+    || fragment.get('target') !== target
+    || !fragment.get('ssh-port')
+    || !fragment.get('runtime-port')
+  ) {
+    throw new Error(`Remote smoke client URL lost its connection identity: ${value}`)
+  }
 }
 
 function waitForExit(child, timeoutMs) {

--- a/src/webui/routes/trading-config.spec.ts
+++ b/src/webui/routes/trading-config.spec.ts
@@ -101,6 +101,14 @@ describe('GET /broker-packs — optional engine requirements', () => {
     const ccxt = (body as { packs: Array<{ engine: string; requiredBy: string[] }> }).packs
       .find((pack) => pack.engine === 'ccxt')
     expect(ccxt?.requiredBy).toEqual(['Main OKX', 'binance K-line vendor'])
+    expect((body as { accounts: unknown[] }).accounts).toEqual([
+      expect.objectContaining({
+        accountId: 'okx-main', configuredEnabled: true, engine: 'ccxt', state: 'needs-install', operational: false, action: 'install',
+      }),
+      expect.objectContaining({
+        accountId: 'okx-disabled', configuredEnabled: false, engine: 'ccxt', state: 'needs-install', operational: false, action: 'install',
+      }),
+    ])
   })
 
   it('surfaces broken local status without dropping the accounts that require it', async () => {
@@ -122,6 +130,9 @@ describe('GET /broker-packs — optional engine requirements', () => {
       reason: 'API version mismatch',
       requiredBy: ['Main OKX'],
     }))
+    expect((body as { accounts: unknown[] }).accounts).toContainEqual(expect.objectContaining({
+      accountId: 'okx-main', state: 'needs-repair', operational: false, action: 'repair', reason: 'API version mismatch',
+    }))
   })
 
   it('keeps pack recovery UI available when a legacy account references a removed preset', async () => {
@@ -135,11 +146,32 @@ describe('GET /broker-packs — optional engine requirements', () => {
 
     expect(status).toBe(200)
     expect((body as { packs: unknown[] }).packs).toHaveLength(6)
+    expect((body as { accounts: unknown[] }).accounts).toEqual([
+      expect.objectContaining({
+        accountId: 'legacy-account', state: 'unsupported-preset', operational: false,
+      }),
+    ])
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('legacy-account'),
       expect.stringMatching(/unknown broker preset/i),
     )
     warn.mockRestore()
+  })
+
+  it('keeps an installed Pack operational while advertising an update', async () => {
+    utaStore = [{
+      id: 'okx-main', label: 'Main OKX', presetId: 'okx', enabled: true,
+      presetConfig: {}, guards: [], asVendor: true,
+    }]
+    brokerPackMocks.getBrokerPackLocalStatus.mockImplementation(async (engine: string) => engine === 'ccxt'
+      ? { engine, installed: true, source: 'downloaded', version: '0.90.2', updateAvailable: true }
+      : { engine, installed: engine === 'mock', source: engine === 'mock' ? 'builtin' : 'missing' })
+
+    const { body } = await req(makeRoutes(), 'GET', '/broker-packs')
+
+    expect((body as { accounts: unknown[] }).accounts).toContainEqual(expect.objectContaining({
+      accountId: 'okx-main', state: 'ready', operational: true, action: 'update',
+    }))
   })
 })
 

--- a/src/webui/routes/trading-config.ts
+++ b/src/webui/routes/trading-config.ts
@@ -94,35 +94,65 @@ export function createTradingConfigRoutes(ctx: EngineContext) {
       const [accounts, config, statuses] = await Promise.all([
         readUTAsConfig(),
         loadConfig(),
-        Promise.all(INSTALLABLE_BROKER_ENGINES.map((engine) => getBrokerPackLocalStatus(engine))),
+        Promise.all([
+          getBrokerPackLocalStatus('mock'),
+          ...INSTALLABLE_BROKER_ENGINES.map((engine) => getBrokerPackLocalStatus(engine)),
+        ]),
       ])
       const requiredBy = new Map<string, string[]>()
-      for (const account of accounts) {
-        if (account.enabled === false) continue
-        let engine: string
+      const statusByEngine = new Map(statuses.map((status) => [status.engine, status]))
+      const accountReadiness = accounts.map((account) => {
+        const label = account.label ?? account.id
         try {
-          engine = getBrokerPreset(account.presetId).engine
+          const engine = getBrokerPreset(account.presetId).engine
+          const status = statusByEngine.get(engine)
+          if (account.enabled !== false) {
+            const rows = requiredBy.get(engine) ?? []
+            rows.push(label)
+            requiredBy.set(engine, rows)
+          }
+          const operational = status?.installed === true && status.source !== 'broken'
+          return {
+            accountId: account.id,
+            label,
+            presetId: account.presetId,
+            configuredEnabled: account.enabled !== false,
+            engine,
+            state: operational ? 'ready' as const : status?.source === 'broken' ? 'needs-repair' as const : 'needs-install' as const,
+            operational,
+            ...(status?.source === 'broken'
+              ? { action: 'repair' as const }
+              : !operational
+                ? { action: 'install' as const }
+                : status.updateAvailable
+                  ? { action: 'update' as const }
+                  : {}),
+            ...(status?.reason ? { reason: status.reason } : {}),
+          }
         } catch (err) {
           console.warn(
             `[trading-config] unable to map UTA ${account.id} to a Broker Pack:`,
             err instanceof Error ? err.message : err,
           )
-          continue
+          return {
+            accountId: account.id,
+            label,
+            presetId: account.presetId,
+            configuredEnabled: account.enabled !== false,
+            state: 'unsupported-preset' as const,
+            operational: false,
+            reason: `Unknown broker preset: ${account.presetId}`,
+          }
         }
-        const rows = requiredBy.get(engine) ?? []
-        rows.push(account.label ?? account.id)
-        requiredBy.set(engine, rows)
-      }
+      })
       if (config.trading.keylessDataSources.length > 0) {
         const rows = requiredBy.get('ccxt') ?? []
         rows.push(...config.trading.keylessDataSources.map((source) => `${source} K-line vendor`))
         requiredBy.set('ccxt', rows)
       }
       return c.json({
-        packs: [
-          { ...(await getBrokerPackLocalStatus('mock')), requiredBy: requiredBy.get('mock') ?? [] },
-          ...statuses.map((status) => ({ ...status, requiredBy: requiredBy.get(status.engine) ?? [] })),
-        ],
+        packs: statuses.map((status) => ({ ...status, requiredBy: requiredBy.get(status.engine) ?? [] })),
+        accounts: accountReadiness,
       })
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -1187,7 +1187,10 @@ describe('POST /:id/headless/:taskId/session', () => {
     };
     const svc = {
       registry: { get: (id: string) => id === 'ws-1' ? { id, dir: '/w' } : undefined },
-      headlessTasks: { get: (id: string) => id === task.taskId ? task : null },
+      headlessTasks: {
+        get: (id: string) => id === task.taskId ? task : null,
+        latestForResumeId: (resumeId: string) => resumeId === task.resumeId ? task : null,
+      },
       sessionRegistry,
       sessionCoordinator,
       resumeRegistry: {
@@ -1242,7 +1245,7 @@ describe('POST /:id/headless/:taskId/session', () => {
   });
 
   it('opens the same conversation directly by resumeId without a native id in the request', async () => {
-    const { app } = buildHeadlessSession();
+    const { app, records } = buildHeadlessSession();
     const opened = await post(app, '/ws-1/resumes/resume-run-1/session', {
       title: 'Durable Inbox report',
     });
@@ -1252,6 +1255,9 @@ describe('POST /:id/headless/:taskId/session', () => {
       sourceRunId: 'run-1',
       resumeId: 'resume-run-1',
       runtime: { credentialSource: 'native' },
+    });
+    expect(Array.from(records.values())[0]).toMatchObject({
+      fallbackTitle: 'Durable Inbox report',
     });
   });
 

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -606,6 +606,8 @@ export function createWorkspaceRoutes(
       runtimeBinding: binding,
       ...(identity?.displayName ? { displayName: identity.displayName } : {}),
       ...(identity ? { presence: sessionPresence(identity) } : {}),
+      ...(identity?.metadata?.createdBy ? { createdBy: identity.metadata.createdBy } : {}),
+      latestExecution: svc.headlessTasks?.latestForResumeId(record.resumeId) ?? null,
     });
   };
 
@@ -662,7 +664,7 @@ export function createWorkspaceRoutes(
     const spawned = await spawnInteractiveSession(meta, {
       agentId: identity.agent,
       resumeId,
-      title: task?.prompt ?? title ?? `Conversation ${resumeId}`,
+      title: title?.trim() || task?.prompt || `Conversation ${resumeId}`,
       ...(task ? { sourceRunId: task.taskId } : {}),
     });
     if (!spawned.ok) {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -903,6 +903,7 @@ export function createWorkspaceRoutes(
           capabilities: a.capabilities,
           installed: av?.installed ?? true,
           binPath: av?.path ?? null,
+          fingerprint: av?.fingerprint ?? null,
         };
       }),
     });

--- a/src/workspaces/agent-detect.spec.ts
+++ b/src/workspaces/agent-detect.spec.ts
@@ -70,6 +70,7 @@ describe('detectBinary', () => {
     expect(detectBinary('claude', { platform: 'linux', env: { PATH: dir } })).toEqual({
       installed: true,
       path: p,
+      fingerprint: expect.any(String),
     });
   });
 
@@ -77,6 +78,7 @@ describe('detectBinary', () => {
     expect(detectBinary('claude', { platform: 'linux', env: { PATH: dir } })).toEqual({
       installed: false,
       path: null,
+      fingerprint: null,
     });
   });
 });
@@ -91,7 +93,7 @@ describe('detectAgentBinary', () => {
         OPENALICE_MANAGED_PI_PATH: managedPi,
         PATH: dir,
       },
-    })).toEqual({ installed: true, path: managedPi });
+    })).toEqual({ installed: true, path: managedPi, fingerprint: expect.any(String) });
     expect(findExecutableOnPath('pi', { platform: 'linux', env: { PATH: dir } })).toBe(pathPi);
   });
 
@@ -103,7 +105,7 @@ describe('detectAgentBinary', () => {
         OPENALICE_MANAGED_PI_PATH: join(dir, 'missing-pi'),
         PATH: dir,
       },
-    })).toEqual({ installed: true, path: pathPi });
+    })).toEqual({ installed: true, path: pathPi, fingerprint: expect.any(String) });
   });
 });
 

--- a/src/workspaces/agent-detect.ts
+++ b/src/workspaces/agent-detect.ts
@@ -30,6 +30,12 @@ export interface AgentAvailability {
   readonly installed: boolean;
   /** Absolute path the binary resolved to, or null when not found. */
   readonly path: string | null;
+  /**
+   * Cheap identity for the resolved file. A readiness probe is valid only for
+   * the exact binary it checked; replacing an executable in place must retire
+   * the cached result even when PATH still resolves to the same string.
+   */
+  readonly fingerprint?: string | null;
 }
 
 export function detectAgentBinary(
@@ -39,7 +45,7 @@ export function detectAgentBinary(
 ): AgentAvailability {
   const env = opts.env ?? process.env;
   const managed = id === 'pi' ? runtimeProfileFromEnv(env).managedPiPath : null;
-  if (managed && isFile(managed)) return { installed: true, path: managed };
+  if (managed && isFile(managed)) return availabilityForPath(managed);
   return detectBinary(binary, opts);
 }
 
@@ -126,7 +132,24 @@ export function detectBinary(
   opts: { platform?: NodeJS.Platform; env?: NodeJS.ProcessEnv } = {},
 ): AgentAvailability {
   const path = findExecutableOnPath(binary, opts);
-  return { installed: path !== null, path };
+  return path ? availabilityForPath(path) : { installed: false, path: null, fingerprint: null };
+}
+
+function availabilityForPath(path: string): AgentAvailability {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile()) return { installed: false, path: null, fingerprint: null };
+    return {
+      installed: true,
+      path,
+      // Metadata is intentionally sufficient here: this runs on every cheap
+      // discovery. Package managers replace or rewrite shims with at least one
+      // of inode/size/mtime changing, without the cost of hashing binaries.
+      fingerprint: `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`,
+    };
+  } catch {
+    return { installed: false, path: null, fingerprint: null };
+  }
 }
 
 function isFile(p: string): boolean {

--- a/src/workspaces/agent-runtime-readiness.spec.ts
+++ b/src/workspaces/agent-runtime-readiness.spec.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   classifyRuntimeReadinessFailure,
   failedRuntimeReadinessRow,
+  initialRuntimeReadinessRow,
   runtimeProbeSucceeded,
+  shareRuntimeReadinessProbe,
   snapshotRuntimeReadiness,
+  type AgentRuntimeReadinessProbeInFlight,
   type AgentRuntimeReadinessRow,
 } from './agent-runtime-readiness.js';
 import { emptyAgentSessionRuntime, type CliAdapter } from './cli-adapter.js';
@@ -55,6 +58,41 @@ function result(overrides: Partial<HeadlessTaskResult>): HeadlessTaskResult {
 }
 
 describe('agent runtime readiness helpers', () => {
+  it('shares an in-flight probe only while executable path and fingerprint match', async () => {
+    const inFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
+    const probes = [
+      deferred<AgentRuntimeReadinessRow>(),
+      deferred<AgentRuntimeReadinessRow>(),
+      deferred<AgentRuntimeReadinessRow>(),
+    ];
+    let probeIndex = 0;
+    const start = vi.fn(() => probes[probeIndex++]!.promise);
+    const v1 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v1' };
+    const v2 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v2' };
+    const rerouted = { installed: true, path: '/opt/bin/pi', fingerprint: 'pi-v2' };
+
+    const first = shareRuntimeReadinessProbe(inFlight, 'pi', v1, start);
+    expect(shareRuntimeReadinessProbe(inFlight, 'pi', v1, start)).toBe(first);
+    expect(start).toHaveBeenCalledTimes(1);
+
+    const replacement = shareRuntimeReadinessProbe(inFlight, 'pi', v2, start);
+    expect(replacement).not.toBe(first);
+    expect(start).toHaveBeenCalledTimes(2);
+
+    probes[0]!.resolve(initialRuntimeReadinessRow(piAdapter, v1));
+    await first;
+    await Promise.resolve();
+    expect(shareRuntimeReadinessProbe(inFlight, 'pi', v2, start)).toBe(replacement);
+
+    const reroutedProbe = shareRuntimeReadinessProbe(inFlight, 'pi', rerouted, start);
+    expect(reroutedProbe).not.toBe(replacement);
+    expect(start).toHaveBeenCalledTimes(3);
+
+    probes[1]!.resolve(initialRuntimeReadinessRow(piAdapter, v2));
+    probes[2]!.resolve(initialRuntimeReadinessRow(piAdapter, rerouted));
+    await Promise.all([replacement, reroutedProbe]);
+  });
+
   it('classifies timeout, auth, provider, and generic failures', () => {
     expect(classifyRuntimeReadinessFailure(result({ killed: true }))).toBe('timeout');
     expect(
@@ -202,3 +240,14 @@ describe('agent runtime readiness helpers', () => {
     });
   });
 });
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve(value: T): void
+} {
+  let resolvePromise!: (value: T) => void
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}

--- a/src/workspaces/agent-runtime-readiness.spec.ts
+++ b/src/workspaces/agent-runtime-readiness.spec.ts
@@ -142,6 +142,7 @@ describe('agent runtime readiness helpers', () => {
       displayName: 'Pi',
       installed: true,
       binPath: '/usr/bin/pi',
+      fingerprint: 'pi-v1',
       status: 'ready',
       ready: true,
       source: 'global-config',
@@ -151,12 +152,53 @@ describe('agent runtime readiness helpers', () => {
 
     const ready = snapshotRuntimeReadiness(
       [piAdapter],
-      { pi: { installed: true, path: '/usr/bin/pi' } },
+      { pi: { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v1' } },
       cache,
     );
 
     expect(ready.overallReady).toBe(true);
     expect(ready.checkedAt).toBe('2026-07-08T00:00:00.000Z');
     expect(ready.agents.pi?.source).toBe('global-config');
+  });
+
+  it('invalidates a cached probe when fresh install identity changes', () => {
+    const cache = new Map<string, AgentRuntimeReadinessRow>([['pi', {
+      agent: 'pi',
+      displayName: 'Pi',
+      installed: true,
+      binPath: '/usr/bin/pi',
+      fingerprint: 'pi-v1',
+      status: 'ready',
+      ready: true,
+      source: 'global-config',
+      checkedAt: '2026-07-08T00:00:00.000Z',
+      durationMs: 25,
+    }]]);
+
+    const replaced = snapshotRuntimeReadiness(
+      [piAdapter],
+      { pi: { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v2' } },
+      cache,
+    );
+
+    expect(replaced.agents.pi).toMatchObject({
+      installed: true,
+      fingerprint: 'pi-v2',
+      status: 'unknown',
+      ready: false,
+      checkedAt: null,
+    });
+    expect(cache.get('pi')).toEqual(replaced.agents.pi);
+
+    const uninstalled = snapshotRuntimeReadiness(
+      [piAdapter],
+      { pi: { installed: false, path: null, fingerprint: null } },
+      cache,
+    );
+    expect(uninstalled.agents.pi).toMatchObject({
+      installed: false,
+      status: 'not_installed',
+      ready: false,
+    });
   });
 });

--- a/src/workspaces/agent-runtime-readiness.spec.ts
+++ b/src/workspaces/agent-runtime-readiness.spec.ts
@@ -7,6 +7,7 @@ import {
   runtimeProbeSucceeded,
   shareRuntimeReadinessProbe,
   snapshotRuntimeReadiness,
+  type AgentRuntimeReadinessProbeAuthority,
   type AgentRuntimeReadinessProbeInFlight,
   type AgentRuntimeReadinessRow,
 } from './agent-runtime-readiness.js';
@@ -60,6 +61,7 @@ function result(overrides: Partial<HeadlessTaskResult>): HeadlessTaskResult {
 describe('agent runtime readiness helpers', () => {
   it('shares an in-flight probe only while executable path and fingerprint match', async () => {
     const inFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
+    const authority = new Map<string, AgentRuntimeReadinessProbeAuthority>();
     const probes = [
       deferred<AgentRuntimeReadinessRow>(),
       deferred<AgentRuntimeReadinessRow>(),
@@ -71,26 +73,141 @@ describe('agent runtime readiness helpers', () => {
     const v2 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v2' };
     const rerouted = { installed: true, path: '/opt/bin/pi', fingerprint: 'pi-v2' };
 
-    const first = shareRuntimeReadinessProbe(inFlight, 'pi', v1, start);
-    expect(shareRuntimeReadinessProbe(inFlight, 'pi', v1, start)).toBe(first);
+    const first = shareRuntimeReadinessProbe(inFlight, authority, 'pi', v1, start);
+    expect(shareRuntimeReadinessProbe(inFlight, authority, 'pi', v1, start)).toBe(first);
     expect(start).toHaveBeenCalledTimes(1);
 
-    const replacement = shareRuntimeReadinessProbe(inFlight, 'pi', v2, start);
+    const replacement = shareRuntimeReadinessProbe(inFlight, authority, 'pi', v2, start);
     expect(replacement).not.toBe(first);
     expect(start).toHaveBeenCalledTimes(2);
 
     probes[0]!.resolve(initialRuntimeReadinessRow(piAdapter, v1));
     await first;
     await Promise.resolve();
-    expect(shareRuntimeReadinessProbe(inFlight, 'pi', v2, start)).toBe(replacement);
+    expect(shareRuntimeReadinessProbe(inFlight, authority, 'pi', v2, start)).toBe(replacement);
 
-    const reroutedProbe = shareRuntimeReadinessProbe(inFlight, 'pi', rerouted, start);
+    const reroutedProbe = shareRuntimeReadinessProbe(inFlight, authority, 'pi', rerouted, start);
     expect(reroutedProbe).not.toBe(replacement);
     expect(start).toHaveBeenCalledTimes(3);
 
     probes[1]!.resolve(initialRuntimeReadinessRow(piAdapter, v2));
     probes[2]!.resolve(initialRuntimeReadinessRow(piAdapter, rerouted));
     await Promise.all([replacement, reroutedProbe]);
+  });
+
+  it('does not let a retired executable probe overwrite its replacement after v2 finishes first', async () => {
+    const inFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
+    const authority = new Map<string, AgentRuntimeReadinessProbeAuthority>();
+    const cache = new Map<string, AgentRuntimeReadinessRow>();
+    const probes = [deferred<AgentRuntimeReadinessRow>(), deferred<AgentRuntimeReadinessRow>()];
+    let probeIndex = 0;
+    const start = vi.fn((mayPublish: () => boolean) => {
+      const probe = probes[probeIndex++]!;
+      return probe.promise.then((row) => {
+        if (mayPublish()) cache.set('pi', row);
+        return row;
+      });
+    });
+    const v1 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v1' };
+    const v2 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v2' };
+
+    const retired = shareRuntimeReadinessProbe(
+      inFlight,
+      authority,
+      'pi',
+      v1,
+      start,
+    );
+    const replacement = shareRuntimeReadinessProbe(
+      inFlight,
+      authority,
+      'pi',
+      v2,
+      start,
+    );
+
+    probes[1]!.resolve(initialRuntimeReadinessRow(piAdapter, v2));
+    await replacement;
+    await Promise.resolve();
+    expect(cache.get('pi')?.fingerprint).toBe('pi-v2');
+    expect(inFlight.has('pi')).toBe(false);
+
+    probes[0]!.resolve(initialRuntimeReadinessRow(piAdapter, v1));
+    await retired;
+    expect(cache.get('pi')?.fingerprint).toBe('pi-v2');
+  });
+
+  it('keeps A1 retired when executable identity cycles from A to B to A2', async () => {
+    const inFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
+    const authority = new Map<string, AgentRuntimeReadinessProbeAuthority>();
+    const cache = new Map<string, AgentRuntimeReadinessRow>();
+    const probes = [
+      deferred<AgentRuntimeReadinessRow>(),
+      deferred<AgentRuntimeReadinessRow>(),
+      deferred<AgentRuntimeReadinessRow>(),
+    ];
+    let probeIndex = 0;
+    const start = vi.fn((mayPublish: () => boolean) => {
+      const probe = probes[probeIndex++]!;
+      return probe.promise.then((row) => {
+        if (mayPublish()) cache.set('pi', row);
+        return row;
+      });
+    });
+    const v1 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v1' };
+    const v2 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v2' };
+
+    const a1 = shareRuntimeReadinessProbe(inFlight, authority, 'pi', v1, start);
+    const b = shareRuntimeReadinessProbe(inFlight, authority, 'pi', v2, start);
+    const a2 = shareRuntimeReadinessProbe(inFlight, authority, 'pi', v1, start);
+
+    expect(a2).not.toBe(a1);
+    expect(start).toHaveBeenCalledTimes(3);
+    probes[2]!.resolve({ ...initialRuntimeReadinessRow(piAdapter, v1), message: 'A2' });
+    await a2;
+    expect(cache.get('pi')?.message).toBe('A2');
+
+    probes[0]!.resolve({ ...initialRuntimeReadinessRow(piAdapter, v1), message: 'A1' });
+    probes[1]!.resolve({ ...initialRuntimeReadinessRow(piAdapter, v2), message: 'B' });
+    await Promise.all([a1, b]);
+    expect(cache.get('pi')?.message).toBe('A2');
+  });
+
+  it.each([
+    {
+      change: 'an in-place replacement',
+      fresh: { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v2' },
+      expectedStatus: 'unknown',
+    },
+    {
+      change: 'an uninstall',
+      fresh: { installed: false, path: null, fingerprint: null },
+      expectedStatus: 'not_installed',
+    },
+  ] as const)('retires an old probe when GET discovers $change', async ({ fresh, expectedStatus }) => {
+    const inFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
+    const authority = new Map<string, AgentRuntimeReadinessProbeAuthority>();
+    const cache = new Map<string, AgentRuntimeReadinessRow>();
+    const late = deferred<AgentRuntimeReadinessRow>();
+    const v1 = { installed: true, path: '/usr/bin/pi', fingerprint: 'pi-v1' };
+    const oldProbe = shareRuntimeReadinessProbe(
+      inFlight,
+      authority,
+      'pi',
+      v1,
+      (mayPublish) => late.promise.then((row) => {
+        if (mayPublish()) cache.set('pi', row);
+        return row;
+      }),
+    );
+
+    const snapshot = snapshotRuntimeReadiness([piAdapter], { pi: fresh }, cache, authority);
+    expect(snapshot.agents.pi?.status).toBe(expectedStatus);
+    expect(authority.has('pi')).toBe(false);
+
+    late.resolve({ ...initialRuntimeReadinessRow(piAdapter, v1), message: 'late old probe' });
+    await oldProbe;
+    expect(cache.get('pi')).toEqual(snapshot.agents.pi);
   });
 
   it('classifies timeout, auth, provider, and generic failures', () => {

--- a/src/workspaces/agent-runtime-readiness.ts
+++ b/src/workspaces/agent-runtime-readiness.ts
@@ -56,7 +56,13 @@ export interface AgentRuntimeReadinessSnapshot {
 
 export interface AgentRuntimeReadinessProbeInFlight {
   readonly identity: string
+  readonly epoch: symbol
   readonly promise: Promise<AgentRuntimeReadinessRow>
+}
+
+export interface AgentRuntimeReadinessProbeAuthority {
+  readonly identity: string
+  readonly epoch: symbol
 }
 
 function runtimeReadinessProbeIdentity(
@@ -77,16 +83,27 @@ function runtimeReadinessProbeIdentity(
  * the result Promise for the retired executable. */
 export function shareRuntimeReadinessProbe(
   inFlight: Map<string, AgentRuntimeReadinessProbeInFlight>,
+  authority: Map<string, AgentRuntimeReadinessProbeAuthority>,
   agent: string,
   availability: AgentAvailability | undefined,
-  start: () => Promise<AgentRuntimeReadinessRow>,
+  start: (mayPublish: () => boolean) => Promise<AgentRuntimeReadinessRow>,
 ): Promise<AgentRuntimeReadinessRow> {
   const identity = runtimeReadinessProbeIdentity(agent, availability)
   const existing = inFlight.get(agent)
-  if (existing?.identity === identity) return existing.promise
+  if (
+    existing?.identity === identity
+    && authority.get(agent)?.epoch === existing.epoch
+  ) {
+    return existing.promise
+  }
 
-  const promise = start()
-  const entry = { identity, promise }
+  // Identity is repeatable (A -> B -> A), so it cannot itself be publication
+  // authority. Every newly started probe gets a unique epoch that outlives its
+  // in-flight entry; only the latest epoch may publish to the cache.
+  const epoch = Symbol(`${agent}:runtime-readiness-probe`)
+  authority.set(agent, { identity, epoch })
+  const promise = start(() => authority.get(agent)?.epoch === epoch)
+  const entry = { identity, epoch, promise }
   inFlight.set(agent, entry)
   const clear = () => {
     if (inFlight.get(agent) === entry) inFlight.delete(agent)
@@ -132,9 +149,22 @@ export function snapshotRuntimeReadiness(
   adapters: readonly CliAdapter[],
   availability: Record<string, AgentAvailability>,
   cache: Map<string, AgentRuntimeReadinessRow>,
+  authority?: Map<string, AgentRuntimeReadinessProbeAuthority>,
 ): AgentRuntimeReadinessSnapshot {
   const rows = adapters.map((adapter) => {
-    const fresh = initialRuntimeReadinessRow(adapter, availability[adapter.id]);
+    const freshAvailability = availability[adapter.id]
+    const fresh = initialRuntimeReadinessRow(adapter, freshAvailability);
+    const activeAuthority = authority?.get(adapter.id)
+    if (
+      activeAuthority
+      && activeAuthority.identity !== runtimeReadinessProbeIdentity(adapter.id, freshAvailability)
+      && authority?.get(adapter.id) === activeAuthority
+    ) {
+      // Discovery is authoritative even while a probe is running. Retiring
+      // the epoch prevents a late result for a replaced or uninstalled binary
+      // from repopulating the cache after this snapshot invalidates it.
+      authority.delete(adapter.id)
+    }
     const cached = cache.get(adapter.id);
     if (
       cached

--- a/src/workspaces/agent-runtime-readiness.ts
+++ b/src/workspaces/agent-runtime-readiness.ts
@@ -54,6 +54,47 @@ export interface AgentRuntimeReadinessSnapshot {
   readonly checkedAt: string | null;
 }
 
+export interface AgentRuntimeReadinessProbeInFlight {
+  readonly identity: string
+  readonly promise: Promise<AgentRuntimeReadinessRow>
+}
+
+function runtimeReadinessProbeIdentity(
+  agent: string,
+  availability: AgentAvailability | undefined,
+): string {
+  return JSON.stringify([
+    agent,
+    availability?.installed ?? true,
+    availability?.path ?? null,
+    availability?.fingerprint ?? null,
+  ])
+}
+
+/** Share only probes that target the same executable identity. A package
+ * manager may replace a binary in place while the old probe is still running;
+ * that fresh path/fingerprint must start its own probe instead of inheriting
+ * the result Promise for the retired executable. */
+export function shareRuntimeReadinessProbe(
+  inFlight: Map<string, AgentRuntimeReadinessProbeInFlight>,
+  agent: string,
+  availability: AgentAvailability | undefined,
+  start: () => Promise<AgentRuntimeReadinessRow>,
+): Promise<AgentRuntimeReadinessRow> {
+  const identity = runtimeReadinessProbeIdentity(agent, availability)
+  const existing = inFlight.get(agent)
+  if (existing?.identity === identity) return existing.promise
+
+  const promise = start()
+  const entry = { identity, promise }
+  inFlight.set(agent, entry)
+  const clear = () => {
+    if (inFlight.get(agent) === entry) inFlight.delete(agent)
+  }
+  void promise.then(clear, clear)
+  return promise
+}
+
 export function initialRuntimeReadinessRow(
   adapter: CliAdapter,
   availability: AgentAvailability | undefined,

--- a/src/workspaces/agent-runtime-readiness.ts
+++ b/src/workspaces/agent-runtime-readiness.ts
@@ -37,6 +37,8 @@ export interface AgentRuntimeReadinessRow {
   readonly displayName: string
   readonly installed: boolean
   readonly binPath: string | null
+  /** Binary identity this probe result was produced against. */
+  readonly fingerprint?: string | null
   readonly status: AgentRuntimeReadinessStatus
   readonly ready: boolean
   readonly source: AgentRuntimeReadinessSource
@@ -62,6 +64,7 @@ export function initialRuntimeReadinessRow(
     displayName: adapter.displayName,
     installed,
     binPath: availability?.path ?? null,
+    fingerprint: availability?.fingerprint ?? null,
     status: installed ? 'unknown' : 'not_installed',
     ready: false,
     source: 'unknown',
@@ -87,11 +90,25 @@ export function checkingRuntimeReadinessRow(row: AgentRuntimeReadinessRow): Agen
 export function snapshotRuntimeReadiness(
   adapters: readonly CliAdapter[],
   availability: Record<string, AgentAvailability>,
-  cache: ReadonlyMap<string, AgentRuntimeReadinessRow>,
+  cache: Map<string, AgentRuntimeReadinessRow>,
 ): AgentRuntimeReadinessSnapshot {
-  const rows = adapters.map((adapter) =>
-    cache.get(adapter.id) ?? initialRuntimeReadinessRow(adapter, availability[adapter.id]),
-  );
+  const rows = adapters.map((adapter) => {
+    const fresh = initialRuntimeReadinessRow(adapter, availability[adapter.id]);
+    const cached = cache.get(adapter.id);
+    if (
+      cached
+      && cached.installed === fresh.installed
+      && cached.binPath === fresh.binPath
+      && (cached.fingerprint ?? null) === (fresh.fingerprint ?? null)
+    ) {
+      return cached;
+    }
+    // Discovery is authoritative for install identity. A probe made against a
+    // prior executable must not survive an install, uninstall, PATH change, or
+    // in-place package-manager replacement.
+    cache.set(adapter.id, fresh);
+    return fresh;
+  });
   const checked = rows
     .map((row) => row.checkedAt)
     .filter((value): value is string => value !== null)
@@ -112,6 +129,7 @@ export function notInstalledRuntimeReadinessRow(
     displayName: adapter.displayName,
     installed: false,
     binPath: availability?.path ?? null,
+    fingerprint: availability?.fingerprint ?? null,
     status: 'not_installed',
     ready: false,
     source: 'unknown',
@@ -133,6 +151,7 @@ export function readyRuntimeReadinessRow(opts: {
     displayName: opts.adapter.displayName,
     installed: true,
     binPath: opts.availability?.path ?? null,
+    fingerprint: opts.availability?.fingerprint ?? null,
     status: 'ready',
     ready: true,
     source: opts.source,
@@ -154,6 +173,7 @@ export function failedRuntimeReadinessRow(opts: {
     displayName: opts.adapter.displayName,
     installed: true,
     binPath: opts.availability?.path ?? null,
+    fingerprint: opts.availability?.fingerprint ?? null,
     status,
     ready: false,
     source: opts.source ?? 'unknown',

--- a/src/workspaces/issues/automation-health.spec.ts
+++ b/src/workspaces/issues/automation-health.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   issueAutomationHealth,
+  issueAutomationOwnerState,
   issueAutomationRuntime,
   type IssueAutomationHealthInput,
 } from './automation-health.js'
@@ -82,6 +83,17 @@ describe('issueAutomationHealth', () => {
     expect(issueAutomationHealth({ ...base, ownerState: 'missing' }).state).toBe('blocked')
     expect(issueAutomationHealth({ ...base, ownerState: 'retired' }).message).toMatch(/retired/)
     expect(issueAutomationHealth({ ...base, ownerState: 'unbound' }).message).toMatch(/resumable/)
+    expect(issueAutomationHealth({ ...base, ownerState: 'workspace_missing' })).toMatchObject({
+      state: 'blocked',
+      message: expect.stringMatching(/Workspace is unavailable/),
+    })
+  })
+
+  it('uses the authoritative assignee projection for exact Session health', () => {
+    expect(issueAutomationOwnerState('@new-each-run')).toBe('workspace')
+    expect(issueAutomationOwnerState('@resume-1', { state: 'workspace_missing' }))
+      .toBe('workspace_missing')
+    expect(issueAutomationOwnerState('@resume-missing')).toBe('missing')
   })
 
   it('lets an in-flight run finish before surfacing a newly blocked owner', () => {

--- a/src/workspaces/issues/automation-health.spec.ts
+++ b/src/workspaces/issues/automation-health.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { issueAutomationHealth, type IssueAutomationHealthInput } from './automation-health.js'
+import {
+  issueAutomationHealth,
+  issueAutomationRuntime,
+  type IssueAutomationHealthInput,
+} from './automation-health.js'
 
 const base: IssueAutomationHealthInput = {
   status: 'todo',
@@ -10,6 +14,33 @@ const base: IssueAutomationHealthInput = {
 }
 
 describe('issueAutomationHealth', () => {
+  it('resolves effective runtime from Session, Issue, then default precedence', () => {
+    const availability = {
+      pi: { installed: true },
+      codex: { installed: false },
+      grok: { installed: false },
+    }
+    const displayNameFor = (agent: string) => agent.toUpperCase()
+    expect(issueAutomationRuntime({
+      sessionAgent: 'grok',
+      issueAgent: 'codex',
+      defaultAgent: 'pi',
+      availability,
+      displayNameFor,
+    })).toEqual({ agent: 'grok', displayName: 'GROK', installed: false })
+    expect(issueAutomationRuntime({
+      issueAgent: 'codex',
+      defaultAgent: 'pi',
+      availability,
+      displayNameFor,
+    })?.agent).toBe('codex')
+    expect(issueAutomationRuntime({
+      defaultAgent: 'pi',
+      availability,
+      displayNameFor,
+    })?.agent).toBe('pi')
+  })
+
   it('distinguishes an untouched schedule from one that is due', () => {
     expect(issueAutomationHealth(base).state).toBe('not_started')
     expect(issueAutomationHealth({ ...base, nextDueAtMs: base.nowMs }).state).toBe('due')
@@ -59,6 +90,31 @@ describe('issueAutomationHealth', () => {
       ownerState: 'retired',
       latestRun: { taskId: 'run-live', status: 'running' },
     }).state).toBe('running')
+  })
+
+  it('projects a missing effective runtime as a structured blocker', () => {
+    expect(issueAutomationHealth({
+      ...base,
+      runtime: { agent: 'grok', displayName: 'Grok', installed: false },
+    })).toMatchObject({
+      state: 'blocked',
+      blocker: {
+        kind: 'agent_runtime_missing',
+        agent: 'grok',
+        displayName: 'Grok',
+      },
+      message: expect.stringMatching(/Grok.*not installed/),
+    })
+  })
+
+  it('does not let a missing runtime hide an in-flight run or terminal Issue', () => {
+    const runtime = { agent: 'grok', displayName: 'Grok', installed: false }
+    expect(issueAutomationHealth({
+      ...base,
+      runtime,
+      latestRun: { taskId: 'run-live', status: 'running' },
+    }).state).toBe('running')
+    expect(issueAutomationHealth({ ...base, status: 'done', runtime }).state).toBe('inactive')
   })
 
   it('makes terminal Issue status the schedule switch', () => {

--- a/src/workspaces/issues/automation-health.ts
+++ b/src/workspaces/issues/automation-health.ts
@@ -19,6 +19,12 @@ export type IssueAutomationHealthState =
 export interface IssueAutomationHealth {
   state: IssueAutomationHealthState
   message: string
+  /** Machine-readable reason for a blocked schedule. */
+  blocker?: {
+    kind: 'agent_runtime_missing'
+    agent: string
+    displayName: string
+  }
   /** Latest scheduled execution, when one exists. Useful to jump from a health
    * warning to the authoritative run log without guessing from timestamps. */
   latestTaskId?: string
@@ -31,7 +37,28 @@ export interface IssueAutomationHealthInput {
   nowMs: number
   nextDueAtMs: number | null
   ownerState: IssueAutomationOwnerState
+  /** Effective runtime after resolving exact Session, Issue override, then Workspace default. */
+  runtime?: { agent: string; displayName: string; installed: boolean }
   latestRun?: { taskId: string; status: HeadlessTaskStatus; failure?: IssueRunFailure }
+}
+
+/** Resolve the Agent whose executable will service the next scheduled fire.
+ * The caller supplies the exact Session Agent when applicable; otherwise the
+ * Issue override and Workspace/default chain apply in order. */
+export function issueAutomationRuntime(input: {
+  sessionAgent?: string
+  issueAgent?: string
+  defaultAgent?: string
+  availability: Readonly<Record<string, { installed: boolean } | undefined>>
+  displayNameFor(agent: string): string | undefined
+}): { agent: string; displayName: string; installed: boolean } | undefined {
+  const agent = input.sessionAgent ?? input.issueAgent ?? input.defaultAgent
+  if (!agent) return undefined
+  return {
+    agent,
+    displayName: input.displayNameFor(agent) ?? agent,
+    installed: input.availability[agent]?.installed ?? false,
+  }
 }
 
 /** Derive one scheduler-health answer from authoritative stores. Ordering is
@@ -60,6 +87,17 @@ export function issueAutomationHealth(input: IssueAutomationHealthInput): IssueA
   }
   if (input.ownerState === 'unbound') {
     return withLatest({ state: 'blocked', message: 'Assigned Session has no resumable runtime conversation yet.' })
+  }
+  if (input.runtime && !input.runtime.installed) {
+    return withLatest({
+      state: 'blocked',
+      message: `${input.runtime.displayName} is not installed or not on PATH. Install it before the next scheduled run.`,
+      blocker: {
+        kind: 'agent_runtime_missing',
+        agent: input.runtime.agent,
+        displayName: input.runtime.displayName,
+      },
+    })
   }
   if (latest?.status === 'interrupted' || latest?.failure?.kind === 'system_paused') {
     return {

--- a/src/workspaces/issues/automation-health.ts
+++ b/src/workspaces/issues/automation-health.ts
@@ -1,5 +1,5 @@
 import type { HeadlessTaskStatus } from '../headless-task-registry.js'
-import type { IssueStatus } from './declaration.js'
+import { issueAssigneeResumeId, type IssueStatus } from './declaration.js'
 import type { IssueRunFailure } from './run-failure.js'
 
 /** Operational state of a scheduled Issue. This is a live projection, never a
@@ -30,7 +30,28 @@ export interface IssueAutomationHealth {
   latestTaskId?: string
 }
 
-export type IssueAutomationOwnerState = 'workspace' | 'ready' | 'missing' | 'retired' | 'deleted' | 'unbound'
+export type IssueAutomationOwnerState =
+  | 'workspace'
+  | 'ready'
+  | 'missing'
+  | 'retired'
+  | 'deleted'
+  | 'unbound'
+  | 'workspace_missing'
+
+type ExactIssueAutomationOwnerState = Exclude<IssueAutomationOwnerState, 'workspace'>
+
+/** Map the authoritative exact-Session projection onto scheduler health. The
+ * projection already owns Workspace presence, lifecycle, deletion, and native
+ * resume availability, so health must not re-derive a weaker answer from only
+ * the resume registry. */
+export function issueAutomationOwnerState(
+  assignee: string,
+  assigneeSession?: { state: ExactIssueAutomationOwnerState },
+): IssueAutomationOwnerState {
+  if (!issueAssigneeResumeId(assignee)) return 'workspace'
+  return assigneeSession?.state ?? 'missing'
+}
 
 export interface IssueAutomationHealthInput {
   status: IssueStatus
@@ -87,6 +108,9 @@ export function issueAutomationHealth(input: IssueAutomationHealthInput): IssueA
   }
   if (input.ownerState === 'unbound') {
     return withLatest({ state: 'blocked', message: 'Assigned Session has no resumable runtime conversation yet.' })
+  }
+  if (input.ownerState === 'workspace_missing') {
+    return withLatest({ state: 'blocked', message: 'Assigned Session Workspace is unavailable. Restore it or reassign the Issue before its next run.' })
   }
   if (input.runtime && !input.runtime.installed) {
     return withLatest({

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -31,6 +31,7 @@ import type { IssuePriority, IssueRecord, IssueStatus, IssueTimeout } from './de
 import type { IssueComment } from './comments.js'
 import type { IssueAutomationHealth } from './automation-health.js'
 import { issueRunFailure, type IssueRunFailure } from './run-failure.js'
+import type { PublicSessionRuntime } from '../public-session.js'
 
 /** One board row: the issue's display fields, plus — iff it self-schedules — its
  *  `when` and the scanner's firing markers. No markdown What (Phase 2 loads it). */
@@ -267,10 +268,27 @@ export interface IssueDetailIssue {
   telegramConnector?: true
 }
 
+/** Authoritative resolution of an Issue's exact @resume owner. Unlike a
+ * Workspace directory page, this lookup is global, uncapped, and tied to the
+ * detail read, so it cannot become stale while the Issue assignee advances. */
+export interface IssueAssigneeSession {
+  resumeId: string
+  state: 'ready' | 'missing' | 'retired' | 'deleted' | 'unbound' | 'workspace_missing'
+  workspace?: { id: string; tag: string }
+  agent?: string
+  displayName?: string
+  createdAt?: number
+  updatedAt?: number
+  active: boolean
+  runtime?: PublicSessionRuntime
+}
+
 /** GET /api/issues/:wsId/:id — one issue + its human-facing Activity timeline,
  *  operational run history, and the inbox reports it produced. */
 export interface IssueDetail {
   issue: IssueDetailIssue
+  /** Present when assignee is an exact @resume identity. */
+  assigneeSession?: IssueAssigneeSession
   /** Structured markdown comments loaded from the adjacent JSON sidecar. */
   comments: IssueComment[]
   /** This issue's headless runs (wsId + issueId match), newest first.

--- a/src/workspaces/public-session.spec.ts
+++ b/src/workspaces/public-session.spec.ts
@@ -80,4 +80,22 @@ describe('projectPublicSession', () => {
       title: 'Investigate the market',
     });
   });
+
+  it('projects structured Issue identity without mutating the stored launch title', () => {
+    const scheduledPrompt = 'Run every instruction in the scheduled Issue body.';
+    expect(projectPublicSession({
+      ...record,
+      surface: 'headless',
+      fallbackTitle: scheduledPrompt,
+    }, {
+      createdBy: {
+        kind: 'issue',
+        workspaceId: 'workspace-1',
+        issueId: 'daily-close-review',
+        policy: 'new-then-resume',
+        fire: 'schedule',
+      },
+    })).toMatchObject({ title: 'Daily Close Review' });
+    expect(scheduledPrompt).toBe('Run every instruction in the scheduled Issue body.');
+  });
 });

--- a/src/workspaces/public-session.ts
+++ b/src/workspaces/public-session.ts
@@ -1,6 +1,9 @@
 import type { ModelReasoningEffort } from '../ai-providers/model-semantics.js';
 import type { SessionRuntimeBinding } from './cli-adapter.js';
-import { sessionPreferredTitle, type SessionRecord } from './session-registry.js';
+import type { HeadlessTaskRecord } from './headless-task-registry.js';
+import type { SessionCreatedBy } from './session-metadata.js';
+import { projectSessionPresentationTitle } from './session-presentation.js';
+import type { SessionRecord } from './session-registry.js';
 
 export interface PublicSessionRuntime {
   readonly credentialSource: 'native' | 'vault' | 'workspace';
@@ -57,6 +60,10 @@ export interface PublicSessionProjectionContext {
   readonly runtimeBinding?: SessionRuntimeBinding | null;
   readonly displayName?: string;
   readonly presence?: 'active' | 'archived' | 'deleted';
+  /** Structured provenance used only for the public read-side title. */
+  readonly createdBy?: SessionCreatedBy;
+  readonly latestExecution?: Pick<HeadlessTaskRecord, 'trigger' | 'inquiry' | 'output'> | null;
+  readonly issueTitleFor?: (workspaceId: string, issueId: string) => string | undefined;
 }
 
 /**
@@ -85,7 +92,14 @@ export function projectPublicSession(
     resumeId: record.resumeId,
     pid: terminal?.pid ?? webPi?.pid ?? null,
     startedAt: terminal?.startedAt ?? webPi?.startedAt ?? null,
-    title: sessionPreferredTitle(record) ?? null,
+    title: projectSessionPresentationTitle({
+      record,
+      ...(context.createdBy ? { createdBy: context.createdBy } : {}),
+      ...(context.latestExecution !== undefined
+        ? { latestExecution: context.latestExecution }
+        : {}),
+      ...(context.issueTitleFor ? { issueTitleFor: context.issueTitleFor } : {}),
+    }) ?? null,
     ...(context.displayName ? { displayName: context.displayName } : {}),
     sourceRunId: record.sourceRunId ?? null,
     ...(context.presence ? { presence: context.presence } : {}),

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -66,6 +66,7 @@ import {
   snapshotRuntimeReadiness,
   RUNTIME_READINESS_PROMPT,
   RUNTIME_READINESS_TIMEOUT_MS,
+  type AgentRuntimeReadinessProbeAuthority,
   type AgentRuntimeReadinessProbeInFlight,
   type AgentRuntimeReadinessRow,
   type AgentRuntimeReadinessSnapshot,
@@ -989,6 +990,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   const resolveRuntimeWorkspace = (workspaceId: string): WorkspaceMeta | undefined =>
     workspaceId === managerWorkspace.id ? managerWorkspace : registry.get(workspaceId);
   const runtimeReadinessCache = new Map<string, AgentRuntimeReadinessRow>();
+  const runtimeReadinessProbeInFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
+  const runtimeReadinessProbeAuthority = new Map<string, AgentRuntimeReadinessProbeAuthority>();
 
   const creator = new WorkspaceCreator({
     workspacesRoot: `${config.launcherRoot}/workspaces`,
@@ -1254,7 +1257,12 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   const getRuntimeAdapters = () => adapters.list().filter(isAgentRuntime);
 
   const getAgentRuntimeReadinessMethod = (): AgentRuntimeReadinessSnapshot =>
-    snapshotRuntimeReadiness(getRuntimeAdapters(), detectAgents(), runtimeReadinessCache);
+    snapshotRuntimeReadiness(
+      getRuntimeAdapters(),
+      detectAgents(),
+      runtimeReadinessCache,
+      runtimeReadinessProbeAuthority,
+    );
 
   const runtimeReadinessSourceFor = (
     adapter: CliAdapter,
@@ -1413,16 +1421,18 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     },
   });
 
-  const runtimeReadinessProbeInFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
-
   const executeSingleAgentRuntimeReadinessProbe = async (
     adapter: CliAdapter,
-    availability?: AgentAvailability,
+    availability: AgentAvailability | undefined,
+    mayPublish: () => boolean,
   ): Promise<AgentRuntimeReadinessRow> => {
+    const publish = (row: AgentRuntimeReadinessRow): AgentRuntimeReadinessRow => {
+      if (mayPublish()) runtimeReadinessCache.set(adapter.id, row);
+      return row;
+    };
     if (!availability?.installed) {
       const row = notInstalledRuntimeReadinessRow(adapter, availability);
-      runtimeReadinessCache.set(adapter.id, row);
-      return row;
+      return publish(row);
     }
     if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
       const row = failedRuntimeReadinessRow({
@@ -1430,13 +1440,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         availability,
         result: syntheticRuntimeReadinessFailure('Agent does not support headless probes.'),
       });
-      runtimeReadinessCache.set(adapter.id, row);
-      return row;
+      return publish(row);
     }
 
-    const existing =
-      runtimeReadinessCache.get(adapter.id) ?? initialRuntimeReadinessRow(adapter, availability);
-    runtimeReadinessCache.set(adapter.id, checkingRuntimeReadinessRow(existing));
+    publish(checkingRuntimeReadinessRow(initialRuntimeReadinessRow(adapter, availability)));
 
     const globalSource = runtimeReadinessSourceFor(adapter, availability);
     let lastAttempt: Awaited<ReturnType<typeof runRuntimeReadinessProbeAttempt>> | null = null;
@@ -1450,8 +1457,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           source: lastAttempt.source,
           durationMs: lastAttempt.result.durationMs,
         });
-        runtimeReadinessCache.set(adapter.id, row);
-        return row;
+        return publish(row);
       }
 
       const row = failedRuntimeReadinessRow({
@@ -1462,8 +1468,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           syntheticRuntimeReadinessFailure('The native runtime login or Workspace provider config is not ready.'),
         source: lastAttempt?.source ?? globalSource,
       });
-      runtimeReadinessCache.set(adapter.id, row);
-      return row;
+      return publish(row);
     } catch (err) {
       const row = failedRuntimeReadinessRow({
         adapter,
@@ -1471,8 +1476,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         result: syntheticRuntimeReadinessFailure(err instanceof Error ? err.message : String(err)),
         source: lastAttempt?.source ?? globalSource,
       });
-      runtimeReadinessCache.set(adapter.id, row);
-      return row;
+      return publish(row);
     }
   };
 
@@ -1482,9 +1486,10 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   ): Promise<AgentRuntimeReadinessRow> =>
     shareRuntimeReadinessProbe(
       runtimeReadinessProbeInFlight,
+      runtimeReadinessProbeAuthority,
       adapter.id,
       availability,
-      () => executeSingleAgentRuntimeReadinessProbe(adapter, availability),
+      (mayPublish) => executeSingleAgentRuntimeReadinessProbe(adapter, availability, mayPublish),
     );
 
   const readinessTargets = (agentId?: string): CliAdapter[] => {
@@ -1519,7 +1524,12 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     await Promise.all(
       targets.map((adapter) => probeSingleAgentRuntimeReadiness(adapter, availability[adapter.id])),
     );
-    return snapshotRuntimeReadiness(getRuntimeAdapters(), detectAgents(), runtimeReadinessCache);
+    return snapshotRuntimeReadiness(
+      getRuntimeAdapters(),
+      detectAgents(),
+      runtimeReadinessCache,
+      runtimeReadinessProbeAuthority,
+    );
   };
 
   const computeSpawnPlan = (

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -62,9 +62,11 @@ import {
   notInstalledRuntimeReadinessRow,
   readyRuntimeReadinessRow,
   runtimeProbeSucceeded,
+  shareRuntimeReadinessProbe,
   snapshotRuntimeReadiness,
   RUNTIME_READINESS_PROMPT,
   RUNTIME_READINESS_TIMEOUT_MS,
+  type AgentRuntimeReadinessProbeInFlight,
   type AgentRuntimeReadinessRow,
   type AgentRuntimeReadinessSnapshot,
   type AgentRuntimeReadinessSource,
@@ -124,8 +126,8 @@ import {
 import { updateIssueFields } from './issues/mutate.js';
 import {
   issueAutomationHealth,
+  issueAutomationOwnerState,
   issueAutomationRuntime,
-  type IssueAutomationOwnerState,
 } from './issues/automation-health.js';
 import {
   issueAssigneeClaimsFirstSession,
@@ -190,18 +192,6 @@ import {
   type ChatWorkspaceResolution,
   type TemplateWorkspaceResolution,
 } from './chat-workspace-resolver.js';
-
-/** Resolve only the operational facts automation health needs. Product APIs do
- * not expose the runtime-native session id itself. */
-function automationOwnerState(assignee: string, resumes: ResumeRegistry): IssueAutomationOwnerState {
-  const resumeId = issueAssigneeResumeId(assignee);
-  if (!resumeId) return 'workspace';
-  const identity = resumes.get(resumeId);
-  if (!identity) return 'missing';
-  if (identity.lifecycle === 'retired') return 'retired';
-  if (identity.presence === 'deleted') return 'deleted';
-  return identity.agentSessionId ? 'ready' : 'unbound';
-}
 
 function automationLatestRun(task: HeadlessTaskRecord) {
   const failure = issueRunFailure(task);
@@ -1423,7 +1413,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     },
   });
 
-  const runtimeReadinessProbeInFlight = new Map<string, Promise<AgentRuntimeReadinessRow>>();
+  const runtimeReadinessProbeInFlight = new Map<string, AgentRuntimeReadinessProbeInFlight>();
 
   const executeSingleAgentRuntimeReadinessProbe = async (
     adapter: CliAdapter,
@@ -1489,18 +1479,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   const probeSingleAgentRuntimeReadiness = (
     adapter: CliAdapter,
     availability?: AgentAvailability,
-  ): Promise<AgentRuntimeReadinessRow> => {
-    const existing = runtimeReadinessProbeInFlight.get(adapter.id);
-    if (existing) return existing;
-    const probe = executeSingleAgentRuntimeReadinessProbe(adapter, availability);
-    runtimeReadinessProbeInFlight.set(adapter.id, probe);
-    void probe.finally(() => {
-      if (runtimeReadinessProbeInFlight.get(adapter.id) === probe) {
-        runtimeReadinessProbeInFlight.delete(adapter.id);
-      }
-    });
-    return probe;
-  };
+  ): Promise<AgentRuntimeReadinessRow> =>
+    shareRuntimeReadinessProbe(
+      runtimeReadinessProbeInFlight,
+      adapter.id,
+      availability,
+      () => executeSingleAgentRuntimeReadinessProbe(adapter, availability),
+    );
 
   const readinessTargets = (agentId?: string): CliAdapter[] => {
     const runtimeAdapters = getRuntimeAdapters();
@@ -2384,6 +2369,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
             scheduleMarkers.getHeld(ws.id, issue.id) ?? null,
           );
           const latestRun = headlessTasks.list({ issue: { workspaceId: ws.id, issueId: issue.id } })[0];
+          const assigneeSession = projectIssueAssigneeSession(issue.assignee);
           return snapshotBoardIssue(
             issue,
             {
@@ -2393,7 +2379,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
                 status: issue.status,
                 nowMs,
                 nextDueAtMs: fired.nextDueAtMs,
-                ownerState: automationOwnerState(issue.assignee, resumeRegistry),
+                ownerState: issueAutomationOwnerState(issue.assignee, assigneeSession),
                 runtime: issueRuntimeAvailability(issue, defaultIssueAgent, availability),
                 ...(latestRun ? { latestRun: automationLatestRun(latestRun) } : {}),
               }),
@@ -2459,7 +2445,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         status: issue.status,
         nowMs: Date.now(),
         nextDueAtMs: scheduledSnapshot.nextDueAtMs,
-        ownerState: automationOwnerState(issue.assignee, resumeRegistry),
+        ownerState: issueAutomationOwnerState(issue.assignee, assigneeSession),
         runtime: runtimeAvailability,
         ...(runs[0] ? {
           latestRun: {

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -2672,6 +2672,9 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           }),
         })
       : new Set<string>();
+    const issueTitles = issueRead.ok
+      ? new Map(issueRead.issues.map((issue) => [issue.id, issue.title] as const))
+      : new Map<string, string>();
     return buildWorkspaceSessionDirectory({
       workspace: { id: ws.id, tag: ws.tag },
       identities: resumeRegistry.list({ wsId, limit }),
@@ -2680,6 +2683,9 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       isActive: (resumeId) => activeResumeIds.has(resumeId),
       rosterVisibilityFor: (resumeId) => rosterExclusions.has(resumeId) ? 'hidden' : undefined,
       issueAttachedFor: (resumeId) => issueAttachments.has(resumeId) ? true : undefined,
+      issueTitleFor: (workspaceId, issueId) => workspaceId === wsId
+        ? issueTitles.get(issueId)
+        : undefined,
     });
   };
 
@@ -3025,6 +3031,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         runtimeBinding: identity.runtimeBinding,
         displayName: identity.displayName,
         presence: sessionPresence(identity),
+        ...(identity.metadata?.createdBy ? { createdBy: identity.metadata.createdBy } : {}),
+        latestExecution: headlessTasks.latestForResumeId(record.resumeId),
       })];
     });
     // Deprecated native-project compatibility-export signals. Retained in the

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -90,6 +90,7 @@ import {
   issueProvenanceRecords,
   snapshotBoardIssue,
   type IssueDetail,
+  type IssueAssigneeSession,
   issueRunRecord,
   type IssueFiringMarkers,
   type IssuesSnapshot,
@@ -123,6 +124,7 @@ import {
 import { updateIssueFields } from './issues/mutate.js';
 import {
   issueAutomationHealth,
+  issueAutomationRuntime,
   type IssueAutomationOwnerState,
 } from './issues/automation-health.js';
 import {
@@ -366,7 +368,7 @@ import {
   type SessionRecord,
 } from './session-registry.js';
 import { ProductSessionCoordinator } from './product-session-coordinator.js';
-import { projectPublicSession } from './public-session.js';
+import { projectPublicSession, projectPublicSessionRuntime } from './public-session.js';
 import { NativeSessionTitleResolver } from './session-title-resolver.js';
 import { buildCliPath, buildSpawnEnv } from './spawn-env.js';
 import { TemplateRegistry } from './template-registry.js';
@@ -1085,6 +1087,53 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         : null) ??
       validRegisteredRuntime(await readIssueDefaultAgent().catch(() => null)) ??
       await resolveDefaultAgentId(wsMeta);
+  };
+
+  const projectIssueAssigneeSession = (assignee: string): IssueAssigneeSession | undefined => {
+    const resumeId = issueAssigneeResumeId(assignee);
+    if (!resumeId) return undefined;
+    const identity = resumeRegistry.get(resumeId);
+    if (!identity) return { resumeId, state: 'missing', active: false };
+    const workspace = registry.get(identity.wsId);
+    const presence = sessionPresence(identity);
+    const state: IssueAssigneeSession['state'] = identity.lifecycle === 'retired'
+      ? 'retired'
+      : presence === 'deleted'
+        ? 'deleted'
+        : !workspace
+          ? 'workspace_missing'
+          : identity.agentSessionId
+            ? 'ready'
+            : 'unbound';
+    return {
+      resumeId,
+      state,
+      ...(workspace ? { workspace: { id: workspace.id, tag: workspace.tag } } : {}),
+      agent: identity.agent,
+      ...(identity.displayName ? { displayName: identity.displayName } : {}),
+      createdAt: identity.createdAt,
+      updatedAt: identity.updatedAt,
+      active: state === 'ready' && activeResumeIds.has(resumeId),
+      ...(identity.runtimeBinding
+        ? { runtime: projectPublicSessionRuntime(identity.runtimeBinding) }
+        : {}),
+    };
+  };
+
+  const issueRuntimeAvailability = (
+    issue: IssueRecord,
+    defaultAgent: string | undefined,
+    availability: Record<string, AgentAvailability>,
+  ): { agent: string; displayName: string; installed: boolean } | undefined => {
+    const resumeId = issueAssigneeResumeId(issue.assignee);
+    const sessionAgent = resumeId ? resumeRegistry.get(resumeId)?.agent : undefined;
+    return issueAutomationRuntime({
+      ...(sessionAgent ? { sessionAgent } : {}),
+      ...(issue.agent ? { issueAgent: issue.agent } : {}),
+      ...(defaultAgent ? { defaultAgent } : {}),
+      availability,
+      displayNameFor: (agent) => adapters.get(agent)?.displayName,
+    });
   };
 
   /**
@@ -2301,6 +2350,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   // board's unscheduled work items — and the board is a low-frequency poll.
   const issuesSnapshot = async (): Promise<IssuesSnapshot> => {
     const nowMs = Date.now();
+    const availability = detectAgents();
     const workspaces = await Promise.all(
       registry.list().map(async (ws): Promise<IssuesSnapshotWorkspace> => {
         const res = await readWorkspaceIssues(ws.dir);
@@ -2314,6 +2364,12 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           return { wsId: ws.id, tag: ws.tag, status: 'invalid', error: res.error, issues: [] };
         }
         await observeIssueRecords(ws, res.issues);
+        const needsDefaultAgent = res.issues.some((issue) =>
+          Boolean(issue.when) && !issueAssigneeResumeId(issue.assignee) && !issue.agent,
+        );
+        const defaultIssueAgent = needsDefaultAgent
+          ? await resolveIssueDefaultAgentId(ws)
+          : undefined;
         const issues: IssuesSnapshotIssue[] = res.issues.filter((issue) => !isConnectorDeskIssue(issue)).map((issue) => {
           // Unscheduled ⇒ pure board work item, no firing markers.
           if (!issue.when) return snapshotBoardIssue(issue, null);
@@ -2338,6 +2394,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
                 nowMs,
                 nextDueAtMs: fired.nextDueAtMs,
                 ownerState: automationOwnerState(issue.assignee, resumeRegistry),
+                runtime: issueRuntimeAvailability(issue, defaultIssueAgent, availability),
                 ...(latestRun ? { latestRun: automationLatestRun(latestRun) } : {}),
               }),
             },
@@ -2366,6 +2423,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     await observeIssueRecords(ws, res.issues);
     const issue = res.issues.find((i) => i.id === id);
     if (!issue) return null;
+    const assigneeSession = projectIssueAssigneeSession(issue.assignee);
+    const defaultIssueAgent = issue.when && !issueAssigneeResumeId(issue.assignee) && !issue.agent
+      ? await resolveIssueDefaultAgentId(ws)
+      : undefined;
+    const runtimeAvailability = issue.when
+      ? issueRuntimeAvailability(issue, defaultIssueAgent, detectAgents())
+      : undefined;
     const commentsResult = await readIssueComments(ws.dir, issue.id);
     const comments = commentsResult.ok ? commentsResult.comments : [];
     if (!commentsResult.ok) {
@@ -2396,6 +2460,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         nowMs: Date.now(),
         nextDueAtMs: scheduledSnapshot.nextDueAtMs,
         ownerState: automationOwnerState(issue.assignee, resumeRegistry),
+        runtime: runtimeAvailability,
         ...(runs[0] ? {
           latestRun: {
             taskId: runs[0].taskId,
@@ -2428,7 +2493,15 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       artifact: { kind: 'issue', workspaceId: ws.id, issueId: issue.id },
     }));
     const activity = issueActivityRecords(provenance, comments);
-    return { issue: detailIssue(issue, markers), comments, runs, inboxReports, provenance, activity };
+    return {
+      issue: detailIssue(issue, markers),
+      ...(assigneeSession ? { assigneeSession } : {}),
+      comments,
+      runs,
+      inboxReports,
+      provenance,
+      activity,
+    };
   };
 
   const retryingIssueKeys = new Set<string>();

--- a/src/workspaces/session-directory.spec.ts
+++ b/src/workspaces/session-directory.spec.ts
@@ -59,6 +59,11 @@ describe('buildWorkspaceSessionDirectory', () => {
         output: { hasAssistantReply: true, assistantPreview: 'done', blockCount: 1, toolCalls: 0, toolFailures: 0 },
       }),
       isActive: () => false,
+      issueTitleFor: (workspaceId, issueId) => (
+        workspaceId === 'ws-1' && issueId === 'daily-market-close'
+          ? 'Daily market close review'
+          : undefined
+      ),
     })
 
     expect(result.sessions[0]).toMatchObject({
@@ -73,6 +78,7 @@ describe('buildWorkspaceSessionDirectory', () => {
       },
       displayName: 'AAPL desk',
       runtime: { credentialSource: 'vault', credentialSlug: 'secret-slug', model: 'gpt-5.6-terra', reasoningEffort: 'high' },
+      presentationTitle: 'Daily market close review',
       interactive: { name: 'c1', title: 'Investigate provenance' },
       latestExecution: { taskId: 'task-1', assistantPreview: 'done' },
     })

--- a/src/workspaces/session-directory.ts
+++ b/src/workspaces/session-directory.ts
@@ -11,6 +11,7 @@ import {
 } from './resume-registry.js'
 import { sessionPreferredTitle, type SessionRecord } from './session-registry.js'
 import type { SessionCreatedBy } from './session-metadata.js'
+import { projectSessionPresentationTitle } from './session-presentation.js'
 import {
   projectPublicSessionRuntime,
   type PublicSessionRuntime,
@@ -36,6 +37,8 @@ export interface WorkspaceSessionDirectoryEntry {
   /** Live Issue ownership/occupancy. Presentation preferences decide whether to show it. */
   issueAttached?: true
   runtime?: PublicSessionRuntime
+  /** Backend-authoritative title with internal launch wrappers projected away. */
+  presentationTitle?: string
   latestExecution?: {
     taskId: string
     status: HeadlessTaskStatus
@@ -104,6 +107,7 @@ export function buildWorkspaceSessionDirectory(input: {
   isActive(resumeId: string): boolean
   rosterVisibilityFor?(resumeId: string): 'hidden' | undefined
   issueAttachedFor?(resumeId: string): true | undefined
+  issueTitleFor?(workspaceId: string, issueId: string): string | undefined
 }): WorkspaceSessionDirectory {
   return {
     workspace: input.workspace,
@@ -111,6 +115,16 @@ export function buildWorkspaceSessionDirectory(input: {
       const execution = input.latestExecutionFor(identity.resumeId)
       const interactive = input.interactiveFor(identity.resumeId)
       const interactiveTitle = interactive ? sessionPreferredTitle(interactive) : undefined
+      const presentationTitle = interactive
+        ? projectSessionPresentationTitle({
+            record: interactive,
+            ...(identity.metadata?.createdBy
+              ? { createdBy: identity.metadata.createdBy }
+              : {}),
+            ...(execution ? { latestExecution: execution } : {}),
+            ...(input.issueTitleFor ? { issueTitleFor: input.issueTitleFor } : {}),
+          })
+        : undefined
       return {
         resumeId: identity.resumeId,
         agent: identity.agent,
@@ -132,6 +146,7 @@ export function buildWorkspaceSessionDirectory(input: {
         ...(identity.runtimeBinding
           ? { runtime: projectPublicSessionRuntime(identity.runtimeBinding) }
           : {}),
+        ...(presentationTitle ? { presentationTitle } : {}),
         ...(execution
           ? {
               latestExecution: {

--- a/src/workspaces/session-presentation.spec.ts
+++ b/src/workspaces/session-presentation.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  projectSessionPresentationTitle,
+  readableIssueIdentity,
+} from './session-presentation.js';
+import type { SessionRecord } from './session-registry.js';
+
+const rawReconstruction = [
+  'You are reconstructing a prior Alice Session.',
+  '{"target":{"kind":"issue","issueId":"telegram-phone-desk"}}',
+].join('\n');
+
+function record(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'session-1',
+    resumeId: 'resume-1',
+    wsId: 'ws-1',
+    agent: 'pi',
+    name: 'p1',
+    createdAt: '2026-09-01T00:00:00.000Z',
+    lastActiveAt: '2026-09-01T00:01:00.000Z',
+    state: 'paused',
+    surface: 'headless',
+    fallbackTitle: rawReconstruction,
+    ...overrides,
+  };
+}
+
+describe('projectSessionPresentationTitle', () => {
+  it('uses Issue birth provenance instead of the scheduled instruction', () => {
+    expect(projectSessionPresentationTitle({
+      record: record({ fallbackTitle: 'Run the entire daily close checklist.' }),
+      createdBy: {
+        kind: 'issue',
+        workspaceId: 'ws-1',
+        issueId: 'daily-market-close',
+        policy: 'new-then-resume',
+        fire: 'schedule',
+      },
+    })).toBe('Daily Market Close');
+  });
+
+  it('uses an Issue conversation subject instead of reconstruction JSON', () => {
+    expect(projectSessionPresentationTitle({
+      record: record(),
+      createdBy: {
+        kind: 'conversation',
+        caller: { kind: 'human' },
+        reason: 'issue-comment',
+        subject: {
+          kind: 'issue',
+          workspaceId: 'ws-1',
+          issueId: 'telegram-phone-desk',
+          relation: 'owner',
+        },
+      },
+    })).toBe('Telegram Phone Desk');
+  });
+
+  it('uses the original inquiry question for a reconstructed Inbox follow-up', () => {
+    expect(projectSessionPresentationTitle({
+      record: record(),
+      createdBy: {
+        kind: 'conversation',
+        caller: { kind: 'human' },
+        reason: 'prior-reconstruction',
+      },
+      latestExecution: {
+        inquiry: {
+          subject: { kind: 'inbox', entryId: 'entry-1' },
+          question: '  What changed after the close?  ',
+          resolution: { mode: 'reconstructed' },
+        },
+      },
+    })).toBe('What changed after the close?');
+  });
+
+  it('recovers historical headless Issue identity without guessing from prompt text', () => {
+    expect(projectSessionPresentationTitle({
+      record: record({ sourceRunId: 'run-legacy' }),
+      latestExecution: {
+        trigger: { kind: 'issue', workspaceId: 'ws-1', issueId: 'risk_watch' },
+      },
+      issueTitleFor: (_workspaceId, issueId) => issueId === 'risk_watch'
+        ? 'Overnight risk watch'
+        : undefined,
+    })).toBe('Overnight risk watch');
+  });
+
+  it('does not let a later Issue turn rename an interactive-born Session', () => {
+    expect(projectSessionPresentationTitle({
+      record: record({ surface: 'terminal', sourceRunId: undefined, fallbackTitle: 'My thesis' }),
+      createdBy: { kind: 'interactive', surface: 'quick-chat' },
+      latestExecution: {
+        trigger: { kind: 'issue', workspaceId: 'ws-1', issueId: 'later-run' },
+      },
+    })).toBe('My thesis');
+  });
+
+  it('keeps direct headless prompts because no structured business source supersedes them', () => {
+    expect(projectSessionPresentationTitle({
+      record: record({ fallbackTitle: 'Summarize this repository' }),
+      createdBy: { kind: 'headless', surface: 'api' },
+    })).toBe('Summarize this repository');
+  });
+});
+
+describe('readableIssueIdentity', () => {
+  it('keeps acronyms and CJK while humanizing separators', () => {
+    expect(readableIssueIdentity('AAPL_每日-risk-watch')).toBe('AAPL 每日 Risk Watch');
+  });
+});

--- a/src/workspaces/session-presentation.ts
+++ b/src/workspaces/session-presentation.ts
@@ -1,0 +1,103 @@
+import type { HeadlessTaskRecord } from './headless-task-registry.js';
+import type { SessionCreatedBy } from './session-metadata.js';
+import { sessionPreferredTitle, type SessionRecord } from './session-registry.js';
+
+const ISSUE_ID_SPLIT = /[-_]+/u;
+const PREVIEW_TITLE_LIMIT = 120;
+
+type PresentationRecord = Pick<
+  SessionRecord,
+  'resumeId' | 'name' | 'surface' | 'sourceRunId' | 'title' | 'fallbackTitle'
+>;
+
+type PresentationExecution = Pick<HeadlessTaskRecord, 'trigger' | 'inquiry' | 'output'>;
+
+export interface SessionPresentationInput {
+  readonly record: PresentationRecord;
+  readonly createdBy?: SessionCreatedBy;
+  readonly latestExecution?: PresentationExecution | null;
+  /** Optional live Issue-title resolver. The readable Issue id remains the safe fallback. */
+  readonly issueTitleFor?: (workspaceId: string, issueId: string) => string | undefined;
+}
+
+/**
+ * Public, read-side Session title projection.
+ *
+ * Persisted launcher/native titles remain untouched. Structured product
+ * provenance wins only when it proves that the stored launch title belongs to
+ * an Issue or reconstructed inquiry; direct and interactive prompts retain the
+ * historical title contract.
+ */
+export function projectSessionPresentationTitle(input: SessionPresentationInput): string | undefined {
+  const { record, createdBy, latestExecution } = input;
+
+  if (createdBy?.kind === 'issue') {
+    return issueTitle(input, createdBy.workspaceId, createdBy.issueId);
+  }
+
+  if (createdBy?.kind === 'conversation') {
+    const subject = createdBy.subject;
+    if (subject?.kind === 'issue') {
+      return issueTitle(input, subject.workspaceId, subject.issueId);
+    }
+    const question = normalizedPreview(latestExecution?.inquiry?.question);
+    if (question) return question;
+  }
+
+  // Before immutable birth provenance shipped, a headless launcher record and
+  // its execution registry still formed a structured pair. Restrict this
+  // fallback to headless-born records so a later scheduled turn cannot rename
+  // an ordinary interactive conversation.
+  const mayUseExecutionSource = createdBy?.kind === 'headless'
+    || (!createdBy && (record.surface === 'headless' || Boolean(record.sourceRunId)));
+  if (mayUseExecutionSource) {
+    const subject = latestExecution?.inquiry?.subject;
+    if (subject?.kind === 'issue') {
+      return issueTitle(input, subject.workspaceId, subject.issueId);
+    }
+    if (latestExecution?.trigger?.kind === 'issue') {
+      return issueTitle(input, latestExecution.trigger.workspaceId, latestExecution.trigger.issueId);
+    }
+    const question = normalizedPreview(latestExecution?.inquiry?.question);
+    if (question) return question;
+  }
+
+  const stored = sessionPreferredTitle(record);
+  if (stored) return stored;
+
+  const assistantPreview = normalizedPreview(latestExecution?.output?.assistantPreview);
+  if (assistantPreview) return assistantPreview;
+  return undefined;
+}
+
+export function readableIssueIdentity(issueId: string): string {
+  const trimmed = issueId.trim();
+  if (!trimmed) return trimmed;
+  const parts = trimmed.split(ISSUE_ID_SPLIT).filter(Boolean);
+  if (parts.length === 0) return trimmed;
+  return parts.map(titleCaseIssuePart).join(' ');
+}
+
+function issueTitle(
+  input: SessionPresentationInput,
+  workspaceId: string,
+  issueId: string,
+): string {
+  const liveTitle = input.issueTitleFor?.(workspaceId, issueId)?.trim();
+  return liveTitle || readableIssueIdentity(issueId);
+}
+
+function normalizedPreview(value: string | undefined): string | undefined {
+  const normalized = value?.replace(/\s+/gu, ' ').trim();
+  if (!normalized) return undefined;
+  return normalized.length > PREVIEW_TITLE_LIMIT
+    ? `${normalized.slice(0, PREVIEW_TITLE_LIMIT - 1)}…`
+    : normalized;
+}
+
+function titleCaseIssuePart(part: string): string {
+  if (part.length === 0) return part;
+  if (part === part.toUpperCase() && /[A-Za-z]/u.test(part)) return part;
+  if (!/[A-Za-z]/u.test(part)) return part;
+  return part.charAt(0).toUpperCase() + part.slice(1);
+}

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -49,6 +49,11 @@ export type IssueAutomationHealthState =
 export interface IssueAutomationHealth {
   state: IssueAutomationHealthState
   message: string
+  blocker?: {
+    kind: 'agent_runtime_missing'
+    agent: string
+    displayName: string
+  }
   latestTaskId?: string
 }
 export type IssueProvenanceAction = 'created' | 'updated' | 'commented' | 'sent' | 'decided' | 'reconstructed'
@@ -276,9 +281,28 @@ export interface IssueDetailIssue {
   telegramConnector?: true
 }
 
+export interface IssueAssigneeSession {
+  resumeId: string
+  state: 'ready' | 'missing' | 'retired' | 'deleted' | 'unbound' | 'workspace_missing'
+  workspace?: { id: string; tag: string }
+  agent?: string
+  displayName?: string
+  createdAt?: number
+  updatedAt?: number
+  active: boolean
+  runtime?: {
+    credentialSource: 'native' | 'vault' | 'workspace'
+    credentialSlug?: string
+    model?: string
+    reasoningEffort?: ModelReasoningEffort
+  }
+}
+
 /** GET /api/issues/:wsId/:id — one issue + Activity, Runs, and reports. */
 export interface IssueDetail {
   issue: IssueDetailIssue
+  /** Authoritative global lookup for an exact @resume assignee. */
+  assigneeSession?: IssueAssigneeSession
   /** Structured markdown comments from `<id>.comments.json`. */
   comments?: IssueComment[]
   /** This issue's headless runs (wsId + issueId match), newest first. */

--- a/ui/src/api/trading.ts
+++ b/ui/src/api/trading.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from './client'
-import type { UTASummary, AccountInfo, SubAccountRef, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, BrokerEngine, BrokerPackStatus, UTASnapshotSummary, EquityCurvePoint, PlaceOrderRequest, ClosePositionRequest, CancelOrderRequest, OrderErrorResponse, OrderHistoryEntry, TradeHistoryEntry } from './types'
+import type { UTASummary, AccountInfo, SubAccountRef, Position, WalletCommitLog, ReconnectResult, UTAConfig, WalletStatus, WalletPushResult, WalletRejectResult, TestConnectionResult, BrokerPreset, BrokerEngine, BrokerPackStatus, BrokerPackReadinessResponse, UTASnapshotSummary, EquityCurvePoint, PlaceOrderRequest, ClosePositionRequest, CancelOrderRequest, OrderErrorResponse, OrderHistoryEntry, TradeHistoryEntry } from './types'
 
 /** Thrown by the one-shot order endpoints when the server returns non-2xx. Carries the phase. */
 export class OrderEntryError extends Error {
@@ -190,7 +190,7 @@ export const tradingApi = {
     return fetchJson('/api/trading/config/broker-presets')
   },
 
-  async getBrokerPacks(): Promise<{ packs: BrokerPackStatus[] }> {
+  async getBrokerPacks(): Promise<BrokerPackReadinessResponse> {
     return fetchJson('/api/trading/config/broker-packs')
   },
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -535,6 +535,8 @@ export interface UTAConfig {
   presetConfig: Record<string, unknown>
   /** Whether broker-side account mutations are refused. */
   readOnly: boolean
+  /** Public-data-only UTA; excluded from account and portfolio surfaces. */
+  keyless?: boolean
   /** Whether this UTA participates in broker-backed market-data discovery. */
   asVendor: boolean
 }
@@ -579,6 +581,29 @@ export interface BrokerPackStatus {
   updateAvailable?: boolean
   reason?: string
   requiredBy: string[]
+}
+
+export type BrokerAccountPackState =
+  | 'ready'
+  | 'needs-install'
+  | 'needs-repair'
+  | 'unsupported-preset'
+
+export interface BrokerAccountPackReadiness {
+  accountId: string
+  label: string
+  presetId: string
+  configuredEnabled: boolean
+  engine?: BrokerEngine
+  state: BrokerAccountPackState
+  operational: boolean
+  action?: 'install' | 'repair' | 'update'
+  reason?: string
+}
+
+export interface BrokerPackReadinessResponse {
+  packs: BrokerPackStatus[]
+  accounts: BrokerAccountPackReadiness[]
 }
 
 export interface GuardEntry {

--- a/ui/src/auth/AuthContext.spec.tsx
+++ b/ui/src/auth/AuthContext.spec.tsx
@@ -18,10 +18,11 @@ import { AuthGate, BackendUnavailableScreen } from './AuthGate'
 import { BACKEND_PROBE_REQUESTED_EVENT } from './backendConnectivity'
 
 function WorkspaceHarness() {
-  const { refresh } = useAuth()
+  const { backendRecoveryGeneration, refresh } = useAuth()
   return (
     <>
       <div>workspace-app</div>
+      <span data-testid="backend-recovery-generation">{backendRecoveryGeneration}</span>
       <button type="button" onClick={() => void refresh()}>Refresh auth</button>
     </>
   )
@@ -121,6 +122,37 @@ describe('AuthProvider backend recovery', () => {
 
     expect(screen.getByText('workspace-app')).toBeTruthy()
     expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByTestId('backend-recovery-generation').textContent).toBe('1')
+  })
+
+  it('increments the recovery generation once per unavailable-to-available transition', async () => {
+    vi.useFakeTimers()
+    mocks.getStatus
+      .mockResolvedValueOnce({ authed: true, tokenConfigured: true })
+      .mockRejectedValueOnce(new Error('backend restarting'))
+      .mockResolvedValueOnce({ authed: true, tokenConfigured: true })
+      .mockResolvedValueOnce({ authed: true, tokenConfigured: true })
+
+    render(
+      <AuthProvider>
+        <AuthGate><WorkspaceHarness /></AuthGate>
+      </AuthProvider>,
+    )
+    await flushEffects()
+    expect(screen.getByTestId('backend-recovery-generation').textContent).toBe('0')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh auth' }))
+    await flushEffects()
+    expect(screen.getByTestId('backend-recovery-generation').textContent).toBe('0')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250)
+    })
+    expect(screen.getByTestId('backend-recovery-generation').textContent).toBe('1')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh auth' }))
+    await flushEffects()
+    expect(screen.getByTestId('backend-recovery-generation').textContent).toBe('1')
   })
 
   it('detects a quiet backend shutdown with the core heartbeat', async () => {

--- a/ui/src/auth/AuthContext.spec.tsx
+++ b/ui/src/auth/AuthContext.spec.tsx
@@ -13,7 +13,12 @@ vi.mock('./api', () => ({
   getStatus: mocks.getStatus,
 }))
 
-import { AuthProvider, BACKEND_HEALTH_POLL_MS, useAuth } from './AuthContext'
+import {
+  AuthProvider,
+  BACKEND_HEALTH_POLL_MS,
+  useAuth,
+  useBackendRecoverySignal,
+} from './AuthContext'
 import { AuthGate, BackendUnavailableScreen } from './AuthGate'
 import { BACKEND_PROBE_REQUESTED_EVENT } from './backendConnectivity'
 
@@ -26,6 +31,11 @@ function WorkspaceHarness() {
       <button type="button" onClick={() => void refresh()}>Refresh auth</button>
     </>
   )
+}
+
+function OptionalBackendSignalHarness() {
+  const { backendUnavailable, backendRecoveryGeneration } = useBackendRecoverySignal()
+  return <span>{`${backendUnavailable}:${backendRecoveryGeneration}`}</span>
 }
 
 async function flushEffects() {
@@ -42,6 +52,11 @@ afterEach(() => {
 })
 
 describe('AuthProvider backend recovery', () => {
+  it('lets reusable domain hooks default to no observed outage outside AuthProvider', () => {
+    render(<OptionalBackendSignalHarness />)
+    expect(screen.getByText('false:0')).toBeTruthy()
+  })
+
   it('shows the exact SSH route when a remote Runtime is unavailable', () => {
     render(
       <BackendUnavailableScreen

--- a/ui/src/auth/AuthContext.tsx
+++ b/ui/src/auth/AuthContext.tsx
@@ -47,6 +47,9 @@ interface AuthContextValue {
   /** The last status check was inconclusive because Alice is unavailable.
    *  Keep the last confirmed auth decision while retrying. */
   backendUnavailable: boolean
+  /** Monotonic signal for consumers with their own transport. Increments only
+   *  when Alice answers again after a confirmed transport outage. */
+  backendRecoveryGeneration: number
   /** Re-check /api/auth/status. Called after login success. */
   refresh: () => Promise<void>
   /** Locally flip state to login-required (e.g. after logout). */
@@ -71,8 +74,10 @@ function deriveState(status: AuthStatus | null): AuthState {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<AuthStatus | null>(null)
   const [backendUnavailable, setBackendUnavailable] = useState(false)
+  const [backendRecoveryGeneration, setBackendRecoveryGeneration] = useState(0)
   const [retryAttempt, setRetryAttempt] = useState(0)
   const mountedRef = useRef(false)
+  const backendUnavailableRef = useRef(false)
   const requestGenerationRef = useRef(0)
   const requestedProbeTimerRef = useRef<number | null>(null)
   const state = deriveState(status)
@@ -83,6 +88,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const next = await getStatus()
       if (!mountedRef.current || generation !== requestGenerationRef.current) return
       setStatus(next)
+      if (backendUnavailableRef.current) {
+        backendUnavailableRef.current = false
+        setBackendRecoveryGeneration((current) => current + 1)
+      }
       setBackendUnavailable(false)
       setRetryAttempt(0)
     } catch {
@@ -90,6 +99,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Absence of an answer is not an authentication decision. Preserve the
       // last confirmed status (and therefore the mounted App) while Alice's
       // watch process comes back, then retry with a short capped backoff.
+      backendUnavailableRef.current = true
       setBackendUnavailable(true)
       setRetryAttempt((attempt) => attempt + 1)
     }
@@ -97,6 +107,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const markUnauthorized = useCallback(() => {
     requestGenerationRef.current += 1
+    backendUnavailableRef.current = false
     setStatus({ authed: false, tokenConfigured: true })
     setBackendUnavailable(false)
     setRetryAttempt(0)
@@ -166,6 +177,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       state,
       status,
       backendUnavailable,
+      backendRecoveryGeneration,
       refresh,
       markUnauthorized,
     }}>

--- a/ui/src/auth/AuthContext.tsx
+++ b/ui/src/auth/AuthContext.tsx
@@ -57,11 +57,27 @@ interface AuthContextValue {
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
+const DEFAULT_BACKEND_RECOVERY_SIGNAL = Object.freeze({
+  backendUnavailable: false,
+  backendRecoveryGeneration: 0,
+})
 
 export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext)
   if (!ctx) throw new Error('useAuth must be used within AuthProvider')
   return ctx
+}
+
+/** Optional connectivity signal for reusable domain hooks. Those hooks are
+ * also rendered in isolated tests and embedded surfaces that do not own auth;
+ * absence of the provider means no observed outage, while auth decisions
+ * themselves continue to require the strict useAuth() contract above. */
+export function useBackendRecoverySignal(): Pick<
+  AuthContextValue,
+  'backendUnavailable' | 'backendRecoveryGeneration'
+> {
+  const ctx = useContext(AuthContext)
+  return ctx ?? DEFAULT_BACKEND_RECOVERY_SIGNAL
 }
 
 function deriveState(status: AuthStatus | null): AuthState {

--- a/ui/src/components/IssueDetail.spec.tsx
+++ b/ui/src/components/IssueDetail.spec.tsx
@@ -145,6 +145,7 @@ beforeEach(async () => {
   resetAgentRuntimesStore()
   await i18n.changeLanguage('en')
   delete scheduledIssue.issue.automationHealth
+  delete scheduledIssue.assigneeSession
   delete scheduledIssue.issue.credential
   delete scheduledIssue.issue.model
   delete scheduledIssue.issue.effort
@@ -462,21 +463,20 @@ describe('IssueDetail property controls', () => {
   it('confirms a bound Session capability change without rewriting Issue frontmatter', async () => {
     scheduledIssue.issue.assignee = '@resume-kind-owl-abc123'
     delete scheduledIssue.issue.agent
-    mocks.getWorkspaceSessionDirectory.mockResolvedValue({
-      sessions: [{
-        resumeId: 'resume-kind-owl-abc123',
-        agent: 'codex',
-        createdAt: Date.now() - 86_400_000,
-        updatedAt: Date.now() - 60_000,
-        resumable: true,
-        active: false,
-        runtime: {
-          credentialSource: 'native',
-          model: 'claude-sonnet-4-5',
-          reasoningEffort: 'high',
-        },
-      }],
-    })
+    scheduledIssue.assigneeSession = {
+      resumeId: 'resume-kind-owl-abc123',
+      state: 'ready',
+      workspace: { id: 'demo-ws-remote', tag: 'remote' },
+      agent: 'codex',
+      displayName: 'Remote researcher',
+      active: false,
+      runtime: {
+        credentialSource: 'native',
+        model: 'claude-sonnet-4-5',
+        reasoningEffort: 'high',
+      },
+    }
+    mocks.getWorkspaceSessionDirectory.mockResolvedValue({ sessions: [] })
 
     render(<IssueDetail wsId="demo-ws-auto-quant" id="morning-scan" />)
 
@@ -486,6 +486,7 @@ describe('IssueDetail property controls', () => {
     expect(trigger.textContent).toContain('claude-sonnet-4-5 · high')
     expect(screen.queryByRole('combobox', { name: 'Runtime' })).toBeNull()
     expect(screen.getByText('codex')).toBeTruthy()
+    expect(screen.queryByText('This bound Session is no longer available.')).toBeNull()
 
     fireEvent.click(trigger)
     expect(screen.queryByRole('checkbox', { name: 'Follow Workspace headless preference' })).toBeNull()
@@ -501,7 +502,7 @@ describe('IssueDetail property controls', () => {
     fireEvent.click(within(confirm).getByRole('button', { name: 'Change capabilities' }))
 
     await waitFor(() => expect(mocks.updateResumeRuntime).toHaveBeenCalledWith(
-      'demo-ws-auto-quant',
+      'demo-ws-remote',
       'resume-kind-owl-abc123',
       {
         credentialSource: 'native',

--- a/ui/src/components/IssueDetail.tsx
+++ b/ui/src/components/IssueDetail.tsx
@@ -8,6 +8,7 @@ import type { HeadlessTaskStatus, HeadlessTurnProgress } from '../api/headless'
 import type { InboxEntry } from '../api/inbox'
 import type {
   IssueDetail as IssueDetailData,
+  IssueAssigneeSession,
   IssueDetailIssue,
   IssuePatch,
   IssueActivityRecord,
@@ -23,7 +24,6 @@ import { DEFAULT_ISSUE_COMMENT_PROMPT, ISSUE_TIMEOUTS, issuesApi } from '../api/
 
 import {
   getAgentReadiness,
-  getWorkspaceSessionDirectory,
   listAgentCredentials,
   updateResumeRuntime,
   type AgentCredentialReadiness,
@@ -41,6 +41,7 @@ import {
   usePinnedRuntimeDraft,
 } from '../hooks/usePinnedRuntimeDraft'
 import { useIssueDetail } from '../hooks/useIssueDetail'
+import { useWorkspaceSessionDirectory } from '../hooks/useWorkspaceSessionDirectory'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { formatRelativeTime } from '../lib/intl'
 import { useInboxRead } from '../live/inbox-read'
@@ -147,12 +148,14 @@ function AssigneeEditor({
   value,
   scheduled,
   sessions,
+  authoritativeOwner,
   disabled,
   onChange,
 }: {
   value: string
   scheduled: boolean
   sessions: readonly WorkspaceSessionDirectoryEntry[]
+  authoritativeOwner?: IssueAssigneeSession
   disabled?: boolean
   onChange: (next: string) => Promise<boolean>
 }) {
@@ -170,7 +173,12 @@ function AssigneeEditor({
     .toSorted((a, b) => Number(b.active) - Number(a.active) || b.updatedAt - a.updatedAt)
   const selectedResumeId = value.startsWith('@resume-') ? value.slice(1) : null
   const draftResumeId = draftValue.startsWith('@resume-') ? draftValue.slice(1) : null
-  const hasSelected = !selectedResumeId || sessionChoices.some((session) => session.resumeId === selectedResumeId)
+  const authoritativeSelected = selectedResumeId && authoritativeOwner?.resumeId === selectedResumeId
+    ? authoritativeOwner
+    : undefined
+  const hasSelected = !selectedResumeId
+    || sessionChoices.some((session) => session.resumeId === selectedResumeId)
+    || authoritativeSelected?.state === 'ready'
   const contextFor = (session: WorkspaceSessionDirectoryEntry) => {
     const rawContext = session.interactive?.title
       || session.interactive?.name
@@ -201,9 +209,13 @@ function AssigneeEditor({
   const selectedPolicy = policyChoices.find((choice) => choice.value === value)
   const selectedLabel = selectedSession
     ? contextFor(selectedSession) ?? selectedSession.resumeId
+    : authoritativeSelected?.state === 'ready'
+      ? authoritativeSelected.displayName ?? authoritativeSelected.resumeId
     : selectedPolicy?.label ?? (selectedResumeId ? selectedResumeId : value)
   const selectedDescription = selectedSession
     ? `${selectedSession.agent} · ${selectedSession.active ? t('issues.detail.activeNow') : formatRelativeTime(selectedSession.updatedAt)}`
+    : authoritativeSelected?.state === 'ready'
+      ? [authoritativeSelected.agent, authoritativeSelected.workspace?.tag].filter(Boolean).join(' · ')
     : selectedPolicy?.description
   const draftSession = draftResumeId
     ? sessionChoices.find((session) => session.resumeId === draftResumeId)
@@ -304,6 +316,19 @@ function AssigneeEditor({
               <AssigneeChoice
                 label={t('issues.detail.signedSession', { resumeId: selectedResumeId })}
                 description={t('issues.detail.sessionUnavailable')}
+                selected={draftValue === value}
+                onClick={() => setDraftValue(value)}
+              />
+            )}
+            {authoritativeSelected?.state === 'ready'
+              && !sessionChoices.some((session) => session.resumeId === authoritativeSelected.resumeId) && (
+              <AssigneeChoice
+                label={authoritativeSelected.displayName ?? authoritativeSelected.resumeId}
+                description={[
+                  authoritativeSelected.resumeId,
+                  authoritativeSelected.agent,
+                  authoritativeSelected.workspace?.tag,
+                ].filter(Boolean).join(' · ')}
                 selected={draftValue === value}
                 onClick={() => setDraftValue(value)}
               />
@@ -488,7 +513,11 @@ function runtimeUpdateToIssuePatch(
   }
 }
 
-function ownerSessionBusy(session: WorkspaceSessionDirectoryEntry | undefined): boolean {
+function ownerSessionBusy(session: {
+  active?: boolean
+  interactive?: { state: string }
+  latestExecution?: { status: string }
+} | undefined): boolean {
   return Boolean(
     session?.active
     || session?.interactive?.state === 'running'
@@ -936,6 +965,7 @@ function PropertiesRail({
   headlessRuntime,
   agentReadiness,
   sessions,
+  assigneeSession,
   saving,
   retrying,
   error,
@@ -956,6 +986,7 @@ function PropertiesRail({
   headlessRuntime: WorkspaceRuntimeModeSettings | null
   agentReadiness: Readonly<Record<string, AgentCredentialReadiness>>
   sessions: readonly WorkspaceSessionDirectoryEntry[]
+  assigneeSession?: IssueAssigneeSession
   saving: boolean
   retrying: boolean
   error: string | null
@@ -982,10 +1013,18 @@ function PropertiesRail({
   const ownerResumeId = issue.assignee.startsWith('@resume-')
     ? issue.assignee.slice(1)
     : null
-  const ownerSession = ownerResumeId
+  const directoryOwner = ownerResumeId
     ? sessions.find((session) => session.resumeId === ownerResumeId)
     : undefined
-  const effectiveAgent = ownerSession?.agent || issue.agent || issueDefaultInOptions || defaultInOptions || agents[0]?.id || null
+  const authoritativeOwner = ownerResumeId && assigneeSession?.resumeId === ownerResumeId
+    ? assigneeSession
+    : undefined
+  const ownerSession = authoritativeOwner
+    ? (authoritativeOwner.state === 'ready' ? authoritativeOwner : undefined)
+    : directoryOwner
+  const ownerResolved = Boolean(ownerSession)
+  const ownerResolutionLoaded = Boolean(authoritativeOwner) || sessionsLoaded
+  const effectiveAgent = authoritativeOwner?.agent || directoryOwner?.agent || issue.agent || issueDefaultInOptions || defaultInOptions || agents[0]?.id || null
   const selectedReadiness = effectiveAgent ? agentReadiness[effectiveAgent] : undefined
   const [credentialOptions, setCredentialOptions] = useState<{
     agent: string
@@ -1031,6 +1070,11 @@ function PropertiesRail({
     // Failure/interruption messages may contain authoritative runtime diagnostics.
     // Keep those verbatim; only localize launcher-owned, deterministic states.
     if (health.state === 'failed' || health.state === 'interrupted') return health.message
+    if (health.blocker?.kind === 'agent_runtime_missing') {
+      return t('issues.detail.healthMessage.runtimeMissing', {
+        agent: health.blocker.displayName || health.blocker.agent,
+      })
+    }
     if (health.state === 'inactive') {
       return t('issues.detail.healthMessage.inactive', {
         status: t(`issues.status.${issue.status}`),
@@ -1152,6 +1196,7 @@ function PropertiesRail({
               value={issue.assignee}
               scheduled={Boolean(issue.when)}
               sessions={sessions}
+              authoritativeOwner={authoritativeOwner}
               disabled={saving}
               onChange={(assignee) => onPatch({ assignee })}
             />
@@ -1224,7 +1269,7 @@ function PropertiesRail({
                     agents={agents}
                     mode={headlessRuntime}
                     credentials={availableCredentials}
-                    disabled={saving || Boolean(ownerResumeId && (ownerSessionBusy(ownerSession) || (sessionsLoaded && !ownerSession)))}
+                    disabled={saving || Boolean(ownerResumeId && (ownerSessionBusy(ownerSession) || (ownerResolutionLoaded && !ownerResolved)))}
                     bound={Boolean(ownerResumeId)}
                     boundRuntime={ownerSession?.runtime}
                     onConfigureProvider={() => {
@@ -1249,7 +1294,7 @@ function PropertiesRail({
               {ownerResumeId && ownerSessionBusy(ownerSession) && (
                 <p className="mt-2 text-xs leading-snug text-muted-foreground">{t('issues.detail.sessionTurnInProgress')}</p>
               )}
-              {ownerResumeId && sessionsLoaded && !ownerSession && (
+              {ownerResumeId && ownerResolutionLoaded && !ownerResolved && (
                 <p className="mt-2 text-xs leading-snug text-muted-foreground">{t('issues.detail.sessionUnavailable')}</p>
               )}
               {agentNeedsCredential && (
@@ -1285,7 +1330,7 @@ function PropertiesRail({
           variant="primary"
           onConfirm={async () => {
             try {
-              await updateResumeRuntime(wsId, ownerResumeId, pendingCapability.update)
+              await updateResumeRuntime(authoritativeOwner?.workspace?.id ?? wsId, ownerResumeId, pendingCapability.update)
               await onRefreshSessions()
               setPendingCapability(null)
               setRuntimeError(null)
@@ -2023,8 +2068,9 @@ export function IssueDetail({
   const [retrying, setRetrying] = useState(false)
   const [actionError, setActionError] = useState<string | null>(null)
   const [agentReadiness, setAgentReadiness] = useState<Record<string, AgentCredentialReadiness>>({})
-  const [sessionDirectory, setSessionDirectory] = useState<readonly WorkspaceSessionDirectoryEntry[]>([])
-  const [sessionsLoaded, setSessionsLoaded] = useState(false)
+  const sessionSnapshot = useWorkspaceSessionDirectory(wsId)
+  const sessionDirectory = sessionSnapshot.directory?.sessions ?? []
+  const sessionsLoaded = !sessionSnapshot.loading
   // Set when a clicked `[[name]]` resolves to >1 target — drives the picker.
   const [picker, setPicker] = useState<WikilinkResolution | null>(null)
   const workspace = workspaces.find((candidate) => candidate.id === wsId) ?? null
@@ -2045,21 +2091,7 @@ export function IssueDetail({
     return () => { live = false }
   }, [wsId])
 
-  const refreshSessions = useCallback(async () => {
-    try {
-      const directory = await getWorkspaceSessionDirectory(wsId)
-      setSessionDirectory(Array.isArray(directory.sessions) ? directory.sessions : [])
-    } catch {
-      setSessionDirectory([])
-    } finally {
-      setSessionsLoaded(true)
-    }
-  }, [wsId])
-
-  useEffect(() => {
-    setSessionsLoaded(false)
-    void refreshSessions()
-  }, [refreshSessions])
+  const refreshSessions = sessionSnapshot.refresh
 
   const gotoIssue = useCallback(
     (ref: WikilinkIssueRef) => {
@@ -2266,6 +2298,7 @@ export function IssueDetail({
           headlessRuntime={workspace?.runtimeSettings?.runtime.headless ?? null}
           agentReadiness={agentReadiness}
           sessions={sessionDirectory}
+          assigneeSession={data.assigneeSession}
           saving={saving}
           retrying={retrying}
           error={actionError}

--- a/ui/src/components/ReconnectButton.tsx
+++ b/ui/src/components/ReconnectButton.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useRef } from 'react'
 import { api } from '../api'
 
-export function ReconnectButton({ accountId }: { accountId: string }) {
+export function ReconnectButton({ accountId, disabled = false, disabledReason }: {
+  accountId: string
+  disabled?: boolean
+  disabledReason?: string
+}) {
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
   const [message, setMessage] = useState('')
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -9,6 +13,7 @@ export function ReconnectButton({ accountId }: { accountId: string }) {
   useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
 
   const handleReconnect = async () => {
+    if (disabled) return
     setStatus('loading')
     setMessage('')
     try {
@@ -34,7 +39,8 @@ export function ReconnectButton({ accountId }: { accountId: string }) {
     <div className="flex items-center gap-2">
       <button
         onClick={handleReconnect}
-        disabled={status === 'loading'}
+        disabled={disabled || status === 'loading'}
+        title={disabled ? disabledReason : undefined}
         className="btn-secondary-sm"
       >
         {status === 'loading' ? 'Connecting...' : 'Reconnect'}

--- a/ui/src/components/Toggle.tsx
+++ b/ui/src/components/Toggle.tsx
@@ -5,9 +5,10 @@ interface ToggleProps {
   size?: 'sm' | 'md'
   ariaLabel: string
   disabled?: boolean
+  title?: string
 }
 
-export function Toggle({ id, checked, onChange, size = 'md', ariaLabel, disabled = false }: ToggleProps) {
+export function Toggle({ id, checked, onChange, size = 'md', ariaLabel, disabled = false, title }: ToggleProps) {
   const track = size === 'sm' ? 'w-8 h-[18px]' : 'w-10 h-[22px]'
   const thumb = size === 'sm' ? 'w-3 h-3 bottom-[2.5px] left-[3px]' : 'w-4 h-4 bottom-[3px] left-[3px]'
   const translate = size === 'sm' ? 'translate-x-[14px]' : 'translate-x-[18px]'
@@ -22,6 +23,7 @@ export function Toggle({ id, checked, onChange, size = 'md', ariaLabel, disabled
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel}
+      title={title}
       disabled={disabled}
       onClick={() => onChange(!checked)}
       className={`inline-flex size-10 shrink-0 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background ${footprint} ${

--- a/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getVersion: vi.fn(),
   checkVersion: vi.fn(),
   getAliceProject: vi.fn(),
+  getBackendConnection: vi.fn(),
 }))
 
 vi.mock('../../api', () => ({
@@ -19,6 +20,10 @@ vi.mock('../../api', () => ({
       get: mocks.getAliceProject,
     },
   },
+}))
+
+vi.mock('../../auth/backendConnection', () => ({
+  getBackendConnection: mocks.getBackendConnection,
 }))
 
 import '../../i18n'
@@ -53,6 +58,7 @@ beforeEach(() => {
   mocks.getVersion.mockResolvedValue(currentVersion)
   mocks.checkVersion.mockResolvedValue(currentVersion)
   mocks.getAliceProject.mockResolvedValue({ project: currentProject })
+  mocks.getBackendConnection.mockReturnValue({ kind: 'local', endpoint: '127.0.0.1:47331' })
 })
 
 afterEach(() => {
@@ -91,6 +97,24 @@ describe('AboutOpenAliceSection', () => {
     render(<AboutOpenAliceSection />)
 
     expect(await screen.findByText('Development channel')).toBeTruthy()
+  })
+
+  it('shows the healthy SSH route that owns this browser surface', async () => {
+    mocks.getBackendConnection.mockReturnValue({
+      kind: 'remote',
+      target: 'alice@example.com',
+      sshPort: 2222,
+      runtimePort: 47331,
+      localEndpoint: '127.0.0.1:40123',
+    })
+
+    render(<AboutOpenAliceSection />)
+
+    expect(await screen.findByRole('heading', { name: 'Backend connection' })).toBeTruthy()
+    expect(screen.getByText('Connected')).toBeTruthy()
+    expect(screen.getByText('alice@example.com:2222')).toBeTruthy()
+    expect(screen.getByText('127.0.0.1:40123')).toBeTruthy()
+    expect(screen.getByText('127.0.0.1:47331')).toBeTruthy()
   })
 
   it.each([

--- a/ui/src/components/settings/AboutOpenAliceSection.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
-import { CheckCircle2, Download, ExternalLink, FolderKanban, LoaderCircle, RefreshCw, Server } from 'lucide-react'
+import { Cable, CheckCircle2, Download, ExternalLink, FolderKanban, LoaderCircle, RefreshCw, Server } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { api } from '../../api'
 import type { VersionInfo } from '../../api/types'
+import { getBackendConnection } from '../../auth/backendConnection'
 import { useAliceProject } from '../../hooks/useAliceProject'
 import { Button } from '../ui/button'
 import { ConfigSection } from '../form'
@@ -24,6 +25,13 @@ const RELEASES_URL = 'https://github.com/TraderAlice/OpenAlice/releases'
 
 export function AboutOpenAliceSection() {
   const { t } = useTranslation()
+  const backendConnection = getBackendConnection()
+  const remoteConnection = backendConnection.kind === 'remote' ? backendConnection : null
+  const remoteTarget = remoteConnection
+    ? remoteConnection.sshPort === 22
+      ? remoteConnection.target
+      : `${remoteConnection.target}:${remoteConnection.sshPort}`
+    : null
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null)
   const [runtimeMode, setRuntimeMode] = useState<RuntimeMode>('browser')
   const [nativeStatus, setNativeStatus] = useState<NativeUpdaterStatus | null>(null)
@@ -291,6 +299,39 @@ export function AboutOpenAliceSection() {
           </button>
           </div>
         </div>
+
+        {remoteConnection && remoteTarget && (
+          <section className="overflow-hidden rounded-xl border border-border/70 bg-secondary/35" aria-labelledby="backend-connection-title">
+            <div className="flex flex-col gap-3 border-b border-border/70 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 items-start gap-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground shadow-sm">
+                  <Cable size={18} aria-hidden />
+                </div>
+                <div className="min-w-0">
+                  <h4 id="backend-connection-title" className="text-[13px] font-semibold text-foreground">
+                    {t('settings.about.connection.title')}
+                  </h4>
+                  <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+                    {t('settings.about.connection.description')}
+                  </p>
+                </div>
+              </div>
+              <span className="inline-flex w-fit shrink-0 items-center gap-1.5 rounded-full border border-success/25 bg-success/10 px-2 py-1 text-[10px] font-medium text-success">
+                <span className="size-1.5 rounded-full bg-success" aria-hidden />
+                {t('settings.about.connection.connected')}
+              </span>
+            </div>
+            <dl className="grid min-w-0 gap-2 px-4 py-4 sm:grid-cols-2">
+              <ProjectField label={t('auth.remoteTarget')} value={remoteTarget} />
+              <ProjectField label={t('auth.localTunnelEndpoint')} value={remoteConnection.localEndpoint} />
+              <ProjectField
+                className="sm:col-span-2"
+                label={t('auth.remoteRuntimeEndpoint')}
+                value={`127.0.0.1:${remoteConnection.runtimePort}`}
+              />
+            </dl>
+          </section>
+        )}
 
         <section className="overflow-hidden rounded-xl border border-border/70 bg-secondary/35" aria-labelledby="current-alice-project-title">
         <div className="flex flex-col gap-3 border-b border-border/70 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">

--- a/ui/src/components/uta/BrokerPackGate.spec.tsx
+++ b/ui/src/components/uta/BrokerPackGate.spec.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AccountReadinessBadge, BrokerSupportGate } from './BrokerPackGate'
+
+afterEach(cleanup)
+
+const missing = {
+  accountId: 'main', label: 'Main', presetId: 'okx', configuredEnabled: true,
+  engine: 'ccxt' as const, state: 'needs-install' as const, operational: false,
+  action: 'install' as const,
+}
+
+describe('Broker Pack account gates', () => {
+  it('separates configured state from machine-local support and only installs on click', () => {
+    const onInstall = vi.fn().mockResolvedValue(undefined)
+    render(<BrokerSupportGate readiness={missing} onInstall={onInstall} onRetry={vi.fn()} />)
+
+    expect(screen.getByText(/account is still configured/i)).toBeTruthy()
+    expect(onInstall).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }))
+    expect(onInstall).toHaveBeenCalledWith('ccxt')
+  })
+
+  it('offers Retry when the Runtime cannot report support status', () => {
+    const onRetry = vi.fn().mockResolvedValue(undefined)
+    render(<BrokerSupportGate readiness={{ ...missing, engine: undefined, state: 'status-unavailable', reason: 'Runtime offline' }} onRetry={onRetry} />)
+
+    expect(screen.getByText('Runtime offline')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('reports an install failure instead of leaking a rejected promise', async () => {
+    render(<BrokerSupportGate
+      readiness={missing}
+      onInstall={vi.fn().mockRejectedValue(new Error('download failed'))}
+      onRetry={vi.fn()}
+    />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }))
+    expect((await screen.findByRole('alert')).textContent).toContain('download failed')
+  })
+
+  it('never labels a configured-but-missing account Connected', () => {
+    render(<AccountReadinessBadge readiness={missing} health={{
+      status: 'healthy', reach: 'readable', tier: 'trading', consecutiveFailures: 0,
+      recovering: false, connecting: false, disabled: false,
+    }} />)
+
+    expect(screen.getByText('Support not installed')).toBeTruthy()
+    expect(screen.queryByText('Connected')).toBeNull()
+  })
+})

--- a/ui/src/components/uta/BrokerPackGate.tsx
+++ b/ui/src/components/uta/BrokerPackGate.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import type { BrokerEngine, BrokerHealthInfo } from '../../api/types'
+import type { AccountPackReadiness } from '../../hooks/useBrokerPackReadiness'
+import { HealthBadge } from './HealthBadge'
+
+export function AccountReadinessBadge({ readiness, health, size = 'sm' }: {
+  readiness: AccountPackReadiness
+  health?: BrokerHealthInfo
+  size?: 'sm' | 'md'
+}) {
+  if (!readiness.configuredEnabled) {
+    return <span className="text-[11px] text-muted-foreground">Disabled in config</span>
+  }
+  if (readiness.operational) return <HealthBadge health={health} size={size} />
+
+  const label = readiness.state === 'checking'
+    ? 'Checking support…'
+    : readiness.state === 'needs-repair'
+      ? 'Support needs repair'
+      : readiness.state === 'needs-install'
+        ? 'Support not installed'
+        : readiness.state === 'unsupported-preset'
+          ? 'Unsupported preset'
+          : 'Support status unavailable'
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-[11px] text-warning"
+      title={readiness.reason}
+      data-testid="account-readiness-badge"
+    >
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full bg-warning ${readiness.state === 'checking' ? 'animate-pulse' : ''}`} />
+      {label}
+    </span>
+  )
+}
+
+export function BrokerSupportGate({ readiness, installingEngine, onInstall, onRetry, compact = false }: {
+  readiness: AccountPackReadiness
+  installingEngine?: BrokerEngine | null
+  onInstall?: (engine: Exclude<BrokerEngine, 'mock'>) => Promise<void>
+  onRetry: () => Promise<void>
+  compact?: boolean
+}) {
+  const [actionError, setActionError] = useState<string | null>(null)
+  if (readiness.operational) return null
+
+  const installable = readiness.engine && readiness.engine !== 'mock' && onInstall
+  const isInstalling = installingEngine === readiness.engine
+  const actionLabel = readiness.state === 'needs-repair' ? 'Repair' : 'Install'
+  const title = readiness.state === 'checking'
+    ? 'Checking broker support'
+    : readiness.state === 'needs-repair'
+      ? 'Broker support needs repair'
+      : readiness.state === 'needs-install'
+        ? 'Broker support is not installed'
+        : readiness.state === 'unsupported-preset'
+          ? 'This broker preset is no longer supported'
+          : 'Broker support status is unavailable'
+
+  return (
+    <div
+      className={`rounded-lg border border-warning/30 bg-warning/5 ${compact ? 'px-3 py-2.5' : 'px-4 py-3'}`}
+      role="status"
+      data-testid="broker-support-gate"
+    >
+      <div className="flex items-start gap-2.5">
+        <AlertTriangle size={15} className="mt-0.5 shrink-0 text-warning" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <div className="text-[12px] font-medium text-foreground">{title}</div>
+          <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+            {readiness.reason ?? (
+              readiness.state === 'checking'
+                ? 'Reading support installed on this Runtime.'
+                : 'This account is still configured, but this Runtime cannot load it until its machine-local Broker Pack is available.'
+            )}
+          </p>
+          {!compact && !readiness.operational && readiness.state !== 'checking' && (
+            <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground/80">
+              Installing or repairing support changes this Runtime only. It does not connect the broker or submit a trade.
+            </p>
+          )}
+          {actionError && <p className="mt-1 text-[11px] text-destructive" role="alert">{actionError}</p>}
+        </div>
+        {installable && (readiness.state === 'needs-install' || readiness.state === 'needs-repair') ? (
+          <button
+            type="button"
+            className="btn-secondary-sm shrink-0"
+            disabled={Boolean(installingEngine)}
+            onClick={() => {
+              setActionError(null)
+              void onInstall(readiness.engine as Exclude<BrokerEngine, 'mock'>).catch((err: unknown) => {
+                setActionError(err instanceof Error ? err.message : String(err))
+              })
+            }}
+          >
+            {isInstalling ? (actionLabel === 'Repair' ? 'Repairing…' : 'Installing…') : actionLabel}
+          </button>
+        ) : readiness.state !== 'checking' ? (
+          <button type="button" className="btn-secondary-sm shrink-0" onClick={() => {
+            setActionError(null)
+            void onRetry().catch((err: unknown) => {
+              setActionError(err instanceof Error ? err.message : String(err))
+            })
+          }}>
+            Retry
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/uta/EditUTADialog.spec.tsx
+++ b/ui/src/components/uta/EditUTADialog.spec.tsx
@@ -53,6 +53,18 @@ describe('EditUTADialog compact layout', () => {
         uta={uta}
         preset={preset}
         health={health}
+        readiness={{
+          accountId: uta.id,
+          label: uta.label!,
+          presetId: uta.presetId,
+          configuredEnabled: true,
+          engine: 'alpaca',
+          state: 'ready',
+          operational: true,
+        }}
+        policy={{ canRead: true, canReconnect: true, canTrade: false, reason: 'This account is configured read-only.' }}
+        onInstallBrokerPack={vi.fn().mockResolvedValue(undefined)}
+        onRetryBrokerPack={vi.fn().mockResolvedValue(undefined)}
         onSave={vi.fn().mockResolvedValue(undefined)}
         onDelete={vi.fn().mockResolvedValue(undefined)}
         onViewInPortfolio={vi.fn()}

--- a/ui/src/components/uta/EditUTADialog.tsx
+++ b/ui/src/components/uta/EditUTADialog.tsx
@@ -4,10 +4,11 @@ import { Toggle } from '../Toggle'
 import { GuardsSection, CRYPTO_GUARD_TYPES, SECURITIES_GUARD_TYPES } from '../guards'
 import { ReconnectButton } from '../ReconnectButton'
 import { useSchemaForm } from '../../hooks/useSchemaForm'
-import type { UTAConfig, BrokerPreset, BrokerHealthInfo } from '../../api/types'
+import type { UTAConfig, BrokerPreset, BrokerHealthInfo, BrokerEngine } from '../../api/types'
+import type { AccountInteractionPolicy, AccountPackReadiness } from '../../hooks/useBrokerPackReadiness'
 import { displayNameForUTA } from '../../lib/uta-account-filter'
 import { Dialog } from './Dialog'
-import { HealthBadge } from './HealthBadge'
+import { AccountReadinessBadge, BrokerSupportGate } from './BrokerPackGate'
 import { SchemaFormFields } from './SchemaFormFields'
 
 /**
@@ -20,10 +21,15 @@ import { SchemaFormFields } from './SchemaFormFields'
  * drill-in for this account. When opened from inside Portfolio's detail
  * page, that prop is omitted (the user is already in that context).
  */
-export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInPortfolio, onClose }: {
+export function EditUTADialog({ uta, preset, health, readiness, policy, installingEngine, onInstallBrokerPack, onRetryBrokerPack, onSave, onDelete, onViewInPortfolio, onClose }: {
   uta: UTAConfig
   preset?: BrokerPreset
   health?: BrokerHealthInfo
+  readiness: AccountPackReadiness
+  policy: AccountInteractionPolicy
+  installingEngine?: BrokerEngine | null
+  onInstallBrokerPack: (engine: Exclude<BrokerEngine, 'mock'>) => Promise<void>
+  onRetryBrokerPack: () => Promise<void>
   onSave: (a: UTAConfig) => Promise<void>
   onDelete: () => Promise<void>
   onViewInPortfolio?: () => void
@@ -85,7 +91,7 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
               <div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">{uta.id}</div>
             )}
           </div>
-          <HealthBadge health={health} size="md" />
+          <AccountReadinessBadge readiness={readiness} health={health} size="md" />
         </div>
         <div className={`${onViewInPortfolio ? 'mt-2' : ''} flex shrink-0 items-center sm:mt-0 sm:gap-3`}>
           {onViewInPortfolio && (
@@ -118,6 +124,15 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
         data-testid="edit-uta-scroll"
         className="min-h-0 flex-1 space-y-5 overflow-y-auto overscroll-contain px-4 py-4 [scrollbar-gutter:stable] sm:px-6 sm:py-6"
       >
+        {!readiness.operational && (
+          <BrokerSupportGate
+            readiness={readiness}
+            installingEngine={installingEngine}
+            onInstall={onInstallBrokerPack}
+            onRetry={onRetryBrokerPack}
+            compact
+          />
+        )}
         <Section title="Configuration">
           <div className="mb-3">
             <span className="text-[12px] text-muted-foreground">Type</span>
@@ -207,18 +222,22 @@ export function EditUTADialog({ uta, preset, health, onSave, onDelete, onViewInP
               {saving ? 'Saving...' : 'Save'}
             </button>
           )}
-          {draft.enabled !== false && <ReconnectButton accountId={uta.id} />}
+          {draft.enabled !== false && (
+            <ReconnectButton accountId={uta.id} disabled={!policy.canReconnect} disabledReason={policy.reason} />
+          )}
           <label className="flex items-center gap-2 cursor-pointer">
             <Toggle
               ariaLabel={`${uta.id} enabled`}
               checked={draft.enabled !== false}
+              disabled={draft.enabled === false && !readiness.operational}
+              title={draft.enabled === false && !readiness.operational ? policy.reason : undefined}
               onChange={async (v) => {
                 const updated = { ...draft, enabled: v }
                 setDraft(updated)
                 await onSave(updated)
               }}
             />
-            <span className="text-[12px] text-muted-foreground">{draft.enabled !== false ? 'Enabled' : 'Disabled'}</span>
+            <span className="text-[12px] text-muted-foreground">{draft.enabled !== false ? 'Configured on' : 'Configured off'}</span>
           </label>
           {msg && <span className="text-[12px] text-muted-foreground">{msg}</span>}
         </div>

--- a/ui/src/components/workspace/OverviewCard.tsx
+++ b/ui/src/components/workspace/OverviewCard.tsx
@@ -1,9 +1,9 @@
-import { useMemo } from 'react'
 import { formatRelativeTime } from '../../lib/intl'
 import { ArrowUpCircle, Bot, ChevronRight, Code, Cpu, GitBranch, ScrollText, Sparkles, Terminal, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { GitLogEntry, Workspace } from './api'
 import { sessionCoworkerLabel, workspaceDisplayName, workspaceDisplayTitle } from './display'
+import { workspaceActivityMs } from './sidebar-order'
 
 /**
  * Single-workspace card for the Workspaces Overview dashboard. Variant B
@@ -60,13 +60,7 @@ export function OverviewCard({
   const hiddenSessionCount = w.sessions.length - previewSessions.length
   const mobileHiddenSessionCount = Math.max(0, w.sessions.length - MOBILE_SESSION_PREVIEW_LIMIT)
 
-  const lastActivityMs = useMemo(() => {
-    const sessionTs = w.sessions
-      .map((s) => new Date(s.lastActiveAt).getTime())
-      .filter((n) => Number.isFinite(n))
-    if (sessionTs.length === 0) return new Date(w.createdAt).getTime()
-    return Math.max(...sessionTs)
-  }, [w.sessions, w.createdAt])
+  const lastActivityMs = workspaceActivityMs(w)
 
   const dotClass = hasRunning
     ? 'bg-success'

--- a/ui/src/components/workspace/Sidebar.spec.tsx
+++ b/ui/src/components/workspace/Sidebar.spec.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { HeadlessTaskRecord } from '../../api/headless'
 import { i18n } from '../../i18n'
 import type { AgentInfo, SessionRecord, Workspace } from './api'
 import { SessionRow, WorkspaceRow } from './Sidebar'
@@ -133,6 +134,55 @@ describe('WorkspaceRow session launcher', () => {
     await user.keyboard('{ArrowDown}')
     fireEvent.click(screen.getByRole('menuitem', { name: 'Offboard workspace' }))
     expect(onDelete).toHaveBeenCalledWith(workspace.id)
+  })
+
+  it('presents headless Issue work by business identity and opens it with a clean title', () => {
+    const onOpenHeadlessRun = vi.fn()
+    const run: HeadlessTaskRecord = {
+      taskId: 'run-daily-risk-scan',
+      resumeId: 'resume-daily-risk-scan',
+      resumable: true,
+      wsId: workspace.id,
+      agent: 'codex',
+      prompt: 'Reconstruct the Issue context, inject target JSON, and continue.',
+      status: 'done',
+      startedAt: Date.now() - 1_000,
+      trigger: {
+        kind: 'issue',
+        workspaceId: workspace.id,
+        issueId: 'daily-risk-scan',
+      },
+    }
+
+    render(
+      <WorkspaceRow
+        workspace={workspace}
+        agents={agents}
+        defaultAgent="pi"
+        selection={null}
+        headlessTasks={[run]}
+        onSelectWorkspace={vi.fn()}
+        onSelectSession={vi.fn()}
+        onSpawn={vi.fn()}
+        onOpenHeadlessRun={onOpenHeadlessRun}
+        onPauseSession={vi.fn()}
+        onResumeSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+        onDelete={vi.fn(async () => undefined)}
+      />,
+    )
+
+    expect(screen.queryByText(run.prompt)).toBeNull()
+    fireEvent.click(screen.getByTitle('Headless runs (automation)'))
+    expect(screen.getByText('Daily Risk Scan')).toBeTruthy()
+    expect(screen.queryByText(run.prompt)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open this run as an interactive session' }))
+    expect(onOpenHeadlessRun).toHaveBeenCalledWith(
+      workspace.id,
+      run.resumeId,
+      { title: 'Daily Risk Scan' },
+    )
   })
 })
 

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -19,6 +19,7 @@ import { orderSessionsForSidebar, orderWorkspacesForSidebar, workspaceActivityMs
 import { useReorderMotion } from './useReorderMotion';
 import { SidebarActionMenu } from './SidebarActionMenu';
 import { AgentRuntimeIcon } from '../../lib/agentRuntimeIcon';
+import { projectHeadlessTaskPresentation } from './headless-task-presentation';
 
 /**
  * Workspace launcher sidebar.
@@ -523,7 +524,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
         <HeadlessGroup
           tasks={props.headlessTasks!}
           onOpenAsSession={(task) => props.onOpenHeadlessRun(w.id, task.resumeId, {
-            title: task.prompt,
+            title: projectHeadlessTaskPresentation(task).title,
           })}
         />
       )}
@@ -594,10 +595,12 @@ function HeadlessTaskRow(props: {
 }): ReactElement {
   const { t } = useTranslation();
   const task = props.task;
+  const presentation = projectHeadlessTaskPresentation(task);
   const openable = task.status !== 'running' && task.resumable;
   const titleParts = [`${task.agent} · ${task.status}`, formatRelativeTime(task.startedAt)];
   if (task.error) titleParts.push(task.error);
-  titleParts.push(task.prompt);
+  titleParts.push(presentation.title);
+  if (presentation.summary) titleParts.push(presentation.summary);
 
   return (
     <div className="group flex items-center gap-1.5 pl-3 pr-2 py-1 text-[11px]" title={titleParts.join('\n')}>
@@ -605,7 +608,7 @@ function HeadlessTaskRow(props: {
       <span className="shrink-0 flex items-center justify-center w-3.5 text-muted-foreground/50">
         <AgentBadgeGlyph agentId={task.agent} />
       </span>
-      <span className="flex-1 truncate text-muted-foreground">{task.prompt}</span>
+      <span className="flex-1 truncate text-muted-foreground">{presentation.title}</span>
       {openable && (
         <button
           type="button"

--- a/ui/src/components/workspace/Sidebar.tsx
+++ b/ui/src/components/workspace/Sidebar.tsx
@@ -15,7 +15,7 @@ import { CreateWorkspaceDialog } from './CreateWorkspaceDialog';
 import { WorkspaceOffboardingDialog } from './WorkspaceOffboardingDialog';
 import { Skeleton } from '../StateViews';
 import { sessionCoworkerLabel, workspaceDisplayName, workspaceDisplayTitle } from './display';
-import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order';
+import { orderSessionsForSidebar, orderWorkspacesForSidebar, workspaceActivityMs } from './sidebar-order';
 import { useReorderMotion } from './useReorderMotion';
 import { SidebarActionMenu } from './SidebarActionMenu';
 import { AgentRuntimeIcon } from '../../lib/agentRuntimeIcon';
@@ -372,6 +372,9 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
     : w.sessions.length > 0
       ? 'bg-muted-foreground/40'
       : 'border border-border';
+  const activityLabel = t('workspace.activeAgo', {
+    time: formatRelativeTime(workspaceActivityMs(w)),
+  });
 
   return (
     <div data-reorder-id={props.reorderId}>
@@ -385,6 +388,7 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
           type="button"
           onClick={() => props.onSelectWorkspace(w.id)}
           title={workspaceDisplayTitle(w)}
+          aria-label={`${label}. ${activityLabel}`}
           aria-current={isSelected ? 'page' : undefined}
           className="flex-1 min-w-0 flex items-center gap-2 text-left"
         >
@@ -393,7 +397,12 @@ export function WorkspaceRow(props: WorkspaceRowProps): ReactElement {
             title={hasRunning ? t('workspace.runningCount', { count: runningCount }) : t('workspace.idle')}
           />
           <span className="truncate font-medium">{label}</span>
-          <span className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0">{formatRelativeTime(w.createdAt)}</span>
+          <span
+            className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0"
+            title={activityLabel}
+          >
+            {formatRelativeTime(workspaceActivityMs(w))}
+          </span>
         </button>
         {props.agents.length > 0 && (
           <div ref={spawnControlsRef} className="relative flex shrink-0 items-center">

--- a/ui/src/components/workspace/Terminal.recovery.spec.tsx
+++ b/ui/src/components/workspace/Terminal.recovery.spec.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  backendRecoveryGeneration: 0,
+  sockets: [] as Array<{
+    url: string
+    emitClose: (code: number) => void
+  }>,
+}))
+
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => ({ backendRecoveryGeneration: mocks.backendRecoveryGeneration }),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80
+    rows = 24
+    element = document.createElement('div')
+    options: Record<string, unknown>
+    parser = {
+      registerCsiHandler: () => ({ dispose() {} }),
+    }
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options
+    }
+
+    loadAddon() {}
+    open(container: HTMLElement) { container.appendChild(this.element) }
+    attachCustomKeyEventHandler() {}
+    hasSelection() { return false }
+    focus() {}
+    reset() {}
+    write(_data: unknown, callback?: () => void) { callback?.() }
+    onData() { return { dispose() {} } }
+    onBinary() { return { dispose() {} } }
+    dispose() {}
+  },
+}))
+
+vi.mock('./renderer', () => ({
+  attachWebglRenderer: () => null,
+}))
+
+vi.mock('./terminal-keyboard-controller', () => ({
+  installTerminalKeyboardController: () => ({
+    handle: () => true,
+    dispose() {},
+  }),
+}))
+
+vi.mock('./terminal-kitty-keyboard-mode-tracker', () => ({
+  TerminalKittyKeyboardModeTracker: class {
+    flags = 0
+    reset() { this.flags = 0 }
+    scan() {}
+  },
+}))
+
+vi.mock('./terminalAppearance', () => ({
+  colorSchemeUpdateSequence: () => '',
+  terminalThemesEqual: () => true,
+  useTerminalAppearance: () => ({
+    mode: 'dark',
+    theme: {},
+    viewAttributes: {
+      foreground: [255, 255, 255],
+      background: [0, 0, 0],
+      cursor: [255, 255, 255],
+      ansi: [],
+      colorSchemeMode: 'dark',
+      cursorStyle: 'block',
+      cursorBlink: true,
+    },
+  }),
+}))
+
+import { TerminalView } from './Terminal'
+
+type SocketListener = (() => void) | ((event: { code: number } | { data: unknown }) => void)
+
+class FakeWebSocket {
+  readonly OPEN = 1
+  readyState = 0
+  binaryType: BinaryType = 'blob'
+  readonly url: string
+  private readonly listeners = new Map<string, SocketListener[]>()
+
+  constructor(url: string | URL) {
+    this.url = String(url)
+    mocks.sockets.push({
+      url: this.url,
+      emitClose: (code) => this.emit('close', { code }),
+    })
+  }
+
+  send() {}
+  close() { this.readyState = 3 }
+
+  addEventListener(type: string, listener: SocketListener) {
+    const listeners = this.listeners.get(type) ?? []
+    listeners.push(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  private emit(type: string, event: { code: number } | { data: unknown }) {
+    this.readyState = 3
+    for (const listener of this.listeners.get(type) ?? []) {
+      ;(listener as (value: typeof event) => void)(event)
+    }
+  }
+}
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+const reconnectDelays = [500, 1_000, 2_000, 4_000, 8_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000]
+
+async function startTerminal() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+  expect(mocks.sockets).toHaveLength(1)
+}
+
+async function exhaustReconnectBudget() {
+  for (const delay of reconnectDelays) {
+    act(() => mocks.sockets.at(-1)!.emitClose(1006))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(delay)
+    })
+  }
+  act(() => mocks.sockets.at(-1)!.emitClose(1006))
+  expect(screen.getByRole('button', { name: 'retry this terminal connection' })).toBeTruthy()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.backendRecoveryGeneration = 0
+  mocks.sockets.length = 0
+  vi.stubGlobal('WebSocket', FakeWebSocket)
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 800 })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 500 })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('TerminalView backend recovery', () => {
+  it('re-attaches the same Session when backend health recovers after the retry budget expires', async () => {
+    const view = render(<TerminalView wsId="research" sessionId="session-1" wsUrl="ws://127.0.0.1:40123/pty" />)
+    await startTerminal()
+    await exhaustReconnectBudget()
+    expect(mocks.sockets).toHaveLength(13)
+
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(<TerminalView wsId="research" sessionId="session-1" wsUrl="ws://127.0.0.1:40123/pty" />)
+
+    expect(mocks.sockets).toHaveLength(14)
+    const recovered = new URL(mocks.sockets.at(-1)!.url)
+    expect(recovered.searchParams.get('session')).toBe('session-1')
+    expect(recovered.searchParams.get('takeover')).toBeNull()
+  })
+
+  it('offers an explicit retry after automatic reconnect stops', async () => {
+    render(<TerminalView wsId="research" sessionId="session-1" wsUrl="ws://127.0.0.1:40123/pty" />)
+    await startTerminal()
+    await exhaustReconnectBudget()
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry this terminal connection' }))
+
+    expect(mocks.sockets).toHaveLength(14)
+    expect(new URL(mocks.sockets.at(-1)!.url).searchParams.get('takeover')).toBeNull()
+  })
+
+  it.each([
+    ['auth', 4401],
+    ['forbidden', 4403],
+    ['another controller', 4001],
+    ['locked ownership', 4409],
+    ['missing Session', 4404],
+  ] as const)('does not turn a fatal %s close into automatic recovery', async (_reason, code) => {
+    const onSessionLost = vi.fn()
+    const view = render(
+      <TerminalView
+        wsId="research"
+        sessionId="session-1"
+        wsUrl="ws://127.0.0.1:40123/pty"
+        onSessionLost={onSessionLost}
+      />,
+    )
+    await startTerminal()
+
+    act(() => mocks.sockets[0]!.emitClose(code))
+    expect(screen.queryByRole('button', { name: 'retry this terminal connection' })).toBeNull()
+
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(
+      <TerminalView
+        wsId="research"
+        sessionId="session-1"
+        wsUrl="ws://127.0.0.1:40123/pty"
+        onSessionLost={onSessionLost}
+      />,
+    )
+
+    expect(mocks.sockets).toHaveLength(1)
+    expect(onSessionLost).toHaveBeenCalledTimes(code === 4404 ? 1 : 0)
+  })
+})

--- a/ui/src/components/workspace/Terminal.recovery.spec.tsx
+++ b/ui/src/components/workspace/Terminal.recovery.spec.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   backendRecoveryGeneration: 0,
   sockets: [] as Array<{
     url: string
+    emitOpen: () => void
     emitClose: (code: number) => void
   }>,
 }))
@@ -104,6 +105,7 @@ class FakeWebSocket {
     this.url = String(url)
     mocks.sockets.push({
       url: this.url,
+      emitOpen: () => this.emitOpen(),
       emitClose: (code) => this.emit('close', { code }),
     })
   }
@@ -115,6 +117,13 @@ class FakeWebSocket {
     const listeners = this.listeners.get(type) ?? []
     listeners.push(listener)
     this.listeners.set(type, listeners)
+  }
+
+  private emitOpen() {
+    this.readyState = this.OPEN
+    for (const listener of this.listeners.get('open') ?? []) {
+      ;(listener as () => void)()
+    }
   }
 
   private emit(type: string, event: { code: number } | { data: unknown }) {
@@ -139,14 +148,20 @@ async function startTerminal() {
   expect(mocks.sockets).toHaveLength(1)
 }
 
-async function exhaustReconnectBudget() {
+async function exhaustReconnectBudget(options: { openBeforeClose?: boolean } = {}) {
   for (const delay of reconnectDelays) {
-    act(() => mocks.sockets.at(-1)!.emitClose(1006))
+    act(() => {
+      if (options.openBeforeClose) mocks.sockets.at(-1)!.emitOpen()
+      mocks.sockets.at(-1)!.emitClose(1006)
+    })
     await act(async () => {
       await vi.advanceTimersByTimeAsync(delay)
     })
   }
-  act(() => mocks.sockets.at(-1)!.emitClose(1006))
+  act(() => {
+    if (options.openBeforeClose) mocks.sockets.at(-1)!.emitOpen()
+    mocks.sockets.at(-1)!.emitClose(1006)
+  })
   expect(screen.getByRole('button', { name: 'retry this terminal connection' })).toBeTruthy()
 }
 
@@ -167,6 +182,15 @@ afterEach(() => {
 })
 
 describe('TerminalView backend recovery', () => {
+  it('exhausts the retry budget when sockets open but close before attached', async () => {
+    render(<TerminalView wsId="research" sessionId="session-1" wsUrl="ws://127.0.0.1:40123/pty" />)
+    await startTerminal()
+
+    await exhaustReconnectBudget({ openBeforeClose: true })
+
+    expect(mocks.sockets).toHaveLength(13)
+  })
+
   it('re-attaches the same Session when backend health recovers after the retry budget expires', async () => {
     const view = render(<TerminalView wsId="research" sessionId="session-1" wsUrl="ws://127.0.0.1:40123/pty" />)
     await startTerminal()

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -520,7 +520,6 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       setStatus(hasConnectedOnce ? 'reconnecting' : 'connecting');
 
       ws.addEventListener('open', () => {
-        attempts = 0;
         recoverableTransportFailure = false;
         setClosedRecoverable(false);
         takeoverNextAttachRef.current = false;
@@ -547,6 +546,11 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
           if (!msg) return;
           switch (msg.type) {
             case 'attached':
+              // A transport-level open is not proof that the backend accepted
+              // this Session. Only the authoritative attached frame retires
+              // the reconnect history; open-then-close loops must still
+              // exhaust the bounded retry budget.
+              attempts = 0;
               setPid(msg.pid);
               setScrollbackTruncated(msg.scrollbackTruncated);
               kittyKeyboardMode.scan(`\x1b[=${msg.kittyKeyboardFlags};1u`);

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -6,6 +6,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal as Xterm } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 
+import { useAuth } from '../../auth/AuthContext';
 import {
   parseServerControl,
   type ClientControlMessage,
@@ -206,13 +207,17 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     );
   }
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const { backendRecoveryGeneration } = useAuth();
   const [status, setStatus] = useState<Status>('connecting');
+  const [closedRecoverable, setClosedRecoverable] = useState(false);
   const [pid, setPid] = useState<number | null>(null);
   const [scrollbackTruncated, setScrollbackTruncated] = useState(false);
   const [exitInfo, setExitInfo] = useState<ExitInfo | null>(null);
   const [childExited, setChildExited] = useState(false);
   const takeoverNextAttachRef = useRef(false);
   const connectRef = useRef<(() => void) | null>(null);
+  const retryRecoverableRef = useRef<(() => void) | null>(null);
+  const observedBackendRecoveryGenerationRef = useRef(backendRecoveryGeneration);
 
   const wsId = props.wsId;
   const wsUrl = props.wsUrl;
@@ -239,6 +244,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     if (!container) return undefined;
 
     setStatus('connecting');
+    setClosedRecoverable(false);
     setPid(null);
     setScrollbackTruncated(false);
     setExitInfo(null);
@@ -308,6 +314,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
     let activeWs: SocketLike | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     let attempts = 0;
+    let recoverableTransportFailure = false;
     let hasConnectedOnce = false;
     let teardown = false;
     let resizeObserver: ResizeObserver | null = null;
@@ -467,7 +474,9 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
     const scheduleReconnect = (): void => {
       if (teardown) return;
+      recoverableTransportFailure = true;
       if (attempts >= RECONNECT_MAX_ATTEMPTS) {
+        setClosedRecoverable(true);
         setStatus('closed');
         return;
       }
@@ -512,6 +521,8 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
 
       ws.addEventListener('open', () => {
         attempts = 0;
+        recoverableTransportFailure = false;
+        setClosedRecoverable(false);
         takeoverNextAttachRef.current = false;
         // A reconnect re-attaches to a live xterm that already shows the
         // pre-drop screen, but the server restores its current snapshot on
@@ -573,16 +584,28 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
         // or removed). Neither should reconnect: 4001 means another client owns
         // the session, 4404 means it's gone.
         if (ev.code === 4001) {
+          recoverableTransportFailure = false;
+          setClosedRecoverable(false);
           setStatus('kicked');
           return;
         }
         if (ev.code === 4409) {
+          recoverableTransportFailure = false;
+          setClosedRecoverable(false);
           setStatus('locked');
           return;
         }
         if (ev.code === 4404) {
+          recoverableTransportFailure = false;
+          setClosedRecoverable(false);
           onSessionLostRef.current?.();
           setStatus('closed');
+          return;
+        }
+        if (ev.code === 4401 || ev.code === 4403) {
+          recoverableTransportFailure = false;
+          setClosedRecoverable(false);
+          setStatus('error');
           return;
         }
         if (teardown) return;
@@ -594,6 +617,16 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
       ws.addEventListener('error', () => {});
     }
     connectRef.current = connect;
+    const retryRecoverableConnection = (): void => {
+      if (teardown || !recoverableTransportFailure) return;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      reconnectTimer = undefined;
+      attempts = 0;
+      recoverableTransportFailure = false;
+      setClosedRecoverable(false);
+      connect();
+    };
+    retryRecoverableRef.current = retryRecoverableConnection;
 
     const stdinSub = term.onData(sendStdin);
     const binarySub = term.onBinary((d) => {
@@ -648,11 +681,18 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
         // ignore
       }
       if (connectRef.current === connect) connectRef.current = null;
+      if (retryRecoverableRef.current === retryRecoverableConnection) retryRecoverableRef.current = null;
       if (applyAppearanceRef.current === applyAppearance) applyAppearanceRef.current = null;
       webgl?.dispose();
       term.dispose();
     };
   }, [wsId, sessionId, wsUrl, props.renderer]);
+
+  useEffect(() => {
+    if (observedBackendRecoveryGenerationRef.current === backendRecoveryGeneration) return;
+    observedBackendRecoveryGenerationRef.current = backendRecoveryGeneration;
+    retryRecoverableRef.current?.();
+  }, [backendRecoveryGeneration]);
 
   return (
     <div className={`terminal-shell${props.chrome === 'canvas' ? ' is-canvas' : ''}`}>
@@ -687,6 +727,17 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
             title="take over this session"
           >
             take over
+          </button>
+        )}
+        {status === 'closed' && closedRecoverable && (
+          <button
+            type="button"
+            className="terminal-header-action"
+            onClick={() => retryRecoverableRef.current?.()}
+            aria-label="retry this terminal connection"
+            title="retry this terminal connection"
+          >
+            retry
           </button>
         )}
         {props.headerActions && (

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -570,6 +570,8 @@ export interface AgentInfo {
   readonly installed?: boolean;
   /** Absolute path the CLI resolved to, when installed. */
   readonly binPath?: string | null;
+  /** Opaque identity for the currently resolved executable. */
+  readonly fingerprint?: string | null;
 }
 
 export type AgentRuntimeReadinessStatus =
@@ -602,6 +604,7 @@ export interface AgentRuntimeReadinessRow {
   readonly displayName: string;
   readonly installed: boolean;
   readonly binPath: string | null;
+  readonly fingerprint?: string | null;
   readonly status: AgentRuntimeReadinessStatus;
   readonly ready: boolean;
   readonly source: AgentRuntimeReadinessSource;

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -880,6 +880,8 @@ export interface WorkspaceSessionDirectoryEntry {
     readonly model?: string;
     readonly reasoningEffort?: ModelReasoningEffort;
   };
+  /** Backend-authoritative title with internal launch wrappers projected away. */
+  readonly presentationTitle?: string;
   readonly latestExecution?: {
     readonly taskId: string;
     readonly status: 'running' | 'done' | 'failed' | 'interrupted';

--- a/ui/src/components/workspace/harness-session-presentation.spec.ts
+++ b/ui/src/components/workspace/harness-session-presentation.spec.ts
@@ -144,6 +144,30 @@ describe('projectHarnessSessionPresentation', () => {
     })
   })
 
+  it('uses the backend read-side title without exposing the stored reconstruction wrapper', () => {
+    expect(projectHarnessSessionPresentation(
+      session({ title: ISSUE_PROMPT, surface: 'headless' }),
+      entry({
+        presentationTitle: 'Telegram support desk',
+        createdBy: {
+          kind: 'conversation',
+          caller: { kind: 'human' },
+          reason: 'issue-comment',
+          subject: {
+            kind: 'issue',
+            workspaceId: 'ws-1',
+            issueId: 'telegram-phone-desk',
+            relation: 'owner',
+          },
+        },
+      }),
+    )).toEqual({
+      title: 'Telegram support desk',
+      sourceKind: 'conversation',
+      issueId: 'telegram-phone-desk',
+    })
+  })
+
   it('prefers birth issueId over a later execution id', () => {
     expect(projectHarnessSessionPresentation(
       session({ title: ISSUE_PROMPT }),

--- a/ui/src/components/workspace/harness-session-presentation.ts
+++ b/ui/src/components/workspace/harness-session-presentation.ts
@@ -66,6 +66,9 @@ export function projectHarnessSessionPresentation(
   const coworkerName = session?.displayName?.trim() || entry?.displayName?.trim()
   if (coworkerName) return withProvenance(coworkerName)
 
+  const backendPresentation = entry?.presentationTitle?.trim()
+  if (backendPresentation) return withProvenance(backendPresentation)
+
   // Issue birth is roster identity. Do not surface the launch prompt, native
   // title seeded from that prompt, or a later assistant preview as the name.
   if (birthIssueId) {

--- a/ui/src/components/workspace/headless-task-presentation.spec.ts
+++ b/ui/src/components/workspace/headless-task-presentation.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { projectHeadlessTaskPresentation } from './headless-task-presentation'
+
+const wrapper = 'You are a fresh worker reconstructing a follow-up. Target: {"kind":"issue"}'
+
+describe('projectHeadlessTaskPresentation', () => {
+  it('uses Issue provenance instead of delivered reconstruction instructions', () => {
+    expect(projectHeadlessTaskPresentation({
+      prompt: wrapper,
+      inquiry: {
+        subject: {
+          kind: 'issue',
+          workspaceId: 'ws-1',
+          issueId: 'telegram-phone-desk',
+          relation: 'owner',
+        },
+        question: '刚才给你升级了一下，你看看现在的版本呢',
+        resolution: { mode: 'reconstructed' },
+      },
+    })).toEqual({
+      title: 'Telegram Phone Desk',
+      summary: '刚才给你升级了一下，你看看现在的版本呢',
+    })
+  })
+
+  it('uses scheduled Issue identity without exposing its work instructions', () => {
+    expect(projectHeadlessTaskPresentation({
+      prompt: 'Long internal scheduled instructions',
+      trigger: { kind: 'issue', workspaceId: 'ws-1', issueId: 'daily-market-close' },
+    })).toEqual({ title: 'Daily Market Close' })
+  })
+
+  it('keeps direct API prompts available as bounded public titles', () => {
+    expect(projectHeadlessTaskPresentation({ prompt: 'Reply with exactly OK.' }))
+      .toEqual({ title: 'Reply with exactly OK.' })
+  })
+})

--- a/ui/src/components/workspace/headless-task-presentation.ts
+++ b/ui/src/components/workspace/headless-task-presentation.ts
@@ -1,0 +1,39 @@
+import type { HeadlessTaskRecord } from '../../api/headless'
+import { readableIssueIdentity } from './harness-session-presentation'
+
+const SUMMARY_LENGTH = 96
+
+export interface HeadlessTaskPresentation {
+  readonly title: string
+  readonly summary?: string
+}
+
+export function summarizeHeadlessTaskText(value: string): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (!normalized) return 'Untitled task'
+  const characters = Array.from(normalized)
+  if (characters.length <= SUMMARY_LENGTH) return normalized
+  return `${characters.slice(0, SUMMARY_LENGTH - 1).join('').trimEnd()}…`
+}
+
+/**
+ * Public run identity comes from business provenance. The delivered prompt may
+ * contain reconstruction policy and raw target JSON, so it is diagnostic-only
+ * whenever Issue or inquiry metadata is available.
+ */
+export function projectHeadlessTaskPresentation(
+  task: Pick<HeadlessTaskRecord, 'inquiry' | 'prompt' | 'trigger'>,
+): HeadlessTaskPresentation {
+  const issueId = task.trigger?.issueId
+    ?? (task.inquiry?.subject.kind === 'issue' ? task.inquiry.subject.issueId : undefined)
+  const question = task.inquiry?.question.trim()
+
+  if (issueId) {
+    return {
+      title: readableIssueIdentity(issueId),
+      ...(question ? { summary: summarizeHeadlessTaskText(question) } : {}),
+    }
+  }
+  if (question) return { title: summarizeHeadlessTaskText(question) }
+  return { title: summarizeHeadlessTaskText(task.prompt) }
+}

--- a/ui/src/components/workspace/sidebar-order.spec.ts
+++ b/ui/src/components/workspace/sidebar-order.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import type { SessionRecord, Workspace } from './api'
-import { orderSessionsForSidebar, orderWorkspacesForSidebar } from './sidebar-order'
+import {
+  orderSessionsForSidebar,
+  orderWorkspacesForSidebar,
+  workspaceActivityMs,
+} from './sidebar-order'
 
 function session(
   id: string,
@@ -69,6 +73,14 @@ describe('sidebar attention order', () => {
 
     expect(orderWorkspacesForSidebar([older, newer]).map((candidate) => candidate.id))
       .toEqual(['newer', 'older'])
+  })
+
+  it('projects recent Session activity instead of the Workspace birth date', () => {
+    const candidate = workspace('long-lived', '2026-06-15T00:00:00Z', [
+      session('recent', 'paused', '2026-09-01T07:00:00Z'),
+    ])
+
+    expect(workspaceActivityMs(candidate)).toBe(Date.parse('2026-09-01T07:00:00Z'))
   })
 
   it('lifts running sessions, then recent activity', () => {

--- a/ui/src/components/workspace/sidebar-order.ts
+++ b/ui/src/components/workspace/sidebar-order.ts
@@ -5,7 +5,8 @@ function timestamp(value: string): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
-function workspaceActivityMs(workspace: Workspace): number {
+/** Canonical Workspace recency used by every overview and navigation surface. */
+export function workspaceActivityMs(workspace: Workspace): number {
   const sessionActivity = workspace.sessions.map((session) => timestamp(session.lastActiveAt))
   return sessionActivity.length > 0
     ? Math.max(timestamp(workspace.createdAt), ...sessionActivity)

--- a/ui/src/demo/fixtures/issues.ts
+++ b/ui/src/demo/fixtures/issues.ts
@@ -448,6 +448,25 @@ function findBoardIssue(wsId: string, id: string) {
   return ws?.issues.find((i) => i.id === id) ?? null
 }
 
+const demoAssigneeSessions: Record<string, NonNullable<IssueDetail['assigneeSession']>> = {
+  'resume-demo-thesis-owner': {
+    resumeId: 'resume-demo-thesis-owner',
+    state: 'ready',
+    workspace: { id: 'demo-ws-auto-quant', tag: 'auto-quant' },
+    agent: 'codex',
+    displayName: 'Thesis monitor',
+    createdAt: now - 14 * DAY,
+    updatedAt: now - HOUR / 2,
+    active: false,
+    runtime: { credentialSource: 'native' },
+  },
+  'resume-demo-cpi-owner': {
+    resumeId: 'resume-demo-cpi-owner',
+    state: 'missing',
+    active: false,
+  },
+}
+
 /** Build the IssueDetail the GET /api/issues/:wsId/:id mock returns, or null if
  *  the (wsId, id) pair doesn't exist on the board (→ 404). Display fields come
  *  from the board snapshot; body / what / agent / runs come from the extras map
@@ -463,6 +482,9 @@ export function demoIssueDetail(wsId: string, id: string): IssueDetail | null {
     : explicitWhat || legacyBody || boardIssue.title
   const runs = extras?.runs ?? []
   const comments = demoIssueComments[`${wsId}/${id}`] ?? []
+  const assigneeResumeId = boardIssue.assignee.startsWith('@resume-')
+    ? boardIssue.assignee.slice(1)
+    : null
   return {
     issue: {
       ...boardIssue,
@@ -470,6 +492,13 @@ export function demoIssueDetail(wsId: string, id: string): IssueDetail | null {
       ...(extras?.agent ? { agent: extras.agent } : {}),
       ...(extras?.commentPrompt ? { commentPrompt: extras.commentPrompt } : {}),
     },
+    ...(assigneeResumeId
+      ? { assigneeSession: demoAssigneeSessions[assigneeResumeId] ?? {
+          resumeId: assigneeResumeId,
+          state: 'missing' as const,
+          active: false,
+        } }
+      : {}),
     comments,
     runs,
     activity: comments

--- a/ui/src/demo/handlers/trading.ts
+++ b/ui/src/demo/handlers/trading.ts
@@ -8,6 +8,8 @@ import {
   demoSubAccountsByUTA,
   demoCryptoAccountBySub,
   demoCryptoPositionsBySub,
+  DEMO_UTA_PAPER,
+  DEMO_UTA_IBKR,
   DEMO_UTA_CRYPTO,
   demoUTAConfigs,
   demoUTAConfig,
@@ -200,6 +202,11 @@ export const tradingHandlers = [
       { engine: 'ibkr', installed: false, source: 'missing', requiredBy: [] },
       { engine: 'leverup', installed: false, source: 'missing', requiredBy: [] },
       { engine: 'longbridge', installed: false, source: 'missing', requiredBy: [] },
+    ],
+    accounts: [
+      { accountId: DEMO_UTA_PAPER, label: 'Alpaca Paper', presetId: 'alpaca-paper', configuredEnabled: true, engine: 'alpaca', state: 'needs-install', operational: false, action: 'install' },
+      { accountId: DEMO_UTA_IBKR, label: 'IBKR Demo', presetId: 'ibkr', configuredEnabled: true, engine: 'ibkr', state: 'needs-install', operational: false, action: 'install' },
+      { accountId: DEMO_UTA_CRYPTO, label: 'Binance', presetId: 'ccxt', configuredEnabled: true, engine: 'ccxt', state: 'ready', operational: true },
     ],
   })),
   http.post('/api/trading/config/broker-packs/:engine/install', ({ params }) => HttpResponse.json({

--- a/ui/src/hooks/useAgentRuntimes.spec.ts
+++ b/ui/src/hooks/useAgentRuntimes.spec.ts
@@ -17,7 +17,7 @@ const authMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('../auth/AuthContext', () => ({
-  useAuth: () => ({ backendRecoveryGeneration: authMocks.backendRecoveryGeneration }),
+  useBackendRecoverySignal: () => ({ backendRecoveryGeneration: authMocks.backendRecoveryGeneration }),
 }))
 
 vi.mock('../api/preferences', () => ({

--- a/ui/src/hooks/useAgentRuntimes.spec.ts
+++ b/ui/src/hooks/useAgentRuntimes.spec.ts
@@ -12,6 +12,14 @@ import {
 } from '../components/workspace/api'
 import { resetAgentRuntimesStore, useAgentRuntimes } from './useAgentRuntimes'
 
+const authMocks = vi.hoisted(() => ({
+  backendRecoveryGeneration: 0,
+}))
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ backendRecoveryGeneration: authMocks.backendRecoveryGeneration }),
+}))
+
 vi.mock('../api/preferences', () => ({
   preferencesApi: {
     getAgentRuntimes: vi.fn(),
@@ -70,6 +78,7 @@ const readiness = {
 describe('useAgentRuntimes', () => {
   beforeEach(() => {
     resetAgentRuntimesStore()
+    authMocks.backendRecoveryGeneration = 0
     vi.mocked(listAgents).mockReset()
     vi.mocked(getAgentRuntimeReadiness).mockReset()
     vi.mocked(probeAgentRuntimeReadiness).mockReset()
@@ -197,6 +206,56 @@ describe('useAgentRuntimes', () => {
     expect(getAgentRuntimeReadiness).toHaveBeenCalledTimes(3)
     expect(probeAgentRuntimeReadiness).not.toHaveBeenCalled()
     visibility.mockRestore()
+  })
+
+  it('cheaply rediscovers runtimes when backend recovery generation advances', async () => {
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+
+    const updatedAgents = agents.map((entry) => entry.id === 'codex'
+      ? { ...entry, installed: true, binPath: '/usr/local/bin/codex', fingerprint: 'codex-recovered' }
+      : entry)
+    const updatedReadiness = {
+      ...readiness,
+      overallReady: false,
+      checkedAt: null,
+      agents: {
+        ...readiness.agents,
+        codex: {
+          agent: 'codex',
+          displayName: 'Codex',
+          installed: true,
+          binPath: '/usr/local/bin/codex',
+          fingerprint: 'codex-recovered',
+          status: 'unknown' as const,
+          ready: false,
+          source: 'unknown' as const,
+          checkedAt: null,
+          durationMs: null,
+        },
+      },
+    }
+    vi.mocked(listAgents).mockResolvedValue(updatedAgents)
+    vi.mocked(getAgentRuntimeReadiness).mockResolvedValue(updatedReadiness)
+
+    authMocks.backendRecoveryGeneration = 1
+    runtimes.rerender()
+
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(2))
+    expect(getAgentRuntimeReadiness).toHaveBeenCalledTimes(2)
+    expect(probeAgentRuntimeReadiness).not.toHaveBeenCalled()
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.installed).toBe(true)
+    expect(runtimes.result.current.readiness?.agents.codex?.status).toBe('unknown')
+
+    runtimes.rerender()
+    await act(async () => undefined)
+    expect(listAgents).toHaveBeenCalledTimes(2)
+
+    authMocks.backendRecoveryGeneration = 2
+    runtimes.rerender()
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(3))
+    expect(getAgentRuntimeReadiness).toHaveBeenCalledTimes(3)
+    expect(probeAgentRuntimeReadiness).not.toHaveBeenCalled()
   })
 
   it('restores the last confirmed pins and exposes an error when an optimistic save fails', async () => {

--- a/ui/src/hooks/useAgentRuntimes.spec.ts
+++ b/ui/src/hooks/useAgentRuntimes.spec.ts
@@ -150,6 +150,55 @@ describe('useAgentRuntimes', () => {
     expect(second.result.current.refreshing).toBe(false)
   })
 
+  it('rediscovers installed runtimes on focus without starting a readiness probe', async () => {
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+
+    const updatedAgents = agents.map((entry) => entry.id === 'codex'
+      ? { ...entry, installed: true, binPath: '/usr/local/bin/codex', fingerprint: 'codex-v2' }
+      : entry)
+    const updatedReadiness = {
+      ...readiness,
+      overallReady: false,
+      checkedAt: null,
+      agents: {
+        ...readiness.agents,
+        codex: {
+          agent: 'codex',
+          displayName: 'Codex',
+          installed: true,
+          binPath: '/usr/local/bin/codex',
+          fingerprint: 'codex-v2',
+          status: 'unknown' as const,
+          ready: false,
+          source: 'unknown' as const,
+          checkedAt: null,
+          durationMs: null,
+        },
+      },
+    }
+    vi.mocked(listAgents).mockResolvedValue(updatedAgents)
+    vi.mocked(getAgentRuntimeReadiness).mockResolvedValue(updatedReadiness)
+
+    act(() => window.dispatchEvent(new Event('focus')))
+
+    await waitFor(() => expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.installed).toBe(true))
+    expect(listAgents).toHaveBeenCalledTimes(2)
+    expect(getAgentRuntimeReadiness).toHaveBeenCalledTimes(2)
+    expect(probeAgentRuntimeReadiness).not.toHaveBeenCalled()
+    expect(runtimes.result.current.readiness?.agents.codex?.status).toBe('unknown')
+
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    expect(listAgents).toHaveBeenCalledTimes(2)
+    visibility.mockReturnValue('visible')
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(3))
+    expect(getAgentRuntimeReadiness).toHaveBeenCalledTimes(3)
+    expect(probeAgentRuntimeReadiness).not.toHaveBeenCalled()
+    visibility.mockRestore()
+  })
+
   it('restores the last confirmed pins and exposes an error when an optimistic save fails', async () => {
     const { result } = renderHook(() => useAgentRuntimes())
     await waitFor(() => expect(result.current.loading).toBe(false))

--- a/ui/src/hooks/useAgentRuntimes.spec.ts
+++ b/ui/src/hooks/useAgentRuntimes.spec.ts
@@ -9,8 +9,13 @@ import {
   listAgents,
   probeAgentRuntimeReadiness,
   type AgentInfo,
+  type AgentRuntimeReadinessSnapshot,
 } from '../components/workspace/api'
-import { resetAgentRuntimesStore, useAgentRuntimes } from './useAgentRuntimes'
+import {
+  resetAgentRuntimesStore,
+  useAgentRuntimes,
+  useAgentRuntimesStore,
+} from './useAgentRuntimes'
 
 const authMocks = vi.hoisted(() => ({
   backendRecoveryGeneration: 0,
@@ -73,6 +78,23 @@ const readiness = {
       durationMs: 12,
     },
   },
+}
+
+function discoveredCodex(fingerprint: string): AgentInfo[] {
+  return agents.map((entry) => entry.id === 'codex'
+    ? { ...entry, installed: true, binPath: '/usr/local/bin/codex', fingerprint }
+    : entry)
+}
+
+function readinessSnapshot(label: string): AgentRuntimeReadinessSnapshot {
+  return {
+    ...readiness,
+    checkedAt: label,
+    agents: {
+      ...readiness.agents,
+      pi: { ...readiness.agents.pi, fingerprint: label },
+    },
+  }
 }
 
 describe('useAgentRuntimes', () => {
@@ -258,6 +280,283 @@ describe('useAgentRuntimes', () => {
     expect(probeAgentRuntimeReadiness).not.toHaveBeenCalled()
   })
 
+  it('reconciles a shared cached inventory when the first subscriber mounts after recovery', async () => {
+    useAgentRuntimesStore.setState({
+      agents,
+      readiness,
+      loaded: true,
+      loading: false,
+      observedBackendRecoveryGeneration: 0,
+    })
+    const recoveredAgents = agents.map((entry) => entry.id === 'codex'
+      ? { ...entry, installed: true, binPath: '/usr/local/bin/codex', fingerprint: 'codex-late-mount' }
+      : entry)
+    vi.mocked(listAgents).mockResolvedValueOnce(recoveredAgents)
+    vi.mocked(getAgentRuntimeReadiness).mockResolvedValueOnce(readiness)
+    authMocks.backendRecoveryGeneration = 3
+
+    const runtimes = renderHook(() => useAgentRuntimes())
+
+    await waitFor(() => expect(listAgents).toHaveBeenCalledOnce())
+    await waitFor(() => expect(
+      runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint,
+    ).toBe('codex-late-mount'))
+    expect(useAgentRuntimesStore.getState().observedBackendRecoveryGeneration).toBe(3)
+  })
+
+  it('supersedes a hanging pre-recovery rediscovery and ignores its late snapshot', async () => {
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+
+    const staleAgents = deferred<AgentInfo[]>()
+    const staleReadiness = deferred<typeof readiness>()
+    vi.mocked(listAgents).mockReturnValueOnce(staleAgents.promise)
+    vi.mocked(getAgentRuntimeReadiness).mockReturnValueOnce(staleReadiness.promise)
+    act(() => window.dispatchEvent(new Event('focus')))
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(2))
+
+    const recoveredAgents = agents.map((entry) => entry.id === 'codex'
+      ? { ...entry, installed: true, binPath: '/usr/local/bin/codex', fingerprint: 'codex-recovered' }
+      : entry)
+    const recoveredReadiness = {
+      ...readiness,
+      agents: {
+        ...readiness.agents,
+        codex: {
+          agent: 'codex',
+          displayName: 'Codex',
+          installed: true,
+          binPath: '/usr/local/bin/codex',
+          fingerprint: 'codex-recovered',
+          status: 'unknown' as const,
+          ready: false,
+          source: 'unknown' as const,
+          checkedAt: null,
+          durationMs: null,
+        },
+      },
+    }
+    vi.mocked(listAgents).mockResolvedValueOnce(recoveredAgents)
+    vi.mocked(getAgentRuntimeReadiness).mockResolvedValueOnce(recoveredReadiness)
+
+    authMocks.backendRecoveryGeneration = 1
+    runtimes.rerender()
+
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(3))
+    await waitFor(() => expect(
+      runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint,
+    ).toBe('codex-recovered'))
+
+    await act(async () => {
+      staleAgents.resolve(agents)
+      staleReadiness.resolve(readiness)
+      await staleAgents.promise
+      await staleReadiness.promise
+    })
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('codex-recovered')
+  })
+
+  it('supersedes a hanging initial load when backend recovery arrives before loaded', async () => {
+    const staleAgents = deferred<AgentInfo[]>()
+    const staleReadiness = deferred<typeof readiness>()
+    const stalePreferences = deferred<{ quickAccessIds: string[]; recentAgentIds: string[] }>()
+    vi.mocked(listAgents).mockReturnValueOnce(staleAgents.promise)
+    vi.mocked(getAgentRuntimeReadiness).mockReturnValueOnce(staleReadiness.promise)
+    vi.mocked(preferencesApi.getAgentRuntimes).mockReturnValueOnce(stalePreferences.promise)
+
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(listAgents).toHaveBeenCalledOnce())
+    expect(runtimes.result.current.loading).toBe(true)
+
+    const recoveredAgents = agents.map((entry) => entry.id === 'codex'
+      ? { ...entry, installed: true, binPath: '/usr/local/bin/codex', fingerprint: 'codex-initial-recovery' }
+      : entry)
+    vi.mocked(listAgents).mockResolvedValueOnce(recoveredAgents)
+    vi.mocked(getAgentRuntimeReadiness).mockResolvedValueOnce(readiness)
+    vi.mocked(preferencesApi.getAgentRuntimes).mockResolvedValueOnce({
+      quickAccessIds: ['cursor'],
+      recentAgentIds: ['claude'],
+    })
+
+    authMocks.backendRecoveryGeneration = 1
+    runtimes.rerender()
+
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('codex-initial-recovery')
+    expect(runtimes.result.current.quickAccessIds).toEqual(['cursor'])
+
+    await act(async () => {
+      staleAgents.resolve(agents)
+      staleReadiness.resolve(readiness)
+      stalePreferences.resolve({ quickAccessIds: ['pi'], recentAgentIds: ['opencode'] })
+      await Promise.all([staleAgents.promise, staleReadiness.promise, stalePreferences.promise])
+    })
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('codex-initial-recovery')
+    expect(runtimes.result.current.quickAccessIds).toEqual(['cursor'])
+  })
+
+  it('releases a failed recovery claim so a later subscriber retries the same generation', async () => {
+    const first = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(first.result.current.loading).toBe(false))
+
+    vi.mocked(listAgents).mockRejectedValueOnce(new Error('inventory still restarting'))
+    vi.mocked(getAgentRuntimeReadiness).mockRejectedValueOnce(new Error('readiness still restarting'))
+    authMocks.backendRecoveryGeneration = 1
+    first.rerender()
+
+    await waitFor(() => expect(first.result.current.error).toBe('inventory still restarting'))
+    expect(useAgentRuntimesStore.getState()).toMatchObject({
+      observedBackendRecoveryGeneration: 0,
+      backendRecoveryInflightGeneration: null,
+      backendRecoveryInflight: null,
+    })
+
+    vi.mocked(listAgents).mockResolvedValueOnce(discoveredCodex('same-generation-retry'))
+    vi.mocked(getAgentRuntimeReadiness).mockResolvedValueOnce(readinessSnapshot('same-generation-retry'))
+    const second = renderHook(() => useAgentRuntimes())
+
+    await waitFor(() => expect(
+      second.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint,
+    ).toBe('same-generation-retry'))
+    expect(useAgentRuntimesStore.getState()).toMatchObject({
+      observedBackendRecoveryGeneration: 1,
+      backendRecoveryInflightGeneration: null,
+      backendRecoveryInflight: null,
+    })
+  })
+
+  it('lets an explicit diagnostic refresh supersede a pending rediscovery', async () => {
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+
+    const rediscoveredAgents = deferred<AgentInfo[]>()
+    const rediscoveredReadiness = deferred<AgentRuntimeReadinessSnapshot>()
+    vi.mocked(listAgents).mockReturnValueOnce(rediscoveredAgents.promise)
+    vi.mocked(getAgentRuntimeReadiness).mockReturnValueOnce(rediscoveredReadiness.promise)
+    act(() => window.dispatchEvent(new Event('focus')))
+    await waitFor(() => expect(listAgents).toHaveBeenCalledTimes(2))
+
+    const probedAgents = deferred<AgentInfo[]>()
+    const probedReadiness = deferred<AgentRuntimeReadinessSnapshot>()
+    vi.mocked(listAgents).mockReturnValueOnce(probedAgents.promise)
+    vi.mocked(probeAgentRuntimeReadiness).mockReturnValueOnce(probedReadiness.promise)
+    let refreshPromise!: Promise<void>
+    act(() => {
+      refreshPromise = runtimes.result.current.refresh('pi')
+    })
+    expect(runtimes.result.current.refreshing).toBe(true)
+
+    await act(async () => {
+      probedAgents.resolve(discoveredCodex('probe-current'))
+      probedReadiness.resolve(readinessSnapshot('probe-current'))
+      await refreshPromise
+    })
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('probe-current')
+    expect(runtimes.result.current.readiness?.checkedAt).toBe('probe-current')
+    expect(runtimes.result.current.refreshing).toBe(false)
+
+    await act(async () => {
+      rediscoveredAgents.resolve(discoveredCodex('rediscovery-stale'))
+      rediscoveredReadiness.resolve(readinessSnapshot('rediscovery-stale'))
+      await Promise.all([rediscoveredAgents.promise, rediscoveredReadiness.promise])
+    })
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('probe-current')
+    expect(runtimes.result.current.readiness?.checkedAt).toBe('probe-current')
+    expect(runtimes.result.current.refreshing).toBe(false)
+  })
+
+  it('keeps refresh B authoritative when refresh A callbacks and result arrive later', async () => {
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+
+    const agentsA = deferred<AgentInfo[]>()
+    const readinessA = deferred<AgentRuntimeReadinessSnapshot>()
+    const agentsB = deferred<AgentInfo[]>()
+    const readinessB = deferred<AgentRuntimeReadinessSnapshot>()
+    let publishA: ((snapshot: AgentRuntimeReadinessSnapshot) => void) | undefined
+    let publishB: ((snapshot: AgentRuntimeReadinessSnapshot) => void) | undefined
+    vi.mocked(listAgents)
+      .mockReturnValueOnce(agentsA.promise)
+      .mockReturnValueOnce(agentsB.promise)
+    vi.mocked(probeAgentRuntimeReadiness)
+      .mockImplementationOnce((_agent, publish) => {
+        publishA = publish
+        return readinessA.promise
+      })
+      .mockImplementationOnce((_agent, publish) => {
+        publishB = publish
+        return readinessB.promise
+      })
+
+    let refreshA!: Promise<void>
+    let refreshB!: Promise<void>
+    act(() => {
+      refreshA = runtimes.result.current.refresh('pi')
+      refreshB = runtimes.result.current.refresh('pi')
+    })
+    act(() => publishB?.(readinessSnapshot('probe-b-progress')))
+    expect(runtimes.result.current.readiness?.checkedAt).toBe('probe-b-progress')
+    expect(runtimes.result.current.refreshing).toBe(true)
+
+    await act(async () => {
+      agentsB.resolve(discoveredCodex('probe-b-final'))
+      readinessB.resolve(readinessSnapshot('probe-b-final'))
+      await refreshB
+    })
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('probe-b-final')
+    expect(runtimes.result.current.readiness?.checkedAt).toBe('probe-b-final')
+    expect(runtimes.result.current.refreshing).toBe(false)
+
+    await act(async () => {
+      publishA?.(readinessSnapshot('probe-a-late-progress'))
+      agentsA.resolve(discoveredCodex('probe-a-late-final'))
+      readinessA.resolve(readinessSnapshot('probe-a-late-final'))
+      await refreshA
+    })
+    expect(runtimes.result.current.catalog.find((entry) => entry.id === 'codex')?.fingerprint)
+      .toBe('probe-b-final')
+    expect(runtimes.result.current.readiness?.checkedAt).toBe('probe-b-final')
+    expect(runtimes.result.current.refreshing).toBe(false)
+    expect(runtimes.result.current.error).toBeNull()
+  })
+
+  it('retires probe callbacks when the sibling Agent inventory refresh fails first', async () => {
+    const runtimes = renderHook(() => useAgentRuntimes())
+    await waitFor(() => expect(runtimes.result.current.loading).toBe(false))
+
+    const probedReadiness = deferred<AgentRuntimeReadinessSnapshot>()
+    let publish: ((snapshot: AgentRuntimeReadinessSnapshot) => void) | undefined
+    vi.mocked(listAgents).mockRejectedValueOnce(new Error('inventory unavailable'))
+    vi.mocked(probeAgentRuntimeReadiness).mockImplementationOnce((_agent, next) => {
+      publish = next
+      return probedReadiness.promise
+    })
+
+    let refreshPromise!: Promise<void>
+    act(() => {
+      refreshPromise = runtimes.result.current.refresh('pi')
+    })
+    await expect(refreshPromise).rejects.toThrow('inventory unavailable')
+    expect(runtimes.result.current.refreshing).toBe(false)
+    expect(runtimes.result.current.error).toBe('inventory unavailable')
+    const retained = runtimes.result.current.readiness
+
+    await act(async () => {
+      publish?.(readinessSnapshot('late-failed-progress'))
+      probedReadiness.resolve(readinessSnapshot('late-failed-final'))
+      await probedReadiness.promise
+    })
+    expect(runtimes.result.current.readiness).toBe(retained)
+    expect(runtimes.result.current.error).toBe('inventory unavailable')
+  })
+
   it('restores the last confirmed pins and exposes an error when an optimistic save fails', async () => {
     const { result } = renderHook(() => useAgentRuntimes())
     await waitFor(() => expect(result.current.loading).toBe(false))
@@ -347,3 +646,11 @@ describe('useAgentRuntimes', () => {
     expect(preferencesApi.rememberAgentRuntimeUse).toHaveBeenNthCalledWith(2, 'claude')
   })
 })
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolvePromise!: (value: T) => void
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}

--- a/ui/src/hooks/useAgentRuntimes.ts
+++ b/ui/src/hooks/useAgentRuntimes.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { create } from 'zustand'
 
 import { preferencesApi } from '../api/preferences'
+import { useAuth } from '../auth/AuthContext'
 import {
   getAgentRuntimeReadiness,
   listAgents,
@@ -267,6 +268,8 @@ export function resetAgentRuntimesStore(): void {
  * runtime outside primary does not write pins.
  */
 export function useAgentRuntimes(): AgentRuntimesState {
+  const { backendRecoveryGeneration } = useAuth()
+  const observedBackendRecoveryGenerationRef = useRef(backendRecoveryGeneration)
   const agents = useAgentRuntimesStore((state) => state.agents)
   const readiness = useAgentRuntimesStore((state) => state.readiness)
   const quickAccessIds = useAgentRuntimesStore((state) => state.quickAccessIds)
@@ -283,6 +286,13 @@ export function useAgentRuntimes(): AgentRuntimesState {
   useEffect(() => {
     void ensureLoaded()
   }, [ensureLoaded])
+
+  useEffect(() => {
+    const observed = observedBackendRecoveryGenerationRef.current
+    observedBackendRecoveryGenerationRef.current = backendRecoveryGeneration
+    if (backendRecoveryGeneration <= observed) return
+    void rediscoverStore()
+  }, [backendRecoveryGeneration, rediscoverStore])
 
   useEffect(() => {
     const rediscover = () => void rediscoverStore()

--- a/ui/src/hooks/useAgentRuntimes.ts
+++ b/ui/src/hooks/useAgentRuntimes.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { create } from 'zustand'
 
 import { preferencesApi } from '../api/preferences'
@@ -45,16 +45,25 @@ interface AgentRuntimesStore {
   loaded: boolean
   inflight: Promise<void> | null
   rediscoveryInflight: Promise<void> | null
-  loadGeneration: number
+  refreshInflight: Promise<void> | null
+  publicationEpoch: number
+  observedBackendRecoveryGeneration: number
+  backendRecoveryInflightGeneration: number | null
+  backendRecoveryInflight: Promise<void> | null
   saveGeneration: number
   saveQueue: Promise<unknown>
   recentGeneration: number
   recentQueue: Promise<unknown>
-  ensureLoaded(): Promise<void>
-  rediscover(): Promise<void>
+  ensureLoaded(options?: AgentRuntimeDiscoveryOptions): Promise<void>
+  rediscover(options?: AgentRuntimeDiscoveryOptions): Promise<void>
+  recoverAfterBackend(generation: number): Promise<void>
   refresh(agent?: string): Promise<void>
   saveQuickAccess(ids: readonly string[]): Promise<void>
   recordSuccessfulUse(agentId: string): Promise<void>
+}
+
+interface AgentRuntimeDiscoveryOptions {
+  readonly supersedePending?: boolean
 }
 
 function errorMessage(cause: unknown): string {
@@ -83,29 +92,46 @@ const emptyStoreSlice = {
   loaded: false,
   inflight: null as Promise<void> | null,
   rediscoveryInflight: null as Promise<void> | null,
+  refreshInflight: null as Promise<void> | null,
+  backendRecoveryInflightGeneration: null as number | null,
+  backendRecoveryInflight: null as Promise<void> | null,
 }
 
 export const useAgentRuntimesStore = create<AgentRuntimesStore>((set, get) => ({
   ...emptyStoreSlice,
-  loadGeneration: 0,
+  publicationEpoch: 0,
+  observedBackendRecoveryGeneration: 0,
   saveGeneration: 0,
   saveQueue: Promise.resolve(),
   recentGeneration: 0,
   recentQueue: Promise.resolve(),
 
-  async ensureLoaded() {
-    if (get().loaded) return
+  async ensureLoaded(options) {
+    const supersedePending = options?.supersedePending === true
+    if (get().loaded && !supersedePending) return
+    const refreshInflight = get().refreshInflight
+    if (refreshInflight && !supersedePending) return refreshInflight
     const inflight = get().inflight
-    if (inflight) return inflight
-    const generation = get().loadGeneration
-    const request = (async () => {
-      set({ loading: true })
+    if (inflight && !supersedePending) return inflight
+    const epoch = get().publicationEpoch + 1
+    set({
+      publicationEpoch: epoch,
+      loading: true,
+      ...(supersedePending ? {
+        inflight: null,
+        rediscoveryInflight: null,
+        refreshInflight: null,
+        refreshing: false,
+      } : {}),
+    })
+    let request!: Promise<void>
+    request = (async () => {
       const [listed, snapshot, preferences] = await Promise.all([
         asSettled(() => listAgents()),
         asSettled(() => getAgentRuntimeReadiness()),
         asSettled(() => preferencesApi.getAgentRuntimes()),
       ])
-      if (get().loadGeneration !== generation) return
+      if (get().publicationEpoch !== epoch || get().inflight !== request) return
       const agents = listed.status === 'fulfilled'
         ? listed.value ?? []
         : get().agents
@@ -132,47 +158,91 @@ export const useAgentRuntimesStore = create<AgentRuntimesStore>((set, get) => ({
     try {
       await request
     } finally {
-      if (get().inflight === request) set({ inflight: null })
+      if (get().publicationEpoch === epoch && get().inflight === request) {
+        set({ inflight: null })
+      }
     }
   },
 
   async refresh(agent?: string) {
-    const generation = get().loadGeneration
-    set({ refreshing: true, error: null })
+    const epoch = get().publicationEpoch + 1
+    set({
+      publicationEpoch: epoch,
+      inflight: null,
+      rediscoveryInflight: null,
+      refreshInflight: null,
+      loading: false,
+      refreshing: true,
+      error: null,
+    })
+    let request!: Promise<void>
+    request = (async () => {
+      try {
+        const [listed, snapshot] = await Promise.all([
+          listAgents(),
+          probeAgentRuntimeReadiness(agent, (next) => {
+            if (
+              get().publicationEpoch === epoch
+              && get().refreshInflight === request
+            ) {
+              set({ readiness: next })
+            }
+          }),
+        ])
+        if (get().publicationEpoch !== epoch || get().refreshInflight !== request) return
+        set({
+          agents: listed,
+          readiness: snapshot,
+          refreshing: false,
+          error: null,
+          loaded: true,
+          loading: false,
+          refreshInflight: null,
+        })
+      } catch (cause) {
+        if (get().publicationEpoch !== epoch || get().refreshInflight !== request) return
+        // Retire callback publication before surfacing the failure. The probe
+        // transport may still deliver progress after its sibling inventory
+        // request has already failed.
+        set({ refreshing: false, error: errorMessage(cause), refreshInflight: null })
+        throw cause
+      }
+    })()
+    set({ refreshInflight: request })
     try {
-      const [listed, snapshot] = await Promise.all([
-        listAgents(),
-        probeAgentRuntimeReadiness(agent, (next) => {
-          if (get().loadGeneration === generation) set({ readiness: next })
-        }),
-      ])
-      if (get().loadGeneration !== generation) return
-      set({
-        agents: listed,
-        readiness: snapshot,
-        refreshing: false,
-        error: null,
-        loaded: true,
-        loading: false,
-      })
-    } catch (cause) {
-      if (get().loadGeneration !== generation) return
-      set({ refreshing: false, error: errorMessage(cause) })
-      throw cause
+      await request
+    } finally {
+      if (get().publicationEpoch === epoch && get().refreshInflight === request) {
+        set({ refreshInflight: null })
+      }
     }
   },
 
-  async rediscover() {
-    if (!get().loaded) return get().ensureLoaded()
+  async rediscover(options) {
+    const supersedePending = options?.supersedePending === true
+    if (!get().loaded) return get().ensureLoaded(options)
+    const refreshInflight = get().refreshInflight
+    if (refreshInflight && !supersedePending) return refreshInflight
     const inflight = get().rediscoveryInflight
-    if (inflight) return inflight
-    const generation = get().loadGeneration
-    const request = (async () => {
+    if (inflight && !supersedePending) return inflight
+    const epoch = get().publicationEpoch + 1
+    set({
+      publicationEpoch: epoch,
+      ...(supersedePending ? {
+        inflight: null,
+        rediscoveryInflight: null,
+        refreshInflight: null,
+        loading: false,
+        refreshing: false,
+      } : {}),
+    })
+    let request!: Promise<void>
+    request = (async () => {
       const [listed, snapshot] = await Promise.all([
         asSettled(() => listAgents()),
         asSettled(() => getAgentRuntimeReadiness()),
       ])
-      if (get().loadGeneration !== generation) return
+      if (get().publicationEpoch !== epoch || get().rediscoveryInflight !== request) return
       const failed = [listed, snapshot].find((result) => result.status === 'rejected')
       set({
         agents: listed.status === 'fulfilled' ? listed.value ?? [] : get().agents,
@@ -184,8 +254,44 @@ export const useAgentRuntimesStore = create<AgentRuntimesStore>((set, get) => ({
     try {
       await request
     } finally {
-      if (get().rediscoveryInflight === request) set({ rediscoveryInflight: null })
+      if (get().publicationEpoch === epoch && get().rediscoveryInflight === request) {
+        set({ rediscoveryInflight: null })
+      }
     }
+  },
+
+  async recoverAfterBackend(generation) {
+    const state = get()
+    if (generation <= state.observedBackendRecoveryGeneration) return
+    if (
+      state.backendRecoveryInflightGeneration === generation
+      && state.backendRecoveryInflight
+    ) {
+      return state.backendRecoveryInflight
+    }
+
+    let recovery!: Promise<void>
+    recovery = (async () => {
+      const discovery = get().rediscover({ supersedePending: true })
+      const epoch = get().publicationEpoch
+      await discovery
+      const current = get()
+      if (current.backendRecoveryInflight !== recovery) return
+      const succeeded = current.publicationEpoch === epoch && current.error === null
+      set({
+        ...(succeeded ? { observedBackendRecoveryGeneration: generation } : {}),
+        backendRecoveryInflightGeneration: null,
+        backendRecoveryInflight: null,
+      })
+    })()
+    // The coordinator, not a hopeful request start, owns the claim. Failed or
+    // superseded recovery releases it so a later subscriber at the same Auth
+    // generation can reconcile again.
+    set({
+      backendRecoveryInflightGeneration: generation,
+      backendRecoveryInflight: recovery,
+    })
+    return recovery
   },
 
   async saveQuickAccess(ids: readonly string[]) {
@@ -254,7 +360,10 @@ export const useAgentRuntimesStore = create<AgentRuntimesStore>((set, get) => ({
 export function resetAgentRuntimesStore(): void {
   useAgentRuntimesStore.setState({
     ...emptyStoreSlice,
-    loadGeneration: useAgentRuntimesStore.getState().loadGeneration + 1,
+    publicationEpoch: useAgentRuntimesStore.getState().publicationEpoch + 1,
+    observedBackendRecoveryGeneration: 0,
+    backendRecoveryInflightGeneration: null,
+    backendRecoveryInflight: null,
     saveGeneration: useAgentRuntimesStore.getState().saveGeneration + 1,
     saveQueue: Promise.resolve(),
     recentGeneration: useAgentRuntimesStore.getState().recentGeneration + 1,
@@ -269,7 +378,6 @@ export function resetAgentRuntimesStore(): void {
  */
 export function useAgentRuntimes(): AgentRuntimesState {
   const { backendRecoveryGeneration } = useBackendRecoverySignal()
-  const observedBackendRecoveryGenerationRef = useRef(backendRecoveryGeneration)
   const agents = useAgentRuntimesStore((state) => state.agents)
   const readiness = useAgentRuntimesStore((state) => state.readiness)
   const quickAccessIds = useAgentRuntimesStore((state) => state.quickAccessIds)
@@ -279,6 +387,7 @@ export function useAgentRuntimes(): AgentRuntimesState {
   const error = useAgentRuntimesStore((state) => state.error)
   const ensureLoaded = useAgentRuntimesStore((state) => state.ensureLoaded)
   const rediscoverStore = useAgentRuntimesStore((state) => state.rediscover)
+  const recoverAfterBackendStore = useAgentRuntimesStore((state) => state.recoverAfterBackend)
   const refreshStore = useAgentRuntimesStore((state) => state.refresh)
   const saveStore = useAgentRuntimesStore((state) => state.saveQuickAccess)
   const recordSuccessfulUseStore = useAgentRuntimesStore((state) => state.recordSuccessfulUse)
@@ -288,11 +397,12 @@ export function useAgentRuntimes(): AgentRuntimesState {
   }, [ensureLoaded])
 
   useEffect(() => {
-    const observed = observedBackendRecoveryGenerationRef.current
-    observedBackendRecoveryGenerationRef.current = backendRecoveryGeneration
-    if (backendRecoveryGeneration <= observed) return
-    void rediscoverStore()
-  }, [backendRecoveryGeneration, rediscoverStore])
+    // The store, rather than an individual mounted consumer, claims each
+    // generation. A surface mounted after recovery must still reconcile a
+    // cached inventory left behind by an earlier subscriber.
+    if (backendRecoveryGeneration <= 0) return
+    void recoverAfterBackendStore(backendRecoveryGeneration)
+  }, [backendRecoveryGeneration, recoverAfterBackendStore])
 
   useEffect(() => {
     const rediscover = () => void rediscoverStore()

--- a/ui/src/hooks/useAgentRuntimes.ts
+++ b/ui/src/hooks/useAgentRuntimes.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { create } from 'zustand'
 
 import { preferencesApi } from '../api/preferences'
-import { useAuth } from '../auth/AuthContext'
+import { useBackendRecoverySignal } from '../auth/AuthContext'
 import {
   getAgentRuntimeReadiness,
   listAgents,
@@ -268,7 +268,7 @@ export function resetAgentRuntimesStore(): void {
  * runtime outside primary does not write pins.
  */
 export function useAgentRuntimes(): AgentRuntimesState {
-  const { backendRecoveryGeneration } = useAuth()
+  const { backendRecoveryGeneration } = useBackendRecoverySignal()
   const observedBackendRecoveryGenerationRef = useRef(backendRecoveryGeneration)
   const agents = useAgentRuntimesStore((state) => state.agents)
   const readiness = useAgentRuntimesStore((state) => state.readiness)

--- a/ui/src/hooks/useAgentRuntimes.ts
+++ b/ui/src/hooks/useAgentRuntimes.ts
@@ -24,6 +24,8 @@ export interface AgentRuntimesState extends AgentRuntimeQuickAccessProjection {
   readonly loading: boolean
   readonly refreshing: boolean
   readonly error: string | null
+  /** Cheap host rediscovery: GET inventory + cached readiness, never a probe. */
+  rediscover(): Promise<void>
   refresh(agent?: string): Promise<void>
   saveQuickAccess(ids: readonly string[]): Promise<void>
   recordSuccessfulUse(agentId: string): Promise<void>
@@ -41,12 +43,14 @@ interface AgentRuntimesStore {
   error: string | null
   loaded: boolean
   inflight: Promise<void> | null
+  rediscoveryInflight: Promise<void> | null
   loadGeneration: number
   saveGeneration: number
   saveQueue: Promise<unknown>
   recentGeneration: number
   recentQueue: Promise<unknown>
   ensureLoaded(): Promise<void>
+  rediscover(): Promise<void>
   refresh(agent?: string): Promise<void>
   saveQuickAccess(ids: readonly string[]): Promise<void>
   recordSuccessfulUse(agentId: string): Promise<void>
@@ -77,6 +81,7 @@ const emptyStoreSlice = {
   error: null as string | null,
   loaded: false,
   inflight: null as Promise<void> | null,
+  rediscoveryInflight: null as Promise<void> | null,
 }
 
 export const useAgentRuntimesStore = create<AgentRuntimesStore>((set, get) => ({
@@ -153,6 +158,32 @@ export const useAgentRuntimesStore = create<AgentRuntimesStore>((set, get) => ({
       if (get().loadGeneration !== generation) return
       set({ refreshing: false, error: errorMessage(cause) })
       throw cause
+    }
+  },
+
+  async rediscover() {
+    if (!get().loaded) return get().ensureLoaded()
+    const inflight = get().rediscoveryInflight
+    if (inflight) return inflight
+    const generation = get().loadGeneration
+    const request = (async () => {
+      const [listed, snapshot] = await Promise.all([
+        asSettled(() => listAgents()),
+        asSettled(() => getAgentRuntimeReadiness()),
+      ])
+      if (get().loadGeneration !== generation) return
+      const failed = [listed, snapshot].find((result) => result.status === 'rejected')
+      set({
+        agents: listed.status === 'fulfilled' ? listed.value ?? [] : get().agents,
+        readiness: snapshot.status === 'fulfilled' ? snapshot.value ?? null : get().readiness,
+        error: failed && failed.status === 'rejected' ? errorMessage(failed.reason) : null,
+      })
+    })()
+    set({ rediscoveryInflight: request })
+    try {
+      await request
+    } finally {
+      if (get().rediscoveryInflight === request) set({ rediscoveryInflight: null })
     }
   },
 
@@ -244,6 +275,7 @@ export function useAgentRuntimes(): AgentRuntimesState {
   const refreshing = useAgentRuntimesStore((state) => state.refreshing)
   const error = useAgentRuntimesStore((state) => state.error)
   const ensureLoaded = useAgentRuntimesStore((state) => state.ensureLoaded)
+  const rediscoverStore = useAgentRuntimesStore((state) => state.rediscover)
   const refreshStore = useAgentRuntimesStore((state) => state.refresh)
   const saveStore = useAgentRuntimesStore((state) => state.saveQuickAccess)
   const recordSuccessfulUseStore = useAgentRuntimesStore((state) => state.recordSuccessfulUse)
@@ -251,6 +283,19 @@ export function useAgentRuntimes(): AgentRuntimesState {
   useEffect(() => {
     void ensureLoaded()
   }, [ensureLoaded])
+
+  useEffect(() => {
+    const rediscover = () => void rediscoverStore()
+    const rediscoverWhenVisible = () => {
+      if (document.visibilityState === 'visible') rediscover()
+    }
+    window.addEventListener('focus', rediscover)
+    document.addEventListener('visibilitychange', rediscoverWhenVisible)
+    return () => {
+      window.removeEventListener('focus', rediscover)
+      document.removeEventListener('visibilitychange', rediscoverWhenVisible)
+    }
+  }, [rediscoverStore])
 
   const projection = useMemo(
     () => projectAgentRuntimeQuickAccess(agents, quickAccessIds, recentAgentIds),
@@ -266,6 +311,7 @@ export function useAgentRuntimes(): AgentRuntimesState {
     loading,
     refreshing,
     error,
+    rediscover: useCallback(() => rediscoverStore(), [rediscoverStore]),
     refresh: useCallback((agent?: string) => refreshStore(agent), [refreshStore]),
     saveQuickAccess: useCallback(
       (ids: readonly string[]) => saveStore(ids),

--- a/ui/src/hooks/useBrokerPackReadiness.spec.ts
+++ b/ui/src/hooks/useBrokerPackReadiness.spec.ts
@@ -8,9 +8,16 @@ const apiMocks = vi.hoisted(() => ({
   getBrokerPacks: vi.fn(),
   installBrokerPack: vi.fn(),
 }))
+const authMocks = vi.hoisted(() => ({
+  backendUnavailable: false,
+  backendRecoveryGeneration: 0,
+}))
 
 vi.mock('../api', () => ({
   api: { trading: apiMocks },
+}))
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => authMocks,
 }))
 
 import {
@@ -37,6 +44,8 @@ const response: BrokerPackReadinessResponse = {
 }
 
 beforeEach(() => {
+  authMocks.backendUnavailable = false
+  authMocks.backendRecoveryGeneration = 0
   apiMocks.getBrokerPacks.mockResolvedValue(response)
   apiMocks.installBrokerPack.mockResolvedValue(response.packs[0])
   vi.clearAllMocks()
@@ -51,6 +60,12 @@ describe('account Broker Pack readiness policy', () => {
 
     expect(selectAccountPackReadiness(account, { data: null, loading: false, error: 'Runtime offline' })).toMatchObject({
       state: 'status-unavailable', operational: false, reason: 'Runtime offline',
+    })
+    expect(selectAccountPackReadiness(account, { data: response, loading: false, error: 'Runtime offline' })).toMatchObject({
+      state: 'status-unavailable', operational: false, reason: 'Runtime offline',
+    })
+    expect(selectAccountPackReadiness(account, { data: response, loading: true, error: null })).toMatchObject({
+      state: 'checking', operational: false,
     })
   })
 
@@ -79,5 +94,33 @@ describe('useBrokerPackReadiness', () => {
     await act(async () => { await result.current.install('ccxt') })
     expect(apiMocks.installBrokerPack).toHaveBeenCalledWith('ccxt')
     expect(apiMocks.getBrokerPacks).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails closed after a refresh error and reloads on backend recovery', async () => {
+    const { result, rerender } = renderHook(() => useBrokerPackReadiness())
+
+    await waitFor(() => expect(result.current.forAccount(account).operational).toBe(true))
+
+    apiMocks.getBrokerPacks.mockRejectedValueOnce(new Error('Runtime offline'))
+    await act(async () => { await result.current.refresh() })
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.forAccount(account)).toMatchObject({
+      state: 'status-unavailable', operational: false, reason: 'Runtime offline',
+    })
+
+    authMocks.backendUnavailable = true
+    rerender()
+    expect(result.current.forAccount(account)).toMatchObject({
+      state: 'status-unavailable', operational: false,
+    })
+
+    apiMocks.getBrokerPacks.mockResolvedValueOnce(response)
+    authMocks.backendUnavailable = false
+    authMocks.backendRecoveryGeneration += 1
+    rerender()
+
+    await waitFor(() => expect(result.current.forAccount(account).operational).toBe(true))
+    expect(apiMocks.getBrokerPacks).toHaveBeenCalledTimes(3)
   })
 })

--- a/ui/src/hooks/useBrokerPackReadiness.spec.ts
+++ b/ui/src/hooks/useBrokerPackReadiness.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrokerHealthInfo, BrokerPackReadinessResponse, UTAConfig } from '../api/types'
+
+const apiMocks = vi.hoisted(() => ({
+  getBrokerPacks: vi.fn(),
+  installBrokerPack: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  api: { trading: apiMocks },
+}))
+
+import {
+  deriveAccountInteractionPolicy,
+  selectAccountPackReadiness,
+  useBrokerPackReadiness,
+} from './useBrokerPackReadiness'
+
+const account: UTAConfig = {
+  id: 'main', label: 'Main', presetId: 'okx', enabled: true,
+  guards: [], presetConfig: {}, readOnly: false, asVendor: true,
+}
+const ready = {
+  accountId: 'main', label: 'Main', presetId: 'okx', configuredEnabled: true,
+  engine: 'ccxt' as const, state: 'ready' as const, operational: true,
+}
+const health: BrokerHealthInfo = {
+  status: 'healthy', reach: 'readable', tier: 'trading', consecutiveFailures: 0,
+  recovering: false, connecting: false, disabled: false,
+}
+const response: BrokerPackReadinessResponse = {
+  packs: [{ engine: 'ccxt', installed: true, source: 'downloaded', requiredBy: ['Main'] }],
+  accounts: [ready],
+}
+
+beforeEach(() => {
+  apiMocks.getBrokerPacks.mockResolvedValue(response)
+  apiMocks.installBrokerPack.mockResolvedValue(response.packs[0])
+  vi.clearAllMocks()
+})
+
+describe('account Broker Pack readiness policy', () => {
+  it('fails closed while support is missing or its status cannot be read', () => {
+    const missing = { ...ready, state: 'needs-install' as const, operational: false, action: 'install' as const }
+    expect(deriveAccountInteractionPolicy({ account, readiness: missing, health, tradingMode: 'pro' })).toMatchObject({
+      canRead: false, canReconnect: false, canTrade: false,
+    })
+
+    expect(selectAccountPackReadiness(account, { data: null, loading: false, error: 'Runtime offline' })).toMatchObject({
+      state: 'status-unavailable', operational: false, reason: 'Runtime offline',
+    })
+  })
+
+  it('requires config, mode, health reach, tier, and writable account before trading', () => {
+    expect(deriveAccountInteractionPolicy({ account, readiness: ready, health, tradingMode: 'pro' })).toEqual({
+      canRead: true, canReconnect: true, canTrade: true,
+    })
+    expect(deriveAccountInteractionPolicy({ account: { ...account, readOnly: true }, readiness: ready, health, tradingMode: 'pro' })).toMatchObject({
+      canRead: true, canReconnect: true, canTrade: false,
+    })
+    expect(deriveAccountInteractionPolicy({ account, readiness: ready, health, tradingMode: 'readonly' })).toMatchObject({ canTrade: false })
+    expect(deriveAccountInteractionPolicy({ account, readiness: ready, health: { ...health, reach: 'down' }, tradingMode: 'pro' })).toMatchObject({ canTrade: false })
+    expect(deriveAccountInteractionPolicy({ account, readiness: ready, health: { ...health, tier: 'account' }, tradingMode: 'pro' })).toMatchObject({ canTrade: false })
+  })
+})
+
+describe('useBrokerPackReadiness', () => {
+  it('discovers support without installing anything implicitly', async () => {
+    const { result } = renderHook(() => useBrokerPackReadiness())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.forAccount(account)).toMatchObject({ state: 'ready', operational: true })
+    expect(apiMocks.getBrokerPacks).toHaveBeenCalledOnce()
+    expect(apiMocks.installBrokerPack).not.toHaveBeenCalled()
+
+    await act(async () => { await result.current.install('ccxt') })
+    expect(apiMocks.installBrokerPack).toHaveBeenCalledWith('ccxt')
+    expect(apiMocks.getBrokerPacks).toHaveBeenCalledTimes(2)
+  })
+})

--- a/ui/src/hooks/useBrokerPackReadiness.spec.ts
+++ b/ui/src/hooks/useBrokerPackReadiness.spec.ts
@@ -17,7 +17,7 @@ vi.mock('../api', () => ({
   api: { trading: apiMocks },
 }))
 vi.mock('../auth/AuthContext', () => ({
-  useAuth: () => authMocks,
+  useBackendRecoverySignal: () => authMocks,
 }))
 
 import {

--- a/ui/src/hooks/useBrokerPackReadiness.ts
+++ b/ui/src/hooks/useBrokerPackReadiness.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../api'
+import { useAuth } from '../auth/AuthContext'
 import type {
   BrokerAccountPackReadiness,
   BrokerEngine,
@@ -10,6 +11,7 @@ import type {
 } from '../api/types'
 
 const REFRESH_TTL_MS = 15_000
+const BACKEND_UNAVAILABLE_REASON = 'OpenAlice Runtime is unavailable.'
 
 export type AccountPackReadinessState = BrokerAccountPackReadiness['state'] | 'checking' | 'status-unavailable'
 
@@ -34,9 +36,6 @@ export function selectAccountPackReadiness(
   account: Pick<UTAConfig, 'id' | 'label' | 'presetId' | 'enabled'>,
   state: ReadinessSelectionState,
 ): AccountPackReadiness {
-  const exact = state.data?.accounts.find((candidate) => candidate.accountId === account.id)
-  if (exact) return exact
-
   const base = {
     accountId: account.id,
     label: account.label ?? account.id,
@@ -44,11 +43,21 @@ export function selectAccountPackReadiness(
     configuredEnabled: account.enabled !== false,
     operational: false,
   }
-  if (state.loading && !state.data) return { ...base, state: 'checking' }
+  // Readiness is a live capability, not a historical snapshot. A refresh or
+  // transport error must invalidate even an exact row from the previous
+  // response so trading surfaces always fail closed.
+  if (state.loading) return { ...base, state: 'checking' }
+  if (state.error) {
+    return { ...base, state: 'status-unavailable', reason: state.error }
+  }
+
+  const exact = state.data?.accounts.find((candidate) => candidate.accountId === account.id)
+  if (exact) return exact
+
   return {
     ...base,
     state: 'status-unavailable',
-    reason: state.error ?? 'Broker support status is unavailable on this Runtime.',
+    reason: 'Broker support status is unavailable on this Runtime.',
   }
 }
 
@@ -100,6 +109,7 @@ export function deriveAccountInteractionPolicy({
 }
 
 export function useBrokerPackReadiness() {
+  const { backendUnavailable, backendRecoveryGeneration } = useAuth()
   const [data, setData] = useState<BrokerPackReadinessResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -107,29 +117,60 @@ export function useBrokerPackReadiness() {
   const dataRef = useRef<BrokerPackReadinessResponse | null>(null)
   const lastLoadedAt = useRef(0)
   const inFlight = useRef<Promise<void> | null>(null)
+  const requestGeneration = useRef(0)
 
-  const refresh = useCallback(async () => {
-    if (inFlight.current) return inFlight.current
-    const request = (async () => {
-      if (!dataRef.current) setLoading(true)
+  const failClosed = useCallback((nextError: string | null, nextLoading: boolean) => {
+    requestGeneration.current += 1
+    dataRef.current = null
+    lastLoadedAt.current = 0
+    setData(null)
+    setError(nextError)
+    setLoading(nextLoading)
+  }, [])
+
+  const performRefresh = useCallback(async (supersedePending: boolean) => {
+    if (!supersedePending && inFlight.current) return inFlight.current
+    const generation = ++requestGeneration.current
+    dataRef.current = null
+    lastLoadedAt.current = 0
+    setData(null)
+    setError(null)
+    setLoading(true)
+
+    let request!: Promise<void>
+    request = (async () => {
       try {
         const next = await api.trading.getBrokerPacks()
+        if (generation !== requestGeneration.current) return
         dataRef.current = next
         setData(next)
         setError(null)
         lastLoadedAt.current = Date.now()
       } catch (err) {
+        if (generation !== requestGeneration.current) return
+        dataRef.current = null
+        setData(null)
         setError(err instanceof Error ? err.message : String(err))
       } finally {
-        setLoading(false)
-        inFlight.current = null
+        if (generation === requestGeneration.current) setLoading(false)
+        if (inFlight.current === request) inFlight.current = null
       }
     })()
     inFlight.current = request
     return request
   }, [])
 
-  useEffect(() => { void refresh() }, [refresh])
+  const refresh = useCallback(() => performRefresh(false), [performRefresh])
+
+  useEffect(() => {
+    if (backendUnavailable) {
+      failClosed(BACKEND_UNAVAILABLE_REASON, false)
+      return
+    }
+    // Recovery must not wait for a request left hanging by the outage. Start a
+    // new generation immediately and ignore any late response from the old one.
+    void performRefresh(true)
+  }, [backendRecoveryGeneration, backendUnavailable, failClosed, performRefresh])
 
   useEffect(() => {
     const refreshIfStale = () => {
@@ -158,9 +199,24 @@ export function useBrokerPackReadiness() {
     }
   }, [refresh])
 
+  const visibleData = backendUnavailable ? null : data
+  const visibleLoading = backendUnavailable ? false : loading
+  const visibleError = backendUnavailable ? BACKEND_UNAVAILABLE_REASON : error
   const forAccount = useCallback((account: Pick<UTAConfig, 'id' | 'label' | 'presetId' | 'enabled'>) => (
-    selectAccountPackReadiness(account, { data, loading, error })
-  ), [data, loading, error])
+    selectAccountPackReadiness(account, {
+      data: visibleData,
+      loading: visibleLoading,
+      error: visibleError,
+    })
+  ), [visibleData, visibleError, visibleLoading])
 
-  return { data, loading, error, installingEngine, refresh, install, forAccount }
+  return {
+    data: visibleData,
+    loading: visibleLoading,
+    error: visibleError,
+    installingEngine,
+    refresh,
+    install,
+    forAccount,
+  }
 }

--- a/ui/src/hooks/useBrokerPackReadiness.ts
+++ b/ui/src/hooks/useBrokerPackReadiness.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '../api'
+import type {
+  BrokerAccountPackReadiness,
+  BrokerEngine,
+  BrokerHealthInfo,
+  BrokerPackReadinessResponse,
+  TradingMode,
+  UTAConfig,
+} from '../api/types'
+
+const REFRESH_TTL_MS = 15_000
+
+export type AccountPackReadinessState = BrokerAccountPackReadiness['state'] | 'checking' | 'status-unavailable'
+
+export interface AccountPackReadiness extends Omit<BrokerAccountPackReadiness, 'state'> {
+  state: AccountPackReadinessState
+}
+
+export interface AccountInteractionPolicy {
+  canRead: boolean
+  canReconnect: boolean
+  canTrade: boolean
+  reason?: string
+}
+
+interface ReadinessSelectionState {
+  data: BrokerPackReadinessResponse | null
+  loading: boolean
+  error: string | null
+}
+
+export function selectAccountPackReadiness(
+  account: Pick<UTAConfig, 'id' | 'label' | 'presetId' | 'enabled'>,
+  state: ReadinessSelectionState,
+): AccountPackReadiness {
+  const exact = state.data?.accounts.find((candidate) => candidate.accountId === account.id)
+  if (exact) return exact
+
+  const base = {
+    accountId: account.id,
+    label: account.label ?? account.id,
+    presetId: account.presetId,
+    configuredEnabled: account.enabled !== false,
+    operational: false,
+  }
+  if (state.loading && !state.data) return { ...base, state: 'checking' }
+  return {
+    ...base,
+    state: 'status-unavailable',
+    reason: state.error ?? 'Broker support status is unavailable on this Runtime.',
+  }
+}
+
+export function deriveAccountInteractionPolicy({
+  account,
+  readiness,
+  health,
+  tradingMode,
+}: {
+  account: Pick<UTAConfig, 'enabled' | 'readOnly'>
+  readiness: AccountPackReadiness
+  health?: BrokerHealthInfo
+  tradingMode: TradingMode
+}): AccountInteractionPolicy {
+  if (account.enabled === false || !readiness.configuredEnabled) {
+    return { canRead: false, canReconnect: false, canTrade: false, reason: 'This account is disabled in configuration.' }
+  }
+  if (!readiness.operational) {
+    const reason = readiness.state === 'checking'
+      ? 'Checking broker support on this Runtime.'
+      : readiness.reason ?? (readiness.state === 'status-unavailable'
+          ? 'Broker support status is unavailable on this Runtime.'
+          : 'This Runtime needs broker support before it can use this account.')
+    return { canRead: false, canReconnect: false, canTrade: false, reason }
+  }
+
+  const readable = { canRead: true, canReconnect: true }
+  if (account.readOnly) return { ...readable, canTrade: false, reason: 'This account is configured read-only.' }
+  if (tradingMode !== 'pro') {
+    return {
+      ...readable,
+      canTrade: false,
+      reason: tradingMode === 'readonly'
+        ? 'Agent Permissions are in read-only mode.'
+        : 'Trading is unavailable in Lite mode.',
+    }
+  }
+  if (!health) return { ...readable, canTrade: false, reason: 'Waiting for current broker health.' }
+  if (health.disabled) return { ...readable, canTrade: false, reason: 'The broker runtime reports this account disabled.' }
+  if (health.connecting) return { ...readable, canTrade: false, reason: 'The broker connection is still starting.' }
+  if (health.recovering) return { ...readable, canTrade: false, reason: health.lastError ?? 'The broker connection is recovering.' }
+  if (health.status !== 'healthy' || health.reach !== 'readable') {
+    return { ...readable, canTrade: false, reason: health.lastError ?? 'The broker account is not currently reachable.' }
+  }
+  if (health.tier !== 'trading') {
+    return { ...readable, canTrade: false, reason: 'The broker runtime exposes this account for reading only.' }
+  }
+  return { ...readable, canTrade: true }
+}
+
+export function useBrokerPackReadiness() {
+  const [data, setData] = useState<BrokerPackReadinessResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [installingEngine, setInstallingEngine] = useState<BrokerEngine | null>(null)
+  const dataRef = useRef<BrokerPackReadinessResponse | null>(null)
+  const lastLoadedAt = useRef(0)
+  const inFlight = useRef<Promise<void> | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return inFlight.current
+    const request = (async () => {
+      if (!dataRef.current) setLoading(true)
+      try {
+        const next = await api.trading.getBrokerPacks()
+        dataRef.current = next
+        setData(next)
+        setError(null)
+        lastLoadedAt.current = Date.now()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setLoading(false)
+        inFlight.current = null
+      }
+    })()
+    inFlight.current = request
+    return request
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  useEffect(() => {
+    const refreshIfStale = () => {
+      if (document.visibilityState === 'hidden') return
+      if (Date.now() - lastLoadedAt.current >= REFRESH_TTL_MS) void refresh()
+    }
+    window.addEventListener('focus', refreshIfStale)
+    document.addEventListener('visibilitychange', refreshIfStale)
+    return () => {
+      window.removeEventListener('focus', refreshIfStale)
+      document.removeEventListener('visibilitychange', refreshIfStale)
+    }
+  }, [refresh])
+
+  const install = useCallback(async (engine: Exclude<BrokerEngine, 'mock'>) => {
+    setInstallingEngine(engine)
+    setError(null)
+    try {
+      await api.trading.installBrokerPack(engine)
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      throw err
+    } finally {
+      setInstallingEngine(null)
+    }
+  }, [refresh])
+
+  const forAccount = useCallback((account: Pick<UTAConfig, 'id' | 'label' | 'presetId' | 'enabled'>) => (
+    selectAccountPackReadiness(account, { data, loading, error })
+  ), [data, loading, error])
+
+  return { data, loading, error, installingEngine, refresh, install, forAccount }
+}

--- a/ui/src/hooks/useBrokerPackReadiness.ts
+++ b/ui/src/hooks/useBrokerPackReadiness.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../api'
-import { useAuth } from '../auth/AuthContext'
+import { useBackendRecoverySignal } from '../auth/AuthContext'
 import type {
   BrokerAccountPackReadiness,
   BrokerEngine,
@@ -109,7 +109,7 @@ export function deriveAccountInteractionPolicy({
 }
 
 export function useBrokerPackReadiness() {
-  const { backendUnavailable, backendRecoveryGeneration } = useAuth()
+  const { backendUnavailable, backendRecoveryGeneration } = useBackendRecoverySignal()
   const [data, setData] = useState<BrokerPackReadinessResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -216,6 +216,7 @@ export const en = {
         due: 'The schedule is due and waiting to dispatch.',
         running: 'A scheduled run is in progress.',
         healthy: 'Latest scheduled run completed.',
+        runtimeMissing: '{{agent}} is not installed on this host. Install it before the next scheduled run.',
         missingSession: 'Assigned Session does not exist. Choose an active Session or New Session each run.',
         retiredSession: 'Assigned Session is retired. Reassign the Issue before its next run.',
         unboundSession: 'Assigned Session has no resumable runtime conversation yet.',
@@ -403,6 +404,11 @@ export const en = {
     about: {
       title: 'About OpenAlice',
       description: 'Installation, runtime, update status, and the AliceProject currently open here.',
+      connection: {
+        title: 'Backend connection',
+        description: 'This browser is connected to a remote OpenAlice Runtime through an SSH tunnel.',
+        connected: 'Connected',
+      },
       aliceProject: {
         title: 'Current AliceProject',
         description: 'The top-level project that owns this data home, Guardian, backend, and frontend endpoint.',
@@ -486,6 +492,7 @@ export const en = {
       recent: 'Recent locations',
       useAndRestart: 'Use and restart',
       browserOnly: 'Folder selection is available in the desktop app. Browser and development launches can select the same boundary from the command line:',
+      remoteManaged: 'This data home belongs to the connected remote Runtime. Manage its location on that host or through its deployment service.',
       lockedByHome: 'This launch is locked by OPENALICE_HOME. Remove that environment override before switching from the desktop UI.',
       lockedByWorkspace: 'This launch has a fixed AQ_LAUNCHER_ROOT. Remove that environment override before switching the complete home from the desktop UI.',
       loadError: 'Could not read the desktop data-location setting.',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -205,6 +205,7 @@ export const ja: Resources = {
         due: '実行時刻を迎え、ディスパッチを待っています。',
         running: 'スケジュール実行中です。',
         healthy: '直近のスケジュール実行が完了しました。',
+        runtimeMissing: 'このホストには {{agent}} がインストールされていません。次回のスケジュール実行前にインストールしてください。',
         missingSession: '割り当てたセッションが存在しません。アクティブなセッションまたは実行ごとの新しいセッションを選択してください。',
         retiredSession: '割り当てたセッションはアーカイブ済みです。次回実行前に課題を再割り当てしてください。',
         unboundSession: '割り当てたセッションには、再開可能なランタイム会話がまだありません。',
@@ -392,6 +393,11 @@ export const ja: Resources = {
     about: {
       title: 'OpenAlice について',
       description: 'インストール、実行環境、更新状況、現在開いている AliceProject を確認します。',
+      connection: {
+        title: 'バックエンド接続',
+        description: 'このブラウザーは SSH トンネル経由でリモート OpenAlice Runtime に接続しています。',
+        connected: '接続済み',
+      },
       aliceProject: {
         title: '現在の AliceProject',
         description: 'このデータホーム、Guardian、バックエンド、フロントエンド接続先を所有する最上位プロジェクトです。',
@@ -475,6 +481,7 @@ export const ja: Resources = {
       recent: '最近使った場所',
       useAndRestart: '使用して再起動',
       browserOnly: 'フォルダー選択はデスクトップアプリで利用できます。ブラウザーと開発起動では次のコマンドで同じ境界を選べます：',
+      remoteManaged: 'このデータホームは接続先のリモート Runtime が所有しています。場所はリモートホストまたはデプロイサービスで管理してください。',
       lockedByHome: 'この起動は OPENALICE_HOME で固定されています。デスクトップ UI から切り替える前に環境変数を外してください。',
       lockedByWorkspace: 'この起動は AQ_LAUNCHER_ROOT で固定されています。完全なホームを切り替える前に環境変数を外してください。',
       loadError: 'デスクトップのデータ保存場所を読み込めませんでした。',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -212,6 +212,7 @@ export const zhHant: Resources = {
         due: '已到執行時間，正在等待派發。',
         running: '排程工作正在執行。',
         healthy: '最近一次排程工作已完成。',
+        runtimeMissing: '這台主機尚未安裝 {{agent}}。請在下次排程執行前完成安裝。',
         missingSession: '指定的工作階段不存在。請選擇活躍工作階段或「每次執行都建立新工作階段」。',
         retiredSession: '指定的工作階段已封存。請在下次執行前重新分配議題。',
         unboundSession: '指定的工作階段還沒有可恢復的執行環境對話。',
@@ -399,6 +400,11 @@ export const zhHant: Resources = {
     about: {
       title: '關於 OpenAlice',
       description: '查看目前安裝、執行環境、更新狀態，以及此處開啟的 AliceProject。',
+      connection: {
+        title: '後端連線',
+        description: '此瀏覽器正透過 SSH 通道連線遠端 OpenAlice Runtime。',
+        connected: '已連線',
+      },
       aliceProject: {
         title: '目前 AliceProject',
         description: '擁有此資料目錄、Guardian、後端與前端入口的頂層專案。',
@@ -482,6 +488,7 @@ export const zhHant: Resources = {
       recent: '最近使用的位置',
       useAndRestart: '使用並重新啟動',
       browserOnly: '桌面端可以直接選擇資料夾；瀏覽器與開發模式可用下列命令選擇相同邊界：',
+      remoteManaged: '此資料目錄屬於目前連線的遠端 Runtime。請在遠端主機或其部署服務中管理該位置。',
       lockedByHome: '本次啟動被 OPENALICE_HOME 鎖定。請先移除該環境變數，再從桌面 UI 切換。',
       lockedByWorkspace: '本次啟動固定了 AQ_LAUNCHER_ROOT。請先移除該環境變數，再從桌面 UI 切換完整主目錄。',
       loadError: '無法讀取桌面端的資料位置設定。',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -204,6 +204,7 @@ export const zh: Resources = {
         due: '已到运行时间，正在等待派发。',
         running: '计划任务正在运行。',
         healthy: '最近一次计划任务已完成。',
+        runtimeMissing: '这台主机尚未安装 {{agent}}。请在下次计划运行前完成安装。',
         missingSession: '指定的会话不存在。请选择活跃会话或“每次运行都新建会话”。',
         retiredSession: '指定的会话已归档。请在下次运行前重新分配议题。',
         unboundSession: '指定的会话还没有可恢复的运行时对话。',
@@ -391,6 +392,11 @@ export const zh: Resources = {
     about: {
       title: '关于 OpenAlice',
       description: '查看当前安装、运行环境、更新状态，以及此处打开的 AliceProject。',
+      connection: {
+        title: '后端连接',
+        description: '此浏览器正通过 SSH 隧道连接远端 OpenAlice Runtime。',
+        connected: '已连接',
+      },
       aliceProject: {
         title: '当前 AliceProject',
         description: '拥有此数据目录、Guardian、后端与前端入口的顶层项目。',
@@ -474,6 +480,7 @@ export const zh: Resources = {
       recent: '最近使用的位置',
       useAndRestart: '使用并重启',
       browserOnly: '桌面端可以直接选择文件夹；浏览器和开发模式可用以下命令选择同一套边界：',
+      remoteManaged: '此数据目录属于当前连接的远端 Runtime。请在远端主机或其部署服务中管理该位置。',
       lockedByHome: '本次启动被 OPENALICE_HOME 锁定。请先移除该环境变量，再从桌面 UI 切换。',
       lockedByWorkspace: '本次启动固定了 AQ_LAUNCHER_ROOT。请先移除该环境变量，再从桌面 UI 切换完整主目录。',
       loadError: '无法读取桌面端的资料位置设置。',

--- a/ui/src/pages/AutomationRunsSection.spec.tsx
+++ b/ui/src/pages/AutomationRunsSection.spec.tsx
@@ -161,7 +161,7 @@ describe('AutomationRunsSection workspace identity', () => {
 
     const issueTitle = await screen.findByText('Daily portfolio risk scan')
     expect(screen.getByText('Issue')).toBeTruthy()
-    expect(screen.getByText('Inspect every live position and report only material changes.')).toBeTruthy()
+    expect(screen.queryByText('Inspect every live position and report only material changes.')).toBeNull()
     expect(screen.getByRole('button', {
       name: 'Run details, running: Daily portfolio risk scan. codex in quant-desk.',
     })).toBeTruthy()
@@ -169,6 +169,12 @@ describe('AutomationRunsSection workspace identity', () => {
     const article = issueTitle.closest('article')
     expect(article).toBeTruthy()
     fireEvent.click(within(article as HTMLElement).getAllByRole('button')[0]!)
+    const instructions = within(article as HTMLElement)
+      .getByText('Inspect every live position and report only material changes.')
+      .closest('details')
+    expect(instructions?.hasAttribute('open')).toBe(false)
+    fireEvent.click(within(article as HTMLElement).getByText('Task instructions'))
+    expect(instructions?.hasAttribute('open')).toBe(true)
     fireEvent.click(within(article as HTMLElement).getByRole('button', { name: 'Open Issue' }))
 
     expect(mocks.openOrFocus).toHaveBeenCalledWith({
@@ -192,7 +198,8 @@ describe('AutomationRunsSection workspace identity', () => {
 
     render(<AutomationRunsSection />)
 
-    expect((await screen.findByText('departed-daily-scan')).className).toContain('font-mono')
+    expect(await screen.findByText('Departed Daily Scan')).toBeTruthy()
+    expect(screen.getByTitle(`Issue: departed-daily-scan · ${liveWorkspace.id}`)).toBeTruthy()
   })
 
   it('identifies an Issue comment follow-up as a reply to its owning Issue', async () => {
@@ -232,6 +239,8 @@ describe('AutomationRunsSection workspace identity', () => {
 
     expect(await screen.findByText('Daily portfolio risk scan')).toBeTruthy()
     expect(screen.getByText('Reply')).toBeTruthy()
+    expect(screen.getByText('What changed?')).toBeTruthy()
+    expect(screen.queryByText('Reconstruct the Issue context and answer the new comment.')).toBeNull()
   })
 })
 
@@ -274,7 +283,7 @@ describe('AutomationRunsSection run controls', () => {
     render(<AutomationRunsSection />)
 
     fireEvent.click(await screen.findByRole('button', {
-      name: 'Run details, done: daily-risk-scan. codex in quant-desk.',
+      name: 'Run details, done: Daily Risk Scan. codex in quant-desk.',
     }))
 
     expect(screen.getByText('Task instructions').className).toContain('min-h-10')
@@ -284,7 +293,7 @@ describe('AutomationRunsSection run controls', () => {
     expect(screen.getByTestId('runs-load-more').className).toContain('min-h-10')
   })
 
-  it('gives long task instructions a concise accessible name without hiding the visible prompt', async () => {
+  it('gives long task instructions a concise roster identity and keeps the full prompt in details', async () => {
     const omittedTail = 'TAIL_MARKER_THAT_MUST_NOT_BE_READ_FOR_EVERY_RUN'
     const prompt = `Review the latest market snapshot and summarize material changes. ${'Include supporting detail. '.repeat(12)}${omittedTail}`
     mocks.snapshot.mockResolvedValue(snapshot([task({ prompt })]))
@@ -297,12 +306,13 @@ describe('AutomationRunsSection run controls', () => {
     expect(accessibleName).toContain('codex in quant-desk')
     expect(accessibleName).not.toContain(omittedTail)
     expect(accessibleName?.length).toBeLessThan(160)
-    expect(screen.getByText(prompt)).toBeTruthy()
+    expect(screen.queryByText(prompt)).toBeNull()
 
     control.focus()
     await userEvent.keyboard('{Enter}')
     expect(control.getAttribute('aria-expanded')).toBe('true')
     expect(screen.getByText('Task instructions')).toBeTruthy()
+    expect(screen.getByText(prompt)).toBeTruthy()
   })
 
   it('labels an empty stored prompt without exposing a blank control', async () => {
@@ -337,6 +347,12 @@ describe('AutomationRunsSection run controls', () => {
       taskId: 'run-open',
       status: 'done',
       resumable: true,
+      prompt: 'Reconstruct the Issue context, inject target JSON, and continue.',
+      trigger: {
+        kind: 'issue',
+        workspaceId: liveWorkspace.id,
+        issueId: 'daily-risk-scan',
+      },
     })
     let rejectOpen: ((reason?: unknown) => void) | undefined
     mocks.snapshot.mockResolvedValue(snapshot([resumable]))
@@ -353,6 +369,11 @@ describe('AutomationRunsSection run controls', () => {
     fireEvent.click(openButton)
 
     expect(mocks.openHeadlessRun).toHaveBeenCalledTimes(1)
+    expect(mocks.openHeadlessRun).toHaveBeenCalledWith(
+      liveWorkspace.id,
+      resumable.resumeId,
+      { title: 'Daily Risk Scan' },
+    )
     expect((screen.getByRole('button', { name: 'Opening…' }) as HTMLButtonElement).disabled).toBe(true)
 
     await act(async () => rejectOpen?.(new Error('Session service is unavailable')))

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -21,6 +21,7 @@ import type {
 } from '../api/headless'
 import { MarkdownContent } from '../components/MarkdownContent'
 import { Skeleton } from '../components/StateViews'
+import { projectHeadlessTaskPresentation } from '../components/workspace/headless-task-presentation'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { useIssues } from '../hooks/useIssues'
 import { formatRelativeTime } from '../lib/intl'
@@ -34,7 +35,6 @@ const STATUS_STYLE: Record<HeadlessTaskStatus, string> = {
 }
 
 const RUNS_PAGE_SIZE = 25
-const RUN_PROMPT_SUMMARY_LENGTH = 96
 
 function fmtDuration(ms?: number): string {
   if (ms == null) return '—'
@@ -51,15 +51,6 @@ function formatValue(value: unknown): string {
   } catch {
     return String(value)
   }
-}
-
-function summarizeRunPrompt(prompt: string): string {
-  const normalized = prompt.replace(/\s+/g, ' ').trim()
-  if (!normalized) return 'Untitled task'
-
-  const characters = Array.from(normalized)
-  if (characters.length <= RUN_PROMPT_SUMMARY_LENGTH) return normalized
-  return `${characters.slice(0, RUN_PROMPT_SUMMARY_LENGTH - 1).join('').trimEnd()}…`
 }
 
 function ToolBlock({ block }: { block: Extract<HeadlessMessageBlock, { type: 'tool' }> }) {
@@ -293,10 +284,11 @@ function AutomationRunTitle({
   source: IssueRunSource | null
   issue?: IssueRunIdentity
 }) {
+  const presentation = projectHeadlessTaskPresentation(task)
   if (!source) {
     return (
       <span className="block max-h-10 overflow-hidden text-[13px] leading-5 text-foreground">
-        {task.prompt}
+        {presentation.title}
       </span>
     )
   }
@@ -323,9 +315,11 @@ function AutomationRunTitle({
           </span>
         )}
       </span>
-      <span className="mt-0.5 block truncate text-[12px] leading-5 text-muted-foreground">
-        {task.prompt}
-      </span>
+      {presentation.summary && (
+        <span className="mt-0.5 block truncate text-[12px] leading-5 text-muted-foreground">
+          {presentation.summary}
+        </span>
+      )}
     </>
   )
 }
@@ -452,7 +446,9 @@ export function AutomationRunsSection() {
       return next
     })
     try {
-      await openHeadlessRun(task.wsId, task.resumeId, { title: task.prompt })
+      await openHeadlessRun(task.wsId, task.resumeId, {
+        title: projectHeadlessTaskPresentation(task).title,
+      })
     } catch (e) {
       setOpenErrors((previous) => ({
         ...previous,
@@ -530,9 +526,9 @@ export function AutomationRunsSection() {
                 ? issueIdentities.get(issueIdentityKey(issueSource.workspaceId, issueSource.issueId))
                 : undefined
               const workspaceName = workspaceLabel?.label ?? task.wsId
+              const presentation = projectHeadlessTaskPresentation(task)
               const runSubject = issueIdentity?.title
-                ?? issueSource?.issueId
-                ?? summarizeRunPrompt(task.prompt)
+                ?? presentation.title
               const runLabel = `Run details, ${task.status}: ${runSubject}. ${task.agent} in ${workspaceName}.`
               const toolSummary = task.output?.toolCalls
                 ? `${task.output.toolCalls} tool${task.output.toolCalls === 1 ? '' : 's'}`

--- a/ui/src/pages/AutomationRunsSection.tsx
+++ b/ui/src/pages/AutomationRunsSection.tsx
@@ -293,7 +293,7 @@ function AutomationRunTitle({
     )
   }
 
-  const issueTitle = issue?.title ?? source.issueId
+  const issueTitle = issue?.title ?? presentation.title
   const issueWorkspace = issue?.workspaceTag ?? source.workspaceId
   const crossWorkspace = source.workspaceId !== task.wsId
 
@@ -304,8 +304,8 @@ function AutomationRunTitle({
           {source.label}
         </span>
         <span
-          className={`truncate text-[13px] font-medium text-foreground${issue ? '' : ' font-mono'}`}
-          title={`Issue: ${issueTitle} · ${issueWorkspace}`}
+          className="truncate text-[13px] font-medium text-foreground"
+          title={`Issue: ${source.issueId} · ${issueWorkspace}`}
         >
           {issueTitle}
         </span>

--- a/ui/src/pages/PortfolioPage.readiness.spec.tsx
+++ b/ui/src/pages/PortfolioPage.readiness.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { UTAConfig } from '../api/types'
+import { PortfolioPage } from './PortfolioPage'
+
+const mocks = vi.hoisted(() => ({
+  equity: vi.fn(), fxRates: vi.fn(), equityCurve: vi.fn(), utaAccount: vi.fn(),
+  utaPositions: vi.fn(), walletLog: vi.fn(), snapshots: vi.fn(),
+}))
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      config: { ...actual.api.config, load: vi.fn(async () => ({ snapshot: { enabled: true, every: '15m' } })) },
+      trading: {
+        ...actual.api.trading,
+        equity: mocks.equity, fxRates: mocks.fxRates, equityCurve: mocks.equityCurve,
+        utaAccount: mocks.utaAccount, utaPositions: mocks.utaPositions,
+        walletLog: mocks.walletLog, snapshots: mocks.snapshots,
+      },
+    },
+  }
+})
+
+const uta: UTAConfig = {
+  id: 'remote-okx', label: 'Remote OKX', presetId: 'okx', enabled: true,
+  guards: [], presetConfig: {}, readOnly: false, asVendor: true,
+}
+const readiness = {
+  accountId: uta.id, label: uta.label!, presetId: uta.presetId, configuredEnabled: true,
+  engine: 'ccxt' as const, state: 'needs-install' as const, operational: false, action: 'install' as const,
+}
+const configuredUtas = [uta]
+const brokerRefresh = vi.fn().mockResolvedValue(undefined)
+const brokerInstall = vi.fn().mockResolvedValue(undefined)
+const brokerForAccount = vi.fn(() => readiness)
+
+vi.mock('../hooks/useTradingConfig', () => ({
+  useTradingConfig: () => ({ utas: configuredUtas, loading: false, error: null }),
+}))
+
+vi.mock('../hooks/useBrokerPackReadiness', () => ({
+  useBrokerPackReadiness: () => ({
+    data: { packs: [], accounts: [readiness] }, loading: false, error: null, installingEngine: null,
+    forAccount: brokerForAccount,
+    refresh: brokerRefresh, install: brokerInstall,
+  }),
+}))
+
+vi.mock('../hooks/useAccountHealth', () => ({ useAccountHealth: () => ({}) }))
+vi.mock('../live/trading-mode', () => ({
+  ensureTradingModePolling: vi.fn(),
+  useTradingMode: (selector: (state: { status: { mode: 'pro' }; loading: boolean }) => unknown) => selector({ status: { mode: 'pro' }, loading: false }),
+}))
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: () => void; setSidebar: () => void }) => unknown) => selector({ openOrFocus: vi.fn(), setSidebar: vi.fn() }),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Portfolio broker support gating', () => {
+  it('keeps the configured account visible without polling its live endpoints', async () => {
+    mocks.snapshots.mockResolvedValue({ snapshots: [] })
+
+    render(<PortfolioPage />)
+
+    expect(await screen.findByText('Remote OKX')).toBeTruthy()
+    expect(screen.getByText('Broker support is not installed')).toBeTruthy()
+    await waitFor(() => expect(mocks.snapshots).toHaveBeenCalledWith(uta.id, { limit: 200 }))
+    expect(mocks.equity).not.toHaveBeenCalled()
+    expect(mocks.fxRates).not.toHaveBeenCalled()
+    expect(mocks.utaAccount).not.toHaveBeenCalled()
+    expect(mocks.utaPositions).not.toHaveBeenCalled()
+    expect(mocks.walletLog).not.toHaveBeenCalled()
+    expect(screen.queryByText('No trading accounts connected.')).toBeNull()
+    expect(screen.queryByLabelText('Live')).toBeNull()
+  })
+})

--- a/ui/src/pages/PortfolioPage.snapshot-settings.spec.tsx
+++ b/ui/src/pages/PortfolioPage.snapshot-settings.spec.tsx
@@ -10,6 +10,10 @@ const mocks = vi.hoisted(() => ({
   updateSection: vi.fn(),
   openOrFocus: vi.fn(),
   setSidebar: vi.fn(),
+  emptyUtas: [] as never[],
+  brokerRefresh: vi.fn().mockResolvedValue(undefined),
+  brokerInstall: vi.fn().mockResolvedValue(undefined),
+  brokerForAccount: vi.fn(),
 }))
 
 vi.mock('../api', async (importOriginal) => {
@@ -36,6 +40,18 @@ vi.mock('../api', async (importOriginal) => {
 
 vi.mock('../hooks/useAccountHealth', () => ({
   useAccountHealth: () => ({}),
+}))
+
+vi.mock('../hooks/useTradingConfig', () => ({
+  useTradingConfig: () => ({ utas: mocks.emptyUtas, loading: false, error: null }),
+}))
+
+vi.mock('../hooks/useBrokerPackReadiness', () => ({
+  useBrokerPackReadiness: () => ({
+    data: { packs: [], accounts: [] }, loading: false, error: null, installingEngine: null,
+    refresh: mocks.brokerRefresh, install: mocks.brokerInstall,
+    forAccount: mocks.brokerForAccount,
+  }),
 }))
 
 vi.mock('../live/trading-mode', () => ({

--- a/ui/src/pages/PortfolioPage.tsx
+++ b/ui/src/pages/PortfolioPage.tsx
@@ -3,6 +3,8 @@ import { ChevronDown } from 'lucide-react'
 import { api, type Position, type WalletCommitLog, type EquityCurvePoint, type UTASnapshotSummary } from '../api'
 import { useAutoSave } from '../hooks/useAutoSave'
 import { useAccountHealth } from '../hooks/useAccountHealth'
+import { useTradingConfig } from '../hooks/useTradingConfig'
+import { useBrokerPackReadiness } from '../hooks/useBrokerPackReadiness'
 import { useWorkspace } from '../tabs/store'
 import { PageHeader } from '../components/PageHeader'
 import { EmptyState, Skeleton } from '../components/StateViews'
@@ -14,8 +16,9 @@ import { Metric, signFromDelta } from '../components/Metric'
 import { Sparkline } from '../components/Sparkline'
 import { fmt, fmtPnl, fmtNum, fmtPctSigned } from '../lib/format'
 import { contractPrimary } from '../lib/contract-display'
-import { displayProviderForUTA, filterAccountTierUTAs } from '../lib/uta-account-filter'
+import { displayProviderForUTA } from '../lib/uta-account-filter'
 import { TradingModeGate } from '../components/TradingModeGate'
+import { AccountReadinessBadge, BrokerSupportGate } from '../components/uta/BrokerPackGate'
 import { ensureTradingModePolling, useTradingMode } from '../live/trading-mode'
 import { computeTodayDelta, type CurvePointSummary } from './portfolio-metrics'
 
@@ -114,9 +117,12 @@ export function PortfolioPage() {
   const tradingMode = useTradingMode((s) => s.status.mode)
   const tradingModeLoading = useTradingMode((s) => s.loading)
   const healthMap = useAccountHealth()
+  const tradingConfig = useTradingConfig()
+  const brokerReadiness = useBrokerPackReadiness()
   const [data, setData] = useState<PortfolioData>(EMPTY)
   const [loading, setLoading] = useState(true)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  const [refreshError, setRefreshError] = useState<string | null>(null)
   const [curvePoints, setCurvePoints] = useState<EquityCurvePoint[]>([])
   const [curveAccountId, setCurveAccountId] = useState<string | 'all'>('') // '' = not yet initialized
   const [selectedTimestamp, setSelectedTimestamp] = useState<string | null>(null)
@@ -128,6 +134,17 @@ export function PortfolioPage() {
   // hero today-PnL delta and per-account sparklines. Distinct from
   // curvePoints which follows the user's chart-account selection.
   const [aggregateCurve, setAggregateCurve] = useState<CurveSummary | null>(null)
+  const portfolioConfigs = useMemo(() => tradingConfig.utas.filter((uta) => uta.keyless !== true), [tradingConfig.utas])
+
+  const accountReadiness = useMemo(() => new Map(
+    portfolioConfigs.map((uta) => [uta.id, brokerReadiness.forAccount(uta)]),
+  ), [portfolioConfigs, brokerReadiness.forAccount])
+  const operationalAccounts = useMemo(() => portfolioConfigs.filter((uta) => (
+    uta.enabled !== false && accountReadiness.get(uta.id)?.operational
+  )), [accountReadiness, portfolioConfigs])
+  const blockedAccounts = useMemo(() => portfolioConfigs.filter((uta) => (
+    uta.enabled !== false && !accountReadiness.get(uta.id)?.operational
+  )), [accountReadiness, portfolioConfigs])
 
   const snapshotConfig = useMemo(() => ({ enabled: snapshotEnabled, every: snapshotEvery }), [snapshotEnabled, snapshotEvery])
   const saveSnapshotConfig = useCallback(async (d: Record<string, unknown>) => {
@@ -160,7 +177,7 @@ export function PortfolioPage() {
   }, [])
 
   const refresh = useCallback(async () => {
-    if (tradingModeLoading) return
+    if (tradingModeLoading || tradingConfig.loading || brokerReadiness.loading) return
     if (tradingMode === 'lite') {
       setData(EMPTY)
       setAggregateCurve(null)
@@ -168,16 +185,19 @@ export function PortfolioPage() {
       setSelectedSnapshot(null)
       setSelectedTimestamp(null)
       setLoading(false)
-      setLastRefresh(new Date())
+      setLastRefresh(null)
+      setRefreshError(null)
       return
     }
     setLoading(true)
-    const [result, configResult, aggregateResult] = await Promise.all([
-      fetchPortfolioData(),
+    const [portfolioResult, configResult, aggregateResult] = await Promise.all([
+      fetchPortfolioData(operationalAccounts),
       api.config.load().catch(() => null),
-      api.trading.equityCurve({ limit: 1500 }).catch(() => ({ points: [] as EquityCurvePoint[] })),
+      operationalAccounts.length > 0
+        ? api.trading.equityCurve({ limit: 1500 }).catch(() => ({ points: [] as EquityCurvePoint[] }))
+        : Promise.resolve({ points: [] as EquityCurvePoint[] }),
     ])
-    setData(result)
+    setData(portfolioResult.data)
     setAggregateCurve(summarizeAggregateCurve(aggregateResult.points))
     if (configResult?.snapshot) {
       setSnapshotEnabled(configResult.snapshot.enabled)
@@ -186,14 +206,15 @@ export function PortfolioPage() {
     setSnapshotConfigLoaded(true)
 
     // Default to first account on initial load
-    const effectiveId = curveAccountId || result.accounts[0]?.id || 'all'
+    const effectiveId = curveAccountId || portfolioConfigs[0]?.id || 'all'
     if (!curveAccountId && effectiveId) setCurveAccountId(effectiveId)
     const points = await fetchCurveData(effectiveId)
     setCurvePoints(points)
 
-    setLastRefresh(new Date())
+    setLastRefresh(portfolioResult.liveSucceeded ? new Date() : null)
+    setRefreshError(portfolioResult.error)
     setLoading(false)
-  }, [curveAccountId, fetchCurveData, tradingMode, tradingModeLoading])
+  }, [brokerReadiness.loading, curveAccountId, fetchCurveData, operationalAccounts, portfolioConfigs, tradingConfig.loading, tradingMode, tradingModeLoading])
 
   useEffect(() => { ensureTradingModePolling() }, [])
   useEffect(() => { refresh() }, [refresh])
@@ -212,7 +233,7 @@ export function PortfolioPage() {
   )
 
   // Account list for the chart switcher
-  const chartAccounts = data.accounts.map(a => ({ id: a.id, label: a.label }))
+  const chartAccounts = portfolioConfigs.map(a => ({ id: a.id, label: a.label ?? a.id }))
 
   const handleAccountChange = useCallback(async (id: string | 'all') => {
     setCurveAccountId(id)
@@ -247,7 +268,7 @@ export function PortfolioPage() {
       <PageHeader
         title="Portfolio"
         description="Live portfolio overview across all trading accounts."
-        live={{ lastUpdated: lastRefresh }}
+        live={lastRefresh ? { lastUpdated: lastRefresh } : undefined}
         right={
           <button
             onClick={refresh}
@@ -264,24 +285,56 @@ export function PortfolioPage() {
         <div className="flex gap-6 items-start">
           {/* Main column */}
           <div className="flex-1 min-w-0 space-y-5">
-            {!lastRefresh ? <PortfolioSkeleton /> : <>
+            {loading && data === EMPTY ? <PortfolioSkeleton /> : <>
             {!tradingModeLoading && tradingMode === 'lite' ? (
               <TradingModeGate
                 title="Portfolio is unavailable in Lite mode."
                 description="Lite mode keeps UTA disconnected, so there are no broker accounts, positions, or equity snapshots to show. Change the trading mode in Agent Permissions to connect UTA."
               />
             ) : <>
-            <HeroMetrics equity={data.equity} curve={aggregateCurve?.total ?? null} />
+            {refreshError && (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-[12px] text-destructive" role="alert">
+                Live portfolio data is unavailable: {refreshError}
+              </div>
+            )}
+
+            {blockedAccounts.map((uta) => {
+              const readiness = accountReadiness.get(uta.id)!
+              return (
+                <div key={uta.id} className="space-y-2">
+                  <div className="flex items-center justify-between gap-3 px-1">
+                    <span className="text-[12px] font-medium text-foreground">{uta.label ?? uta.id}</span>
+                    <AccountReadinessBadge readiness={readiness} health={healthMap[uta.id]} />
+                  </div>
+                  <BrokerSupportGate
+                    readiness={readiness}
+                    installingEngine={brokerReadiness.installingEngine}
+                    onInstall={brokerReadiness.install}
+                    onRetry={brokerReadiness.refresh}
+                  />
+                </div>
+              )
+            })}
+            {operationalAccounts.length > 0 && (
+              <HeroMetrics equity={data.equity} curve={aggregateCurve?.total ?? null} />
+            )}
 
             {curvePoints.length > 0 && (
-              <EquityCurve
-                points={curvePoints}
-                accounts={chartAccounts}
-                selectedAccountId={curveAccountId}
-                onAccountChange={handleAccountChange}
-                onPointClick={handlePointClick}
-                selectedTimestamp={selectedTimestamp}
-              />
+              <div className="space-y-2">
+                {curveAccountId !== 'all' && !accountReadiness.get(curveAccountId)?.operational && (
+                  <p className="text-[11px] text-warning" role="status">
+                    Historical snapshot · broker support is unavailable on this Runtime, so this chart is not live.
+                  </p>
+                )}
+                <EquityCurve
+                  points={curvePoints}
+                  accounts={chartAccounts}
+                  selectedAccountId={curveAccountId}
+                  onAccountChange={handleAccountChange}
+                  onPointClick={handlePointClick}
+                  selectedTimestamp={selectedTimestamp}
+                />
+              </div>
             )}
 
             <SnapshotSettings
@@ -311,7 +364,7 @@ export function PortfolioPage() {
             )}
 
             {/* Empty states */}
-            {data.accounts.length === 0 && !loading && (
+            {portfolioConfigs.length === 0 && !loading && (
               <NoAccountsEmpty />
             )}
             {data.accounts.length > 0 && allPositions.length === 0 && !loading && (
@@ -339,35 +392,49 @@ export function PortfolioPage() {
 
 // ==================== Data Fetching ====================
 
-async function fetchPortfolioData(): Promise<PortfolioData> {
-  try {
-    const [equityResult, utasResult, fxResult] = await Promise.allSettled([
-      api.trading.equity(),
-      api.trading.listUTASummaries(),
-      api.trading.fxRates(),
-    ])
+async function fetchPortfolioData(configuredAccounts: Array<{ id: string; label?: string }>): Promise<{
+  data: PortfolioData
+  liveSucceeded: boolean
+  error: string | null
+}> {
+  if (configuredAccounts.length === 0) return { data: EMPTY, liveSucceeded: false, error: null }
 
-    const equity = equityResult.status === 'fulfilled' ? equityResult.value : null
-    const utasList = utasResult.status === 'fulfilled' ? filterAccountTierUTAs(utasResult.value.utas) : []
-    const fxRates = fxResult.status === 'fulfilled' ? fxResult.value.rates : []
+  const [equityResult, fxResult, accountResults] = await Promise.all([
+    api.trading.equity().then((value) => ({ value })).catch((error: unknown) => ({ error })),
+    api.trading.fxRates().then((value) => ({ value })).catch(() => ({ value: { rates: [] as FxRateInfo[] } })),
+    Promise.all(configuredAccounts.map(async (configured): Promise<{ account: AccountData; live: boolean }> => {
+      const [accountResult, positionResult, logResult] = await Promise.allSettled([
+        api.trading.utaAccount(configured.id),
+        api.trading.utaPositions(configured.id),
+        api.trading.walletLog(configured.id, 10),
+      ])
+      const live = accountResult.status === 'fulfilled'
+      return {
+        live,
+        account: {
+          id: configured.id,
+          label: configured.label ?? configured.id,
+          provider: displayProviderForUTA(configured),
+          positions: positionResult.status === 'fulfilled' ? positionResult.value.positions : [],
+          walletLog: logResult.status === 'fulfilled' ? logResult.value.commits : [],
+          ...(!live ? { error: 'Live account data is unavailable' } : {}),
+        },
+      }
+    })),
+  ])
 
-    const accounts = await Promise.all(
-      utasList.map(async (acct): Promise<AccountData> => {
-        try {
-          const [posResp, logResp] = await Promise.all([
-            api.trading.utaPositions(acct.id),
-            api.trading.walletLog(acct.id, 10),
-          ])
-          return { ...acct, provider: displayProviderForUTA(acct), positions: posResp.positions, walletLog: logResp.commits }
-        } catch {
-          return { ...acct, provider: displayProviderForUTA(acct), positions: [], walletLog: [], error: 'Not connected' }
-        }
-      }),
-    )
-
-    return { equity, accounts, fxRates }
-  } catch {
-    return EMPTY
+  const equity = 'value' in equityResult ? equityResult.value : null
+  const fxRates = fxResult.value.rates
+  const liveSucceeded = equity !== null || accountResults.some((result) => result.live)
+  const error = liveSucceeded
+    ? null
+    : ('error' in equityResult && equityResult.error instanceof Error
+        ? equityResult.error.message
+        : 'No configured account returned live data.')
+  return {
+    data: { equity, accounts: accountResults.map((result) => result.account), fxRates },
+    liveSucceeded,
+    error,
   }
 }
 

--- a/ui/src/pages/SettingsPage.data-home.spec.tsx
+++ b/ui/src/pages/SettingsPage.data-home.spec.tsx
@@ -1,7 +1,15 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getBackendConnection: vi.fn(),
+}))
+
+vi.mock('../auth/backendConnection', () => ({
+  getBackendConnection: mocks.getBackendConnection,
+}))
 
 import '../i18n'
 import { i18n } from '../i18n'
@@ -42,6 +50,10 @@ beforeAll(async () => {
   await i18n.changeLanguage('en')
 })
 
+beforeEach(() => {
+  mocks.getBackendConnection.mockReturnValue({ kind: 'local', endpoint: '127.0.0.1:47331' })
+})
+
 afterEach(() => {
   cleanup()
   Reflect.deleteProperty(window, 'openAlice')
@@ -55,6 +67,22 @@ describe('DataHomeSection', () => {
     expect(screen.getByText('openalice start --home <path>')).toBeTruthy()
     expect(screen.getByText('pnpm dev -- --home <path>')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Choose folder and restart' })).toBeNull()
+  })
+
+  it('does not suggest local launch commands for a remote service-owned data home', () => {
+    mocks.getBackendConnection.mockReturnValue({
+      kind: 'remote',
+      target: 'railway@example.com',
+      sshPort: 22,
+      runtimePort: 47331,
+      localEndpoint: '127.0.0.1:40123',
+    })
+
+    render(<DataHomeSection />)
+
+    expect(screen.getByText(/belongs to the connected remote Runtime/)).toBeTruthy()
+    expect(screen.queryByText('openalice start --home <path>')).toBeNull()
+    expect(screen.queryByText('pnpm dev -- --home <path>')).toBeNull()
   })
 
   it('shows the complete desktop home and can switch to a recent location', async () => {

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -27,6 +27,7 @@ import {
 } from '../theme/styleProfiles'
 import { useEffectivePreferenceSlot } from '../theme/useEffectiveTheme'
 import { AboutOpenAliceSection } from '../components/settings/AboutOpenAliceSection'
+import { getBackendConnection } from '../auth/backendConnection'
 
 // ==================== Appearance ====================
 
@@ -562,6 +563,7 @@ export function LanguageSection() {
 export function DataHomeSection() {
   const { t } = useTranslation()
   const bridge = window.openAlice?.dataHome
+  const backendConnection = getBackendConnection()
   const [status, setStatus] = useState<OpenAliceDataHomeStatus | null>(null)
   const [busy, setBusy] = useState(false)
   const [restarting, setRestarting] = useState(false)
@@ -581,13 +583,21 @@ export function DataHomeSection() {
         description={t('settings.dataHome.description')}
       >
         <div className="rounded-lg border border-border/60 bg-secondary/50 px-3 py-3">
-          <p className="text-[13px] text-foreground">{t('settings.dataHome.browserOnly')}</p>
-          <p className="mt-2 break-all font-mono text-[12px] text-muted-foreground">
-            openalice start --home &lt;path&gt;
-          </p>
-          <p className="mt-1 break-all font-mono text-[12px] text-muted-foreground">
-            pnpm dev -- --home &lt;path&gt;
-          </p>
+          {backendConnection.kind === 'remote' ? (
+            <p className="text-[13px] leading-relaxed text-foreground">
+              {t('settings.dataHome.remoteManaged')}
+            </p>
+          ) : (
+            <>
+              <p className="text-[13px] text-foreground">{t('settings.dataHome.browserOnly')}</p>
+              <p className="mt-2 break-all font-mono text-[12px] text-muted-foreground">
+                openalice start --home &lt;path&gt;
+              </p>
+              <p className="mt-1 break-all font-mono text-[12px] text-muted-foreground">
+                pnpm dev -- --home &lt;path&gt;
+              </p>
+            </>
+          )}
         </div>
       </ConfigSection>
     )

--- a/ui/src/pages/TradingPage.broker-packs.spec.tsx
+++ b/ui/src/pages/TradingPage.broker-packs.spec.tsx
@@ -42,7 +42,7 @@ describe('MissingBrokerPacksNotice', () => {
         { engine: 'alpaca', installed: false, source: 'missing', requiredBy: [] },
         { engine: 'ibkr', installed: true, source: 'downloaded', requiredBy: ['IBKR Main'] },
       ]}
-      onInstalled={vi.fn()}
+      onInstall={vi.fn().mockResolvedValue(undefined)}
     />)
 
     expect(screen.getByText('Broker support needs attention')).toBeTruthy()
@@ -62,7 +62,7 @@ describe('MissingBrokerPacksNotice', () => {
         version: '0.84.0-beta',
         updateAvailable: true,
       }]}
-      onInstalled={vi.fn()}
+      onInstall={vi.fn().mockResolvedValue(undefined)}
     />)
 
     expect(screen.getByText('Installed support is from OpenAlice 0.84.0-beta')).toBeTruthy()
@@ -70,16 +70,16 @@ describe('MissingBrokerPacksNotice', () => {
   })
 
   it('installs from the notice and reports a failed repair in place', async () => {
-    const onInstalled = vi.fn()
+    const onInstall = vi.fn(async (engine: string) => { await installBrokerPack(engine) })
     const { rerender } = render(
-      <MissingBrokerPacksNotice packs={[missingCcxt]} onInstalled={onInstalled} />,
+      <MissingBrokerPacksNotice packs={[missingCcxt]} onInstall={onInstall} />,
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Install' }))
-    await waitFor(() => expect(onInstalled).toHaveBeenCalledWith(expect.objectContaining({ installed: true })))
+    await waitFor(() => expect(onInstall).toHaveBeenCalledWith('ccxt'))
 
     installBrokerPack.mockRejectedValueOnce(new Error('download failed'))
-    rerender(<MissingBrokerPacksNotice packs={[missingCcxt]} onInstalled={onInstalled} />)
+    rerender(<MissingBrokerPacksNotice packs={[missingCcxt]} onInstall={onInstall} />)
     fireEvent.click(screen.getByRole('button', { name: 'Install' }))
     await waitFor(() => expect(screen.getByText('download failed')).toBeTruthy())
   })
@@ -91,7 +91,7 @@ describe('KeylessDataSourcesRow', () => {
       trading: { observeExternalOrdersEvery: '15m', keylessDataSources: ['binance'] },
     }), { status: 200, headers: { 'content-type': 'application/json' } })))
 
-    render(<KeylessDataSourcesRow ccxtPack={missingCcxt} onPackInstalled={vi.fn()} />)
+    render(<KeylessDataSourcesRow ccxtPack={missingCcxt} onInstall={vi.fn().mockResolvedValue(undefined)} />)
 
     const binance = await screen.findByRole('switch', { name: 'Binance public data source' })
     const okx = screen.getByRole('switch', { name: 'OKX public data source' })
@@ -106,13 +106,13 @@ describe('KeylessDataSourcesRow', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       trading: { observeExternalOrdersEvery: '15m', keylessDataSources: [] },
     }), { status: 200, headers: { 'content-type': 'application/json' } })))
-    const onPackInstalled = vi.fn()
-    render(<KeylessDataSourcesRow ccxtPack={missingCcxt} onPackInstalled={onPackInstalled} />)
+    const onInstall = vi.fn(async () => { await installBrokerPack('ccxt') })
+    render(<KeylessDataSourcesRow ccxtPack={missingCcxt} onInstall={onInstall} />)
 
     fireEvent.click(await screen.findByRole('button', { name: 'Install data support' }))
 
     await waitFor(() => expect(installBrokerPack).toHaveBeenCalledWith('ccxt'))
-    expect(onPackInstalled).toHaveBeenCalledWith(expect.objectContaining({ engine: 'ccxt', installed: true }))
+    expect(onInstall).toHaveBeenCalledOnce()
     expect(screen.getByText('Installed — choose the feeds you want')).toBeTruthy()
   })
 })

--- a/ui/src/pages/TradingPage.broker-packs.spec.tsx
+++ b/ui/src/pages/TradingPage.broker-packs.spec.tsx
@@ -1,18 +1,72 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrokerPackStatus } from '../api/types'
 
-const { installBrokerPack } = vi.hoisted(() => ({ installBrokerPack: vi.fn() }))
+const apiMocks = vi.hoisted(() => ({
+  installBrokerPack: vi.fn(),
+  getBrokerPresets: vi.fn(),
+  status: vi.fn(),
+  equity: vi.fn(),
+}))
+const pageMocks = vi.hoisted(() => ({
+  readable: false,
+  openOrFocus: vi.fn(),
+  setSidebar: vi.fn(),
+}))
 
 vi.mock('../api', () => ({
-  api: { trading: { installBrokerPack } },
+  api: { trading: apiMocks },
+}))
+vi.mock('../hooks/useTradingConfig', () => ({
+  useTradingConfig: () => ({
+    utas: [{
+      id: 'main', label: 'Main', presetId: 'okx', enabled: true,
+      guards: [], presetConfig: {}, readOnly: false, asVendor: true,
+    }],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    createUTA: vi.fn(),
+    saveUTA: vi.fn(),
+    deleteUTA: vi.fn(),
+    reconnectUTA: vi.fn(),
+  }),
+}))
+vi.mock('../hooks/useAccountHealth', () => ({
+  useAccountHealth: () => ({}),
+}))
+vi.mock('../hooks/useBrokerPackReadiness', () => ({
+  useBrokerPackReadiness: () => ({
+    data: { packs: [], accounts: [] },
+    loading: false,
+    error: null,
+    installingEngine: null,
+    install: vi.fn(),
+    refresh: vi.fn(),
+    forAccount: () => ({
+      accountId: 'main', label: 'Main', presetId: 'okx', configuredEnabled: true,
+      engine: 'ccxt', state: pageMocks.readable ? 'ready' : 'needs-install',
+      operational: pageMocks.readable,
+    }),
+  }),
+  deriveAccountInteractionPolicy: () => ({
+    canRead: pageMocks.readable,
+    canReconnect: pageMocks.readable,
+    canTrade: false,
+  }),
+}))
+vi.mock('../tabs/store', () => ({
+  useWorkspace: (selector: (state: { openOrFocus: typeof pageMocks.openOrFocus; setSidebar: typeof pageMocks.setSidebar }) => unknown) => selector(pageMocks),
 }))
 
 import {
   ExternalOrderMonitoringRow,
   KeylessDataSourcesRow,
   MissingBrokerPacksNotice,
+  TradingPage,
 } from './TradingPage'
 
 const missingCcxt: BrokerPackStatus = {
@@ -23,8 +77,15 @@ const missingCcxt: BrokerPackStatus = {
 }
 
 beforeEach(() => {
-  installBrokerPack.mockResolvedValue({
+  pageMocks.readable = false
+  apiMocks.installBrokerPack.mockResolvedValue({
     engine: 'ccxt', installed: true, source: 'downloaded', version: '0.80.0-beta', requiredBy: [],
+  })
+  apiMocks.getBrokerPresets.mockResolvedValue({ presets: [] })
+  apiMocks.status.mockResolvedValue({ available: true, state: 'ready', mode: 'pro' })
+  apiMocks.equity.mockResolvedValue({
+    totalEquity: '100', totalCash: '100', totalUnrealizedPnL: '0', totalRealizedPnL: '0',
+    accounts: [{ id: 'main', label: 'Main', equity: '100', cash: '100' }],
   })
 })
 
@@ -70,7 +131,7 @@ describe('MissingBrokerPacksNotice', () => {
   })
 
   it('installs from the notice and reports a failed repair in place', async () => {
-    const onInstall = vi.fn(async (engine: string) => { await installBrokerPack(engine) })
+    const onInstall = vi.fn(async (engine: string) => { await apiMocks.installBrokerPack(engine) })
     const { rerender } = render(
       <MissingBrokerPacksNotice packs={[missingCcxt]} onInstall={onInstall} />,
     )
@@ -78,7 +139,7 @@ describe('MissingBrokerPacksNotice', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Install' }))
     await waitFor(() => expect(onInstall).toHaveBeenCalledWith('ccxt'))
 
-    installBrokerPack.mockRejectedValueOnce(new Error('download failed'))
+    apiMocks.installBrokerPack.mockRejectedValueOnce(new Error('download failed'))
     rerender(<MissingBrokerPacksNotice packs={[missingCcxt]} onInstall={onInstall} />)
     fireEvent.click(screen.getByRole('button', { name: 'Install' }))
     await waitFor(() => expect(screen.getByText('download failed')).toBeTruthy())
@@ -106,14 +167,49 @@ describe('KeylessDataSourcesRow', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       trading: { observeExternalOrdersEvery: '15m', keylessDataSources: [] },
     }), { status: 200, headers: { 'content-type': 'application/json' } })))
-    const onInstall = vi.fn(async () => { await installBrokerPack('ccxt') })
+    const onInstall = vi.fn(async () => { await apiMocks.installBrokerPack('ccxt') })
     render(<KeylessDataSourcesRow ccxtPack={missingCcxt} onInstall={onInstall} />)
 
     fireEvent.click(await screen.findByRole('button', { name: 'Install data support' }))
 
-    await waitFor(() => expect(installBrokerPack).toHaveBeenCalledWith('ccxt'))
+    await waitFor(() => expect(apiMocks.installBrokerPack).toHaveBeenCalledWith('ccxt'))
     expect(onInstall).toHaveBeenCalledOnce()
     expect(screen.getByText('Installed — choose the feeds you want')).toBeTruthy()
+  })
+})
+
+describe('TradingPage broker polling', () => {
+  it('starts and stops status and equity polling with readable account readiness', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      trading: { observeExternalOrdersEvery: '15m', keylessDataSources: [] },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })))
+
+    try {
+      const { rerender } = render(<TradingPage />)
+      await act(async () => { await Promise.resolve() })
+
+      expect(apiMocks.status).not.toHaveBeenCalled()
+      expect(apiMocks.equity).not.toHaveBeenCalled()
+
+      pageMocks.readable = true
+      rerender(<TradingPage />)
+      await act(async () => { await Promise.resolve() })
+
+      expect(apiMocks.status).toHaveBeenCalledOnce()
+      expect(apiMocks.equity).toHaveBeenCalledOnce()
+
+      pageMocks.readable = false
+      rerender(<TradingPage />)
+      const statusCalls = apiMocks.status.mock.calls.length
+      const equityCalls = apiMocks.equity.mock.calls.length
+      await act(async () => { vi.advanceTimersByTime(60_000) })
+
+      expect(apiMocks.status).toHaveBeenCalledTimes(statusCalls)
+      expect(apiMocks.equity).toHaveBeenCalledTimes(equityCalls)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -5,8 +5,9 @@ import { Skeleton } from '../components/StateViews'
 import { Toggle } from '../components/Toggle'
 import { useTradingConfig } from '../hooks/useTradingConfig'
 import { useAccountHealth } from '../hooks/useAccountHealth'
+import { useBrokerPackReadiness, deriveAccountInteractionPolicy } from '../hooks/useBrokerPackReadiness'
 import { PageHeader } from '../components/PageHeader'
-import { HealthBadge } from '../components/uta/HealthBadge'
+import { AccountReadinessBadge } from '../components/uta/BrokerPackGate'
 import { CreateUTADialog } from '../components/uta/CreateUTADialog'
 import { EditUTADialog } from '../components/uta/EditUTADialog'
 import { fmt } from '../lib/format'
@@ -14,6 +15,7 @@ import { api } from '../api'
 import type { TradingServiceStatus } from '../api/trading'
 import { useWorkspace } from '../tabs/store'
 import type { UTAConfig, BrokerPreset, BrokerHealthInfo, BrokerPackStatus } from '../api/types'
+import type { AccountPackReadiness } from '../hooks/useBrokerPackReadiness'
 
 // ==================== External order monitoring cadence ====================
 //
@@ -143,9 +145,9 @@ export function ExternalOrderMonitoringRow() {
   )
 }
 
-export function KeylessDataSourcesRow({ ccxtPack, onPackInstalled }: {
+export function KeylessDataSourcesRow({ ccxtPack, onInstall }: {
   ccxtPack?: BrokerPackStatus
-  onPackInstalled: (status: BrokerPackStatus) => void
+  onInstall: () => Promise<void>
 }) {
   const [runtimeConfig, setRuntimeConfig] = useState<TradingRuntimeConfig | null>(null)
   const [msg, setMsg] = useState('')
@@ -187,8 +189,7 @@ export function KeylessDataSourcesRow({ ccxtPack, onPackInstalled }: {
     setInstalling(true)
     setMsg('Installing crypto data support…')
     try {
-      const installed = await api.trading.installBrokerPack('ccxt')
-      onPackInstalled(installed)
+      await onInstall()
       setMsg('Installed — choose the feeds you want')
     } catch (err) {
       setMsg(err instanceof Error ? err.message : 'Install failed')
@@ -253,9 +254,9 @@ interface EquitySummary {
   accounts: Array<{ id: string; label: string; equity: string; cash: string }>
 }
 
-export function MissingBrokerPacksNotice({ packs, onInstalled }: {
+export function MissingBrokerPacksNotice({ packs, onInstall }: {
   packs: BrokerPackStatus[]
-  onInstalled: (status: BrokerPackStatus) => void
+  onInstall: (engine: Exclude<BrokerPackStatus['engine'], 'mock'>) => Promise<void>
 }) {
   const actionable = packs.filter(
     (pack) => (!pack.installed || pack.updateAvailable) && pack.requiredBy.length > 0,
@@ -270,7 +271,7 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
     setInstalling(pack.engine)
     setError('')
     try {
-      onInstalled(await api.trading.installBrokerPack(pack.engine))
+      await onInstall(pack.engine)
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to install ${pack.engine} support`)
     } finally {
@@ -328,6 +329,7 @@ export function MissingBrokerPacksNotice({ packs, onInstalled }: {
 export function TradingPage() {
   const tc = useTradingConfig()
   const healthMap = useAccountHealth()
+  const brokerReadiness = useBrokerPackReadiness()
   const openOrFocus = useWorkspace((s) => s.openOrFocus)
   const setSidebar = useWorkspace((s) => s.setSidebar)
   const [showAdd, setShowAdd] = useState(false)
@@ -336,18 +338,20 @@ export function TradingPage() {
   const [equity, setEquity] = useState<EquitySummary | null>(null)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
   const [serviceStatus, setServiceStatus] = useState<TradingServiceStatus | null>(null)
-  const [brokerPacks, setBrokerPacks] = useState<BrokerPackStatus[]>([])
-
-  const updateBrokerPack = (status: BrokerPackStatus) => {
-    setBrokerPacks((rows) => [...rows.filter((row) => row.engine !== status.engine), status])
-  }
+  const brokerPacks = brokerReadiness.data?.packs ?? []
 
   useEffect(() => {
     api.trading.getBrokerPresets().then(r => setPresets(r.presets)).catch(() => {})
-    api.trading.getBrokerPacks().then(r => setBrokerPacks(r.packs)).catch(() => {})
   }, [])
 
+  const hasReadableAccount = tc.utas.some((uta) => brokerReadiness.forAccount(uta).operational && uta.enabled !== false)
+
   useEffect(() => {
+    if (!hasReadableAccount) {
+      setEquity(null)
+      setLastUpdated(null)
+      return
+    }
     let cancelled = false
     const refresh = async () => {
       try {
@@ -380,7 +384,7 @@ export function TradingPage() {
     const refresh = async () => {
       const eq = await api.trading.equity().catch(() => null)
       if (cancelled) return
-      if (eq) {
+      if (eq && eq.accounts.length > 0) {
         setEquity(eq)
         setLastUpdated(new Date())
       }
@@ -388,7 +392,7 @@ export function TradingPage() {
     refresh()
     const id = setInterval(refresh, 60_000)
     return () => { cancelled = true; clearInterval(id) }
-  }, [])
+  }, [hasReadableAccount])
 
   const editingUTA = editingId ? tc.utas.find(u => u.id === editingId) : null
   const editingPreset = editingUTA ? presets.find(p => p.id === editingUTA.presetId) : undefined
@@ -429,25 +433,29 @@ export function TradingPage() {
       <PageHeader
         title="Trading"
         description="Configure your UTAs (Unified Trading Accounts)."
-        live={tc.utas.length > 0 ? { lastUpdated } : undefined}
+        live={lastUpdated && equity?.accounts.some((row) => brokerReadiness.data?.accounts.some(
+          (account) => account.accountId === row.id && account.operational,
+        )) ? { lastUpdated } : undefined}
       />
 
       <SettingsScrollArea className="px-4 py-5 md:px-6">
         <div className="max-w-[820px] mx-auto space-y-4">
           {serviceStatus?.available === false && <TradingServiceOfflineBanner status={serviceStatus} />}
-          <MissingBrokerPacksNotice packs={brokerPacks} onInstalled={updateBrokerPack} />
+          <MissingBrokerPacksNotice packs={brokerPacks} onInstall={brokerReadiness.install} />
           {tc.utas.length === 0 ? (
             <EmptyState onAdd={() => setShowAdd(true)} />
           ) : (
             <div className="space-y-2.5">
               {tc.utas.map((uta) => {
                 const equityRow = equity?.accounts.find(a => a.id === uta.id) ?? null
+                const readiness = brokerReadiness.forAccount(uta)
                 return (
                   <UTACard
                     key={uta.id}
                     uta={uta}
                     preset={presets.find(p => p.id === uta.presetId)}
                     health={healthMap[uta.id]}
+                    readiness={readiness}
                     equity={equityRow}
                     onClick={() => setEditingId(uta.id)}
                   />
@@ -464,7 +472,7 @@ export function TradingPage() {
 
           <KeylessDataSourcesRow
             ccxtPack={brokerPacks.find((row) => row.engine === 'ccxt')}
-            onPackInstalled={updateBrokerPack}
+            onInstall={() => brokerReadiness.install('ccxt')}
           />
           {tc.utas.length > 0 && <ExternalOrderMonitoringRow />}
         </div>
@@ -492,7 +500,7 @@ export function TradingPage() {
             setEditingId(id)
           }}
           onClose={() => setShowAdd(false)}
-          onPackInstalled={updateBrokerPack}
+          onPackInstalled={() => { void brokerReadiness.refresh() }}
         />
       )}
 
@@ -501,6 +509,16 @@ export function TradingPage() {
           uta={editingUTA}
           preset={editingPreset}
           health={healthMap[editingUTA.id]}
+          readiness={brokerReadiness.forAccount(editingUTA)}
+          policy={deriveAccountInteractionPolicy({
+            account: editingUTA,
+            readiness: brokerReadiness.forAccount(editingUTA),
+            health: healthMap[editingUTA.id],
+            tradingMode: serviceStatus?.mode ?? 'lite',
+          })}
+          installingEngine={brokerReadiness.installingEngine}
+          onInstallBrokerPack={brokerReadiness.install}
+          onRetryBrokerPack={brokerReadiness.refresh}
           onSave={async (next) => { await tc.saveUTA(next) }}
           onDelete={async () => {
             await tc.deleteUTA(editingUTA.id)
@@ -583,10 +601,11 @@ function buildSubtitle(uta: UTAConfig, preset?: BrokerPreset): string {
 
 // ==================== UTA Card ====================
 
-function UTACard({ uta, preset, health, equity, onClick }: {
+function UTACard({ uta, preset, health, readiness, equity, onClick }: {
   uta: UTAConfig
   preset?: BrokerPreset
   health?: BrokerHealthInfo
+  readiness: AccountPackReadiness
   equity?: { equity: string; cash: string } | null
   onClick: () => void
 }) {
@@ -626,10 +645,7 @@ function UTACard({ uta, preset, health, equity, onClick }: {
           {equityNode && (
             <span className="text-[11px] text-muted-foreground/80 hidden sm:inline">{equityNode}</span>
           )}
-          {uta.enabled === false
-            ? <span className="text-[11px] text-muted-foreground">Disabled</span>
-            : <HealthBadge health={health} />
-          }
+          <AccountReadinessBadge readiness={readiness} health={health} />
         </div>
       </div>
     </button>

--- a/ui/src/pages/TradingPage.tsx
+++ b/ui/src/pages/TradingPage.tsx
@@ -348,8 +348,7 @@ export function TradingPage() {
 
   useEffect(() => {
     if (!hasReadableAccount) {
-      setEquity(null)
-      setLastUpdated(null)
+      setServiceStatus(null)
       return
     }
     let cancelled = false
@@ -373,13 +372,18 @@ export function TradingPage() {
     void refresh()
     const id = setInterval(refresh, 15_000)
     return () => { cancelled = true; clearInterval(id) }
-  }, [])
+  }, [hasReadableAccount])
 
   // Per-card liveness signal — `equity()` lets each card show "this
   // connection actually returned an account balance" rather than just
   // "ping went through". 60s cadence is enough; trend/sparkline/aggregate
   // moved to Portfolio.
   useEffect(() => {
+    if (!hasReadableAccount) {
+      setEquity(null)
+      setLastUpdated(null)
+      return
+    }
     let cancelled = false
     const refresh = async () => {
       const eq = await api.trading.equity().catch(() => null)
@@ -389,7 +393,7 @@ export function TradingPage() {
         setLastUpdated(new Date())
       }
     }
-    refresh()
+    void refresh()
     const id = setInterval(refresh, 60_000)
     return () => { cancelled = true; clearInterval(id) }
   }, [hasReadableAccount])

--- a/ui/src/pages/UTADetailPage.positions.spec.tsx
+++ b/ui/src/pages/UTADetailPage.positions.spec.tsx
@@ -86,4 +86,26 @@ describe('UTADetailPage responsive positions', () => {
     fireEvent.click(close)
     expect(onCloseClick).toHaveBeenCalledWith(aapl)
   })
+
+  it('disables close actions on both layouts when the account cannot trade', () => {
+    const aapl = position('AAPL')
+    const onCloseClick = vi.fn()
+    render(
+      <PositionsSection
+        positions={[aapl]}
+        onCloseClick={onCloseClick}
+        canClose={false}
+        closeDisabledReason="Account is read-only"
+      />,
+    )
+
+    const buttons = screen.getAllByRole('button', { name: 'Close AAPL position' })
+    expect(buttons).toHaveLength(2)
+    for (const button of buttons) {
+      expect(button.hasAttribute('disabled')).toBe(true)
+      expect(button.getAttribute('title')).toBe('Account is read-only')
+      fireEvent.click(button)
+    }
+    expect(onCloseClick).not.toHaveBeenCalled()
+  })
 })

--- a/ui/src/pages/UTADetailPage.readiness.spec.tsx
+++ b/ui/src/pages/UTADetailPage.readiness.spec.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UTAConfig } from '../api/types'
+import { UTADetailPage } from './UTADetailPage'
+
+const mocks = vi.hoisted(() => ({
+  utaAccount: vi.fn(), utaPositions: vi.fn(), utaOrders: vi.fn(),
+  utaSubAccounts: vi.fn(), marketClock: vi.fn(), snapshots: vi.fn(),
+  getBrokerPacks: vi.fn(),
+  reconnectUTA: vi.fn(), placeOrder: vi.fn(), closePosition: vi.fn(), cancelOrder: vi.fn(),
+  saveUTA: vi.fn(), deleteUTA: vi.fn(),
+}))
+const pageState = vi.hoisted(() => {
+  const uta = {
+    id: 'remote-okx', label: 'Remote OKX', presetId: 'okx', enabled: true,
+    guards: [], presetConfig: {}, readOnly: false, asVendor: true,
+  }
+  return {
+    uta,
+    utas: [uta],
+    mode: 'pro' as 'lite' | 'readonly' | 'pro',
+    health: {
+      status: 'healthy' as 'healthy' | 'degraded' | 'offline',
+      reach: 'readable' as 'down' | 'connected' | 'readable',
+      tier: 'trading' as 'data' | 'account' | 'trading',
+      consecutiveFailures: 0, recovering: false, connecting: false, disabled: false,
+      lastError: undefined as string | undefined,
+    },
+  }
+})
+
+vi.mock('../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      trading: {
+        ...actual.api.trading,
+        getBrokerPresets: vi.fn(async () => ({ presets: [] })),
+        getBrokerPacks: mocks.getBrokerPacks,
+        installBrokerPack: vi.fn(),
+        snapshots: mocks.snapshots,
+        utaAccount: mocks.utaAccount,
+        utaPositions: mocks.utaPositions,
+        utaOrders: mocks.utaOrders,
+        utaSubAccounts: mocks.utaSubAccounts,
+        marketClock: mocks.marketClock,
+        reconnectUTA: mocks.reconnectUTA,
+        placeOrder: mocks.placeOrder,
+        closePosition: mocks.closePosition,
+        cancelOrder: mocks.cancelOrder,
+      },
+    },
+  }
+})
+
+const uta = pageState.uta as UTAConfig
+
+vi.mock('../hooks/useTradingConfig', () => ({
+  useTradingConfig: () => ({
+    utas: pageState.utas, loading: false, error: null,
+    saveUTA: mocks.saveUTA, deleteUTA: mocks.deleteUTA, refresh: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useAccountHealth', () => ({
+  useAccountHealth: () => ({
+    [uta.id]: pageState.health,
+  }),
+}))
+
+vi.mock('../live/trading-mode', () => ({
+  ensureTradingModePolling: vi.fn(),
+  useTradingMode: (selector: (state: { status: { mode: 'lite' | 'readonly' | 'pro' }; loading: boolean }) => unknown) => selector({ status: { mode: pageState.mode }, loading: false }),
+}))
+
+beforeEach(() => {
+  pageState.uta.readOnly = false
+  pageState.uta.enabled = true
+  pageState.mode = 'pro'
+  Object.assign(pageState.health, {
+    status: 'healthy', reach: 'readable', tier: 'trading', consecutiveFailures: 0,
+    recovering: false, connecting: false, disabled: false, lastError: undefined,
+  })
+  mocks.snapshots.mockResolvedValue({ snapshots: [] })
+  mocks.utaSubAccounts.mockResolvedValue({ subAccounts: [] })
+  mocks.marketClock.mockResolvedValue({ isOpen: true })
+  mocks.utaAccount.mockRejectedValue(new Error('account unavailable in test'))
+  mocks.utaPositions.mockResolvedValue({ positions: [] })
+  mocks.utaOrders.mockResolvedValue({ orders: [] })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('UTA Detail broker support gating', () => {
+  it('does not poll live account APIs or open a deep-linked order when the Pack is missing', async () => {
+    mocks.getBrokerPacks.mockResolvedValue({
+      packs: [{ engine: 'ccxt', installed: false, source: 'missing', requiredBy: ['Remote OKX'] }],
+      accounts: [{
+        accountId: uta.id, label: uta.label, presetId: uta.presetId, configuredEnabled: true,
+        engine: 'ccxt', state: 'needs-install', operational: false, action: 'install',
+      }],
+    })
+    render(
+      <MemoryRouter initialEntries={['/?aliceId=okx%7CBTC-USDT']}>
+        <UTADetailPage spec={{ kind: 'uta-detail', params: { id: uta.id } }} />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Broker support is not installed')).toBeTruthy()
+    await waitFor(() => expect(mocks.getBrokerPacks).toHaveBeenCalledOnce())
+    expect(mocks.utaAccount).not.toHaveBeenCalled()
+    expect(mocks.utaPositions).not.toHaveBeenCalled()
+    expect(mocks.utaOrders).not.toHaveBeenCalled()
+    expect(mocks.utaSubAccounts).not.toHaveBeenCalled()
+    expect(mocks.marketClock).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Reconnect' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: '+ Place Order' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.queryByLabelText('Live')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it.each([
+    ['read-only account', () => { pageState.uta.readOnly = true }],
+    ['non-pro mode', () => { pageState.mode = 'readonly' }],
+    ['unhealthy broker', () => { Object.assign(pageState.health, { status: 'offline', reach: 'down', lastError: 'Broker offline' }) }],
+  ])('does not open or call an order write for a deep link on a %s', async (_label, configure) => {
+    configure()
+    mocks.getBrokerPacks.mockResolvedValue({
+      packs: [{ engine: 'ccxt', installed: true, source: 'downloaded', requiredBy: ['Remote OKX'] }],
+      accounts: [{
+        accountId: uta.id, label: uta.label, presetId: uta.presetId, configuredEnabled: true,
+        engine: 'ccxt', state: 'ready', operational: true,
+      }],
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/?aliceId=okx%7CBTC-USDT']}>
+        <UTADetailPage spec={{ kind: 'uta-detail', params: { id: uta.id } }} />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mocks.getBrokerPacks).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.getByRole('button', { name: '+ Place Order' }).hasAttribute('disabled')).toBe(true))
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(mocks.placeOrder).not.toHaveBeenCalled()
+    expect(mocks.closePosition).not.toHaveBeenCalled()
+    expect(mocks.cancelOrder).not.toHaveBeenCalled()
+    expect(mocks.reconnectUTA).not.toHaveBeenCalled()
+  })
+
+  it('blocks enabling a configured-off account until its Pack is available', async () => {
+    pageState.uta.enabled = false
+    mocks.getBrokerPacks.mockResolvedValue({
+      packs: [{ engine: 'ccxt', installed: false, source: 'missing', requiredBy: [] }],
+      accounts: [{
+        accountId: uta.id, label: uta.label, presetId: uta.presetId, configuredEnabled: false,
+        engine: 'ccxt', state: 'needs-install', operational: false, action: 'install',
+      }],
+    })
+
+    render(
+      <MemoryRouter>
+        <UTADetailPage spec={{ kind: 'uta-detail', params: { id: uta.id } }} />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Broker support is not installed')).toBeTruthy()
+    expect(screen.getByRole('switch', { name: 'remote-okx enabled' }).hasAttribute('disabled')).toBe(true)
+    expect(mocks.saveUTA).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/pages/UTADetailPage.tsx
+++ b/ui/src/pages/UTADetailPage.tsx
@@ -7,11 +7,12 @@ import { getIntlLocale } from '../lib/intl'
 import type { UTAConfig, BrokerPreset, AccountInfo, SubAccountRef, Position, BrokerHealthInfo, UTASnapshotSummary, EquityCurvePoint, OrderHistoryEntry, OrderHistoryStatus, TradeHistoryEntry } from '../api/types'
 import { useTradingConfig } from '../hooks/useTradingConfig'
 import { useAccountHealth } from '../hooks/useAccountHealth'
+import { deriveAccountInteractionPolicy, useBrokerPackReadiness } from '../hooks/useBrokerPackReadiness'
 import { PageHeader } from '../components/PageHeader'
 import { EmptyState, Skeleton } from '../components/StateViews'
 import { ReconnectButton } from '../components/ReconnectButton'
 import { Toggle } from '../components/Toggle'
-import { HealthBadge } from '../components/uta/HealthBadge'
+import { AccountReadinessBadge, BrokerSupportGate } from '../components/uta/BrokerPackGate'
 import { EditUTADialog } from '../components/uta/EditUTADialog'
 import { OrderEntryDialog, type OrderEntryMode } from '../components/uta/OrderEntryDialog'
 import { EquityCurve } from '../components/EquityCurve'
@@ -20,6 +21,7 @@ import { fmt, fmtPnl, fmtNum, fmtPctSigned, isUnsetDecimal } from '../lib/format
 import { secTypeToClass, assetClassLabel, ASSET_CLASS_ORDER, type AssetClass } from '../lib/asset-class'
 import { ContractCell, contractPrimary } from '../lib/contract-display'
 import { displayNameForUTA } from '../lib/uta-account-filter'
+import { ensureTradingModePolling, useTradingMode } from '../live/trading-mode'
 
 // ==================== Page ====================
 
@@ -33,6 +35,9 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   const navigate = useNavigate()
   const tc = useTradingConfig()
   const healthMap = useAccountHealth()
+  const brokerReadiness = useBrokerPackReadiness()
+  const tradingMode = useTradingMode((state) => state.status.mode)
+  const tradingModeLoading = useTradingMode((state) => state.loading)
   const [presets, setPresets] = useState<BrokerPreset[]>([])
   const [account, setAccount] = useState<AccountInfo | null>(null)
   const [positions, setPositions] = useState<Position[]>([])
@@ -48,6 +53,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   const [dataError, setDataError] = useState<string | null>(null)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
   const [clock, setClock] = useState<MarketClockState>(null)
+  const [interactionNotice, setInteractionNotice] = useState<string | null>(null)
 
   useEffect(() => {
     api.trading.getBrokerPresets().then(r => setPresets(r.presets)).catch(() => {})
@@ -56,18 +62,26 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   const uta = useMemo<UTAConfig | undefined>(() => tc.utas.find(u => u.id === id), [tc.utas, id])
   const preset = useMemo<BrokerPreset | undefined>(() => presets.find(p => p.id === uta?.presetId), [presets, uta])
   const health: BrokerHealthInfo | undefined = id ? healthMap[id] : undefined
+  const readiness = uta ? brokerReadiness.forAccount(uta) : null
+  const policy = uta && readiness ? deriveAccountInteractionPolicy({ account: uta, readiness, health, tradingMode }) : null
+
+  useEffect(() => { ensureTradingModePolling() }, [])
 
   // Sub-account discovery — once per UTA. A failure (or a single-wallet
   // broker) leaves the list empty, so the selector simply never renders.
   useEffect(() => {
-    if (!id) return
+    if (!id || !policy?.canRead) {
+      setSubAccounts([])
+      setSelectedSub(undefined)
+      return
+    }
     let cancelled = false
     api.trading.utaSubAccounts(id)
       .then(r => { if (!cancelled) setSubAccounts(r.subAccounts ?? []) })
       .catch(() => { if (!cancelled) setSubAccounts([]) })
     setSelectedSub(undefined)  // reset to aggregate when switching UTAs
     return () => { cancelled = true }
-  }, [id])
+  }, [id, policy?.canRead])
 
   // Live polling — account/positions/orders refresh every 15s. Account +
   // positions scope to the selected wallet (undefined ⇒ aggregate); orders
@@ -81,25 +95,43 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   // the newest in flight.
   const reqSeq = useRef(0)
   const refreshLive = useCallback(async () => {
-    if (!id) return
+    if (!id || !policy?.canRead) {
+      setAccount(null)
+      setPositions([])
+      setOrders([])
+      setLastUpdated(null)
+      setDataError(null)
+      return
+    }
     const seq = ++reqSeq.current
     setDataError(null)
     try {
-      const [acct, pos, ord] = await Promise.all([
-        api.trading.utaAccount(id, selectedSub).catch(() => null),
-        api.trading.utaPositions(id, selectedSub).catch(() => ({ positions: [] as Position[] })),
-        api.trading.utaOrders(id).catch(() => ({ orders: [] as unknown[] })),
+      const [acct, pos, ord] = await Promise.allSettled([
+        api.trading.utaAccount(id, selectedSub),
+        api.trading.utaPositions(id, selectedSub),
+        api.trading.utaOrders(id),
       ])
       if (seq !== reqSeq.current) return  // superseded by a newer refresh — discard
-      setAccount(acct)
-      setPositions(pos.positions)
-      setOrders(ord.orders)
+      if (acct.status === 'rejected') {
+        setAccount(null)
+        setPositions([])
+        setOrders([])
+        setLastUpdated(null)
+        setDataError(acct.reason instanceof Error ? acct.reason.message : String(acct.reason))
+        return
+      }
+      setAccount(acct.value)
+      setPositions(pos.status === 'fulfilled' ? pos.value.positions : [])
+      setOrders(ord.status === 'fulfilled' ? ord.value.orders : [])
+      setDataError(pos.status === 'rejected' || ord.status === 'rejected'
+        ? 'Some live account details could not be loaded.'
+        : null)
       setLastUpdated(new Date())
     } catch (err) {
       if (seq !== reqSeq.current) return
       setDataError(err instanceof Error ? err.message : String(err))
     }
-  }, [id, selectedSub])
+  }, [id, policy?.canRead, selectedSub])
 
   // Snapshots refresh more slowly (60s); same data feeds the NAV chart and
   // the 24h-delta anchor — no extra fetches needed.
@@ -124,7 +156,10 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
   // Market clock — mount + every 60s. The poll itself re-renders the
   // "opens in Xh Ym" countdown, so no separate ticker is needed.
   useEffect(() => {
-    if (!id) return
+    if (!id || !policy?.canRead) {
+      setClock(null)
+      return
+    }
     let cancelled = false
     const load = () => api.trading.marketClock(id)
       .then(c => { if (!cancelled) setClock(c) })
@@ -132,19 +167,20 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
     load()
     const t = setInterval(load, 60_000)
     return () => { cancelled = true; clearInterval(t) }
-  }, [id])
+  }, [id, policy?.canRead])
 
   // ?aliceId=... auto-opens the place-order form prefilled (e.g. clicked
   // from TradeableContractsPanel on the market workbench).
   useEffect(() => {
     const queryAlice = searchParams.get('aliceId')
-    if (queryAlice && !orderMode) {
-      setOrderMode({ kind: 'place', aliceId: queryAlice })
+    if (queryAlice && !orderMode && policy && readiness?.state !== 'checking' && !tradingModeLoading) {
+      if (policy.canTrade) setOrderMode({ kind: 'place', aliceId: queryAlice })
+      else setInteractionNotice(policy.reason ?? 'Trading is unavailable for this account.')
       const next = new URLSearchParams(searchParams)
       next.delete('aliceId')
       setSearchParams(next, { replace: true })
     }
-  }, [searchParams, setSearchParams, orderMode])
+  }, [searchParams, setSearchParams, orderMode, policy, readiness?.state, tradingModeLoading])
 
   // 24h delta = current NLV − the oldest snapshot still within the trailing
   // 24h window. Labeled "24h" in the UI — it IS a trailing-24h diff, not a
@@ -200,12 +236,13 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
 
   const isDisabled = uta.enabled === false
   const displayName = displayNameForUTA(uta, preset)
+  if (!readiness || !policy) return <Shell title={displayName}><UTADetailMainSkeleton /></Shell>
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
         title={displayName}
-        live={{ lastUpdated }}
+        live={lastUpdated && policy.canRead ? { lastUpdated } : undefined}
         stackActionsOnNarrow
         description={
           <>
@@ -213,7 +250,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
             <span className="mx-2 text-muted-foreground/40">·</span>
             <span className="font-mono text-muted-foreground">{uta.id}</span>
             <span className="mx-2 text-muted-foreground/40">·</span>
-            <HealthBadge health={health} size="sm" />
+            <AccountReadinessBadge readiness={readiness} health={health} size="sm" />
           </>
         }
         right={
@@ -228,21 +265,24 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
                 ariaLabel={`${preset?.label ?? uta.id} enabled`}
                 size="sm"
                 checked={!isDisabled}
+                disabled={isDisabled && !readiness.operational}
+                title={isDisabled && !readiness.operational ? policy.reason : undefined}
                 onChange={async (v) => { await tc.saveUTA({ ...uta, enabled: v }) }}
               />
               <span className="text-[11px] text-muted-foreground">
-                {isDisabled ? 'Account disabled' : 'Account enabled'}
+                {isDisabled ? 'Configured off' : 'Configured on'}
               </span>
             </div>
             <div className="oa-uta-header-divider h-5 w-px bg-border" />
             <div className="flex flex-wrap items-center gap-2">
-              <ReconnectButton accountId={uta.id} />
+              <ReconnectButton accountId={uta.id} disabled={!policy.canReconnect} disabledReason={policy.reason} />
               <button onClick={() => setEditing(true)} className="btn-secondary-sm">
                 Edit
               </button>
               <button
-                onClick={() => setOrderMode({ kind: 'place' })}
-                disabled={isDisabled}
+                onClick={() => { if (policy.canTrade) setOrderMode({ kind: 'place' }) }}
+                disabled={!policy.canTrade}
+                title={!policy.canTrade ? policy.reason : undefined}
                 className="btn-primary-sm"
               >
                 + Place Order
@@ -260,7 +300,37 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
             </div>
           )}
 
-          {!lastUpdated ? <UTADetailMainSkeleton /> : (
+          {interactionNotice && (
+            <div className="mb-4 rounded-md border border-warning/30 bg-warning/5 px-3 py-2 text-[12px] text-warning" role="status">
+              {interactionNotice}
+            </div>
+          )}
+
+          {!policy.canRead ? (
+            <div className="space-y-4">
+              <BrokerSupportGate
+                readiness={readiness}
+                installingEngine={brokerReadiness.installingEngine}
+                onInstall={brokerReadiness.install}
+                onRetry={brokerReadiness.refresh}
+              />
+              {curvePoints.length >= 2 && (
+                <div className="space-y-2">
+                  <p className="text-[11px] text-warning" role="status">
+                    Historical snapshot · broker support is unavailable on this Runtime, so these values are stale and not live.
+                  </p>
+                  <EquityCurve
+                    points={curvePoints}
+                    accounts={[{ id, label: displayName }]}
+                    selectedAccountId={id}
+                    onAccountChange={() => {}}
+                  />
+                </div>
+              )}
+            </div>
+          ) : !lastUpdated && !dataError ? <UTADetailMainSkeleton /> : !lastUpdated ? (
+            <EmptyState title="Live account data is unavailable." description="Retry after checking the broker connection and account health." />
+          ) : (
             <div className="space-y-5">
               {/* Keep the visual overview together, then give the operational
                   tables the full content width. The auto-fit grid responds to
@@ -302,6 +372,8 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
 
               <PositionsSection
                 positions={positions}
+                canClose={policy.canTrade}
+                closeDisabledReason={policy.reason}
                 onCloseClick={(p) => setOrderMode({
                   kind: 'close',
                   aliceId: p.contract.aliceId ?? p.contract.localSymbol ?? p.contract.symbol ?? '',
@@ -321,6 +393,11 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
           uta={uta}
           preset={preset}
           health={health}
+          readiness={readiness}
+          policy={policy}
+          installingEngine={brokerReadiness.installingEngine}
+          onInstallBrokerPack={brokerReadiness.install}
+          onRetryBrokerPack={brokerReadiness.refresh}
           onSave={async (next) => { await tc.saveUTA(next) }}
           onDelete={async () => {
             await tc.deleteUTA(uta.id)
@@ -331,7 +408,7 @@ export function UTADetailPage({ spec }: UTADetailPageProps) {
         />
       )}
 
-      {orderMode && (
+      {orderMode && policy.canTrade && (
         <OrderEntryDialog
           utaId={uta.id}
           mode={orderMode}
@@ -590,9 +667,11 @@ function Section({ title, action, children }: { title: string; action?: React.Re
 
 interface PositionGroup { class: AssetClass; positions: Position[] }
 
-export function PositionsSection({ positions, onCloseClick }: {
+export function PositionsSection({ positions, onCloseClick, canClose = true, closeDisabledReason }: {
   positions: Position[]
   onCloseClick: (p: Position) => void
+  canClose?: boolean
+  closeDisabledReason?: string
 }) {
   const groups = useMemo<PositionGroup[]>(() => {
     const buckets = new Map<AssetClass, Position[]>()
@@ -653,6 +732,8 @@ export function PositionsSection({ positions, onCloseClick }: {
                   key={`${g.class}-${index}`}
                   position={position}
                   onClose={() => onCloseClick(position)}
+                  canClose={canClose}
+                  closeDisabledReason={closeDisabledReason}
                 />
               ))}
             </div>
@@ -708,7 +789,7 @@ export function PositionsSection({ positions, onCloseClick }: {
                     </td>
                   </tr>
                   {g.positions.map((p, i) => (
-                    <PositionRow key={`${g.class}-${i}`} position={p} onClose={() => onCloseClick(p)} />
+                    <PositionRow key={`${g.class}-${i}`} position={p} onClose={() => onCloseClick(p)} canClose={canClose} closeDisabledReason={closeDisabledReason} />
                   ))}
                 </Fragment>
               )
@@ -737,7 +818,7 @@ function PositionMetric({
   )
 }
 
-function PositionMobileRow({ position: p, onClose }: { position: Position; onClose: () => void }) {
+function PositionMobileRow({ position: p, onClose, canClose, closeDisabledReason }: { position: Position; onClose: () => void; canClose: boolean; closeDisabledReason?: string }) {
   const ccy = p.currency ?? 'USD'
   const cost = Number(p.avgCost) * Number(p.quantity)
   const pnl = Number(p.unrealizedPnL)
@@ -786,6 +867,8 @@ function PositionMobileRow({ position: p, onClose }: { position: Position; onClo
         <button
           type="button"
           onClick={onClose}
+          disabled={!canClose}
+          title={!canClose ? closeDisabledReason : undefined}
           aria-label={`Close ${name} position`}
           className="oa-pressable inline-flex min-h-10 items-center justify-center rounded-md border border-destructive/30 px-3 text-[12px] font-medium text-destructive transition-colors hover:bg-destructive/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
         >
@@ -796,7 +879,7 @@ function PositionMobileRow({ position: p, onClose }: { position: Position; onClo
   )
 }
 
-function PositionRow({ position: p, onClose }: { position: Position; onClose: () => void }) {
+function PositionRow({ position: p, onClose, canClose, closeDisabledReason }: { position: Position; onClose: () => void; canClose: boolean; closeDisabledReason?: string }) {
   const ccy = p.currency ?? 'USD'
   const cost = Number(p.avgCost) * Number(p.quantity)
   const pnl = Number(p.unrealizedPnL)
@@ -825,6 +908,8 @@ function PositionRow({ position: p, onClose }: { position: Position; onClose: ()
         <button
           type="button"
           onClick={onClose}
+          disabled={!canClose}
+          title={!canClose ? closeDisabledReason : undefined}
           aria-label={`Close ${contractPrimary(p.contract)} position`}
           className="text-[11px] text-muted-foreground hover:text-destructive transition-colors"
         >

--- a/ui/src/pages/WorkspaceListPage.tsx
+++ b/ui/src/pages/WorkspaceListPage.tsx
@@ -20,6 +20,7 @@ import { useWorkspace } from '../tabs/store'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { PageLoading, RecoverySurface, RefreshNotice } from '../components/StateViews'
 import { OverviewCard } from '../components/workspace/OverviewCard'
+import { workspaceActivityMs } from '../components/workspace/sidebar-order'
 import {
   getGitLog,
   listDepartedWorkspaces,
@@ -30,14 +31,6 @@ import {
   type TemplateInfo,
   type Workspace,
 } from '../components/workspace/api'
-
-function lastActivityMs(w: Workspace): number {
-  const sessionTs = w.sessions
-    .map((s) => new Date(s.lastActiveAt).getTime())
-    .filter((n) => Number.isFinite(n))
-  if (sessionTs.length === 0) return new Date(w.createdAt).getTime()
-  return Math.max(...sessionTs)
-}
 
 /** Best-effort humanization for templates that don't declare a `displayName`. */
 function humanize(name: string): string {
@@ -87,7 +80,7 @@ function buildSections(
   for (const t of orderedTemplates) {
     const ws = buckets.get(t.name)
     if (!ws || ws.length === 0) continue
-    const sorted = [...ws].sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
+    const sorted = [...ws].sort((a, b) => workspaceActivityMs(b) - workspaceActivityMs(a))
     sections.push({
       key: t.name,
       title: t.displayName ?? humanize(t.name),
@@ -96,7 +89,7 @@ function buildSections(
   }
   const others = buckets.get(UNKNOWN_KEY)
   if (others && others.length > 0) {
-    const sorted = [...others].sort((a, b) => lastActivityMs(b) - lastActivityMs(a))
+    const sorted = [...others].sort((a, b) => workspaceActivityMs(b) - workspaceActivityMs(a))
     sections.push({ key: UNKNOWN_KEY, title: otherTitle, workspaces: sorted })
   }
   return sections

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,13 @@ export default defineConfig({
     alias: workspaceAliases,
   },
   test: {
+    // The Node suite includes installer, PTY, Guardian, and Railway specs that
+    // spawn their own process trees. Leaving Vitest at `available CPUs - 1`
+    // lets those children contend with a worker per core on constrained CI
+    // hosts, turning fast installer checks into timeout flakes. Keep enough
+    // parallelism for the unit-heavy majority while reserving capacity for the
+    // subprocesses owned by each worker.
+    maxWorkers: '50%',
     projects: [
       {
         resolve: {


### PR DESCRIPTION
## Outcome

Makes the first remote/Railway browser experience report the authority that actually owns each capability instead of collapsing connection, Agent, Session, and Broker state into one green status.

## Product decision

The UI keeps the existing multi-process and remote-control model. It projects four independent facts:

- connection and deployment ownership;
- native Agent executable/readiness;
- scheduled Issue owner/runtime dispatchability;
- per-account Broker Pack and broker health.

Only actions that depend on an unavailable layer fail closed. Existing configured accounts, historical snapshots, Sessions, and remote Project identity remain visible.

## What changed

- preserves full remote client identity and shows SSH/Railway-owned runtime guidance;
- recovers the same Terminal Session after long outages and bounds pre-attach retry loops;
- rediscovers Agent executables on focus/backend recovery with executable-fingerprint and publication-epoch protection;
- blocks schedules whose exact Session, Workspace, or Agent runtime cannot dispatch;
- joins configured accounts to Broker Pack readiness and gates polling/reconnect/trading consistently;
- replaces internal headless wrappers with structured public Session titles and latest-activity timestamps;
- expands the real SSH Docker journey and makes subprocess-heavy Vitest execution less flaky.

The recovery implementation includes deterministic tests for A-to-B-to-A executable replacement, GET invalidation, reversed refresh completion, failed recovery retry, and late callbacks.

## Verification

- npx tsc --noEmit
- pnpm --dir ui exec tsc -b
- pnpm -F @traderalice/openalice-cli typecheck
- pnpm test: 634 passed files, 5429 passed tests; 2 files / 13 tests skipped
- CLI package: 41 files, 431 tests passed
- pnpm test:remote:docker on OrbStack Linux arm64, including full TUI paths
- pnpm docker:smoke on OrbStack Linux arm64
- pnpm electron:smoke:workspace on unsigned macOS arm64
- real Railway beta2 UI/UX discovery pass; beta3 long-outage acceptance remains the post-release gate

No Agent was started during readiness acceptance, no Broker Pack was installed, no broker was contacted, and no trading write was attempted.
