### PR TITLE
feat: Windows x64 and ARM64 native CLI previews

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -2,6 +2,11 @@ name: CLI Installer Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      windows_preview:
+        description: Build only the independent Windows x64/ARM64 preview
+        type: boolean
+        default: false
   # Routine dev PRs prove the checkout installer locally, then the dev push
   # below builds every native candidate and accepts the live preview channel.
   # Hosted checkout/Bun/SSH candidate work begins at the master boundary.
@@ -56,12 +61,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: cli-installer-smoke-${{ github.event.pull_request.number || github.ref }}
+  group: cli-installer-smoke-${{ github.event.pull_request.number || github.ref }}-${{ inputs.windows_preview && 'windows-preview' || 'default' }}
   cancel-in-progress: true
 
 jobs:
+  windows-preview:
+    if: github.event_name == 'workflow_dispatch' && inputs.windows_preview
+    uses: ./.github/workflows/windows-cli-preview.yml
+
   release-prep-scope:
-    if: github.event_name != 'push'
+    if: github.event_name != 'push' && !inputs.windows_preview
     name: release-prep scope
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -87,6 +96,7 @@ jobs:
     needs: release-prep-scope
     if: >-
       !cancelled() &&
+      !inputs.windows_preview &&
       github.event_name != 'push' &&
       (github.event_name != 'pull_request' || github.base_ref == 'master') &&
       (
@@ -153,6 +163,7 @@ jobs:
     needs: release-prep-scope
     if: >-
       !cancelled() &&
+      !inputs.windows_preview &&
       github.event_name != 'push' &&
       (
         needs.release-prep-scope.result != 'success' ||
@@ -176,6 +187,7 @@ jobs:
     needs: release-prep-scope
     if: >-
       !cancelled() &&
+      !inputs.windows_preview &&
       github.event_name != 'push' &&
       (github.event_name != 'pull_request' || github.base_ref == 'master') &&
       (
@@ -537,7 +549,7 @@ jobs:
           echo "activated=true" >> "$GITHUB_OUTPUT"
 
   dev-channel-install:
-    if: always() && ((github.event_name == 'push' && needs.activate-dev-cli.result == 'success' && needs.activate-dev-cli.outputs.activated == 'true') || github.event_name == 'workflow_dispatch')
+    if: always() && !inputs.windows_preview && ((github.event_name == 'push' && needs.activate-dev-cli.result == 'success' && needs.activate-dev-cli.outputs.activated == 'true') || github.event_name == 'workflow_dispatch')
     name: Live raw dev channel install
     needs: activate-dev-cli
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-cli-preview.yml
+++ b/.github/workflows/windows-cli-preview.yml
@@ -1,0 +1,68 @@
+name: Windows CLI Preview
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-cli-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Windows CLI (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            arch: x64
+          - os: windows-11-arm
+            arch: arm64
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+      DUGITE_SKIP_INSTALL: '1'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.2
+          architecture: ${{ matrix.arch }}
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+      - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
+      - run: pnpm build:server
+      - name: Assemble preview before native acceptance
+        run: bun scripts/build-windows-cli-preview.ts ${{ matrix.arch }}
+      - name: Preserve complete candidate for reproduction
+        uses: actions/upload-artifact@v6
+        with:
+          name: openalice-windows-${{ matrix.arch }}-${{ github.sha }}
+          path: |
+            dist/windows-cli-preview/${{ matrix.arch }}/*.zip
+            dist/windows-cli-preview/${{ matrix.arch }}/*.sha256
+            dist/windows-cli-preview/${{ matrix.arch }}/install-preview.ps1
+            dist/windows-cli-preview/${{ matrix.arch }}/candidate.json
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+      - name: Check native ConPTY input resize and independent termination
+        run: bun scripts/bun-native-pty-smoke.ts
+      - name: Install and start the packaged Runtime
+        run: bun scripts/windows-cli-preview-smoke.ts
+      - name: Preserve native verification receipt
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-cli-smoke-${{ matrix.arch }}-${{ github.sha }}
+          path: dist/windows-cli-preview/${{ matrix.arch }}/native-smoke.json
+          if-no-files-found: ignore
+          retention-days: 30

--- a/PLANS.md
+++ b/PLANS.md
@@ -43,7 +43,7 @@ the durable truth after it changes. Git history is the archive.
   OpenAlice CDN manifests. Managed SSH installation and Project transfer pass
   the disposable Docker target; beta3 core Runtime/PTY state survives a long
   tunnel outage, and the following `dev` increment refreshes Settings identity
-  after recovery. Native PowerShell and external package-manager activation
+  after recovery. Native Windows x64/ARM64 ZIP and PowerShell previews plus external package-manager activation
   remain open on focused branches from current `dev`. Routine dev
   and exact-beta source feedback is reduced to local-first, lightweight
   hosted lanes while `master` promotion, stable, and final artifact acceptance

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -51,9 +51,51 @@ bash install --archive ./openalice-cli-0.91.0-linux-x64.tar.gz \
   --sha256 <64-lowercase-hex>
 ```
 
-Native Windows PowerShell installation is deferred. Windows users use the
-Electron distribution or an explicitly chosen POSIX environment until that
-lane is implemented and accepted.
+Native Windows has an independent experimental ZIP/PowerShell lane described
+below. The normal stable/beta/dev installer and npm channels remain macOS/Linux
+only; Windows previews do not silently join those channels.
+
+### Windows x64 and ARM64 preview
+
+`Windows CLI Preview` builds complete native ZIPs with private PortableGit/Bash,
+UI, templates, Workspace helpers, checksums and commit metadata. It does not
+bundle an Agent Runtime, Node, or npm. The host architecture must match the
+package; ARM64 is not an x64-emulation label.
+
+Run the registered workflow from the intended `dev` source:
+
+```bash
+gh workflow run cli-installer-smoke.yml --ref dev -f windows_preview=true
+```
+
+This opts into only the two independent Windows jobs. It does not run the
+macOS/Linux installer matrix, full suite, Electron, signing, npm publication,
+or mutate any release/channel. Each downloadable Actions artifact contains a
+ZIP, its `.sha256`, installer, and candidate receipt. Native acceptance is a
+separate receipt: an available ZIP alone is not a passed smoke.
+
+After downloading the candidate and reviewing its checksum, use ordinary
+Windows PowerShell (no administrator rights):
+
+```powershell
+.\install-preview.ps1 -Archive .\openalice-cli-<version>-windows-<arch>-<commit>.zip `
+  -Sha256 <64-hex-digest> -InstallDir "$env:LOCALAPPDATA\OpenAlice\preview-<commit>" -Yes
+& "$env:LOCALAPPDATA\OpenAlice\preview-<commit>\bin\openalice.exe"
+```
+
+`-Archive` also accepts an explicit HTTPS URL. `-Plan` prints without mutation;
+without `-Yes` installation asks for consent. An existing destination is always
+refused. The script changes neither execution policy nor PATH nor profiles and
+never starts a Runtime. Do not globally relax PowerShell policy to run it;
+follow the machine's script policy or extract the checksum-verified ZIP and
+run `bin\openalice.exe` directly.
+
+Previews record custom/non-updating provenance. For now, install an update into
+a new directory, run the old executable's `down`, then launch the new one using
+the same explicit `--home`. Do not overwrite a running executable. Removal is
+likewise manual after `down`: delete only that chosen preview installation,
+never the AliceProject/user-data directory. Managed update/rollback and npm
+activation are not advertised until their Windows paths are accepted.
 
 ## Artifact contract
 

--- a/docs/local-runtime.md
+++ b/docs/local-runtime.md
@@ -88,6 +88,16 @@ boundary, avoiding an unbounded JavaScript spool. Graceful shutdown resumes a
 stopped group before terminating it. Electron and source-backed Node execution
 continue using `node-pty` pause/resume.
 
+The experimental Windows CLI uses Bun ConPTY without pretending POSIX group
+signals work on Windows. This backend advertises no read-side pause support;
+when an attached WebSocket exceeds its high watermark, Alice detaches that
+consumer with retryable close code 1013, retaining the independent agent and
+bounded replay buffer. macOS/Linux keep producer pause/resume unchanged.
+Windows npm-installed agents use the user's `node.exe`, never the compiled
+OpenAlice executable as a general JavaScript interpreter. Native agent `.exe`
+files do not gain a Node dependency. Private PortableGit supplies the Windows
+Git/Bash layout for both x64 and ARM64, independently of managed Pi.
+
 ## Broker Packs
 
 UTA remains a separate process and optional for non-trading use. Activated

--- a/install-preview.ps1
+++ b/install-preview.ps1
@@ -1,0 +1,86 @@
+# Windows CLI preview: checksum-verified, side-by-side, standard-user install.
+# No administrator rights, execution-policy changes, PATH/profile mutations,
+# service registration, Agent Runtime installation, or user-data removal.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Archive,
+    [Parameter(Mandatory = $true)][ValidatePattern('^[a-fA-F0-9]{64}$')][string]$Sha256,
+    [Parameter(Mandatory = $true)][string]$InstallDir,
+    [switch]$Yes,
+    [switch]$Plan
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+if ($env:OS -ne 'Windows_NT') { throw 'This preview installer requires Windows.' }
+$destination = [IO.Path]::GetFullPath($InstallDir)
+if (Test-Path -LiteralPath $destination) {
+    throw "Destination already exists. Choose a new side-by-side directory: $destination"
+}
+Write-Host "OpenAlice Windows preview -> $destination"
+Write-Host "Archive: $Archive"
+Write-Host "SHA-256: $Sha256"
+Write-Host 'Installs OpenAlice and private Git/Bash only. Does not start services or install agents.'
+Write-Host 'Updates are manual: install into a new directory, stop the old Runtime, then start the new one.'
+if ($Plan) { return }
+if (-not $Yes -and (Read-Host 'Install this preview? [y/N]') -notmatch '^[yY]$') {
+    throw 'Installation declined.'
+}
+$parent = [IO.Path]::GetDirectoryName($destination)
+[IO.Directory]::CreateDirectory($parent) | Out-Null
+$stage = Join-Path $parent ('.openalice-preview-' + [Guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($stage) | Out-Null
+try {
+    $zipPath = Join-Path $stage 'candidate.zip'
+    if ($Archive -match '^https://') {
+        Invoke-WebRequest -UseBasicParsing -Uri $Archive -OutFile $zipPath
+    } elseif ($Archive -match '^[a-zA-Z]+://') {
+        throw 'Only HTTPS downloads or local archives are allowed.'
+    } else {
+        Copy-Item -LiteralPath $Archive -Destination $zipPath
+    }
+    if ((Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash -ine $Sha256) {
+        throw 'Archive SHA-256 mismatch.'
+    }
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [IO.Compression.ZipFile]::OpenRead($zipPath)
+    $unpacked = Join-Path $stage 'payload'
+    $roots = @{}
+    $paths = @{}
+    try {
+        foreach ($entry in $zip.Entries) {
+            $name = $entry.FullName.Replace('\', '/')
+            $parts = $name.TrimEnd('/').Split('/')
+            if ($name.StartsWith('/') -or $name.Contains(':') -or $parts.Count -lt 1) { throw 'Unsafe archive path.' }
+            foreach ($part in $parts) {
+                if ($part -eq '' -or $part -eq '.' -or $part -eq '..' -or $part -match '[. ]$' -or
+                    $part -match '[\x00-\x1f]' -or $part -match '^(?i:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.|$)') {
+                    throw "Unsafe archive path: $name"
+                }
+            }
+            # Reject Unix symlinks even when unpacking on Windows.
+            if ((($entry.ExternalAttributes -shr 16) -band 0xf000) -eq 0xa000) { throw 'Archive symlinks are not allowed.' }
+            if ($paths.ContainsKey($name.ToLowerInvariant())) { throw 'Duplicate archive path.' }
+            $paths[$name.ToLowerInvariant()] = $true
+            $roots[$parts[0]] = $true
+        }
+    } finally { $zip.Dispose() }
+    if ($roots.Count -ne 1) { throw 'Expected exactly one release directory.' }
+    [IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $unpacked)
+    $release = Join-Path $unpacked @($roots.Keys)[0]
+    $metadata = Get-Content -LiteralPath (Join-Path $release 'release.json') -Raw | ConvertFrom-Json
+    $hostArch = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+    if ($metadata.platform -ne 'win32' -or $metadata.arch -ne $hostArch -or $metadata.preview -ne $true -or
+        $metadata.executable -ne 'bin/openalice.exe' -or $metadata.resourceRoot -ne 'share/openalice') {
+        throw "Archive does not match this Windows $hostArch host."
+    }
+    $exe = Join-Path $release 'bin/openalice.exe'
+    $version = & $exe --version
+    if ($LASTEXITCODE -ne 0 -or $version.Trim() -ne $metadata.version) { throw 'Staged executable version check failed.' }
+    # Directory.Move refuses an existing destination, including a competing install.
+    [IO.Directory]::Move($release, $destination)
+} finally {
+    # Only this invocation's random staging directory is removed; no user data.
+    Remove-Item -LiteralPath $stage -Recurse -Force
+}
+Write-Host "Installed preview. Run: & '$destination\bin\openalice.exe'"
+Write-Host 'To remove it, stop its Runtime and delete this installation directory only. Keep your OpenAlice data.'

--- a/packages/cli/src/bun-standalone.mjs
+++ b/packages/cli/src/bun-standalone.mjs
@@ -58,7 +58,15 @@ export function buildBunRuntimeEnvironment(
 ) {
   const gitRoot = join(resourceRoot, 'runtime', 'git')
   const gitBin = join(gitRoot, 'bin')
+  const windows = (options.platform ?? process.platform) === 'win32'
+  const gitPrefix = (options.arch ?? process.arch) === 'arm64' ? 'clangarm64' : 'mingw64'
   const runtimeEnv = buildExternalAgentRuntimeEnvironment(env)
+  // Windows environment names are case-insensitive; do not pass both Path and PATH.
+  const inheritedPath = runtimeEnv.PATH ?? runtimeEnv.Path ?? ''
+  if (windows) delete runtimeEnv.Path
+  const gitPaths = windows
+    ? [join(gitRoot, 'cmd'), gitBin, join(gitRoot, 'usr', 'bin'), join(gitRoot, gitPrefix, 'bin')]
+    : [gitBin]
   const installSource = resolveBunInstallSourcePath(
     runtimeEnv,
     executable,
@@ -70,9 +78,14 @@ export function buildBunRuntimeEnvironment(
     ...(installSource ? { OPENALICE_INSTALL_SOURCE: installSource } : {}),
     OPENALICE_RUNTIME_EXECUTABLE: executable,
     LOCAL_GIT_DIRECTORY: gitRoot,
-    GIT_EXEC_PATH: join(gitRoot, 'libexec', 'git-core'),
-    GIT_TEMPLATE_DIR: join(gitRoot, 'share', 'git-core', 'templates'),
-    PATH: runtimeEnv.PATH ? `${gitBin}${delimiter}${runtimeEnv.PATH}` : gitBin,
+    ...(windows ? { OPENALICE_MANAGED_SHELL_PATH: join(gitBin, 'bash.exe') } : {}),
+    GIT_EXEC_PATH: windows
+      ? join(gitRoot, gitPrefix, 'libexec', 'git-core')
+      : join(gitRoot, 'libexec', 'git-core'),
+    GIT_TEMPLATE_DIR: windows
+      ? join(gitRoot, gitPrefix, 'share', 'git-core', 'templates')
+      : join(gitRoot, 'share', 'git-core', 'templates'),
+    PATH: [...gitPaths, ...(inheritedPath ? [inheritedPath] : [])].join(windows ? ';' : delimiter),
   }
 }
 

--- a/packages/cli/src/bun-standalone.spec.mjs
+++ b/packages/cli/src/bun-standalone.spec.mjs
@@ -12,6 +12,19 @@ import {
 } from './bun-standalone.mjs'
 
 describe('Bun standalone launch boundary', () => {
+  it.each(['x64', 'arm64'])('uses private Windows Git/Bash without selecting managed Pi (%s)', (arch) => {
+    const resourceRoot = resolve('/preview/share/openalice')
+    const prefix = arch === 'arm64' ? 'clangarm64' : 'mingw64'
+    const env = buildBunRuntimeEnvironment({ Path: 'user-tools', OPENALICE_MANAGED_PI_PATH: 'old' },
+      resourceRoot, '/preview/bin/openalice.exe', { platform: 'win32', arch, exists: () => false })
+    expect(env).not.toHaveProperty('Path')
+    expect(env).not.toHaveProperty('OPENALICE_MANAGED_PI_PATH')
+    expect(env.OPENALICE_MANAGED_SHELL_PATH).toBe(resolve(resourceRoot, 'runtime/git/bin/bash.exe'))
+    expect(env.GIT_EXEC_PATH).toBe(resolve(resourceRoot, `runtime/git/${prefix}/libexec/git-core`))
+    expect(env.PATH).toBe([
+      'cmd', 'bin', 'usr/bin', `${prefix}/bin`,
+    ].map(path => resolve(resourceRoot, 'runtime/git', path)).concat('user-tools').join(';'))
+  })
   it('derives an installed sidecar resource root from the executable', () => {
     expect(resolveBunResourceRoot({}, '/opt/openalice/releases/v1/bin/openalice'))
       .toBe(resolve('/opt/openalice/releases/v1/share/openalice'))

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -3,7 +3,7 @@
 Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separately
 dispatched v0.91.0-beta.3 is externally verified; stable remains v0.90.2 while
 stable/beta discovery authority is converged on the OpenAlice CDN. Native
-PowerShell and Homebrew/AUR activation remain deferred. npm/Bun's five public
+Windows x64/ARM64 preview and Homebrew/AUR activation remain in progress. npm/Bun's five public
 packages are published at v0.90.2 under maintainer `jiaran258`.
 
 Accepted OIDC increment: replace the temporary npm token with GitHub OIDC trust on
@@ -31,8 +31,43 @@ the real trusted workflow identity. Owner contract: [[docs/cli-package-managers.
 The next authorized stable release still owns real new-version upload and
 provenance acceptance. The persistent npm channel switch remains unchanged;
 normal source promotion must carry the OIDC workflow to `master` before a new
-stable release uses it. Windows x64 is the maintainer's accepted next platform
-increment, separate from this completed authentication change.
+stable release uses it. Windows x64 and ARM64 are the maintainer's accepted next
+platform increment, separate from this completed authentication change.
+
+## Current increment: Windows previews
+
+Accepted 2026-09-04: ship both Windows architectures iteratively, without making
+the Windows experiment a prerequisite for existing macOS/Linux channels.
+Owner contracts: [[docs/cli-installer.md]], [[docs/local-runtime.md]].
+
+Choose a portable ZIP plus checksum-bound, side-by-side PowerShell installation
+first. This gives testers a complete product immediately without prematurely
+claiming stable npm availability or adding Windows junction/update recovery to
+the first increment. A direct managed updater and npm registration remain later
+acceptance steps; custom preview provenance deliberately disables automatic
+channel discovery. Agent CLIs remain user-owned.
+
+- [x] Compile both Windows architectures with pinned Bun 1.4.0 locally.
+- [x] Assemble complete ZIPs with UI, templates, helpers and checksum-pinned
+  PortableGit/Bash; use the existing desktop Git pins, not desktop managed Pi.
+- [x] Add explicit PowerShell archive installation into a new directory, with
+  checksum/path/host checks, consent, no admin/PATH changes, and no data removal.
+- [x] Correct Windows Git environment, npm-agent interpreter resolution and
+  ConPTY termination; bound slow WebSocket consumers without POSIX signals.
+- [x] Add an independently retryable, manual x64/ARM64 workflow. Preserve each
+  archive before its native smoke so failures retain reproduction bytes.
+- [ ] Complete local regression/type checks and integrate this increment.
+- [ ] Run native Windows installation, Guardian/Alice/Web, Git, ConPTY input,
+  resize, independent termination and stop checks for each architecture.
+- [ ] Perform interactive external-agent/provider acceptance; record concrete
+  failures instead of claiming cross-compilation proves Windows runtime support.
+- [ ] Add accepted Windows artifacts to the normal direct-channel manifest and
+  npm topology, then first-publish and enroll the two new package identities.
+
+The first preview is not a new beta/stable release. It is commit-addressed
+Actions output with a separate native acceptance receipt and no mutable channel
+alias. `CLI Installer Smoke` can dispatch only this lane from integrated `dev`
+using `windows_preview=true`, without the normal manual installer matrix.
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`
@@ -252,19 +287,17 @@ installations are never removal targets.
 
 ### Initial build matrix
 
-The current cutover gate covers macOS and Linux. Native Windows is explicitly
-deferred; its PowerShell, PTY, path, junction, signing, and locked-executable
-work remains a later platform initiative rather than blocking this plan.
+The original cutover gate covers macOS and Linux. Windows x64 and ARM64 now
+have a separate preview increment above; they do not block the existing matrix.
 
 | Platform | Architectures | Initial gate |
 |---|---|---|
 | macOS | arm64, x64 | Required |
 | Linux glibc | arm64, x64 | Required |
-| Windows | x64 | Deferred |
+| Windows | x64, arm64 | Independent preview; native acceptance pending |
 
-Linux musl and Windows arm64 are follow-up targets only after there is a
-supported-user or deployment requirement. Do not multiply release variants
-before the required matrix is proven.
+Linux musl remains deferred. Windows ARM64 is explicitly requested and is not
+replaced by an x64 emulation claim.
 
 ## Installation and Package-manager Topology
 

--- a/scripts/build-windows-cli-preview.ts
+++ b/scripts/build-windows-cli-preview.ts
@@ -1,0 +1,137 @@
+import { createHash } from 'node:crypto'
+import { cp, mkdir, mkdtemp, readdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { bunReleaseContentIdentity } from './bun-release-content-identity.mjs'
+import { resolveWindowsGitRuntimeSpec } from './vendor-managed-runtime.mjs'
+
+// A deliberately independent preview lane. No stable/beta/dev aliases and no
+// npm publication are mutated by this build. Native smoke is a separate step,
+// so a failed smoke never discards the package needed to reproduce it.
+const root = fileURLToPath(new URL('..', import.meta.url))
+const arch = process.argv[2] ?? process.arch
+if (!['x64', 'arm64'].includes(arch)) throw new Error(`Unsupported Windows architecture: ${arch}`)
+const pinned = (await readFile(join(root, '.bun-version'), 'utf8')).trim()
+if (Bun.version !== pinned) throw new Error(`Expected Bun ${pinned}, found ${Bun.version}`)
+const product = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const cli = JSON.parse(await readFile(join(root, 'packages/cli/package.json'), 'utf8'))
+if (product.version !== cli.version) throw new Error('Product and CLI versions must match')
+const version: string = product.version
+if (!/^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(version)) throw new Error('Invalid product version')
+const sourceCommit = run(['git', 'rev-parse', 'HEAD']).trim()
+const sourceDirty = run(['git', 'status', '--porcelain']).trim().length > 0
+const output = resolve(process.env.OPENALICE_BUN_OUTPUT_DIR ?? join(root, 'dist/windows-cli-preview', arch))
+await mkdir(output, { recursive: true })
+const staging = await mkdtemp(join(output, 'build-'))
+const name = `openalice-cli-${version}-windows-${arch}-${sourceCommit.slice(0,8)}${sourceDirty ? '-dirty' : ''}`
+const release = join(staging, name)
+const resources = join(release, 'share/openalice')
+const executable = join(release, 'bin/openalice.exe')
+await mkdir(dirname(executable), { recursive: true })
+await mkdir(resources, { recursive: true })
+await stat(join(root, 'ui/dist/index.html'))
+const built = await Bun.build({
+  entrypoints: [join(root, 'packages/cli/bin/openalice-bun.ts')],
+  compile: {
+    target: `bun-windows-${arch}` as 'bun-windows-x64' | 'bun-windows-arm64',
+    outfile: executable,
+    autoloadBunfig: false,
+    autoloadDotenv: false,
+  },
+  define: {
+    'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(version),
+    'globalThis.__OPENALICE_BUN_STANDALONE__': 'true',
+  },
+  minify: true,
+})
+if (!built.success) throw new Error(built.logs.map(String).join('\n'))
+for (const path of ['ui/dist', 'default', 'src/workspaces/templates']) {
+  await cp(join(root, path), join(resources, path), { recursive: true, dereference: true })
+}
+await cp(join(root, 'package.json'), join(resources, 'package.json'))
+for (const path of ['LICENSE', 'THIRD_PARTY_NOTICES.md']) await cp(join(root, path), join(release, path))
+const helperDir = join(resources, 'src/workspaces/cli/bin')
+await mkdir(helperDir, { recursive: true })
+await cp(join(root, 'src/workspaces/cli/bin/pi-session-provider.ts'), join(helperDir, 'pi-session-provider.ts'))
+for (const helper of ['alice', 'alice-workspace', 'alice-uta', 'traderhub']) {
+  await writeFile(join(helperDir, `${helper}.cmd`),
+    `@echo off\r\nif not defined OPENALICE_RUNTIME_EXECUTABLE exit /b 1\r\n"%OPENALICE_RUNTIME_EXECUTABLE%" --workspace-cli ${helper} %*\r\n`)
+  // Git Bash is also an ordinary Workspace surface. Avoid MSYS translating
+  // /cli URLs, named pipes, or native Windows executable paths.
+  await writeFile(join(helperDir, helper), `#!/bin/sh
+set -eu
+: "\${OPENALICE_RUNTIME_EXECUTABLE:?OpenAlice Runtime executable is not configured}"
+export MSYS_NO_PATHCONV=1
+export MSYS2_ENV_CONV_EXCL='OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET'
+exec "$(cygpath -u "$OPENALICE_RUNTIME_EXECUTABLE")" --workspace-cli ${helper} "$@"
+`, { mode: 0o755 })
+}
+
+const git = resolveWindowsGitRuntimeSpec({ platform: 'win32', arch })!
+const gitArchive = join(staging, basename(git.url))
+const response = await fetch(git.url, { signal: AbortSignal.timeout(180_000) })
+if (!response.ok) throw new Error(`PortableGit download: HTTP ${response.status}`)
+const gitBytes = new Uint8Array(await response.arrayBuffer())
+if (sha256(gitBytes) !== git.sha256) throw new Error('PortableGit SHA-256 mismatch')
+await writeFile(gitArchive, gitBytes)
+const gitRoot = join(resources, 'runtime/git')
+await mkdir(gitRoot, { recursive: true })
+if (process.platform === 'win32' && arch === process.arch) {
+  run([gitArchive, '-y', `-o${gitRoot}`])
+} else {
+  // Cross-builds extract data; they never execute the target's installer.
+  run([process.env.OPENALICE_7ZIP ?? '7zz', 'x', '-y', `-o${gitRoot}`, gitArchive])
+}
+for (const path of [git.gitBin, git.shellPath, git.shPath]) await stat(join(gitRoot, path))
+await cp(join(root, 'install-preview.ps1'), join(release, 'install-preview.ps1'))
+await writeFile(join(release, 'install-source.json'), JSON.stringify({
+  schemaVersion: 2, repository: 'TraderAlice/OpenAlice', cliVersion: version,
+  selector: { kind: 'branch', value: sourceCommit },
+  installerUrl: 'https://github.com/TraderAlice/OpenAlice', updateChannel: 'custom',
+}, null, 2) + '\n')
+// Portable metadata is custom/non-updating, not a direct install with managed
+// current/rollback pointers. The external ZIP sidecar binds the entire package.
+const unsigned = {
+  schemaVersion: 1, product: 'OpenAlice CLI', version, platform: 'win32', arch,
+  bunVersion: Bun.version, sourceCommit, sourceDirty, preview: true,
+  executable: 'bin/openalice.exe', resourceRoot: 'share/openalice',
+  git: { source: 'PortableGit', sourceVersion: git.version, sourceSha256: git.sha256 },
+  files: await files(release),
+}
+const metadata = { ...unsigned, contentIdentity: bunReleaseContentIdentity(unsigned) }
+await writeFile(join(release, 'release.json'), JSON.stringify(metadata, null, 2) + '\n')
+const archive = join(output, `${name}.zip`)
+// Do not overwrite an older candidate or update an existing ZIP in place.
+try { await stat(archive); throw new Error(`Candidate already exists: ${archive}`) }
+catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error }
+if (process.platform === 'win32') run(['tar.exe', '-a', '-cf', archive, '-C', staging, name])
+else run(['zip', '-qr', archive, name], staging)
+const digest = sha256(await readFile(archive))
+await writeFile(`${archive}.sha256`, `${digest}  ${basename(archive)}\n`)
+await cp(join(root, 'install-preview.ps1'), join(output, 'install-preview.ps1'))
+await writeFile(join(output, 'candidate.json'), JSON.stringify({
+  archive, sha256: digest, release, executable, sourceCommit, sourceDirty, version, arch,
+  contentIdentity: metadata.contentIdentity, runtimeVerification: 'not-run',
+}, null, 2) + '\n')
+console.log(`Windows ${arch} preview built (native runtime verification pending): ${archive}`)
+
+function run(command: string[], cwd = root) {
+  const child = Bun.spawnSync(command, { cwd, stdout: 'pipe', stderr: 'pipe' })
+  if (child.exitCode !== 0) throw new Error(`${command[0]} failed: ${child.stderr.toString()}`)
+  return child.stdout.toString()
+}
+function sha256(bytes: Uint8Array) { return createHash('sha256').update(bytes).digest('hex') }
+async function files(directory: string): Promise<Array<{ path: string; type: 'file'; bytes: number; mode: number; sha256: string }>> {
+  const result: Array<{ path: string; type: 'file'; bytes: number; mode: number; sha256: string }> = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) result.push(...await files(path))
+    else if (entry.isFile()) {
+      const bytes = await readFile(path)
+      result.push({ path: relative(release, path).replaceAll('\\', '/'), type: 'file',
+        bytes: bytes.length, mode: (await stat(path)).mode & 0o777, sha256: sha256(bytes) })
+    } else throw new Error(`Windows preview cannot contain special files: ${path}`)
+  }
+  return result
+}

--- a/scripts/bun-native-pty-smoke.ts
+++ b/scripts/bun-native-pty-smoke.ts
@@ -27,8 +27,9 @@ try {
 
   one.term.resize(91, 31)
   two.term.resize(103, 37)
-  one.term.write('alpha\n')
-  two.term.write('beta\n')
+  const enter = process.platform === 'win32' ? '\r' : '\n'
+  one.term.write(`alpha${enter}`)
+  two.term.write(`beta${enter}`)
   await Promise.all([
     waitForOutput(one, 'OA_ONE_INPUT:alpha'),
     waitForOutput(two, 'OA_TWO_INPUT:beta'),
@@ -37,9 +38,9 @@ try {
   one.term.kill()
   await one.exited
 
-  two.term.write('still-alive\n')
+  two.term.write(`still-alive${enter}`)
   await waitForOutput(two, 'OA_TWO_INPUT:still-alive')
-  flowControl = await probeFlowControl()
+  if (process.platform !== 'win32') flowControl = await probeFlowControl()
 } finally {
   try {
     one.term.kill()

--- a/scripts/windows-cli-preview-smoke.ts
+++ b/scripts/windows-cli-preview-smoke.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+if (process.platform !== 'win32') throw new Error('Run this smoke on native Windows')
+const candidateFile = resolve(process.argv[2] ?? `dist/windows-cli-preview/${process.arch}/candidate.json`)
+const candidate = JSON.parse(await readFile(candidateFile, 'utf8'))
+if (candidate.arch !== process.arch) throw new Error('Native smoke architecture mismatch')
+const scratch = await mkdtemp(join(tmpdir(), 'openalice-preview-smoke-'))
+const installDir = join(scratch, 'installed preview')
+const home = join(scratch, 'alice-home')
+const powershell = join(process.env.SystemRoot!, 'System32/WindowsPowerShell/v1.0/powershell.exe')
+await command(powershell, ['-NoProfile', '-File', resolve('install-preview.ps1'),
+  '-Archive', candidate.archive, '-Sha256', candidate.sha256, '-InstallDir', installDir, '-Yes'])
+const executable = join(installDir, 'bin/openalice.exe')
+const portProbe = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } })
+const port = portProbe.port
+portProbe.stop(true)
+const environment = {
+  SystemRoot: process.env.SystemRoot!, WINDIR: process.env.WINDIR!,
+  TEMP: scratch, TMP: scratch, HOME: scratch, USERPROFILE: scratch,
+  PATH: join(process.env.SystemRoot!, 'System32'),
+  OPENALICE_HOME: home, OPENALICE_TRADING_MODE: 'lite',
+  OPENALICE_DISABLE_AUTH: '1', OPENALICE_BIND_HOST: '127.0.0.1',
+}
+try {
+  await command(executable, ['up', '--home', home, '--port', String(port), '--wait', '90', '--no-update-check'], environment)
+  const status = JSON.parse(await command(executable, ['status', '--home', home, '--json'], environment)).result.status
+  if (status.class !== 'running' || status.provider?.kind !== 'bun' ||
+      status.provider.contentIdentity !== candidate.contentIdentity ||
+      !status.owner?.pid || !status.componentDetail?.alice?.pid ||
+      status.owner.pid === status.componentDetail.alice.pid) throw new Error('Runtime status/identity mismatch')
+  const html = await (await fetch(`http://127.0.0.1:${port}/`)).text()
+  if (!html.includes('<div id="root">')) throw new Error('Real Web UI was not served')
+  const git = join(installDir, 'share/openalice/runtime/git/cmd/git.exe')
+  await command(git, ['--version'], environment)
+  await command(executable, ['down', '--home', home, '--wait', '30'], environment)
+  const stopped = JSON.parse(await command(executable, ['status', '--home', home, '--json'], environment)).result.status
+  if (stopped.class === 'running') throw new Error('Runtime did not stop')
+  await writeFile(resolve(candidateFile, '..', 'native-smoke.json'), JSON.stringify({
+    status: 'pass', arch: process.arch, archiveSha256: candidate.sha256,
+    contentIdentity: candidate.contentIdentity, sourceCommit: candidate.sourceCommit,
+    accepted: ['PowerShell ZIP install', 'detached Guardian/Alice', 'real Web UI', 'Git', 'stop'],
+    remaining: ['interactive agent/provider acceptance', 'manual upgrade/removal'],
+  }, null, 2) + '\n')
+} finally {
+  await command(executable, ['down', '--home', home, '--wait', '30'], environment).catch(console.error)
+}
+
+async function command(exe: string, args: string[], env = process.env) {
+  const child = Bun.spawn([exe, ...args], { env, cwd: scratch, stdout: 'pipe', stderr: 'pipe' })
+  const stdout = new Response(child.stdout).text()
+  const stderr = new Response(child.stderr).text()
+  const timeout = setTimeout(() => child.kill(), 120_000)
+  try {
+    const code = await child.exited
+    const [out, err] = await Promise.all([stdout, stderr])
+    if (code !== 0) throw new Error(`${exe} ${args[0]} exited ${code}: ${err}\n${out}`)
+    return out
+  } finally { clearTimeout(timeout) }
+}

--- a/scripts/windows-cli-preview.spec.ts
+++ b/scripts/windows-cli-preview.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import YAML from 'yaml'
+
+const root = resolve(import.meta.dirname, '..')
+const read = (file: string) => readFileSync(resolve(root, file), 'utf8')
+
+describe('Windows preview delivery boundary', () => {
+  it('is manually dispatched, independent per architecture, and cannot publish stable aliases', () => {
+    const workflow = YAML.parse(read('.github/workflows/windows-cli-preview.yml'))
+    expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch', 'workflow_call'])
+    expect(workflow.permissions).toEqual({ contents: 'read' })
+    const job = workflow.jobs.preview
+    expect(job.needs).toBeUndefined()
+    expect(job.strategy['fail-fast']).toBe(false)
+    expect(job.strategy.matrix.include).toEqual([
+      { os: 'windows-latest', arch: 'x64' }, { os: 'windows-11-arm', arch: 'arm64' },
+    ])
+    const steps = job.steps as Array<{ name?: string; run?: string }>
+    expect(steps.findIndex(s => s.name === 'Preserve complete candidate for reproduction'))
+      .toBeLessThan(steps.findIndex(s => s.name === 'Install and start the packaged Runtime'))
+    expect(steps.some(s => /pnpm test(?:\s|$)|npm publish|electron:pack/.test(s.run ?? ''))).toBe(false)
+  })
+
+  it('the registered installer workflow can dispatch previews without its normal manual gates or dev activation', () => {
+    const workflow = YAML.parse(read('.github/workflows/cli-installer-smoke.yml'))
+    expect(workflow.on.workflow_dispatch.inputs.windows_preview.default).toBe(false)
+    expect(workflow.jobs['windows-preview'].uses).toBe('./.github/workflows/windows-cli-preview.yml')
+    for (const job of ['release-prep-scope', 'bun-cli-feasibility', 'checkout-install', 'checkout-remote', 'dev-channel-install']) {
+      expect(workflow.jobs[job].if).toContain('!inputs.windows_preview')
+    }
+    for (const job of ['build-dev-cli-neutral', 'build-dev-cli', 'publish-dev-cli-candidate', 'activate-dev-cli']) {
+      expect(workflow.jobs[job].if).toBe("github.event_name == 'push'")
+    }
+  })
+
+  it('keeps the installer opt-in, checksum-bound, non-destructive, and independent of agent installation', () => {
+    const source = read('install-preview.ps1')
+    expect(source).toContain('Archive SHA-256 mismatch')
+    expect(source).toContain('Destination already exists')
+    expect(source).toContain('[IO.Directory]::Move($release, $destination)')
+    expect(source).toContain('if ($Plan) { return }')
+    expect(source).not.toMatch(/Set-ExecutionPolicy|SetEnvironmentVariable|npm install|Invoke-Expression/)
+    expect(source).toContain('Remove-Item -LiteralPath $stage -Recurse -Force')
+    expect(source).not.toContain('Remove-Item -LiteralPath $destination')
+  })
+})

--- a/src/workspaces/persistent-session.spec.ts
+++ b/src/workspaces/persistent-session.spec.ts
@@ -112,6 +112,24 @@ describe('PersistentSession backpressure / socket-drop deadlock', () => {
     vi.clearAllMocks();
   });
 
+  it('bounds a slow consumer without killing a ConPTY agent when pause is unavailable', () => {
+    const unpausable = { ...term, pause: undefined, resume: undefined };
+    const session = new PersistentSession(makeOptions({
+      pty: { name: 'bun-native', supportsFlowControl: false, spawn: () => unpausable as never },
+    }));
+    const ws = new FakeWs();
+    session.attach(ws as never, 80, 24, undefined);
+    ws.send.mockClear();
+    ws.bufferedAmount = 2048;
+    term.emitData(Buffer.from('slow consumer output'));
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(ws.close).toHaveBeenCalledWith(1013, expect.stringContaining('reconnect'));
+    expect(term.kill).not.toHaveBeenCalled();
+    term.emitData(Buffer.from('agent survives detached'));
+    expect(ws.send).not.toHaveBeenCalled();
+    session.dispose('test complete');
+  });
+
   it('resumes the PTY when a backpressure-paused socket drops (detach)', () => {
     const session = new PersistentSession(makeOptions());
     const ws = new FakeWs();

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -509,6 +509,15 @@ export class PersistentSession {
       forwardQueryReplies: ws === null || ws.readyState !== ws.OPEN,
     });
     if (ws !== null) {
+      // Backends without a native pause primitive (Windows Bun ConPTY) must
+      // not accumulate an unbounded socket queue. Preserve the agent and its
+      // bounded scrollback; the client can reconnect and replay that tail.
+      if (!this.term.pause && ws.bufferedAmount >= this.opts.highWatermarkBytes) {
+        this.log.warn('session.slow_consumer_detached');
+        this.detach();
+        ws.close(1013, 'Terminal consumer is too slow; reconnect to resume');
+        return;
+      }
       ws.send(buf, { binary: true }, (err) => {
         if (err) {
           this.log.warn('session.send_error', { err });

--- a/src/workspaces/pty-bun.spec.ts
+++ b/src/workspaces/pty-bun.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBunPtyBackend } from './pty-bun.js';
+
+describe('Bun Windows ConPTY boundary', () => {
+  it('preserves input, resize, and child termination without pretending to pause a POSIX group', () => {
+    const terminal = { write: vi.fn(() => 1), resize: vi.fn(), close: vi.fn() };
+    const child = { pid: 42, terminal, kill: vi.fn() };
+    const spawn = vi.fn(() => child);
+    const backend = createBunPtyBackend({ spawn }, 'win32');
+    const term = backend.spawn('agent.exe', ['argument'], {
+      name: 'xterm', cols: 80, rows: 24, cwd: 'workspace', env: {},
+    });
+    expect(backend.supportsFlowControl).toBe(false);
+    expect(term.pause).toBeUndefined();
+    expect(term.resume).toBeUndefined();
+    term.write('hello\r');
+    term.resize(120, 40);
+    term.kill('SIGTERM');
+    expect(terminal.write).toHaveBeenCalledWith('hello\r');
+    expect(terminal.resize).toHaveBeenCalledWith(120, 40);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(terminal.close).not.toHaveBeenCalled();
+  });
+});

--- a/src/workspaces/pty-bun.ts
+++ b/src/workspaces/pty-bun.ts
@@ -40,10 +40,13 @@ interface BunPtyRuntime {
 }
 
 const bunRuntime = (globalThis as typeof globalThis & { Bun: BunPtyRuntime }).Bun;
+export const ptyBackend: PtyBackend = createBunPtyBackend(bunRuntime);
 
-export const ptyBackend: PtyBackend = {
+export function createBunPtyBackend(runtime: BunPtyRuntime, platform = process.platform): PtyBackend {
+  const windows = platform === 'win32';
+  return {
   name: 'bun-native',
-  supportsFlowControl: true,
+  supportsFlowControl: !windows,
   spawn(file, args, options) {
     const dataListeners = new Set<(data: Buffer) => void>();
     const exitListeners = new Set<(event: PtyExitEvent) => void>();
@@ -51,7 +54,7 @@ export const ptyBackend: PtyBackend = {
     let exitEvent: PtyExitEvent | undefined;
     let paused = false;
 
-    const child = bunRuntime.spawn([file, ...args], {
+    const child = runtime.spawn([file, ...args], {
       cwd: options.cwd,
       env: options.env,
       terminal: {
@@ -115,6 +118,13 @@ export const ptyBackend: PtyBackend = {
         terminal.resize(cols, rows);
       },
       kill(signal) {
+        if (windows) {
+          // ConPTY has no POSIX process groups or SIGSTOP/SIGCONT. Terminate
+          // the child before closing the pseudoconsole (older Windows can
+          // block ClosePseudoConsole while a child is still alive).
+          child.kill(signal as NodeJS.Signals | undefined);
+          return;
+        }
         const requestedSignal = signal as NodeJS.Signals | undefined;
         // A graceful signal remains pending while the process group is
         // stopped. Resume first so shutdown handlers can actually run.
@@ -124,17 +134,20 @@ export const ptyBackend: PtyBackend = {
         }
         signalProcessGroup(child, requestedSignal ?? 'SIGTERM');
       },
-      pause() {
-        if (paused || exitEvent) return;
-        if (signalProcessGroup(child, 'SIGSTOP')) paused = true;
-      },
-      resume() {
-        if (!paused || exitEvent) return;
-        if (signalProcessGroup(child, 'SIGCONT')) paused = false;
-      },
+      ...(!windows ? {
+        pause() {
+          if (paused || exitEvent) return;
+          if (signalProcessGroup(child, 'SIGSTOP')) paused = true;
+        },
+        resume() {
+          if (!paused || exitEvent) return;
+          if (signalProcessGroup(child, 'SIGCONT')) paused = false;
+        },
+      } : {}),
     } satisfies PtyProcess;
   },
 };
+}
 
 /**
  * Bun.Terminal is callback-only and currently has no read-side pause method.

--- a/src/workspaces/win-command.spec.ts
+++ b/src/workspaces/win-command.spec.ts
@@ -47,6 +47,20 @@ afterEach(async () => {
 });
 
 describe('resolveLaunchCommand', () => {
+  it('compiled Windows CLI uses external Node for npm agents, not its own executable', async () => {
+    await stockNpmShim('pi.cmd');
+    await touch('node.exe');
+    const result = resolveLaunchCommand(['pi', '-p', 'a & b'], { platform: 'win32', env, bunStandalone: true });
+    expect(result.mode).toBe('node-shim');
+    expect(result.argv).toEqual([join(dir, 'node.exe'), join(dir, 'node_modules/pkg/cli.js'), '-p', 'a & b']);
+  });
+
+  it('does not turn the compiled product into an interpreter when host Node is absent', async () => {
+    await stockNpmShim('pi.cmd');
+    const result = resolveLaunchCommand(['pi'], { platform: 'win32', env, bunStandalone: true });
+    expect(result.mode).not.toBe('node-shim');
+    expect(result.argv[0]).not.toBe(process.execPath);
+  });
   it('is the identity function off win32', () => {
     const r = resolveLaunchCommand(['pi', '--continue'], { platform: 'linux', env });
     expect(r).toEqual({ argv: ['pi', '--continue'], viaShell: false, mode: 'direct' });

--- a/src/workspaces/win-command.ts
+++ b/src/workspaces/win-command.ts
@@ -57,6 +57,7 @@ export function resolveLaunchCommand(
     platform?: NodeJS.Platform;
     env?: NodeJS.ProcessEnv;
     nodeExecPath?: string;
+    bunStandalone?: boolean;
     cwd?: string;
   } = {},
 ): ResolvedCommand {
@@ -96,7 +97,14 @@ export function resolveLaunchCommand(
     // wrapper has the stock shape.  Besides avoiding an unnecessary shell,
     // this is what makes user-controlled headless prompts safe: cmd.exe never
     // gets a chance to re-parse &, |, %, ^, and friends.
-    const direct = resolveStockNpmShim(resolved, rest, opts.nodeExecPath ?? process.execPath);
+    const standalone = opts.bunStandalone
+      ?? (globalThis as typeof globalThis & { __OPENALICE_BUN_STANDALONE__?: boolean }).__OPENALICE_BUN_STANDALONE__ === true;
+    // A compiled OpenAlice executable is not a general Node interpreter.
+    // External npm agents retain their own host Node requirement.
+    const node = opts.nodeExecPath ?? (standalone
+      ? lookupExactOnWindowsPath('node.exe', env)
+      : process.execPath);
+    const direct = node ? resolveStockNpmShim(resolved, rest, node) : null;
     if (direct) return { argv: direct, viaShell: false, mode: 'node-shim' };
 
     // npm-style installs also publish an extensionless POSIX shim next to the


### PR DESCRIPTION
## Scope
Add an independent, manually selected Windows CLI preview lane for x64 and ARM64. Assemble complete ZIPs with pinned PortableGit/Bash and external-agent-only ownership; preserve each candidate before native acceptance. The PowerShell installer checks the ZIP checksum and host architecture and installs only into a new side-by-side directory. No existing data, PATH, execution policy, product channel, release version or npm publication is mutated.

Windows Bun uses ConPTY without POSIX pause/group signals. Slow consumers detach while their agent remains alive. npm-installed external agents use host Node rather than treating the compiled product as a JS interpreter. macOS/Linux retain their current backend behavior.

## Verification
- Local full Vitest baseline: 709 files, 6342 passed, 3 expected skips; final targeted rerun including added backend/workflow cases: 7 files, 74 passed, 1 expected skip.
- Root tsc and @traderalice/openalice-cli typecheck passed; pnpm build:server passed.
- Complete x64 and ARM64 ZIPs assembled locally, including pinned Git payload checksums.
- macOS Bun native PTY input/resize/isolation/backpressure smoke passed.
- Complete macOS Bun release smoke passed: real Web UI, detached component identity, Workspace helpers, external agent PTYs and Git; 22 seconds.
- Native Windows install/start/stop and ConPTY checks dispatched separately. No native Windows acceptance claim until those receipts pass; interactive external-agent/provider acceptance remains pending.

## Distribution boundary
Actions candidates only, with custom/non-updating provenance. Normal Windows npm and managed update/rollback remain follow-up acceptance work. No beta/stable release is created by this PR.