### PR TITLE
fix: align source version and system test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
   test:
     needs: change-scope
     # Local verification plus build/type/contracts are the routine dev gate.
-    # Keep the full suite for master, scheduled, and manually requested runs.
+    # Keep the hermetic suite and serialized local Railway lifecycle suite for
+    # master, scheduled, and manually requested runs.
     # A classifier/preflight failure falls back to the full suite only where
     # full validation already belongs: master, scheduled, and manual lanes.
     if: >-
@@ -114,7 +115,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm test
+      - name: Run hermetic monorepo suite
+        run: pnpm test
+
+      - name: Run local Railway lifecycle system suite
+        run: pnpm test:railway:local
+        timeout-minutes: 5
 
   # Preserve the established check name for branch protection and external
   # consumers while the two independent validations report failures earlier.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ pnpm install              # full local install, including Electron
 pnpm dev                  # Guardian -> UTA + Alice + Vite
 pnpm dev --takeover       # replace the recorded local Guardian owner tree
 pnpm build                # packages + UI + UTA + Alice
-pnpm test                 # monorepo Vitest suite
+pnpm test                 # hermetic monorepo Vitest suite
+pnpm test:railway:local   # explicit local Railway entrypoint/fence system suite
 pnpm test:e2e             # non-trading product/integration E2E
 ```
 
@@ -101,6 +102,12 @@ for current ownership and entry points.
   installer, while stable CDN product aliases and package-manager metadata are
   updated only by a stable release tag. Mirror repair never rewrites the shared
   installer.
+- The root and CLI package versions are runtime-visible build metadata, including
+  in source mode. After a release succeeds and its public surface is accepted,
+  synchronize those two version values back to `dev` in a focused dev-targeted
+  PR without importing unrelated `master` changes. Runtime identity still owns
+  channel selection: `OPENALICE_LAUNCHER=dev` and `electron-dev` remain
+  `dev`/source even when the synchronized package version is stable or beta.
 - An exact forward beta version-only PR uses a lightweight trusted-classifier,
   workflow-contract, and typecheck lane. Beta publication is gated by the
   Release workflow's final artifact build/install/start/update acceptance, not
@@ -191,7 +198,7 @@ Add checks according to the touched surface:
 | Guardian locks, process ownership, takeover | `pnpm test:guardian-recovery`; exercise the real launcher path |
 | Desktop, IPC, PTY, managed Pi, shell, packaging | Follow [Managed Workspace runtime](docs/managed-workspace-runtime.md) and run the matching Electron/package smoke |
 | Root installer or distributed CLI payload | Follow [CLI installer](docs/cli-installer.md) and run `pnpm test:install:docker`; manually walk the interactive playground before release |
-| Docker/server image, Compose, remote deployment | Follow [Docker deployment](docs/docker-deployment.md) and run `pnpm docker:smoke`; before release, opt into the credentialed agent/CLI check documented there |
+| Docker/server image, Compose, remote deployment | Follow [Docker deployment](docs/docker-deployment.md); run `pnpm test:railway:local` for Railway lifecycle/fence changes and `pnpm docker:smoke` for the server image; before release, opt into the credentialed agent/CLI check documented there |
 | Persisted data shape | First apply the release-boundary rule above. For a shipped shape, add an idempotent migration + spec, register it, then run `pnpm build:migration-index`; replace unreleased shapes directly |
 | Onboarding/first run/auth | Use isolated data; exercise dev and packaged onboarding paths where relevant |
 
@@ -202,6 +209,13 @@ routine CI or against real-money accounts. Inspect the account mode and the
 pre-test positions/orders before acknowledging it, then verify the account is
 flat after the run even when a test fails. Do not call a change verified when
 the surface-specific path was skipped; state the remaining gap.
+
+`pnpm test` is the hermetic default contract. It must not invoke Railway CLI,
+open real remote SSH, read cloud credentials, deploy, publish, or contend for a
+host-global Railway lifecycle fence. The local entrypoint and Linux fence/PTY
+harnesses run only through `pnpm test:railway:local`; real Railway migration,
+restart, and upgrade journeys remain explicit external acceptance and are not a
+routine `dev` or beta gate.
 
 For local package verification, prefer `pnpm electron:smoke:workspace`: it owns
 an isolated package output and removes that large expanded app after the smoke

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -298,7 +298,9 @@ change channels or trust boundaries.
 Installed provenance and the runtime profile determine which surface may
 offer an update; package semver alone is not authority:
 
-- source checkouts use Git and may show source-update guidance;
+- source checkouts launched by `pnpm dev` or Electron development identify as
+  `dev`/source before package-semver fallback, use Git for source movement, and
+  may show source-update guidance;
 - packaged Electron uses the native desktop updater;
 - installed stable and beta releases use `openalice update` as the update entry
   point; that command defers to npm, Bun, Homebrew, or AUR when provenance says
@@ -315,6 +317,12 @@ channel and update authority. They never expose the provenance file path.
 Service-managed, dev, pinned, and custom contexts do not fetch a release
 manifest through these routes, so the Web UI cannot invent a second update
 path beside the native CLI or deployment workflow.
+
+The root and CLI package versions still supply runtime-visible build metadata.
+After a beta or stable release is publicly accepted, copy the two synchronized
+version values back to `dev` in a focused PR. That bookkeeping keeps source
+display and consumers of `getCurrentVersion()` current; it does not select the
+source checkout's update channel or import unrelated `master` changes.
 
 The standalone launcher propagates the already-discovered `install-source.json`
 path into Guardian and Alice. This covers metadata beside the install prefix
@@ -497,14 +505,18 @@ pnpm test
 For a volume-backed Railway bootstrap or managed cross-target change, also run:
 
 ```bash
