### PR TITLE
fix(ui): refresh remote identity after backend recovery

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -34,10 +34,12 @@ the durable truth after it changes. Git history is the archive.
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set. The
   CLI package owns OpenAlice only: Agent Runtime installation and Electron
   packaging stay outside this plan. The native CLI is public through the
-  separately dispatched `v0.91.0-beta.2`; stable/beta discovery now uses the
+  separately dispatched `v0.91.0-beta.3`; stable/beta discovery now uses the
   OpenAlice CDN manifests. The retained no-domain Railway profile has passed
   real migration, OpenCode resume, normal restart, hard-kill recovery, and a
-  non-destructive dev-to-pinned-beta2 replacement; disposable empty-Volume and
+  non-destructive dev-to-pinned-beta3 replacement. Beta3 core Runtime/PTY state
+  survives a long tunnel outage, and the following `dev` increment refreshes
+  Settings identity after recovery; disposable empty-Volume and
   failure-fallback journeys, native PowerShell, and external package-manager
   activation remain open on focused branches from current `dev`. Routine dev
   and exact-beta source feedback is reduced to local-first, lightweight
@@ -46,8 +48,8 @@ the durable truth after it changes. Git history is the archive.
 - [[plans/remote-project-fleet.md]] — Adds a machine-aware Supervisor fleet,
   remote AliceProject inventory/connection, and safe local-to-SSH project
   transfer for portable configuration and Workspaces while deliberately
-  excluding native/OpenAlice Session continuation state. The current
-  beta-blocking increment makes the attached browser truthful about remote
+  excluding native/OpenAlice Session continuation state. The completed
+  remote-readiness increment makes the attached browser truthful about remote
   identity, Agent and Broker Pack capability, scheduled-work blockers,
   reconnect recovery, and public Session titles. Controller/remote release
   negotiation and a consented Railway redeploy adapter remain a separate

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -134,13 +134,14 @@ previous release still validates, the host starts the previous release. An
 empty or damaged install with a failed bootstrap stops instead of running an
 unverified fallback.
 
-The Railway profile currently requires `railway-runtime-lock-v2`. Public
-stable `v0.90.2` and beta `v0.91.0-beta.1` predate that capability, so they are
-not eligible Railway fallbacks. A completed dev artifact that explicitly
-advertises both Railway capabilities has passed retained-Volume acceptance; a
-stable or beta host still requires a later explicit release that carries the
-same capabilities. Do not infer eligibility from package version or branch
-name, and do not treat this guide as authority to publish or promote a channel.
+The Railway profile currently requires `railway-runtime-lock-v2`. Public stable
+`v0.90.2` predates that capability and is not an eligible Railway fallback.
+Accepted beta `v0.91.0-beta.3` and completed dev artifacts that explicitly
+advertise both Railway capabilities are eligible; beta3 has passed retained
+Volume replacement plus core Runtime/PTY recovery through a long tunnel outage.
+The Settings identity-refresh fix found by that journey lands after beta3. Do
+not infer eligibility from package version or branch name, and do not treat this
+guide as authority to publish or promote a channel.
 
 After selection, the image atomically replaces the persistent `openalice`,
 `alice`, `alice-workspace`, `alice-uta`, and `traderhub` shims with its Railway
@@ -316,10 +317,13 @@ show that a replacement still cannot acquire the fence; only process/container
 death may release it, and simultaneous replacements must produce one winner.
 
 The retained-data Railway journey has passed through migration, a real Agent
-turn, normal restart, and hard-kill replacement. The disposable clean-bootstrap
-and forced installer-failure journeys remain separate required acceptance;
-never relabel or clear an existing user Volume merely to obtain an empty-host
-result:
+turn, normal restart, hard-kill replacement, beta3 replacement, and a tunnel
+outage beyond the Terminal retry budget with automatic core browser and PTY
+recovery. That beta3 journey exposed a stale Settings identity read which is
+fixed on the following development increment.
+The disposable clean-bootstrap and forced installer-failure journeys remain
+separate required acceptance; never relabel or clear an existing user Volume
+merely to obtain an empty-host result:
 
 1. on a disposable service and empty `/data` Volume, bootstrap the image and
    prove that a failed initial install stops without an unverified fallback;

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -692,6 +692,10 @@ when Alice transitions from unavailable back to available. PTY views use that
 signal to re-attach the same Session after a recoverable tunnel/backend outage,
 including after their bounded exponential retry budget has expired. A stopped
 retry loop remains visibly closed with an explicit **Retry** action.
+Runtime-identity reads such as the running version/update authority and current
+AliceProject also invalidate outage-era requests and refetch on that recovery
+generation, so a replacement owner cannot leave Settings describing the old
+Runtime after the global overlay disappears.
 Authentication failures, another controller's ownership, and a missing Session
 remain fatal to that attachment: recovery never implies takeover, Session
 recreation, or a new Agent Runtime.

--- a/docs/remote-quickstart.md
+++ b/docs/remote-quickstart.md
@@ -166,14 +166,15 @@ at that exact Volume-root path, and startup fails closed otherwise. Never
 clear the Project or Volume; if an owner still matches a
 running deployment, stop instead of quarantining it.
 
