### PR TITLE
docs: record activated Homebrew distribution

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -36,8 +36,9 @@ the durable truth after it changes. Git history is the archive.
   before any `dev` PR.
 - [[plans/bun-cli-distribution.md]] — Replaces the expanded Node headless
   Runtime with a Bun-compiled, multi-process CLI distribution. Direct,
-  npm/Bun, Homebrew, and AUR channels consume one accepted artifact set. The
-  CLI package owns OpenAlice only: Agent Runtime installation and Electron
+  npm/Bun, Homebrew, and AUR channels consume one accepted artifact set.
+  Homebrew tap is public at `0.90.2` with lightweight hourly/manual stable sync.
+  The CLI package owns OpenAlice only: Agent Runtime installation and Electron
   packaging stay outside this plan. The native CLI is public through the
   separately dispatched `v0.91.0-beta.3`; stable/beta discovery now uses the
   OpenAlice CDN manifests. Managed SSH installation and Project transfer pass

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -14,8 +14,14 @@ Public npm activation: `openalice` and its four platform packages were first
 published as `0.90.2` on 2026-09-04 under maintainer `jiaran258`. The registry
 integrities and a fresh npm 12 installation/start/stop were independently
 verified after [publication](https://github.com/TraderAlice/OpenAlice/actions/runs/33860369715).
-Homebrew and AUR still require their separate external activation; package
-metadata in a GitHub Release alone does not make those commands available.
+Homebrew was activated at `0.90.2` on 2026-09-04 in
+[`TraderAlice/homebrew-tap`](https://github.com/TraderAlice/homebrew-tap).
+The first [sync](https://github.com/TraderAlice/homebrew-tap/actions/runs/33889442153)
+verified all four public archives and committed the unchanged formula using
+the tap's built-in token. A fresh public macOS ARM64 Homebrew installation and
+isolated Runtime startup/stop/removal passed; no new product version was made.
+AUR still requires separate external activation. Package metadata in a GitHub
+Release alone does not make a channel available.
 
 ## User commands
 
@@ -100,6 +106,21 @@ inputs and cannot mutate any of those public package channels.
 
 ## Homebrew and AUR topology
 
+The public `TraderAlice/homebrew-tap` consumes the unchanged `openalice.rb`
+asset from the current stable release. Its small `Sync stable formula` workflow
+checks hourly (minute 23) or by manual dispatch, waits for matching GitHub/CDN
+stable versions, verifies the formula asset digest and all four Homebrew archive
+hashes/sidecars, then commits only the formula with the tap's own `GITHUB_TOKEN`.
+An unchanged version performs no archive downloads or commits. It never builds
+the product and needs no cross-repository token. GitHub can delay schedules and
+disable them after 60 days without repository activity; maintainers can
+re-enable/run the tap workflow in Actions.
+
+Keep `OPENALICE_PUBLISH_HOMEBREW` disabled in OpenAlice: the older push-based
+writer below is an alternative, not a second active writer. New stable release
+acceptance should include the tap sync receipt (manual dispatch is available
+without waiting for the hourly schedule). Beta/dev never update the formula.
+
 The generated Homebrew formula selects the accepted archive and SHA-256 for the
 current macOS or Linux architecture. It installs the executable, immutable
 resources, release metadata, notices, and Homebrew provenance without compiling
@@ -136,7 +157,7 @@ External channels are explicit release switches:
 | Channel | Repository variable | Required authority |
 |---|---|---|
 | npm + Bun | `OPENALICE_PUBLISH_NPM=true` | npm Trusted Publishing for all seven names, bound to `TraderAlice/OpenAlice` / `release.yml` |
-| Homebrew | `OPENALICE_PUBLISH_HOMEBREW=true` | `HOMEBREW_TAP_TOKEN` with write access to `TraderAlice/homebrew-tap` |
+| Homebrew (alternative push writer; disabled for our tap) | `OPENALICE_PUBLISH_HOMEBREW=true` | `HOMEBREW_TAP_TOKEN` with write access to `TraderAlice/homebrew-tap` |
 | AUR / paru | `OPENALICE_PUBLISH_AUR=true` | dedicated `AUR_SSH_PRIVATE_KEY` plus manually verified `AUR_KNOWN_HOSTS` |
 
 Before a stable GitHub Release can be created, the release workflow preflights

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1,9 +1,37 @@
 # Bun-native CLI Distribution
 
+## Homebrew activation — 2026-09-04
+
+The maintainer created `TraderAlice/homebrew-tap` and authorized completing
+the channel. Use the existing stable `v0.90.2` formula and archive bytes, not
+new dev builds or an invented version. The tap owns one lightweight hourly/manual
+stable sync workflow, using its own `GITHUB_TOKEN`; the main repository's
+cross-repository token writer remains disabled. Owner contract:
+[[docs/cli-package-managers.md]].
+
+- [x] Verify all four public archive checksums, sidecars, and formula asset digest.
+- [x] Exercise native macOS ARM64 Homebrew install and real detached Runtime
+  startup with an isolated AliceProject and no Node/Bun/agent commands in PATH.
+- [x] Publish the tap, verify its public install and hosted sync receipt.
+- [x] Confirm manager-owned update/removal, user-data preservation, and record
+  final acceptance links. Existing user PATH and installations remain untouched.
+
+Accepted [tap PR #1](https://github.com/TraderAlice/homebrew-tap/pull/1);
+[sync run 33889442153](https://github.com/TraderAlice/homebrew-tap/actions/runs/33889442153)
+used `GITHUB_TOKEN` to publish formula commit `43d9f20`. Public
+`brew install traderalice/tap/openalice` resolved `0.90.2` on macOS ARM64.
+Local verification covered five sync contracts, four public archive hashes and
+sidecars, formula digest/byte equality, real isolated Runtime/Web start/stop,
+package-manager update/uninstall guidance, and data preservation. No new
+Linux/Intel runtime test was purchased for byte-identical release assets.
+A second [sync run](https://github.com/TraderAlice/homebrew-tap/actions/runs/33889497212)
+verified the unchanged version without archive downloads or an empty commit.
+
 Status: Active — macOS/Linux native CLI is public in v0.90.2 and the separately
 dispatched v0.91.0-beta.3 is externally verified; stable remains v0.90.2 while
 stable/beta discovery authority is converged on the OpenAlice CDN. Native
-Windows x64/ARM64 unified-channel integration and Homebrew/AUR activation remain in progress. npm/Bun's five public
+Windows x64/ARM64 channel acceptance and AUR activation remain in progress;
+Homebrew is public at `0.90.2`. npm/Bun's five public
 packages are published at v0.90.2 under maintainer `jiaran258`.
 
 Accepted OIDC increment: replace the temporary npm token with GitHub OIDC trust on


### PR DESCRIPTION
Record the now-public TraderAlice/homebrew-tap at 0.90.2 and its single hourly/manual stable writer. The tap uses its own GITHUB_TOKEN; the old optional cross-repository writer remains disabled. No product version, release workflow, npm channel, AUR, or user PATH changes. Evidence: tap PR https://github.com/TraderAlice/homebrew-tap/pull/1; first real token-backed publication https://github.com/TraderAlice/homebrew-tap/actions/runs/33889442153; idempotent 7-second rerun https://github.com/TraderAlice/homebrew-tap/actions/runs/33889497212. Verification: five sync contract tests; four public archive hashes/sidecars and formula digest; native macOS ARM64 public brew install, real isolated Runtime/Web startup and stop without Node/Bun/agents in PATH, manager-owned update/uninstall guidance, already-current brew upgrade, removal and preserved data. Temporary package/taps removed; pre-existing installation untouched. This PR changes documentation only; git diff --check passed.