### PR TITLE
feat: publish existing stable npm assets without rebuilding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Create a release or repair mirrors for a channel-aware release made by this workflow.
+        description: Create a release, repair mirrors, or publish existing stable npm assets without rebuilding.
         required: true
         default: release
         type: choice
         options:
           - release
           - mirror
+          - publish-npm
       tag:
         description: Release tag, for example v0.91.0 or v0.91.0-beta.1.
         required: true
@@ -31,6 +32,7 @@ concurrency:
 jobs:
   release:
     name: Plan release candidate
+    if: inputs.operation != 'publish-npm'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1021,6 +1023,85 @@ jobs:
             dist/release-cli-packages/cli-package-channels/aur/openalice-bin.SRCINFO
             dist/release-cli-packages/cli-npm-tarballs/*.tgz
             dist/release-cli-packages/cli-npm-tarballs/npm-publish-order.json
+
+  publish-existing-npm:
+    name: Publish existing stable npm assets
+    if: inputs.operation == 'publish-npm'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+      RELEASE_CHANNEL: ${{ inputs.channel }}
+      SOURCE_REF: ${{ github.ref }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.2
+          registry-url: https://registry.npmjs.org
+
+      - name: Require the current published stable release
+        run: |
+          set -euo pipefail
+          # This operation distributes existing bytes; dev may carry newer tooling.
+          [[ "$SOURCE_REF" = refs/heads/dev || "$SOURCE_REF" = refs/heads/master ]]
+          [[ "$RELEASE_CHANNEL" = stable && "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/releases/latest" > release.json
+          jq -e --arg tag "$RELEASE_TAG" '.tag_name == $tag and .draft == false and .prerelease == false' release.json
+          git merge-base --is-ancestor "$RELEASE_TAG^{commit}" origin/master
+          for manifest in package.json packages/cli/package.json; do
+            test "$(git show "$RELEASE_TAG:$manifest" | jq -r .version)" = "${RELEASE_TAG#v}"
+          done
+
+      - name: Verify npm authority for this explicit publication
+        run: node scripts/preflight-public-cli-authority.mjs
+        env:
+          OPENALICE_PUBLISH_NPM: 'true'
+          OPENALICE_PUBLISH_HOMEBREW: 'false'
+          OPENALICE_PUBLISH_AUR: 'false'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Download and verify existing public release bytes
+        run: |
+          set -euo pipefail
+          mkdir -p dist/existing-npm
+          base="https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG"
+          for metadata in npm-publish-order.json cli-package-channels.json; do
+            curl --fail --location --retry 3 "$base/$metadata" -o "dist/existing-npm/$metadata"
+          done
+          jq -e --arg version "${RELEASE_TAG#v}" '.version == $version' dist/existing-npm/npm-publish-order.json
+          for package in openalice-darwin-arm64 openalice-darwin-x64 openalice-linux-arm64 openalice-linux-x64 openalice; do
+            filename="$package-${RELEASE_TAG#v}.tgz"
+            curl --fail --location --retry 3 "$base/$filename" -o "dist/existing-npm/$filename"
+          done
+          node --input-type=module -e "import { verifyCliNpmPackages } from './scripts/publish-cli-npm-packages.mjs'; verifyCliNpmPackages('dist/existing-npm');"
+          node scripts/verify-public-cli-channels.mjs \
+            --manifest dist/existing-npm/cli-package-channels.json \
+            --version "${RELEASE_TAG#v}" > dist/existing-npm/public-channel-receipt.json
+
+      - name: Publish platform packages before the meta package
+        run: node scripts/publish-cli-npm-packages.mjs --packages-dir dist/existing-npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Preserve publication receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: existing-npm-publication
+          path: |
+            dist/existing-npm/npm-publish-order.json
+            dist/existing-npm/public-channel-receipt.json
+          if-no-files-found: ignore
+          retention-days: 30
 
   publish-cli-npm:
     name: Publish npm CLI packages

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -13,13 +13,15 @@ covers macOS and glibc Linux on arm64 and x64.
 Stable package-manager installs use:
 
 ```bash
-npm install -g openalice
+npm install -g openalice --allow-scripts=openalice
 bun add -g --trust openalice
 brew install traderalice/tap/openalice
 paru -S openalice-bin
 ```
 
-Bun does not run dependency lifecycle scripts by default. `--trust` is the
+npm 12 requires explicit installation-script approval; `--allow-scripts=openalice`
+allows only this package's materialization step. Bun likewise does not run
+dependency lifecycle scripts by default. `--trust` is the
 explicit Bun authorization that lets the small `openalice` meta package select
 and materialize its already-published native platform package. It does not give
 OpenAlice permission to install an Agent Runtime or another system dependency.
@@ -146,13 +148,30 @@ deliberate maintainer actions. Enabling a switch without its external
 repository or authority is a release failure, not permission to invent another
 channel or silently skip publication.
 
+### First npm publication or retry without rebuilding
+
+Dispatch the existing `Release` workflow with `operation=publish-npm`,
+`channel=stable`, and the current published stable tag. This explicit operation
+authorizes only that npm publication; it does not enable the persistent
+`OPENALICE_PUBLISH_NPM` switch. It can run from integrated `dev` tooling or
+`master`, but accepts only GitHub's current non-draft, non-prerelease latest
+release, whose tag is on `master` and whose two product manifests agree.
+
+The single job checks npm authority, downloads the release-owned npm tarballs
+and manifests, verifies every tarball before any upload, verifies the public
+native archives, then uses the same platform-first publisher as a new stable
+release. No build, signing, version change, tag creation, CDN mutation,
+Homebrew, or AUR job runs. After upload, verify an actual registry install.
+Trusted publishing configuration and retirement of the temporary token are
+separate follow-up actions; do not confuse `--provenance` with OIDC authority.
+
 ## Update and uninstall ownership
 
 The installer that owns the visible command also owns later file mutation:
 
 | Method | Update | Uninstall |
 |---|---|---|
-| npm | `npm install -g openalice@latest` | `npm uninstall -g openalice` |
+| npm | `npm install -g openalice@latest --allow-scripts=openalice` | `npm uninstall -g openalice` |
 | Bun | `bun add -g --trust openalice@latest` | `bun remove -g openalice` |
 | Homebrew | `brew upgrade traderalice/tap/openalice` | `brew uninstall traderalice/tap/openalice` |
 | AUR | `paru -S openalice-bin` | `paru -Rns openalice-bin` |

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -21,6 +21,10 @@ Canonical startup rules: [[AGENTS.md]]. Guide index: [[docs/README.md]].
   manifests must agree before candidate work begins. Each accepted tag may
   update only its own mutable product aliases; a newly accepted release may
   also refresh the shared channel-neutral `install` bootstrap.
+- The separate `Release` operation `publish-npm` only distributes an already
+  published stable release. It may use integrated `dev` or `master` tooling;
+  it cannot create a version, rebuild an artifact, or mutate product channels.
+  See [[docs/cli-package-managers.md]] for its first-publication/retry contract.
 - `archive/dev-pre-beta6` is a historical snapshot; do not modify or delete it.
 - `local` is a legacy shared-worktree branch. It is not the default workflow;
   audit its unmerged commits before deciding whether to retain or retire it.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -762,6 +762,17 @@ This plan is complete only when:
     an ordinary SSH-reachable host without owning its infrastructure provider.
 ## Progress Log
 
+- 2026-09-04: Maintainer authorized attempting the five unscoped npm names
+  with the accepted v0.90.2 tarballs. A seven-day bootstrap token is configured
+  in GitHub Actions. Added an explicit `Release / publish-npm` operation for
+  current stable assets only, without rebuilding or changing version/CDN state.
+  npm 12 installation requires explicit `--allow-scripts=openalice`. An
+  isolated local registry serving the original, integrity-verified tarballs
+  passed npm 12.0.2 / Node 22.22.2 install, version, detached start, status, and
+  stop on macOS arm64 with no Node/Bun in Runtime PATH. Actual registry
+  publication is pending, not inferred from absent public names. OIDC remains
+  follow-up work.
+
 - 2026-08-29: Maintainer selected the architecture after comparing Herdr and
   OpenCode. CLI is treated as a primary long-running distribution. The selected
   direction is one Bun-compiled OpenAlice artifact that re-executes into the

--- a/scripts/publish-cli-npm-packages.mjs
+++ b/scripts/publish-cli-npm-packages.mjs
@@ -20,12 +20,11 @@ export function publishCliNpmPackages({
   logger = console,
 } = {}) {
   const root = resolve(packagesDir ?? process.cwd())
-  const manifest = readManifest(root)
-  const packages = validateManifest(manifest)
+  const manifest = verifyCliNpmPackages(root)
+  const packages = manifest.packages
 
   for (const entry of packages) {
     const tarballPath = resolveTarball(root, entry.filename)
-    verifyTarball(tarballPath, entry)
     const current = readPublishedIntegrity(runNpm, entry)
     if (current === entry.integrity) {
       logger.log(`[npm-publish] ${entry.name}@${entry.version} already matches; skipping`)
@@ -49,6 +48,15 @@ export function publishCliNpmPackages({
   }
 
   return { version: manifest.version, packages: packages.map(({ name }) => name) }
+}
+
+export function verifyCliNpmPackages(packagesDir) {
+  const root = resolve(packagesDir)
+  const manifest = readManifest(root)
+  for (const entry of validateManifest(manifest)) {
+    verifyTarball(resolveTarball(root, entry.filename), entry)
+  }
+  return manifest
 }
 
 function readManifest(root) {

--- a/scripts/publish-cli-npm-packages.spec.mjs
+++ b/scripts/publish-cli-npm-packages.spec.mjs
@@ -83,7 +83,8 @@ describe('publish CLI npm packages', () => {
 
   it('verifies local tarball bytes before reading or mutating the registry', () => {
     const root = fixture()
-    writeFileSync(join(root, 'openalice-darwin-arm64-0.90.2.tgz'), 'tampered')
+    // Even the last package must be verified before the first platform publishes.
+    writeFileSync(join(root, 'openalice-0.90.2.tgz'), 'tampered')
     const runNpm = vi.fn()
 
     expect(() => publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() }))

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -55,13 +55,35 @@ function needs(job: WorkflowJob): string[] {
 }
 
 describe('Release workflow critical path', () => {
+  it('publishes existing stable npm assets without rebuilding or changing product channels', () => {
+    const job = workflow.jobs['publish-existing-npm']
+    expect(job.if).toBe("inputs.operation == 'publish-npm'")
+    expect(workflow.jobs.release.if).toBe("inputs.operation != 'publish-npm'")
+    expect(needs(job)).toEqual([])
+    expect(job['timeout-minutes']).toBe(15)
+    const guard = step(job, 'Require the current published stable release').run ?? ''
+    expect(guard).toContain('refs/heads/dev')
+    expect(guard).toContain('releases/latest')
+    expect(guard).toContain('.draft == false and .prerelease == false')
+    expect(guard).toContain('merge-base --is-ancestor')
+    expect(guard).toContain('packages/cli/package.json')
+    const download = step(job, 'Download and verify existing public release bytes').run ?? ''
+    expect(download).toContain('verifyCliNpmPackages')
+    expect(download).toContain('verify-public-cli-channels.mjs')
+    expect(download).toContain('npm-publish-order.json')
+    const allSteps = job.steps?.map((candidate) => candidate.run ?? '').join('\n') ?? ''
+    expect(allSteps).not.toMatch(/pnpm build|electron:|aws s3|gh release create/)
+    expect(step(job, 'Publish platform packages before the meta package').run)
+      .toContain('publish-cli-npm-packages.mjs --packages-dir dist/existing-npm')
+  })
+
   it('requires an explicit tag/package release decision instead of publishing on master push', () => {
     expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch'])
     expect(workflow.on.workflow_dispatch?.inputs).toMatchObject({
       operation: {
         required: true,
         type: 'choice',
-        options: ['release', 'mirror'],
+        options: ['release', 'mirror', 'publish-npm'],
       },
       tag: {
         required: true,


### PR DESCRIPTION
## Summary

- Add `Release / publish-npm` for the current already-published stable release, without rebuilding desktop or CLI artifacts.
- Accept only integrated dev/master tooling, a public stable latest tag on master, and matching version metadata. Check npm authority, public native artifacts, and all npm tarball hashes before platform-first publication.
- Keep product releases, mirrors, beta, Homebrew, AUR, and persistent channel switches untouched.
- Document npm 12's explicit installation-script authorization.

## Verification

- Root TypeScript check passed; complete hermetic suite passed (708 files, 6,319 tests, 3 expected skips; 273.54 seconds).
- 34 focused release/publication/authority/public-byte tests passed.
- Exact v0.90.2 npm tarballs served by an isolated local registry passed npm 12.0.2 / Node 22.22.2 install, version, detached start, status, and stop on native macOS arm64. Runtime PATH contained neither Node nor Bun.
- Public v0.90.2 manifest matches local accepted tarballs. GitHub latest is stable v0.90.2; tag is reachable from master and both tagged package manifests agree.

## Boundary

Publication credentials remain Actions secrets. No token material is tracked or printed. Explicit manual operation authorizes only this npm upload; it does not enable subsequent automatic npm publication. The installed product artifacts are unchanged. OIDC and public registry acceptance remain separate outcomes, not claims of this source PR.
