### PR TITLE
Promote bounded npm package inventory assembly for v0.91.0

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -44,7 +44,8 @@ the durable truth after it changes. Git history is the archive.
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set.
   Homebrew tap is public at `0.90.2` with lightweight hourly/manual stable sync.
   Stable `0.91.0` source and version preparation are merged; final validation
-  exposed host-dependent TUI fixtures, now being isolated before re-promotion.
+  exposed and repaired host-dependent TUI fixtures; the release then exposed
+  npm's 1 MiB subprocess-report buffer, now under bounded repair.
   Native Intel acceptance passed; renderer latency remains tracked in #1350.
   AUR registration remains deferred.
   The CLI package owns OpenAlice only: Agent Runtime installation and Electron

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -2,6 +2,17 @@
 
 ## Stable 0.91.0 acceptance — 2026-09-05
 
+Stable release run
+[33903395758](https://github.com/TraderAlice/OpenAlice/actions/runs/33903395758)
+built all six native archives, but package-manager metadata assembly failed at
+`npm pack` with `spawnSync npm ENOBUFS`. The JSON report now includes the full
+native runtime inventory and exceeds Node's 1 MiB default buffer. Give this
+bounded subprocess 64 MiB and cover the exact option through injected test
+process output; do not suppress npm errors or omit its integrity report. Repair
+through dev/master before dispatching a new release commit. The focused
+package-channel checks passed (seven tests), followed by root types and the
+complete local suite (714 files, 6,361 passes, three skips, 195.26 seconds).
+
 Release source `af04fec0` (including UI integration #1352) was explicitly
 selected by the maintainer and promoted through #1349 after all local and
 hosted source/package/installer/SSH/dev-activation gates passed. Version-only

--- a/scripts/pack-cli-npm-packages.mjs
+++ b/scripts/pack-cli-npm-packages.mjs
@@ -18,6 +18,7 @@ export function packCliNpmPackages({
   inputDir,
   outputDir,
   npm = process.platform === 'win32' ? 'npm.cmd' : 'npm',
+  spawnNpm = spawnSync,
 }) {
   const inputRoot = resolve(inputDir)
   const outputRoot = resolve(outputDir)
@@ -45,7 +46,7 @@ export function packCliNpmPackages({
   mkdirSync(outputRoot, { recursive: true })
   const packages = []
   for (const name of [...platformNames, meta.name]) {
-    const packed = pack(join(inputRoot, name), outputRoot, npm)
+    const packed = pack(join(inputRoot, name), outputRoot, npm, spawnNpm)
     packages.push({
       name,
       version: meta.version,
@@ -64,13 +65,16 @@ export function packCliNpmPackages({
   return manifest
 }
 
-function pack(packageRoot, outputRoot, npm) {
-  const result = spawnSync(npm, [
+function pack(packageRoot, outputRoot, npm, spawnNpm) {
+  const result = spawnNpm(npm, [
     'pack', packageRoot, '--json', '--pack-destination', outputRoot,
   ], {
     encoding: 'utf8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    // npm --json includes the complete file inventory. Native runtime packages
+    // legitimately exceed Node's 1 MiB spawnSync default before compression.
+    maxBuffer: 64 * 1024 * 1024,
   })
   if (result.error) throw result.error
   if (result.status !== 0) {

--- a/scripts/pack-cli-npm-packages.spec.mjs
+++ b/scripts/pack-cli-npm-packages.spec.mjs
@@ -42,6 +42,32 @@ describe('CLI npm package packing', () => {
       outputDir: join(root, 'output'),
     })).toThrow('platform package does not match')
   })
+
+  it('allows npm to report the complete native runtime inventory', async () => {
+    const root = await fixture()
+    const calls = []
+    const spawnNpm = (command, args, options) => {
+      calls.push({ command, args, options })
+      return {
+        status: 0,
+        stdout: JSON.stringify([{
+          filename: `package-${calls.length}.tgz`,
+          shasum: 'a'.repeat(40),
+          integrity: 'sha512-fixture',
+        }]),
+        stderr: '',
+      }
+    }
+
+    packCliNpmPackages({
+      inputDir: join(root, 'input'),
+      outputDir: join(root, 'output'),
+      spawnNpm,
+    })
+
+    expect(calls).toHaveLength(3)
+    expect(calls.every(({ options }) => options.maxBuffer === 64 * 1024 * 1024)).toBe(true)
+  })
 })
 
 async function fixture({ platformVersion = '0.90.1' } = {}) {


### PR DESCRIPTION
This promotion carries only #1358: a 64 MiB bounded `npm pack --json` subprocess buffer, its focused option contract, and the existing release plan/index update. It fixes the actual `spawnSync npm ENOBUFS` failure from stable run 33903395758 after all six native archives were built. Runtime/native payload behavior is unchanged; master already owns version 0.91.0 and merge-tree verification must preserve both version fields.

Local acceptance: focused package-channel specs 7 passed; root TypeScript passed; full suite 714 files / 6361 tests / 3 skips. Wait for exact dev candidate activation/live install and applicable promotion checks. The failed release run is continuing its three platform N-1 desktop receipts so additional product failures are not hidden. After promotion, repeat final full source validation and dispatch a new exact-master stable release; old run cannot publish a tag because package-manager assembly failed.