### PR TITLE
fix(media): contain media file resolution inside the store (CWE-22 path traversal)

### DIFF
--- a/src/core/media-store.spec.ts
+++ b/src/core/media-store.spec.ts
@@ -12,6 +12,16 @@ describe('resolveMediaPath', () => {
     const result = resolveMediaPath('2026-01-01/ace-aim-air.png')
     expect(result).toContain(join('data', 'media', '2026-01-01', 'ace-aim-air.png'))
   })
+
+  it.each([
+    '../config/auth.json',
+    '../../config/auth.json',
+    '2026-01-01/../../../etc/passwd',
+    '..',
+    '../..',
+  ])('should reject path traversal input %s (CWE-22)', (name) => {
+    expect(() => resolveMediaPath(name)).toThrow(/escapes the media store/)
+  })
 })
 
 // ==================== persistMedia ====================

--- a/src/core/media-store.ts
+++ b/src/core/media-store.ts
@@ -9,7 +9,7 @@
 import { createHash } from 'node:crypto'
 import { readFile, copyFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { extname, join, posix } from 'node:path'
+import { extname, join, posix, relative, sep, isAbsolute } from 'node:path'
 import { dataPath } from '@/core/paths.js'
 
 /** 256 short, common English words — one per byte value. */
@@ -84,5 +84,12 @@ export async function persistMedia(filePath: string): Promise<string> {
 
 /** Resolve a media relative path to its absolute path on disk. */
 export function resolveMediaPath(name: string): string {
-  return join(MEDIA_DIR, name)
+  const resolved = join(MEDIA_DIR, name)
+  // Path fence: the resolved path must stay inside MEDIA_DIR. Reject '..'
+  // traversal attempts instead of letting them read files outside the store.
+  const rel = relative(MEDIA_DIR, resolved)
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`media path escapes the media store: ${name}`)
+  }
+  return resolved
 }

--- a/src/webui/routes/media.spec.ts
+++ b/src/webui/routes/media.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Route-level regression for GET /api/media/:date/:name (CWE-22):
+ *  - a benign file inside the store is served,
+ *  - percent-encoded '..' traversal is answered 404 instead of disclosing files.
+ * Note: createMediaRoutes() mounts at '/:date/:name'; the '/api/media' prefix is
+ * added by the web plugin, so requests here omit it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+type MediaRoutes = typeof import('./media.js')
+
+describe('GET /api/media/:date/:name path traversal', () => {
+  let home = ''
+  let createMediaRoutes: MediaRoutes['createMediaRoutes']
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'oa-media-route-spec-'))
+    process.env['OPENALICE_HOME'] = home
+    const mediaDir = join(home, 'data', 'media', '2026-09-02')
+    await mkdir(mediaDir, { recursive: true })
+    await writeFile(join(mediaDir, 'a.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    vi.resetModules()
+    createMediaRoutes = (await import('./media.js')).createMediaRoutes
+  })
+
+  it('serves a file that lives inside the store', async () => {
+    const app = createMediaRoutes()
+    const res = await app.request('/2026-09-02/a.png')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(Buffer.from(await res.arrayBuffer())[0]).toBe(0x89)
+  })
+
+  it('answers percent-encoded .. traversal with 404 instead of leaking files', async () => {
+    const app = createMediaRoutes()
+    const res = await app.request(
+      '/2026-09-02/..%2F..%2Fconfig%2Fauth.json',
+    )
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/webui/routes/media.ts
+++ b/src/webui/routes/media.ts
@@ -24,7 +24,15 @@ export function createMediaRoutes() {
 
   app.get('/:date/:name', async (c) => {
     const { date, name } = c.req.param()
-    const filePath = resolveMediaPath(join(date, name))
+    const ext = extname(name).toLowerCase()
+    if (!MIME[ext]) return c.notFound()
+
+    let filePath: string
+    try {
+      filePath = resolveMediaPath(join(date, name))
+    } catch {
+      return c.notFound()
+    }
 
     try {
       const buf = await readFile(filePath)


### PR DESCRIPTION
Security fix: GET /api/media/:date/:name allowed arbitrary file disclosure.

What: URL segments were joined into the media path without a containment
check; Hono percent-decodes route params, so a request such as
GET /api/media/<date>/..%2F..%2Fconfig%2Fauth.json read files outside the
store (auth.json, accounts.json with broker credentials, and any file
readable by Alice).

Fix:
1. resolveMediaPath now rejects any result outside MEDIA_DIR (path.relative fence);
2. the media route only serves known media extensions and answers traversal with 404;
3. regression specs cover both the fence and the route behaviour.

Verified:
- npx vitest run --project node src/core/media-store.spec.ts src/webui/routes/media.spec.ts (12 passed)
- npx tsc --noEmit
- local live check: the traversal request returns 404 after the fix (was 200 before)