### PR TITLE
Stabilize CLI promotion coverage

### DIFF
--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -46,14 +46,18 @@ const cliVersion = JSON.parse(
 ).version
 const temporaryPaths: string[] = []
 const originalStartView = process.env.OPENALICE_TUI_START_VIEW
+const originalNoColor = process.env.NO_COLOR
 
 beforeAll(() => {
   process.env.OPENALICE_TUI_START_VIEW = 'home'
+  process.env.NO_COLOR = '1'
 })
 
 afterAll(() => {
   if (originalStartView === undefined) delete process.env.OPENALICE_TUI_START_VIEW
   else process.env.OPENALICE_TUI_START_VIEW = originalStartView
+  if (originalNoColor === undefined) delete process.env.NO_COLOR
+  else process.env.NO_COLOR = originalNoColor
 })
 
 function stripSgr(value: string): string {

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -3772,7 +3772,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(calls).toEqual(['start'])
     expect(screen?.snapshot.launchFlight).toBeNull()
-  })
+  }, 10_000)
 
   it('returns to the Launcher when the active local Runtime disappears', async () => {
     let inputListener: ((data: string) => unknown) | undefined
@@ -4582,7 +4582,7 @@ describe('Supervisor TUI screen', () => {
       'configure-project',
       'start',
     ])
-  })
+  }, 10_000)
 
   it('keeps foreign-owned lifecycle mutations unavailable', () => {
     const actions: SupervisorAction[] = []

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,12 +43,12 @@ export default defineConfig({
     // absolute, slash-normalized globs explicit for every platform.
     forceRerunTriggers: collectionWideTestInputs,
     // The Node suite includes installer, PTY, and Guardian specs that spawn
-    // their own process trees. Leaving Vitest at `available CPUs - 1`
-    // lets those children contend with a worker per core on constrained CI
-    // hosts, turning fast installer checks into timeout flakes. Keep enough
-    // parallelism for the unit-heavy majority while reserving capacity for the
-    // subprocesses owned by each worker.
-    maxWorkers: '50%',
+    // their own process trees. CPU-relative worker counts scale the contention
+    // back up on larger development hosts and turn fast installer checks into
+    // timeout flakes. Keep this deterministic across laptops and CI: two
+    // workers retain useful parallelism while leaving capacity for child
+    // processes owned by each worker.
+    maxWorkers: 2,
     projects: [
       {
         resolve: {


### PR DESCRIPTION
## What changed
- force deterministic no-color output for transcript-oriented Supervisor TUI PTY assertions while preserving the explicit color tests
- give the two async lifecycle cases a bounded 10-second budget under full-suite load
- cap Vitest at two workers so installer, PTY, and Guardian child processes are not starved by CPU-relative worker scaling

## Evidence
- reproduced the macOS promotion failures with `NO_COLOR` removed
- targeted CLI TUI suite: 150 tests passed
- Node suite at two workers: 426 files / 4,639 tests passed
- `npx tsc --noEmit`
- `pnpm test`: 707 files / 6,315 tests passed in 198s

This repairs deterministic test infrastructure failures found by promotion PR #1330; it does not change product runtime behavior.