### PR TITLE
chore(release): sync accepted 0.91.1-beta.1 to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.0-beta.4",
+  "version": "0.91.1-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.0-beta.4",
+  "version": "0.91.1-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -13,7 +13,7 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
 
 ### Active release journey
 
-- [ ] Repair and accept dev preview: run 33948606732 exposed the old multiprocess
+- [x] Repair and accept dev preview: run 33948606732 exposed the old multiprocess
   fixture's empty PATH, which incorrectly hides required system Git/Bash. Give
   that fixture an isolated tool-only PATH; keep Node/npm/Bun absent.
   Local repaired four-process recovery and external Broker Pack acceptance pass;
@@ -27,8 +27,13 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   typecheck and full 6,424-test suite pass. Dev run 33949126590 is green.
   Intel promotion PTY confirmation timed out after main logged attachment;
   evidence was added to #1350, not dismissed as a proven infrastructure cause.
-- [ ] Promote accepted dev and prepare/publish 0.91.1-beta.1.
-- [ ] Verify public beta installation/update and unchanged stable surfaces.
+- [x] Promote accepted dev and prepare/publish 0.91.1-beta.1. PRs #1367/#1369;
+  release run 33950551159 succeeded, tag binds 1b509852.
+- [x] Verify public beta installation/update and unchanged stable surfaces.
+  Public macOS ARM64 0.91.0 -> beta update, real Settings version/channel,
+  retained Workspace, rollback to 0.91.0 and back to beta all passed. Stable
+  manifest and five update feeds match the pre-beta baseline byte-for-byte.
+  Isolated acceptance root: /tmp/openalice-0911-public.Iut9Ho.
 - [ ] Complete Windows x64 npm first-publication/OIDC prerequisites.
 - [ ] Prepare and publish 0.91.1 independently after beta acceptance; verify
   public release, npm/Bun, and Homebrew. AUR registration remains deferred.


### PR DESCRIPTION
Synchronize only the two product version values from accepted v0.91.1-beta.1; source launcher identity remains dev. Record public acceptance in the canonical plan, without merging unrelated master changes.

Release run 33950551159 completed successfully at 1b509852. Public macOS ARM64 0.91.0 update to beta, real Settings UI, retained Workspace, and bidirectional local rollback passed. Stable manifest and five update feeds remain byte-identical. Version values agree and git diff --check passes. No runtime code changes.