### PR TITLE
fix(test): preserve AUR container sandbox settings through upgrades

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -37,6 +37,18 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
 - [ ] Complete Windows x64 npm first-publication/OIDC prerequisites.
 - [ ] Prepare and publish 0.91.1 independently after beta acceptance; verify
   public release, npm/Bun, and Homebrew. AUR registration remains deferred.
+  Stable preparation #1371 and full source run 33952791151 passed on f1ac9ece.
+  Release run 33953350725 accepted all six native CLI targets, then ARM64 AUR
+  acceptance exposed a fixture defect: later pacman -U dependency downloads
+  did not inherit the bootstrap command's Landlock sandbox exception. Apply
+  that existing exception to pacman configuration only inside the disposable
+  pinned container; retain dependency resolution and signature verification.
+  Local Docker ARM64 and emulated x64 replays of the exact 0.91.1 candidates
+  pass the complete pacman install/update/pending-activation/removal lifecycle. Root typecheck,
+  719 files / 6,425 tests pass (3 skipped); the added contract covers container
+  scope, read-only checkout and unchanged package-signature policy.
+  Intel signing independently failed to obtain a timestamp; no signature gate
+  is relaxed. Repair and re-promote through dev before retrying stable.
 
 ### Implemented boundary
 

--- a/scripts/cli-aur-container-smoke.mjs
+++ b/scripts/cli-aur-container-smoke.mjs
@@ -28,9 +28,11 @@ export function runAurContainerSmoke(options) {
   const currentPackageRoot = containerDirectory(options.currentPackage)
   const command = [
     // GitHub and OrbStack containers do not expose Landlock. Pacman 7's
-    // download sandbox must be disabled explicitly inside this disposable,
-    // digest-pinned acceptance container.
-    'pacman --disable-sandbox -Syu --noconfirm nodejs',
+    // download sandbox must be disabled for every pacman invocation inside
+    // this disposable, digest-pinned acceptance container, including later
+    // pacman -U dependency downloads. Keep signature checking unchanged.
+    "sed -i '/^\\[options\\]$/a DisableSandbox' /etc/pacman.conf",
+    'pacman -Syu --noconfirm nodejs',
     'useradd --create-home builder',
     'install -d -o builder -g builder /tmp/openalice-aur-previous /tmp/openalice-aur-current',
     'cp -a "$PREVIOUS_PACKAGE_ROOT/." /tmp/openalice-aur-previous/',

--- a/scripts/cli-aur-container-smoke.spec.mjs
+++ b/scripts/cli-aur-container-smoke.spec.mjs
@@ -1,8 +1,30 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
 
-import { AUR_IMAGES, parseArgs } from './cli-aur-container-smoke.mjs'
+import { AUR_IMAGES, parseArgs, runAurContainerSmoke } from './cli-aur-container-smoke.mjs'
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn(() => ({ status: 0 })) }))
 
 describe('AUR container lifecycle smoke', () => {
+  it('scopes the unsupported download sandbox setting to the disposable container and all lifecycle commands', () => {
+    runAurContainerSmoke({
+      arch: 'arm64', docker: 'docker',
+      previousVersion: '0.91.0', currentVersion: '0.91.1',
+      previousContentIdentity: '0123456789abcdef',
+      currentContentIdentity: 'fedcba9876543210',
+      previousPackage: 'scripts/cli-aur-container-smoke.spec.mjs',
+      currentPackage: 'scripts/cli-aur-container-smoke.spec.mjs',
+    })
+    const [command, args] = vi.mocked(spawnSync).mock.calls.at(-1)
+    expect(command).toBe('docker')
+    expect(args.slice(0, 2)).toEqual(['run', '--rm'])
+    expect(args).not.toContain('--privileged')
+    expect(args.at(-1)).toMatch(/^sed -i .*DisableSandbox.*\/etc\/pacman.conf && pacman -Syu/)
+    expect(args.at(-1)).toContain('exec /usr/bin/node /work/scripts/cli-system-package-manager-smoke.mjs')
+    expect(args.at(-1)).not.toMatch(/SigLevel|--disable-sandbox|nodejs git/)
+    expect(args.find((value) => value.endsWith(':/work:ro'))).toBeDefined()
+  })
+
   it('pins native Arch-family images for Linux arm64 and x64', () => {
     expect(AUR_IMAGES.arm64).toMatchObject({ platform: 'linux/arm64' })
     expect(AUR_IMAGES.x64).toMatchObject({ platform: 'linux/amd64' })


### PR DESCRIPTION
## Summary
The 0.91.1 stable candidate exposed a test-fixture bug on native ARM64: only the first pacman command disabled the unsupported Landlock download sandbox. Later pacman -U downloads for declared Git dependencies failed. Apply the same exception through pacman.conf inside the disposable pinned container, without changing user installers, signature checking, Docker privileges, dependency resolution, or runtime bytes.

## Verification
- Root typecheck passed.
- Full hermetic suite: 719 files, 6425 passed, 3 skipped.
- Focused container contracts: 4 passed.
- Exact candidate archives from release run 33953350725 replayed successfully through full AUR lifecycle on local ARM64 and emulated x64: installation, update, pending activation, startup/stop, and removal.
- Logs: /tmp/openalice-0911-aur-replay.log and /tmp/openalice-0911-aur-x64-replay.log.

## Release evidence
Failing job: https://github.com/TraderAlice/OpenAlice/actions/runs/33953350725/job/101272955850 . The separate Intel signing timestamp failure is not weakened or hidden by this fix. Stable tag remains unpublished; re-promotion and release gates remain required.

## Boundary
Test-container-only configuration. No trading or user credentials.