### PR TITLE
Promote hermetic TUI release-test correction for v0.91.0

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -43,8 +43,9 @@ the durable truth after it changes. Git history is the archive.
   Runtime with a Bun-compiled, multi-process CLI distribution. Direct,
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set.
   Homebrew tap is public at `0.90.2` with lightweight hourly/manual stable sync.
-  Stable `0.91.0` is authorized; native Intel acceptance passed with a measured
-  renderer delay (#1350), and bounded smoke-budget correction precedes promotion.
+  Stable `0.91.0` source and version preparation are merged; final validation
+  exposed host-dependent TUI fixtures, now being isolated before re-promotion.
+  Native Intel acceptance passed; renderer latency remains tracked in #1350.
   AUR registration remains deferred.
   The CLI package owns OpenAlice only: Agent Runtime installation and Electron
   packaging stay outside this plan. The native CLI is public through the

--- a/packages/cli/src/supervisor-tui.spec.ts
+++ b/packages/cli/src/supervisor-tui.spec.ts
@@ -39,7 +39,6 @@ import {
 } from './supervisor-launch-flight.ts'
 
 const matchesKey = (data: string, key: string) => data === key
-const asyncTuiTimeoutMs = process.env.CI ? 15_000 : 5_000
 const pointerClick = (col: number, row: number) => ({
   button: 0,
   col,
@@ -3766,6 +3765,9 @@ describe('Supervisor TUI screen', () => {
         calls.push('open')
       },
       discoverUpdate: async () => null,
+      seedFleet: isolatedLocalFleet,
+      inspectFleet: isolatedLocalFleet,
+      readInbox: isolatedEmptyInbox,
       loadTui: async () => fakePiTui as never,
       version: '0.87.0-beta',
       channel: 'stable',
@@ -3773,7 +3775,7 @@ describe('Supervisor TUI screen', () => {
 
     expect(calls).toEqual(['start'])
     expect(screen?.snapshot.launchFlight).toBeNull()
-  }, asyncTuiTimeoutMs)
+  })
 
   it('returns to the Launcher when the active local Runtime disappears', async () => {
     let inputListener: ((data: string) => unknown) | undefined
@@ -4074,11 +4076,9 @@ describe('Supervisor TUI screen', () => {
         }
         throw new Error('fixture inspection timeout')
       },
-      seedFleet: async () => ({
-        schemaVersion: 1,
-        generatedAt: '2026-09-02T00:00:00Z',
-        machines: fleetMachines(),
-      }),
+      seedFleet: isolatedLocalFleet,
+      inspectFleet: isolatedLocalFleet,
+      readInbox: isolatedEmptyInbox,
       pollIntervalMs: 5,
       connectionPollIntervalMs: 60_000,
       discoverUpdate: async () => null,
@@ -4104,6 +4104,7 @@ describe('Supervisor TUI screen', () => {
       'unreachable',
       'recovered',
     ])
+    expect(inspections).toBeGreaterThanOrEqual(5)
   })
 
   it('preserves remote Fleet focus while the selected local Runtime polls', async () => {
@@ -4573,6 +4574,9 @@ describe('Supervisor TUI screen', () => {
         calls.push('open')
       },
       discoverUpdate: async () => null,
+      seedFleet: isolatedLocalFleet,
+      inspectFleet: isolatedLocalFleet,
+      readInbox: isolatedEmptyInbox,
       loadTui: async () => fakePiTui as never,
       version: '0.87.0-beta',
       channel: 'branch dev',
@@ -4584,7 +4588,7 @@ describe('Supervisor TUI screen', () => {
       'configure-project',
       'start',
     ])
-  }, asyncTuiTimeoutMs)
+  })
 
   it('keeps foreign-owned lifecycle mutations unavailable', () => {
     const actions: SupervisorAction[] = []
@@ -5171,6 +5175,20 @@ describe('Supervisor TUI screen', () => {
     expect(applyUpdate).not.toHaveBeenCalled()
   })
 })
+
+// Runtime polling fixtures must not discover the host's real registry or use
+// their scripted inspect responses to populate the independent Fleet inventory.
+async function isolatedLocalFleet(): Promise<MachineFleetEnvelope> {
+  return {
+    schemaVersion: 1,
+    generatedAt: '2026-09-02T00:00:00Z',
+    machines: fleetMachines().filter((machine) => machine.key === 'local'),
+  }
+}
+
+async function isolatedEmptyInbox(endpoint: string) {
+  return { endpoint, entries: [], hasMore: false, refreshedAt: 0 }
+}
 
 function fleetMachines(): MachineInventory[] {
   const project = (key: string): MachineInventory['projects'][number] => ({

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -2,9 +2,37 @@
 
 ## Stable 0.91.0 acceptance — 2026-09-05
 
+Release source `af04fec0` (including UI integration #1352) was explicitly
+selected by the maintainer and promoted through #1349 after all local and
+hosted source/package/installer/SSH/dev-activation gates passed. Version-only
+#1353 then passed its stable gates and set both manifests to `0.91.0` on master
+`190778de`. No `v0.91.0` tag or public assets have been created.
+
+Final manual Full Source Validation
+[33899369066](https://github.com/TraderAlice/OpenAlice/actions/runs/33899369066)
+found two TUI fixture timeouts on clean macOS and three failures on Linux.
+The same three failures reproduce in isolated local Linux Docker, despite all
+91 TUI tests passing on the development Mac. The fixtures let Fleet discovery
+read the host registry/Home and consume scripted Runtime inspection results:
+an absent host Home disables Launch, while background inventory consumes a
+failure intended for the active-target health sequence. Replace these incidental
+host/network reads with explicit local Fleet and empty Inbox fixtures; retain
+the complete launch/recovery assertions and remove the ineffective CI-only
+timeout increase. This is a test-only dev-lane correction, not a runtime fix or
+a reason to waive final stable validation. Re-promote only this correction,
+preserving the already prepared stable manifest versions.
+
+The corrected fixture passes all 91 TUI tests twice in a fresh Linux container
+(1.77s and 1.81s total, compared with reproducible 31.85s failed baseline),
+without changing production code or weakening the three-failure recovery
+sequence. CLI/root types and full local regression passed: 714 files, 6,360
+tests passed, three expected skips, 243.48 seconds.
+
+Earlier acceptance evidence:
+
 Maintainer authorized stable publication, including both Windows CLI targets.
 AUR activation is deferred while account registration is closed. Promotion
-[PR #1349](https://github.com/TraderAlice/OpenAlice/pull/1349) remains unmerged:
+[PR #1349](https://github.com/TraderAlice/OpenAlice/pull/1349) initially waited on:
 local full regression (712 files, 6,360 passes, three expected skips), root
 types, unsigned packaged Workspace/Pi acceptance, OrbStack Docker and Guardian
 recovery passed. The exact dev channel and both Windows native replay receipts
@@ -12,10 +40,9 @@ passed. Hosted Docker passed unchanged on retry, as did Windows desktop/upgrade,
 Windows Broker Packs and Apple Silicon desktop/upgrade.
 
 Intel desktop Guardian/PTY smoke timed out twice after successful takeover;
-the second run also recorded a spawned Shell but no PTY connection. Do not retry
-blindly or waive it. Add smoke-only boundary diagnostics and a single-host manual
-rehearsal selector, identify the cause, then resume promotion and the separate
-version-only preparation. No stable tag or public 0.91.0 bytes exist yet. Release
+the second run also recorded a spawned Shell but no PTY connection. Smoke-only
+boundary diagnostics and a single-host rehearsal then passed as described below.
+No stable tag or public 0.91.0 bytes exist yet. Release
 and package-manager authority remain owned by [[docs/development-workflow.md]]
 and [[docs/cli-package-managers.md]].
 
@@ -24,8 +51,8 @@ passed native Intel takeover, PTY/CLI, packaged Workspace/Pi, and previous-app
 upgrade acceptance. Main returned Workspace HTTP 201 at `16:17:23.386Z`; the
 renderer observed response headers at `16:18:24.943Z`, then successfully spawned
 and attached the Shell. Total takeover smoke was 88 seconds against a 90-second
-budget. Increase only the smoke's bounded overall deadline to 180 seconds;
-retain every assertion and phase diagnostic, with no sleep, retry loop or
+budget. PR #1351 increased only the bounded overall deadline to 180 seconds,
+retaining every assertion and phase diagnostic, with no sleep, retry loop or
 production transport workaround. The underlying renderer delivery latency is
 not explained or claimed fixed; track it in [#1350](https://github.com/TraderAlice/OpenAlice/issues/1350). Local diagnostic regression
 passed 712 files / 6,361 tests with three expected skips, root/Desktop types and


### PR DESCRIPTION
This promotion carries only the test-fixture isolation and release-plan record from #1354. Product source remains the maintainer-selected af04fec0; master already owns the accepted 0.91.0 version bump from #1353, which the merge must preserve.

The final full-source run 33899369066 exposed real host dependence in three TUI fixtures, reproduced in fresh local Linux Docker. After isolation, 91 TUI tests passed twice in Linux (1.77s / 1.81s), CLI/root types passed, and the complete Mac suite passed (714 files / 6360 tests / 3 expected skips). No production runtime, installer, build or workflow change is included. The earlier complete native desktop N-1 gates remain relevant to the unchanged product tree.

Wait for applicable promotion checks and the matching post-merge dev candidate activation/live install. Then repeat manual Full Source Validation on the exact merged master SHA before dispatching stable Release. No stable tag or assets have been created.