### PR TITLE
Make full source validation opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: Full Source Validation
 on:
   pull_request:
     branches: [master]
-  # Scheduled workflows load from the default branch, then validate the latest
-  # dev source through the explicit checkout refs below.
-  schedule:
-    - cron: "0 19 * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,11 +13,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # This job is the bounded source gate for every full-validation event and the
-  # complete central gate for an exact beta version-only PR. The classifier is
+  # This is the bounded automatic gate for master PRs and the entry gate for an
+  # explicitly requested full validation. The classifier is
   # loaded from the trusted base revision so a candidate cannot weaken its own
-  # lane. Any classifier or source-gate failure falls back to the complete
-  # validation matrix instead of granting the beta fast path.
+  # lane. A classifier failure retains the normal Windows PR smoke instead of
+  # granting the exact-beta fast path; a source-gate failure stops dependents.
   source-contracts:
     runs-on: ubuntu-latest
     outputs:
@@ -31,7 +27,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - name: Detect exact beta release preparation
         id: beta-release-prep
@@ -63,16 +58,12 @@ jobs:
     needs: source-contracts
     if: >-
       !cancelled() &&
-      (
-        needs.source-contracts.result != 'success' ||
-        needs.source-contracts.outputs.beta_release_prep != 'true'
-      )
+      github.event_name == 'workflow_dispatch' &&
+      needs.source-contracts.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v6
 
@@ -90,16 +81,12 @@ jobs:
     needs: source-contracts
     if: >-
       !cancelled() &&
-      (
-        needs.source-contracts.result != 'success' ||
-        needs.source-contracts.outputs.beta_release_prep != 'true'
-      )
+      github.event_name == 'workflow_dispatch' &&
+      needs.source-contracts.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v6
 
@@ -117,10 +104,8 @@ jobs:
     needs: source-contracts
     if: >-
       !cancelled() &&
-      (
-        needs.source-contracts.result != 'success' ||
-        needs.source-contracts.outputs.beta_release_prep != 'true'
-      )
+      github.event_name == 'workflow_dispatch' &&
+      needs.source-contracts.result == 'success'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -133,8 +118,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v6
 
@@ -153,26 +136,21 @@ jobs:
         run: pnpm test
         timeout-minutes: 15
 
-  # Boots the real `pnpm dev` stack on Windows and an Ubuntu control host. This
-  # owns native process-spawn feedback that transpiled tests cannot provide.
+  # Windows remains the one automatic native-host smoke because it is not
+  # covered by the maintainer's local macOS/Linux development loop.
   dev-smoke:
     needs: source-contracts
     if: >-
       !cancelled() &&
+      needs.source-contracts.result == 'success' &&
       (
-        needs.source-contracts.result != 'success' ||
+        github.event_name == 'workflow_dispatch' ||
         needs.source-contracts.outputs.beta_release_prep != 'true'
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || '' }}
 
       - uses: pnpm/action-setup@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,10 @@ parallel workers hand off commits rather than racing to push or creating one PR
 per finding.
 
 Pending CI alone does not block serial progress, but a known product or contract
-failure must be understood and repaired before adding scope. Master promotion,
-stable release, explicit review pauses, and untrusted contributions retain
-their synchronous gates.
+failure must be understood and repaired before adding scope. Beta promotion may
+use recorded local acceptance plus the lightweight master PR gates. Stable
+release, explicit review pauses, and untrusted contributions retain their full
+synchronous gates.
 
 ## Verification Ladder
 
@@ -120,7 +121,8 @@ with ownership breadth and risk:
 | Leaf change inside one owner | `pnpm test:changed` or an explicit `test:select` intersection; owning typecheck; real affected surface |
 | Shared change inside one owner | Matching `pnpm test:owner:*` suite or package-local test; owning typecheck; real affected surface |
 | Cross-owner, shared test/build infrastructure, dependency/config change, or uncertain impact | Root and applicable package/UI typechecks; complete `pnpm test`; every touched surface's acceptance |
