### PR TITLE
fix: replay Windows CLI acceptance against preserved previews

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -7,6 +7,10 @@ on:
         description: Build only the independent Windows x64/ARM64 preview
         type: boolean
         default: false
+      windows_candidate_run:
+        description: Optional existing Windows preview run ID; accept its ZIPs without rebuilding
+        type: string
+        default: ''
   # Routine dev PRs prove the checkout installer locally, then the dev push
   # below builds every native candidate and accepts the live preview channel.
   # Hosted checkout/Bun/SSH candidate work begins at the master boundary.
@@ -59,6 +63,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: cli-installer-smoke-${{ github.event.pull_request.number || github.ref }}-${{ inputs.windows_preview && 'windows-preview' || 'default' }}
@@ -68,6 +73,8 @@ jobs:
   windows-preview:
     if: github.event_name == 'workflow_dispatch' && inputs.windows_preview
     uses: ./.github/workflows/windows-cli-preview.yml
+    with:
+      candidate_run: ${{ inputs.windows_candidate_run || '' }}
 
   release-prep-scope:
     if: github.event_name != 'push' && !inputs.windows_preview

--- a/.github/workflows/windows-cli-preview.yml
+++ b/.github/workflows/windows-cli-preview.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Preserve complete candidate for reproduction
         uses: actions/upload-artifact@v6
         with:
