### PR TITLE
chore(release): prepare v0.91.0 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0-beta.4",
+  "version": "0.91.0",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0-beta.4",
+  "version": "0.91.0",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release intent
Maintainer-authorized v0.91.0 stable, from the frozen af04fec0 source promoted by #1349. This PR changes only the root and CLI package versions from 0.91.0-beta.4 to 0.91.0. It does not publish a tag or release.

## Verification
Source acceptance is recorded in #1349: local full suite (714 files, 6360 passed, 3 skipped), root types, real unsigned packaged Workspace/Pi acceptance; green three-host desktop N-1, Windows Broker Packs, Docker, installer/managed SSH, and exact dev activation/live install. Version-prep workflow contracts and root TypeScript passed locally. This stable PR retains its synchronous applicable host gates. After merge, dispatch Full Source Validation on the exact final master SHA before the separate stable Release operation.

## Publication boundary
Release must verify final signed candidates, immutable assets and CDN bytes before completion. Windows npm first publication and trusted-publisher activation follow accepted public stable assets; Homebrew uses its independent token-free tap sync. AUR activation remains deferred because registration is closed. After public acceptance, copy only these two version fields to dev in a focused PR.