### PR TITLE
fix(office): open sessions in owning harness

### DIFF
--- a/ui/src/office/office-destination.spec.ts
+++ b/ui/src/office/office-destination.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  officeWorkspaceDestination,
+  officeWorkspaceSource,
+} from './office-destination'
+
+describe('office destination', () => {
+  it.each([
+    ['chat', 'chat'],
+    ['auto-quant', 'auto-quant'],
+    ['prediction', 'prediction'],
+    ['other', undefined],
+  ] as const)('maps the %s Harness to its product source', (harness, source) => {
+    expect(officeWorkspaceSource(harness)).toBe(source)
+  })
+
+  it('opens an exact Session inside its Harness-owned product area', () => {
+    expect(officeWorkspaceDestination(
+      { id: 'chat-jun15', harness: 'chat' },
+      'grok-brisk-maple-path',
+    )).toEqual({
+      kind: 'workspace',
+      params: {
+        wsId: 'chat-jun15',
+        sessionId: 'grok-brisk-maple-path',
+        source: 'chat',
+      },
+    })
+  })
+
+  it('keeps the Harness source when opening a Workspace without a Session', () => {
+    expect(officeWorkspaceDestination({ id: 'quant-1', harness: 'auto-quant' })).toEqual({
+      kind: 'workspace',
+      params: { wsId: 'quant-1', source: 'auto-quant' },
+    })
+  })
+
+  it('falls back to the global Workspace surface for an unknown Harness', () => {
+    expect(officeWorkspaceDestination(
+      { id: 'custom-1', harness: 'other' },
+      'session-1',
+    )).toEqual({
+      kind: 'workspace',
+      params: { wsId: 'custom-1', sessionId: 'session-1' },
+    })
+  })
+})

--- a/ui/src/office/office-destination.ts
+++ b/ui/src/office/office-destination.ts
@@ -1,0 +1,26 @@
+import type { OfficeHarness } from '../api/office'
+import type { ViewSpec, WorkspaceSource } from '../tabs/types'
+
+export interface OfficeWorkspaceDestination {
+  readonly id: string
+  readonly harness: OfficeHarness
+}
+
+export function officeWorkspaceSource(harness: OfficeHarness): WorkspaceSource | undefined {
+  return harness === 'other' ? undefined : harness
+}
+
+export function officeWorkspaceDestination(
+  workspace: OfficeWorkspaceDestination,
+  sessionId?: string,
+): Extract<ViewSpec, { kind: 'workspace' }> {
+  const source = officeWorkspaceSource(workspace.harness)
+  return {
+    kind: 'workspace',
+    params: {
+      wsId: workspace.id,
+      ...(sessionId ? { sessionId } : {}),
+      ...(source ? { source } : {}),
+    },
+  }
+}

--- a/ui/src/pages/OfficePage.spec.tsx
+++ b/ui/src/pages/OfficePage.spec.tsx
@@ -862,6 +862,50 @@ describe('OfficePage localization', () => {
     expect(await screen.findByRole('dialog', { name: /Codex/ })).toBeTruthy()
   })
 
