### PR TITLE
feat: use npm trusted publishing without rotating tokens

### DIFF
--- a/.github/workflows/cli-channel-authority.yml
+++ b/.github/workflows/cli-channel-authority.yml
@@ -3,11 +3,6 @@ name: Public CLI Channel Authority
 on:
   workflow_dispatch:
     inputs:
-      npm:
-        description: Verify npm and Bun package-name authority.
-        required: true
-        default: true
-        type: boolean
       homebrew:
         description: Verify TraderAlice Homebrew Tap write authority.
         required: true
@@ -37,11 +32,10 @@ jobs:
 
       - name: Require at least one selected channel
         env:
-          CHECK_NPM: ${{ inputs.npm }}
           CHECK_HOMEBREW: ${{ inputs.homebrew }}
           CHECK_AUR: ${{ inputs.aur }}
         run: |
-          if [ "$CHECK_NPM" != "true" ] && [ "$CHECK_HOMEBREW" != "true" ] && [ "$CHECK_AUR" != "true" ]; then
+          if [ "$CHECK_HOMEBREW" != "true" ] && [ "$CHECK_AUR" != "true" ]; then
             echo "::error::Select at least one public CLI channel to verify."
             exit 1
           fi
@@ -49,10 +43,8 @@ jobs:
       - name: Verify selected channel authority without publishing
         run: node scripts/preflight-public-cli-authority.mjs
         env:
-          OPENALICE_PUBLISH_NPM: ${{ inputs.npm }}
           OPENALICE_PUBLISH_HOMEBREW: ${{ inputs.homebrew }}
           OPENALICE_PUBLISH_AUR: ${{ inputs.aur }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Create a release, repair mirrors, or publish existing stable npm assets without rebuilding.
+        description: Create a release, repair mirrors, publish existing stable npm assets, or verify npm OIDC without publishing.
         required: true
         default: release
         type: choice
@@ -12,9 +12,10 @@ on:
           - release
           - mirror
           - publish-npm
+          - verify-npm
       tag:
-        description: Release tag, for example v0.91.0 or v0.91.0-beta.1.
-        required: true
+        description: Required except for verify-npm; for example v0.91.0 or v0.91.0-beta.1.
+        required: false
         type: string
       channel:
         description: Mutable release channel that this tag is allowed to update.
@@ -32,7 +33,7 @@ concurrency:
 jobs:
   release:
     name: Plan release candidate
-    if: inputs.operation != 'publish-npm'
+    if: inputs.operation == 'release' || inputs.operation == 'mirror'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -175,6 +176,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7
@@ -189,7 +191,6 @@ jobs:
           OPENALICE_PUBLISH_NPM: ${{ vars.OPENALICE_PUBLISH_NPM }}
           OPENALICE_PUBLISH_HOMEBREW: ${{ vars.OPENALICE_PUBLISH_HOMEBREW }}
           OPENALICE_PUBLISH_AUR: ${{ vars.OPENALICE_PUBLISH_AUR }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
@@ -1024,6 +1025,30 @@ jobs:
             dist/release-cli-packages/cli-npm-tarballs/*.tgz
             dist/release-cli-packages/cli-npm-tarballs/npm-publish-order.json
 
+  # Keep this rehearsal in the trusted publishing workflow: npm validates the
+  # workflow filename, so another workflow cannot prove release.yml's identity.
+  verify-npm:
+    name: Verify npm OIDC without publishing
+    if: inputs.operation == 'verify-npm'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.2
+      - name: Require integrated release tooling
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        run: '[[ "$SOURCE_REF" = refs/heads/dev || "$SOURCE_REF" = refs/heads/master ]]'
+      - name: Verify all five trusted publisher connections
+        run: node scripts/preflight-public-cli-authority.mjs
+        env:
+          OPENALICE_PUBLISH_NPM: 'true'
+
   publish-existing-npm:
     name: Publish existing stable npm assets
     if: inputs.operation == 'publish-npm'
@@ -1047,6 +1072,10 @@ jobs:
         with:
           node-version: 22.22.2
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@12.0.2 --ignore-scripts --no-audit --no-fund
 
       - name: Require the current published stable release
         run: |
@@ -1067,7 +1096,6 @@ jobs:
           OPENALICE_PUBLISH_NPM: 'true'
           OPENALICE_PUBLISH_HOMEBREW: 'false'
           OPENALICE_PUBLISH_AUR: 'false'
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Download and verify existing public release bytes
         run: |
@@ -1089,8 +1117,6 @@ jobs:
 
       - name: Publish platform packages before the meta package
         run: node scripts/publish-cli-npm-packages.mjs --packages-dir dist/existing-npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Preserve publication receipt
         if: always()
@@ -1117,8 +1143,12 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22.19.0
+          node-version: 22.22.2
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@12.0.2 --ignore-scripts --no-audit --no-fund
 
       - uses: actions/download-artifact@v4
         with:
@@ -1129,8 +1159,6 @@ jobs:
         run: >-
           node scripts/publish-cli-npm-packages.mjs
           --packages-dir dist/cli-package-channels/cli-npm-tarballs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   verify-public-cli-channels:
     name: Verify public CLI channel assets

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -121,27 +121,28 @@ External channels are explicit release switches:
 
 | Channel | Repository variable | Required authority |
 |---|---|---|
-| npm + Bun | `OPENALICE_PUBLISH_NPM=true` | `NPM_TOKEN` for all five public package names |
+| npm + Bun | `OPENALICE_PUBLISH_NPM=true` | npm Trusted Publishing for all five names, bound to `TraderAlice/OpenAlice` / `release.yml` |
 | Homebrew | `OPENALICE_PUBLISH_HOMEBREW=true` | `HOMEBREW_TAP_TOKEN` with write access to `TraderAlice/homebrew-tap` |
 | AUR / paru | `OPENALICE_PUBLISH_AUR=true` | dedicated `AUR_SSH_PRIVATE_KEY` plus manually verified `AUR_KNOWN_HOSTS` |
 
 Before a stable GitHub Release can be created, the release workflow preflights
-every enabled switch. npm must identify the token owner, confirm that every
-existing package lists that identity as a maintainer, and report any 404 names
-as explicit first-publication targets. A missing name is not proof of npm
-ownership, but the enabled stable publication switch is the maintainer's
-deliberate instruction to claim that fixed OpenAlice package name. The
+every enabled switch. npm exchanges a GitHub OIDC identity for a short-lived,
+package-scoped credential for each of the five existing names. Missing packages
+or missing/mismatched trusted publishers fail the check; there is no token
+fallback or automatic name reservation. Credentials stay in memory and are
+discarded without publishing. The
 Homebrew token must see `TraderAlice/homebrew-tap` with push authority; and the
 AUR key plus pinned known-hosts entry must be able to read the `openalice-bin`
 Git repository. Disabled channels perform no external authority checks. This
 makes missing credentials or conflicting ownership a release-planning failure
 instead of discovering it after the accepted assets are already public.
 
-The `Public CLI Channel Authority` workflow exposes the same checks as a manual
-read-only rehearsal. Select npm, Homebrew, AUR, or any combination before a
-stable promotion; the run uses repository secrets but cannot publish packages,
-push metadata, or create a GitHub Release. Use it after reserving names and
-installing credentials, before enabling the corresponding release switch.
+The `Public CLI Channel Authority` workflow rehearses Homebrew and/or AUR
+authority without publishing. npm uses `Release` with `operation=verify-npm`
+from integrated `dev` or `master` (no tag required). The rehearsal must run in
+`release.yml` because npm validates that exact workflow identity. It exchanges
+credentials for all five packages but does not upload, build, sign, change a
+version, or create a release. Use it before enabling the npm switch.
 
 The npm, Tap, and AUR writers are idempotent. npm verifies each local tarball
 against the accepted publish manifest, skips an already-public version only
@@ -169,8 +170,44 @@ and manifests, verifies every tarball before any upload, verifies the public
 native archives, then uses the same platform-first publisher as a new stable
 release. No build, signing, version change, tag creation, CDN mutation,
 Homebrew, or AUR job runs. After upload, verify an actual registry install.
-Trusted publishing configuration and retirement of the temporary token are
-separate follow-up actions; do not confuse `--provenance` with OIDC authority.
+This operation uses OIDC too; an already-published identical version is skipped.
+That skip alone is not proof of OIDC authorization.
+
+### npm Trusted Publishing (OIDC)
+
+For each of `openalice`, `openalice-darwin-arm64`, `openalice-darwin-x64`,
+`openalice-linux-arm64`, and `openalice-linux-x64`, configure npm Package Settings
+→ Trusted Publisher → GitHub Actions:
+
+- Organization/user: `TraderAlice`; repository: `OpenAlice`.
+- Workflow filename: `release.yml` (not its directory path).
+- Allow `npm publish`; leave environment empty because these jobs do not use a
+  GitHub environment. Access to changing/running the trusted workflow is a
+  publishing security boundary.
+
+Publication runs on GitHub-hosted Ubuntu with `id-token: write`, Node 22.22.2,
+and pinned npm 12.0.2. npm handles its own short-lived credential exchange when
+publishing; neither `NPM_TOKEN` nor `NODE_AUTH_TOKEN` is configured. The generated
+packages must retain the matching `TraderAlice/OpenAlice` repository URL.
+Provenance is not itself proof of OIDC authentication.
+
+After adding all five connections, run:
+
+```bash
+gh workflow run release.yml --ref dev -f operation=verify-npm
+```
+
+A successful exchange proves npm accepted the workflow identity for each
+package; it does not exercise upload/provenance acceptance for a new version.
+Record that last boundary at the next authorized stable publication, rather
+than inventing a release to test authentication. After verification, revoke
+the temporary first-publication token and remove the repository's `NPM_TOKEN`
+secret. npm's restrictive 2FA/token policy is compatible with OIDC.
+
+See [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) and
+the [registry OIDC exchange API](https://api-docs.npmjs.com/). Adding future
+platform packages (including Windows) requires first publication and their own
+trusted-publisher connections; the current native matrix is macOS/Linux only.
 
 ## Update and uninstall ownership
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -25,6 +25,9 @@ Canonical startup rules: [[AGENTS.md]]. Guide index: [[docs/README.md]].
   published stable release. It may use integrated `dev` or `master` tooling;
   it cannot create a version, rebuild an artifact, or mutate product channels.
   See [[docs/cli-package-managers.md]] for its first-publication/retry contract.
+- `Release` operation `verify-npm` checks all five npm OIDC connections from
+  `dev` or `master` without a tag, build, or package upload. npm publishing uses
+  the workflow's identity, not a rotating repository token.
 - `archive/dev-pre-beta6` is a historical snapshot; do not modify or delete it.
 - `local` is a legacy shared-worktree branch. It is not the default workflow;
   audit its unmerged commits before deciding whether to retain or retire it.

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -6,6 +6,21 @@ stable/beta discovery authority is converged on the OpenAlice CDN. Native
 PowerShell and Homebrew/AUR activation remain deferred. npm/Bun's five public
 packages are published at v0.90.2 under maintainer `jiaran258`.
 
+Current increment: replace the temporary npm token with GitHub OIDC trust on
+the same five packages. Preserve stable-only publication and accepted artifact
+bytes; no Windows activation, new version, or package-manager switch changes.
+The non-publishing exchange rehearsal lives in `release.yml` so it verifies
+the real trusted workflow identity. Owner contract: [[docs/cli-package-managers.md]].
+
+- [x] Replace token-based preflight/publication wiring and add OIDC contract tests.
+- [x] Save all five npm Trusted Publisher connections, allowing direct publish
+  from `TraderAlice/OpenAlice` / `release.yml` (2026-09-04).
+- [x] Complete local verification: root typecheck; 708 full-suite files,
+  6,331 passed and 3 expected skips; 47 focused checks and 82 workflow contracts.
+- [ ] Integrate the focused PR to `dev`.
+- [ ] Run the real five-package OIDC exchange rehearsal without publishing.
+- [ ] Retire the temporary npm token and GitHub secret after verification.
+
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`
 tip contains superseded release-flow experiments and must not be promoted as a

--- a/scripts/cli-channel-authority-workflow.spec.ts
+++ b/scripts/cli-channel-authority-workflow.spec.ts
@@ -25,6 +25,8 @@ describe('Public CLI channel authority workflow', () => {
     expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch'])
     expect(workflow.permissions).toEqual({ contents: 'read' })
     expect(workflow.jobs.preflight['timeout-minutes']).toBe(5)
+    // npm trust must be exercised by release.yml, not this workflow identity.
+    expect(JSON.stringify(workflow)).not.toMatch(/NPM_TOKEN|OPENALICE_PUBLISH_NPM|inputs.npm/)
   })
 
   it('requires a selection and calls the non-publishing preflight', () => {

--- a/scripts/preflight-public-cli-authority.mjs
+++ b/scripts/preflight-public-cli-authority.mjs
@@ -31,22 +31,16 @@ export async function preflightPublicCliAuthority({
   const selected = Object.entries(enabled).filter(([, value]) => value).map(([name]) => name)
   if (selected.length === 0) {
     logger.log('[public-cli-authority] no external CLI channels are enabled')
-    return { enabled: selected, npmUsername: null, npmUnreservedPackages: [] }
+    return { enabled: selected, npmPackages: [] }
   }
 
   const failures = []
-  let npmUsername = null
-  let npmUnreservedPackages = []
+  let npmPackages = []
 
   if (enabled.npm) {
     try {
-      const npmAuthority = await verifyNpmAuthority({ env, fetchImpl })
-      npmUsername = npmAuthority.username
-      npmUnreservedPackages = npmAuthority.unreservedPackages
-      logger.log(`[public-cli-authority] npm authority verified for ${npmUsername}`)
-      if (npmUnreservedPackages.length > 0) {
-        logger.log(`[public-cli-authority] npm names available for first publication: ${npmUnreservedPackages.join(', ')}`)
-      }
+      npmPackages = await verifyNpmAuthority({ env, fetchImpl })
+      logger.log(`[public-cli-authority] npm OIDC exchange verified: ${npmPackages.join(', ')} (no packages published)`)
     } catch (error) {
       failures.push(message(error))
     }
@@ -76,45 +70,63 @@ export async function preflightPublicCliAuthority({
     throw new Error(`public CLI channel authority preflight failed:\n- ${failures.join('\n- ')}`)
   }
 
-  return { enabled: selected, npmUsername, npmUnreservedPackages }
+  return { enabled: selected, npmPackages }
 }
 
 async function verifyNpmAuthority({ env, fetchImpl }) {
-  const token = requireSecret(env, 'NPM_TOKEN', 'npm publication')
-  const registry = trimTrailingSlash(env.OPENALICE_NPM_REGISTRY_URL || DEFAULT_NPM_REGISTRY)
-  const headers = {
-    accept: 'application/json',
-    authorization: `Bearer ${token}`,
+  // Use the same package-scoped exchange as npm publish, without uploading a
+  // version. npm whoami and an idempotent publish skip cannot test OIDC trust.
+  const requestToken = requireSecret(env, 'ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'npm OIDC')
+  const rawRequestUrl = requireSecret(env, 'ACTIONS_ID_TOKEN_REQUEST_URL', 'npm OIDC')
+  let requestUrl
+  try {
+    requestUrl = new URL(rawRequestUrl)
+  } catch {
+    throw new Error('npm OIDC requires the GitHub Actions identity endpoint')
   }
-  const whoami = await fetchJson(fetchImpl, `${registry}/-/whoami`, { headers }, 'npm token identity')
-  const username = typeof whoami.username === 'string' ? whoami.username.trim() : ''
-  if (!username) throw new Error('npm token identity did not return a username')
-
-  const unreservedPackages = []
+  if (requestUrl.protocol !== 'https:' || requestUrl.username || requestUrl.password ||
+      !requestUrl.hostname.endsWith('.actions.githubusercontent.com')) {
+    throw new Error('npm OIDC requires the GitHub Actions identity endpoint')
+  }
+  requestUrl.searchParams.set('audience', 'npm:registry.npmjs.org')
+  const identity = await fetchOidcJson(fetchImpl, requestUrl.href, {
+    headers: { authorization: `Bearer ${requestToken}` },
+  }, 'GitHub OIDC identity')
+  if (typeof identity?.value !== 'string' || !identity.value.trim()) {
+    throw new Error('GitHub OIDC identity did not return an ID token')
+  }
   for (const packageName of NPM_PACKAGE_NAMES) {
-    const response = await fetchImpl(`${registry}/${encodeURIComponent(packageName)}`, { headers })
-    if (response.status === 404) {
-      unreservedPackages.push(packageName)
-      continue
+    const exchanged = await fetchOidcJson(fetchImpl,
+      `${DEFAULT_NPM_REGISTRY}/-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(packageName)}`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${identity.value}` },
+      }, `npm OIDC exchange for ${packageName}`)
+    if (exchanged?.token_type !== 'oidc' || typeof exchanged.token !== 'string' || !exchanged.token.trim()) {
+      throw new Error(`npm OIDC exchange for ${packageName} did not return a publishing token`)
     }
-    if (!response.ok) {
-      throw new Error(`npm package ${packageName} request failed with HTTP ${response.status}`)
-    }
-    let metadata
-    try {
-      metadata = await response.json()
-    } catch {
-      throw new Error(`npm package ${packageName} returned invalid JSON`)
-    }
-    const maintainers = Array.isArray(metadata.maintainers)
-      ? metadata.maintainers.map((entry) => typeof entry?.name === 'string' ? entry.name : '')
-      : []
-    if (!maintainers.includes(username)) {
-      throw new Error(`npm token identity ${username} is not a maintainer of ${packageName}`)
-    }
+    // Never log, persist, return, or reuse the temporary publishing credential.
   }
+  return [...NPM_PACKAGE_NAMES]
+}
 
-  return { username, unreservedPackages }
+async function fetchOidcJson(fetchImpl, url, options, label) {
+  let response
+  try {
+    response = await fetchImpl(url, {
+      ...options,
+      redirect: 'error',
+      signal: AbortSignal.timeout(20_000),
+    })
+  } catch {
+    // Raw transport errors or response bodies may contain credential material.
+    throw new Error(`${label} request failed`)
+  }
+  if (!response.ok) throw new Error(`${label} request failed with HTTP ${response.status}`)
+  try {
+    return await response.json()
+  } catch {
+    throw new Error(`${label} returned invalid JSON`)
+  }
 }
 
 async function verifyHomebrewAuthority({ env, fetchImpl }) {
@@ -191,10 +203,6 @@ function requireSecret(env, name, purpose) {
   const value = typeof env[name] === 'string' ? env[name].trim() : ''
   if (!value) throw new Error(`${purpose} is enabled but ${name} is missing`)
   return value
-}
-
-function trimTrailingSlash(value) {
-  return value.replace(/\/+$/, '')
 }
 
 function message(error) {

--- a/scripts/preflight-public-cli-authority.spec.mjs
+++ b/scripts/preflight-public-cli-authority.spec.mjs
@@ -15,6 +15,18 @@ function response(status, body) {
   }
 }
 
+const oidcEnv = {
+  OPENALICE_PUBLISH_NPM: 'true',
+  ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-secret',
+  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id?existing=1',
+}
+
+function oidcResponse(url) {
+  return url.includes('actions.githubusercontent.com')
+    ? response(200, { value: 'github-id-secret' })
+    : response(201, { token_type: 'oidc', token: 'npm-exchanged-secret' })
+}
+
 describe('public CLI authority preflight', () => {
   it('does no external work while every publication switch is disabled', async () => {
     const fetchImpl = vi.fn()
@@ -22,25 +34,23 @@ describe('public CLI authority preflight', () => {
     const logger = { log: vi.fn() }
 
     await expect(preflightPublicCliAuthority({ env: {}, fetchImpl, verifyAur, logger }))
-      .resolves.toEqual({ enabled: [], npmUsername: null, npmUnreservedPackages: [] })
+      .resolves.toEqual({ enabled: [], npmPackages: [] })
     expect(fetchImpl).not.toHaveBeenCalled()
     expect(verifyAur).not.toHaveBeenCalled()
   })
 
-  it('verifies the npm identity owns all names and the Tap token can push', async () => {
+  it('exchanges OIDC for every package and independently checks Tap and AUR', async () => {
     const env = {
-      OPENALICE_PUBLISH_NPM: 'true',
+      ...oidcEnv,
       OPENALICE_PUBLISH_HOMEBREW: 'true',
       OPENALICE_PUBLISH_AUR: 'true',
-      NPM_TOKEN: 'npm-secret',
       HOMEBREW_TAP_TOKEN: 'tap-secret',
       AUR_SSH_PRIVATE_KEY: 'aur-secret',
       AUR_KNOWN_HOSTS: 'aur.example ssh-ed25519 key',
     }
     const fetchImpl = vi.fn(async (url) => {
-      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
       if (url.includes('api.github.com')) return response(200, { permissions: { push: true } })
-      return response(200, { maintainers: [{ name: 'alice-release' }] })
+      return oidcResponse(url)
     })
     const verifyAur = vi.fn(async () => {})
 
@@ -51,8 +61,7 @@ describe('public CLI authority preflight', () => {
       logger: { log: vi.fn() },
     })).resolves.toEqual({
       enabled: ['npm', 'homebrew', 'aur'],
-      npmUsername: 'alice-release',
-      npmUnreservedPackages: [],
+      npmPackages: NPM_PACKAGE_NAMES,
     })
     expect(fetchImpl).toHaveBeenCalledTimes(NPM_PACKAGE_NAMES.length + 2)
     expect(verifyAur).toHaveBeenCalledWith({ env })
@@ -71,18 +80,14 @@ describe('public CLI authority preflight', () => {
       verifyAur: vi.fn(),
       logger: { log: vi.fn() },
     })).rejects.toThrow(new RegExp([
-      'NPM_TOKEN is missing',
+      'ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing',
       'HOMEBREW_TAP_TOKEN is missing',
       'AUR_SSH_PRIVATE_KEY is missing',
     ].join('[\\s\\S]*')))
   })
 
-  it('rejects an authenticated npm token that does not own the reserved names', async () => {
-    const fetchImpl = vi.fn(async (url) => {
-      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
-      return response(200, { maintainers: [{ name: 'someone-else' }] })
-    })
-
+  it('never falls back to an old npm token outside GitHub OIDC', async () => {
+    const fetchImpl = vi.fn()
     await expect(preflightPublicCliAuthority({
       env: {
         OPENALICE_PUBLISH_NPM: 'true',
@@ -90,43 +95,102 @@ describe('public CLI authority preflight', () => {
       },
       fetchImpl,
       logger: { log: vi.fn() },
-    })).rejects.toThrow('npm token identity alice-release is not a maintainer of openalice')
+    })).rejects.toThrow('ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing')
+    expect(fetchImpl).not.toHaveBeenCalled()
   })
 
-  it('accepts unreserved npm names as explicit first-publication targets', async () => {
+  it.each([401, 403, 404, 500])('rejects missing or unauthorized trust (HTTP %s)', async (status) => {
     const fetchImpl = vi.fn(async (url) => {
-      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
-      return response(404, {})
+      if (url.includes('actions.githubusercontent.com')) return oidcResponse(url)
+      return response(status, { error: 'private server response' })
     })
 
     await expect(preflightPublicCliAuthority({
-      env: {
-        OPENALICE_PUBLISH_NPM: 'true',
-        NPM_TOKEN: 'npm-secret',
-      },
+      env: oidcEnv,
       fetchImpl,
       logger: { log: vi.fn() },
-    })).resolves.toEqual({
-      enabled: ['npm'],
-      npmUsername: 'alice-release',
-      npmUnreservedPackages: NPM_PACKAGE_NAMES,
+    })).rejects.toThrow(`npm OIDC exchange for openalice request failed with HTTP ${status}`)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the npm audience and fixed registry, without publishing or leaking credentials', async () => {
+    const fetchImpl = vi.fn(async (url) => oidcResponse(url))
+    const logger = { log: vi.fn() }
+    const result = await preflightPublicCliAuthority({
+      env: { ...oidcEnv, OPENALICE_NPM_REGISTRY_URL: 'https://untrusted.example' },
+      fetchImpl, logger,
     })
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      `${oidcEnv.ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org`,
+    )
+    expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe('Bearer github-request-secret')
+    expect(fetchImpl.mock.calls.slice(1).map(([url]) => url)).toEqual(
+      NPM_PACKAGE_NAMES.map((name) => `https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${name}`),
+    )
+    for (const [, options] of fetchImpl.mock.calls.slice(1)) {
+      expect(options.method).toBe('POST')
+      expect(options.headers.authorization).toBe('Bearer github-id-secret')
+      expect(options.body).toBeUndefined()
+    }
+    for (const [, options] of fetchImpl.mock.calls) {
+      expect(options.redirect).toBe('error')
+      expect(options.signal).toBeInstanceOf(AbortSignal)
+    }
+    expect(JSON.stringify([result, logger.log.mock.calls])).not.toContain('secret')
+  })
+
+  it.each(['not-a-url', 'http://token.actions.githubusercontent.com/id', 'https://untrusted.example/id', 'https://user@token.actions.githubusercontent.com/id'])('rejects an unsafe identity endpoint: %s', async (url) => {
+    const fetchImpl = vi.fn()
+    await expect(preflightPublicCliAuthority({
+      env: { ...oidcEnv, ACTIONS_ID_TOKEN_REQUEST_URL: url }, fetchImpl,
+    })).rejects.toThrow('requires the GitHub Actions identity endpoint')
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('fails if any platform connection is missing, even when the meta package passed', async () => {
+    const logger = { log: vi.fn() }
+    await expect(preflightPublicCliAuthority({
+      env: oidcEnv, logger,
+      fetchImpl: async (url) => url.endsWith('/openalice-linux-x64') ? response(404, {}) : oidcResponse(url),
+    })).rejects.toThrow('npm OIDC exchange for openalice-linux-x64 request failed with HTTP 404')
+    expect(logger.log).not.toHaveBeenCalled()
+  })
+
+  it('sanitizes invalid JSON errors', async () => {
+    await expect(preflightPublicCliAuthority({
+      env: oidcEnv,
+      fetchImpl: async () => ({ ok: true, json() { throw new Error('private response') } }),
+    })).rejects.toThrow('GitHub OIDC identity returned invalid JSON')
+  })
+
+  it.each([{}, { token_type: 'oidc', token: '' }, { token_type: 'bearer', token: 'secret' }])('rejects malformed exchange responses: %j', async (body) => {
+    await expect(preflightPublicCliAuthority({
+      env: oidcEnv,
+      fetchImpl: async (url) => url.includes('actions.githubusercontent.com') ? oidcResponse(url) : response(201, body),
+    })).rejects.toThrow('did not return a publishing token')
+  })
+
+  it('sanitizes transport errors and rejects an empty identity response', async () => {
+    await expect(preflightPublicCliAuthority({
+      env: oidcEnv, fetchImpl: async () => { throw new Error('sensitive-credential') },
+    })).rejects.toThrow('GitHub OIDC identity request failed')
+    await expect(preflightPublicCliAuthority({
+      env: oidcEnv, fetchImpl: async () => response(200, {}),
+    })).rejects.toThrow('did not return an ID token')
   })
 
   it('rejects read-only Tap tokens and inaccessible AUR repos', async () => {
     const env = {
-      OPENALICE_PUBLISH_NPM: 'true',
+      ...oidcEnv,
       OPENALICE_PUBLISH_HOMEBREW: 'true',
       OPENALICE_PUBLISH_AUR: 'true',
-      NPM_TOKEN: 'npm-secret',
       HOMEBREW_TAP_TOKEN: 'tap-secret',
       AUR_SSH_PRIVATE_KEY: 'aur-secret',
       AUR_KNOWN_HOSTS: 'aur.example ssh-ed25519 key',
     }
     const fetchImpl = vi.fn(async (url) => {
-      if (url.endsWith('/-/whoami')) return response(200, { username: 'alice-release' })
       if (url.includes('api.github.com')) return response(200, { permissions: { push: false } })
-      return response(200, { maintainers: [{ name: 'alice-release' }] })
+      return oidcResponse(url)
     })
 
     await expect(preflightPublicCliAuthority({

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -12,6 +12,7 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
+  permissions?: Record<string, string>
   if?: string
   needs?: string | string[]
   'timeout-minutes'?: number
@@ -58,7 +59,7 @@ describe('Release workflow critical path', () => {
   it('publishes existing stable npm assets without rebuilding or changing product channels', () => {
     const job = workflow.jobs['publish-existing-npm']
     expect(job.if).toBe("inputs.operation == 'publish-npm'")
-    expect(workflow.jobs.release.if).toBe("inputs.operation != 'publish-npm'")
+    expect(workflow.jobs.release.if).toBe("inputs.operation == 'release' || inputs.operation == 'mirror'")
     expect(needs(job)).toEqual([])
     expect(job['timeout-minutes']).toBe(15)
     const guard = step(job, 'Require the current published stable release').run ?? ''
@@ -83,10 +84,10 @@ describe('Release workflow critical path', () => {
       operation: {
         required: true,
         type: 'choice',
-        options: ['release', 'mirror', 'publish-npm'],
+        options: ['release', 'mirror', 'publish-npm', 'verify-npm'],
       },
       tag: {
-        required: true,
+        required: false,
         type: 'string',
       },
       channel: {
@@ -116,6 +117,30 @@ describe('Release workflow critical path', () => {
       expect(step(workflow.jobs['publish-release'], name).with?.target_commitish)
         .toBe('${{ needs.release.outputs.source_sha }}')
     }
+  })
+
+  it('rehearses real OIDC exchanges under the trusted workflow without release work', () => {
+    const job = workflow.jobs['verify-npm']
+    expect(job.if).toBe("inputs.operation == 'verify-npm'")
+    expect(needs(job)).toEqual([])
+    expect(job['timeout-minutes']).toBe(5)
+    expect(job.permissions).toEqual({ contents: 'read', 'id-token': 'write' })
+    expect(step(job, 'Require integrated release tooling').run).toContain('refs/heads/dev')
+    expect(step(job, 'Verify all five trusted publisher connections').run)
+      .toBe('node scripts/preflight-public-cli-authority.mjs')
+    expect(JSON.stringify(job)).not.toMatch(/secrets\.|publish-cli-npm|pnpm build|gh release/)
+  })
+
+  it('uses modern npm and OIDC permissions without long-lived token fallback', () => {
+    for (const name of ['publish-cli-npm', 'publish-existing-npm']) {
+      const job = workflow.jobs[name]
+      expect(job.permissions?.['id-token']).toBe('write')
+      expect(job.steps?.find((entry) => entry.uses === 'actions/setup-node@v7')?.with)
+        .toMatchObject({ 'node-version': '22.22.2', 'package-manager-cache': false })
+      expect(step(job, 'Install OIDC-capable npm').run).toContain('npm@12.0.2')
+    }
+    expect(workflow.jobs['preflight-public-cli-authority'].permissions?.['id-token']).toBe('write')
+    expect(JSON.stringify(workflow)).not.toMatch(/NPM_TOKEN|NODE_AUTH_TOKEN/)
   })
 
   it('selects the previous release from the same channel', () => {


### PR DESCRIPTION
## Summary
- Replace npm token preflight with the official package-scoped GitHub OIDC exchange; never persist or print exchanged credentials.
- Use Node 22.22.2 and npm 12.0.2 for both npm publication paths, without NPM_TOKEN or NODE_AUTH_TOKEN.
- Add Release operation verify-npm: one hosted job, no build, tag, artifact upload, or package publication. Keep npm rehearsal under the actual trusted workflow identity.
- Preserve stable-only channels, public-byte verification and idempotent platform-first publishing. Document setup and token retirement.

## Verification
- Root typecheck passed.
- Complete local suite: 708 files, 6331 passed, 3 expected skips (319.86 seconds).
- Focused publication/authentication tests: 47 passed; workflow contracts: 82 passed.
- git diff --check passed.
- All five package connections saved on npm with maintainer security-key verification.
- Previous PR #1341 checks and post-merge dev preview succeeded.
- After integration, dispatch verify-npm from dev to prove real exchanges. Actual new-version upload remains the next authorized stable publication boundary.

## Boundary touch
Release credentials and workflow authority. Short-lived credentials stay in memory; no token fallback. Existing secret retained until external verification succeeds.

## Non-goals
No new product release, master promotion, channel switch activation, Windows implementation, Homebrew/AUR activation, or artifact changes.