-          name: openalice-windows-${{ matrix.arch }}-${{ github.sha }}
+          name: openalice-windows-${{ matrix.arch }}-${{ github.sha }}-${{ github.run_attempt }}
           path: |
             dist/windows-cli-preview/${{ matrix.arch }}/*.zip
             dist/windows-cli-preview/${{ matrix.arch }}/*.sha256
@@ -62,7 +62,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: windows-cli-smoke-${{ matrix.arch }}-${{ github.sha }}
+          name: windows-cli-smoke-${{ matrix.arch }}-${{ github.sha }}-${{ github.run_attempt }}
           path: dist/windows-cli-preview/${{ matrix.arch }}/native-smoke.json
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/windows-cli-preview.yml
+++ b/.github/workflows/windows-cli-preview.yml
@@ -2,10 +2,20 @@ name: Windows CLI Preview
 
 on:
   workflow_dispatch:
+    inputs:
+      candidate_run:
+        description: Existing preview run ID to accept without rebuilding
+        type: string
+        default: ''
   workflow_call:
+    inputs:
+      candidate_run:
+        type: string
+        default: ''
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: windows-cli-preview-${{ github.ref }}
@@ -30,7 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
+        if: inputs.candidate_run == ''
       - uses: actions/setup-node@v7
+        if: inputs.candidate_run == ''
         with:
           node-version: 22.22.2
           architecture: ${{ matrix.arch }}
@@ -39,10 +51,14 @@ jobs:
         with:
           bun-version-file: .bun-version
       - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
+        if: inputs.candidate_run == ''
       - run: pnpm build:server
+        if: inputs.candidate_run == ''
       - name: Assemble preview before native acceptance
+        if: inputs.candidate_run == ''
         run: bun scripts/build-windows-cli-preview.ts ${{ matrix.arch }}
       - name: Preserve complete candidate for reproduction
+        if: inputs.candidate_run == ''
         uses: actions/upload-artifact@v6
         with:
           name: openalice-windows-${{ matrix.arch }}-${{ github.sha }}-${{ github.run_attempt }}
@@ -54,6 +70,15 @@ jobs:
           if-no-files-found: error
           retention-days: 30
           compression-level: 0
+      - name: Reuse an existing candidate without installing dependencies or rebuilding
+        if: inputs.candidate_run != ''
+        uses: actions/download-artifact@v5
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.candidate_run }}
+          pattern: openalice-windows-${{ matrix.arch }}-*
+          path: dist/windows-cli-preview/${{ matrix.arch }}
+          merge-multiple: false
       - name: Check native ConPTY input resize and independent termination
         run: bun scripts/bun-native-pty-smoke.ts
       - name: Install and start the packaged Runtime

--- a/docs/cli-installer.md
+++ b/docs/cli-installer.md
@@ -74,6 +74,14 @@ or mutate any release/channel. Each downloadable Actions artifact contains a
 ZIP, its `.sha256`, installer, and candidate receipt. Native acceptance is a
 separate receipt: an available ZIP alone is not a passed smoke.
 
+To retry only native acceptance after fixing a smoke/installer issue, add
+`-f windows_candidate_run=<run-id>` to that command. This downloads the preserved
+candidate of each architecture and skips Node/pnpm setup, dependency install,
+source build, compilation and candidate upload. It requires exactly one
+candidate per architecture in the selected run and verifies its archive digest.
+The receipt identifies the original product commit, not the newer smoke source.
+Rebuild after changing product code; an old package cannot verify that fix.
+
 After downloading the candidate and reviewing its checksum, use ordinary
 Windows PowerShell (no administrator rights):
 

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -5,8 +5,9 @@ OpenAlice CLI. The accepted native archive and direct Bash installer remain
 owned by [[docs/cli-installer.md]]. Runtime lifecycle after installation remains
 owned by [[docs/cli-supervisor.md]] and [[docs/local-runtime.md]].
 
-Native Windows package-manager and PowerShell channels are deferred. This guide
-covers macOS and glibc Linux on arm64 and x64.
+Native Windows package-manager channels are deferred. Independent Windows
+x64/ARM64 ZIP and PowerShell previews live in [[docs/cli-installer.md]]; they
+are not npm publications. This guide covers macOS and glibc Linux on arm64 and x64.
 
 Public npm activation: `openalice` and its four platform packages were first
 published as `0.90.2` on 2026-09-04 under maintainer `jiaran258`. The registry

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -59,7 +59,7 @@ channel discovery. Agent CLIs remain user-owned.
 - [x] Complete local regression/type checks and integrate [PR #1344](https://github.com/TraderAlice/OpenAlice/pull/1344)
   into `dev` at `1d1dc21d`: full baseline 6,342 passes, final focused 74 passes,
   root/CLI types, local Windows ZIP builds and complete macOS native smoke.
-- [ ] Run native Windows installation, Guardian/Alice/Web, Git, ConPTY input,
+- [x] Run native Windows installation, Guardian/Alice/Web, Git, ConPTY input,
   resize, independent termination and stop checks for each architecture.
 - [ ] Perform interactive external-agent/provider acceptance; record concrete
   failures instead of claiming cross-compilation proves Windows runtime support.
@@ -80,6 +80,22 @@ recognize the manual Windows-only selector. Neither failure is waived.
 The next smoke attempt accepts the saved ZIPs with `windows_candidate_run`,
 skipping dependency installation and all rebuilds; product changes still need
 a newly compiled candidate. Ambiguous/missing archived candidates fail closed.
+
+Accepted native replay: [33875035438](https://github.com/TraderAlice/OpenAlice/actions/runs/33875035438)
+passed on both native hosts, reusing product commit `579bd53e` from the first
+build. ARM64 took 66 seconds and x64 67 seconds; both skipped Node/pnpm setup,
+dependency installation and all builds. The receipts bind these exact archives:
+
+| Architecture | Content identity | Archive SHA-256 |
+|---|---|---|
+| x64 | `bec6a7546a3e1c4c` | `66f98d667861df4e8bc74a60f2e12665dd1bbbcbbfe76495d0b7764bc25bcf0c` |
+| ARM64 | `dc78db8c9192513a` | `8ad8791c605e5105dedfe84c8e5faa56258e706d653914d64275d5a08cd41fc8` |
+
+[x64 preview](https://github.com/TraderAlice/OpenAlice/actions/runs/33874069985/artifacts/9937224452)
+and [ARM64 preview](https://github.com/TraderAlice/OpenAlice/actions/runs/33874069985/artifacts/9937338651)
+are retained for 30 days as Actions artifacts, not permanent GitHub Release or
+npm assets. Real interactive Agent/provider use and manual upgrade/removal are
+still explicit follow-up acceptance, not implied by this smoke.
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -77,6 +77,9 @@ Its installation smoke exposed inherited PowerShell 7 `PSModulePath` preventing
 Windows PowerShell 5.1 from discovering `Get-FileHash`; reset only that child
 environment, not the host. A separate old classifier assertion also needed to
 recognize the manual Windows-only selector. Neither failure is waived.
+The next smoke attempt accepts the saved ZIPs with `windows_candidate_run`,
+skipping dependency installation and all rebuilds; product changes still need
+a newly compiled candidate. Ambiguous/missing archived candidates fail closed.
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -56,7 +56,9 @@ channel discovery. Agent CLIs remain user-owned.
   ConPTY termination; bound slow WebSocket consumers without POSIX signals.
 - [x] Add an independently retryable, manual x64/ARM64 workflow. Preserve each
   archive before its native smoke so failures retain reproduction bytes.
-- [ ] Complete local regression/type checks and integrate this increment.
+- [x] Complete local regression/type checks and integrate [PR #1344](https://github.com/TraderAlice/OpenAlice/pull/1344)
+  into `dev` at `1d1dc21d`: full baseline 6,342 passes, final focused 74 passes,
+  root/CLI types, local Windows ZIP builds and complete macOS native smoke.
 - [ ] Run native Windows installation, Guardian/Alice/Web, Git, ConPTY input,
   resize, independent termination and stop checks for each architecture.
 - [ ] Perform interactive external-agent/provider acceptance; record concrete
@@ -68,6 +70,13 @@ The first preview is not a new beta/stable release. It is commit-addressed
 Actions output with a separate native acceptance receipt and no mutable channel
 alias. `CLI Installer Smoke` can dispatch only this lane from integrated `dev`
 using `windows_preview=true`, without the normal manual installer matrix.
+
+Native rehearsal [33874069985](https://github.com/TraderAlice/OpenAlice/actions/runs/33874069985)
+preserved the x64 ZIP and passed ConPTY input/resize/independent termination.
+Its installation smoke exposed inherited PowerShell 7 `PSModulePath` preventing
+Windows PowerShell 5.1 from discovering `Get-FileHash`; reset only that child
+environment, not the host. A separate old classifier assertion also needed to
+recognize the manual Windows-only selector. Neither failure is waived.
 
 Delivery mode: Serial / interactive from current `dev`. The accepted native CLI
 increments have already reached `dev`; the old `codex/usability-improvements`

--- a/scripts/beta-release-prep-workflow.spec.ts
+++ b/scripts/beta-release-prep-workflow.spec.ts
@@ -103,7 +103,7 @@ describe('exact beta release-preparation workflow lane', () => {
     expect(cli.on?.pull_request?.branches).toEqual(['master'])
     expectTrustedClassifier(scope)
     expectOutcomeGatedOutput(scope)
-    expect(scope.if).toBe("github.event_name != 'push'")
+    expect(scope.if).toBe("github.event_name != 'push' && !inputs.windows_preview")
     for (const name of ['bun-cli-feasibility', 'checkout-install', 'checkout-remote']) {
       expect(jobs[name].needs).toBe('release-prep-scope')
       expect(jobs[name].if).toContain('!cancelled()')

--- a/scripts/bun-native-pty-smoke.ts
+++ b/scripts/bun-native-pty-smoke.ts
@@ -11,6 +11,7 @@ if (backend.name !== 'bun-native') {
 const env = Object.fromEntries(
   Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
 )
+if (process.platform === 'win32') delete env.PSModulePath
 const one = spawnInteractive('ONE')
 const two = spawnInteractive('TWO')
 let flowControl: Awaited<ReturnType<typeof probeFlowControl>> | undefined
@@ -191,7 +192,7 @@ function interactiveCommand(label: string): { file: string; args: string[] } {
 async function waitForOutput(
   session: { output: string },
   expected: string,
-  timeoutMs = 10_000,
+  timeoutMs = process.platform === 'win32' ? 30_000 : 10_000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {

--- a/scripts/windows-cli-preview-smoke.ts
+++ b/scripts/windows-cli-preview-smoke.ts
@@ -10,8 +10,13 @@ const scratch = await mkdtemp(join(tmpdir(), 'openalice-preview-smoke-'))
 const installDir = join(scratch, 'installed preview')
 const home = join(scratch, 'alice-home')
 const powershell = join(process.env.SystemRoot!, 'System32/WindowsPowerShell/v1.0/powershell.exe')
+// GitHub starts this script from PowerShell 7. Do not leak its module search
+// path into Windows PowerShell 5.1: the latter must discover its own Utility
+// module (Get-FileHash, ConvertFrom-Json), just as on an ordinary user host.
+const powershellEnv = { ...process.env }
+delete powershellEnv.PSModulePath
 await command(powershell, ['-NoProfile', '-File', resolve('install-preview.ps1'),
-  '-Archive', candidate.archive, '-Sha256', candidate.sha256, '-InstallDir', installDir, '-Yes'])
+  '-Archive', candidate.archive, '-Sha256', candidate.sha256, '-InstallDir', installDir, '-Yes'], powershellEnv)
 const executable = join(installDir, 'bin/openalice.exe')
 const portProbe = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } })
 const port = portProbe.port

--- a/scripts/windows-cli-preview-smoke.ts
+++ b/scripts/windows-cli-preview-smoke.ts
@@ -1,10 +1,16 @@
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 
 if (process.platform !== 'win32') throw new Error('Run this smoke on native Windows')
-const candidateFile = resolve(process.argv[2] ?? `dist/windows-cli-preview/${process.arch}/candidate.json`)
+const outputRoot = resolve(`dist/windows-cli-preview/${process.arch}`)
+const candidates = process.argv[2] ? [resolve(process.argv[2])] : await findCandidates(outputRoot)
+if (candidates.length !== 1) throw new Error(`Expected one candidate for this architecture, found ${candidates.length}`)
+const candidateFile = candidates[0]!
 const candidate = JSON.parse(await readFile(candidateFile, 'utf8'))
+// Actions downloads have a new filesystem root. The candidate's ZIP and
+// checksum travel together; never execute paths recorded on the old runner.
+const archive = join(dirname(candidateFile), basename(candidate.archive))
 if (candidate.arch !== process.arch) throw new Error('Native smoke architecture mismatch')
 const scratch = await mkdtemp(join(tmpdir(), 'openalice-preview-smoke-'))
 const installDir = join(scratch, 'installed preview')
@@ -16,7 +22,7 @@ const powershell = join(process.env.SystemRoot!, 'System32/WindowsPowerShell/v1.
 const powershellEnv = { ...process.env }
 delete powershellEnv.PSModulePath
 await command(powershell, ['-NoProfile', '-File', resolve('install-preview.ps1'),
-  '-Archive', candidate.archive, '-Sha256', candidate.sha256, '-InstallDir', installDir, '-Yes'], powershellEnv)
+  '-Archive', archive, '-Sha256', candidate.sha256, '-InstallDir', installDir, '-Yes'], powershellEnv)
 const executable = join(installDir, 'bin/openalice.exe')
 const portProbe = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } })
 const port = portProbe.port
@@ -42,7 +48,7 @@ try {
   await command(executable, ['down', '--home', home, '--wait', '30'], environment)
   const stopped = JSON.parse(await command(executable, ['status', '--home', home, '--json'], environment)).result.status
   if (stopped.class === 'running') throw new Error('Runtime did not stop')
-  await writeFile(resolve(candidateFile, '..', 'native-smoke.json'), JSON.stringify({
+  await writeFile(join(outputRoot, 'native-smoke.json'), JSON.stringify({
     status: 'pass', arch: process.arch, archiveSha256: candidate.sha256,
     contentIdentity: candidate.contentIdentity, sourceCommit: candidate.sourceCommit,
     accepted: ['PowerShell ZIP install', 'detached Guardian/Alice', 'real Web UI', 'Git', 'stop'],
@@ -50,6 +56,16 @@ try {
   }, null, 2) + '\n')
 } finally {
   await command(executable, ['down', '--home', home, '--wait', '30'], environment).catch(console.error)
+}
+
+async function findCandidates(directory: string): Promise<string[]> {
+  const result: string[] = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) result.push(...await findCandidates(path))
+    else if (entry.name === 'candidate.json') result.push(path)
+  }
+  return result
 }
 
 async function command(exe: string, args: string[], env = process.env) {

--- a/scripts/windows-cli-preview.spec.ts
+++ b/scripts/windows-cli-preview.spec.ts
@@ -10,7 +10,7 @@ describe('Windows preview delivery boundary', () => {
   it('is manually dispatched, independent per architecture, and cannot publish stable aliases', () => {
     const workflow = YAML.parse(read('.github/workflows/windows-cli-preview.yml'))
     expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch', 'workflow_call'])
-    expect(workflow.permissions).toEqual({ contents: 'read' })
+    expect(workflow.permissions).toEqual({ contents: 'read', actions: 'read' })
     const job = workflow.jobs.preview
     expect(job.needs).toBeUndefined()
     expect(job.strategy['fail-fast']).toBe(false)
@@ -21,6 +21,20 @@ describe('Windows preview delivery boundary', () => {
     expect(steps.findIndex(s => s.name === 'Preserve complete candidate for reproduction'))
       .toBeLessThan(steps.findIndex(s => s.name === 'Install and start the packaged Runtime'))
     expect(steps.some(s => /pnpm test(?:\s|$)|npm publish|electron:pack/.test(s.run ?? ''))).toBe(false)
+  })
+
+  it('replays existing bytes without dependency setup, compilation, or candidate re-upload', () => {
+    const workflow = YAML.parse(read('.github/workflows/windows-cli-preview.yml'))
+    const steps = workflow.jobs.preview.steps as Array<{ uses?: string; name?: string; run?: string; if?: string; with?: Record<string, unknown> }>
+    for (const step of steps.filter(s => s.uses === 'pnpm/action-setup@v6' || s.uses === 'actions/setup-node@v7' ||
+      s.run?.startsWith('pnpm ') || s.run?.includes('build-windows-cli-preview.ts') ||
+      s.name === 'Preserve complete candidate for reproduction')) {
+      expect(step.if).toBe("inputs.candidate_run == ''")
+    }
+    const download = steps.find(s => s.uses === 'actions/download-artifact@v5')!
+    expect(download.if).toBe("inputs.candidate_run != ''")
+    expect(download.with?.['merge-multiple']).toBe(false)
+    expect(download.with?.['run-id']).toBe('${{ inputs.candidate_run }}')
   })
 
   it('the registered installer workflow can dispatch previews without its normal manual gates or dev activation', () => {


### PR DESCRIPTION
## Follow-up to #1344
Repair the stale exact-string beta workflow assertion and isolate Windows PowerShell 5.1 probes from an inherited PowerShell 7 module path. Give the cold native Windows PTY probe a bounded 30-second startup window. Windows x64 already produced an archive and passed ConPTY; ARM64 produced its archive but its PowerShell readiness probe timed out. Native installation and startup acceptance remain under verification, not waived.

Add an explicit windows_candidate_run input to accept the same saved ZIPs without Node/pnpm setup, dependency installation, rebuilding or re-uploading. Downloads remain in this repository, ambiguous candidate sets fail closed, and installation checks the candidate archive digest. Product code changes still require new bytes. Each upload attempt keeps a distinct artifact name.

## Verification
- Complete local workflow contract lane: 82 passed.
- Windows preview/replay contract tests: 4 passed.
- Root TypeScript check passed.
- macOS native Bun PTY input/resize/isolation/backpressure smoke passed after the fixture adjustment.
- Current native replay reuses run 33874069985; final receipts pending.

No version, tag, stable/beta/dev alias, npm package, credential or user data mutation.