### PR TITLE
Prepare v0.91.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0-beta.3",
+  "version": "0.91.0-beta.4",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0-beta.3",
+  "version": "0.91.0-beta.4",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Prepare the exact synchronized beta version transition from 0.91.0-beta.3 to 0.91.0-beta.4.

Only package.json and packages/cli/package.json change.

Verification:
- Trusted classifier result: exact beta release preparation 0.91.0-beta.3 -> 0.91.0-beta.4.
- Classifier and beta workflow specs: 10 passed.
- Root TypeScript check passed.
- Diff contains exactly the two supported manifests.