-| Master promotion, scheduled/manual backstop, or stable release | Complete remote matrix and release gates from [[docs/development-workflow.md]] |
+| Beta promotion | Recorded local full-suite/surface acceptance plus automatic master source gate and Windows dev-stack smoke |
+| Manual backstop or stable release | Complete remote matrix and release gates from [[docs/development-workflow.md]] |
 
 `pnpm test:changed` compares the feature branch and working tree with freshly
 fetched `origin/dev`. It follows Vitest's static import graph; dynamic imports,

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -252,7 +252,7 @@ surface; changed-test selection does not replace that acceptance.
 Record the exact commands and real-surface result in the PR. Use the matching
 `pnpm test:owner:*` suite when one owner's impact is wider than the static
 dependency closure. Keep `pnpm test` as the explicit hermetic full-suite
-backstop for the third row and for master, scheduled, manual, and stable lanes.
+backstop for the third row and for manually dispatched/stable lanes.
 The complete command catalog, package-local contract, selector composition,
 and side-effect rules live in [[docs/testing.md]].
 
@@ -269,14 +269,14 @@ delivery lane:
   record the applicable owner-scoped tests, typecheck, browser, Electron,
   Docker, installer, or native-runtime evidence from the ladder above; hosted
   CI is not a second purchase of the same confidence.
-- PRs to `master`, `master` pushes, scheduled runs, and manual validation retain
-  the hermetic Ubuntu suite, macOS build-and-test repetition, and native
-  Windows/Ubuntu dev-smoke. Windows desktop and Broker Pack packaging remain in
-  the separate package workflow. Routine
-  integration PRs do not allocate those runners. There is no hosted changed-path
-  or actor/label router: the branch boundary is intentionally simple, local
-  development owns changed-test selection, and current `dev` receives a daily
-  full cross-platform backstop.
+- PRs to `master` automatically run the trusted source-contract/typecheck gate
+  and the native Windows dev-stack smoke. The hermetic Ubuntu suite, complete
+  workspace build, and macOS build-and-test repetition run only when a
+  maintainer explicitly dispatches Full Source Validation for the selected
+  commit. Windows desktop and Broker Pack packaging remain in the separate
+  package workflow. Local development owns macOS/Linux changed-test selection;
+  hosted runners are a deliberate native-host or release-candidate tool, not a
+  second purchase of every local check.
 - A `master`-targeted PR whose complete diff is exactly the synchronized,
   forward beta `version` value in `package.json` and
   `packages/cli/package.json` takes the release-preparation fast lane. It keeps
@@ -288,7 +288,7 @@ delivery lane:
   `master` SHA.
   The classifier is read from the trusted base commit and fails closed: stable
   versions, extra bytes or paths, mismatches, invalid versions, and classifier
-  errors all retain the full PR suite.
+  errors all retain the normal master PR gate.
 - Superseded runs for the same PR are cancelled. Only the latest-head result is
   actionable evidence.
 - The central CI aggregate owns workflow contracts and root typecheck for an
@@ -314,9 +314,10 @@ delivery lane:
   CLI candidates are assembled and each candidate runs its packaged
   Guardian/Alice, Web, Workspace, PTY, and release-owned Git acceptance before
   one atomic dev manifest is activated. The heavier UTA/Connector recovery and
-  external Broker Pack fixture run once on Linux x64; `master`, scheduled, and
-  final Release lanes keep the broader native-host coverage. The scheduled CI
-  run remains the daily full cross-platform backstop for current `dev`.
+  external Broker Pack fixture run once on Linux x64; manual Full Source
+  Validation and final Release lanes keep broader native-host coverage. Full
+  Source Validation is an explicit maintainer action when that broader
+  Ubuntu/macOS backstop is useful.
 - Installer or distributed-CLI work proves the checked-out tree locally with
   the deterministic clean-container HTTP install. A routine `dev` PR does not
   purchase a second hosted copy of that fixture. After merge, the `dev` push
