### PR TITLE
feat(market-data): add native Tushare provider

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -29,6 +29,10 @@ the durable truth after it changes. Git history is the archive.
 
 ## Active
 
+- [[plans/tushare-cn-data.md]] — Adds an opt-in native Tushare provider for
+  A-share search, point-in-time-safe qfq bars, fundamentals, and typed China
+  reference datasets. Credentials and endpoint are hot-read; the provider is
+  disabled by default and exposes no arbitrary API passthrough.
 - [[plans/bun-cli-distribution.md]] — Replaces the expanded Node headless
   Runtime with a Bun-compiled, multi-process CLI distribution. Direct,
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set. The

--- a/default/skills/traderhub/SKILL.md
+++ b/default/skills/traderhub/SKILL.md
@@ -6,11 +6,14 @@ description: >
   term structure, sector rotation), equity fundamentals (profile, financials,
   ratios, estimates, insiders, short interest), ETF drilldowns, FRED/BLS/EIA
   macro series, OECD cross-country indicators, IMF PortWatch shipping, and
-  Deribit crypto curves. Use whenever you need a macro number, a fundamental,
+  Deribit crypto curves. With an enabled Tushare token it also covers A-share
+  fundamentals, calendars, status, disclosures, industries, and index members.
+  Use whenever you need a macro number, a fundamental,
   a calendar, or a ready-made board: "what's CPI", "AAPL ratios", "earnings
   this week", "which sectors are rotating in", "Suez canal traffic", "Fed
   balance sheet". Data is served hub-first (hosted TraderHub) with local
-  fallback — no API keys needed. Discover flags live with
+  fallback. Hosted boards need no API keys; native China data requires the
+  user's Tushare token. Discover flags live with
   `traderhub <group> <verb> --help`; do NOT guess flags.
 ---
 
@@ -57,6 +60,8 @@ seeing the last good snapshot — say so if it matters to the conclusion.
 traderhub equity profile --symbol AAPL
 traderhub equity financials --symbol AAPL --type income --period annual --limit 5
 traderhub equity ratios --symbol AAPL --period annual --limit 5   # ttm=include by default
+traderhub equity financials --symbol 600519.SH --type income --period annual --limit 5 --as-of 2026-04-01
+traderhub equity ratios --symbol 600519.SH --period annual --limit 5 --as-of 2026-04-01
 traderhub equity estimates --symbol NVDA                          # analyst consensus + price targets
 traderhub equity insiders --symbol NVDA --limit 20                # Form-4 transactions
 traderhub equity short-interest --symbol GME                      # short shares/ratio/float %
@@ -64,6 +69,34 @@ traderhub equity earnings --start-date 2026-06-15 --end-date 2026-06-30
 traderhub equity discover --list gainers                          # or: losers, active,
                                    # undervalued_growth, growth_tech, small_caps, undervalued_large
 ```
+
+Symbols ending `.SH`, `.SZ`, or `.BJ` route profile, financials, and ratios to
+the native Tushare provider. `--as-of` is an announcement-date cutoff: a later
+restatement is excluded even when its reporting period is earlier.
+
+## China market data (Tushare)
+
+Tushare must be enabled and its token configured in Settings → Market Data.
+Use Tushare `ts_code` identities; dates accept `YYYY-MM-DD` or `YYYYMMDD`.
+
+```bash
+traderhub china calendar --exchange SSE --start-date 2026-09-01 --end-date 2026-09-30
+traderhub china daily-basic --ts-code 600519.SH --trade-date 2026-08-31
+traderhub china status --type st
+traderhub china status --type namechange --ts-code 600519.SH
+traderhub china status --type suspension --trade-date 2026-09-01
+traderhub china forecast --ts-code 600519.SH
+traderhub china express --ts-code 600519.SH
+traderhub china disclosures --ts-code 600519.SH
+traderhub china industry --level L1 --src SW2021
+traderhub china index-basic --market SSE
+traderhub china index-members --l1-code 801010.SI --is-new Y
+traderhub china index-weights --index-code 000300.SH --trade-date 2026-08-31
+```
+
+For K-lines, discover the operational id with `alice analysis search-bars` and
+use the returned `tushare|<ts_code>` barId. P0 is daily qfq only; metadata names
+the adjustment anchor and normalized units (shares and CNY).
 
 ## ETF drilldown (the theme workflow)
 

--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -65,6 +65,10 @@ Configuration lives in
   },
   "extraVendors": [],
   "providerKeys": {},
+  "tushare": {
+    "enabled": false,
+    "baseUrl": "https://api.tushare.pro"
+  },
   "hub": {
     "enabled": true,
     "baseUrl": "https://traderhub.openalice.ai"
@@ -100,6 +104,27 @@ New K-line sources should implement the bar/provider contract and appear in bar
 source discovery. They should not require a new OpenBB-style asset-class client
 or a copied OpenBB route hierarchy.
 
+### Native Tushare provider
+
+`src/domain/market-data/tushare/` is the native China-market adapter. It is
+deliberately outside `packages/opentypebb`: A-share symbols, point-in-time
+financial filings, classifications, and Tushare's daily-plus-adjustment-factor
+bar construction are product contracts rather than OpenBB compatibility
+models.
+
+The adapter is disabled by default. `marketData.tushare` controls enabled state
+and endpoint; `marketData.providerKeys.tushare` is mirrored to the user-global
+provider-key store. All three values are read from disk for each request, so
+token rotation and endpoint changes do not require a restart. Endpoints must be
+HTTPS, except loopback HTTP for development, and may not include URL
+credentials, queries, or fragments. Tokens are sent only in the POST body.
+
+Tushare bar identities use `tushare|<ts_code>`. P0 supports daily qfq bars.
+Qfq factors are anchored at the request `end`/`asOf` boundary, so future
+corporate actions cannot leak into historical snapshots. Raw `vol` hands are
+normalized to shares and raw `amount` thousands of CNY to CNY; the units and
+adjustment anchor are carried in `BarMeta`.
+
 ## Embedded Compatibility Package
 
 `packages/opentypebb/` is private to this monorepo. It still supplies useful
@@ -125,7 +150,7 @@ contracts should not start there.
 | New low-frequency board or hosted dataset | `src/domain/market-data/reference/`, TraderHub tool/CLI mapping |
 | New K-line vendor or broker source | `src/domain/market-data/bars/`, provider discovery, UTA when broker-owned |
 | Existing fundamentals/search provider fix | `packages/opentypebb/src/providers/` plus the typed Alice client |
-| New user credential name | market-data config schema and `src/domain/market-data/credential-map.ts` |
+| New user credential name | market-data config schema; add `credential-map.ts` projection only when an embedded compatibility provider consumes it |
 | Compatibility HTTP behavior | `src/server/market-data-compat.ts` and focused route tests |
 
 Provider discovery is self-described. Optional vendors expose `vendorMeta`, and

--- a/plans/tushare-cn-data.md
+++ b/plans/tushare-cn-data.md
@@ -36,7 +36,8 @@ package.
 - [x] Settings UI, masked credential flow, connectivity/capability test
 - [x] Unit/integration tests and owner-guide updates
 - [x] Typecheck, focused suites, full build, and demo UI verification
-- [ ] Commit, PR, and CI acceptance
+- [x] Commit and open PR #1311 against `dev`
+- [ ] CI acceptance
 
 ## Completion
 

--- a/plans/tushare-cn-data.md
+++ b/plans/tushare-cn-data.md
@@ -1,0 +1,43 @@
+# Plan: Native Tushare China market data
+
+**Status:** active  
+**Owner guides:** [[docs/market-data-architecture.md]], [[docs/project-structure.md]]  
+**Delivery:** serial PR to `dev` (`area:market-data`).
+
+## Goal
+
+Add an opt-in, native Tushare HTTP provider for China equity research. The
+provider supplies discoverable A-share identities, point-in-time-safe qfq
+daily bars, low-frequency China reference datasets, and A-share fundamentals
+without routing new product contracts through the OpenTypeBB compatibility
+package.
+
+## Decisions
+
+- Credentials remain in the existing user-global provider-key store. The
+  default endpoint is `https://api.tushare.pro`; custom endpoints must be HTTPS
+  unless they are loopback development URLs, and may not contain query strings
+  or fragments.
+- Runtime reads enabled state, endpoint, and token per request so token rotation
+  needs no restart. Tokens are POST-body only and never included in errors.
+- The public surface is an allowlisted set of typed datasets, not an arbitrary
+  `api_name` passthrough.
+- Daily bars use `daily` plus `adj_factor`. Qfq is anchored to the request
+  `end`/`asOf`, never a future factor. Tushare volume hands become shares and
+  amount thousands of CNY become CNY.
+- Operational identities use `tushare|<ts_code>` (for example
+  `tushare|600519.SH`). The provider is disabled by default.
+
+## Work
+
+- [x] Configuration, secure hot-read HTTP client, cache/rate/retry behavior
+- [x] Typed China datasets, symbol search, qfq daily bars and metadata
+- [x] A-share equity profile/financials/ratios routing and `traderhub china`
+- [x] Settings UI, masked credential flow, connectivity/capability test
+- [x] Unit/integration tests and owner-guide updates
+- [x] Typecheck, focused suites, full build, and demo UI verification
+- [ ] Commit, PR, and CI acceptance
+
+## Completion
+
+Delete this file and its [[PLANS.md]] bullet when accepted.

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -342,7 +342,17 @@ const marketDataSchema = z.object({
     benzinga: z.string().optional(),
     tiingo: z.string().optional(),
     biztoc: z.string().optional(),
+    /** Tushare Pro token. Stored in the user-global provider-key file and
+     *  hot-read by the native China-market adapter on every request. */
+    tushare: z.string().optional(),
   }).default({}),
+  /** Native Tushare HTTP adapter. Disabled by default because it is a
+   *  credentialed, user-selected source. Custom proxy endpoints are validated
+   *  again at the network boundary before any request is made. */
+  tushare: z.object({
+    enabled: z.boolean().default(false),
+    baseUrl: z.string().default('https://api.tushare.pro'),
+  }).default({ enabled: false, baseUrl: 'https://api.tushare.pro' }),
   /** Hosted reference-data hub (TraderHub). Enabled by default: anonymous
    *  GETs of public boards, no user data attached; one switch to opt out.
    *  Self-hosters point baseUrl at their own instance. */
