### PR TITLE
test: diagnose and bound native Electron smoke latency

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -2,6 +2,12 @@ name: Desktop Package Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      host:
+        description: Native host for manual rehearsal; promotion PRs always retain every host.
+        type: choice
+        default: all
+        options: [all, macos-14, macos-15-intel, windows-latest]
   pull_request:
     branches: [master]
     paths:
@@ -98,7 +104,9 @@ jobs:
   broker-packs-windows:
     name: broker-packs windows-latest
     needs: preflight
-    if: needs.preflight.outputs.beta_release_prep != 'true'
+    if: >-
+      needs.preflight.outputs.beta_release_prep != 'true' &&
+      (github.event_name != 'workflow_dispatch' || inputs.host == 'all' || inputs.host == 'windows-latest')
     runs-on: windows-latest
     timeout-minutes: 25
 
@@ -134,13 +142,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos-14
-            arch: arm64
-          - os: macos-15-intel
-            arch: x64
-          - os: windows-latest
-            arch: x64
+        include: >-
+          ${{ fromJSON(
+            github.event_name == 'workflow_dispatch' && inputs.host == 'macos-14' && '[{"os":"macos-14","arch":"arm64"}]' ||
+            github.event_name == 'workflow_dispatch' && inputs.host == 'macos-15-intel' && '[{"os":"macos-15-intel","arch":"x64"}]' ||
+            github.event_name == 'workflow_dispatch' && inputs.host == 'windows-latest' && '[{"os":"windows-latest","arch":"x64"}]' ||
+            '[{"os":"macos-14","arch":"arm64"},{"os":"macos-15-intel","arch":"x64"},{"os":"windows-latest","arch":"x64"}]'
+          ) }}
 
     steps:
       - uses: actions/checkout@v7

--- a/PLANS.md
+++ b/PLANS.md
@@ -38,6 +38,8 @@ the durable truth after it changes. Git history is the archive.
   Runtime with a Bun-compiled, multi-process CLI distribution. Direct,
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set.
   Homebrew tap is public at `0.90.2` with lightweight hourly/manual stable sync.
+  Stable `0.91.0` is authorized; promotion awaits diagnosis of the repeated
+  Intel Electron PTY smoke timeout. AUR registration remains deferred.
   The CLI package owns OpenAlice only: Agent Runtime installation and Electron
   packaging stay outside this plan. The native CLI is public through the
   separately dispatched `v0.91.0-beta.3`; stable/beta discovery now uses the

--- a/PLANS.md
+++ b/PLANS.md
@@ -38,8 +38,9 @@ the durable truth after it changes. Git history is the archive.
   Runtime with a Bun-compiled, multi-process CLI distribution. Direct,
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set.
   Homebrew tap is public at `0.90.2` with lightweight hourly/manual stable sync.