@@ -325,18 +326,13 @@ delivery lane:
   provenance, commands, server control surface, and idempotent reuse. Hosted
   checkout, Bun host, package-manager, and managed-SSH candidate acceptance
   begins at the `master`/manual boundary.
-- A push to `master` always runs the complete matrix. Reusing PR evidence after
-  merge remains a useful accepted-tree provenance backstop. For stable it is a
-  synchronous release gate. For an exact beta, it may finish after dispatch and
-  is not a second source-test gate: the trusted version PR plus the Release
-  workflow's final artifact acceptance own publication. A real product failure
-  still stops or withdraws a candidate; hosted-runner starvation and a known
-  non-product fixture timeout do not become product risk through repetition.
-- Once this workflow version reaches the default `master` branch, the scheduled
-  validation checks out current `dev` and runs the same complete lane set:
-  Ubuntu hermetic/build, macOS build-and-test, and native Windows/Ubuntu
-  dev-smoke. It provides a daily multi-host backstop for lightweight PRs
-  without repeating the entire repository suite on Windows.
+- A beta promotion uses recorded local acceptance, the automatic source gate,
+  Windows dev-stack smoke, and the final Release workflow's artifact acceptance;
+  it does not wait for a duplicate hosted macOS/Linux full suite. A stable
+  candidate requires a manually dispatched Full Source Validation on its exact
+  commit before release. A real product failure still stops or withdraws a
+  candidate; hosted-runner starvation and a known non-product fixture timeout
+  do not become product risk through repetition.
 
 Routine integration has no hosted changed-path allowlist. Serial development
 uses the local ladder above, adding `pnpm test:system:remote`, real browser,
@@ -344,9 +340,8 @@ OrbStack, installer, unsigned Electron/package, and native runtime acceptance
 only when those surfaces change. Remote acceptance starts from a host the user
 already made reachable through ordinary SSH; CI and repository scripts do not
 provision or manage a cloud provider. Record the commands and results in the
-PR. A promotion to `master` re-establishes full remote evidence; stable keeps
-the complete matrix even when routine integration and beta used lighter hosted
-feedback.
+PR. Stable release preparation re-establishes the complete manually dispatched
+matrix even when routine integration and beta used lighter hosted feedback.
 
 ### Package signing boundary
 
@@ -384,8 +379,9 @@ Optimize measured waiting time without collapsing the confidence lanes:
    inputs across the remaining jobs;
 5. measure queue time versus install/build/test time before buying larger
    runners;
-6. keep complete `master` promotion and stable acceptance, signing, and
-   publication gated even when routine `dev` and beta feedback are light.
+6. keep complete stable-candidate acceptance, signing, and publication gated;
+   beta promotion may use recorded local acceptance plus the lightweight
+   automatic master gate.
 
 Any CI optimization PR should include before/after timing evidence and name the
 confidence gate it preserves, moves, or removes.

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -39,6 +39,7 @@ import {
 } from './supervisor-launch-flight.ts'
 
 const matchesKey = (data: string, key: string) => data === key
