### PR TITLE
Stop repeating the full suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest]
+        # Ubuntu owns the hermetic full suite. macOS keeps one native-host
+        # repetition; Windows is covered by the real dev-stack smoke below
+        # and the separate desktop/package acceptance workflow.
+        os: [macos-14]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -270,8 +270,9 @@ delivery lane:
   Docker, installer, or native-runtime evidence from the ladder above; hosted
   CI is not a second purchase of the same confidence.
 - PRs to `master`, `master` pushes, scheduled runs, and manual validation retain
-  the hermetic Ubuntu suite, macOS/Windows build-and-test matrix, and native
-  dev-smoke. Routine
+  the hermetic Ubuntu suite, macOS build-and-test repetition, and native
+  Windows/Ubuntu dev-smoke. Windows desktop and Broker Pack packaging remain in
+  the separate package workflow. Routine
   integration PRs do not allocate those runners. There is no hosted changed-path
   or actor/label router: the branch boundary is intentionally simple, local
   development owns changed-test selection, and current `dev` receives a daily
@@ -332,8 +333,10 @@ delivery lane:
   still stops or withdraws a candidate; hosted-runner starvation and a known
   non-product fixture timeout do not become product risk through repetition.
 - Once this workflow version reaches the default `master` branch, the scheduled
-  validation checks out current `dev` and runs the complete matrix, providing a
-  daily cross-platform backstop for lightweight PRs.
+  validation checks out current `dev` and runs the same complete lane set:
+  Ubuntu hermetic/build, macOS build-and-test, and native Windows/Ubuntu
+  dev-smoke. It provides a daily multi-host backstop for lightweight PRs
+  without repeating the entire repository suite on Windows.
 
 Routine integration has no hosted changed-path allowlist. Serial development
 uses the local ladder above, adding `pnpm test:system:remote`, real browser,

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -137,7 +137,7 @@ describe('CI workflow authority lanes', () => {
     expect(commands(tests)).toContain('pnpm test')
     expect(commands(tests)).not.toContain('pnpm build')
 
-    expect(crossPlatform.strategy?.matrix?.os).toEqual(['macos-14', 'windows-latest'])
+    expect(crossPlatform.strategy?.matrix?.os).toEqual(['macos-14'])
     expect(step(crossPlatform, 'Build complete workspace').run).toBe('pnpm build')
     expect(step(crossPlatform, 'Run complete suite').run).toBe('pnpm test')
     expect(crossPlatform['timeout-minutes']).toBe(30)


### PR DESCRIPTION
## What changed
- keep the full hermetic suite on Ubuntu and the native build-and-test repetition on macOS
- remove Windows from the duplicate full-repository build/test matrix
- retain Windows Guardian + complete dev-stack smoke and the independent desktop/Broker Pack packaging workflow
- update the CI contract spec and development workflow to describe the new ownership

## Why
The Windows full-build repetition failed twice with `0xC0000142` while the real Windows dev-stack smoke passed. Re-running all 6,315 tests on the same constrained host duplicated Ubuntu authority without eliminating product bugs.

## Evidence
- `pnpm test:contract:workflow`: 79 tests passed
- `npx tsc --noEmit`
- `pnpm test`: 707 files / 6,315 tests passed
- `git diff --check`

Windows is weakened, not removed: real process startup and install/package surfaces remain Windows-native.