### PR TITLE
Bound workspace build concurrency

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "concurrency": "50%",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## What changed
- cap Turborepo task concurrency at 50% across the workspace

## Why
The Windows promotion build failed twice with `0xC0000142` (DLL initialization failure) while Turbo launched nine independent TypeScript/tsup processes at once. The real Windows Guardian/dev-stack smoke passed both times, and no compiler diagnostic was emitted before process initialization failed. A proportional Turbo limit makes a two-core runner build serially while preserving useful parallelism on larger development hosts.

## Evidence
- `pnpm build`: all 15 package builds passed
- `pnpm test:contract:workflow`: 79 tests passed
- `npx tsc --noEmit`
- preceding same-head `CI=1 pnpm test`: 707 files / 6,315 tests passed

This changes build scheduling only; it does not add a Windows-specific build path.