### PR TITLE
chore(release): prepare 0.91.1 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.1-beta.1",
+  "version": "0.91.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.1-beta.1",
+  "version": "0.91.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Separate stable release intent
The maintainer authorized the complete beta-to-stable journey. v0.91.1-beta.1 is now publicly accepted; this PR changes only root and CLI version values to 0.91.1 on that same product source.

## Beta acceptance
- Release run 33950551159 succeeded; tag binds 1b509852.
- Public 0.91.0 CLI detected and updated to 0.91.1-beta.1 through its native update command.
- Real Settings UI reports beta and up-to-date; existing Chat Workspace survives.
- Local rollback to 0.91.0 and back to beta, including successful runtime startup and retained Workspace, passed.
- Stable manifest and five updater feeds remain byte-for-byte unchanged.

Stable keeps its own full source and final artifact gates. No tag or publication occurs in this PR. npm Windows x64 first publication/OIDC and stable public package-manager verification remain part of the release work, not implied by the beta receipt.