+  it('opens an exact Session inside the Harness that owns its Office', async () => {
+    officeFloorMock.mockReturnValue({
+      ...defaultOfficeFloor(),
+      building: {
+        ...defaultOfficeFloor().building,
+        offices: [{
+          workspace: { id: 'chat-custom', tag: 'chat-jun15', harness: 'chat' },
+          lastInteractionAt: Date.now(),
+          sleeping: false,
+          employees: [{
+            resumeId: 'resume-grok',
+            sessionRecordId: 'grok-brisk-maple-path',
+            agent: 'grok',
+            name: 'g6',
+            title: 'Inspect the Harness-owned Session route',
+            mood: 'idle' as const,
+            awake: false,
+            bubble: null,
+            lastSeq: 1,
+            lastInteractionAt: 1,
+            drawers: [],
+          }],
+        }],
+      },
+    })
+
+    render(<OfficePage />)
+
+    await userEvent.click(screen.getByTestId('office-desk-resume-grok'))
+    await userEvent.click(await screen.findByRole('button', { name: '打开 Session' }))
+
+    expect(openOrFocusMock).toHaveBeenLastCalledWith({
+      kind: 'workspace',
+      params: {
+        wsId: 'chat-custom',
+        sessionId: 'grok-brisk-maple-path',
+        source: 'chat',
+      },
+    })
+    expect(navigateMock).toHaveBeenLastCalledWith('/office/return', {
+      state: { officeExcursion: true },
+    })
+  })
+
   it('opens a failed coworker activity at its last event and returns to the Agent file', async () => {
     officeFloorMock.mockReturnValue({
       ...defaultOfficeFloor(),

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -49,6 +49,10 @@ import { useOfficeDay } from '../office/useOfficeDay'
 import { useOfficeRoutineFollowUps } from '../office/useOfficeRoutineFollowUps'
 import { useOfficeShift } from '../office/useOfficeShift'
 import {
+  officeWorkspaceDestination,
+  officeWorkspaceSource,
+} from '../office/office-destination'
+import {
   useOfficeProductActivity,
 } from '../office/useOfficeProductActivity'
 import {
@@ -64,19 +68,11 @@ import {
 import { useIssues } from '../hooks/useIssues'
 import '../office/office.css'
 import { useWorkspace } from '../tabs/store'
-import type { WorkspaceSource } from '../tabs/types'
 import {
   OfficeRuntimeSection,
   type OfficeDutyReview,
   type OfficeLogChannel,
 } from './OfficeRuntimeSection'
-
-function sourceForTag(tag: string): WorkspaceSource | undefined {
-  if (tag === 'chat') return 'chat'
-  if (tag === 'auto-quant') return 'auto-quant'
-  if (tag === 'prediction') return 'prediction'
-  return undefined
-}
 
 function officeActivityDutyReview(
   kind: OfficeDutyReview['kind'],
@@ -409,45 +405,40 @@ export function OfficePage() {
     })
   }
 
+  const officeWorkspaceFor = (workspaceId: string) => (
+    building?.offices.find((office) => office.workspace.id === workspaceId)?.workspace
+  )
+
   const openEmployee = (workspaceId: string, employee: OfficeFloorEmployee) => {
-    const workspace = workspaces.find((item) => item.id === workspaceId)
-    const source = workspace ? sourceForTag(workspace.tag) : undefined
+    const workspace = officeWorkspaceFor(workspaceId)
+    if (!workspace) return
     markExcursion()
-    openOrFocus({
-      kind: 'workspace',
-      params: {
-        wsId: workspaceId,
-        ...(employee.sessionRecordId ? { sessionId: employee.sessionRecordId } : {}),
-        ...(source ? { source } : {}),
-      },
-    })
+    openOrFocus(officeWorkspaceDestination(
+      workspace,
+      employee.sessionRecordId,
+    ))
   }
 
   const openWorkspaceFiles = (workspaceId: string) => {
-    const workspace = workspaces.find((item) => item.id === workspaceId)
-    const source = workspace ? sourceForTag(workspace.tag) : undefined
+    const workspace = officeWorkspaceFor(workspaceId)
+    if (!workspace) return
     useWorkspaceSidePanels.getState().setFiles(true)
     markExcursion()
-    openOrFocus({
-      kind: 'workspace',
-      params: { wsId: workspaceId, ...(source ? { source } : {}) },
-    })
+    openOrFocus(officeWorkspaceDestination(workspace))
   }
 
   const openWorkspace = (workspaceId: string) => {
-    const workspace = workspaces.find((item) => item.id === workspaceId)
-    const source = workspace ? sourceForTag(workspace.tag) : undefined
+    const workspace = officeWorkspaceFor(workspaceId)
+    if (!workspace) return
     useWorkspaceSidePanels.getState().setFiles(false)
     markExcursion()
-    openOrFocus({
-      kind: 'workspace',
-      params: { wsId: workspaceId, ...(source ? { source } : {}) },
-    })
+    openOrFocus(officeWorkspaceDestination(workspace))
   }
 
   const openDrawer = (workspaceId: string, employee: OfficeFloorEmployee, item: OfficeDrawerItem) => {
-    const workspace = workspaces.find((row) => row.id === workspaceId)
-    const source = workspace ? sourceForTag(workspace.tag) : undefined
+    const workspace = officeWorkspaceFor(workspaceId)
+    if (!workspace) return
+    const source = officeWorkspaceSource(workspace.harness)
     if (item.kind === 'report' && item.path) {
       markExcursion()
       openOrFocus({


### PR DESCRIPTION
## Outcome

Office now returns each coworker and Workspace entry to the product Harness that owns it. Ask Alice, AutoQuant, and Prediction keep their own sidebar/shell and exact SessionRecord selection; unknown Harnesses retain the generic Workspaces fallback.

## Design

Considered tag-prefix inference, Workspace-template inference, and the canonical Harness identity already projected by the Office floor API. Chose the Office Harness identity so mutable labels cannot change navigation ownership. The interaction, focus behavior, and responsive layout are unchanged; the change only corrects the destination hierarchy.

The same resolver now serves coworker Sessions, Workspace signs, filing cabinets, and report-return links. Missing room identities stop the stale interaction instead of silently sending it to the global Workspace surface.

## Verification

- `npx tsc --noEmit`
- `cd ui && npx tsc -b`
- `pnpm test` — 679 files passed, 6040 tests passed
- Targeted Office + route suite — 75 tests passed
- Real Office Lab: coworker → Open session reached `/chat/workspaces/chat-polished-laurel-grove/s/grok-open-stone-terrace`, rendered the Ask Alice shell and exact paused Session, with no browser errors

## UI review

This removes the duplicate global-Workspace navigation context and makes the next action land where the user expects. Narrow/medium/wide behavior, existing primitives, keyboard behavior, and visual language are unchanged.