### PR TITLE
fix(test): expose system tools in Bun recovery acceptance

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -7,10 +7,23 @@ curl/PowerShell, npm/Bun, Homebrew, and AUR. CLI uses system Git/Bash; Electron
 retains its independent bundled runtime. Existing working tools are reused,
 not downgraded or overwritten. Agent Runtimes remain user-selected and external.
 
-Delivery: [Draft PR #1365](https://github.com/TraderAlice/OpenAlice/pull/1365)
-targets dev. Implementation and acceptance below are complete; the draft remains
-unmerged for maintainer acceptance. No version, registry package, public AUR
-entry, release asset, or production installation was changed by this goal.
+Delivery: [PR #1365](https://github.com/TraderAlice/OpenAlice/pull/1365)
+was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
+0.91.1-beta.1 followed by 0.91.1 release journey, with separate public acceptance.
+
+### Active release journey
+
+- [ ] Repair and accept dev preview: run 33948606732 exposed the old multiprocess
+  fixture's empty PATH, which incorrectly hides required system Git/Bash. Give
+  that fixture an isolated tool-only PATH; keep Node/npm/Bun absent.
+  Local repaired four-process recovery and external Broker Pack acceptance pass;
+  root typecheck and 719 files / 6,424 tests pass (3 skipped). Public dev
+  acceptance remains required before promotion.
+- [ ] Promote accepted dev and prepare/publish 0.91.1-beta.1.
+- [ ] Verify public beta installation/update and unchanged stable surfaces.
+- [ ] Complete Windows x64 npm first-publication/OIDC prerequisites.
+- [ ] Prepare and publish 0.91.1 independently after beta acceptance; verify
+  public release, npm/Bun, and Homebrew. AUR registration remains deferred.
 
 ### Implemented boundary
 

--- a/scripts/build-bun-runtime-feasibility.ts
+++ b/scripts/build-bun-runtime-feasibility.ts
@@ -1,9 +1,10 @@
 import { createServer } from 'node:net'
-import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { prepareBunBrokerPackFixture } from './bun-broker-pack-fixture.js'
+import { inspectSystemDependencies } from '../packages/cli/src/system-dependencies.mjs'
 
 const repositoryRoot = fileURLToPath(new URL('..', import.meta.url))
 const pinnedBunVersion = (await readFile(join(repositoryRoot, '.bun-version'), 'utf8')).trim()
@@ -61,6 +62,15 @@ if (!build.success) {
 const buildDurationMs = Math.round(performance.now() - buildStartedAt)
 
 const [webPort, mcpPort, utaPort, connectorPort] = await allocatePorts(4)
+// Expose only required system tools, not the host's Node/npm/Bun installation.
+const dependencyBin = join(outputRoot, 'system-bin')
+await mkdir(dependencyBin, { recursive: true })
+for (const dependency of await inspectSystemDependencies()) {
+  if (dependency.status !== 'available' || !dependency.executable) {
+    throw new Error(`Runtime acceptance requires working system ${dependency.id}`)
+  }
+  await symlink(dependency.executable, join(dependencyBin, dependency.id))
+}
 const smokeEnvironment = minimalSmokeEnvironment({
   home: smokeHome,
   executable: executablePath,
@@ -73,6 +83,7 @@ const version = runProbe(['--version'], smokeEnvironment)
 if (version.stdout.trim() !== product.version) {
   throw new Error(`compiled Runtime reported version ${JSON.stringify(version.stdout.trim())}`)
 }
+runProbe(['setup', '--check'], smokeEnvironment)
 
 const runtimeStartedAt = performance.now()
 const runtime = Bun.spawn([
@@ -390,7 +401,7 @@ function minimalSmokeEnvironment(options: {
 }): Record<string, string> {
   return {
     HOME: options.home,
-    PATH: '',
+    PATH: dependencyBin,
     TMPDIR: process.env['TMPDIR'] ?? '/tmp',
     OPENALICE_HOME: options.home,
     OPENALICE_APP_HOME: repositoryRoot,


### PR DESCRIPTION
## Summary
Repair the release prerequisite exposed by dev run 33948606732. The multiprocess fixture kept an empty PATH after CLI installation switched to system Git/Bash, so startup correctly refused to proceed.

Expose only verified Git/Bash through an isolated symlink directory, preserving the no-host-Node/npm/Bun acceptance boundary. Check setup before waiting for HTTP readiness.

## Verification
- pnpm build:bun-runtime:feasibility: passed on macOS ARM64, including four independent processes, Connector and UTA recovery, external Broker Pack loading, and lock release.
- npx tsc --noEmit: passed.
- pnpm test: 719 files, 6424 passed, 3 skipped.
- git diff --check: passed.

## Scope
Test fixture and canonical release plan only. Supports the maintainer-authorized beta-to-stable release journey; no product version or registry mutation in this PR. The post-merge dev preview must pass before promotion.