### PR TITLE
feat: unblock first npm CLI publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1032,6 +1032,8 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: actions/setup-node@v7
         with:
           node-version: 22.19.0
@@ -1043,13 +1045,9 @@ jobs:
           path: dist/cli-package-channels
 
       - name: Publish platform packages before the meta package
-        working-directory: dist/cli-package-channels/cli-npm-tarballs
-        run: |
-          set -euo pipefail
-          node -e 'const m=require("./npm-publish-order.json");for(const p of m.packages.slice(0,-1))console.log(p.filename)' |
-            while IFS= read -r package; do npm publish "$package" --access public --provenance; done
-          META=$(node -e 'const m=require("./npm-publish-order.json");process.stdout.write(m.packages.at(-1).filename)')
-          npm publish "$META" --access public --provenance
+        run: >-
+          node scripts/publish-cli-npm-packages.mjs
+          --packages-dir dist/cli-package-channels/cli-npm-tarballs
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -117,13 +117,16 @@ External channels are explicit release switches:
 | AUR / paru | `OPENALICE_PUBLISH_AUR=true` | dedicated `AUR_SSH_PRIVATE_KEY` plus manually verified `AUR_KNOWN_HOSTS` |
 
 Before a stable GitHub Release can be created, the release workflow preflights
-every enabled switch. npm must identify the token owner and confirm that all
-five package names already list that identity as a maintainer; the Homebrew
-token must see `TraderAlice/homebrew-tap` with push authority; and the AUR key
-plus pinned known-hosts entry must be able to read the `openalice-bin` Git
-repository. Disabled channels perform no external authority checks. This makes
-missing setup a release-planning failure instead of discovering it after the
-accepted assets are already public.
+every enabled switch. npm must identify the token owner, confirm that every
+existing package lists that identity as a maintainer, and report any 404 names
+as explicit first-publication targets. A missing name is not proof of npm
+ownership, but the enabled stable publication switch is the maintainer's
+deliberate instruction to claim that fixed OpenAlice package name. The
+Homebrew token must see `TraderAlice/homebrew-tap` with push authority; and the
+AUR key plus pinned known-hosts entry must be able to read the `openalice-bin`
+Git repository. Disabled channels perform no external authority checks. This
+makes missing credentials or conflicting ownership a release-planning failure
+instead of discovering it after the accepted assets are already public.
 
 The `Public CLI Channel Authority` workflow exposes the same checks as a manual
 read-only rehearsal. Select npm, Homebrew, AUR, or any combination before a
@@ -131,13 +134,17 @@ stable promotion; the run uses repository secrets but cannot publish packages,
 push metadata, or create a GitHub Release. Use it after reserving names and
 installing credentials, before enabling the corresponding release switch.
 
-The Tap and AUR writers are idempotent: if the verified metadata is already
-active, they make no commit. AUR never learns its SSH host key from the same
-untrusted connection used to publish; the maintainer supplies the verified
-known-hosts entry as a secret. Creating registry packages, creating the Tap,
-and enrolling the AUR key remain deliberate maintainer actions. Enabling a
-switch without its external repository or authority is a release failure, not
-permission to invent another channel or silently skip publication.
+The npm, Tap, and AUR writers are idempotent. npm verifies each local tarball
+against the accepted publish manifest, skips an already-public version only
+when registry integrity is identical, and keeps the meta package last. This
+makes a partially successful first publication safe to retry. Tap and AUR make
+no commit when the verified metadata is already active. AUR never learns its
+SSH host key from the same untrusted connection used to publish; the
+maintainer supplies the verified known-hosts entry as a secret. Creating
+registry packages, creating the Tap, and enrolling the AUR key remain
+deliberate maintainer actions. Enabling a switch without its external
+repository or authority is a release failure, not permission to invent another
+channel or silently skip publication.
 
 ## Update and uninstall ownership
 

