### PR TITLE
chore: sync dev to beta.4 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0-beta.3",
+  "version": "0.91.0-beta.4",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0-beta.3",
+  "version": "0.91.0-beta.4",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Sync the root and native CLI package manifests to the accepted v0.91.0-beta.4 release version so source-backed dev runtimes do not advertise the previous beta version. Verified workflow contracts, manifest equality, root typecheck, and diff integrity locally.