+const asyncTuiTimeoutMs = process.env.CI ? 15_000 : 5_000
 const pointerClick = (col: number, row: number) => ({
   button: 0,
   col,
@@ -3772,7 +3773,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(calls).toEqual(['start'])
     expect(screen?.snapshot.launchFlight).toBeNull()
-  })
+  }, asyncTuiTimeoutMs)
 
   it('returns to the Launcher when the active local Runtime disappears', async () => {
     let inputListener: ((data: string) => unknown) | undefined
@@ -4089,13 +4090,14 @@ describe('Supervisor TUI screen', () => {
     })).resolves.toBe(0)
 
     expect(phases).toContain('degraded')
-    expect(phases).toContain('unreachable')
     expect(phases.at(-1)).toBe('connected')
     expect(screen?.snapshot.panel).toBe('overview')
     expect(screen?.snapshot.activeTarget).toMatchObject({
       kind: 'local',
       health: { phase: 'connected', consecutiveFailures: 0 },
     })
+    // Render requests may coalesce while the host is busy; the durable event
+    // sequence is the authoritative proof that unreachable was observed.
     expect(screen?.snapshot.connectionEvents?.map((event) => event.kind)).toEqual([
       'connected',
       'degraded',
@@ -4582,7 +4584,7 @@ describe('Supervisor TUI screen', () => {
       'configure-project',
       'start',
     ])
-  })
+  }, asyncTuiTimeoutMs)
 
   it('keeps foreign-owned lifecycle mutations unavailable', () => {
     const actions: SupervisorAction[] = []

--- a/scripts/beta-release-prep-workflow.spec.ts
+++ b/scripts/beta-release-prep-workflow.spec.ts
@@ -53,7 +53,7 @@ function expectOutcomeGatedOutput(job: WorkflowJob): void {
 }
 
 describe('exact beta release-preparation workflow lane', () => {
-  it('keeps trusted source contracts while skipping build, test, and host matrices', () => {
+  it('keeps trusted source contracts while full Linux/macOS validation stays manual', () => {
     const jobs = workflow('ci.yml').jobs
     expectTrustedClassifier(jobs['source-contracts'])
     expectOutcomeGatedOutput(jobs['source-contracts'])
@@ -65,13 +65,15 @@ describe('exact beta release-preparation workflow lane', () => {
       'workspace-build',
       'hermetic-tests',
       'cross-platform-test',
-      'dev-smoke',
     ]) {
       expect(jobs[name].needs).toBe('source-contracts')
       expect(jobs[name].if).toContain('!cancelled()')
-      expect(jobs[name].if).toContain("needs.source-contracts.result != 'success'")
-      expect(jobs[name].if).toContain("beta_release_prep != 'true'")
+      expect(jobs[name].if).toContain("github.event_name == 'workflow_dispatch'")
+      expect(jobs[name].if).toContain("needs.source-contracts.result == 'success'")
     }
+    expect(jobs['dev-smoke'].if).toContain("needs.source-contracts.result == 'success'")
+    expect(jobs['dev-smoke'].if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(jobs['dev-smoke'].if).toContain("beta_release_prep != 'true'")
     expect(jobs['build-and-test']).toBeUndefined()
   })
 

--- a/scripts/ci-workflow.spec.ts
+++ b/scripts/ci-workflow.spec.ts
@@ -64,15 +64,15 @@ function step(job: WorkflowJob, name: string): WorkflowStep {
   return found
 }
 
-function expectFullValidationGate(job: WorkflowJob): void {
+function expectManualFullValidationGate(job: WorkflowJob): void {
   expect(job.needs).toBe('source-contracts')
   expect(job.if).toContain('!cancelled()')
-  expect(job.if).toContain("needs.source-contracts.result != 'success'")
-  expect(job.if).toContain("beta_release_prep != 'true'")
+  expect(job.if).toContain("github.event_name == 'workflow_dispatch'")
+  expect(job.if).toContain("needs.source-contracts.result == 'success'")
 }
 
 describe('CI workflow authority lanes', () => {
-  it('gives dev PRs one clean-build workflow and reserves full validation for master/manual/scheduled events', () => {
+  it('gives dev PRs one clean-build workflow and makes full source validation opt-in', () => {
     expect(devPrWorkflow.name).toBe('Dev PR Clean Build')
     expect(devPrWorkflow.on?.pull_request?.branches).toEqual(['dev'])
     expect(devPrWorkflow.on?.push).toBeUndefined()
@@ -82,7 +82,7 @@ describe('CI workflow authority lanes', () => {
     expect(fullWorkflow.name).toBe('Full Source Validation')
     expect(fullWorkflow.on?.pull_request?.branches).toEqual(['master'])
     expect(fullWorkflow.on?.push).toBeUndefined()
-    expect(fullWorkflow.on?.schedule).toEqual([{ cron: '0 19 * * *' }])
+    expect(fullWorkflow.on?.schedule).toBeUndefined()
     expect(fullWorkflow.on).toHaveProperty('workflow_dispatch')
     expect(fullWorkflow.jobs['build-and-test']).toBeUndefined()
     expect(fullWorkflow.jobs['post-merge-dev-smoke']).toBeUndefined()
@@ -122,14 +122,14 @@ describe('CI workflow authority lanes', () => {
     expect(commands(sourceContracts)).not.toContain('pnpm test')
   })
 
-  it('runs complete build, hermetic, host, and native smoke lanes outside exact beta prep', () => {
+  it('runs Linux/macOS full validation only when a maintainer dispatches it', () => {
     const workspaceBuild = fullWorkflow.jobs['workspace-build']
     const tests = fullWorkflow.jobs['hermetic-tests']
     const crossPlatform = fullWorkflow.jobs['cross-platform-test']
     const devSmoke = fullWorkflow.jobs['dev-smoke']
 
-    for (const job of [workspaceBuild, tests, crossPlatform, devSmoke]) {
-      expectFullValidationGate(job)
+    for (const job of [workspaceBuild, tests, crossPlatform]) {
+      expectManualFullValidationGate(job)
     }
 
     expect(commands(workspaceBuild)).toContain('pnpm build')
@@ -142,15 +142,18 @@ describe('CI workflow authority lanes', () => {
     expect(step(crossPlatform, 'Run complete suite').run).toBe('pnpm test')
     expect(crossPlatform['timeout-minutes']).toBe(30)
 
-    expect(devSmoke.strategy?.matrix?.os).toEqual(['windows-latest', 'ubuntu-latest'])
+    expect(devSmoke.strategy).toBeUndefined()
+    expect(devSmoke.if).toContain("needs.source-contracts.result == 'success'")
+    expect(devSmoke.if).toContain("github.event_name == 'workflow_dispatch'")
+    expect(devSmoke.if).toContain("beta_release_prep != 'true'")
     expect(commands(devSmoke)).toContain('pnpm test:system:guardian')
     expect(commands(devSmoke)).toContain('pnpm test:system:dev-stack')
   })
 
-  it('checks out current dev for every scheduled full-validation job', () => {
+  it('validates the selected ref without a hidden scheduled checkout override', () => {
     for (const job of Object.values(fullWorkflow.jobs)) {
       const checkout = job.steps?.find((candidate) => candidate.uses === 'actions/checkout@v7')
-      expect(checkout?.with?.ref).toBe("${{ github.event_name == 'schedule' && 'dev' || '' }}")
+      expect(checkout?.with?.ref).toBeUndefined()
     }
   })
 


### PR DESCRIPTION
What changed:
- Keep the trusted source/typecheck gate and Windows dev-stack smoke automatic for master PRs.
- Move Ubuntu full tests/build and macOS full validation behind manual workflow dispatch.
- Remove the daily scheduled full run.
- Stabilize three Supervisor TUI assertions that failed only under heavily starved hosted runners.
- Update AGENTS.md and the development workflow contract.

Why:
The promotion run repeated 6,315 local-passing tests on both Ubuntu and macOS. Both hosts failed only timer/render-sampling assertions after taking 7-10 minutes; a retry reproduced them. Windows native startup and desktop/package acceptance remain automatic because they are not covered by the maintainer local macOS/Linux loop.

Verification:
- CI-mode Supervisor TUI spec: 91 passed.
- Root TypeScript check passed.
- Full local suite: 707 files, 6,312 passed, 3 skipped.
- Workflow contracts: 79 passed.
- git diff --check passed.
- Latest pre-change hosted desktop acceptance: macOS arm64, macOS Intel retry, Windows desktop, and Windows Broker Packs all passed.