@@ -879,6 +889,20 @@ export async function updateExtraVendors(
   await mkdir(CONFIG_DIR, { recursive: true })
   await writeFile(resolve(CONFIG_DIR, 'market-data.json'), JSON.stringify(updated, null, 2) + '\n')
   return next
+}
+
+/** Toggle the native Tushare source without snapshotting globally merged keys
+ * into the workspace config. Effective on the next request. */
+export async function updateTushareEnabled(enabled: boolean): Promise<boolean> {
+  const raw = (await loadJsonFile('market-data.json')) ?? {}
+  const parsed = marketDataSchema.parse(raw)
+  const updated = marketDataSchema.parse({
+    ...parsed,
+    tushare: { ...parsed.tushare, enabled },
+  })
+  await mkdir(CONFIG_DIR, { recursive: true })
+  await writeFile(resolve(CONFIG_DIR, 'market-data.json'), JSON.stringify(updated, null, 2) + '\n')
+  return updated.tushare.enabled
 }
 
 /** Read tools config from disk (called per-request for hot-reload). */

--- a/src/domain/market-data/aggregate-search.spec.ts
+++ b/src/domain/market-data/aggregate-search.spec.ts
@@ -34,4 +34,16 @@ describe('aggregateSymbolSearch limits', () => {
     expect(searchDeps.symbolIndex.search).toHaveBeenCalledWith('EURUSD', 2)
     expect(searchDeps.commodityCatalog.search).toHaveBeenCalledWith('EURUSD', 2)
   })
+
+  it('keeps native equity results in their provider namespace', async () => {
+    const searchDeps = deps()
+    searchDeps.nativeEquitySources = [{
+      sourceId: 'tushare',
+      search: async () => [{ symbol: '600519.SH', name: '贵州茅台', assetClass: 'equity' }],
+    }]
+    const results = await aggregateSymbolSearch(searchDeps, '贵州茅台', 5)
+    expect(results[0]).toMatchObject({
+      symbol: '600519.SH', name: '贵州茅台', assetClass: 'equity', sourceId: 'tushare',
+    })
+  })
 })

