### PR TITLE
fix(connector): use native AbortController instead of bundled polyfill

### DIFF
--- a/services/connector/src/shims/abort-controller.spec.ts
+++ b/services/connector/src/shims/abort-controller.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AbortController,
+  AbortSignal,
+  default as DefaultExport,
+} from './abort-controller.js'
+
+describe('abort-controller shim', () => {
+  it('re-exports the native global AbortController', () => {
+    expect(AbortController).toBe(globalThis.AbortController)
+    expect(DefaultExport).toBe(globalThis.AbortController)
+  })
+
+  it('re-exports the native global AbortSignal', () => {
+    expect(AbortSignal).toBe(globalThis.AbortSignal)
+  })
+
+  it('produces a signal whose prototype name is AbortSignal', () => {
+    const signal = new AbortController().signal
+    const proto = Object.getPrototypeOf(signal)
+    expect(proto?.constructor?.name).toBe('AbortSignal')
+  })
+})

--- a/services/connector/src/shims/abort-controller.ts
+++ b/services/connector/src/shims/abort-controller.ts
@@ -1,0 +1,19 @@
+/**
+ * Runtime shim replacing the bundled `abort-controller` polyfill with Node's
+ * native global implementations.
+ *
+ * grammY's Node shim imports `abort-controller` because it supports old Node
+ * runtimes. Our connector bundle externalizes nothing, so esbuild would inline
+ * that polyfill. esbuild renames its `AbortSignal` class to avoid a collision
+ * with the native global, and node-fetch v2 (v2.7.0) gates every request on
+ * the signal prototype's constructor name being exactly "AbortSignal". The
+ * renamed class no longer matches, so every grammY HTTP call fails with
+ * "Expected signal to be an instanceof AbortSignal".
+ *
+ * Rather than ship a legacy polyfill (the runtime is Node >= 22), alias
+ * `abort-controller` to this module so grammY hands node-fetch the native
+ * `AbortSignal`, whose constructor keeps its real name.
+ */
+export const AbortController = globalThis.AbortController
+export const AbortSignal = globalThis.AbortSignal
+export default globalThis.AbortController

--- a/services/connector/tsup.config.ts
+++ b/services/connector/tsup.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
@@ -15,5 +16,14 @@ export default defineConfig({
   outExtension: () => ({ js: '.cjs' }),
   esbuildOptions: (options) => {
     options.conditions = ['openalice-source', ...(options.conditions ?? [])]
+    // grammY's Node shim imports the legacy `abort-controller` polyfill.
+    // Bundling it makes esbuild rename its AbortSignal class, which breaks
+    // node-fetch@2.7.0's `constructor.name === "AbortSignal"` check and fails
+    // every grammY call. Point it at Node's native global instead (runtime is
+    // Node >= 22). See src/shims/abort-controller.ts.
+    options.alias = {
+      ...(options.alias ?? {}),
+      'abort-controller': resolve(import.meta.dirname, 'src/shims/abort-controller.ts'),
+    }
   },
 })


### PR DESCRIPTION
## Problem

The Telegram (and Discord) connector never reaches a healthy polling session on a freshly built image. Both `.cjs` and the packaged runtime show a perpetual degraded loop with:

```
Telegram polling session did not become ready within 30000ms
```

## Root cause

grammY's Node shim (`shim.node.js`) imports the legacy `abort-controller` polyfill. The connector bundle inlines everything (`noExternal`), so esbuild packs that polyfill in. esbuild renames the polyfill's `AbortSignal` class to `AbortSignal2` to avoid colliding with the native global, and node-fetch v2 (v2.7.0) gates every request on:

```js
Object.getPrototypeOf(signal).constructor.name === "AbortSignal"
```

The renamed class no longer matches, so every grammY HTTP call fails with `Expected signal to be an instanceof AbortSignal`, and long polling never becomes ready.

Outside the bundle (plain `node_modules` resolution) the polyfill class keeps its real name, so the failure only appears in the packaged connector — which is why it is easy to miss in dev/test but breaks deployed images.

## Fix

Alias `abort-controller` (in `services/connector/tsup.config.ts`) to a small shim that re-exports Node's native `AbortController`/`AbortSignal` (runtime is Node >= 22). This drops the legacy polyfill from the bundle and hands node-fetch a native `AbortSignal` whose constructor keeps its real name.

## Verification

- `services/connector` typecheck + 122 tests pass (incl. 3 new shim specs)
- root `tsc --noEmit` passes
- Rebuilt `connector.cjs` and ran it against a real Telegram bot: reaches `healthy` and links the owner
