### PR TITLE
chore(release): prepare 0.91.1-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0",
+  "version": "0.91.1-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0",
+  "version": "0.91.1-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release preparation
Set only the root and CLI product versions to 0.91.1-beta.1, matching the intended v0.91.1-beta.1 tag.

Source was promoted in #1367 after all current-head checks passed, including six-platform dev publication/live installation, macOS and Windows desktop Workspace/upgrade acceptance, managed SSH, Docker, Windows Broker Packs, and source contracts. Local full suite: 6424 passed; isolated desktop and real dependency installation acceptance recorded there.

This PR does not create a tag. After its exact-beta version-only gate passes, dispatch the beta Release workflow separately. Stable 0.91.1 remains a later independent release after public beta acceptance.