-bash -n scripts/railway/*.sh
+pnpm test:railway:local
 pnpm exec vitest run \
-  scripts/railway-entrypoint.spec.ts \
   packages/cli/src/remote.spec.mjs \
   packages/cli/src/project-transfer.spec.ts \
   packages/cli/src/project-transfer-ssh.spec.ts \
   packages/cli/src/project-transfer-stream.spec.ts
 ```
+
+The explicit Railway-local command is serialized because its entrypoint and
+Linux fence/PTY fixtures may own a host-global mount lock. It uses fake
+installer/Runtime processes and never calls Railway CLI or a hosted Project;
+the two hosted acceptance journeys below remain manual and external.
 
 These local checks replace neither hosted acceptance journey: a disposable
 empty-Volume bootstrap/fail-closed drill, nor a non-destructive deployment,

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -237,10 +237,11 @@ delivery lane:
   Electron, Docker, installer, or native-runtime evidence; hosted CI is not a
   second purchase of the same confidence.
 - PRs to `master`, `master` pushes, scheduled runs, and manual validation retain
-  the full Ubuntu test lane, macOS/Windows build-and-test matrix, and native
-  dev-smoke. Routine integration PRs do not allocate those runners. There is no
-  changed-test or actor/label router: the branch boundary is intentionally
-  simple, and current `dev` receives a daily full cross-platform backstop.
+  the hermetic Ubuntu suite, the serialized local Railway lifecycle system
+  suite, macOS/Windows build-and-test matrix, and native dev-smoke. Routine
+  integration PRs do not allocate those runners. There is no changed-test or
+  actor/label router: the branch boundary is intentionally simple, and current
+  `dev` receives a daily full cross-platform backstop.
 - A `master`-targeted PR whose complete diff is exactly the synchronized,
   forward beta `version` value in `package.json` and
   `packages/cli/package.json` takes the release-preparation fast lane. It keeps
@@ -300,12 +301,15 @@ delivery lane:
   daily cross-platform backstop for lightweight PRs.
 
 Routine integration has no hosted changed-path allowlist. Serial development
-uses the local Mac for the complete `npx tsc --noEmit` and `pnpm test` contract,
-adding real browser, OrbStack, installer, unsigned Electron/package, and native
-runtime acceptance when those surfaces change. Record those commands and
-results in the PR. A promotion to `master` re-establishes full remote evidence;
-stable keeps the complete matrix even when routine integration and beta used
-lighter hosted feedback.
+uses the local Mac for the complete `npx tsc --noEmit` and hermetic `pnpm test`
+contract, adding `pnpm test:railway:local`, real browser, OrbStack, installer,
+unsigned Electron/package, and native runtime acceptance only when those
+surfaces change. Record those commands and results in the PR. The Railway local
+suite executes the image entrypoint and Linux mount-fence/PTY harness against
+disposable fixtures; it never invokes Railway CLI or a live Project. A
+promotion to `master` re-establishes full remote evidence; stable keeps the
+complete matrix even when routine integration and beta used lighter hosted
+feedback.
 
 ### Package signing boundary
 
@@ -405,11 +409,15 @@ Before merging a promotion:
 After promotion, a maintainer may prepare a focused version-only branch from
 `master` and target its PR back to `master` when the source is ready to release.
 This maintainer-directed release-prep PR is the narrow exception to the normal
-`dev` base. Keep this publication-only version commit on `master`: the `dev`
-preview keeps its integration version, and a later merge preserves the
-master-only change unless the manifests themselves conflict. Run the `Release`
-workflow manually from `master`, choose the `release` operation, and supply both
-the channel and tag:
+`dev` base. Keep this publication-only commit on `master` until the release and
+its public surface are accepted. Then copy only the synchronized root and CLI
+`version` values back to `dev` through a focused dev-targeted PR; do not merge
+unrelated `master` changes or turn that bookkeeping into a second implementation
+lane. Source runtime identity remains independent of that value:
+`OPENALICE_LAUNCHER=dev` and `electron-dev` select the `dev` channel, while
+`package.json` supplies the display/build baseline. Run the `Release` workflow
+manually from `master`, choose the `release` operation, and supply both the
+channel and tag:
 `beta` accepts `vX.Y.Z-beta` or `vX.Y.Z-beta.N`; `stable` accepts only
 `vX.Y.Z`. The workflow rejects an existing tag, a channel/tag mismatch, or a
 version that disagrees with either the root or `packages/cli` package. It binds

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -275,9 +275,8 @@ plugins, and upgrades remain outside the OpenAlice release transaction.
 Local contract checks for this profile are:
 
 ```bash
-bash -n scripts/railway/*.sh
+pnpm test:railway:local
 pnpm exec vitest run \
-  scripts/railway-entrypoint.spec.ts \
   packages/guardian-runtime/src/runtime-lock.spec.ts \
   packages/cli/src/lifecycle.spec.mjs \
   packages/cli/src/server-control.spec.mjs \
@@ -286,6 +285,13 @@ pnpm exec vitest run \
   packages/cli/src/project-transfer-ssh.spec.ts \
   packages/cli/src/project-transfer-stream.spec.ts
 ```
+
+`pnpm test:railway:local` owns shell syntax, the fake-installer/fake-Runtime
+entrypoint journey, and the Linux `/dev/shm` lifecycle-fence/PTY proof. It is a
+serialized local system test: it does not call Railway CLI, open remote SSH,
+read cloud credentials, or touch a hosted Project. It is intentionally outside
+the default hermetic `pnpm test` suite. The retained and disposable hosted
+Volume journeys below remain explicit operator acceptance.
 
 The entrypoint fixture must cover empty-volume bootstrap, verified-install
 reuse without installer access, failed forced-refresh fallback, and fail-closed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.90.1",
+  "version": "0.91.0-beta.3",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {
@@ -53,9 +53,10 @@
     "electron:smoke:upgrade": "node scripts/desktop-upgrade-smoke.mjs",
     "vendor:runtime": "node scripts/vendor-managed-runtime.mjs",
     "test": "vitest run",
+    "test:railway:local": "bash -n scripts/railway/*.sh && vitest run --config vitest.railway.config.ts",
     "test:workflow-contracts": "vitest run --project node scripts/classify-beta-release-prep.spec.mjs scripts/ci-workflow.spec.ts scripts/beta-release-prep-workflow.spec.ts scripts/cli-channel-authority-workflow.spec.ts scripts/cli-installer-workflow.spec.ts scripts/desktop-package-workflow.spec.ts scripts/release-workflow.spec.ts",
     "test:cli": "pnpm -F @traderalice/openalice-cli test",
-    "test:platform-contracts": "vitest run --project node packages/cli/src packages/guardian-runtime/src scripts/guardian/shared.spec.ts scripts/pnpm-command.spec.ts scripts/railway-entrypoint.spec.ts services/connector/src/core/io-journal.spec.ts services/uta/src/uta-startup-resilience.spec.ts src/core/windows-workspace-shell.spec.ts src/services/auth/session-store.spec.ts src/services/auth/token-store.spec.ts src/workspaces/adapters/ai-config.spec.ts src/workspaces/adapters/shell.spec.ts src/workspaces/agent-conversation-log.spec.ts src/workspaces/agent-detect.spec.ts src/workspaces/cli/shim.spec.ts src/workspaces/headless-task-win-shim.spec.ts src/workspaces/spawn-env.spec.ts src/workspaces/win-command.spec.ts src/workspaces/workspace-creator.spec.ts",
+    "test:platform-contracts": "vitest run --project node packages/cli/src packages/guardian-runtime/src scripts/guardian/shared.spec.ts scripts/pnpm-command.spec.ts services/connector/src/core/io-journal.spec.ts services/uta/src/uta-startup-resilience.spec.ts src/core/windows-workspace-shell.spec.ts src/services/auth/session-store.spec.ts src/services/auth/token-store.spec.ts src/workspaces/adapters/ai-config.spec.ts src/workspaces/adapters/shell.spec.ts src/workspaces/agent-conversation-log.spec.ts src/workspaces/agent-detect.spec.ts src/workspaces/cli/shim.spec.ts src/workspaces/headless-task-win-shim.spec.ts src/workspaces/spawn-env.spec.ts src/workspaces/win-command.spec.ts src/workspaces/workspace-creator.spec.ts",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:uta:live-paper": "vitest run --config vitest.uta-live.config.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.90.1",
+  "version": "0.91.0-beta.3",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -357,6 +357,11 @@ by the native CLI or deployment through checksum and content identity, not by
 package semver in the browser. Pinned, custom, and invalid provenance fail
 closed without an implicit update action.
 
+Package semver remains build/display metadata rather than source-channel
+authority. Once a release is accepted, a focused two-manifest PR synchronizes
+its root and CLI versions back to `dev`; explicit source launcher identity keeps
+that checkout on the dev channel.
+
 ## Alternatives Considered
 
 | Shape | Decision | Reason |
@@ -571,7 +576,8 @@ artifacts.
 - [x] Promote the exact accepted `dev` tip, including the GitHub-safe AUR
   metadata asset contract, to `master` through the full promotion gate.
 - [x] Use a focused `master` branch and PR to set both product manifests to
-  `0.91.0-beta.1`; do not merge that version-only commit back to `dev`.
+  `0.91.0-beta.1`; keep release preparation isolated from implementation, then
+  synchronize only the accepted published version metadata back to `dev`.
 - [x] Dispatch one `beta` release for `v0.91.0-beta.1`. Do not produce or queue
   a stable release from the same run.
 - [x] Externally verify the beta GitHub Release, updater feeds, CLI manifest,
@@ -588,6 +594,9 @@ artifacts.
   replace the retained Railway beta2 Runtime through its service-owned selector
   and pass the retained core Runtime/PTY long-outage journey. Record the
   resulting Settings identity-refresh fix as the following `dev` increment.
+- [x] Synchronize the root and CLI package baselines to `0.91.0-beta.3` on
+  `dev`, while making explicit source launcher identity—not package semver—the
+  authority for the `dev` update channel.
 
 ### 11. Converge channel discovery authority
 
@@ -790,8 +799,8 @@ pnpm test:install:dev-channel
 pnpm test:remote:docker
 pnpm electron:smoke:pty
 pnpm electron:smoke:workspace
-bash -n scripts/railway/*.sh
-pnpm exec vitest run scripts/railway-entrypoint.spec.ts \
+pnpm test:railway:local
+pnpm exec vitest run \
   packages/cli/src/install.spec.mjs \
   packages/cli/src/lifecycle.spec.mjs \
   packages/cli/src/project-command.spec.ts \

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -34,8 +34,14 @@ const workflow = YAML.parse(
   readFileSync(resolve(root, '.github/workflows/ci.yml'), 'utf8'),
 ) as Workflow
 const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+  version: string
   scripts: Record<string, string>
 }
+const cliPackageJson = JSON.parse(
+  readFileSync(resolve(root, 'packages/cli/package.json'), 'utf8'),
+) as { version: string }
+const defaultVitestConfig = readFileSync(resolve(root, 'vitest.config.ts'), 'utf8')
+const railwayVitestConfig = readFileSync(resolve(root, 'vitest.railway.config.ts'), 'utf8')
 
 function commands(job: WorkflowJob): string[] {
   return job.steps?.flatMap((step) => step.run ? [step.run] : []) ?? []
@@ -66,7 +72,7 @@ describe('CI workflow fast failure lanes', () => {
     )
   })
 
-  it('builds every ordinary candidate but reserves the full root suite for master lanes', () => {
+  it('builds every ordinary candidate but reserves full local suites for master lanes', () => {
     const build = workflow.jobs.build
     const test = workflow.jobs.test
     const buildStep = build.steps?.find((step) => step.name === 'Build complete workspace')
@@ -83,7 +89,25 @@ describe('CI workflow fast failure lanes', () => {
     expect(test.if).toContain("beta_release_prep != 'true'")
     expect(test.if).toContain("github.base_ref == 'master'")
     expect(commands(test)).toContain('pnpm test')
+    expect(commands(test)).toContain('pnpm test:railway:local')
     expect(commands(test)).not.toContain('pnpm build')
+  })
+
+  it('keeps Railway lifecycle system tests explicit, local, and serialized', () => {
+    expect(packageJson.scripts.test).toBe('vitest run')
+    expect(packageJson.scripts['test:railway:local']).toContain('vitest.railway.config.ts')
+    expect(packageJson.scripts['test:platform-contracts']).not.toContain('railway-entrypoint.spec.ts')
+    expect(defaultVitestConfig).toContain("'scripts/railway-entrypoint.spec.ts'")
+    expect(defaultVitestConfig).toContain("'scripts/railway-fence-pty.spec.ts'")
+    expect(railwayVitestConfig).toContain("'scripts/railway-entrypoint.spec.ts'")
+    expect(railwayVitestConfig).toContain("'scripts/railway-fence-pty.spec.ts'")
+    expect(railwayVitestConfig).toContain('fileParallelism: false')
+    expect(railwayVitestConfig).toContain('maxWorkers: 1')
+    expect(railwayVitestConfig).toContain('testTimeout: 35_000')
+  })
+
+  it('keeps the runtime-visible root and CLI version baselines synchronized', () => {
+    expect(packageJson.version).toBe(cliPackageJson.version)
   })
 
   it('keeps build-and-test successful for intentional dev and beta skips only', () => {
@@ -127,6 +151,7 @@ describe('CI workflow fast failure lanes', () => {
     expect(crossPlatform.if).toContain("github.base_ref == 'master'")
     expect(fullBuild?.run).toBe('pnpm build')
     expect(fullTest?.run).toBe('pnpm test')
+    expect(commands(crossPlatform)).not.toContain('pnpm test:railway:local')
     expect(crossPlatform.steps?.some(
       (step) => step.name === 'Run native platform contracts for routine integration PRs',
     )).toBe(false)

--- a/src/core/version.spec.ts
+++ b/src/core/version.spec.ts
@@ -354,6 +354,38 @@ describe('getVersionInfo', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['Guardian source launcher', { OPENALICE_LAUNCHER: 'dev' }],
+    ['explicit source profile', { OPENALICE_RUNTIME_PROFILE: 'dev' }],
+    ['Electron source profile', { OPENALICE_RUNTIME_PROFILE: 'electron-dev' }],
+    ['legacy Electron source launcher', { OPENALICE_LAUNCHER: 'electron' }],
+  ] as const)('keeps %s on the dev channel without release discovery', async (_label, env) => {
+    const fetchMock = vi.fn()
+    const readTextFile = vi.fn(() => JSON.stringify(installSource('stable')))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const info = await getVersionInfo({
+      env: {
+        ...env,
+        // A developer shell may inherit installed-CLI provenance. Explicit
+        // source identity still owns this process and must take precedence.
+        OPENALICE_INSTALL_SOURCE: '/runtime/install-source.json',
+      },
+      readTextFile,
+    })
+
+    expect(info).toMatchObject({
+      current: getCurrentVersion(),
+      channel: 'dev',
+      updateAuthority: 'source',
+      latest: null,
+      hasUpdate: false,
+      error: null,
+    })
+    expect(readTextFile).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('normalizes legacy non-master branch provenance to the development channel', async () => {
     const fetchMock = vi.fn()
     globalThis.fetch = fetchMock as unknown as typeof fetch

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -4,10 +4,12 @@
  * The current version comes from package.json#version (read once at module
  * load). The latest stable or beta version comes from the matching OpenAlice
  * CDN manifest and is cached in memory with separate success/error TTLs.
- * Installed provenance, rather than package semver, selects the channel and
- * update authority. Dev discovery stays in the native CLI, pinned/custom
- * installs do not discover updates, and service-managed runtimes defer to the
- * service that deployed them.
+ * Explicit runtime identity and installed provenance, rather than package
+ * semver alone, select the channel and update authority. Source development
+ * stays on the dev channel even though package.json still supplies its display
+ * version. Dev discovery stays in the native CLI, pinned/custom installs do
+ * not discover updates, and service-managed runtimes defer to the service that
+ * deployed them.
  * GitHub Release assets remain the immutable payload source, but update
  * discovery does not depend on GitHub's anonymous API.
  */
