### PR TITLE
Reclaim stale runtime locks after Docker container restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,10 @@ ENV OPENALICE_APP_HOME=/app \
     OPENALICE_MCP_PORT=47332 \
     OPENALICE_UTA_PORT=47333 \
     OPENALICE_CONNECTOR_PORT=47334 \
-    OPENALICE_BIND_HOST=0.0.0.0
+    OPENALICE_BIND_HOST=0.0.0.0 \
+    # No /etc/machine-id in this image, and the hostname changes on every
+    # recreate. Override per host if one /data volume is shared (unsupported).
+    OPENALICE_MACHINE_ID=openalice-docker
 
 VOLUME ["/data"]
 EXPOSE 47331

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -711,6 +711,9 @@ app.whenReady().then(async () => {
       launcher: app.isPackaged ? 'guardian-electron-packaged' : 'guardian-electron-dev',
       takeover,
       processStartedAt: guardianStartedAt,
+      onOwnerReclaimed: ({ owner, state, reason }) => {
+        console.warn(`[guardian] reclaimed ${owner?.launcher ?? 'unknown'} lock from pid ${owner?.pid ?? 'unknown'} (${state}: ${reason})`)
+      },
       onOwnershipLost: (err) => {
         console.error('[guardian] runtime ownership lost:', err)
         shutdown()

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -53,6 +53,19 @@ launchers must use an activated downloaded Pack. Set
 `OPENALICE_BROKER_PACK_ALLOW_WORKSPACE=1` only for an intentional source-tree
 runtime; never use it to disguise a missing production artifact.
 
+Each `packages/uta-broker-<engine>/src/index.ts` imports its broker
+implementation from outside the package
+(`services/uta/src/domain/trading/brokers/<engine>/...`), and tsup's
+`noExternal` bundles that source directly into `dist/index.js` rather than
+treating it as an external dependency. Because this is a relative-path import
+and not a `package.json` dependency edge, Turbo cannot infer it: `turbo.json`
+declares an explicit `inputs` override for each `uta-broker-*` package that
+adds `$TURBO_ROOT$/services/uta/src/**` on top of `$TURBO_DEFAULT$`, so editing
+UTA broker source correctly invalidates that pack's build cache. If a new
+broker wrapper package bundles files from outside its own directory, add a
+matching per-package `inputs` override or its `pnpm broker-packs:build` output
+can silently ship stale code from a cache hit.
+
 Pack-local dependency copies cross a structural API boundary. Core code must
 not depend on class identity from a Pack's dependency tree; use structural
 checks such as `Decimal.isDecimal` and stable error codes instead of

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -96,6 +96,16 @@ docker compose up -d --build
 `docker compose down` preserves the named volume. `docker compose down -v` is
 a factory reset and permanently removes user data.
 
+The image pins `OPENALICE_MACHINE_ID=openalice-docker` because slim runtime
+images have no `/etc/machine-id`, and the container hostname (Guardian's
+fallback) changes on every recreate; since `/data` is a host-local volume, a
+stable identity lets Guardian reclaim a stale `runtime.lock` left by an
+unclean shutdown instead of crash-looping with an "owner belongs to another
+machine" error. The pin only affects records written by images that carry it;
+locks written before it are reclaimed because Guardian never treats a
+hostname-derived machine id as another machine. `OPENALICE_TAKEOVER=1` remains
+the manual escape hatch when a lock genuinely needs to be forced.
+
 ## Backup and Restore
 
 Stop the container before taking a filesystem-consistent volume snapshot:

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -103,8 +103,15 @@ stable identity lets Guardian reclaim a stale `runtime.lock` left by an
 unclean shutdown instead of crash-looping with an "owner belongs to another
 machine" error. The pin only affects records written by images that carry it;
 locks written before it are reclaimed because Guardian never treats a
-hostname-derived machine id as another machine. `OPENALICE_TAKEOVER=1` remains
-the manual escape hatch when a lock genuinely needs to be forced.
+hostname-derived machine id as another machine.
+
+`OPENALICE_TAKEOVER=1` is the manual escape hatch for a lock that must be
+forced, including one recorded against a different machine id (an overridden
+`OPENALICE_MACHINE_ID`, or a volume restored from another host). Guardian never
+signals a process it cannot address, so it clears such a record only once the
+owner's heartbeat has gone stale. A cross-machine owner that is still
+heartbeating keeps refusing takeover: something is running against this state
+and the correct fix is to stop it, not to force the lock.
 
 ## Backup and Restore
 

--- a/packages/guardian-runtime/src/process-control.spec.ts
+++ b/packages/guardian-runtime/src/process-control.spec.ts
@@ -2,7 +2,15 @@ import { spawn } from 'node:child_process'
 import { once } from 'node:events'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { normalizeProcessExitCode, terminateProcessTree } from './process-control.js'
+import {
+  compareProcessIdentity,
+  currentProcessStartedAt,
+  defaultProcessController,
+  normalizeProcessExitCode,
+  parseProcBootTimeSeconds,
+  parseProcStatStartTicks,
+  terminateProcessTree,
+} from './process-control.js'
 
 const cleanupPids = new Set<number>()
 
@@ -25,6 +33,78 @@ describe('normalizeProcessExitCode', () => {
     expect(normalizeProcessExitCode('SIGTERM')).toBe(0)
     expect(normalizeProcessExitCode(Number.NaN)).toBe(0)
     expect(normalizeProcessExitCode(-1)).toBe(0)
+  })
+})
+
+describe('procfs process start time parsing', () => {
+  const commWithParens = '4242 (my (weird) proc name) S 1 4242 4242 0 -1 4194304 1234 0 0 0 12 7 0 0 20 0 9 0 8675309 123456 789 18446744073709551615 1 1 0 0 0 0 0 0 0 0 0 0 17 3 0 0 0 0 0\n'
+
+  it('reads field 22 past a comm containing spaces and parentheses', () => {
+    expect(parseProcStatStartTicks(commWithParens)).toBe(8_675_309)
+  })
+
+  it('reads a plain comm', () => {
+    expect(parseProcStatStartTicks('7 (node) S 0 7 7 0 -1 4194304 1 0 0 0 1 1 0 0 20 0 11 0 4242 1 1')).toBe(4_242)
+  })
+
+  it('rejects malformed stat lines', () => {
+    expect(parseProcStatStartTicks('')).toBeNull()
+    expect(parseProcStatStartTicks('7 node S 1 2 3')).toBeNull()
+    expect(parseProcStatStartTicks('7 (node) S 1')).toBeNull()
+  })
+
+  it('reads btime from /proc/stat and ignores other rows', () => {
+    const content = [
+      'cpu  1 2 3 4',
+      'intr 0 0 0',
+      'btime 1756800000',
+      'processes 4242',
+    ].join('\n')
+    expect(parseProcBootTimeSeconds(content)).toBe(1_756_800_000)
+    expect(parseProcBootTimeSeconds('cpu 1 2 3\nprocesses 4')).toBeNull()
+  })
+})
+
+describe('compareProcessIdentity', () => {
+  const controller = {
+    isAlive: () => true,
+    startedAt: async () => {
+      throw new Error('startedAt must not be consulted for our own pid')
+    },
+    machineId: async () => 'machine-a',
+    signalTree: async () => undefined,
+    sleep: async () => undefined,
+  }
+
+  it('reports a recorded owner that reuses our own pid as a different process', async () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1_000).toISOString()
+    await expect(compareProcessIdentity(process.pid, twoDaysAgo, controller)).resolves.toBe('different')
+  })
+
+  it('recognizes our own pid when the recorded start time is ours', async () => {
+    const ours = new Date(currentProcessStartedAt()).toISOString()
+    await expect(compareProcessIdentity(process.pid, ours, controller)).resolves.toBe('same')
+  })
+
+  it('records our own start time on the same clock the controller reports', async () => {
+    // A guardian writes `currentProcessStartedAt()` into the lock; a different
+    // process reads that pid back through the controller. Any systematic gap
+    // between the two is spent out of the pid-reuse tolerance before reuse is
+    // even considered.
+    const reported = await defaultProcessController.startedAt(process.pid)
+    expect(reported).not.toBeNull()
+    if (process.platform === 'linux') expect(currentProcessStartedAt()).toBe(reported)
+    else expect(Math.abs(reported! - currentProcessStartedAt())).toBeLessThan(2_000)
+  })
+
+  it('reads a real foreign pid start time on Linux without shelling out', async () => {
+    if (process.platform !== 'linux') return
+    const child = spawn(process.execPath, ['-e', 'setInterval(()=>{},1000)'], { stdio: 'ignore' })
+    if (!child.pid) throw new Error('child did not start')
+    cleanupPids.add(child.pid)
+    const startedAt = new Date().toISOString()
+    await expect(compareProcessIdentity(child.pid, startedAt)).resolves.toBe('same')
+    await expect(compareProcessIdentity(child.pid, '2020-01-01T00:00:00.000Z')).resolves.toBe('different')
   })
 })
 