--- a/src/domain/market-data/aggregate-search.ts
+++ b/src/domain/market-data/aggregate-search.ts
@@ -30,6 +30,12 @@ export interface MarketSearchDeps {
   cryptoClient: CryptoClientLike
   currencyClient: CurrencyClientLike
   commodityCatalog: CommodityCatalog
+  /** Product-native equity sources that do not belong to the OpenTypeBB
+   * compatibility package. Each source owns its operational namespace. */
+  nativeEquitySources?: Array<{
+    sourceId: string
+    search(query: string, limit: number): Promise<MarketSearchResult[]>
+  }>
 }
 
 export interface MarketSearchResult {
@@ -103,7 +109,7 @@ export async function aggregateSymbolSearch(
   // eastmoney). Each equity vendor lives in its own symbol namespace — yfinance
   // returns Yahoo tickers (600519.SS), eastmoney returns secids (1.600519) for
   // CN names yfinance can't match — so all are kept as redundant candidates.
-  const [coreSettled, equitySettled] = await Promise.all([
+  const [coreSettled, equitySettled, nativeEquitySettled] = await Promise.all([
     Promise.allSettled([
       deps.cryptoClient.search({ query: q, provider: 'yfinance' }),
       deps.currencyClient.search({ query: q, provider: 'yfinance' }),
@@ -113,6 +119,11 @@ export async function aggregateSymbolSearch(
         deps.equityClient
           .search({ query: q, provider: v, is_symbol: false })
           .then((rows) => ({ vendor: v, rows })),
+      ),
+    ),
+    Promise.allSettled(
+      (deps.nativeEquitySources ?? []).map((source) =>
+        source.search(q, boundedLimit).then((rows) => ({ sourceId: source.sourceId, rows })),
       ),
     ),
   ])
@@ -146,6 +157,17 @@ export async function aggregateSymbolSearch(
       if (!sym || seenEquity.has(key)) continue
       seenEquity.add(key)
       equityOnlineResults.push({ ...r, symbol: sym, assetClass: 'equity', sourceId: vendor })
+    }
+  }
+  for (const settled of nativeEquitySettled) {
+    if (settled.status !== 'fulfilled') continue
+    const { sourceId, rows } = settled.value
+    for (const row of rows) {
+      const sym = String(row.symbol ?? '')
+      const key = `${sourceId}|${sym.toUpperCase()}`
+      if (!sym || seenEquity.has(key)) continue
+      seenEquity.add(key)
+      equityOnlineResults.push({ ...row, symbol: sym, assetClass: 'equity', sourceId })
     }
   }
 

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -122,6 +122,27 @@ describe('getBars — barId forms', () => {
     expect(deps.equityClient.getHistorical).toHaveBeenCalled()
   })
 
+  it('routes native provider barIds before the compatibility clients', async () => {
+    const getBars = vi.fn(async () => ({
+      bars: [{ date: '2026-08-31', open: 1, high: 2, low: 1, close: 2, volume: 100 }],
+      meta: {
+        symbol: '600519.SH', from: '2026-08-31', to: '2026-08-31', bars: 1,
+        adjustment: 'qfq' as const, adjustmentAnchor: '2026-08-31',
+      },
+    }))
+    const deps = makeDeps({ nativeVendors: { tushare: { getBars, barCapability: 'delayed' } } })
+    const svc = createBarService(deps)
+    const { meta } = await svc.getBars(
+      { barId: 'tushare|600519.SH', assetClass: 'equity' },
+      { interval: '1d', asOf: '2026-08-31' },
+    )
+    expect(getBars).toHaveBeenCalledWith('600519.SH', { interval: '1d', asOf: '2026-08-31' })
+    expect(deps.equityClient.getHistorical).not.toHaveBeenCalled()
+    expect(meta).toMatchObject({
+      barId: 'tushare|600519.SH', provider: 'tushare', adjustment: 'qfq', adjustmentAnchor: '2026-08-31',
+    })
+  })
+
   it('vendor barId without assetClass throws a clear error', async () => {
     const svc = createBarService(makeDeps())
     await expect(svc.getBars({ barId: 'yfinance|AAPL' }, { interval: '1d' })).rejects.toThrow(/needs an assetClass/)

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -198,6 +198,27 @@ export function createBarService(deps: BarServiceDeps): BarService {
     symbol: string,
     opts: GetBarsOpts,
   ): Promise<BarsResult> {
+    const native = deps.nativeVendors?.[provider]
+    if (native) {
+      const result = await native.getBars(symbol, opts)
+      const bars = finalize(result.bars, opts.count)
+      return {
+        bars,
+        meta: {
+          ...result.meta,
+          symbol,
+          from: bars[0]?.date ?? '',
+          to: bars[bars.length - 1]?.date ?? '',
+          bars: bars.length,
+          source: 'vendor',
+          sourceId: provider,
+          barId: formatBarId(provider, symbol),
+          provider,
+          barCapability: native.barCapability ?? result.meta.barCapability,
+          ...computeFreshness(bars[bars.length - 1]?.date ?? '', opts, () => new Date()),
+        },
+      }
+    }
     const start_date = startDateFor(opts)
     // Upper bound: the provider compatibility models apply end_date;
     // we also post-filter defensively in case a provider ignores it.
@@ -302,7 +323,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
           // Per-result vendor attribution (multi-vendor equity); falls back to
           // the configured per-asset provider for crypto/currency/commodity.
           const provider = r.sourceId ?? deps.vendorProviders[r.assetClass]
-          const cap = VENDOR_CAPABILITY[provider]
+          const cap = deps.nativeVendors?.[provider]?.barCapability ?? VENDOR_CAPABILITY[provider]
           const base = r.name ? `${symbol} · ${r.name} (${provider})` : `${symbol} (${provider})`
           append({
             barId: formatBarId(provider, symbol),

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -89,6 +89,13 @@ export interface BarMeta {
   isLatestActual?: boolean
   /** Trading-day gap between the last bar and `asOf` (0 when current). */
   staleTradingDays?: number
+  /** Price adjustment performed by the source. */
+  adjustment?: 'none' | 'qfq' | 'hfq'
+  /** Point-in-time factor anchor used for adjusted prices. */
+  adjustmentAnchor?: string
+  priceUnit?: string
+  volumeUnit?: string
+  amountUnit?: string
 }
 
 export interface BarSourceCandidate {
@@ -166,4 +173,9 @@ export interface BarServiceDeps {
   utaManager: UtaBarGateway
   /** Configured default provider per asset class — the `provider` we report. */
   vendorProviders: Record<AssetClass, string>
+  /** Product-native bar providers keyed by sourceId. */
+  nativeVendors?: Record<string, {
+    getBars(symbol: string, opts: GetBarsOpts): Promise<BarsResult>
+    barCapability?: BarCapability
+  }>
 }

--- a/src/domain/market-data/tushare/client.spec.ts
+++ b/src/domain/market-data/tushare/client.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TushareClient, validateTushareBaseUrl } from './client.js'
+
+const ok = (fields: string[], items: unknown[][]) => new Response(JSON.stringify({
+  code: 0,
+  msg: null,
+  data: { fields, items },
+}), { status: 200, headers: { 'content-type': 'application/json' } })
+
+describe('TushareClient', () => {
+  it('posts the official envelope, parses field/item rows, and caches identical reads', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(ok(['cal_date', 'is_open'], [['20260901', 1]]))
+    const client = new TushareClient({
+      getConfig: () => ({ enabled: true, baseUrl: 'https://api.tushare.pro', token: 'secret-token' }),
+      fetch,
+      minIntervalMs: 0,
+    })
+
+    await expect(client.query('trade_cal', { exchange: 'SSE' })).resolves.toEqual([
+      { cal_date: '20260901', is_open: 1 },
+    ])
+    await client.query('trade_cal', { exchange: 'SSE' })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const request = fetch.mock.calls[0]
+    expect(request?.[0]).toBe('https://api.tushare.pro/')
+    expect(JSON.parse(String(request?.[1]?.body))).toEqual({
+      api_name: 'trade_cal',
+      token: 'secret-token',
+      params: { exchange: 'SSE' },
+      fields: '',
+    })
+  })
+
+  it('redacts the token from API errors', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(new Response(JSON.stringify({
+      code: -2001,
+      msg: 'bad token secret-token',
+      data: null,
+    }), { status: 200 }))
+    const client = new TushareClient({
+      getConfig: () => ({ enabled: true, baseUrl: 'https://api.tushare.pro', token: 'secret-token' }),
+      fetch,
+      retries: 0,
+    })
+    await expect(client.query('stock_basic')).rejects.toThrow('bad token [redacted]')
+  })
+
+  it('hot-reads configuration before each cache lookup', async () => {
+    let enabled = true
+    const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(ok(['ts_code'], [['600519.SH']]))
+    const client = new TushareClient({
+      getConfig: () => ({ enabled, baseUrl: 'https://api.tushare.pro', token: 'token' }),
+      fetch,
+    })
+    await client.query('stock_basic')
+    enabled = false
+    await expect(client.query('stock_basic')).rejects.toThrow('disabled')
+  })
+
+  it('retries transient upstream failures', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(ok(['ts_code'], [['600519.SH']]))
+    const client = new TushareClient({
+      getConfig: () => ({ enabled: true, baseUrl: 'https://api.tushare.pro', token: 'token' }),
+      fetch,
+      sleep: async () => {},
+    })
+    await expect(client.query('stock_basic')).resolves.toEqual([{ ts_code: '600519.SH' }])
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('validateTushareBaseUrl', () => {
+  it('accepts HTTPS and loopback HTTP only', () => {
+    expect(validateTushareBaseUrl('https://example.com/tushare')).toBe('https://example.com/tushare')
+    expect(validateTushareBaseUrl('http://127.0.0.1:8000/')).toBe('http://127.0.0.1:8000/')
+    expect(() => validateTushareBaseUrl('http://example.com')).toThrow('HTTPS')
+  })
+
+  it('rejects query strings, fragments, and URL credentials', () => {
+    expect(() => validateTushareBaseUrl('https://example.com/?token=x')).toThrow('query string')
+    expect(() => validateTushareBaseUrl('https://example.com/#x')).toThrow('fragment')
+    expect(() => validateTushareBaseUrl('https://user:pass@example.com/')).toThrow('credentials')
+  })
+})

--- a/src/domain/market-data/tushare/client.ts
+++ b/src/domain/market-data/tushare/client.ts
@@ -1,0 +1,185 @@
+import type {
+  TushareApiName,
+  TushareResponseEnvelope,
+  TushareRow,
+  TushareRuntimeConfig,
+  TushareValue,
+} from './types.js'
+import { createHash } from 'node:crypto'
+
+const DEFAULT_TIMEOUT_MS = 12_000
+const DEFAULT_CACHE_TTL_MS = 60_000
+
+export interface TushareClientOptions {
+  getConfig: () => TushareRuntimeConfig | Promise<TushareRuntimeConfig>
+  fetch?: typeof globalThis.fetch
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+  timeoutMs?: number
+  retries?: number
+  maxConcurrency?: number
+  minIntervalMs?: number
+}
+
+interface CacheEntry {
+  expiresAt: number
+  rows: TushareRow[]
+}
+
+export function validateTushareBaseUrl(input: string): string {
+  let url: URL
+  try {
+    url = new URL(input.trim())
+  } catch {
+    throw new Error('Invalid Tushare endpoint URL')
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Tushare endpoint must not contain credentials, a query string, or a fragment')
+  }
+  const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1'
+  if (url.protocol !== 'https:' && !(loopback && url.protocol === 'http:')) {
+    throw new Error('Tushare endpoint must use HTTPS (HTTP is allowed only for loopback development)')
+  }
+  return url.toString()
+}
+
+function stable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stable)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, nested]) => [key, stable(nested)]),
+    )
+  }
+  return value
+}
+
+function rowsFromEnvelope(envelope: TushareResponseEnvelope): TushareRow[] {
+  const fields = envelope.data?.fields
+  const items = envelope.data?.items
+  if (!Array.isArray(fields) || !fields.every((field) => typeof field === 'string')) {
+    throw new Error('Tushare returned an invalid fields array')
+  }
+  if (!Array.isArray(items)) throw new Error('Tushare returned an invalid items array')
+  return items.map((item) => {
+    if (!Array.isArray(item)) throw new Error('Tushare returned an invalid data row')
+    const row: TushareRow = {}
+    fields.forEach((field, index) => {
+      const value = item[index]
+      if (value == null || ['string', 'number', 'boolean'].includes(typeof value)) {
+        row[field] = (value ?? null) as TushareValue
+      }
+    })
+    return row
+  })
+}
+
+export class TushareClient {
+  private readonly fetchImpl: typeof globalThis.fetch
+  private readonly now: () => number
+  private readonly sleep: (ms: number) => Promise<void>
+  private readonly cache = new Map<string, CacheEntry>()
+  private readonly inflight = new Map<string, Promise<TushareRow[]>>()
+  private readonly waiters: Array<() => void> = []
+  private active = 0
+  private nextRequestAt = 0
+
+  constructor(private readonly options: TushareClientOptions) {
+    this.fetchImpl = options.fetch ?? globalThis.fetch
+    this.now = options.now ?? Date.now
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+  }
+
+  clearCache(): void {
+    this.cache.clear()
+  }
+
+  async query(
+    apiName: TushareApiName,
+    params: Record<string, unknown> = {},
+    fields?: readonly string[],
+    cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  ): Promise<TushareRow[]> {
+    const config = await this.options.getConfig()
+    if (!config.enabled) throw new Error('Tushare provider is disabled')
+    const token = config.token?.trim()
+    if (!token) throw new Error('Tushare token is not configured')
+    const baseUrl = validateTushareBaseUrl(config.baseUrl)
+    // Rotation must take effect even while a previous credential's response is
+    // cached. Use a non-reversible fingerprint; never retain the token in a
+    // cache key or diagnostic string.
+    const credential = createHash('sha256').update(token).digest('hex')
+    const cacheKey = JSON.stringify(stable({ baseUrl, credential, apiName, params, fields }))
+    const cached = this.cache.get(cacheKey)
+    if (cached && cached.expiresAt > this.now()) return cached.rows.map((row) => ({ ...row }))
+    const pending = this.inflight.get(cacheKey)
+    if (pending) return (await pending).map((row) => ({ ...row }))
+
+    const request = this.limited(() => this.request(baseUrl, token, apiName, params, fields))
+      .then((rows) => {
+        if (cacheTtlMs > 0) this.cache.set(cacheKey, { expiresAt: this.now() + cacheTtlMs, rows })
+        return rows
+      })
+      .finally(() => this.inflight.delete(cacheKey))
+    this.inflight.set(cacheKey, request)
+    return (await request).map((row) => ({ ...row }))
+  }
+
+  private async limited<T>(operation: () => Promise<T>): Promise<T> {
+    const max = Math.max(1, this.options.maxConcurrency ?? 2)
+    if (this.active >= max) await new Promise<void>((resolve) => this.waiters.push(resolve))
+    this.active += 1
+    try {
+      const delay = Math.max(0, this.nextRequestAt - this.now())
+      if (delay > 0) await this.sleep(delay)
+      this.nextRequestAt = this.now() + Math.max(0, this.options.minIntervalMs ?? 100)
+      return await operation()
+    } finally {
+      this.active -= 1
+      this.waiters.shift()?.()
+    }
+  }
+
+  private async request(
+    baseUrl: string,
+    token: string,
+    apiName: TushareApiName,
+    params: Record<string, unknown>,
+    fields?: readonly string[],
+  ): Promise<TushareRow[]> {
+    const attempts = Math.max(1, (this.options.retries ?? 2) + 1)
+    let lastError: Error | undefined
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        const response = await this.fetchImpl(baseUrl, {
+          method: 'POST',
+          headers: { accept: 'application/json', 'content-type': 'application/json' },
+          body: JSON.stringify({ api_name: apiName, token, params, fields: fields?.join(',') ?? '' }),
+          signal: AbortSignal.timeout(this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+        })
+        if (!response.ok) {
+          const error = new Error(`Tushare HTTP ${response.status}`)
+          if (response.status === 429 || response.status >= 500) throw error
+          throw Object.assign(error, { retryable: false })
+        }
+        const envelope = await response.json() as TushareResponseEnvelope
+        const code = typeof envelope.code === 'number' ? envelope.code : Number(envelope.code)
+        if (!Number.isFinite(code)) throw new Error('Tushare returned an invalid response envelope')
+        if (code !== 0) {
+          const message = typeof envelope.msg === 'string' && envelope.msg.trim()
+            ? envelope.msg.replaceAll(token, '[redacted]')
+            : `API error ${code}`
+          throw Object.assign(new Error(`Tushare ${message}`), { retryable: false })
+        }
+        return rowsFromEnvelope(envelope)
+      } catch (error) {
+        const raw = error instanceof Error ? error : new Error(String(error))
+        lastError = new Error(raw.message.replaceAll(token, '[redacted]'))
+        if ((error as { retryable?: boolean }).retryable === false || attempt === attempts - 1) break
+        await this.sleep(250 * (2 ** attempt))
+      }
+    }
+    throw lastError ?? new Error('Tushare request failed')
+  }
+}

--- a/src/domain/market-data/tushare/service.spec.ts
+++ b/src/domain/market-data/tushare/service.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { TushareClient } from './client.js'
+import { TushareService } from './service.js'
+
+function serviceWith(query: (api: string, params: Record<string, unknown>) => Promise<Record<string, string | number | null>[]>) {
+  return new TushareService({ query: vi.fn(query) } as unknown as TushareClient, () => new Date('2026-09-01T00:00:00Z'))
+}
+
+describe('TushareService daily bars', () => {
+  it('anchors qfq at asOf, excludes future factors, and normalizes units', async () => {
+    const service = serviceWith(async (api) => {
+      if (api === 'daily') return [
+        { trade_date: '20260831', open: 20, high: 22, low: 19, close: 21, vol: 12, amount: 34 },
+        { trade_date: '20260828', open: 10, high: 11, low: 9, close: 10.5, vol: 8, amount: 9 },
+      ]
+      return [
+        { trade_date: '20260902', adj_factor: 4 },
+        { trade_date: '20260831', adj_factor: 2 },
+        { trade_date: '20260828', adj_factor: 1 },
+      ]
+    })
+
+    const result = await service.getBars('600519.SH', {
+      interval: '1d', start: '2026-08-01', asOf: '2026-08-31',
+    })
+
+    expect(result.bars).toEqual([
+      { date: '2026-08-28', open: 5, high: 5.5, low: 4.5, close: 5.25, volume: 800, amount: 9000 },
+      { date: '2026-08-31', open: 20, high: 22, low: 19, close: 21, volume: 1200, amount: 34000 },
+    ])
+    expect(result.meta).toMatchObject({
+      adjustment: 'qfq', adjustmentAnchor: '2026-08-31', volumeUnit: 'shares', amountUnit: 'CNY',
+    })
+  })
+})
+
+describe('TushareService point-in-time fundamentals', () => {
+  it('keeps the latest revision announced by asOf and excludes later revisions', async () => {
+    const service = serviceWith(async () => [
+      { end_date: '20251231', ann_date: '20260430', revenue: 120, update_flag: '1' },
+      { end_date: '20251231', ann_date: '20260315', revenue: 100, update_flag: '0' },
+      { end_date: '20241231', ann_date: '20250320', revenue: 80, update_flag: '0' },
+    ])
+
+    const beforeRevision = await service.getFinancials('600519.SH', 'income', {
+      asOf: '2026-04-01', period: 'annual', limit: 2,
+    })
+    expect(beforeRevision.data.map((row) => row.revenue)).toEqual([100, 80])
+
+    const afterRevision = await service.getFinancials('600519.SH', 'income', {
+      asOf: '2026-05-01', period: 'annual', limit: 1,
+    })
+    expect(afterRevision.data[0]?.revenue).toBe(120)
+  })
+})
+
+describe('TushareService search', () => {
+  it('preserves Beijing exchange ts_code identities', async () => {
+    const service = serviceWith(async (_api, params) => params.list_status === 'L'
+      ? [{ ts_code: '920001.BJ', symbol: '920001', name: '示例股份', cnspell: 'slgf' }]
+      : [])
+    const rows = await service.searchStocks('920001', 5)
+    expect(rows[0]).toMatchObject({ symbol: '920001.BJ', sourceId: 'tushare', assetClass: 'equity' })
+  })
+
+  it('includes current ST securities in the same Tushare namespace', async () => {
+    const service = serviceWith(async (api) => api === 'stock_st'
+      ? [{ ts_code: '600000.SH', name: 'ST示例', type: 'ST' }]
+      : [])
+    const rows = await service.searchStocks('ST示例', 5)
+    expect(rows[0]).toMatchObject({ symbol: '600000.SH', name: 'ST示例', type: 'ST', sourceId: 'tushare' })
+  })
+})

--- a/src/domain/market-data/tushare/service.ts
+++ b/src/domain/market-data/tushare/service.ts
@@ -1,0 +1,229 @@
+import type { GetBarsOpts, BarsResult, OhlcvBar } from '../bars/types.js'
+import type { MarketSearchResult } from '../aggregate-search.js'
+import { TushareClient } from './client.js'
+import type { TushareApiName, TushareDataset, TushareRow } from './types.js'
+
+const DAY_MS = 86_400_000
+const STOCK_FIELDS = [
+  'ts_code', 'symbol', 'name', 'area', 'industry', 'fullname', 'enname',
+  'cnspell', 'market', 'exchange', 'curr_type', 'list_status', 'list_date',
+  'delist_date', 'is_hs', 'act_name', 'act_ent_type',
+] as const
+
+function tsDate(input: string): string {
+  return input.slice(0, 10).replaceAll('-', '')
+}
+
+function normalizeParams(params: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(params).map(([key, value]) => {
+    if ((key.endsWith('_date') || key === 'period') && typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return [key, tsDate(value)]
+    }
+    return [key, value]
+  }))
+}
+
+function requestedAsOf(params: Record<string, unknown>, fallback: string): string {
+  for (const key of ['end_date', 'trade_date', 'ann_date', 'actual_date', 'pre_date']) {
+    const value = params[key]
+    if (typeof value !== 'string') continue
+    return isoDate(value) ?? value.slice(0, 10)
+  }
+  return fallback
+}
+
+function isoDate(input: unknown): string | null {
+  const value = String(input ?? '')
+  return /^\d{8}$/.test(value) ? `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}` : null
+}
+
+function numberValue(value: unknown): number | null {
+  if (value == null || value === '') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function dataset(data: TushareRow[], asOf: string): TushareDataset {
+  return { data, meta: { provider: 'tushare', asOf, origin: 'local' } }
+}
+
+function financialAsOf(rows: TushareRow[], asOf: string, period: 'annual' | 'quarter', limit: number): TushareRow[] {
+  const cutoff = tsDate(asOf)
+  const eligible = rows.filter((row) => {
+    const announced = String(row.ann_date ?? row.f_ann_date ?? '')
+    const end = String(row.end_date ?? '')
+    return (!announced || announced <= cutoff) && (period !== 'annual' || end.endsWith('1231'))
+  })
+  eligible.sort((a, b) => {
+    const periodOrder = String(b.end_date ?? '').localeCompare(String(a.end_date ?? ''))
+    if (periodOrder) return periodOrder
+    return String(b.ann_date ?? b.f_ann_date ?? '').localeCompare(String(a.ann_date ?? a.f_ann_date ?? ''))
+  })
+  const seen = new Set<string>()
+  return eligible.filter((row) => {
+    const key = String(row.end_date ?? '')
+    if (key && seen.has(key)) return false
+    if (key) seen.add(key)
+    return true
+  }).slice(0, limit)
+}
+
+export class TushareService {
+  constructor(
+    readonly client: TushareClient,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  private today(): string {
+    return this.now().toISOString().slice(0, 10)
+  }
+
+  private async read(
+    apiName: TushareApiName,
+    params: Record<string, unknown> = {},
+    fields?: readonly string[],
+    ttlMs?: number,
+    asOf = this.today(),
+  ): Promise<TushareDataset> {
+    const normalized = normalizeParams(params)
+    return dataset(
+      await this.client.query(apiName, normalized, fields, ttlMs),
+      asOf === this.today() ? requestedAsOf(normalized, asOf) : asOf,
+    )
+  }
+
+  stockBasic(params: Record<string, unknown> = {}) { return this.read('stock_basic', params, STOCK_FIELDS, 6 * 60 * 60_000) }
+  stockCompany(params: Record<string, unknown> = {}) { return this.read('stock_company', params, undefined, 6 * 60 * 60_000) }
+  stockSt(params: Record<string, unknown> = {}) { return this.read('stock_st', params, undefined, 15 * 60_000) }
+  nameChange(params: Record<string, unknown> = {}) { return this.read('namechange', params, undefined, 60 * 60_000) }
+  suspensions(params: Record<string, unknown> = {}) { return this.read('suspend_d', params, undefined, 5 * 60_000) }
+  tradeCalendar(params: Record<string, unknown> = {}) { return this.read('trade_cal', params, undefined, 12 * 60 * 60_000) }
+  dailyBasic(params: Record<string, unknown> = {}) { return this.read('daily_basic', params, undefined, 15 * 60_000) }
+  forecast(params: Record<string, unknown> = {}) { return this.read('forecast', params, undefined, 30 * 60_000) }
+  express(params: Record<string, unknown> = {}) { return this.read('express', params, undefined, 30 * 60_000) }
+  disclosures(params: Record<string, unknown> = {}) { return this.read('disclosure_date', params, undefined, 60 * 60_000) }
+  indexBasic(params: Record<string, unknown> = {}) { return this.read('index_basic', params, undefined, 6 * 60 * 60_000) }
+  industry(params: Record<string, unknown> = {}) { return this.read('index_classify', params, undefined, 6 * 60 * 60_000) }
+  indexMembers(params: Record<string, unknown> = {}) { return this.read('index_member_all', params, undefined, 6 * 60 * 60_000) }
+  indexWeights(params: Record<string, unknown> = {}) { return this.read('index_weight', params, undefined, 6 * 60 * 60_000) }
+
+  async searchStocks(query: string, limit = 20): Promise<MarketSearchResult[]> {
+    const q = query.trim().toLowerCase()
+    if (!q) return []
+    const requests = ['L', 'D', 'P'].map((list_status) =>
+      this.client.query('stock_basic', { list_status }, STOCK_FIELDS, 6 * 60 * 60_000),
+    )
+    requests.push(this.client.query('stock_st', {}, ['ts_code', 'name', 'type'], 15 * 60_000))
+    const settled = await Promise.allSettled(requests)
+    const rows = settled.flatMap((result) => result.status === 'fulfilled' ? result.value : [])
+    return rows
+      .filter((row) => [row.ts_code, row.symbol, row.name, row.fullname, row.cnspell]
+        .some((value) => String(value ?? '').toLowerCase().includes(q)))
+      .slice(0, Math.max(1, Math.min(100, limit)))
+      .map((row) => ({
+        ...row,
+        symbol: String(row.ts_code),
+        name: String(row.name ?? row.fullname ?? ''),
+        assetClass: 'equity' as const,
+        sourceId: 'tushare',
+      }))
+  }
+
+  async getProfile(symbol: string): Promise<{ profile: TushareRow | null; company: TushareRow | null }> {
+    const [basic, company] = await Promise.all([
+      this.client.query('stock_basic', { ts_code: symbol }, STOCK_FIELDS, 60 * 60_000),
+      this.client.query('stock_company', { ts_code: symbol }, undefined, 60 * 60_000),
+    ])
+    return { profile: basic[0] ?? null, company: company[0] ?? null }
+  }
+
+  async getFinancials(
+    symbol: string,
+    type: 'income' | 'balance' | 'cash',
+    options: { period?: 'annual' | 'quarter'; limit?: number; asOf?: string } = {},
+  ): Promise<TushareDataset> {
+    const apiName = type === 'income' ? 'income' : type === 'balance' ? 'balancesheet' : 'cashflow'
+    const asOf = options.asOf ?? this.today()
+    const limit = Math.max(1, Math.min(100, options.limit ?? 5))
+    const rows = await this.client.query(apiName, { ts_code: symbol, limit: Math.max(40, limit * 8) }, undefined, 15 * 60_000)
+    return dataset(financialAsOf(rows, asOf, options.period ?? 'annual', limit), asOf)
+  }
+
+  async getRatios(
+    symbol: string,
+    options: { period?: 'annual' | 'quarter'; limit?: number; asOf?: string } = {},
+  ): Promise<TushareDataset> {
+    const asOf = options.asOf ?? this.today()
+    const limit = Math.max(1, Math.min(100, options.limit ?? 5))
+    const rows = await this.client.query('fina_indicator', { ts_code: symbol, limit: Math.max(40, limit * 8) }, undefined, 15 * 60_000)
+    return dataset(financialAsOf(rows, asOf, options.period ?? 'annual', limit), asOf)
+  }
+
+  async getBars(symbol: string, opts: GetBarsOpts): Promise<BarsResult> {
+    if (!['1d', '1D', 'day', 'daily'].includes(opts.interval)) {
+      throw new Error('Tushare P0 supports daily bars only (interval: 1d)')
+    }
+    const anchor = (opts.end ?? opts.asOf ?? this.today()).slice(0, 10)
+    let start = opts.start?.slice(0, 10)
+    if (!start) {
+      const count = Math.max(1, opts.count ?? 250)
+      start = new Date(new Date(`${anchor}T00:00:00Z`).getTime() - (count * 3 + 30) * DAY_MS)
+        .toISOString().slice(0, 10)
+    }
+    const params = { ts_code: symbol, start_date: tsDate(start), end_date: tsDate(anchor) }
+    const [dailyRows, factorRows] = await Promise.all([
+      this.client.query('daily', params, undefined, 5 * 60_000),
+      this.client.query('adj_factor', params, ['ts_code', 'trade_date', 'adj_factor'], 5 * 60_000),
+    ])
+    const factors = new Map(factorRows.map((row) => [String(row.trade_date), numberValue(row.adj_factor)]))
+    const anchorFactor = factorRows
+      .filter((row) => String(row.trade_date) <= tsDate(anchor))
+      .sort((a, b) => String(b.trade_date).localeCompare(String(a.trade_date)))
+      .map((row) => numberValue(row.adj_factor))
+      .find((value): value is number => value != null)
+    if (dailyRows.length > 0 && !anchorFactor) throw new Error(`Tushare returned no adjustment factor for ${symbol} at ${anchor}`)
+
+    const bars: OhlcvBar[] = dailyRows.flatMap((row) => {
+      const date = isoDate(row.trade_date)
+      const factor = factors.get(String(row.trade_date))
+      const open = numberValue(row.open)
+      const high = numberValue(row.high)
+      const low = numberValue(row.low)
+      const close = numberValue(row.close)
+      if (!date || factor == null || anchorFactor == null || open == null || high == null || low == null || close == null) return []
+      const multiplier = factor / anchorFactor
+      const volume = numberValue(row.vol)
+      const amount = numberValue(row.amount)
+      return [{
+        date,
+        open: open * multiplier,
+        high: high * multiplier,
+        low: low * multiplier,
+        close: close * multiplier,
+        volume: volume == null ? null : volume * 100,
+        amount: amount == null ? null : amount * 1000,
+      }]
+    }).sort((a, b) => a.date.localeCompare(b.date))
+    const bounded = opts.count && bars.length > opts.count ? bars.slice(-opts.count) : bars
+    return {
+      bars: bounded,
+      meta: {
+        symbol,
+        from: bounded[0]?.date ?? '',
+        to: bounded[bounded.length - 1]?.date ?? '',
+        bars: bounded.length,
+        source: 'vendor',
+        sourceId: 'tushare',
+        barId: `tushare|${symbol}`,
+        provider: 'tushare',
+        barCapability: 'delayed',
+        asOf: anchor,
+        adjustment: 'qfq',
+        adjustmentAnchor: anchor,
+        priceUnit: 'CNY',
+        volumeUnit: 'shares',
+        amountUnit: 'CNY',
+      },
+    }
+  }
+}

--- a/src/domain/market-data/tushare/types.ts
+++ b/src/domain/market-data/tushare/types.ts
@@ -1,0 +1,53 @@
+export const TUSHARE_API_NAMES = [
+  'stock_basic',
+  'stock_company',
+  'stock_st',
+  'namechange',
+  'suspend_d',
+  'trade_cal',
+  'daily',
+  'adj_factor',
+  'daily_basic',
+  'income',
+  'balancesheet',
+  'cashflow',
+  'fina_indicator',
+  'forecast',
+  'express',
+  'disclosure_date',
+  'index_basic',
+  'index_classify',
+  'index_member_all',
+  'index_weight',
+] as const
+
+export type TushareApiName = (typeof TUSHARE_API_NAMES)[number]
+
+export type TushareValue = string | number | boolean | null
+export type TushareRow = Record<string, TushareValue>
+
+export interface TushareRuntimeConfig {
+  enabled: boolean
+  baseUrl: string
+  token?: string
+}
+
+export interface TushareResponseData {
+  fields?: unknown
+  items?: unknown
+}
+
+export interface TushareResponseEnvelope {
+  code?: unknown
+  msg?: unknown
+  data?: TushareResponseData | null
+}
+
+export interface TushareDataset {
+  data: TushareRow[]
+  meta: {
+    provider: 'tushare'
+    asOf: string
+    origin: 'local'
+  }
+}

--- a/src/domain/market-data/vendors.spec.ts
+++ b/src/domain/market-data/vendors.spec.ts
@@ -9,10 +9,11 @@ import type { QueryExecutor } from '@traderalice/opentypebb'
 vi.mock('@/core/config.js', () => ({
   readMarketDataConfig: vi.fn(),
   updateExtraVendors: vi.fn(),
+  updateTushareEnabled: vi.fn(),
 }))
 
-import { readMarketDataConfig, updateExtraVendors } from '@/core/config.js'
-import { listMarketVendors, setMarketVendor } from './vendors.js'
+import { readMarketDataConfig, updateExtraVendors, updateTushareEnabled } from '@/core/config.js'
+import { listMarketVendors, setMarketVendor, TUSHARE_VENDOR } from './vendors.js'
 
 const META = { coverage: 'cov', howToUse: 'how' }
 
@@ -38,9 +39,12 @@ beforeEach(() => {
   vi.mocked(readMarketDataConfig).mockResolvedValue({
     providers: { equity: 'yfinance' },
     extraVendors: ['eastmoney'],
+    tushare: { enabled: false, baseUrl: 'https://api.tushare.pro' },
   } as unknown as Awaited<ReturnType<typeof readMarketDataConfig>>)
   vi.mocked(updateExtraVendors).mockReset()
   vi.mocked(updateExtraVendors).mockImplementation(async (mutate) => mutate([]))
+  vi.mocked(updateTushareEnabled).mockReset()
+  vi.mocked(updateTushareEnabled).mockImplementation(async (enabled) => enabled)
 })
 
 describe('listMarketVendors', () => {
@@ -60,6 +64,11 @@ describe('listMarketVendors', () => {
     expect(v.find((x) => x.id === 'eastmoney')).toMatchObject({ alwaysOn: false, enabled: true })
     expect(v.find((x) => x.id === 'twse')).toMatchObject({ alwaysOn: false, enabled: false, coverage: 'cov' })
     expect(v.some((x) => x.id === 'fmp')).toBe(false)
+  })
+
+  it('joins native Tushare state without pretending it is keyless', async () => {
+    const v = await listMarketVendors(fakeExecutor([]), [TUSHARE_VENDOR])
+    expect(v).toEqual([expect.objectContaining({ id: 'tushare', enabled: false, keyless: false })])
   })
 })
 
@@ -91,5 +100,11 @@ describe('setMarketVendor', () => {
   it('rejects an unknown vendor id', async () => {
     await expect(setMarketVendor(exec, 'nope', true)).rejects.toThrow(/Unknown market vendor/)
     expect(updateExtraVendors).not.toHaveBeenCalled()
+  })
+
+  it('toggles native Tushare through its dedicated config field', async () => {
+    const result = await setMarketVendor(exec, 'tushare', true, [TUSHARE_VENDOR])
+    expect(updateTushareEnabled).toHaveBeenCalledWith(true)
+    expect(result).toMatchObject({ id: 'tushare', enabled: true })
   })
 })

--- a/src/domain/market-data/vendors.ts
+++ b/src/domain/market-data/vendors.ts
@@ -18,7 +18,7 @@
  */
 
 import type { QueryExecutor } from '@traderalice/opentypebb'
-import { readMarketDataConfig, updateExtraVendors } from '@/core/config.js'
+import { readMarketDataConfig, updateExtraVendors, updateTushareEnabled } from '@/core/config.js'
 
 export interface MarketVendorInfo {
   /** Vendor id used everywhere (search sourceId, setMarketVendor arg). */
@@ -38,14 +38,28 @@ export interface MarketVendorInfo {
   website?: string
 }
 
+export interface NativeMarketVendor {
+  id: string
+  name: string
+  keyless: boolean
+  coverage: string
+  howToUse: string
+  website?: string
+  enabled(config: Awaited<ReturnType<typeof readMarketDataConfig>>): boolean
+  setEnabled?(enabled: boolean): Promise<void>
+}
+
 /** Every provider that has opted into the vendor picker (declared `vendorMeta`),
  *  joined to current on/off state. Always-on first, then enabled, then the rest. */
-export async function listMarketVendors(executor: QueryExecutor): Promise<MarketVendorInfo[]> {
+export async function listMarketVendors(
+  executor: QueryExecutor,
+  nativeVendors: NativeMarketVendor[] = [],
+): Promise<MarketVendorInfo[]> {
   const md = await readMarketDataConfig()
   const primary = md.providers.equity
   const extra = new Set(md.extraVendors)
 
-  return executor
+  const embedded = executor
     .listProviders()
     .filter((p) => p.vendorMeta)
     .map((p): MarketVendorInfo => {
@@ -61,7 +75,17 @@ export async function listMarketVendors(executor: QueryExecutor): Promise<Market
         website: p.website,
       }
     })
-    .sort(
+  const native = nativeVendors.map((vendor): MarketVendorInfo => ({
+    id: vendor.id,
+    name: vendor.name,
+    enabled: vendor.enabled(md),
+    alwaysOn: false,
+    keyless: vendor.keyless,
+    coverage: vendor.coverage,
+    howToUse: vendor.howToUse,
+    website: vendor.website,
+  }))
+  return [...embedded, ...native].sort(
       (a, b) =>
         Number(b.alwaysOn) - Number(a.alwaysOn) ||
         Number(b.enabled) - Number(a.enabled) ||
@@ -84,11 +108,18 @@ export async function setMarketVendor(
   executor: QueryExecutor,
   id: string,
   enabled: boolean,
+  nativeVendors: NativeMarketVendor[] = [],
 ): Promise<SetVendorResult> {
+  const native = nativeVendors.find((vendor) => vendor.id.toLowerCase() === id.trim().toLowerCase())
+  if (native) {
+    if (!native.setEnabled) throw new Error(`Vendor "${native.id}" cannot be toggled.`)
+    await native.setEnabled(enabled)
+    return { id: native.id, enabled, vendors: await listMarketVendors(executor, nativeVendors) }
+  }
   const known = executor.listProviders().filter((p) => p.vendorMeta)
   const target = known.find((p) => p.name.toLowerCase() === id.trim().toLowerCase())
   if (!target) {
-    const names = known.map((p) => p.name).join(', ')
+    const names = [...known.map((p) => p.name), ...nativeVendors.map((vendor) => vendor.id)].join(', ')
     throw new Error(`Unknown market vendor "${id}". Available vendors: ${names}.`)
   }
 
@@ -103,5 +134,16 @@ export async function setMarketVendor(
     enabled ? [...current, target.name] : current.filter((v) => v !== target.name),
   )
 
-  return { id: target.name, enabled, vendors: await listMarketVendors(executor) }
+  return { id: target.name, enabled, vendors: await listMarketVendors(executor, nativeVendors) }
+}
+
+export const TUSHARE_VENDOR: NativeMarketVendor = {
+  id: 'tushare',
+  name: 'Tushare Pro',
+  keyless: false,
+  coverage: 'China A-shares, indices, fundamentals, calendars, classifications and daily qfq bars',
+  howToUse: 'Enable it and configure a token, then search by ts_code (600519.SH), ticker, Chinese name, or pinyin.',
+  website: 'https://tushare.pro',
+  enabled: (config) => config.tushare.enabled,
+  setEnabled: async (enabled) => { await updateTushareEnabled(enabled) },
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import type { EquityClientLike, CryptoClientLike, CurrencyClientLike, EtfClientL
 import { buildSDKCredentials } from './domain/market-data/credential-map.js'
 import { createMarketSearchTools } from './tool/market.js'
 import { createVendorTools } from './tool/market-vendors.js'
+import { createChinaTools } from './tool/china.js'
 import { createQuantTools } from './tool/quant.js'
 import { createSnapshotTools } from './tool/snapshot.js'
 import { createSimulateTools } from './tool/simulate.js'
@@ -49,6 +50,9 @@ import { createReferenceBoardTools } from './tool/reference-board.js'
 import { createDerivativesTools } from './tool/derivatives.js'
 import { createIndexTools } from './tool/indices.js'
 import { createEconomyTools } from './tool/economy.js'
+import { TushareClient } from './domain/market-data/tushare/client.js'
+import { TushareService } from './domain/market-data/tushare/service.js'
+import { TUSHARE_VENDOR } from './domain/market-data/vendors.js'
 import { SessionStore } from './core/session.js'
 import { createInboxStore } from './core/inbox-store.js'
 import { startInboxConnectorBridge } from './services/connector-client/index.js'
@@ -205,6 +209,19 @@ async function main() {
   const commodityCatalog = new CommodityCatalog()
   commodityCatalog.load()
 
+  // Native China-market provider. Credentials, enabled state and endpoint are
+  // deliberately read per request so scheduled token rotation is immediate.
+  const tushare = new TushareService(new TushareClient({
+    getConfig: async () => {
+      const md = await readMarketDataConfig()
+      return {
+        enabled: md.tushare.enabled,
+        baseUrl: md.tushare.baseUrl,
+        token: md.providerKeys.tushare,
+      }
+    },
+  }))
+
   // Default equity vendor + user-opted incremental vendors (eastmoney, …),
   // de-duped, fanned out in searchBars; yfinance stays the always-on default.
   // Resolved PER search (not a boot snapshot) so a vendor the agent enables at
@@ -215,7 +232,18 @@ async function main() {
     return [...new Set([md.providers.equity, ...md.extraVendors])]
   }
 
-  const marketSearch = { symbolIndex, equityVendors: getEquityVendors, equityClient, cryptoClient, currencyClient, commodityCatalog }
+  const marketSearch = {
+    symbolIndex,
+    equityVendors: getEquityVendors,
+    equityClient,
+    cryptoClient,
+    currencyClient,
+    commodityCatalog,
+    nativeEquitySources: [{
+      sourceId: 'tushare',
+      search: (query: string, limit: number) => tushare.searchStocks(query, limit),
+    }],
+  }
 
   // Federated bar layer — embedded vendor adapters + broker (UTA) OHLCV behind one
   // barId-keyed interface. Vendor branch live now; UTA branch lands with Phase 1.
@@ -227,6 +255,7 @@ async function main() {
     commodityClient,
     utaManager,
     vendorProviders: config.marketData.providers,
+    nativeVendors: { tushare: { getBars: (symbol, opts) => tushare.getBars(symbol, opts), barCapability: 'delayed' } },
   })
 
   // Hub-first calendars: tools, CLI and boards all inherit through the
@@ -258,9 +287,10 @@ async function main() {
   )
 
   toolCenter.register(createMarketSearchTools(marketSearch), 'market-search')
-  toolCenter.register(createVendorTools(getSDKExecutor()), 'market-vendors')
+  toolCenter.register(createVendorTools(getSDKExecutor(), [TUSHARE_VENDOR]), 'market-vendors')
   toolCenter.register(createReferenceBoardTools(reference), 'market-board')
-  toolCenter.register(createEquityTools(equityClient), 'equity')
+  toolCenter.register(createEquityTools(equityClient, tushare), 'equity')
+  toolCenter.register(createChinaTools(tushare), 'china')
   if (etfClient) {
     toolCenter.register(createEtfTools(etfClient), 'etf')
   }

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -32,6 +32,7 @@ import { provenanceShowFactory } from '../tool/provenance-show.js'
 import { conversationToolFactories } from '../tool/conversation.js'
 import { artifactConversationToolFactories } from '../tool/conversation-artifacts.js'
 import { createTradingTools } from '../tool/trading.js'
+import { createChinaTools } from '../tool/china.js'
 
 /**
  * Anti-rot: each export's alias map is hand-authored, so guard it against drift —
@@ -85,6 +86,18 @@ describe('CLI_EXPORTS — uta export (global trading tools)', () => {
   it('binary alice-uta resolves to the uta export', () => {
     expect(exportKeyForBinary('alice-uta')).toBe('uta')
     expect(getExport('uta')?.scope).toBe('global')
+  })
+})
+
+describe('CLI_EXPORTS — native China data', () => {
+  it('maps every traderhub china verb to a Tushare-backed tool', () => {
+    const tools = createChinaTools(any)
+    const commands = CLI_EXPORTS.traderhub.commands.china
+    expect(Object.keys(commands)).toEqual([
+      'calendar', 'daily-basic', 'status', 'forecast', 'express', 'disclosures',
+      'industry', 'index-basic', 'index-members', 'index-weights',
+    ])
+    for (const toolName of Object.values(commands)) expect(tools[toolName as keyof typeof tools]).toBeTruthy()
   })
 })
 

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -104,6 +104,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       fed: 'Read FOMC documents, the Fed balance sheet, and dealer positioning',
       crypto: 'Inspect crypto derivatives markets',
       index: 'Discover index identifiers',
+      china: 'Read Tushare-backed China calendars, valuation, status, disclosures, industries, and index constituents',
     },
     commands: {
       board: {
@@ -160,6 +161,18 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       },
       index: {
         search: 'indexSearch',
+      },
+      china: {
+        calendar: 'chinaTradeCalendar',
+        'daily-basic': 'chinaDailyBasic',
+        status: 'chinaSecurityStatus',
+        forecast: 'chinaForecast',
+        express: 'chinaExpress',
+        disclosures: 'chinaDisclosures',
+        industry: 'chinaIndustry',
+        'index-basic': 'chinaIndexCatalog',
+        'index-members': 'chinaIndexMembers',
+        'index-weights': 'chinaIndexWeights',
       },
     },
   },

--- a/src/tool/china.ts
+++ b/src/tool/china.ts
@@ -1,0 +1,93 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { TushareService } from '@/domain/market-data/tushare/service.js'
+
+const date = z.string().regex(/^\d{4}-?\d{2}-?\d{2}$/, 'Expected YYYY-MM-DD or YYYYMMDD')
+const code = z.string().describe('Tushare ts_code, e.g. 600519.SH or 000001.SZ')
+
+function compact<T extends Record<string, unknown>>(value: T): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined && item !== ''))
+}
+
+export function createChinaTools(tushare: TushareService) {
+  return {
+    chinaTradeCalendar: tool({
+      description: 'Read the official China exchange trading calendar from Tushare, including open/closed days and the previous open day.',
+      inputSchema: z.object({
+        exchange: z.enum(['SSE', 'SZSE', 'BSE', '']).optional(),
+        start_date: date.optional(), end_date: date.optional(), is_open: z.enum(['0', '1']).optional(),
+      }).meta({ examples: [{ exchange: 'SSE', start_date: '2026-01-01', end_date: '2026-01-31' }] }),
+      execute: async (params) => tushare.tradeCalendar(compact(params)),
+    }),
+    chinaDailyBasic: tool({
+      description: 'Read A-share daily valuation and trading indicators: turnover, volume ratio, PE/PB/PS, dividend yield, shares and market value.',
+      inputSchema: z.object({
+        ts_code: code.optional(), trade_date: date.optional(), start_date: date.optional(), end_date: date.optional(),
+        limit: z.number().int().positive().max(6000).optional(),
+      }).meta({ examples: [{ ts_code: '600519.SH', trade_date: '2026-08-31' }] }),
+      execute: async (params) => tushare.dailyBasic(compact(params)),
+    }),
+    chinaSecurityStatus: tool({
+      description: 'Read A-share special-treatment names, historical name changes, or daily suspension/resumption records.',
+      inputSchema: z.object({
+        type: z.enum(['st', 'namechange', 'suspension']), ts_code: code.optional(), trade_date: date.optional(),
+        start_date: date.optional(), end_date: date.optional(),
+      }).meta({ examples: [{ type: 'st', ts_code: '000001.SZ' }] }),
+      execute: async ({ type, ...params }) => {
+        const query = compact(params)
+        if (type === 'st') return tushare.stockSt(query)
+        if (type === 'namechange') return tushare.nameChange(query)
+        return tushare.suspensions(query)
+      },
+    }),
+    chinaForecast: tool({
+      description: 'Read A-share performance forecasts with announcement dates preserved for point-in-time research.',
+      inputSchema: z.object({ ts_code: code.optional(), ann_date: date.optional(), period: date.optional(), type: z.string().optional() })
+        .meta({ examples: [{ ts_code: '600519.SH' }] }),
+      execute: async (params) => tushare.forecast(compact(params)),
+    }),
+    chinaExpress: tool({
+      description: 'Read A-share preliminary earnings reports (业绩快报), including announcement and reporting-period dates.',
+      inputSchema: z.object({
+        ts_code: code.optional(), ann_date: date.optional(), start_date: date.optional(), end_date: date.optional(), period: date.optional(),
+      }).meta({ examples: [{ ts_code: '600519.SH' }] }),
+      execute: async (params) => tushare.express(compact(params)),
+    }),
+    chinaDisclosures: tool({
+      description: 'Read scheduled and actual A-share financial-report disclosure dates.',
+      inputSchema: z.object({ ts_code: code.optional(), end_date: date.optional(), pre_date: date.optional(), actual_date: date.optional() })
+        .meta({ examples: [{ ts_code: '600519.SH' }] }),
+      execute: async (params) => tushare.disclosures(compact(params)),
+    }),
+    chinaIndustry: tool({
+      description: 'Read Shenwan and other China index/industry classifications available from Tushare.',
+      inputSchema: z.object({
+        index_code: z.string().optional(), level: z.enum(['L1', 'L2', 'L3']).optional(), parent_code: z.string().optional(),
+        src: z.string().optional().describe('Classification source, e.g. SW2021'),
+      }).meta({ examples: [{ level: 'L1', src: 'SW2021' }] }),
+      execute: async (params) => tushare.industry(compact(params)),
+    }),
+    chinaIndexCatalog: tool({
+      description: 'Discover Tushare China index identifiers by market, publisher, or category.',
+      inputSchema: z.object({
+        ts_code: z.string().optional(), name: z.string().optional(), market: z.string().optional(),
+        publisher: z.string().optional(), category: z.string().optional(),
+      }).meta({ examples: [{ market: 'SSE' }] }),
+      execute: async (params) => tushare.indexBasic(compact(params)),
+    }),
+    chinaIndexMembers: tool({
+      description: 'Read current or historical members of a China index or industry classification.',
+      inputSchema: z.object({
+        l1_code: z.string().optional(), l2_code: z.string().optional(), l3_code: z.string().optional(),
+        ts_code: code.optional(), is_new: z.enum(['Y', 'N']).optional(),
+      }).meta({ examples: [{ l1_code: '801010.SI', is_new: 'Y' }] }),
+      execute: async (params) => tushare.indexMembers(compact(params)),
+    }),
+    chinaIndexWeights: tool({
+      description: 'Read constituent weights for a China index over a bounded trade-date window.',
+      inputSchema: z.object({ index_code: z.string(), trade_date: date.optional(), start_date: date.optional(), end_date: date.optional() })
+        .meta({ examples: [{ index_code: '000300.SH', trade_date: '2026-08-31' }] }),
+      execute: async (params) => tushare.indexWeights(compact(params)),
+    }),
+  }
+}

--- a/src/tool/equity.ts
+++ b/src/tool/equity.ts
@@ -10,8 +10,11 @@ import { tool } from 'ai'
 import { z } from 'zod'
 import type { EquityClientLike } from '@/domain/market-data/client/types'
 import type { EquityDiscoveryData } from '@traderalice/opentypebb'
+import type { TushareService } from '@/domain/market-data/tushare/service.js'
 
-export function createEquityTools(equityClient: EquityClientLike) {
+const isChinaEquity = (symbol: string) => /\.(SH|SZ|BJ)$/i.test(symbol)
+
+export function createEquityTools(equityClient: EquityClientLike, tushare?: TushareService) {
   return {
     equityGetProfile: tool({
       description: `Get company profile and key valuation metrics for a stock.
@@ -24,6 +27,17 @@ If unsure about the symbol, use marketSearchForResearch to find it.`,
         symbol: z.string().describe('Ticker symbol, e.g. "AAPL", "MSFT"'),
       }).meta({ examples: [{ symbol: 'AAPL' }] }),
       execute: async ({ symbol }) => {
+        if (tushare && isChinaEquity(symbol)) {
+          const [{ profile, company }, valuation] = await Promise.all([
+            tushare.getProfile(symbol.toUpperCase()),
+            tushare.dailyBasic({ ts_code: symbol.toUpperCase(), limit: 1 }),
+          ])
+          return {
+            profile: profile || company ? { ...profile, ...company } : null,
+            metrics: valuation.data[0] ?? null,
+            meta: valuation.meta,
+          }
+        }
         // For Taiwan tickers (2330.TW / 6488.TWO), metrics route to the official
         // twse vendor first (official P/E·殖利率·股價淨值比), then yfinance.
         // Profile stays yfinance-first (richer description/sector), with twse as a
@@ -59,8 +73,12 @@ If unsure about the symbol, use marketSearchForResearch to find it.`,
         type: z.enum(['income', 'balance', 'cash']).describe('Statement type: "income" for income statement, "balance" for balance sheet, "cash" for cash flow'),
         period: z.enum(['annual', 'quarter']).optional().describe('Fiscal period (default: annual)'),
         limit: z.number().int().positive().optional().describe('Number of periods to return (default: 5)'),
+        asOf: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('Point-in-time cutoff; filings announced later are excluded'),
       }).meta({ examples: [{ symbol: 'AAPL', type: 'income', period: 'annual', limit: 5 }] }),
-      execute: async ({ symbol, type, period, limit }) => {
+      execute: async ({ symbol, type, period, limit, asOf }) => {
+        if (tushare && isChinaEquity(symbol)) {
+          return tushare.getFinancials(symbol.toUpperCase(), type, { period, limit, asOf })
+        }
         const params: Record<string, unknown> = { symbol, provider: 'yfinance' }
         if (period) params.period = period
         if (limit) params.limit = limit
@@ -96,8 +114,12 @@ If unsure about the symbol, use marketSearchForResearch to find it.`,
         period: z.enum(['annual', 'quarter']).optional().describe('Fiscal period for the historical series (default: annual)'),
         limit: z.number().int().positive().optional().describe('Number of historical periods to return (default: 5; ignored when ttm="only")'),
         ttm: z.enum(['include', 'exclude', 'only']).optional().describe('TTM handling: "include" (default — TTM + history), "exclude" (history only), "only" (TTM snapshot only)'),
+        asOf: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('Point-in-time cutoff; filings announced later are excluded'),
       }).meta({ examples: [{ symbol: 'AAPL', period: 'annual', limit: 5 }] }),
-      execute: async ({ symbol, period, limit, ttm }) => {
+      execute: async ({ symbol, period, limit, ttm, asOf }) => {
+        if (tushare && isChinaEquity(symbol)) {
+          return tushare.getRatios(symbol.toUpperCase(), { period, limit, asOf })
+        }
         // The FMP fetcher defaults ttm to "only" (a single TTM row, with
         // period/limit dead). Default to "include" here so the historical
         // series — and therefore period/limit — actually come through.

--- a/src/tool/market-vendors.ts
+++ b/src/tool/market-vendors.ts
@@ -13,9 +13,9 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import type { QueryExecutor } from '@traderalice/opentypebb'
-import { listMarketVendors, setMarketVendor } from '@/domain/market-data/vendors.js'
+import { listMarketVendors, setMarketVendor, type NativeMarketVendor } from '@/domain/market-data/vendors.js'
 
-export function createVendorTools(executor: QueryExecutor) {
+export function createVendorTools(executor: QueryExecutor, nativeVendors: NativeMarketVendor[] = []) {
   return {
     listMarketVendors: tool({
       description: `List the market-data vendors available for symbol search, each with its
@@ -26,7 +26,7 @@ working a market you haven't queried (CN A-shares, Taiwan, etc.) — it tells yo
 covers it and how to address symbols. If the right vendor is off, turn it on with
 setMarketVendor; the change is live immediately, no restart.`,
       inputSchema: z.object({}).meta({ examples: [{}] }),
-      execute: async () => ({ vendors: await listMarketVendors(executor) }),
+      execute: async () => ({ vendors: await listMarketVendors(executor, nativeVendors) }),
     }),
 
     setMarketVendor: tool({
@@ -41,7 +41,7 @@ always-on primary vendor (yfinance) cannot be toggled.`,
           enabled: z.boolean().describe('true to turn on, false to turn off'),
         })
         .meta({ examples: [{ vendor: 'twse', enabled: true }] }),
-      execute: async ({ vendor, enabled }) => setMarketVendor(executor, vendor, enabled),
+      execute: async ({ vendor, enabled }) => setMarketVendor(executor, vendor, enabled, nativeVendors),
     }),
   }
 }

--- a/src/webui/routes/config.ts
+++ b/src/webui/routes/config.ts
@@ -35,6 +35,7 @@ import {
   type AdapterRegistry,
   type CliAdapter,
 } from '../../workspaces/cli-adapter.js'
+import { TushareClient } from '../../domain/market-data/tushare/client.js'
 
 interface ConfigRouteOpts {
   ctx?: EngineContext
@@ -476,7 +477,35 @@ export function createMarketDataRoutes(ctx: EngineContext) {
 
   app.post('/test-provider', async (c) => {
     try {
-      const { provider, key } = await c.req.json<{ provider: string; key: string }>()
+      const { provider, key, baseUrl } = await c.req.json<{ provider: string; key: string; baseUrl?: string }>()
+      if (provider === 'tushare') {
+        if (!key) return c.json({ ok: false, error: 'No API token provided' }, 400)
+        const client = new TushareClient({
+          getConfig: () => ({ enabled: true, token: key, baseUrl: baseUrl || 'https://api.tushare.pro' }),
+          retries: 0,
+          timeoutMs: 8_000,
+        })
+        const probes = await Promise.allSettled([
+          client.query('trade_cal', { exchange: 'SSE', limit: 1 }, undefined, 0),
+          client.query('stock_basic', { list_status: 'L', limit: 1 }, ['ts_code', 'name'], 0),
+          client.query(
+            'daily_basic',
+            { ts_code: '000001.SZ', start_date: '20200101', end_date: '20301231', limit: 1 },
+            ['ts_code', 'trade_date'],
+            0,
+          ),
+        ])
+        const capabilities = ['calendar', 'securities', 'fundamentals'].map((name, index) => ({
+          name,
+          ok: probes[index]?.status === 'fulfilled',
+          error: probes[index]?.status === 'rejected'
+            ? (probes[index] as PromiseRejectedResult).reason instanceof Error
+              ? (probes[index] as PromiseRejectedResult).reason.message
+              : 'Probe failed'
+            : undefined,
+        }))
+        return c.json({ ok: capabilities.every((item) => item.ok), capabilities })
+      }
       const endpoint = TEST_ENDPOINTS[provider]
       if (!endpoint) return c.json({ ok: false, error: `Unknown provider: ${provider}` }, 400)
       if (!key) return c.json({ ok: false, error: 'No API key provided' }, 400)

--- a/ui/src/api/openbb.ts
+++ b/ui/src/api/openbb.ts
@@ -7,11 +7,15 @@ export interface HubStatus {
 }
 
 export const marketDataApi = {
-  async testProvider(provider: string, key: string): Promise<{ ok: boolean; error?: string }> {
+  async testProvider(
+    provider: string,
+    key: string,
+    baseUrl?: string,
+  ): Promise<{ ok: boolean; error?: string; capabilities?: Array<{ name: string; ok: boolean; error?: string }> }> {
     const res = await fetch('/api/market-data/test-provider', {
       method: 'POST',
       headers,
-      body: JSON.stringify({ provider, key }),
+      body: JSON.stringify({ provider, key, ...(baseUrl ? { baseUrl } : {}) }),
     })
     return res.json()
   },

--- a/ui/src/pages/MarketDataPage.spec.tsx
+++ b/ui/src/pages/MarketDataPage.spec.tsx
@@ -27,6 +27,7 @@ vi.mock('../hooks/useConfigPage', () => ({
     config: {
       enabled: true,
       hub: { enabled: false, baseUrl: 'https://traderhub.openalice.ai' },
+      tushare: { enabled: false, baseUrl: 'https://api.tushare.pro' },
       extraVendors: [],
       providerKeys: {
         fmp: 'test-fmp-key',
@@ -35,6 +36,7 @@ vi.mock('../hooks/useConfigPage', () => ({
         eia: 'test-eia-key',
         econdb: 'test-econdb-key',
         intrinio: 'test-intrinio-key',
+        tushare: 'test-tushare-token',
       },
     },
     status: 'idle',
@@ -58,6 +60,26 @@ function openProviderKeys() {
 }
 
 describe('MarketDataPage provider credentials', () => {
+  it('configures and probes the native Tushare provider without exposing the token', async () => {
+    render(<MarketDataPage />)
+
+    const token = screen.getByLabelText('Tushare Pro token') as HTMLInputElement
+    expect(token.type).toBe('password')
+    expect(token.value).toBe('test-tushare-token')
+    expect((screen.getByLabelText('Tushare endpoint') as HTMLInputElement).value).toBe('https://api.tushare.pro')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test Tushare Pro key' }))
+    expect(await screen.findByRole('button', { name: 'Tushare Pro key test passed' })).toBeTruthy()
+    expect(mocks.testProvider).toHaveBeenCalledWith(
+      'tushare', 'test-tushare-token', 'https://api.tushare.pro',
+    )
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Tushare Pro' }))
+    expect(mocks.updateConfigImmediate).toHaveBeenCalledWith({
+      tushare: { enabled: true, baseUrl: 'https://api.tushare.pro' },
+    })
+  })
+
   it('gives every key field and test action a provider-specific name', () => {
     openProviderKeys()
 

--- a/ui/src/pages/MarketDataPage.tsx
+++ b/ui/src/pages/MarketDataPage.tsx
@@ -101,12 +101,19 @@ function deriveSourceRows(
   ping: HubPing,
   keys: Record<string, string>,
   extraVendors: string[],
+  tushareEnabled: boolean,
 ): SourceRow[] {
   const hubLive = hubOn && ping !== 'down' // optimistic while checking
   const hub = { source: 'Hub', state: 'ok' as const }
-  const chartVendors = ['yfinance', ...extraVendors].join(' · ')
+  const chartVendors = ['yfinance', ...extraVendors, ...(tushareEnabled ? ['tushare'] : [])].join(' · ')
 
   return [
+    {
+      name: 'China market data',
+      detail: 'A-shares · qfq bars · fundamentals · indices',
+      source: tushareEnabled ? 'Tushare Pro' : 'Off',
+      state: tushareEnabled ? 'ok' as const : 'off' as const,
+    },
     {
       name: 'Market boards',
       detail: 'valuation · macro · futures · risk · rotation',
@@ -207,7 +214,8 @@ export function MarketDataPage() {
 
   const providerKeys = (config.providerKeys ?? {}) as Record<string, string>
   const extraVendors = (config.extraVendors ?? []) as string[]
-  const sourceRows = deriveSourceRows(hub.enabled, ping, providerKeys, extraVendors)
+  const tushare = (config.tushare ?? { enabled: false, baseUrl: 'https://api.tushare.pro' }) as { enabled: boolean; baseUrl: string }
+  const sourceRows = deriveSourceRows(hub.enabled, ping, providerKeys, extraVendors, tushare.enabled)
 
   const handleExtraVendorToggle = (id: string, on: boolean) => {
     const next = on ? [...new Set([...extraVendors, id])] : extraVendors.filter((v) => v !== id)
@@ -216,12 +224,10 @@ export function MarketDataPage() {
 
   const handleKeyChange = (keyName: string, value: string) => {
     const all = (config.providerKeys ?? {}) as Record<string, string>
-    const updated = { ...all, [keyName]: value }
-    const cleaned: Record<string, string> = {}
-    for (const [k, v] of Object.entries(updated)) {
-      if (v) cleaned[k] = v
-    }
-    updateConfig({ providerKeys: cleaned })
+    // Preserve an explicit empty string: the config writer uses it as the
+    // deletion signal for the user-global provider-key store. Omitting the key
+    // would resurrect the old global token on the next read.
+    updateConfig({ providerKeys: { ...all, [keyName]: value } })
   }
 
   const jumpToFmp = () => {
@@ -261,6 +267,13 @@ export function MarketDataPage() {
             onToggle={(v) => updateConfigImmediate({ hub: { ...hub, enabled: v } })}
           />
 
+          <TushareCard
+            settings={tushare}
+            token={providerKeys.tushare ?? ''}
+            onSettingsChange={(next) => updateConfigImmediate({ tushare: next })}
+            onTokenChange={(token) => handleKeyChange('tushare', token)}
+          />
+
           <SourcesCard rows={sourceRows} onAddFmp={jumpToFmp} />
 
           <ChartVendorsSection extraVendors={extraVendors} onToggle={handleExtraVendorToggle} />
@@ -279,6 +292,89 @@ export function MarketDataPage() {
         {loadError && <p className="text-[13px] text-destructive mt-4 max-w-[880px] mx-auto">Failed to load configuration.</p>}
       </SettingsScrollArea>
     </div>
+  )
+}
+
+// ==================== Native Tushare card ====================
+
+function TushareCard({
+  settings,
+  token,
+  onSettingsChange,
+  onTokenChange,
+}: {
+  settings: { enabled: boolean; baseUrl: string }
+  token: string
+  onSettingsChange: (next: { enabled: boolean; baseUrl: string }) => void
+  onTokenChange: (token: string) => void
+}) {
+  const [localToken, setLocalToken] = useState(token)
+  const [testStatus, setTestStatus] = useState<ProviderTestStatus>('idle')
+  const [capabilities, setCapabilities] = useState<Array<{ name: string; ok: boolean }>>([])
+
+  const test = async () => {
+    if (!localToken) return
+    setTestStatus('testing')
+    setCapabilities([])
+    try {
+      const result = await api.marketData.testProvider('tushare', localToken, settings.baseUrl)
+      setCapabilities(result.capabilities ?? [])
+      setTestStatus(result.ok ? 'ok' : 'error')
+    } catch {
+      setTestStatus('error')
+    }
+  }
+
+  return (
+    <section className="mb-6 border border-border/60 rounded-xl bg-secondary/50 p-5">
+      <div className="flex items-center justify-between mb-1.5">
+        <div>
+          <h2 className="text-[14px] font-semibold">Tushare Pro · China</h2>
+          <p className="text-[12px] text-muted-foreground mt-1">A-share search, qfq daily bars, fundamentals, calendars, industries and indices.</p>
+        </div>
+        <Toggle
+          ariaLabel="Tushare Pro"
+          size="sm"
+          checked={settings.enabled}
+          onChange={(enabled) => onSettingsChange({ ...settings, enabled })}
+        />
+      </div>
+      <div className="grid gap-2 mt-4 sm:grid-cols-[1fr_auto]">
+        <input
+          type="password"
+          value={localToken}
+          onChange={(event) => {
+            const value = event.target.value
+            setLocalToken(value)
+            setTestStatus('idle')
+            onTokenChange(value)
+          }}
+          aria-label="Tushare Pro token"
+          placeholder="Token not configured"
+          className={inputClass}
+        />
+        <TestButton
+          providerName="Tushare Pro"
+          status={testStatus}
+          disabled={!localToken || testStatus === 'testing'}
+          onClick={test}
+        />
+      </div>
+      <input
+        type="url"
+        value={settings.baseUrl}
+        onChange={(event) => onSettingsChange({ ...settings, baseUrl: event.target.value })}
+        aria-label="Tushare endpoint"
+        className={`${inputClass} mt-2 font-mono`}
+        placeholder="https://api.tushare.pro"
+      />
+      <p className="text-[11px] text-muted-foreground/60 mt-2">HTTPS only. The token is sent in the POST body and configuration changes take effect without restart.</p>
+      {capabilities.length > 0 && (
+        <p className="text-[11px] text-muted-foreground mt-2">
+          {capabilities.map((item) => `${item.name}: ${item.ok ? 'ok' : 'unavailable'}`).join(' · ')}
+        </p>
+      )}
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in native Tushare client with hot-read provider credentials, safe endpoint validation, retries, throttling, caching, and token redaction
- support A-share search, no-lookahead qfq daily bars, point-in-time financials, corporate status, calendars, industry membership, and index data
- expose typed `traderhub china` commands plus Settings UI configuration and capability probes
- document the source contract, units, adjustment semantics, and token rotation workflow

## Verification

- `npx tsc --noEmit --pretty false`
- `cd ui && npx tsc -b --pretty false`
- focused Tushare/native routing/UI suite: 105 tests passed
- `pnpm build`: 15/15 tasks passed
- demo UI smoke: Tushare card, password input, endpoint and enable toggle rendered without console errors

## Full-suite environment note

`pnpm test` completed with 5,301 passing tests and 160 failures unrelated to this change. The failures reproduce in the current local installed-app environment: Node 25 emits empty `--localstorage-file` state for UI workers, while inherited `OPENALICE_*` app paths point tests at `/Applications/OpenAlice.app` and cause integration timeouts. All focused affected suites pass.