--- a/packages/cli/src/supervisor-tui.pty.spec.ts
+++ b/packages/cli/src/supervisor-tui.pty.spec.ts
@@ -1570,7 +1570,7 @@ describe.skipIf(process.platform === 'win32')('Supervisor TUI PTY', () => {
         expect(transcript).toContain('Transfer Flight Deck')
       }
       if (scenario !== 'default-no') {
-        expect(transcript).toContain('◇ BUILD v0.91.0-beta.3 · DEV')
+        expect(transcript).toContain(`◇ BUILD v${cliVersion} · DEV`)
         expect(transcript).toContain('◆ FOCUS · TRANSFER')
         expect(transcript).toContain('TRANSFER FLIGHT DECK')
         expect(transcript).toContain('◆ TRANSFER')

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -484,6 +484,9 @@ build harness when it improves the next investigation.
   AUR Git access without logging or weakening the external credentials.
 - [x] Expose the authority preflight as a bounded manual, read-only rehearsal
   that cannot publish packages, push metadata, or create a release.
+- [x] Let an authenticated first stable publication claim the five fixed,
+  unreserved npm names, while retaining maintainer checks for existing names
+  and integrity-checked idempotent retries after partial publication.
 - [ ] Publish Brew/AUR metadata only after the referenced release assets are
   public and verified. The opt-in automation and public-byte receipt are ready;
   external repository creation, credentials, activation, and first public
@@ -977,6 +980,16 @@ This plan is complete only when:
   absent from the Runtime `PATH`. Stable registry/tap/AUR publication and the
   tagged-release matrix remain release activation work; Windows remains
   deferred.
+- 2026-09-03: Public-channel inspection confirmed the direct Bash installer is
+  live, all five intended npm names remain unreserved, the Homebrew Tap does
+  not exist, and the repository's `NPM_TOKEN` now returns HTTP 401. The npm
+  authority gate now treats 404 names as explicit first-publication targets
+  after authenticating the token, while existing names still require matching
+  maintainership. Stable npm publication now verifies every tarball against
+  the accepted manifest and safely skips an already-published identical
+  version, so a partial first publication can be retried without weakening
+  package identity. External activation remains blocked on replacing the npm
+  token and deliberately enabling the stable npm switch.
 - 2026-08-30: Closed the Linuxbrew acceptance gap with pinned official
   Homebrew 6.0.15 images for native Linux arm64 and x64 runners. The shared
   system-package lifecycle now accepts Homebrew on macOS or Linux, while a

--- a/scripts/preflight-public-cli-authority.mjs
+++ b/scripts/preflight-public-cli-authority.mjs
@@ -31,16 +31,22 @@ export async function preflightPublicCliAuthority({
   const selected = Object.entries(enabled).filter(([, value]) => value).map(([name]) => name)
   if (selected.length === 0) {
     logger.log('[public-cli-authority] no external CLI channels are enabled')
-    return { enabled: selected, npmUsername: null }
+    return { enabled: selected, npmUsername: null, npmUnreservedPackages: [] }
   }
 
   const failures = []
   let npmUsername = null
+  let npmUnreservedPackages = []
 
   if (enabled.npm) {
     try {
-      npmUsername = await verifyNpmAuthority({ env, fetchImpl })
+      const npmAuthority = await verifyNpmAuthority({ env, fetchImpl })
+      npmUsername = npmAuthority.username
+      npmUnreservedPackages = npmAuthority.unreservedPackages
       logger.log(`[public-cli-authority] npm authority verified for ${npmUsername}`)
+      if (npmUnreservedPackages.length > 0) {
+        logger.log(`[public-cli-authority] npm names available for first publication: ${npmUnreservedPackages.join(', ')}`)
+      }
     } catch (error) {
       failures.push(message(error))
     }
@@ -70,7 +76,7 @@ export async function preflightPublicCliAuthority({
     throw new Error(`public CLI channel authority preflight failed:\n- ${failures.join('\n- ')}`)
   }
 
-  return { enabled: selected, npmUsername }
+  return { enabled: selected, npmUsername, npmUnreservedPackages }
 }
 
 async function verifyNpmAuthority({ env, fetchImpl }) {
@@ -84,14 +90,22 @@ async function verifyNpmAuthority({ env, fetchImpl }) {
   const username = typeof whoami.username === 'string' ? whoami.username.trim() : ''
   if (!username) throw new Error('npm token identity did not return a username')
 
+  const unreservedPackages = []
   for (const packageName of NPM_PACKAGE_NAMES) {
-    const metadata = await fetchJson(
-      fetchImpl,
-      `${registry}/${encodeURIComponent(packageName)}`,
-      { headers },
-      `npm package ${packageName}`,
-      `npm package name ${packageName} is not reserved`,
-    )
+    const response = await fetchImpl(`${registry}/${encodeURIComponent(packageName)}`, { headers })
+    if (response.status === 404) {
+      unreservedPackages.push(packageName)
+      continue
+    }
+    if (!response.ok) {
+      throw new Error(`npm package ${packageName} request failed with HTTP ${response.status}`)
+    }
+    let metadata
+    try {
+      metadata = await response.json()
+    } catch {
+      throw new Error(`npm package ${packageName} returned invalid JSON`)
+    }
     const maintainers = Array.isArray(metadata.maintainers)
       ? metadata.maintainers.map((entry) => typeof entry?.name === 'string' ? entry.name : '')
       : []
@@ -100,7 +114,7 @@ async function verifyNpmAuthority({ env, fetchImpl }) {
     }
   }
 
-  return username
+  return { username, unreservedPackages }
 }
 
 async function verifyHomebrewAuthority({ env, fetchImpl }) {

--- a/scripts/preflight-public-cli-authority.spec.mjs
+++ b/scripts/preflight-public-cli-authority.spec.mjs
@@ -22,7 +22,7 @@ describe('public CLI authority preflight', () => {
     const logger = { log: vi.fn() }
 
     await expect(preflightPublicCliAuthority({ env: {}, fetchImpl, verifyAur, logger }))
-      .resolves.toEqual({ enabled: [], npmUsername: null })
+      .resolves.toEqual({ enabled: [], npmUsername: null, npmUnreservedPackages: [] })
     expect(fetchImpl).not.toHaveBeenCalled()
     expect(verifyAur).not.toHaveBeenCalled()
   })
@@ -52,6 +52,7 @@ describe('public CLI authority preflight', () => {
     })).resolves.toEqual({
       enabled: ['npm', 'homebrew', 'aur'],
       npmUsername: 'alice-release',
+      npmUnreservedPackages: [],
     })
     expect(fetchImpl).toHaveBeenCalledTimes(NPM_PACKAGE_NAMES.length + 2)
     expect(verifyAur).toHaveBeenCalledWith({ env })
@@ -92,7 +93,27 @@ describe('public CLI authority preflight', () => {
     })).rejects.toThrow('npm token identity alice-release is not a maintainer of openalice')
   })
 
-  it('rejects unreserved npm names, read-only Tap tokens, and inaccessible AUR repos', async () => {
+  it('accepts unreserved npm names as explicit first-publication targets', async () => {
+    const fetchImpl = vi.fn(async (url) => {
+      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
+      return response(404, {})
+    })
+
+    await expect(preflightPublicCliAuthority({
+      env: {
+        OPENALICE_PUBLISH_NPM: 'true',
+        NPM_TOKEN: 'npm-secret',
+      },
+      fetchImpl,
+      logger: { log: vi.fn() },
+    })).resolves.toEqual({
+      enabled: ['npm'],
+      npmUsername: 'alice-release',
+      npmUnreservedPackages: NPM_PACKAGE_NAMES,
+    })
+  })
+
+  it('rejects read-only Tap tokens and inaccessible AUR repos', async () => {
     const env = {
       OPENALICE_PUBLISH_NPM: 'true',
       OPENALICE_PUBLISH_HOMEBREW: 'true',
@@ -105,7 +126,7 @@ describe('public CLI authority preflight', () => {
     const fetchImpl = vi.fn(async (url) => {
       if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
       if (url.includes('api.github.com')) return response(200, { permissions: { push: false } })
-      return response(404, {})
+      return response(200, { maintainers: [{ name: 'alice-release' }] })
     })
 
     await expect(preflightPublicCliAuthority({
@@ -114,7 +135,6 @@ describe('public CLI authority preflight', () => {
       verifyAur: vi.fn(async () => { throw new Error('AUR repository is unavailable') }),
       logger: { log: vi.fn() },
     })).rejects.toThrow(new RegExp([
-      'npm package name openalice is not reserved',
       'HOMEBREW_TAP_TOKEN does not have push authority',
       'AUR repository is unavailable',
     ].join('[\\s\\S]*')))

--- a/scripts/publish-cli-npm-packages.mjs
+++ b/scripts/publish-cli-npm-packages.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { basename, parse, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { NPM_PACKAGE_NAMES } from './preflight-public-cli-authority.mjs'
+
+const EXPECTED_PUBLISH_ORDER = Object.freeze([
+  ...NPM_PACKAGE_NAMES.filter((name) => name !== 'openalice').sort(),
+  'openalice',
+])
+
+export function publishCliNpmPackages({
+  packagesDir,
+  npm = process.platform === 'win32' ? 'npm.cmd' : 'npm',
+  runNpm = (args) => spawnSync(npm, args, { encoding: 'utf8', stdio: 'pipe' }),
+  logger = console,
+} = {}) {
+  const root = resolve(packagesDir ?? process.cwd())
+  const manifest = readManifest(root)
+  const packages = validateManifest(manifest)
+
+  for (const entry of packages) {
+    const tarballPath = resolveTarball(root, entry.filename)
+    verifyTarball(tarballPath, entry)
+    const current = readPublishedIntegrity(runNpm, entry)
+    if (current === entry.integrity) {
+      logger.log(`[npm-publish] ${entry.name}@${entry.version} already matches; skipping`)
+      continue
+    }
+    if (current !== null) {
+      throw new Error(`${entry.name}@${entry.version} is already published with different integrity`)
+    }
+
+    const published = runNpm(['publish', tarballPath, '--access', 'public', '--provenance'])
+    if (published.error) throw published.error
+    if (published.status !== 0) {
+      const afterFailure = readPublishedIntegrity(runNpm, entry)
+      if (afterFailure === entry.integrity) {
+        logger.log(`[npm-publish] ${entry.name}@${entry.version} became visible with accepted integrity`)
+        continue
+      }
+      throw new Error(`npm publish failed for ${entry.name}@${entry.version}: ${commandDetail(published)}`)
+    }
+    logger.log(`[npm-publish] published ${entry.name}@${entry.version}`)
+  }
+
+  return { version: manifest.version, packages: packages.map(({ name }) => name) }
+}
+
+function readManifest(root) {
+  const path = resolve(root, 'npm-publish-order.json')
+  if (!existsSync(path)) throw new Error(`npm publish manifest is missing: ${path}`)
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    throw new Error(`npm publish manifest is invalid JSON: ${path}`)
+  }
+}
+
+function validateManifest(manifest) {
+  if (manifest?.schemaVersion !== 1 || typeof manifest.version !== 'string') {
+    throw new Error('npm publish manifest has an unsupported shape')
+  }
+  if (!Array.isArray(manifest.packages) || !Array.isArray(manifest.publishOrder)) {
+    throw new Error('npm publish manifest omits packages or publishOrder')
+  }
+  const names = manifest.packages.map((entry) => entry?.name)
+  if (
+    names.length !== EXPECTED_PUBLISH_ORDER.length
+    || names.some((name, index) => name !== EXPECTED_PUBLISH_ORDER[index])
+    || manifest.publishOrder.some((name, index) => name !== EXPECTED_PUBLISH_ORDER[index])
+    || manifest.publishOrder.length !== EXPECTED_PUBLISH_ORDER.length
+  ) {
+    throw new Error(`npm publish order must be ${EXPECTED_PUBLISH_ORDER.join(', ')}`)
+  }
+  for (const entry of manifest.packages) {
+    if (
+      entry.version !== manifest.version
+      || typeof entry.filename !== 'string'
+      || typeof entry.shasum !== 'string'
+      || typeof entry.integrity !== 'string'
+    ) {
+      throw new Error(`npm publish entry is invalid for ${entry.name ?? 'unknown package'}`)
+    }
+  }
+  return manifest.packages
+}
+
+function resolveTarball(root, filename) {
+  if (filename !== basename(filename)) throw new Error(`unsafe npm tarball filename: ${filename}`)
+  const path = resolve(root, filename)
+  if (path === parse(path).root || path === root || !existsSync(path)) {
+    throw new Error(`npm tarball is missing or unsafe: ${filename}`)
+  }
+  return path
+}
+
+function verifyTarball(path, entry) {
+  const bytes = readFileSync(path)
+  const shasum = createHash('sha1').update(bytes).digest('hex')
+  const integrity = `sha512-${createHash('sha512').update(bytes).digest('base64')}`
+  if (shasum !== entry.shasum || integrity !== entry.integrity) {
+    throw new Error(`npm tarball integrity mismatch for ${entry.filename}`)
+  }
+}
+
+function readPublishedIntegrity(runNpm, entry) {
+  const result = runNpm(['view', `${entry.name}@${entry.version}`, 'dist.integrity', '--json'])
+  if (result.error) throw result.error
+  if (result.status === 0) {
+    try {
+      const integrity = JSON.parse(result.stdout.trim())
+      if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) throw new Error()
+      return integrity
+    } catch {
+      throw new Error(`npm returned invalid integrity for ${entry.name}@${entry.version}`)
+    }
+  }
+  const detail = commandDetail(result)
+  if (/\bE404\b|404 Not Found/i.test(detail)) return null
+  throw new Error(`npm view failed for ${entry.name}@${entry.version}: ${detail}`)
+}
+
+function commandDetail(result) {
+  return `${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim() || `npm exited ${result.status}`
+}
+
+function parseArgs(argv) {
+  const options = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--packages-dir' || arg === '--npm') {
+      const value = argv[++index]
+      if (!value || value.startsWith('--')) throw new Error(`${arg} requires a value`)
+      options[arg === '--packages-dir' ? 'packagesDir' : 'npm'] = value
+    } else {
+      throw new Error(`unknown option: ${arg}`)
+    }
+  }
+  if (!options.packagesDir) {
+    throw new Error('Usage: publish-cli-npm-packages.mjs --packages-dir <dir> [--npm <path>]')
+  }
+  return options
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    publishCliNpmPackages(parseArgs(process.argv.slice(2)))
+  } catch (error) {
+    process.stderr.write(`publish CLI npm packages: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/publish-cli-npm-packages.spec.mjs
+++ b/scripts/publish-cli-npm-packages.spec.mjs
@@ -1,0 +1,129 @@
+import { createHash } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { publishCliNpmPackages } from './publish-cli-npm-packages.mjs'
+
+const roots = []
+const packageNames = [
+  'openalice-darwin-arm64',
+  'openalice-darwin-x64',
+  'openalice-linux-arm64',
+  'openalice-linux-x64',
+  'openalice',
+]
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('publish CLI npm packages', () => {
+  it('publishes missing platform packages before the meta package', () => {
+    const root = fixture()
+    const calls = []
+    const runNpm = vi.fn((args) => {
+      calls.push(args)
+      if (args[0] === 'view') return result(1, '', 'npm error code E404')
+      return result(0, '+ published')
+    })
+
+    expect(publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() }))
+      .toEqual({ version: '0.90.2', packages: packageNames })
+    expect(calls.filter(([command]) => command === 'publish').map(([_, path]) => path.split('/').at(-1)))
+      .toEqual(packageNames.map((name) => `${name}-0.90.2.tgz`))
+  })
+
+  it('makes a retry a no-op when every accepted version is already public', () => {
+    const root = fixture()
+    const manifest = JSON.parse(readFixture(root))
+    const integrity = new Map(manifest.packages.map((entry) => [entry.name, entry.integrity]))
+    const runNpm = vi.fn((args) => {
+      if (args[0] === 'view') {
+        const name = args[1].slice(0, args[1].lastIndexOf('@'))
+        return result(0, JSON.stringify(integrity.get(name)))
+      }
+      return result(0)
+    })
+
+    publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() })
+    expect(runNpm.mock.calls.some(([args]) => args[0] === 'publish')).toBe(false)
+  })
+
+  it('rejects an existing version with different registry integrity', () => {
+    const root = fixture()
+    const runNpm = vi.fn((args) => args[0] === 'view'
+      ? result(0, JSON.stringify('sha512-different'))
+      : result(0))
+
+    expect(() => publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() }))
+      .toThrow('openalice-darwin-arm64@0.90.2 is already published with different integrity')
+  })
+
+  it('accepts a successful publish that became visible after npm returned an error', () => {
+    const root = fixture()
+    const manifest = JSON.parse(readFixture(root))
+    const expected = new Map(manifest.packages.map((entry) => [entry.name, entry.integrity]))
+    const views = new Map()
+    const runNpm = vi.fn((args) => {
+      if (args[0] === 'publish') return result(1, '', 'connection reset')
+      const name = args[1].slice(0, args[1].lastIndexOf('@'))
+      const count = views.get(name) ?? 0
+      views.set(name, count + 1)
+      return count === 0
+        ? result(1, '', 'npm error code E404')
+        : result(0, JSON.stringify(expected.get(name)))
+    })
+
+    expect(() => publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() }))
+      .not.toThrow()
+  })
+
+  it('verifies local tarball bytes before reading or mutating the registry', () => {
+    const root = fixture()
+    writeFileSync(join(root, 'openalice-darwin-arm64-0.90.2.tgz'), 'tampered')
+    const runNpm = vi.fn()
+
+    expect(() => publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() }))
+      .toThrow('npm tarball integrity mismatch')
+    expect(runNpm).not.toHaveBeenCalled()
+  })
+})
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'openalice-npm-publish-'))
+  roots.push(root)
+  const packages = packageNames.map((name) => {
+    const filename = `${name}-0.90.2.tgz`
+    const bytes = Buffer.from(`accepted bytes for ${name}`)
+    writeFileSync(join(root, filename), bytes)
+    return {
+      name,
+      version: '0.90.2',
+      filename,
+      shasum: createHash('sha1').update(bytes).digest('hex'),
+      integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
+    }
+  })
+  writeFileSync(join(root, 'npm-publish-order.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    version: '0.90.2',
+    publishOrder: packageNames,
+    packages,
+  })}\n`)
+  return root
+}
+
+function readFixture(root) {
+  return readFileSync(join(root, 'npm-publish-order.json'), 'utf8')
+}
+
+function result(status, stdout = '', stderr = '') {
+  return { status, stdout, stderr }
+}
+
+function silent() {
+  return { log: vi.fn() }
+}

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -331,8 +331,10 @@ describe('Release workflow critical path', () => {
     ])
     expect(npm.if).toContain("needs.verify-public-cli-channels.result == 'success'")
     expect(npm.if).toContain("needs.release.outputs.channel == 'stable'")
+    expect(npm.steps?.some((candidate) => candidate.uses === 'actions/checkout@v7')).toBe(true)
     const publish = step(npm, 'Publish platform packages before the meta package').run ?? ''
-    expect(publish.indexOf('packages.slice(0,-1)')).toBeLessThan(publish.indexOf('packages.at(-1)'))
+    expect(publish).toContain('publish-cli-npm-packages.mjs')
+    expect(publish).toContain('cli-npm-tarballs')
   })
 
   it('verifies public release bytes before activating external package channels', () => {


### PR DESCRIPTION
Closes the first-publication deadlock for the five fixed npm CLI package names. Authenticated 404 names become explicit bootstrap targets while existing names still require matching maintainership. Stable publication now verifies every tarball against the accepted manifest and skips only an identical already-public version, making partial publication retries safe. Also removes a beta.3 literal from the PTY suite that broke after the beta.4 version sync. Public inspection confirmed the direct installer is live, all five npm names are unreserved, TraderAlice/homebrew-tap is absent, and the current NPM_TOKEN returns HTTP 401. No public package was published and no release switch was enabled. Local verification: root TypeScript; workflow contracts 79/79; focused publication/workflow tests 30/30; PTY tests 59/59; full suite 708 files and 6318 passing tests; public v0.90.2 tarballs passed a no-write integrity rehearsal.