@@ -341,6 +343,18 @@ function resolveUpdateContext(
   readTextFile: ReadTextFile,
   currentVersion: string,
 ): UpdateContext {
+  const serviceManager = env['OPENALICE_SERVICE_MANAGER']?.trim()
+  const runtimeProfile = env['OPENALICE_RUNTIME_PROFILE']?.trim()
+    || env['OPENALICE_LAUNCHER']?.trim()
+
+  // package.json remains the source runtime's display/build baseline, but it
+  // must not turn a dev checkout into the stable or beta update channel. Keep
+  // Railway service ownership ahead of this override because its launcher is
+  // selected by the deployed service rather than the local source tree.
+  if (serviceManager !== 'railway' && isSourceRuntimeProfile(runtimeProfile)) {
+    return { channel: 'dev', authority: 'source', error: null }
+  }
+
   const installedSourcePath = env['OPENALICE_INSTALL_SOURCE']?.trim()
   const installedChannel = installedSourcePath
     ? readInstalledChannel(installedSourcePath, readTextFile)
@@ -354,12 +368,10 @@ function resolveUpdateContext(
       : releaseChannelForVersion(currentVersion)
   )
 
-  if (env['OPENALICE_SERVICE_MANAGER']?.trim() === 'railway') {
+  if (serviceManager === 'railway') {
     return { channel, authority: 'service', error: provenanceError }
   }
 
-  const runtimeProfile = env['OPENALICE_RUNTIME_PROFILE']?.trim()
-    || env['OPENALICE_LAUNCHER']?.trim()
   if (runtimeProfile === 'electron-packaged') {
     return { channel, authority: 'desktop', error: provenanceError }
   }
@@ -373,6 +385,12 @@ function resolveUpdateContext(
   }
 
   return { channel, authority: 'source', error: null }
+}
+
+function isSourceRuntimeProfile(runtimeProfile: string | undefined): boolean {
+  return runtimeProfile === 'dev'
+    || runtimeProfile === 'electron-dev'
+    || runtimeProfile === 'electron'
 }
 
 function readInstalledChannel(path: string, readTextFile: ReadTextFile): VersionChannel | null {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,12 +28,14 @@ export default defineConfig({
     alias: workspaceAliases,
   },
   test: {
-    // The Node suite includes installer, PTY, Guardian, and Railway specs that
-    // spawn their own process trees. Leaving Vitest at `available CPUs - 1`
+    // The Node suite includes installer, PTY, and Guardian specs that spawn
+    // their own process trees. Leaving Vitest at `available CPUs - 1`
     // lets those children contend with a worker per core on constrained CI
     // hosts, turning fast installer checks into timeout flakes. Keep enough
     // parallelism for the unit-heavy majority while reserving capacity for the
-    // subprocesses owned by each worker.
+    // subprocesses owned by each worker. The Railway lifecycle system harness
+    // has its own serialized config because it also owns a host-global mount
+    // fence on Linux.
     maxWorkers: '50%',
     projects: [
       {
@@ -45,7 +47,13 @@ export default defineConfig({
           environment: 'node',
           setupFiles: ['./vitest.setup.ts'],
           include: ['src/**/*.spec.*', 'packages/**/*.spec.*', 'services/**/*.spec.*', 'apps/**/*.spec.*', 'scripts/**/*.spec.*'],
-          exclude: ['**/*.e2e.spec.*', '**/*.bbProvider.spec.*', '**/node_modules/**'],
+          exclude: [
+            '**/*.e2e.spec.*',
+            '**/*.bbProvider.spec.*',
+            '**/node_modules/**',
+            'scripts/railway-entrypoint.spec.ts',
+            'scripts/railway-fence-pty.spec.ts',
+          ],
         },
       },
       {

--- a/vitest.railway.config.ts
+++ b/vitest.railway.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'railway-local',
+    environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
+    include: [
+      'scripts/railway-entrypoint.spec.ts',
+      'scripts/railway-fence-pty.spec.ts',
+    ],
+    // Both files may lock the real /dev/shm mount inode on Linux. Keep them in
+    // one explicit worker so a local safety contract cannot race itself.
+    fileParallelism: false,
+    maxWorkers: 1,
+    // The Linux fence fixture intentionally waits up to 30s for a competing
+    // owner. Leave Vitest enough time to surface the fixture's own assertion.
+    testTimeout: 35_000,
+  },
+})


### PR DESCRIPTION
## Summary

- classify explicit source launchers as the dev/source update context while keeping package versions as runtime-visible build metadata
- synchronize root and CLI package baselines to the accepted v0.91.0-beta.3 release and document the post-release two-manifest dev sync
- remove Railway entrypoint/fence system tests from the hermetic default suite and run them serially in an explicit local/master lane
- update CI contracts, owner guides, and the active CLI distribution plan for the lighter dev/beta boundary

## Verification

- `npx tsc --noEmit`
- `pnpm test` — 6032 passed, 10 skipped; Railway system specs excluded
- `pnpm build`
- `pnpm test:workflow-contracts` — 49 passed
- `pnpm test:platform-contracts` — 730 passed, 4 skipped
- `pnpm test:railway:local` on macOS — 44 passed, 3 platform skips
- `pnpm test:railway:local` in Orb Linux arm64 — 46 passed, 1 intentional skip
- source probe with `OPENALICE_LAUNCHER=dev` — `0.91.0-beta.3`, channel `dev`, authority `source`, no update discovery

## Existing trailing failure classification

The current dev push failure at run 33509135657 passed all four native candidate builds and failed only while Cloudflare R2 completed a multipart alias upload with `InternalError` after four retries. No product assertion failed; this PRs dev publication will provide a fresh attempt.