-The default service variables select the latest stable native release, but the
-currently public stable `v0.90.2` and beta `v0.91.0-beta.1` do not advertise the
-required `railway-runtime-lock-v2` capability and are therefore rejected by
-this profile. The dev manifest current before this change is also v1-only. Do
-not deploy until this change has merged and its matching completed dev manifest
-advertises v2; that later artifact may be used for candidate acceptance. Stable
-or beta still requires a later explicit release, which this guide does not
-authorize or perform. Use only the selectors needed for the intended host:
+The default service variables select the latest stable native release. Public
+stable `v0.90.2` predates `railway-runtime-lock-v2` and is therefore rejected by
+this profile. Accepted beta `v0.91.0-beta.3` advertises both Railway Runtime
+capabilities and has passed retained-Volume replacement plus core Runtime/PTY
+recovery through a long tunnel outage. The Settings identity-refresh fix found
+by that journey lands after beta3. A completed dev manifest is eligible only
+when it advertises those same capabilities. Do not infer eligibility from a
+package version or branch name, and do not treat this guide as release
+authority. Use only the selectors needed for the intended host:
 
 ```text
 OPENALICE_RAILWAY_CHANNEL=stable

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1,12 +1,12 @@
 # Bun-native CLI Distribution
 
 Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separately
-dispatched v0.91.0-beta.2 is externally verified; stable remains v0.90.2 while
+dispatched v0.91.0-beta.3 is externally verified; stable remains v0.90.2 while
 stable/beta discovery authority is converged on the OpenAlice CDN;
 the Railway native CLI SSH host passes local empty-Volume, normal replacement,
 hard-kill recovery, real retained-Volume transfer, hosted Agent turns, and live
 v2 normal-restart/hard-kill reacceptance, plus a non-destructive switch from a
-rolling dev Runtime to pinned beta2; the disposable hosted empty-Volume and
+rolling dev Runtime to pinned beta3; the disposable hosted empty-Volume and
 forced installer-failure fallback journeys remain open; native PowerShell and
 external package-manager activation remain deferred
 
@@ -583,6 +583,11 @@ artifacts.
   `v0.91.0-beta.2`, independently verify its public surface and stable-channel
   isolation, then replace the retained Railway dev Runtime through the
   service-owned selector rather than an SSH-owned install.
+- [x] After the remote-readiness increment, publish only `v0.91.0-beta.3`,
+  independently verify all accepted assets and stable-channel isolation, then
+  replace the retained Railway beta2 Runtime through its service-owned selector
+  and pass the retained core Runtime/PTY long-outage journey. Record the
+  resulting Settings identity-refresh fix as the following `dev` increment.
 
 ### 11. Converge channel discovery authority
 
@@ -1338,6 +1343,26 @@ This plan is complete only when:
   remained executable under `/data/home`, and a fresh inspection-only SSH
   tunnel served the beta2 UI on local loopback. No installer or release-pointer
   mutation ran through Railway SSH.
+- 2026-09-01: Published only
+  [`v0.91.0-beta.3`](https://github.com/TraderAlice/OpenAlice/releases/tag/v0.91.0-beta.3)
+  from `3af7b0b3df46b829c40e6fab6698044dc60e07c7` in
+  [release run 33498423338](https://github.com/TraderAlice/OpenAlice/actions/runs/33498423338).
+  Independent acceptance matched all 49 GitHub assets and their CDN mirrors,
+  including four native CLI archives, updater feeds, installers, Broker Packs,
+  and sidecars. The beta manifest resolved beta3 while GitHub latest, the
+  stable manifest, stable feeds, and stable aliases remained v0.90.2. The
+  retained Railway service then moved from pinned beta2 to pinned beta3 through
+  service variables and deployment `745fbb1f-ed13-4df0-ab20-4d03d6e35ec0`.
+  It accepted Linux x64 SHA-256
+  `9d421eb08e58472509c053aa550db464b2f40c28e51e09da94daadf0fcbd499c`,
+  preserved `/data/projects/main-cloud`, the same AliceProject identity and six
+  Workspace directories, Pi 0.84.4, and OpenCode 1.18.25, and returned Alice,
+  UTA, and Connector ready. A shell PTY retained PID 893 and printed both sides
+  of a 120-second command while its local tunnel stayed absent beyond the
+  terminal retry budget; replacing only the tunnel restored the existing page
+  and reattached the same PTY without a manual retry or page reload. The beta3
+  UI still retained its pre-outage version/Project identity after replacement;
+  the following `dev` increment makes those domain reads recovery-aware.
 - 2026-09-01: Reframed development confidence around local acceptance instead
   of constrained hosted runners. Routine `dev` PRs now retain one clean Ubuntu
   workflow-contract, root-typecheck, and complete-build lane; relevant CLI

--- a/plans/remote-project-fleet.md
+++ b/plans/remote-project-fleet.md
@@ -699,9 +699,10 @@ Rules:
 
 ### Increment 8 — remote readiness and browser truth
 
-This is the current beta-blocking increment and may land before the remaining
-Increment 7 release-apply work. It does not grant the SSH path deployment
-authority or broaden Agent/broker ownership.
+This increment supplied the beta3 remote-readiness boundary; the recovery
+journey's Settings identity fix follows on `dev` after that release. It remains
+independent of the unfinished Increment 7 release-apply work and does not grant
+the SSH path deployment authority or broaden Agent/broker ownership.
 
 - [x] Reconcile Agent readiness from fresh PATH discovery, expose a cheap
   rediscovery action distinct from active probing, and refresh on focus,
@@ -726,10 +727,10 @@ authority or broaden Agent/broker ownership.
 - [x] Add an authoritative Issue assignee-Session projection so a newly claimed
   or cross-Workspace owner cannot coexist with a stale "Session is no longer
   available" warning.
-- [ ] Extend the Docker SSH journey with dynamic free Runtime discovery,
+- [x] Extend the Docker SSH journey with dynamic free Runtime discovery,
   missing-Pack account projection, complete client URL retention, and a real
   shell PTY tunnel reconnect. Cover the longer logical retry window with fake
-  timers and run one retained Railway long-outage journey before beta release.
+  timers and run one retained Railway long-outage journey for beta acceptance.
 - [x] Update the remote access, Agent/runtime, scheduling, Broker Pack, and
   Docker owner guides with the shipped layered-readiness contract.
 
@@ -872,9 +873,26 @@ title projection, long terminal retry exhaustion, and trading-mode/health/write
 gates. The disposable OrbStack Linux arm64 SSH journey passed both its ordinary
 and full TUI paths: an inert Pi shim was discovered and removed without ever
 executing, and a migrated Alpaca account stayed configured but non-operational
-with its Pack missing. The remaining Increment 8 acceptance item is a retained
-Railway long-outage journey on the released candidate; it intentionally stays
-open until beta3 replaces beta2 on that service.
+with its Pack missing.
+
+Increment 8 release acceptance (2026-09-01): public `v0.91.0-beta.3` replaced
+beta2 on the retained Railway service through platform-owned deployment
+`745fbb1f-ed13-4df0-ab20-4d03d6e35ec0`. The accepted Runtime preserved the
+same `/data/projects/main-cloud` AliceProject, six Workspace directories, Pi,
+OpenCode, and ready Alice/UTA/Connector components. A real shell PTY kept PID
+893 while a 120-second command crossed a tunnel outage longer than the terminal
+retry budget. Replacing only the local tunnel made the existing browser page
+recover automatically and reattach that exact PTY without clicking Retry or
+reloading. The journey also found one read-side recovery bug: About retained
+the old Runtime version and Project source after owner replacement. Version and
+AliceProject domain hooks now invalidate outage-era requests, refetch on the
+shared backend-recovery generation, and ignore late stale responses. Confirmed
+snapshots are valid only for their recovery generation, so a failed recovery
+read shows unavailable instead of reviving the old owner; version reads also
+abort when the transport disappears. The source UI repeated the real Railway
+tunnel cut while staying on Settings;
+proxy evidence recorded fresh `/api/version` and `/api/alice-project` reads,
+and the visible beta3 Runtime source remained correct after automatic recovery.
 
 Increment 8 review follow-up (2026-09-01): a read-only recovery-state review
 found six races that isolated happy-path tests had missed. Broker readiness now

--- a/ui/src/api/version.ts
+++ b/ui/src/api/version.ts
@@ -1,13 +1,13 @@
 import type { VersionInfo } from './types'
 
 export const versionApi = {
-  async get(): Promise<VersionInfo> {
-    const res = await fetch('/api/version')
+  async get(signal?: AbortSignal): Promise<VersionInfo> {
+    const res = await fetch('/api/version', { signal })
     if (!res.ok) throw new Error(`Failed to fetch version info: ${res.status}`)
     return res.json()
   },
-  async check(): Promise<VersionInfo> {
-    const res = await fetch('/api/version/check', { method: 'POST' })
+  async check(signal?: AbortSignal): Promise<VersionInfo> {
+    const res = await fetch('/api/version/check', { method: 'POST', signal })
     if (!res.ok) throw new Error(`Failed to check for updates: ${res.status}`)
     return res.json()
   },

--- a/ui/src/components/UpdateBanner.spec.tsx
+++ b/ui/src/components/UpdateBanner.spec.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { VersionInfo } from '../api/types'
 
 const mocks = vi.hoisted(() => ({
   getVersion: vi.fn(),
+  backendUnavailable: false,
+  backendRecoveryGeneration: 0,
 }))
 
 vi.mock('../api', () => ({
@@ -15,6 +17,13 @@ vi.mock('../api', () => ({
       get: mocks.getVersion,
     },
   },
+}))
+
+vi.mock('../auth/AuthContext', () => ({
+  useBackendRecoverySignal: () => ({
+    backendUnavailable: mocks.backendUnavailable,
+    backendRecoveryGeneration: mocks.backendRecoveryGeneration,
+  }),
 }))
 
 import { UpdateBanner } from './UpdateBanner'
@@ -33,6 +42,8 @@ const availableUpdate: VersionInfo = {
 
 beforeEach(() => {
   localStorage.clear()
+  mocks.backendUnavailable = false
+  mocks.backendRecoveryGeneration = 0
   mocks.getVersion.mockResolvedValue(availableUpdate)
 })
 
@@ -87,4 +98,60 @@ describe('UpdateBanner', () => {
       expect(screen.queryByText('v0.90.2')).toBeNull()
     },
   )
+
+  it('shows a newer recovered version after the previous version was skipped', async () => {
+    const view = render(<UpdateBanner />)
+    expect(await screen.findByText('v0.90.2')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Skip this version/ }))
+    expect(screen.queryByText('v0.90.2')).toBeNull()
+
+    mocks.backendUnavailable = true
+    view.rerender(<UpdateBanner />)
+    mocks.getVersion.mockResolvedValueOnce({
+      ...availableUpdate,
+      latest: '0.90.3',
+      releaseUrl: 'https://example.test/v0.90.3',
+    })
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(<UpdateBanner />)
+
+    expect(await screen.findByText('v0.90.3')).toBeTruthy()
+  })
+
+  it('keeps the close action dismissed for the rest of the page session', async () => {
+    const view = render(<UpdateBanner />)
+    expect(await screen.findByText('v0.90.2')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    mocks.backendUnavailable = true
+    view.rerender(<UpdateBanner />)
+    mocks.getVersion.mockResolvedValueOnce({
+      ...availableUpdate,
+      latest: '0.90.3',
+      releaseUrl: 'https://example.test/v0.90.3',
+    })
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(<UpdateBanner />)
+
+    await waitFor(() => expect(mocks.getVersion).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('v0.90.3')).toBeNull()
+  })
+
+  it('hides an old update when the recovered version read fails', async () => {
+    const view = render(<UpdateBanner />)
+    expect(await screen.findByText('v0.90.2')).toBeTruthy()
+
+    mocks.backendUnavailable = true
+    view.rerender(<UpdateBanner />)
+    mocks.getVersion.mockRejectedValueOnce(new Error('version unavailable'))
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(<UpdateBanner />)
+
+    await waitFor(() => expect(mocks.getVersion).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('v0.90.2')).toBeNull()
+  })
 })

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
-import { api } from '../api'
-import type { VersionInfo } from '../api/types'
+import { useVersionInfo } from '../hooks/useVersionInfo'
 
 const SKIP_STORAGE_KEY = 'openalice.update.skipVersion'
 type RuntimeMode = 'browser' | 'electron-dev' | 'electron-packaged'
@@ -21,12 +20,12 @@ type RuntimeMode = 'browser' | 'electron-dev' | 'electron-packaged'
  * native updater. Service-managed and non-updating installs do not render.
  */
 export function UpdateBanner() {
-  const [info, setInfo] = useState<VersionInfo | null>(null)
+  const { info } = useVersionInfo()
   const [runtimeMode, setRuntimeMode] = useState<RuntimeMode>('browser')
   const [sessionDismissed, setSessionDismissed] = useState(false)
+  const [sessionSkippedVersion, setSessionSkippedVersion] = useState<string | null>(null)
 
   useEffect(() => {
-    api.version.get().then(setInfo).catch(() => {})
     window.openAlice?.runtime.info()
       .then((runtime) => setRuntimeMode(runtime.mode))
       .catch(() => setRuntimeMode('browser'))
@@ -43,11 +42,11 @@ export function UpdateBanner() {
   const skippedVersion = (() => {
     try { return localStorage.getItem(SKIP_STORAGE_KEY) } catch { return null }
   })()
-  if (skippedVersion === info.latest) return null
+  if (skippedVersion === info.latest || sessionSkippedVersion === info.latest) return null
 
   const handleSkip = () => {
     try { localStorage.setItem(SKIP_STORAGE_KEY, info.latest!) } catch { /* ignore */ }
-    setSessionDismissed(true)
+    setSessionSkippedVersion(info.latest)
   }
   const handleDismiss = () => {
     setSessionDismissed(true)

--- a/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.spec.tsx
@@ -8,6 +8,8 @@ const mocks = vi.hoisted(() => ({
   checkVersion: vi.fn(),
   getAliceProject: vi.fn(),
   getBackendConnection: vi.fn(),
+  backendUnavailable: false,
+  backendRecoveryGeneration: 0,
 }))
 
 vi.mock('../../api', () => ({
@@ -24,6 +26,13 @@ vi.mock('../../api', () => ({
 
 vi.mock('../../auth/backendConnection', () => ({
   getBackendConnection: mocks.getBackendConnection,
+}))
+
+vi.mock('../../auth/AuthContext', () => ({
+  useBackendRecoverySignal: () => ({
+    backendUnavailable: mocks.backendUnavailable,
+    backendRecoveryGeneration: mocks.backendRecoveryGeneration,
+  }),
 }))
 
 import '../../i18n'
@@ -55,6 +64,8 @@ beforeAll(async () => {
 })
 
 beforeEach(() => {
+  mocks.backendUnavailable = false
+  mocks.backendRecoveryGeneration = 0
   mocks.getVersion.mockResolvedValue(currentVersion)
   mocks.checkVersion.mockResolvedValue(currentVersion)
   mocks.getAliceProject.mockResolvedValue({ project: currentProject })
@@ -97,6 +108,59 @@ describe('AboutOpenAliceSection', () => {
     render(<AboutOpenAliceSection />)
 
     expect(await screen.findByText('Development channel')).toBeTruthy()
+  })
+
+  it('refreshes Runtime and AliceProject identity after backend recovery without remounting', async () => {
+    const recoveredVersion = {
+      ...currentVersion,
+      current: '0.91.0-beta.3',
+      latest: '0.91.0-beta.3',
+      updateAuthority: 'service' as const,
+    }
+    const recoveredProject = {
+      ...currentProject,
+      displayName: 'Railway AliceProject',
+      appRoot: '/data/home/.local/share/openalice/releases/0.91.0-beta.3',
+    }
+    const view = render(<AboutOpenAliceSection />)
+
+    expect(await screen.findByText('v0.82.0-beta')).toBeTruthy()
+    expect(await screen.findByText('Research AliceProject')).toBeTruthy()
+
+    mocks.backendUnavailable = true
+    view.rerender(<AboutOpenAliceSection />)
+
+    mocks.getVersion.mockResolvedValueOnce(recoveredVersion)
+    mocks.getAliceProject.mockResolvedValueOnce({ project: recoveredProject })
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(<AboutOpenAliceSection />)
+
+    expect(await screen.findByText('v0.91.0-beta.3')).toBeTruthy()
+    expect(await screen.findByText('Railway AliceProject')).toBeTruthy()
+    expect(screen.getByText('/data/home/.local/share/openalice/releases/0.91.0-beta.3')).toBeTruthy()
+    expect(mocks.getVersion).toHaveBeenCalledTimes(2)
+    expect(mocks.getAliceProject).toHaveBeenCalledTimes(2)
+  })
+
+  it('hides the previous Runtime identity when recovery reads fail', async () => {
+    const view = render(<AboutOpenAliceSection />)
+    expect(await screen.findByText('v0.82.0-beta')).toBeTruthy()
+    expect(await screen.findByText('Research AliceProject')).toBeTruthy()
+
+    mocks.backendUnavailable = true
+    view.rerender(<AboutOpenAliceSection />)
+
+    mocks.getVersion.mockRejectedValueOnce(new Error('version unavailable'))
+    mocks.getAliceProject.mockRejectedValueOnce(new Error('project unavailable'))
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    view.rerender(<AboutOpenAliceSection />)
+
+    expect(screen.queryByText('v0.82.0-beta')).toBeNull()
+    expect(screen.queryByText('Research AliceProject')).toBeNull()
+    expect(await screen.findByText('Couldn’t check for updates.')).toBeTruthy()
+    expect(await screen.findByText('AliceProject information is unavailable.')).toBeTruthy()
   })
 
   it('shows the healthy SSH route that owns this browser surface', async () => {

--- a/ui/src/components/settings/AboutOpenAliceSection.tsx
+++ b/ui/src/components/settings/AboutOpenAliceSection.tsx
@@ -2,10 +2,9 @@ import { useEffect, useMemo, useState } from 'react'
 import { Cable, CheckCircle2, Download, ExternalLink, FolderKanban, LoaderCircle, RefreshCw, Server } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { api } from '../../api'
-import type { VersionInfo } from '../../api/types'
 import { getBackendConnection } from '../../auth/backendConnection'
 import { useAliceProject } from '../../hooks/useAliceProject'
+import { useVersionInfo } from '../../hooks/useVersionInfo'
 import { Button } from '../ui/button'
 import { ConfigSection } from '../form'
 
@@ -32,12 +31,16 @@ export function AboutOpenAliceSection() {
       ? remoteConnection.target
       : `${remoteConnection.target}:${remoteConnection.sshPort}`
     : null
-  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null)
   const [runtimeMode, setRuntimeMode] = useState<RuntimeMode>('browser')
   const [nativeStatus, setNativeStatus] = useState<NativeUpdaterStatus | null>(null)
   const [checking, setChecking] = useState(false)
   const [installing, setInstalling] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const {
+    info: versionInfo,
+    error: versionError,
+    check: checkVersion,
+  } = useVersionInfo()
   const {
     project,
     loading: projectLoading,
@@ -47,14 +50,6 @@ export function AboutOpenAliceSection() {
 
   useEffect(() => {
     let active = true
-    void api.version.get()
-      .then((next) => {
-        if (active) setVersionInfo(next)
-      })
-      .catch(() => {
-        if (active) setError(t('settings.about.checkError'))
-      })
-
     const runtime = window.openAlice?.runtime
     if (runtime) {
       void runtime.info()
@@ -78,7 +73,7 @@ export function AboutOpenAliceSection() {
       active = false
       unsubscribe()
     }
-  }, [t])
+  }, [])
 
   const currentVersion = versionInfo?.current ?? t('settings.about.versionLoading')
   const updateVersion = nativeStatus && 'version' in nativeStatus && nativeStatus.version
@@ -128,7 +123,7 @@ export function AboutOpenAliceSection() {
           : t('settings.about.status.availableUnknown'),
       }
     }
-    if (nativeStatus?.phase === 'error' || versionInfo?.error || error) {
+    if (nativeStatus?.phase === 'error' || versionInfo?.error || versionError || error) {
       return { kind: 'error' as const, text: t('settings.about.status.error') }
     }
     if (versionInfo?.updateAuthority === 'service') {
@@ -144,7 +139,7 @@ export function AboutOpenAliceSection() {
       return { kind: 'current' as const, text: t('settings.about.status.current') }
     }
     return { kind: 'checking' as const, text: t('settings.about.status.loading') }
-  }, [checking, error, nativeStatus, t, updateVersion, versionInfo])
+  }, [checking, error, nativeStatus, t, updateVersion, versionError, versionInfo])
 
   const checkForUpdates = async () => {
     setChecking(true)
@@ -153,10 +148,9 @@ export function AboutOpenAliceSection() {
       const nativeCheck = window.openAlice?.updater?.checkForUpdates().catch(() => null)
       const [, next] = await Promise.all([
         nativeCheck ?? Promise.resolve(null),
-        api.version.check(),
+        checkVersion(),
       ])
-      setVersionInfo(next)
-      if (next.error) setError(t('settings.about.checkError'))
+      if (next?.error) setError(t('settings.about.checkError'))
     } catch {
       setError(t('settings.about.checkError'))
     } finally {

--- a/ui/src/hooks/useAliceProject.spec.ts
+++ b/ui/src/hooks/useAliceProject.spec.ts
@@ -5,10 +5,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAliceProject } from './useAliceProject'
 
-const mocks = vi.hoisted(() => ({ get: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  backendUnavailable: false,
+  backendRecoveryGeneration: 0,
+}))
 
 vi.mock('../api', () => ({
   api: { aliceProject: { get: mocks.get } },
+}))
+
+vi.mock('../auth/AuthContext', () => ({
+  useBackendRecoverySignal: () => ({
+    backendUnavailable: mocks.backendUnavailable,
+    backendRecoveryGeneration: mocks.backendRecoveryGeneration,
+  }),
 }))
 
 const project = {
@@ -19,7 +30,19 @@ const project = {
   appRoot: '/tmp/source',
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (cause: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 beforeEach(() => {
+  mocks.backendUnavailable = false
+  mocks.backendRecoveryGeneration = 0
   mocks.get.mockResolvedValue({ project })
   Reflect.deleteProperty(window, 'openAlice')
 })
@@ -56,5 +79,92 @@ describe('useAliceProject', () => {
     await act(async () => { await result.current.refresh() })
     expect(result.current.project).toEqual(project)
     expect(result.current.error).toBeNull()
+  })
+
+  it('preserves the confirmed project during an outage and reloads it after recovery', async () => {
+    const recoveredProject = {
+      ...project,
+      displayName: 'Recovered AliceProject',
+      appRoot: '/tmp/recovered-source',
+    }
+    const { result, rerender } = renderHook(() => useAliceProject())
+    await waitFor(() => expect(result.current.project).toEqual(project))
+
+    mocks.backendUnavailable = true
+    rerender()
+    expect(result.current.project).toEqual(project)
+    expect(result.current.loading).toBe(false)
+
+    await act(async () => { await result.current.refresh() })
+    expect(mocks.get).toHaveBeenCalledTimes(1)
+    expect(result.current.project).toEqual(project)
+
+    mocks.get.mockResolvedValueOnce({ project: recoveredProject })
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    rerender()
+
+    await waitFor(() => expect(result.current.project).toEqual(recoveredProject))
+    expect(result.current.error).toBeNull()
+    expect(mocks.get).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores an old request that settles after the recovery refresh', async () => {
+    const staleProject = { ...project, displayName: 'Stale AliceProject' }
+    const recoveredProject = { ...project, displayName: 'Recovered AliceProject' }
+    const stale = deferred<{ project: typeof project }>()
+    const recovered = deferred<{ project: typeof project }>()
+    const { result, rerender } = renderHook(() => useAliceProject())
+    await waitFor(() => expect(result.current.project).toEqual(project))
+
+    mocks.get.mockReturnValueOnce(stale.promise)
+    let staleRefresh!: Promise<void>
+    act(() => {
+      staleRefresh = result.current.refresh()
+    })
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledTimes(2))
+
+    mocks.backendUnavailable = true
+    rerender()
+    expect(result.current.project).toEqual(project)
+
+    mocks.get.mockReturnValueOnce(recovered.promise)
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    rerender()
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledTimes(3))
+
+    await act(async () => {
+      recovered.resolve({ project: recoveredProject })
+      await recovered.promise
+    })
+    await waitFor(() => expect(result.current.project).toEqual(recoveredProject))
+
+    await act(async () => {
+      stale.resolve({ project: staleProject })
+      await staleRefresh
+    })
+    expect(result.current.project).toEqual(recoveredProject)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('does not expose the old owner project when the recovery read fails', async () => {
+    const { result, rerender } = renderHook(() => useAliceProject())
+    await waitFor(() => expect(result.current.project).toEqual(project))
+
+    mocks.backendUnavailable = true
+    rerender()
+    expect(result.current.project).toEqual(project)
+
+    mocks.get.mockRejectedValueOnce(new Error('recovered project read failed'))
+    mocks.backendUnavailable = false
+    mocks.backendRecoveryGeneration = 1
+    rerender()
+
+    expect(result.current.project).toBeNull()
+    await waitFor(() => expect(result.current.error).toBe('recovered project read failed'))
+    expect(result.current.project).toBeNull()
+    expect(result.current.loading).toBe(false)
   })
 })

--- a/ui/src/hooks/useAliceProject.ts
+++ b/ui/src/hooks/useAliceProject.ts
@@ -1,12 +1,18 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { api, type AliceProject } from '../api'
+import { useBackendRecoverySignal } from '../auth/AuthContext'
 
 export interface AliceProjectSnapshot {
   readonly project: AliceProject | null
   readonly loading: boolean
   readonly error: string | null
   refresh(): Promise<void>
+}
+
+interface ConfirmedAliceProject {
+  readonly project: AliceProject
+  readonly backendRecoveryGeneration: number
 }
 
 async function loadAliceProject(): Promise<AliceProject> {
@@ -22,38 +28,91 @@ async function loadAliceProject(): Promise<AliceProject> {
  * never needs transport branching or direct backend reads.
  */
 export function useAliceProject(): AliceProjectSnapshot {
-  const [project, setProject] = useState<AliceProject | null>(null)
+  const { backendUnavailable, backendRecoveryGeneration } = useBackendRecoverySignal()
+  const [confirmed, setConfirmed] = useState<ConfirmedAliceProject | null>(null)
+  const [attemptGeneration, setAttemptGeneration] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const mountedRef = useRef(false)
+  const requestGenerationRef = useRef(0)
+  const backendUnavailableRef = useRef(backendUnavailable)
+  const backendRecoveryGenerationRef = useRef(backendRecoveryGeneration)
+  backendUnavailableRef.current = backendUnavailable
+  backendRecoveryGenerationRef.current = backendRecoveryGeneration
 
-  const refresh = useCallback(async () => {
+  const performRefresh = useCallback(async () => {
+    const requestGeneration = ++requestGenerationRef.current
+    const recoveryGeneration = backendRecoveryGenerationRef.current
+    setAttemptGeneration(recoveryGeneration)
     setLoading(true)
     setError(null)
     try {
-      setProject(await loadAliceProject())
+      const next = await loadAliceProject()
+      if (
+        !mountedRef.current
+        || backendUnavailableRef.current
+        || requestGeneration !== requestGenerationRef.current
+        || recoveryGeneration !== backendRecoveryGenerationRef.current
+      ) return
+      setConfirmed({
+        project: next,
+        backendRecoveryGeneration: recoveryGeneration,
+      })
     } catch (cause) {
+      if (
+        !mountedRef.current
+        || backendUnavailableRef.current
+        || requestGeneration !== requestGenerationRef.current
+        || recoveryGeneration !== backendRecoveryGenerationRef.current
+      ) return
       setError(cause instanceof Error ? cause.message : String(cause))
     } finally {
+      if (
+        mountedRef.current
+        && !backendUnavailableRef.current
+        && requestGeneration === requestGenerationRef.current
+        && recoveryGeneration === backendRecoveryGenerationRef.current
+      ) setLoading(false)
+    }
+  }, [])
+
+  const refresh = useCallback(async () => {
+    if (backendUnavailable) {
       setLoading(false)
+      return
+    }
+    await performRefresh()
+  }, [backendUnavailable, performRefresh])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      requestGenerationRef.current += 1
     }
   }, [])
 
   useEffect(() => {
-    let active = true
-    setLoading(true)
-    setError(null)
-    void loadAliceProject()
-      .then((next) => {
-        if (active) setProject(next)
-      })
-      .catch((cause) => {
-        if (active) setError(cause instanceof Error ? cause.message : String(cause))
-      })
-      .finally(() => {
-        if (active) setLoading(false)
-      })
-    return () => { active = false }
-  }, [])
+    if (backendUnavailable) {
+      // Preserve the last confirmed AliceProject while the shared offline UI
+      // owns outage presentation. Retire any request that may still resolve
+      // after the transport has already disappeared.
+      requestGenerationRef.current += 1
+      setLoading(false)
+      return
+    }
+    // A recovery generation supersedes requests left hanging by the outage.
+    // The request/recovery epochs above prevent their late results from
+    // overwriting this fresh Runtime identity.
+    void performRefresh()
+  }, [backendRecoveryGeneration, backendUnavailable, performRefresh])
 
-  return { project, loading, error, refresh }
+  const snapshotIsCurrent = confirmed?.backendRecoveryGeneration === backendRecoveryGeneration
+  const attemptIsCurrent = attemptGeneration === backendRecoveryGeneration
+  return {
+    project: snapshotIsCurrent ? confirmed.project : null,
+    loading: backendUnavailable ? false : attemptIsCurrent ? loading : true,
+    error: attemptIsCurrent ? error : null,
+    refresh,
+  }
 }

--- a/ui/src/hooks/useVersionInfo.spec.ts
+++ b/ui/src/hooks/useVersionInfo.spec.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  check: vi.fn(),
+  recovery: {
+    backendUnavailable: false,
+    backendRecoveryGeneration: 0,
+  },
+}))
+
+vi.mock('../api', () => ({
+  api: { version: { get: mocks.get, check: mocks.check } },
+}))
+
+vi.mock('../auth/AuthContext', () => ({
+  useBackendRecoverySignal: () => ({ ...mocks.recovery }),
+}))
+
+import type { VersionInfo } from '../api/types'
+import { useVersionInfo } from './useVersionInfo'
+
+function version(current: string): VersionInfo {
+  return {
+    current,
+    channel: 'beta',
+    updateAuthority: 'service',
+    latest: current,
+    hasUpdate: false,
+    releaseUrl: `https://example.test/v${current}`,
+    releaseNotes: null,
+    publishedAt: null,
+    error: null,
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (cause: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  mocks.recovery.backendUnavailable = false
+  mocks.recovery.backendRecoveryGeneration = 0
+  mocks.get.mockResolvedValue(version('0.91.0-beta.2'))
+  mocks.check.mockResolvedValue(version('0.91.0-beta.2'))
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useVersionInfo', () => {
+  it('loads passively and exposes explicit refresh and forced-check reads', async () => {
+    const hook = renderHook(() => useVersionInfo())
+
+    expect(hook.result.current.loading).toBe(true)
+    await waitFor(() => expect(hook.result.current.info?.current).toBe('0.91.0-beta.2'))
+    expect(hook.result.current.error).toBeNull()
+
+    mocks.get.mockResolvedValueOnce(version('0.91.0-beta.3'))
+    await act(async () => { await hook.result.current.refresh() })
+    expect(hook.result.current.info?.current).toBe('0.91.0-beta.3')
+
+    mocks.check.mockResolvedValueOnce(version('0.91.0-beta.4'))
+    await act(async () => { await hook.result.current.check() })
+    expect(hook.result.current.info?.current).toBe('0.91.0-beta.4')
+    expect(mocks.get).toHaveBeenCalledTimes(2)
+    expect(mocks.check).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the last confirmed snapshot when a refresh fails', async () => {
+    const hook = renderHook(() => useVersionInfo())
+    await waitFor(() => expect(hook.result.current.info?.current).toBe('0.91.0-beta.2'))
+
+    mocks.get.mockRejectedValueOnce(new Error('version endpoint offline'))
+    await act(async () => { await hook.result.current.refresh() })
+
+    expect(hook.result.current.info?.current).toBe('0.91.0-beta.2')
+    expect(hook.result.current.loading).toBe(false)
+    expect(hook.result.current.error).toBe('version endpoint offline')
+  })
+
+  it('invalidates an outage request and ignores it after the recovered read wins', async () => {
+    const stale = deferred<VersionInfo>()
+    mocks.get.mockReturnValueOnce(stale.promise)
+    const hook = renderHook(() => useVersionInfo())
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledOnce())
+
+    mocks.recovery.backendUnavailable = true
+    hook.rerender()
+    expect(hook.result.current.loading).toBe(false)
+
+    mocks.get.mockResolvedValueOnce(version('0.91.0-beta.3'))
+    mocks.recovery.backendUnavailable = false
+    mocks.recovery.backendRecoveryGeneration = 1
+    hook.rerender()
+
+    await waitFor(() => expect(hook.result.current.info?.current).toBe('0.91.0-beta.3'))
+    expect(mocks.get).toHaveBeenCalledTimes(2)
+
+    await act(async () => { stale.resolve(version('0.91.0-beta.2')) })
+    expect(hook.result.current.info?.current).toBe('0.91.0-beta.3')
+  })
+
+  it('does not expose the old owner snapshot when the recovery read fails', async () => {
+    const hook = renderHook(() => useVersionInfo())
+    await waitFor(() => expect(hook.result.current.info?.current).toBe('0.91.0-beta.2'))
+
+    mocks.recovery.backendUnavailable = true
+    hook.rerender()
+    expect(hook.result.current.info?.current).toBe('0.91.0-beta.2')
+
+    mocks.get.mockRejectedValueOnce(new Error('recovered version read failed'))
+    mocks.recovery.backendUnavailable = false
+    mocks.recovery.backendRecoveryGeneration = 1
+    hook.rerender()
+
+    expect(hook.result.current.info).toBeNull()
+    await waitFor(() => expect(hook.result.current.error).toBe('recovered version read failed'))
+    expect(hook.result.current.info).toBeNull()
+    expect(hook.result.current.loading).toBe(false)
+  })
+
+  it('aborts an in-flight manual check when the backend becomes unavailable', async () => {
+    const hook = renderHook(() => useVersionInfo())
+    await waitFor(() => expect(hook.result.current.info?.current).toBe('0.91.0-beta.2'))
+    mocks.check.mockImplementationOnce((signal: AbortSignal) => new Promise((_, reject) => {
+      signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+    }))
+
+    let checking!: Promise<VersionInfo | null>
+    act(() => { checking = hook.result.current.check() })
+    await waitFor(() => expect(mocks.check).toHaveBeenCalledOnce())
+
+    mocks.recovery.backendUnavailable = true
+    hook.rerender()
+
+    await expect(checking).resolves.toBeNull()
+    expect(hook.result.current.loading).toBe(false)
+    expect(hook.result.current.error).toBeNull()
+  })
+
+  it('waits for recovery instead of reading while mounted offline', async () => {
+    mocks.recovery.backendUnavailable = true
+    const hook = renderHook(() => useVersionInfo())
+
+    await waitFor(() => expect(hook.result.current.loading).toBe(false))
+    await act(async () => {
+      expect(await hook.result.current.refresh()).toBeNull()
+      expect(await hook.result.current.check()).toBeNull()
+    })
+    expect(mocks.get).not.toHaveBeenCalled()
+    expect(mocks.check).not.toHaveBeenCalled()
+
+    mocks.recovery.backendUnavailable = false
+    mocks.recovery.backendRecoveryGeneration = 1
+    hook.rerender()
+
+    await waitFor(() => expect(hook.result.current.info?.current).toBe('0.91.0-beta.2'))
+    expect(mocks.get).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/hooks/useVersionInfo.ts
+++ b/ui/src/hooks/useVersionInfo.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { api } from '../api'
+import type { VersionInfo } from '../api/types'
+import { useBackendRecoverySignal } from '../auth/AuthContext'
+
+export interface VersionInfoSnapshot {
+  readonly info: VersionInfo | null
+  readonly loading: boolean
+  readonly error: string | null
+  refresh(): Promise<VersionInfo | null>
+  check(): Promise<VersionInfo | null>
+}
+
+interface ConfirmedVersionInfo {
+  readonly info: VersionInfo
+  readonly backendRecoveryGeneration: number
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+/**
+ * Recovery-aware read boundary for the running OpenAlice version and update
+ * channel. A confirmed backend outage invalidates every pending request; the
+ * recovery generation then starts a fresh passive read against the new owner.
+ */
+export function useVersionInfo(): VersionInfoSnapshot {
+  const { backendUnavailable, backendRecoveryGeneration } = useBackendRecoverySignal()
+  const [confirmed, setConfirmed] = useState<ConfirmedVersionInfo | null>(null)
+  const [attemptGeneration, setAttemptGeneration] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const mounted = useRef(true)
+  const requestGeneration = useRef(0)
+  const activeRequest = useRef<AbortController | null>(null)
+  const backendUnavailableRef = useRef(backendUnavailable)
+  const backendRecoveryGenerationRef = useRef(backendRecoveryGeneration)
+  backendUnavailableRef.current = backendUnavailable
+  backendRecoveryGenerationRef.current = backendRecoveryGeneration
+
+  const request = useCallback(async (
+    load: (signal: AbortSignal) => Promise<VersionInfo>,
+  ): Promise<VersionInfo | null> => {
+    if (!mounted.current || backendUnavailableRef.current) return null
+    activeRequest.current?.abort()
+    const controller = new AbortController()
+    activeRequest.current = controller
+    const generation = ++requestGeneration.current
+    const recoveryGeneration = backendRecoveryGenerationRef.current
+    setAttemptGeneration(recoveryGeneration)
+    setLoading(true)
+    setError(null)
+    try {
+      const next = await load(controller.signal)
+      if (
+        !mounted.current
+        || backendUnavailableRef.current
+        || generation !== requestGeneration.current
+        || recoveryGeneration !== backendRecoveryGenerationRef.current
+      ) return null
+      setConfirmed({
+        info: next,
+        backendRecoveryGeneration: recoveryGeneration,
+      })
+      return next
+    } catch (cause) {
+      if (
+        !mounted.current
+        || backendUnavailableRef.current
+        || generation !== requestGeneration.current
+        || recoveryGeneration !== backendRecoveryGenerationRef.current
+      ) return null
+      setError(errorMessage(cause))
+      return null
+    } finally {
+      if (
+        mounted.current
+        && !backendUnavailableRef.current
+        && generation === requestGeneration.current
+        && recoveryGeneration === backendRecoveryGenerationRef.current
+      ) setLoading(false)
+      if (activeRequest.current === controller) activeRequest.current = null
+    }
+  }, [])
+
+  const refresh = useCallback(
+    () => backendUnavailable
+      ? Promise.resolve(null)
+      : request((signal) => api.version.get(signal)),
+    [backendUnavailable, request],
+  )
+  const check = useCallback(
+    () => backendUnavailable
+      ? Promise.resolve(null)
+      : request((signal) => api.version.check(signal)),
+    [backendUnavailable, request],
+  )
+
+  useEffect(() => {
+    // React StrictMode replays effects in development, so every setup must
+    // restore the mounted marker after the preceding probe cleanup.
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      requestGeneration.current += 1
+      activeRequest.current?.abort()
+      activeRequest.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (backendUnavailable) {
+      // The old endpoint may still resolve a request after a tunnel or process
+      // handoff. Retire that generation immediately and keep the last confirmed
+      // snapshot until the replacement backend answers.
+      requestGeneration.current += 1
+      activeRequest.current?.abort()
+      activeRequest.current = null
+      setLoading(false)
+      return
+    }
+    void refresh()
+  }, [backendRecoveryGeneration, backendUnavailable, refresh])
+
+  const snapshotIsCurrent = confirmed?.backendRecoveryGeneration === backendRecoveryGeneration
+  const attemptIsCurrent = attemptGeneration === backendRecoveryGeneration
+  return {
+    info: snapshotIsCurrent ? confirmed.info : null,
+    loading: backendUnavailable ? false : attemptIsCurrent ? loading : true,
+    error: attemptIsCurrent ? error : null,
+    refresh,
+    check,
+  }
+}


### PR DESCRIPTION
## Outcome

Remote clients no longer keep showing the previous backend owner after an SSH tunnel or Railway runtime is replaced. Version and AliceProject identity now refresh through recovery-aware domain hooks, stale responses cannot win, and active reads are aborted when a backend generation is superseded.

## Product behavior

- About OpenAlice and UpdateBanner share one recovery-aware version source.
- AliceProject identity is hidden while a recovered backend is being confirmed instead of reviving stale owner data.
- Failed recovery reads stay unavailable rather than falling back to the old backend.
- Update skip remains version-specific; session close remains session-wide.
- Remote deployment docs and active plans record the beta.3 Railway acceptance boundary and this following-dev fix.

## Verification

- `npx tsc --noEmit`
- `pnpm test`: 5,445 passed, 13 skipped
- focused UI recovery suite: 29 passed
- `cd ui && npx tsc -b`
- `pnpm -F open-alice-ui build`
- `pnpm build`: 15/15 packages
- real Railway beta.3 surface: cut the SSH tunnel for longer than the terminal retry window, restarted only the tunnel, and confirmed the page recovered without reload while the same PTY process remained attached
- final source UI pass confirmed beta.3 version, `/data/projects/main-cloud`, Runtime source, outage overlay, and fresh identity after recovery

## Release boundary

The published `v0.91.0-beta.3` already passed the core Runtime and PTY long-outage recovery exercise. This UI identity-refresh repair is the next `dev` increment; it does not republish or mutate beta.3.