### PR TITLE
fix(ui): scroll settings navigation

### DIFF
--- a/ui/src/components/SettingsCategoryList.spec.tsx
+++ b/ui/src/components/SettingsCategoryList.spec.tsx
@@ -64,6 +64,15 @@ afterEach(() => {
 })
 
 describe('SettingsCategoryList', () => {
+  it('owns the vertical scroll region for long settings navigation', () => {
+    render(<SettingsCategoryList />)
+
+    const list = screen.getByTestId('settings-category-list')
+    expect(list.className).toContain('overflow-y-auto')
+    expect(list.className).toContain('overscroll-contain')
+    expect(list.className).toContain('[scrollbar-gutter:stable]')
+  })
+
   it('hides trading and market-data categories on NanoAlice', () => {
     mocks.product = 'nano'
     render(<SettingsCategoryList />)

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -127,7 +127,10 @@ export function SettingsCategoryList({ onSelect }: { onSelect?: () => void }) {
   }, [developerActive])
 
   return (
-    <div className="pb-2">
+    <div
+      data-testid="settings-category-list"
+      className="h-full min-h-0 overflow-y-auto overscroll-contain pb-2 [scrollbar-gutter:stable]"
+    >
       {groups.map((group) => (
         <div key={group.labelKey}>
           <SidebarSectionHeader>{t(group.labelKey)}</SidebarSectionHeader>


### PR DESCRIPTION
## Summary
- make the Settings category list own its vertical scroll region
- contain scroll chaining and reserve stable scrollbar space
- keep the fix scoped away from page sidebars that already manage their own scrolling

## Verification
- `pnpm exec vitest run --project ui ui/src/components/SettingsCategoryList.spec.tsx`
- `cd ui && npx tsc -b`
- real browser: desktop list scrolled through its full 170px range
- real browser: 390x640 mobile drawer scrolled through its full 440px range
- `git diff --check`

## Boundary touch
- leaf Settings UI layout only; no trading, auth, persistence, runtime, or packaging changes