### PR TITLE
ci: make dev and beta feedback lightweight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 # Agent-driven iterations often supersede an earlier commit before its Windows
 # job finishes. Keep only the latest PR run while never cancelling a master or
@@ -24,14 +23,15 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # UI and prose changes are built and tested on Ubuntu, but do not need to
-  # repeat the host-sensitive runtime suite on macOS and Windows. This is a
-  # deliberately narrow allowlist: every other path keeps the full matrix.
+  # Every PR keeps a small, deterministic contract/type gate. The beta
+  # classifier is loaded from the trusted base revision so a candidate cannot
+  # weaken its own release-preparation lane. Any classifier failure produces
+  # `false`, which fails beta preparation closed; routine integration still
+  # stays on its intentionally light branch lane.
   change-scope:
     if: github.event_name != 'push' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
-      cross_platform: ${{ steps.changes.outputs.cross_platform }}
       beta_release_prep: ${{ steps.beta-release-prep.outcome == 'success' && steps.beta-release-prep.outputs.beta_release_prep || 'false' }}
 
     steps:
@@ -50,47 +50,12 @@ jobs:
           git show "${BASE_SHA}:scripts/classify-beta-release-prep.mjs" > "$RUNNER_TEMP/classify-beta-release-prep.mjs"
           node "$RUNNER_TEMP/classify-beta-release-prep.mjs" --github-output "$GITHUB_OUTPUT"
 
-      - name: Classify changed paths
-        id: changes
-        uses: actions/github-script@v9
-        with:
-          script: |
-            if (context.eventName !== "pull_request") {
-              core.info("Non-PR validation keeps the full platform matrix.");
-              core.setOutput("cross_platform", "true");
-              return;
-            }
-
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 100,
-            });
-            const paths = files.flatMap((file) =>
-              file.previous_filename
-                ? [file.filename, file.previous_filename]
-                : [file.filename],
-            );
-            const isLightweight = (path) =>
-              path.startsWith("ui/") ||
-              path.startsWith("docs/") ||
-              /^[^/]+\.md$/i.test(path) ||
-              path === "LICENSE";
-            const platformSensitive = paths.filter((path) => !isLightweight(path));
-            const runCrossPlatform = paths.length === 0 || platformSensitive.length > 0;
-
-            core.info(`Changed paths: ${paths.join(", ") || "none reported"}`);
-            if (platformSensitive.length > 0) {
-              core.info(`Native host contracts required by: ${platformSensitive.join(", ")}`);
-            } else {
-              core.info("Only UI/docs paths changed; Ubuntu remains the PR gate.");
-            }
-            core.setOutput("cross_platform", String(runCrossPlatform));
-
   build:
-    # Dev pushes belong exclusively to the rolling CLI publication workflow.
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master'
+    needs: change-scope
+    # Keep contracts and typecheck inside the stable aggregate gate for every
+    # PR. Exact beta preparation skips only the complete source build;
+    # classifier failures fall back to it.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:
@@ -107,12 +72,32 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm build
+      - name: Verify CI workflow contracts
+        run: pnpm test:workflow-contracts
+
+      - name: Typecheck root workspace
+        run: npx tsc --noEmit
+        timeout-minutes: 5
+
+      - name: Build complete workspace
+        if: >-
+          needs.change-scope.result != 'success' ||
+          needs.change-scope.outputs.beta_release_prep != 'true'
+        run: pnpm build
 
   test:
