### PR TITLE
Prepare v0.91.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0-beta.2",
+  "version": "0.91.0-beta.3",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0-beta.2",
+  "version": "0.91.0-beta.3",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- advance the root product manifest to `0.91.0-beta.3`
- advance the native CLI manifest to the same version
- keep the diff exact so the beta release-preparation fast lane applies

## Release evidence

- product promotion PR #1295 passed the complete CI, desktop package, Docker, and CLI installer gates before merge
- the redundant master-push full suite later hit only the known Windows real-Git fixture timeout; the same tree passed in the promotion gate
- that CI hygiene fix is isolated in dev PR #1296 and is intentionally not part of this beta package
- local beta classifier: `exact beta release preparation 0.91.0-beta.2 -> 0.91.0-beta.3`
- release workflow specs: 6 files / 41 tests passed

Per maintainer direction, AliceProject migration fixtures remain dev/nightly/stable safety coverage and do not synchronously block beta publication.