### PR TITLE
fix(test): provide system Git on clean CLI acceptance hosts

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -19,6 +19,14 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   Local repaired four-process recovery and external Broker Pack acceptance pass;
   root typecheck and 719 files / 6,424 tests pass (3 skipped). Public dev
   acceptance remains required before promotion.
+  PR #1366 fixed multiprocess PATH. Promotion PR #1367 then exposed missing Git
+  in the SSH fixture's final Debian image; install host Git in SSH and live
+  channel fixtures, and assert live setup readiness without Node/Bun/agents.
+  Local SSH acceptance (including transfer, excluding the separate TUI journey)
+  and real exact-commit dev install at 046d5b03 pass. Fixture revision root
+  typecheck and full 6,424-test suite pass. Dev run 33949126590 is green.
+  Intel promotion PTY confirmation timed out after main logged attachment;
+  evidence was added to #1350, not dismissed as a proven infrastructure cause.
 - [ ] Promote accepted dev and prepare/publish 0.91.1-beta.1.
 - [ ] Verify public beta installation/update and unchanged stable surfaces.
 - [ ] Complete Windows x64 npm first-publication/OIDC prerequisites.

--- a/scripts/install-channel-smoke/Dockerfile
+++ b/scripts/install-channel-smoke/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-  && apt-get install -y --no-install-recommends bash ca-certificates coreutils curl jq tar \
+  && apt-get install -y --no-install-recommends bash ca-certificates coreutils curl git jq tar \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --home-dir /home/smoke --no-create-home --shell /bin/bash --uid 10001 smoke \
   && mkdir -p /home/smoke \

--- a/scripts/install-channel-smoke/run.sh
+++ b/scripts/install-channel-smoke/run.sh
@@ -84,6 +84,7 @@ first_content_identity="$(printf '%s' "$version_json" | jq -er \
   ')" || fail "installed CLI did not preserve native dev-channel provenance"
 
 [[ -n "$($openalice --version)" ]] || fail "installed OpenAlice CLI did not report a version"
+$openalice setup --check || fail "installed CLI could not use host Git/Bash"
 [[ -n "$($openalice completion bash)" ]] || fail "installed OpenAlice CLI could not render completion"
 
 runtime_status="$($openalice status --home "$HOME/runtime-smoke" --json)"

--- a/scripts/remote-smoke/Dockerfile
+++ b/scripts/remote-smoke/Dockerfile
@@ -15,7 +15,7 @@ RUN corepack enable \
 FROM debian:bookworm-slim
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-  && apt-get install -y --no-install-recommends bash ca-certificates curl openssh-server python3 \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl git openssh-server python3 \
   && rm -rf /var/lib/apt/lists/* \
   && useradd --create-home --shell /bin/bash --uid 10001 smoke \
   && passwd --delete smoke \


### PR DESCRIPTION
## Summary
Follow-up release prerequisite for promotion #1367: the clean SSH image omitted Git after native CLI switched to system-owned dependencies. Install Git as a host prerequisite in SSH and live-channel fixtures; assert setup readiness in the live installer fixture. No product installer gains implicit consent or dependency mutation.

## Verification
- Real local Docker managed SSH install/start/tunnel/reconnect/stop/Project transfer passed with --skip-tui.
- Real raw dev installer plus channel dev at 046d5b03 passed, including Git/Bash setup check and idempotent installation.
- Root typecheck passed; pnpm test: 719 files, 6424 passed, 3 skipped.
- CLI installer workflow contract: 10 tests passed; Bash syntax and diff checks passed.

The full isolated Electron Workspace acceptance already passed on the unchanged product tree. Native Intel PTY confirmation timeout remains separately tracked in #1350 and must be rechecked before release. This PR repairs test hosts only as part of the authorized beta-to-stable journey.