-    # Build and Vitest do not consume each other's output. Keep them on
-    # separate runners so either failure becomes actionable immediately.
-    if: github.event_name != 'push' || github.ref == 'refs/heads/master'
+    needs: change-scope
+    # Local verification plus build/type/contracts are the routine dev gate.
+    # Keep the full suite for master, scheduled, and manually requested runs.
+    # A classifier/preflight failure falls back to the full suite only where
+    # full validation already belongs: master, scheduled, and manual lanes.
+    if: >-
+      !cancelled() &&
+      (github.event_name != 'pull_request' || github.base_ref == 'master') &&
+      (
+        needs.change-scope.result != 'success' ||
+        needs.change-scope.outputs.beta_release_prep != 'true'
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -135,38 +120,54 @@ jobs:
   # consumers while the two independent validations report failures earlier.
   build-and-test:
     if: always() && (github.event_name != 'push' || github.ref == 'refs/heads/master')
-    needs: [build, test]
+    needs: [change-scope, build, test]
     runs-on: ubuntu-latest
 
     steps:
       - name: Require successful build and test lanes
         env:
+          PREFLIGHT_RESULT: ${{ needs.change-scope.result }}
+          BETA_RELEASE_PREP: ${{ needs.change-scope.outputs.beta_release_prep }}
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          FULL_VALIDATION: ${{ github.event_name != 'pull_request' || github.base_ref == 'master' }}
         run: |
-          if [[ "$BUILD_RESULT" != "success" || "$TEST_RESULT" != "success" ]]; then
-            echo "Build result: $BUILD_RESULT"
-            echo "Test result: $TEST_RESULT"
+          echo "Preflight result: $PREFLIGHT_RESULT"
+          echo "Beta release preparation: $BETA_RELEASE_PREP"
+          echo "Build result: $BUILD_RESULT"
+          echo "Test result: $TEST_RESULT"
+
+          if [[ "$PREFLIGHT_RESULT" != "success" ]]; then
             exit 1
           fi
 
-  # Routine dev PRs run the complete build and test suite once on Ubuntu, then
-  # exercise only native CLI/Guardian/path/process contracts on macOS and
-  # Windows. Repeating all 5,000+ platform-neutral tests on constrained hosted
-  # runners amplified resource starvation into false serial blockers. Stable
-  # promotion, master, scheduled, and manual validation still run the complete
-  # build and test suite on both hosts.
+          if [[ "$BETA_RELEASE_PREP" == "true" ]]; then
+            [[ "$BUILD_RESULT" == "success" ]] || exit 1
+            [[ "$TEST_RESULT" == "skipped" ]] || exit 1
+            exit 0
+          fi
+
+          if [[ "$BUILD_RESULT" != "success" ]]; then
+            exit 1
+          fi
+
+          if [[ "$FULL_VALIDATION" == "true" ]]; then
+            [[ "$TEST_RESULT" == "success" ]] || exit 1
+          else
+            [[ "$TEST_RESULT" == "skipped" ]] || exit 1
+          fi
+
+  # Cross-platform hosted runners are a master/scheduled/manual safety net.
+  # Routine dev PRs rely on local multi-platform acceptance plus the focused
+  # contracts, typecheck, and complete Ubuntu build above.
   cross-platform-test:
     needs: change-scope
     if: >-
       !cancelled() &&
-      (github.event_name != 'push' || github.ref == 'refs/heads/master') &&
+      (github.event_name != 'pull_request' || github.base_ref == 'master') &&
       (
         needs.change-scope.result != 'success' ||
-        (
-          needs.change-scope.outputs.cross_platform == 'true' &&
-          needs.change-scope.outputs.beta_release_prep != 'true'
-        )
+        needs.change-scope.outputs.beta_release_prep != 'true'
       )
     timeout-minutes: 30
     strategy:
@@ -190,17 +191,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build complete workspace for stable and scheduled validation
-        if: github.event_name != 'pull_request' || github.base_ref == 'master'
         run: pnpm build
         timeout-minutes: 15
 
-      - name: Run native platform contracts for routine integration PRs
-        if: github.event_name == 'pull_request' && github.base_ref != 'master'
-        run: pnpm test:platform-contracts
-        timeout-minutes: 8
-
       - name: Run complete suite for stable and scheduled validation
-        if: github.event_name != 'pull_request' || github.base_ref == 'master'
         run: pnpm test
         timeout-minutes: 15
 
@@ -214,13 +208,10 @@ jobs:
     needs: change-scope
     if: >-
       !cancelled() &&
-      (github.event_name != 'push' || github.ref == 'refs/heads/master') &&
+      (github.event_name != 'pull_request' || github.base_ref == 'master') &&
       (
         needs.change-scope.result != 'success' ||
-        (
-          needs.change-scope.outputs.cross_platform == 'true' &&
-          needs.change-scope.outputs.beta_release_prep != 'true'
-        )
+        needs.change-scope.outputs.beta_release_prep != 'true'
       )
     strategy:
       fail-fast: false

--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -83,6 +83,7 @@ jobs:
     if: >-
       !cancelled() &&
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.base_ref == 'master') &&
       (
         needs.release-prep-scope.result != 'success' ||
         needs.release-prep-scope.outputs.beta_release_prep != 'true'
@@ -171,6 +172,7 @@ jobs:
     if: >-
       !cancelled() &&
       github.event_name != 'push' &&
+      (github.event_name != 'pull_request' || github.base_ref == 'master') &&
       (
         needs.release-prep-scope.result != 'success' ||
         needs.release-prep-scope.outputs.beta_release_prep != 'true'

--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -3,7 +3,7 @@ name: Desktop Package Smoke
 on:
   workflow_dispatch:
   pull_request:
-    branches: [dev, master, codex/usability-improvements]
+    branches: [master]
     paths:
       - ".github/workflows/desktop-package-smoke.yml"
       - ".github/workflows/release.yml"
@@ -74,23 +74,24 @@ jobs:
           node "$RUNNER_TEMP/classify-beta-release-prep.mjs" --github-output "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v6
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
 
       - uses: actions/setup-node@v7
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Verify CI workflow contracts
-        run: >-
-          pnpm exec vitest run
-          scripts/ci-workflow.spec.ts
-          scripts/desktop-package-workflow.spec.ts
-          scripts/release-workflow.spec.ts
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
+        run: pnpm test:workflow-contracts
 
       - name: Typecheck root workspace
+        if: steps.beta-release-prep.outcome != 'success' || steps.beta-release-prep.outputs.beta_release_prep != 'true'
         run: npx tsc --noEmit
         timeout-minutes: 5
 

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -3,7 +3,7 @@ name: Docker Smoke
 on:
   workflow_dispatch:
   pull_request:
-    branches: [dev, master, codex/usability-improvements]
+    branches: [master]
     paths:
       - ".github/workflows/docker-smoke.yml"
       - "Dockerfile"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,12 @@ for current ownership and entry points.
   installer, while stable CDN product aliases and package-manager metadata are
   updated only by a stable release tag. Mirror repair never rewrites the shared
   installer.
+- An exact forward beta version-only PR uses a lightweight trusted-classifier,
+  workflow-contract, and typecheck lane. Beta publication is gated by the
+  Release workflow's final artifact build/install/start/update acceptance, not
+  by repeating the development unit suite or waiting for the post-merge
+  `master` safety-net run. Stable preparation and publication retain the full
+  promotion, cross-platform, package, signing, and upgrade gates.
 - Do not commit directly to `master`. Avoid direct commits to `dev` unless the
   maintainer explicitly requests integration work.
 - Never force-push or delete `master` or `dev`.
@@ -147,8 +153,11 @@ the proportional local/native lane, and no product assertion failed; it should
 be repaired or removed from the routine lane instead of retried blindly. In
 serial work, pending CI likewise must not become a synchronous lock; inspect the
 previous PR checks and post-merge `dev` run before publishing the next
-increment. `master` promotions, releases, explicit review pauses, and untrusted
-contributions keep their full synchronous gates. Detailed topic,
+increment. `master` promotions, stable releases, explicit review pauses, and
+untrusted contributions keep their full synchronous gates. Exact beta
+preparation is the bounded exception above: its own artifact acceptance stays
+synchronous, while the redundant source-test backstop may trail publication.
+Detailed topic,
 branch, PR, promotion, hotfix, and external-contribution procedures live in
 [[docs/development-workflow.md]]
 ([Development workflow](docs/development-workflow.md)).
@@ -161,6 +170,13 @@ For code changes, always run:
 npx tsc --noEmit
 pnpm test
 ```
+
+These local checks are the primary routine-development evidence. Hosted CI for
+a `dev` PR intentionally performs only a clean Ubuntu build, root typecheck,
+and workflow contracts; it does not repeat the full Vitest suite, native-host
+matrix, Electron smoke, or Docker smoke. Record the applicable local
+surface-specific commands and real-runtime result in the PR so the lighter
+hosted lane does not become an excuse to skip acceptance.
 
 Add checks according to the touched surface:
 
@@ -206,8 +222,9 @@ the signing cost.
 When optimizing CI/CD, preserve the lane boundaries above. First remove
 duplicate jobs, cancel superseded runs, narrow path triggers, reuse caches and
 unsigned build artifacts, and measure the slow step before considering larger
-runners. Do not trade away the full `master` promotion/release gates merely to
-make routine `dev` feedback look faster.
+runners. Routine `dev` and exact-beta feedback should stay deliberately light;
+do not trade away the full `master` promotion or stable-release gates merely to
+make those final acceptance lanes look faster.
 
 ## Deferred Work and Issues
 

--- a/PLANS.md
+++ b/PLANS.md
@@ -40,7 +40,7 @@ the durable truth after it changes. Git history is the archive.
   non-destructive dev-to-pinned-beta2 replacement; disposable empty-Volume and
   failure-fallback journeys, native PowerShell, and external package-manager
   activation remain open on focused branches from current `dev`. Routine dev
-  and exact-beta source feedback is being reduced to local-first, lightweight
+  and exact-beta source feedback is reduced to local-first, lightweight
   hosted lanes while `master` promotion, stable, and final artifact acceptance
   retain the complete gates.
 - [[plans/remote-project-fleet.md]] — Adds a machine-aware Supervisor fleet,

--- a/PLANS.md
+++ b/PLANS.md
@@ -39,7 +39,10 @@ the durable truth after it changes. Git history is the archive.
   real migration, OpenCode resume, normal restart, hard-kill recovery, and a
   non-destructive dev-to-pinned-beta2 replacement; disposable empty-Volume and
   failure-fallback journeys, native PowerShell, and external package-manager
-  activation remain open on focused branches from current `dev`.
+  activation remain open on focused branches from current `dev`. Routine dev
+  and exact-beta source feedback is being reduced to local-first, lightweight
+  hosted lanes while `master` promotion, stable, and final artifact acceptance
+  retain the complete gates.
 - [[plans/remote-project-fleet.md]] — Adds a machine-aware Supervisor fleet,
   remote AliceProject inventory/connection, and safe local-to-SSH project
   transfer for portable configuration and Workspaces while deliberately

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -229,20 +229,23 @@ Pull-request CI and the rolling dev CLI publication provide change-level and
 post-merge integration feedback. Their blocking authority depends on the
 delivery lane:
 
-- Every PR to `dev` or `master` runs independent Ubuntu build and unit-test
-  lanes so either failure is visible without waiting for the other. The stable
-  `build-and-test` aggregate check requires both lanes to pass.
-- PRs whose complete diff is limited to `ui/`, `docs/`, or root documentation
-  skip the macOS/Windows runtime matrix. Other routine PRs to `dev` run the
-  focused native CLI, Guardian, filesystem, shell, and process contract suite
-  on macOS and Windows instead of repeating every platform-neutral Vitest file
-  already accepted on Ubuntu. PRs to `master`, `master` pushes, scheduled runs,
-  and manual full validation still build and test the complete tree on both
-  hosts.
+- A routine integration PR whose base is not `master` runs one clean Ubuntu
+  lane: workflow contracts, root typecheck, and the complete workspace build.
+  The stable `build-and-test` check name remains successful by requiring that
+  build and intentionally accepting the skipped full-test lane. The PR must
+  record the applicable local `npx tsc --noEmit`, `pnpm test`, browser,
+  Electron, Docker, installer, or native-runtime evidence; hosted CI is not a
+  second purchase of the same confidence.
+- PRs to `master`, `master` pushes, scheduled runs, and manual validation retain
+  the full Ubuntu test lane, macOS/Windows build-and-test matrix, and native
+  dev-smoke. Routine integration PRs do not allocate those runners. There is no
+  changed-test or actor/label router: the branch boundary is intentionally
+  simple, and current `dev` receives a daily full cross-platform backstop.
 - A `master`-targeted PR whose complete diff is exactly the synchronized,
   forward beta `version` value in `package.json` and
   `packages/cli/package.json` takes the release-preparation fast lane. It keeps
-  Ubuntu build/test, workflow contracts, and root typecheck, while skipping the
+  the trusted classifier, workflow contracts, root typecheck, and the stable
+  aggregate check name, while skipping the source build/full-test lane and the
   Docker, CLI installer, Broker Pack, and desktop/cross-platform PR matrices
   because no runtime implementation changed. The beta Release workflow then
   rebuilds and accepts every final version-bearing candidate from the exact
@@ -252,9 +255,12 @@ delivery lane:
   errors all retain the full PR suite.
 - Superseded runs for the same PR are cancelled. Only the latest-head result is
   actionable evidence.
-- Desktop Package Smoke runs its workflow-contract and root-typecheck preflight
-  before allocating the expensive host package matrix and Windows Broker Pack
-  lane. The native package lanes still start together after that fast gate.
+- The central CI aggregate owns workflow contracts and root typecheck for an
+  exact beta version PR. Desktop Package Smoke keeps only its trusted
+  classifier before skipping the expensive host package matrix and Windows
+  Broker Pack lane. Those package lanes are reserved for `master`-targeted
+  implementation PRs and manual validation; routine integration uses the
+  matching local unsigned package smoke.
 - In serial mode, a `dev` PR may merge after proportional local verification
   while its remote checks are pending. Before the next serial PR is published,
   inspect both that PR's checks and the resulting `dev` push run. A completed
@@ -272,30 +278,34 @@ delivery lane:
   CLI candidates are assembled and each candidate runs its packaged
   Guardian/Alice, Web, Workspace, PTY, and release-owned Git acceptance before
   one atomic dev manifest is activated. The heavier UTA/Connector recovery and
-  external Broker Pack fixture run once on Linux x64; PR and release lanes keep
-  their broader native-host coverage. The scheduled CI run remains the daily
-  full cross-platform backstop for current `dev`.
-- Installer or distributed-CLI PRs run deterministic clean-container install
-  and managed-SSH acceptance against the checked-out tree. After merge, the
-  `dev` push separately downloads `raw/.../dev/install` into a clean container,
-  installs `--channel dev`, and verifies the live preview channel's provenance,
-  commands, server control surface, and idempotent reuse.
+  external Broker Pack fixture run once on Linux x64; `master`, scheduled, and
+  final Release lanes keep the broader native-host coverage. The scheduled CI
+  run remains the daily full cross-platform backstop for current `dev`.
+- Installer or distributed-CLI PRs to a routine integration base retain only
+  the cheap deterministic clean-container HTTP install against the checked-out
+  tree. Bun host feasibility, package-manager, and managed-SSH acceptance run
+  locally during development and in the `master`/manual lanes. After merge,
+  the `dev` push separately downloads `raw/.../dev/install` into a clean
+  container, installs `--channel dev`, and verifies the live preview channel's
+  provenance, commands, server control surface, and idempotent reuse.
 - A push to `master` always runs the complete matrix. Reusing PR evidence after
-  merge remains a separate accepted-tree provenance problem; the semantic beta
-  PR fast lane does not silently solve it by trusting a commit message or diff.
+  merge remains a useful accepted-tree provenance backstop. For stable it is a
+  synchronous release gate. For an exact beta, it may finish after dispatch and
+  is not a second source-test gate: the trusted version PR plus the Release
+  workflow's final artifact acceptance own publication. A real product failure
+  still stops or withdraws a candidate; hosted-runner starvation and a known
+  non-product fixture timeout do not become product risk through repetition.
 - Once this workflow version reaches the default `master` branch, the scheduled
   validation checks out current `dev` and runs the complete matrix, providing a
   daily cross-platform backstop for lightweight PRs.
 
-Keep the lightweight-path allowlist narrow. Changes to dependencies, runtime,
-Guardian, Electron, packaging, scripts, workflows, or any unclassified path
-must still produce Windows and macOS evidence, but routine PR evidence is the
-focused native contract suite plus the relevant real-runtime/package smoke, not
-three copies of all platform-neutral tests. Serial development uses the local
-Mac for the complete `npx tsc --noEmit` and `pnpm test` contract, adding the
-unsigned Electron/package smoke when that surface changes. A product failure
-must be green before promotion to `master` or release; stable keeps the full
-remote matrix even when routine integration used focused host checks.
+Routine integration has no hosted changed-path allowlist. Serial development
+uses the local Mac for the complete `npx tsc --noEmit` and `pnpm test` contract,
+adding real browser, OrbStack, installer, unsigned Electron/package, and native
+runtime acceptance when those surfaces change. Record those commands and
+results in the PR. A promotion to `master` re-establishes full remote evidence;
+stable keeps the complete matrix even when routine integration and beta used
+lighter hosted feedback.
 
 ### Package signing boundary
 
@@ -324,15 +334,17 @@ and resource-layout coverage.
 
 Optimize measured waiting time without collapsing the confidence lanes:
 
-1. cancel superseded work and avoid repeating the PR matrix on `dev` push;
-2. use narrow path classification to skip irrelevant host/package jobs;
-3. cache dependency, build, and safe unsigned-package inputs across jobs;
-4. split fast contract/type gates from slower host/runtime acceptance so the
-   first actionable failure arrives early;
+1. keep routine integration to one clean build/type/contract lane and run
+   surface-specific acceptance on the development machine;
+2. avoid repeating PR acceptance on `dev` push, which owns publication only;
+3. keep exact-beta preparation to trusted version/contracts/type checks and let
+   Release accept the final artifacts once;
+4. cancel superseded work and cache dependency, build, and safe unsigned-package
+   inputs across the remaining jobs;
 5. measure queue time versus install/build/test time before buying larger
    runners;
-6. keep complete promotion/release acceptance, signing, and publication gated
-   even when routine `dev` feedback is deliberately asynchronous.
+6. keep complete `master` promotion and stable acceptance, signing, and
+   publication gated even when routine `dev` and beta feedback are light.
 
 Any CI optimization PR should include before/after timing evidence and name the
 confidence gate it preserves, moves, or removes.
@@ -405,9 +417,11 @@ the accepted candidates and eventual tag to the dispatch commit SHA.
 
 An exact forward beta version-only PR uses the bounded CI fast lane described
 above. Stable version preparation deliberately does not: it retains the full
-PR matrix. The subsequent `master` push also remains complete for both
-channels, and the manually dispatched Release always rebuilds and accepts its
-own final candidates; the fast lane never supplies release artifacts.
+PR matrix. The subsequent `master` push remains a complete asynchronous
+backstop for both channels, but only stable waits for it as a synchronous
+publication gate. The manually dispatched beta Release rebuilds and accepts
+its own final candidates from the exact dispatch SHA; the fast lane never
+supplies release artifacts.
 
 Beta and stable are serial public checkpoints, not paired outputs from one
 release run. After a beta, fixes may continue on `dev`, pass the ordinary
@@ -522,7 +536,11 @@ Keep `AGENTS.md` and `CONTRIBUTING.md` consistent with this guide and with
 For a serial PR to `dev`, satisfy the locally runnable, surface-specific gate
 before merging and report any platform-only residual risk. Remote platform
 evidence may trail that merge under the feedback rule above. Before promotion
-to `master` or release, every applicable gate must be complete and green.
+to `master` or a stable release, every applicable full gate must be complete
+and green. An exact beta requires the bounded version-prep gate, previously
+accepted promotion evidence for its product tree, and a fully green final
+Release artifact workflow; it does not reopen the development source-test
+matrix.
 
 | Boundary | Required evidence |
 |---|---|

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "electron:smoke:upgrade": "node scripts/desktop-upgrade-smoke.mjs",
     "vendor:runtime": "node scripts/vendor-managed-runtime.mjs",
     "test": "vitest run",
+    "test:workflow-contracts": "vitest run --project node scripts/classify-beta-release-prep.spec.mjs scripts/ci-workflow.spec.ts scripts/beta-release-prep-workflow.spec.ts scripts/cli-channel-authority-workflow.spec.ts scripts/cli-installer-workflow.spec.ts scripts/desktop-package-workflow.spec.ts scripts/release-workflow.spec.ts",
     "test:cli": "pnpm -F @traderalice/openalice-cli test",
     "test:platform-contracts": "vitest run --project node packages/cli/src packages/guardian-runtime/src scripts/guardian/shared.spec.ts scripts/pnpm-command.spec.ts scripts/railway-entrypoint.spec.ts services/connector/src/core/io-journal.spec.ts services/uta/src/uta-startup-resilience.spec.ts src/core/windows-workspace-shell.spec.ts src/services/auth/session-store.spec.ts src/services/auth/token-store.spec.ts src/workspaces/adapters/ai-config.spec.ts src/workspaces/adapters/shell.spec.ts src/workspaces/agent-conversation-log.spec.ts src/workspaces/agent-detect.spec.ts src/workspaces/cli/shim.spec.ts src/workspaces/headless-task-win-shim.spec.ts src/workspaces/spawn-env.spec.ts src/workspaces/win-command.spec.ts src/workspaces/workspace-creator.spec.ts",
     "test:watch": "vitest",

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -742,6 +742,29 @@ source-built Docker image.
   empty-Volume install-failure/fail-closed journey isolated to the disposable
   service above.
 
+### 13. Make local acceptance primary for dev and beta
+
+- [x] Fix the confidence boundary: surface-appropriate local tests, browser,
+  OrbStack, and unsigned Electron/package smokes are the primary development
+  evidence. Hosted CI is a cheap integration/build backstop for routine PRs,
+  not a second full test environment.
+- [x] Reduce routine integration PRs to one clean Ubuntu workflow-contract,
+  root-typecheck, and complete-build lane. Do not allocate the full Vitest
+  suite, macOS/Windows matrix, dev-smoke, Docker image, desktop packages, or
+  managed-SSH fixture.
+- [x] Retain only the cheap checkout HTTP installer on relevant dev PRs. Keep
+  the four native dev candidates, packaged-runtime acceptance, atomic alias
+  publication, and live raw-dev install on the post-merge `dev` push.
+- [x] Reduce exact beta version preparation to the trusted base classifier,
+  workflow contracts, root typecheck, and stable aggregate check name. Let the
+  manually dispatched Release build and accept the final version-bearing
+  artifacts once; the post-merge full `master` run is an asynchronous backstop.
+- [x] Keep `master` promotion, stable preparation/release, `master` push,
+  nightly, and manual full validation on the complete cross-platform lanes.
+- [ ] Verify the lightweight lane on its own `dev` PR and record the measured
+  before/after wall and runner time. Local workflow contracts, root typecheck,
+  full tests, and full build must already be green before opening that PR.
+
 ## Verification Matrix
 
 Every code increment runs:
@@ -784,7 +807,8 @@ credentials or broker state. OrbStack validates Linux behavior efficiently,
 including native Bun release and multiprocess Runtime acceptance on Linux
 arm64 and x64, but it does not replace native macOS acceptance. Prefer this
 local native-macOS plus OrbStack matrix during serial development instead of
-waiting on hosted runners; hosted jobs remain publication and release gates.
+waiting on hosted runners; hosted jobs remain final publication and stable
+release gates rather than a duplicate routine-development test harness.
 Windows PowerShell,
 filesystem-locking, PATH, and executable-signing checks belong to the deferred
 Windows lane.
@@ -1314,3 +1338,18 @@ This plan is complete only when:
   remained executable under `/data/home`, and a fresh inspection-only SSH
   tunnel served the beta2 UI on local loopback. No installer or release-pointer
   mutation ran through Railway SSH.
+- 2026-09-01: Reframed development confidence around local acceptance instead
+  of constrained hosted runners. Routine `dev` PRs now retain one clean Ubuntu
+  workflow-contract, root-typecheck, and complete-build lane; relevant CLI
+  changes additionally retain only the clean checkout HTTP installer. Exact
+  beta preparation retains the trusted base classifier plus contracts and
+  typecheck, while the Release workflow owns the final candidate build and
+  artifact acceptance. Full tests, macOS/Windows, dev-smoke, Docker, desktop,
+  Broker Pack, and managed-SSH lanes remain on `master`, stable, nightly, or
+  manual authority rather than synchronously blocking routine development.
+  Before opening the proving PR, local workflow contracts passed 47/47, the
+  root suite passed 5,431 tests with 13 expected skips, root typecheck passed,
+  and the complete workspace build passed. The prior remote baseline was a
+  15:31 desktop critical path for the preceding product PR and a 5:15
+  redundant Ubuntu root-test lane for the version-only beta3 PR; measured
+  post-change timing remains pending on the workflow's own `dev` PR.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -761,7 +761,7 @@ source-built Docker image.
   artifacts once; the post-merge full `master` run is an asynchronous backstop.
 - [x] Keep `master` promotion, stable preparation/release, `master` push,
   nightly, and manual full validation on the complete cross-platform lanes.
-- [ ] Verify the lightweight lane on its own `dev` PR and record the measured
+- [x] Verify the lightweight lane on its own `dev` PR and record the measured
   before/after wall and runner time. Local workflow contracts, root typecheck,
   full tests, and full build must already be green before opening that PR.
 
@@ -1351,5 +1351,11 @@ This plan is complete only when:
   root suite passed 5,431 tests with 13 expected skips, root typecheck passed,
   and the complete workspace build passed. The prior remote baseline was a
   15:31 desktop critical path for the preceding product PR and a 5:15
-  redundant Ubuntu root-test lane for the version-only beta3 PR; measured
-  post-change timing remains pending on the workflow's own `dev` PR.
+  redundant Ubuntu root-test lane for the version-only beta3 PR. On the
+  workflow's own [PR #1298](https://github.com/TraderAlice/OpenAlice/pull/1298),
+  central feedback completed in 2:50 wall and 2:37 runner time; the relevant
+  clean checkout installer completed in 0:31 wall and 0:25 runner time in
+  parallel. All full-test, macOS/Windows, dev-smoke, Bun-feasibility, and
+  managed-SSH jobs were explicitly skipped. The combined critical path fell
+  81.7% from 15:31 to 2:50 and aggregate hosted allocation fell from roughly 70
+  minutes to 3:02 (about 95.7%).

--- a/scripts/beta-release-prep-workflow.spec.ts
+++ b/scripts/beta-release-prep-workflow.spec.ts
@@ -20,6 +20,9 @@ interface WorkflowJob {
 }
 
 interface Workflow {
+  on?: {
+    pull_request?: { branches?: string[] }
+  }
   jobs: Record<string, WorkflowJob>
 }
 
@@ -50,27 +53,50 @@ function expectOutcomeGatedOutput(job: WorkflowJob): void {
 }
 
 describe('exact beta release-preparation workflow lane', () => {
-  it('keeps Linux build/test while skipping only CI host matrices', () => {
+  it('keeps contracts and typecheck while skipping root build, test, and host matrices', () => {
     const jobs = workflow('ci.yml').jobs
     expectTrustedClassifier(jobs['change-scope'])
     expectOutcomeGatedOutput(jobs['change-scope'])
-    expect(jobs.build.needs).toBeUndefined()
-    expect(jobs.test.needs).toBeUndefined()
-    expect(jobs['build-and-test'].needs).toEqual(['build', 'test'])
-    for (const name of ['cross-platform-test', 'dev-smoke']) {
+    expect(step(jobs.build, 'Verify CI workflow contracts').run)
+      .toBe('pnpm test:workflow-contracts')
+    expect(step(jobs.build, 'Typecheck root workspace').run)
+      .toBe('npx tsc --noEmit')
+    expect(jobs.build.needs).toBe('change-scope')
+    expect(jobs.build.if).toContain('!cancelled()')
+    expect(step(jobs.build, 'Build complete workspace').if)
+      .toContain("needs.change-scope.result != 'success'")
+    expect(step(jobs.build, 'Build complete workspace').if)
+      .toContain("beta_release_prep != 'true'")
+    for (const name of ['test', 'cross-platform-test', 'dev-smoke']) {
+      expect(jobs[name].needs).toBe('change-scope')
       expect(jobs[name].if).toContain('!cancelled()')
       expect(jobs[name].if).toContain("needs.change-scope.result != 'success'")
       expect(jobs[name].if).toContain("beta_release_prep != 'true'")
-      expect(jobs[name].if).toContain("github.ref == 'refs/heads/master'")
     }
+    const aggregate = jobs['build-and-test']
+    expect(aggregate.needs).toEqual(['change-scope', 'build', 'test'])
+    expect(aggregate.if).toContain('always()')
+    const gate = step(aggregate, 'Require successful build and test lanes').run ?? ''
+    expect(gate).toContain('[[ "$BETA_RELEASE_PREP" == "true" ]]')
+    expect(gate).toContain('[[ "$BUILD_RESULT" == "success" ]]')
+    expect(gate).toContain('[[ "$TEST_RESULT" == "skipped" ]]')
   })
 
-  it('keeps desktop contracts and typecheck while skipping package matrices', () => {
-    const jobs = workflow('desktop-package-smoke.yml').jobs
+  it('keeps desktop classification cheap while central CI owns contracts and typecheck', () => {
+    const desktop = workflow('desktop-package-smoke.yml')
+    const jobs = desktop.jobs
+    expect(desktop.on?.pull_request?.branches).toEqual(['master'])
     expectTrustedClassifier(jobs.preflight)
     expectOutcomeGatedOutput(jobs.preflight)
-    expect(step(jobs.preflight, 'Verify CI workflow contracts')).toBeDefined()
-    expect(step(jobs.preflight, 'Typecheck root workspace')).toBeDefined()
+    for (const name of [
+      'Install dependencies',
+      'Verify CI workflow contracts',
+      'Typecheck root workspace',
+    ]) {
+      const candidate = step(jobs.preflight, name)
+      expect(candidate.if).toContain("steps.beta-release-prep.outcome != 'success'")
+      expect(candidate.if).toContain("beta_release_prep != 'true'")
+    }
     expect(jobs['broker-packs-windows'].if).toContain("beta_release_prep != 'true'")
     expect(jobs.package.if).toContain("beta_release_prep != 'true'")
   })
@@ -87,13 +113,18 @@ describe('exact beta release-preparation workflow lane', () => {
       expect(jobs[name].if).toContain("needs.release-prep-scope.result != 'success'")
       expect(jobs[name].if).toContain("beta_release_prep != 'true'")
     }
+    expect(jobs['bun-cli-feasibility'].if).toContain("github.base_ref == 'master'")
+    expect(jobs['checkout-remote'].if).toContain("github.base_ref == 'master'")
+    expect(jobs['checkout-install'].if).not.toContain("github.base_ref == 'master'")
     expect(jobs['build-dev-cli'].if).toBe("github.event_name == 'push'")
     expect(jobs['build-dev-cli'].needs).toBeUndefined()
     expect(jobs['publish-dev-cli'].needs).toBe('build-dev-cli')
   })
 
   it('keeps the Docker check green but omits setup, build, and smoke on an exact match', () => {
-    const smoke = workflow('docker-smoke.yml').jobs.smoke
+    const docker = workflow('docker-smoke.yml')
+    const smoke = docker.jobs.smoke
+    expect(docker.on?.pull_request?.branches).toEqual(['master'])
     expectTrustedClassifier(smoke)
     const expensive = smoke.steps?.filter((candidate) => [
       'actions/setup-node@v7',

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 
 interface WorkflowStep {
+  env?: Record<string, string>
   if?: string
   name?: string
   run?: string
@@ -47,38 +48,73 @@ describe('CI workflow fast failure lanes', () => {
     expect(workflow.jobs['post-merge-dev-smoke']).toBeUndefined()
   })
 
-  it('runs build and unit tests independently', () => {
+  it('keeps workflow contracts and root typecheck with the shared build preflight', () => {
+    const build = workflow.jobs.build
+
+    expect(commands(build)).toEqual(expect.arrayContaining([
+      'pnpm test:workflow-contracts',
+      'npx tsc --noEmit',
+    ]))
+    expect(packageJson.scripts['test:workflow-contracts']).toContain(
+      'scripts/classify-beta-release-prep.spec.mjs',
+    )
+    expect(packageJson.scripts['test:workflow-contracts']).toContain(
+      'scripts/ci-workflow.spec.ts',
+    )
+    expect(packageJson.scripts['test:workflow-contracts']).toContain(
+      'scripts/release-workflow.spec.ts',
+    )
+  })
+
+  it('builds every ordinary candidate but reserves the full root suite for master lanes', () => {
     const build = workflow.jobs.build
     const test = workflow.jobs.test
+    const buildStep = build.steps?.find((step) => step.name === 'Build complete workspace')
 
-    expect(build.needs).toBeUndefined()
-    expect(test.needs).toBeUndefined()
+    expect(build.needs).toBe('change-scope')
+    expect(build.if).toContain('!cancelled()')
+    expect(buildStep?.if).toContain("needs.change-scope.result != 'success'")
+    expect(buildStep?.if).toContain("beta_release_prep != 'true'")
     expect(commands(build)).toContain('pnpm build')
     expect(commands(build)).not.toContain('pnpm test')
+
+    expect(test.needs).toBe('change-scope')
+    expect(test.if).toContain("needs.change-scope.result != 'success'")
+    expect(test.if).toContain("beta_release_prep != 'true'")
+    expect(test.if).toContain("github.base_ref == 'master'")
     expect(commands(test)).toContain('pnpm test')
     expect(commands(test)).not.toContain('pnpm build')
   })
 
-  it('preserves build-and-test as the aggregate confidence gate', () => {
+  it('keeps build-and-test successful for intentional dev and beta skips only', () => {
     const aggregate = workflow.jobs['build-and-test']
+    const gate = aggregate.steps?.find(
+      (step) => step.name === 'Require successful build and test lanes',
+    )
 
     expect(aggregate.if).toContain('always()')
-    expect(aggregate.needs).toEqual(['build', 'test'])
-    expect(aggregate.steps?.map((step) => step.name)).toContain(
-      'Require successful build and test lanes',
-    )
+    expect(aggregate.needs).toEqual(['change-scope', 'build', 'test'])
+    expect(gate?.env).toMatchObject({
+      PREFLIGHT_RESULT: '${{ needs.change-scope.result }}',
+      BETA_RELEASE_PREP: '${{ needs.change-scope.outputs.beta_release_prep }}',
+      BUILD_RESULT: '${{ needs.build.result }}',
+      TEST_RESULT: '${{ needs.test.result }}',
+    })
+    expect(gate?.run).toContain('[[ "$PREFLIGHT_RESULT" != "success" ]]')
+    expect(gate?.run).toContain('[[ "$BETA_RELEASE_PREP" == "true" ]]')
+    expect(gate?.run).toContain('[[ "$BUILD_RESULT" == "success" ]]')
+    expect(gate?.run).toContain('[[ "$BUILD_RESULT" != "success" ]]')
+    expect(gate?.run).toContain('[[ "$TEST_RESULT" == "success" ]]')
+    expect(gate?.run).toContain('[[ "$TEST_RESULT" == "skipped" ]]')
   })
 
   it('bounds cross-platform runners even when a step never reports completion', () => {
     expect(workflow.jobs['cross-platform-test']['timeout-minutes']).toBe(30)
   })
 
-  it('keeps routine PR hosts focused while stable and scheduled lanes stay complete', () => {
+  it('omits hosted platform and dev smokes from dev PRs while keeping full master lanes', () => {
     const crossPlatform = workflow.jobs['cross-platform-test']
     expect(crossPlatform.strategy?.matrix?.os).toEqual(['macos-14', 'windows-latest'])
-    const platformContracts = crossPlatform.steps?.find(
-      (step) => step.name === 'Run native platform contracts for routine integration PRs',
-    )
     const fullBuild = crossPlatform.steps?.find(
       (step) => step.name === 'Build complete workspace for stable and scheduled validation',
     )
@@ -86,18 +122,18 @@ describe('CI workflow fast failure lanes', () => {
       (step) => step.name === 'Run complete suite for stable and scheduled validation',
     )
 
-    expect(platformContracts).toMatchObject({
-      if: "github.event_name == 'pull_request' && github.base_ref != 'master'",
-      run: 'pnpm test:platform-contracts',
-      'timeout-minutes': 8,
-    })
-    for (const step of [fullBuild, fullTest]) {
-      expect(step?.if).toBe("github.event_name != 'pull_request' || github.base_ref == 'master'")
-    }
+    expect(crossPlatform.if).toContain("needs.change-scope.result != 'success'")
+    expect(crossPlatform.if).toContain("beta_release_prep != 'true'")
+    expect(crossPlatform.if).toContain("github.base_ref == 'master'")
     expect(fullBuild?.run).toBe('pnpm build')
     expect(fullTest?.run).toBe('pnpm test')
-    expect(packageJson.scripts['test:platform-contracts']).toContain('--project node')
-    expect(packageJson.scripts['test:platform-contracts']).toContain('packages/cli/src')
-    expect(packageJson.scripts['test:platform-contracts']).toContain('packages/guardian-runtime/src')
+    expect(crossPlatform.steps?.some(
+      (step) => step.name === 'Run native platform contracts for routine integration PRs',
+    )).toBe(false)
+
+    const devSmoke = workflow.jobs['dev-smoke']
+    expect(devSmoke.if).toContain("needs.change-scope.result != 'success'")
+    expect(devSmoke.if).toContain("beta_release_prep != 'true'")
+    expect(devSmoke.if).toContain("github.base_ref == 'master'")
   })
 })

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -45,6 +45,21 @@ describe('CLI installer dev publication workflow', () => {
     expect(workflow.on?.pull_request?.branches).toEqual(expect.arrayContaining(['dev', 'master']))
   })
 
+  it('keeps dev PR acceptance to the current checkout installer', () => {
+    const feasibility = workflow.jobs['bun-cli-feasibility']
+    const checkoutInstall = workflow.jobs['checkout-install']
+    const checkoutRemote = workflow.jobs['checkout-remote']
+
+    for (const job of [feasibility, checkoutRemote]) {
+      expect(job.if).toContain("github.event_name != 'pull_request' || github.base_ref == 'master'")
+      expect(job.if).toContain("needs.release-prep-scope.result != 'success'")
+      expect(job.if).toContain("beta_release_prep != 'true'")
+    }
+    expect(checkoutInstall.if).not.toContain("github.base_ref == 'master'")
+    expect(checkoutInstall.if).toContain("needs.release-prep-scope.result != 'success'")
+    expect(checkoutInstall.if).toContain("beta_release_prep != 'true'")
+  })
+
   it('builds all four supported native targets with the pinned Bun version', () => {
     const build = workflow.jobs['build-dev-cli']
     expect(build.strategy?.matrix?.include).toEqual([

--- a/scripts/desktop-package-workflow.spec.ts
+++ b/scripts/desktop-package-workflow.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 
 interface WorkflowStep {
+  if?: string
   name?: string
   run?: string
 }
@@ -16,7 +17,11 @@ interface WorkflowJob {
 }
 
 interface Workflow {
-  on?: Record<string, unknown>
+  on?: {
+    workflow_dispatch?: unknown
+    pull_request?: { branches?: string[] }
+    push?: unknown
+  }
   concurrency?: {
     group?: string
     'cancel-in-progress'?: boolean
@@ -30,9 +35,10 @@ const workflow = YAML.parse(
 ) as Workflow
 
 describe('Desktop Package Smoke workflow critical path', () => {
-  it('keeps manual and pull-request coverage without duplicating master releases', () => {
+  it('keeps manual and master-promotion coverage without taxing dev PRs', () => {
     expect(workflow.on).toHaveProperty('workflow_dispatch')
     expect(workflow.on).toHaveProperty('pull_request')
+    expect(workflow.on?.pull_request?.branches).toEqual(['master'])
     expect(workflow.on).not.toHaveProperty('push')
   })
 
@@ -58,13 +64,15 @@ describe('Desktop Package Smoke workflow critical path', () => {
     })
     expect(preflight.needs).toBeUndefined()
     const preflightSteps = preflight.steps?.map((step) => step.name) ?? []
+    expect(preflightSteps).toContain('Detect exact beta release preparation')
     expect(preflightSteps).toEqual(expect.arrayContaining([
       'Verify CI workflow contracts',
       'Typecheck root workspace',
     ]))
-    expect(preflightSteps.indexOf('Verify CI workflow contracts')).toBeLessThan(
-      preflightSteps.indexOf('Typecheck root workspace'),
-    )
+    for (const stepName of ['Verify CI workflow contracts', 'Typecheck root workspace']) {
+      const candidate = preflight.steps?.find((step) => step.name === stepName)
+      expect(candidate?.if).toContain("beta_release_prep != 'true'")
+    }
     expect(brokerPacks).toMatchObject({
       name: 'broker-packs windows-latest',
       'runs-on': 'windows-latest',


### PR DESCRIPTION
## Outcome

Makes local, surface-appropriate acceptance the primary development evidence instead of purchasing the same confidence again on constrained hosted runners.

- Routine `dev` PRs keep one Ubuntu workflow-contract + root typecheck + complete build lane. They skip the full root suite, macOS/Windows matrix, native dev-smoke, Desktop, Docker, and managed-SSH jobs.
- Relevant CLI PRs retain only the clean checkout HTTP installer. Post-merge `dev` publication remains the four native candidates, packaged-runtime acceptance, atomic alias activation, and live raw-dev install.
- Exact beta version PRs keep the trusted base classifier, workflow contracts, root typecheck, and `build-and-test`; they skip source build/test and host/package matrices. Final Release artifact build/install/start/update/signing/mirroring is unchanged.
- `master` promotion, stable, `master` push, nightly, and manual validation retain the full gates. There is no changed-path, actor, or label router.

## Measured result

- The preceding routine product PR had a 15m31s hosted critical path and allocated roughly 70 runner-minutes after local acceptance was already green.
- This PR completed central feedback in 2m50s wall / 2m37s runner. Its relevant clean checkout installer completed in 31s wall / 25s runner in parallel.
- The critical path fell 81.7%; aggregate hosted allocation fell to 3m02s, about 95.7% below the previous routine baseline.
- Full root test, macOS/Windows, dev-smoke, Bun feasibility, and managed-SSH jobs were all explicitly skipped. This is the intended lane, not an accidental path miss.
- The beta3 version-only PR baseline spent 5m15s on a redundant Ubuntu root suite and 1m59s on a source build. Under this contract, exact beta keeps only its classifier/contracts/typecheck source gate before final artifact acceptance.

## Local acceptance

- `pnpm test:workflow-contracts` — 7 files / 47 tests passed
- `npx tsc --noEmit` — passed
- `pnpm test` — 634 files passed, 2 skipped; 5,431 tests passed, 13 skipped
- `pnpm build` — passed, 15 tasks
- `git diff --check` — passed

## Explicit confidence move

Full root tests and host/runtime/package matrices move from synchronous routine dev/beta feedback to local acceptance plus `master`, stable, nightly, or manual authority. Beta publication still blocks on the final Release artifact workflow; stable remains fully gated.