-  Stable `0.91.0` is authorized; promotion awaits diagnosis of the repeated
-  Intel Electron PTY smoke timeout. AUR registration remains deferred.
+  Stable `0.91.0` is authorized; native Intel acceptance passed with a measured
+  renderer delay (#1350), and bounded smoke-budget correction precedes promotion.
+  AUR registration remains deferred.
   The CLI package owns OpenAlice only: Agent Runtime installation and Electron
   packaging stay outside this plan. The native CLI is public through the
   separately dispatched `v0.91.0-beta.3`; stable/beta discovery now uses the

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -323,6 +323,8 @@ async function waitForUTA(utaUrl: string, timeoutMs = UTA_READY_TIMEOUT_MS): Pro
 async function runRendererPtySmoke(win: BrowserWindow): Promise<void> {
   const keepWorkspace = process.env['OPENALICE_ELECTRON_SMOKE_KEEP_WORKSPACE'] === '1'
   const result = await win.webContents.executeJavaScript(`(async () => {
+    const stage = (value) => console.warn('[desktop-pty-smoke] renderer stage=' + value)
+    stage('bridge')
     const bridge = window.openAlice?.pty
     if (!bridge) throw new Error('window.openAlice.pty missing')
     const keyboard = window.openAlice?.keyboard
@@ -333,7 +335,9 @@ async function runRendererPtySmoke(win: BrowserWindow): Promise<void> {
     }
     const tag = 'electron-smoke-' + Date.now().toString(36)
     const json = async (res) => {
+      stage('response-headers status=' + res.status)
       const text = await res.text()
+      stage('response-body')
       let body = null
       try { body = text ? JSON.parse(text) : null } catch { body = text }
       if (!res.ok) throw new Error(res.status + ' ' + text)
@@ -343,18 +347,21 @@ async function runRendererPtySmoke(win: BrowserWindow): Promise<void> {
     let sessionId = ''
     let connectionId = ''
     try {
+      stage('create-workspace')
       const created = await json(await fetch('/api/workspaces', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ tag, template: 'chat' }),
       }))
       workspaceId = created.workspace.id
+      stage('spawn-shell')
       const spawned = await json(await fetch('/api/workspaces/' + encodeURIComponent(workspaceId) + '/sessions/spawn', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ agent: 'shell' }),
       }))
       sessionId = spawned.sessionId
+      stage('connect-pty')
       const attached = await new Promise((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error('PTY attached timeout')), 10000)
         connectionId = bridge.connect({ sessionId, cols: 80, rows: 24 })
@@ -383,6 +390,7 @@ async function runRendererPtySmoke(win: BrowserWindow): Promise<void> {
       if (typeof attached.kittyKeyboardFlags !== 'number') {
         throw new Error('PTY attach omitted Kitty keyboard flags')
       }
+      stage('attached')
       return { ok: true, workspaceId, sessionId, attached, keyboardInputSourceId }
     } finally {
       if (connectionId) bridge.close(connectionId)
@@ -927,8 +935,14 @@ app.whenReady().then(async () => {
     }),
   })
   protocol.handle('app', async (request) => {
+    const smokeTrace = process.env['OPENALICE_ELECTRON_SMOKE_PTY'] === '1'
+      && request.method === 'POST'
+      && new URL(request.url).pathname.startsWith('/api/workspaces')
+    if (smokeTrace) console.log('[desktop-pty-smoke] main stage=web-request')
     try {
-      return await fetchAliceWebRequest(request, alice)
+      const response = await fetchAliceWebRequest(request, alice)
+      if (smokeTrace) console.log('[desktop-pty-smoke] main stage=web-response status=' + response.status)
+      return response
     } catch (err) {
       return new Response(err instanceof Error ? err.message : String(err), { status: 503 })
     }

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -703,6 +703,11 @@ the other hosts. PTY smoke logs fixed renderer and main-process stages around
 Workspace creation, response consumption, shell spawn and PTY attachment; these
 diagnostics are enabled only by the existing isolated smoke flag and never log
 request bodies, headers, credentials or user prompts.
+The outer PTY/CLI smoke deadline is 180 seconds, not a fixed delay: it exits
+immediately after acceptance and cleanup. Native Intel evidence showed an
+otherwise successful 88-second run, including a roughly 62-second main-to-renderer
+response delay. Preserve that timing as a separate performance finding rather
+than interpreting a larger smoke budget as a runtime performance fix.
 
 A release-facing change should also verify a clean-machine flow:
 

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -695,6 +695,15 @@ on their matching architecture. Apple Silicon uses the canonical
 `latest-mac.yml` update feed; Intel uses `latest-mac-intel.yml` with the
 electron-updater compatibility alias `latest-intel-mac.yml`.
 
+Manual rehearsal can select one `host` (`macos-14`, `macos-15-intel`, or
+`windows-latest`); the default `all` and promotion PRs retain the full matrix.
+For example, dispatch `desktop-package-smoke.yml --ref <branch> -f host=macos-15-intel`
+with `gh workflow run` to investigate a native Intel failure without rebuilding
+the other hosts. PTY smoke logs fixed renderer and main-process stages around
+Workspace creation, response consumption, shell spawn and PTY attachment; these
+diagnostics are enabled only by the existing isolated smoke flag and never log
+request bodies, headers, credentials or user prompts.
+
 A release-facing change should also verify a clean-machine flow:
 
 1. launch the packaged app with no system Node, Git, Bash, or Pi assumption;

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -19,6 +19,18 @@ version-only preparation. No stable tag or public 0.91.0 bytes exist yet. Releas
 and package-manager authority remain owned by [[docs/development-workflow.md]]
 and [[docs/cli-package-managers.md]].
 
+Diagnostic [run 33893555127](https://github.com/TraderAlice/OpenAlice/actions/runs/33893555127)
+passed native Intel takeover, PTY/CLI, packaged Workspace/Pi, and previous-app
+upgrade acceptance. Main returned Workspace HTTP 201 at `16:17:23.386Z`; the
+renderer observed response headers at `16:18:24.943Z`, then successfully spawned
+and attached the Shell. Total takeover smoke was 88 seconds against a 90-second
+budget. Increase only the smoke's bounded overall deadline to 180 seconds;
+retain every assertion and phase diagnostic, with no sleep, retry loop or
+production transport workaround. The underlying renderer delivery latency is
+not explained or claimed fixed; track it in [#1350](https://github.com/TraderAlice/OpenAlice/issues/1350). Local diagnostic regression
+passed 712 files / 6,361 tests with three expected skips, root/Desktop types and
+real isolated takeover/PTY/socket acceptance.
+
 ## Homebrew activation — 2026-09-04
 
 The maintainer created `TraderAlice/homebrew-tap` and authorized completing

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -1,5 +1,24 @@
 # Bun-native CLI Distribution
 
+## Stable 0.91.0 acceptance — 2026-09-05
+
+Maintainer authorized stable publication, including both Windows CLI targets.
+AUR activation is deferred while account registration is closed. Promotion
+[PR #1349](https://github.com/TraderAlice/OpenAlice/pull/1349) remains unmerged:
+local full regression (712 files, 6,360 passes, three expected skips), root
+types, unsigned packaged Workspace/Pi acceptance, OrbStack Docker and Guardian
+recovery passed. The exact dev channel and both Windows native replay receipts
+passed. Hosted Docker passed unchanged on retry, as did Windows desktop/upgrade,
+Windows Broker Packs and Apple Silicon desktop/upgrade.
+
+Intel desktop Guardian/PTY smoke timed out twice after successful takeover;
+the second run also recorded a spawned Shell but no PTY connection. Do not retry
+blindly or waive it. Add smoke-only boundary diagnostics and a single-host manual
+rehearsal selector, identify the cause, then resume promotion and the separate
+version-only preparation. No stable tag or public 0.91.0 bytes exist yet. Release
+and package-manager authority remain owned by [[docs/development-workflow.md]]
+and [[docs/cli-package-managers.md]].
+
 ## Homebrew activation — 2026-09-04
 
 The maintainer created `TraderAlice/homebrew-tap` and authorized completing

--- a/scripts/desktop-package-workflow.spec.ts
+++ b/scripts/desktop-package-workflow.spec.ts
@@ -10,6 +10,8 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
+  if?: string
+  strategy?: { matrix?: { include?: string } }
   name?: string
   needs?: string | string[]
   'runs-on'?: string
@@ -35,6 +37,18 @@ const workflow = YAML.parse(
 ) as Workflow
 
 describe('Desktop Package Smoke workflow critical path', () => {
+  it('narrows only explicitly selected manual rehearsals, not promotion gates', () => {
+    expect(workflow.on?.workflow_dispatch).toMatchObject({
+      inputs: { host: { type: 'choice', default: 'all', options: ['all', 'macos-14', 'macos-15-intel', 'windows-latest'] } },
+    })
+    const matrix = workflow.jobs.package.strategy?.matrix?.include ?? ''
+    for (const host of ['macos-14', 'macos-15-intel', 'windows-latest']) {
+      expect(matrix).toContain(`github.event_name == 'workflow_dispatch' && inputs.host == '${host}'`)
+    }
+    expect(matrix).toContain('[{"os":"macos-14","arch":"arm64"},{"os":"macos-15-intel","arch":"x64"},{"os":"windows-latest","arch":"x64"}]')
+    expect(workflow.jobs['broker-packs-windows'].if).toContain("github.event_name != 'workflow_dispatch' || inputs.host == 'all' || inputs.host == 'windows-latest'")
+  })
+
   it('keeps manual and master-promotion coverage without taxing dev PRs', () => {
     expect(workflow.on).toHaveProperty('workflow_dispatch')
     expect(workflow.on).toHaveProperty('pull_request')

--- a/scripts/desktop-pty-smoke.mjs
+++ b/scripts/desktop-pty-smoke.mjs
@@ -16,7 +16,10 @@ const args = new Set(process.argv.slice(2))
 const skipBuild = args.has('--skip-build')
 const keep = args.has('--keep')
 const guardianRecovery = args.has('--guardian-recovery')
-const timeoutMs = 90_000
+// Native Intel rehearsal recorded a valid response delayed ~62 seconds between
+// main and renderer. Allow bounded startup/transport slack without sleeping or
+// skipping PTY/CLI assertions; stage sentinels retain the slow boundary.
+const timeoutMs = 180_000
 const knownArgs = new Set(['--skip-build', '--keep', '--guardian-recovery', '--help', '-h'])
 const unknownArgs = [...args].filter((arg) => !knownArgs.has(arg))
 


### PR DESCRIPTION
## Summary
- Add fixed, smoke-only renderer/main stage sentinels around Workspace API responses and PTY attachment, without logging request bodies or credentials.
- Add a manual desktop host selector; master promotion retains its full native matrix and default manual behavior remains all hosts.
- Set the overall PTY/CLI smoke deadline to 180 seconds based on an observed successful 88-second Intel run; no sleeps, retries, skipped assertions or runtime transport workaround.

## Evidence and boundary
Promotion #1349 timed out twice at 90 seconds. Diagnostic-only native Intel run https://github.com/TraderAlice/OpenAlice/actions/runs/33893555127 passed takeover, PTY/CLI, packaged Workspace/Pi and previous-desktop upgrade. Main returned HTTP 201 immediately, but renderer delivery took ~61.56 seconds; all following assertions passed. The underlying performance cause is not claimed fixed and is tracked separately in #1350.

Local: 83 workflow contracts passed; root/Desktop types passed; real isolated Electron takeover/PTY/socket acceptance passed; 712 full-suite files and 6,361 tests passed (three expected skips). The final constant/documentation adjustment is undergoing a fresh full regression and real smoke before merge.

## Release intent
This is a dev-first release-fixture correction, not a version-preparation or publication commit. Stable source promotion remains paused until integration and its applicable gates pass. AUR registration remains deferred.