### PR TITLE
Serialize hermetic Vitest workers in CI

### DIFF
--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -3772,7 +3772,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(calls).toEqual(['start'])
     expect(screen?.snapshot.launchFlight).toBeNull()
-  }, 10_000)
+  })
 
   it('returns to the Launcher when the active local Runtime disappears', async () => {
     let inputListener: ((data: string) => unknown) | undefined
@@ -4582,7 +4582,7 @@ describe('Supervisor TUI screen', () => {
       'configure-project',
       'start',
     ])
-  }, 10_000)
+  })
 
   it('keeps foreign-owned lifecycle mutations unavailable', () => {
     const actions: SupervisorAction[] = []

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,12 +43,12 @@ export default defineConfig({
     // absolute, slash-normalized globs explicit for every platform.
     forceRerunTriggers: collectionWideTestInputs,
     // The Node suite includes installer, PTY, and Guardian specs that spawn
-    // their own process trees. CPU-relative worker counts scale the contention
-    // back up on larger development hosts and turn fast installer checks into
-    // timeout flakes. Keep this deterministic across laptops and CI: two
-    // workers retain useful parallelism while leaving capacity for child
-    // processes owned by each worker.
-    maxWorkers: 2,
+    // their own process trees. CPU-relative worker counts scale contention
+    // back up on larger development hosts, while two workers still saturate a
+    // two-core CI runner by running Node and jsdom work together. Keep local
+    // runs bounded at two workers and serialize the hermetic CI gate so child
+    // process and timer-driven lifecycle tests retain execution capacity.
+    maxWorkers: process.env.CI ? 1 : 2,
     projects: [
       {
         resolve: {


### PR DESCRIPTION
## What changed
- use one Vitest worker under CI and retain two bounded workers locally
- remove the per-test 10-second allowances that masked scheduling contention

## Why
Promotion #1330 reproduced the same timer starvation on Ubuntu and macOS when the Node and jsdom projects occupied both cores. The two affected lifecycle tests each consumed the entire 10-second allowance despite completing in milliseconds when they had execution capacity.

## Evidence
- `CI=1 pnpm test`: 707 files / 6,315 tests passed with default 5-second test budgets
- `npx tsc --noEmit`
- `git diff --check`

This is intentionally limited to the full hermetic gate; local development keeps two workers, and dev PR delivery does not wait synchronously on this suite.