--- a/packages/guardian-runtime/src/process-control.ts
+++ b/packages/guardian-runtime/src/process-control.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { hostname } from 'node:os'
 import { promisify } from 'node:util'
@@ -40,8 +41,15 @@ export function machineIdentity(): Promise<string> {
   return machineIdPromise
 }
 
-/** Rounded to seconds so it can be compared with `ps lstart` on POSIX. */
+/**
+ * Must come from the same clock `ProcessController.startedAt()` reads back.
+ * `process.uptime()` counts from Node's main(), about 1s after exec, which
+ * eats most of `PROCESS_START_TOLERANCE_MS`. The fallback is rounded to
+ * seconds to match `ps lstart`.
+ */
 export function currentProcessStartedAt(): number {
+  const fromProcfs = readProcfsProcessStartedAtSync(process.pid)
+  if (fromProcfs !== null) return fromProcfs
   return Math.floor((Date.now() - process.uptime() * 1_000) / 1_000) * 1_000
 }
 
@@ -57,18 +65,45 @@ export function normalizeProcessExitCode(value: unknown): number {
     : 0
 }
 
+/**
+ * Result of comparing a live pid against the start time recorded for it.
+ *
+ * `unverified` means the platform could not report a start time at all, so the
+ * pid may or may not still be the recorded process. Callers decide how to treat
+ * that ambiguity: liveness checks fail open, while lock inspection combines it
+ * with heartbeat age.
+ */
+export type ProcessIdentityMatch = 'same' | 'different' | 'unverified'
+
+/** `ps lstart` reports whole seconds and the fallback in
+ * `currentProcessStartedAt()` rounds to whole seconds, so a small tolerance
+ * keeps every source comparable. */
+const PROCESS_START_TOLERANCE_MS = 2_000
+
+export async function compareProcessIdentity(
+  pid: number,
+  expectedStartedAt: string | undefined,
+  controller: ProcessController = defaultProcessController,
+): Promise<ProcessIdentityMatch> {
+  if (!expectedStartedAt) return 'unverified'
+  const expected = Date.parse(expectedStartedAt)
+  if (!Number.isFinite(expected)) return 'unverified'
+  // A recorded owner pid that is our own pid never needs an external lookup:
+  // we already know when this process started. A container restarted under the
+  // same pid namespace hands the fresh process the same low pid as the owner it
+  // is meant to replace, so this must resolve to `different`, not `unverified`.
+  const actual = pid === process.pid ? currentProcessStartedAt() : await controller.startedAt(pid)
+  if (actual === null) return 'unverified'
+  return Math.abs(actual - expected) <= PROCESS_START_TOLERANCE_MS ? 'same' : 'different'
+}
+
 export async function isSameProcess(
   pid: number,
   expectedStartedAt: string | undefined,
   controller: ProcessController = defaultProcessController,
 ): Promise<boolean> {
   if (!controller.isAlive(pid)) return false
-  if (!expectedStartedAt) return true
-  const expected = Date.parse(expectedStartedAt)
-  if (!Number.isFinite(expected)) return true
-  const actual = await controller.startedAt(pid)
-  if (actual === null) return true
-  return Math.abs(actual - expected) <= 2_000
+  return (await compareProcessIdentity(pid, expectedStartedAt, controller)) !== 'different'
 }
 
 export interface TerminateProcessTreeOptions {
@@ -128,7 +163,74 @@ async function waitForProcessesExit(
   return pids.every((pid) => !controller.isAlive(pid))
 }
 
+/**
+ * Linux exposes process start time in `/proc/<pid>/stat` field 22, counted in
+ * clock ticks since boot. `/proc` always reports these in USER_HZ (100), which
+ * is fixed in the kernel ABI regardless of the compiled-in scheduler HZ, so the
+ * conversion does not need `sysconf(_SC_CLK_TCK)`.
+ *
+ * Field 2 (`comm`) is unquoted and may itself contain spaces and parentheses,
+ * so the fields are parsed after the LAST `)` rather than by splitting the
+ * whole line.
+ */
+export function parseProcStatStartTicks(content: string): number | null {
+  const commEnd = content.lastIndexOf(')')
+  if (commEnd < 0) return null
+  const fields = content.slice(commEnd + 1).trim().split(/\s+/)
+  // Fields resume at 3 (state) after `comm`, so field 22 is index 19.
+  const ticks = Number(fields[19])
+  return Number.isFinite(ticks) && ticks >= 0 ? ticks : null
+}
+
+/** Seconds since the epoch at which the machine booted, from `/proc/stat`. */
+export function parseProcBootTimeSeconds(content: string): number | null {
+  const value = /^btime\s+(\d+)$/m.exec(content)?.[1]
+  if (value === undefined) return null
+  const seconds = Number(value)
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null
+}
+
+const USER_HZ = 100
+
+function procfsStartedAt(statContent: string, bootContent: string): number | null {
+  const ticks = parseProcStatStartTicks(statContent)
+  const bootSeconds = parseProcBootTimeSeconds(bootContent)
+  if (ticks === null || bootSeconds === null) return null
+  return bootSeconds * 1_000 + (ticks / USER_HZ) * 1_000
+}
+
+async function readProcfsProcessStartedAt(pid: number): Promise<number | null> {
+  try {
+    const [statContent, bootContent] = await Promise.all([
+      readFile(`/proc/${pid}/stat`, 'utf8'),
+      readFile('/proc/stat', 'utf8'),
+    ])
+    return procfsStartedAt(statContent, bootContent)
+  } catch {
+    return null
+  }
+}
+
+function readProcfsProcessStartedAtSync(pid: number): number | null {
+  if (process.platform !== 'linux') return null
+  try {
+    return procfsStartedAt(
+      readFileSync(`/proc/${pid}/stat`, 'utf8'),
+      readFileSync('/proc/stat', 'utf8'),
+    )
+  } catch {
+    return null
+  }
+}
+
 async function readProcessStartedAt(pid: number): Promise<number | null> {
+  // Prefer procfs on Linux. Minimal container images (including the OpenAlice
+  // server image) ship no `ps`, and a failed lookup there used to make every
+  // recorded owner look unverifiable forever.
+  if (process.platform === 'linux') {
+    const fromProcfs = await readProcfsProcessStartedAt(pid)
+    if (fromProcfs !== null) return fromProcfs
+  }
   try {
     if (process.platform === 'win32') {
       const script = `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')`
@@ -146,6 +248,15 @@ async function readProcessStartedAt(pid: number): Promise<number | null> {
   } catch {
     return null
   }
+}
+
+/**
+ * `hostname:` ids are the fallback used when no stable machine id exists, e.g.
+ * slim containers without /etc/machine-id. Hostnames change on container
+ * recreate and are not unique, so such an id is not evidence of a machine.
+ */
+export function isWeakMachineId(id: string): boolean {
+  return id.startsWith('hostname:')
 }
 
 async function readMachineId(): Promise<string> {

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { ProcessController } from './process-control.js'
 import {
+  CrossMachineOwnerError,
   RuntimeAlreadyRunningError,
   acquireGuardianRuntime,
   acquireOpenAliceRuntimeLocks,
@@ -316,6 +317,87 @@ describe('runtime lock ownership', () => {
       heartbeatStale: true,
       reason: expect.stringContaining('another machine'),
     })
+  })
+
+  it('claims a stale cross-machine lock under takeover without signalling anything', async () => {
+    controller.currentMachineId = 'linux:aaa'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.currentMachineId = 'linux:bbb'
+    controller.add(202, 20_000)
+
+    const reclaimed = await acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      takeover: true,
+      staleHeartbeatMs: -1,
+      processController: controller,
+    })
+
+    expect(reclaimed.owner.pid).toBe(202)
+    expect(controller.signals).toEqual([])
+    expect(controller.isAlive(101)).toBe(true)
+    await reclaimed.release()
+  })
+
+  it('refuses takeover of a cross-machine lock that is still heartbeating', async () => {
+    controller.currentMachineId = 'linux:aaa'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.currentMachineId = 'linux:bbb'
+    controller.add(202, 20_000)
+
+    const refusal = await acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      takeover: true,
+      processController: controller,
+    }).catch((err: unknown) => err)
+
+    expect(refusal).toBeInstanceOf(CrossMachineOwnerError)
+    expect(refusal).toBeInstanceOf(RuntimeAlreadyRunningError)
+    expect(refusal).toMatchObject({
+      message: 'OpenAlice owner 101 belongs to another machine; refusing to signal it',
+      inspection: { state: 'active', owner: { pid: 101 } },
+    })
+    expect(controller.signals).toEqual([])
+  })
+
+  it('reports a stale cross-machine lock as already running without takeover', async () => {
+    controller.currentMachineId = 'linux:aaa'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.currentMachineId = 'linux:bbb'
+    controller.add(202, 20_000)
+
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      staleHeartbeatMs: -1,
+      processController: controller,
+    })).rejects.toBeInstanceOf(RuntimeAlreadyRunningError)
+    expect(controller.signals).toEqual([])
   })
 
   it('never signals or reclaims an owner recorded on another machine', async () => {

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { ProcessController } from './process-control.js'
+import type { RuntimeLockInspection } from './runtime-lock.js'
 import {
   CrossMachineOwnerError,
   RuntimeAlreadyRunningError,
@@ -135,6 +136,51 @@ describe('runtime lock ownership', () => {
       owner: { pid: 202 },
     })
     await fresh.release()
+  })
+
+  it('reports the inspection that justified reclaiming a dead owner', async () => {
+    controller.add(101, 10_000)
+    controller.add(202, 20_000)
+    const lockDir = join(home, 'runtime.lock')
+    const reclaimed: RuntimeLockInspection[] = []
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      launcher: 'guardian-docker',
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, false)
+
+    const fresh = await acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
+      heartbeatMs: 0,
+      processController: controller,
+      onOwnerReclaimed: (inspection) => { reclaimed.push(inspection) },
+    })
+    expect(reclaimed).toHaveLength(1)
+    expect(reclaimed[0]).toMatchObject({
+      state: 'stale',
+      reason: 'owner process is not running',
+      owner: { pid: 101, launcher: 'guardian-docker' },
+    })
+    await fresh.release()
+  })
+
+  it('does not report a reclaim when the lock was free', async () => {
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    const reclaimed: RuntimeLockInspection[] = []
+    const lock = await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+      onOwnerReclaimed: (inspection) => { reclaimed.push(inspection) },
+    })
+    expect(reclaimed).toEqual([])
+    await lock.release()
   })
 
   it('keeps a live owner authoritative even when its heartbeat is stale', async () => {
@@ -332,6 +378,7 @@ describe('runtime lock ownership', () => {
     controller.currentMachineId = 'linux:bbb'
     controller.add(202, 20_000)
 
+    const reported: RuntimeLockInspection[] = []
     const reclaimed = await acquireRuntimeLock(lockDir, {
       pid: 202,
       processStartedAt: 20_000,
@@ -339,11 +386,18 @@ describe('runtime lock ownership', () => {
       takeover: true,
       staleHeartbeatMs: -1,
       processController: controller,
+      onOwnerReclaimed: (inspection) => { reported.push(inspection) },
     })
 
     expect(reclaimed.owner.pid).toBe(202)
     expect(controller.signals).toEqual([])
     expect(controller.isAlive(101)).toBe(true)
+    expect(reported).toHaveLength(1)
+    expect(reported[0]).toMatchObject({
+      state: 'active',
+      reason: expect.stringContaining('another machine'),
+      owner: { pid: 101 },
+    })
     await reclaimed.release()
   })
 

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -478,6 +478,12 @@ describe('runtime lock ownership', () => {
     await expect(acquireRuntimeLock(lockDir, {
       pid: 202,
       processStartedAt: 20_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })).rejects.toThrow(/already running as pid 101 \(last heartbeat .*; owner belongs to another machine/)
+    await expect(acquireRuntimeLock(lockDir, {
+      pid: 202,
+      processStartedAt: 20_000,
       takeover: true,
       heartbeatMs: 0,
       processController: controller,

--- a/packages/guardian-runtime/src/runtime-lock.spec.ts
+++ b/packages/guardian-runtime/src/runtime-lock.spec.ts
@@ -153,6 +153,171 @@ describe('runtime lock ownership', () => {
     await lock.release()
   })
 
+  it('treats an owner recorded under this process\u2019s own pid as stale after a restart', async () => {
+    // Reproduces the Docker restart crash loop: the container comes back with
+    // the same low pid the previous guardian recorded two days earlier.
+    controller.add(process.pid, 10_000)
+    const lockDir = join(home, 'guardian.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: process.pid,
+      processStartedAt: Date.now() - 2 * 24 * 60 * 60 * 1_000,
+      launcher: 'guardian-docker',
+      heartbeatMs: 0,
+      processController: controller,
+    })
+
+    await expect(inspectRuntimeLock(lockDir, {
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'stale',
+      reason: expect.stringContaining('this process'),
+    })
+
+    const fresh = await acquireRuntimeLock(lockDir, {
+      pid: process.pid,
+      processStartedAt: Date.now(),
+      launcher: 'guardian-docker',
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    expect(controller.signals).toEqual([])
+    await fresh.release()
+  })
+
+  it('reclaims an unverifiable same-machine owner only once its heartbeat is stale', async () => {
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    // Alive, but the platform cannot report a start time for it.
+    controller.alive.set(101, true)
+    controller.starts.delete(101)
+
+    await expect(inspectRuntimeLock(lockDir, { processController: controller })).resolves.toMatchObject({
+      state: 'active',
+      heartbeatStale: false,
+      reason: 'owner process is alive',
+    })
+    await expect(inspectRuntimeLock(lockDir, {
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'stale',
+      heartbeatStale: true,
+      reason: expect.stringContaining('cannot be verified'),
+    })
+  })
+
+  it('keeps an unverifiable stale owner on another machine untouchable', async () => {
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, true)
+    controller.starts.delete(101)
+    controller.currentMachineId = 'machine-b'
+
+    await expect(inspectRuntimeLock(lockDir, {
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'active',
+      reason: expect.stringContaining('another machine'),
+    })
+  })
+
+  it('reclaims a dead hostname-derived owner after the machine id scheme changes', async () => {
+    controller.currentMachineId = 'hostname:ff00126d7ea7'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, false)
+    controller.currentMachineId = 'env:openalice-docker'
+
+    await expect(inspectRuntimeLock(lockDir, {
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'stale',
+      reason: expect.stringContaining('not running'),
+    })
+  })
+
+  it('keeps a live hostname-derived owner active after the machine id scheme changes', async () => {
+    controller.currentMachineId = 'hostname:ff00126d7ea7'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.currentMachineId = 'env:openalice-docker'
+
+    await expect(inspectRuntimeLock(lockDir, { processController: controller })).resolves.toMatchObject({
+      state: 'active',
+      reason: 'owner process is alive',
+    })
+  })
+
+  it('reclaims a dead owner when only the recorded hostname differs', async () => {
+    controller.currentMachineId = 'hostname:a'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, false)
+    controller.currentMachineId = 'hostname:b'
+
+    await expect(inspectRuntimeLock(lockDir, {
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'stale',
+      reason: expect.stringContaining('not running'),
+    })
+  })
+
+  it('still refuses takeover when both machine ids are strong and differ', async () => {
+    controller.currentMachineId = 'linux:aaa'
+    controller.add(101, 10_000)
+    const lockDir = join(home, 'runtime.lock')
+    await acquireRuntimeLock(lockDir, {
+      pid: 101,
+      processStartedAt: 10_000,
+      heartbeatMs: 0,
+      processController: controller,
+    })
+    controller.alive.set(101, false)
+    controller.currentMachineId = 'linux:bbb'
+
+    await expect(inspectRuntimeLock(lockDir, {
+      processController: controller,
+      staleHeartbeatMs: -1,
+    })).resolves.toMatchObject({
+      state: 'active',
+      heartbeatStale: true,
+      reason: expect.stringContaining('another machine'),
+    })
+  })
+
   it('never signals or reclaims an owner recorded on another machine', async () => {
     controller.add(101, 10_000)
     controller.add(202, 20_000)

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -4,9 +4,11 @@ import { hostname } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
 import {
+  compareProcessIdentity,
   currentProcessStartedAt,
   defaultProcessController,
   isSameProcess,
+  isWeakMachineId,
   terminateProcessTree,
   type ProcessController,
 } from './process-control.js'
@@ -148,7 +150,8 @@ export async function inspectRuntimeLock(
   const heartbeatAt = Date.parse(owner.heartbeatAt)
   const heartbeatAgeMs = Number.isFinite(heartbeatAt) ? Math.max(0, Date.now() - heartbeatAt) : null
   const heartbeatStale = heartbeatAgeMs === null || heartbeatAgeMs > staleMs
-  if (owner.machineId && owner.machineId !== await controller.machineId()) {
+  const crossMachine = await isCrossMachineOwner(owner, controller)
+  if (crossMachine) {
     return inspection(
       lockDir,
       'active',
@@ -164,8 +167,34 @@ export async function inspectRuntimeLock(
   if (!controller.isAlive(owner.pid)) {
     return inspection(lockDir, 'stale', owner, heartbeatAgeMs, heartbeatStale, directoryIdentity, 'owner process is not running')
   }
-  if (!(await isSameProcess(owner.pid, owner.processStartedAt, controller))) {
-    return inspection(lockDir, 'stale', owner, heartbeatAgeMs, heartbeatStale, directoryIdentity, 'owner pid has been reused')
+  const identity = await compareProcessIdentity(owner.pid, owner.processStartedAt, controller)
+  if (identity === 'different') {
+    return inspection(
+      lockDir,
+      'stale',
+      owner,
+      heartbeatAgeMs,
+      heartbeatStale,
+      directoryIdentity,
+      owner.pid === process.pid
+        ? 'owner pid is this process, so the recorded owner is gone (pid reuse after a restart)'
+        : 'owner pid has been reused',
+    )
+  }
+  // The owner is on this machine, its recorded identity cannot be confirmed,
+  // and it stopped heartbeating. Failing open here strands the lock forever on
+  // hosts where no start time is readable; the cross-machine refusal above
+  // still runs first, and a fresh heartbeat still keeps the owner authoritative.
+  if (identity === 'unverified' && heartbeatStale && owner.processStartedAt) {
+    return inspection(
+      lockDir,
+      'stale',
+      owner,
+      heartbeatAgeMs,
+      heartbeatStale,
+      directoryIdentity,
+      'owner identity cannot be verified and its heartbeat is stale',
+    )
   }
   return inspection(
     lockDir,
@@ -176,6 +205,23 @@ export async function inspectRuntimeLock(
     directoryIdentity,
     heartbeatStale ? 'owner process is alive but its heartbeat is stale' : 'owner process is alive',
   )
+}
+
+/**
+ * True only when both sides carry strong machine ids that differ. A
+ * `hostname:`-scheme id is the fallback for slim containers without
+ * /etc/machine-id, and hostnames change on every container recreate, so a
+ * mismatch involving one is not evidence of a different machine.
+ */
+async function isCrossMachineOwner(
+  owner: RuntimeLockOwner,
+  controller: ProcessController,
+): Promise<boolean> {
+  const ownerMachineId = owner.machineId
+  if (!ownerMachineId) return false
+  const currentMachineId = await controller.machineId()
+  if (ownerMachineId === currentMachineId) return false
+  return !isWeakMachineId(ownerMachineId) && !isWeakMachineId(currentMachineId)
 }
 
 export async function acquireRuntimeLock(
@@ -295,7 +341,8 @@ export async function recoverRuntimeOwner(
   opts: { readonly processController?: ProcessController } = {},
 ): Promise<void> {
   const controller = opts.processController ?? defaultProcessController
-  if (owner.machineId && owner.machineId !== await controller.machineId()) {
+  const crossMachine = await isCrossMachineOwner(owner, controller)
+  if (crossMachine) {
     throw new Error(`OpenAlice owner ${owner.pid} belongs to another machine; refusing to signal it`)
   }
   if (!controller.isAlive(owner.pid)) return

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -109,7 +109,7 @@ export class CrossMachineOwnerError extends RuntimeAlreadyRunningError {
 function describeUnavailableLock(inspection: RuntimeLockInspection): string {
   const owner = inspection.owner
   return owner
-    ? `OpenAlice ${owner.launcher} is already running as pid ${owner.pid} (last heartbeat ${owner.heartbeatAt})`
+    ? `OpenAlice ${owner.launcher} is already running as pid ${owner.pid} (last heartbeat ${owner.heartbeatAt}; ${inspection.reason})`
     : `OpenAlice runtime lock is not available: ${inspection.lockDir} (${inspection.reason})`
 }
 

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -63,6 +63,7 @@ export interface RuntimeLockOptions {
   readonly initializationGraceMs?: number
   readonly processController?: ProcessController
   readonly onOwnershipLost?: (error: Error) => void
+  readonly onOwnerReclaimed?: (inspection: RuntimeLockInspection) => void
 }
 
 export interface OpenAliceRuntimeOptions extends RuntimeLockOptions {
@@ -279,12 +280,15 @@ export async function acquireRuntimeLock(
     if (current.state === 'active') {
       if (!opts.takeover || !current.owner) throw new RuntimeAlreadyRunningError(current)
       const signalled = await recoverRuntimeOwner(current, { processController: controller })
-      if (!signalled) await claimAndRemove(current)
+      if (!signalled && await claimAndRemove(current)) opts.onOwnerReclaimed?.(current)
       await controller.sleep(25)
       continue
     }
 
-    if (await claimAndRemove(current)) continue
+    if (await claimAndRemove(current)) {
+      opts.onOwnerReclaimed?.(current)
+      continue
+    }
     await controller.sleep(25)
   }
 

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -70,6 +70,10 @@ export interface OpenAliceRuntimeOptions extends RuntimeLockOptions {
   readonly launcherRoot: string
 }
 
+export interface RecoverRuntimeOwnerOptions {
+  readonly processController?: ProcessController
+}
+
 export interface OpenAliceRuntimeLock {
   readonly lockDirs: readonly string[]
   readonly owners: readonly RuntimeLockOwner[]
@@ -88,13 +92,24 @@ export interface PrepareOpenAliceRuntimeOptions {
 }
 
 export class RuntimeAlreadyRunningError extends Error {
-  constructor(readonly inspection: RuntimeLockInspection) {
-    const owner = inspection.owner
-    super(owner
-      ? `OpenAlice ${owner.launcher} is already running as pid ${owner.pid} (last heartbeat ${owner.heartbeatAt})`
-      : `OpenAlice runtime lock is not available: ${inspection.lockDir} (${inspection.reason})`)
+  constructor(readonly inspection: RuntimeLockInspection, message = describeUnavailableLock(inspection)) {
+    super(message)
     this.name = 'RuntimeAlreadyRunningError'
   }
+}
+
+export class CrossMachineOwnerError extends RuntimeAlreadyRunningError {
+  constructor(owner: RuntimeLockOwner, inspection: RuntimeLockInspection) {
+    super(inspection, `OpenAlice owner ${owner.pid} belongs to another machine; refusing to signal it`)
+    this.name = 'CrossMachineOwnerError'
+  }
+}
+
+function describeUnavailableLock(inspection: RuntimeLockInspection): string {
+  const owner = inspection.owner
+  return owner
+    ? `OpenAlice ${owner.launcher} is already running as pid ${owner.pid} (last heartbeat ${owner.heartbeatAt})`
+    : `OpenAlice runtime lock is not available: ${inspection.lockDir} (${inspection.reason})`
 }
 
 export function runtimeLockDir(userDataHome: string): string {
@@ -263,7 +278,8 @@ export async function acquireRuntimeLock(
     }
     if (current.state === 'active') {
       if (!opts.takeover || !current.owner) throw new RuntimeAlreadyRunningError(current)
-      await recoverRuntimeOwner(current.owner, { processController: controller })
+      const signalled = await recoverRuntimeOwner(current, { processController: controller })
+      if (!signalled) await claimAndRemove(current)
       await controller.sleep(25)
       continue
     }
@@ -331,22 +347,29 @@ export async function prepareOpenAliceRuntime(opts: PrepareOpenAliceRuntimeOptio
   const active = dedupeOwners(inspections.filter((row) => row.state === 'active' && row.owner !== null))
   if (active.length > 0 && !opts.takeover) throw new RuntimeAlreadyRunningError(active[0]!)
   for (const row of active) {
-    await recoverRuntimeOwner(row.owner!, { processController: opts.processController })
+    await recoverRuntimeOwner(row, { processController: opts.processController })
   }
   return inspections
 }
 
+/**
+ * Stop the recorded owner and report whether anything was signalled; `false`
+ * means the caller must reclaim the record itself. A cross-machine pid is
+ * never signalled, so its record is only claimable once its heartbeat is stale.
+ */
 export async function recoverRuntimeOwner(
-  owner: RuntimeLockOwner,
-  opts: { readonly processController?: ProcessController } = {},
-): Promise<void> {
+  inspection: RuntimeLockInspection,
+  opts: RecoverRuntimeOwnerOptions = {},
+): Promise<boolean> {
+  const owner = inspection.owner
+  if (!owner) return false
   const controller = opts.processController ?? defaultProcessController
-  const crossMachine = await isCrossMachineOwner(owner, controller)
-  if (crossMachine) {
-    throw new Error(`OpenAlice owner ${owner.pid} belongs to another machine; refusing to signal it`)
+  if (await isCrossMachineOwner(owner, controller)) {
+    if (!inspection.heartbeatStale) throw new CrossMachineOwnerError(owner, inspection)
+    return false
   }
-  if (!controller.isAlive(owner.pid)) return
-  if (!(await isSameProcess(owner.pid, owner.processStartedAt, controller))) return
+  if (!controller.isAlive(owner.pid)) return false
+  if (!(await isSameProcess(owner.pid, owner.processStartedAt, controller))) return false
 
   let targetPid = owner.pid
   if (
@@ -363,6 +386,7 @@ export async function recoverRuntimeOwner(
   if (controller.isAlive(owner.pid)) {
     throw new Error(`OpenAlice owner pid ${owner.pid} is still alive; refusing to unlock`)
   }
+  return true
 }
 
 function makeLock(lockDir: string, initialOwner: RuntimeLockOwner, opts: RuntimeLockOptions): RuntimeProcessLock {

--- a/scripts/guardian/dev.ts
+++ b/scripts/guardian/dev.ts
@@ -94,6 +94,9 @@ async function main(): Promise<void> {
       launcher: 'guardian-dev',
       takeover,
       processStartedAt: guardianStartedAt,
+      onOwnerReclaimed: ({ owner, state, reason }) => {
+        console.warn(`[guardian] reclaimed ${owner?.launcher ?? 'unknown'} lock from pid ${owner?.pid ?? 'unknown'} (${state}: ${reason})`)
+      },
       onOwnershipLost: (err) => {
         console.error('[guardian] runtime ownership lost:', err)
         try { process.kill(process.pid, 'SIGTERM') } catch { process.exit(1) }

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -638,6 +638,9 @@ export async function startGuardianRuntime() {
     launcher: GUARDIAN_LAUNCHER,
     takeover: TAKEOVER,
     processStartedAt: GUARDIAN_STARTED_AT,
+    onOwnerReclaimed: ({ owner, state, reason }) => {
+      console.warn(`[guardian/prod] reclaimed ${owner?.launcher ?? 'unknown'} lock from pid ${owner?.pid ?? 'unknown'} (${state}: ${reason})`)
+    },
     onOwnershipLost: (err) => {
       console.error('[guardian/prod] runtime ownership lost:', err)
       shutdown()

--- a/src/main.ts
+++ b/src/main.ts
@@ -478,6 +478,9 @@ export async function startAliceRuntime(): Promise<void> {
     takeover: takeoverRequested(),
     ...(guardianPid ? { guardianPid } : {}),
     ...(guardianStartedAt ? { guardianStartedAt } : {}),
+    onOwnerReclaimed: ({ owner, state, reason }) => {
+      console.warn(`runtime-lock: reclaimed ${owner?.launcher ?? 'unknown'} lock from pid ${owner?.pid ?? 'unknown'} (${state}: ${reason})`)
+    },
     onOwnershipLost: (err) => {
       console.error('fatal: OpenAlice runtime ownership lost:', err)
       try { process.kill(process.pid, 'SIGTERM') } catch { process.exit(1) }

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,31 @@
     "@traderalice/openalice-cli#build": {
       "dependsOn": [],
       "outputs": []
+    },
+    "@traderalice/uta-broker-alpaca#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/services/uta/src/**"]
+    },
+    "@traderalice/uta-broker-ccxt#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/services/uta/src/**"]
+    },
+    "@traderalice/uta-broker-ibkr#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/services/uta/src/**"]
+    },
+    "@traderalice/uta-broker-leverup#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/services/uta/src/**"]
+    },
+    "@traderalice/uta-broker-longbridge#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/services/uta/src/**"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- After a host reboot, OOM kill, or `docker compose up -d` recreate, Guardian in the server image crash-looped with `RuntimeAlreadyRunningError` until someone deleted `runtime.lock` and `guardian.lock` by hand. The recorded owner was compared with the wrong tools: the slim image has no `ps`, so the pid start-time check failed open; the image has no `/etc/machine-id`, so the machine id fell back to the container hostname, which changes on every recreate and made every old lock look like another machine's; and the value written into the lock came from `process.uptime()`, about 850 ms behind the procfs value it was later compared against.
- Process identity now reads `/proc/<pid>/stat` on Linux with `ps`/PowerShell as the fallback, the image pins `OPENALICE_MACHINE_ID=openalice-docker`, and a hostname-derived machine id is never treated as evidence of a different machine, so locks written by older images are reclaimed too.
- `OPENALICE_TAKEOVER=1` could not clear a lock recorded against a genuinely different machine id: `recoverRuntimeOwner` refused before checking anything. It now claims such a record once its heartbeat is stale, still never signals a pid it cannot address, and still refuses while the remote owner is heartbeating. The refusal is a typed `CrossMachineOwnerError` carrying the inspection, so the dev launcher renders it as an owner report instead of a raw throw.
- Reclaiming a lock was silent. `RuntimeLockOptions.onOwnerReclaimed` reports the inspection that justified the claim, and every launcher (`scripts/guardian/prod.mjs`, `scripts/guardian/dev.ts`, `apps/desktop/src/main.ts`, `src/main.ts`) logs one line, for example `[guardian/prod] reclaimed guardian-docker lock from pid 7 (stale: owner process is not running)`.
- `pnpm broker-packs:build` could ship a stale pack: each `packages/uta-broker-*` bundle inlines `services/uta/src` through a relative import that turbo does not track, so a cache hit restored an old `dist/index.js` after a broker source edit. Each of those packages now declares `$TURBO_ROOT$/services/uta/src/**` as a build input.

Same root cause as #1177 (draft) for the lock reclaim. That branch persists a random UUID under the state directory and gates foreign reclaim behind an opt-in flag; this one fixes the identity comparison itself so the common Docker case needs no flag, and keeps the flag-free cross-machine refusal for strong ids.

## Included increments

- [x] `fix(guardian): reclaim stale runtime locks after Docker container restarts` (procfs start time, `compareProcessIdentity`, machine id pin, weak hostname ids, same-clock start time, typed cross-machine error)
- [x] `fix(guardian): let takeover clear a stale cross-machine lock`
- [x] `feat(guardian): report reclaimed runtime lock owners to the launcher`
- [x] `fix(build): key broker pack turbo cache on the bundled out-of-package sources`

## Verification

Automated:

- `node scripts/run-tests.mjs --package @traderalice/guardian-runtime`: 9 files, 71 tests passed
- `cd packages/guardian-runtime && npx tsc --noEmit`: clean
- root `npx tsc --noEmit`: clean
- Turbo cache proof with `npx turbo run build --filter=@traderalice/uta-broker-ibkr --dry-run=json`: on this branch the task hash changes after editing `services/uta/src/domain/trading/brokers/ibkr/IbkrBroker.ts` (`44ee180cc0c6ef19` to `9dc4c7f0aad5b274`); with `origin/dev`'s `turbo.json` the same edit leaves the hash at `98cb131f58cafd28`.

Manual, in a disposable compose stack (`oa-infra-test`,  fresh volume, lite mode, no ports), each scenario waiting for the container healthcheck:

- Cold start on an empty volume: healthy in 6 s.
- `docker kill` then `up -d --force-recreate` (new container id and hostname): healthy in 6 s, lock rewritten to the new container, no manual removal.
- Lock seeded with `machineId: hostname:deadbeefcafe` and a heartbeat 5 h old (the shape every pre-pin image leaves behind): reclaimed, healthy in 6 s.
- Lock seeded with `machineId: env:openalice-docker`, stale heartbeat, and pid 7 (the pid Guardian actually gets in the container, so pid reuse): reclaimed, healthy, `RestartCount=0`.
- Lock seeded with a strong foreign id (`env:other-host`) and a stale heartbeat, no takeover: refused with `RuntimeAlreadyRunningError` ("owner belongs to another machine and its heartbeat is stale; refusing automatic takeover"), container stays unhealthy.
- Same lock with `OPENALICE_TAKEOVER=1`: healthy in 6 s, log line `[guardian/prod] takeover -> previous OpenAlice runtime stopped`, owner records rewritten; before the takeover commit this case crash-looped on "belongs to another machine; refusing to signal it".
- Same foreign id with a heartbeat refreshed every 5 s by a sidecar, `OPENALICE_TAKEOVER=1`: 10 refusals, 0 takeovers over 140 s; a live remote owner is never displaced.
- Image checks: `OPENALICE_MACHINE_ID` baked in, `/etc/machine-id` absent (confirming why the pin exists).

Not run: `pnpm test:system:guardian` spawns the real `pnpm dev` stack on 47331-47334, which a live container on this host holds. The `ps`/PowerShell fallback path for non-Linux hosts is covered by unit tests only.

## Boundary touch

- runtime (Guardian lock acquisition, takeover semantics, launcher logging)
- packaging (server image env pin, broker pack turbo inputs)
- none for trading, auth, credentials, or migrations

## Non-goals

- Bounded restarts or a distinct exit code when a cross- today it crash-loops under `restart: unless-stopped` andthe reason is only in the logs.
- Removing the `identity === 'unverified'` and stale-heak without terminating an owner; it only triggers whenprocfs, `ps`, and PowerShell all fail and is unchanged here.
- Sharing one `/data` volume across hosts; documented as unsupported, the machine id must be overridden per host.
- Any tooling added to the server image beyond the machine id pin.