### PR TITLE
fix(release): isolate npm bootstrap and sync accepted 0.91.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1096,7 +1096,12 @@ jobs:
           package-manager-cache: false
 
       - name: Install OIDC-capable npm
-        run: npm install --global npm@12.0.2 --ignore-scripts --no-audit --no-fund
+        run: |
+          # Do not replace the npm tree executing this installation.
+          npm_prefix="$RUNNER_TEMP/openalice-release-npm"
+          npm install --global --prefix "$npm_prefix" npm@12.0.2 --ignore-scripts --no-audit --no-fund
+          test "$("$npm_prefix/bin/npm" --version)" = 12.0.2
+          echo "$npm_prefix/bin" >> "$GITHUB_PATH"
 
       - name: Require the current published stable release
         run: |
@@ -1169,7 +1174,12 @@ jobs:
           package-manager-cache: false
 
       - name: Install OIDC-capable npm
-        run: npm install --global npm@12.0.2 --ignore-scripts --no-audit --no-fund
+        run: |
+          # Do not replace the npm tree executing this installation.
+          npm_prefix="$RUNNER_TEMP/openalice-release-npm"
+          npm install --global --prefix "$npm_prefix" npm@12.0.2 --ignore-scripts --no-audit --no-fund
+          test "$("$npm_prefix/bin/npm" --version)" = 12.0.2
+          echo "$npm_prefix/bin" >> "$GITHUB_PATH"
 
       - uses: actions/download-artifact@v4
         with:

--- a/PLANS.md
+++ b/PLANS.md
@@ -44,10 +44,10 @@ the durable truth after it changes. Git history is the archive.
   npm/Bun, Homebrew, and AUR channels consume one accepted artifact set.
   Active follow-up: system-owned Git/Bash and consent-based dependency
   coordination across CLI installers/package managers; Electron stays separate.
-  Homebrew tap is public at `0.90.2` with lightweight hourly/manual stable sync.
-  Stable `0.91.0` source and version preparation are merged; final validation
-  exposed and repaired host-dependent TUI fixtures; the release then exposed
-  npm's 1 MiB subprocess-report buffer, now under bounded repair.
+  Stable `0.91.1` and its Homebrew formula are publicly accepted after the
+  separate beta checkpoint. Windows x64 npm first publication is complete;
+  all seven OIDC exchanges pass. npm/Bun activation is repairing an npm
+  self-upgrade failure before uploading the accepted stable packages.
   Native Intel acceptance passed; renderer latency remains tracked in #1350.
   AUR registration remains deferred.
   The CLI package owns OpenAlice only: Agent Runtime installation and Electron

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -7,8 +7,10 @@ owned by [[docs/cli-supervisor.md]] and [[docs/local-runtime.md]].
 
 The native target set is macOS, glibc Linux, and Windows on arm64 and x64.
 Windows direct installation lives in [[docs/cli-installer.md]]. Generated Windows
-packages are not public npm packages: first publication and Trusted Publisher
-enrollment remain required external activation steps.
+packages have completed first publication and Trusted Publisher enrollment.
+The complete seven-package stable npm activation still requires publication
+and public-install acceptance; the historical four-platform meta package is
+not evidence of Windows availability through `npm install openalice`.
 
 Public npm activation: `openalice` and its four platform packages were first
 published as `0.90.2` on 2026-09-04 under maintainer `jiaran258`. The registry
@@ -221,7 +223,7 @@ That skip alone is not proof of OIDC authorization.
 
 ### npm Trusted Publishing (OIDC)
 
-Activated on 2026-09-04: all five package connections were saved and
+Initially activated on 2026-09-04: all five package connections were saved and
 [real OIDC exchanges passed](https://github.com/TraderAlice/OpenAlice/actions/runs/33871780397)
 from integrated `dev` tooling in a single 15-second job. The temporary
 `openalice-first-publish` token was then revoked and the repository's
@@ -243,8 +245,15 @@ For each of `openalice`, `openalice-darwin-arm64`, `openalice-darwin-x64`,
   GitHub environment. Access to changing/running the trusted workflow is a
   publishing security boundary.
 
+On 2026-09-05 both Windows packages completed first publication and enrollment.
+The [seven-package exchange](https://github.com/TraderAlice/OpenAlice/actions/runs/33957933624)
+passed from `master`, including the new Windows x64 connection. This proves
+authority, not completion of the all-platform meta-package publication.
+
 Publication runs on GitHub-hosted Ubuntu with `id-token: write`, Node 22.22.2,
-and pinned npm 12.0.2. npm handles its own short-lived credential exchange when
+and pinned npm 12.0.2 installed in an isolated runner-temporary prefix. Verify
+its version and add its bin directory to `GITHUB_PATH`; do not globally replace
+the npm tree that is executing its own upgrade. npm handles its short-lived credential exchange when
 publishing; neither `NPM_TOKEN` nor `NODE_AUTH_TOKEN` is configured. The generated
 packages must retain the matching `TraderAlice/OpenAlice` repository URL.
 Provenance is not itself proof of OIDC authentication.
@@ -264,11 +273,11 @@ secret. npm's restrictive 2FA/token policy is compatible with OIDC.
 
 See [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) and
 the [registry OIDC exchange API](https://api-docs.npmjs.com/). Adding future
-platform packages (including Windows) requires first publication and their own
-trusted-publisher connections. The historical receipts above cover only the
-original five names. `openalice-windows-arm64` and `openalice-windows-x64` must be
-enrolled before seven-package publication. Do not restore the revoked bootstrap
-token or count the old receipt as Windows publishing authority.
+platform packages requires first publication and their own trusted-publisher
+connections. The 2026-09-04 receipts cover only the original five names; use
+the seven-package receipt above for Windows authority. Do not restore the
+revoked bootstrap token or count an older, smaller receipt as new-platform
+publishing authority.
 
 ## Update and uninstall ownership
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.1-beta.1",
+  "version": "0.91.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.1-beta.1",
+  "version": "0.91.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -34,9 +34,25 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   retained Workspace, rollback to 0.91.0 and back to beta all passed. Stable
   manifest and five update feeds match the pre-beta baseline byte-for-byte.
   Isolated acceptance root: /tmp/openalice-0911-public.Iut9Ho.
-- [ ] Complete Windows x64 npm first-publication/OIDC prerequisites.
-- [ ] Prepare and publish 0.91.1 independently after beta acceptance; verify
-  public release, npm/Bun, and Homebrew. AUR registration remains deferred.
+- [x] Publish Windows x64 npm bootstrap package: openalice-windows-x64@0.91.1
+  is public and its registry SHA-512 matches the release-owned npm manifest.
+- [x] Enroll Windows x64 OIDC and verify all seven identities. npm confirmed
+  TraderAlice/OpenAlice / release.yml with direct publishing permission;
+  real exchange run 33957933624 passed for the complete seven-package set.
+- [ ] Publish and accept the complete public npm/Bun channel. Run 33957962527
+  failed twice before publication while globally upgrading npm in place:
+  the running npm could no longer resolve its own promise-retry dependency.
+  Isolate pinned npm 12.0.2 in RUNNER_TEMP, verify its version, and prepend that
+  executable directory for subsequent steps without replacing bootstrap npm.
+  This is dev-lane publication tooling only; reuse the accepted stable bytes.
+  Clean Node 22.22.2 Docker reproduces the original promise-retry failure;
+  the isolated-prefix repair passes on native Linux ARM64 and emulated x64,
+  preserves bootstrap npm, and reads the public Windows x64 registry entry.
+  Focused release/OIDC/publisher contracts pass 45 tests.
+  Root typecheck and all 719 files / 6,425 tests pass (3 expected skips,
+  202.39 seconds); /tmp/openalice-0911-npm-bootstrap-tests.log.
+- [x] Prepare and publish 0.91.1 independently after beta acceptance; verify
+  public release, direct upgrade, and Homebrew. AUR registration remains deferred.
   Stable preparation #1371 and full source run 33952791151 passed on f1ac9ece.
   Release run 33953350725 accepted all six native CLI targets, then ARM64 AUR
   acceptance exposed a fixture defect: later pacman -U dependency downloads
@@ -48,7 +64,18 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   719 files / 6,425 tests pass (3 skipped); the added contract covers container
   scope, read-only checkout and unchanged package-signature policy.
   Intel signing independently failed to obtain a timestamp; no signature gate
-  is relaxed. Repair and re-promote through dev before retrying stable.
+  is relaxed. Repair #1372 and promotion #1373 passed, followed by full source
+  run 33954704340 on 52b51f29809178594b7b57bf666133829368b7b4.
+  Stable release run 33955286757 succeeded with all six native CLI targets,
+  final desktop N-1 upgrades, both AUR architectures, package-manager acceptance,
+  signed/notarized macOS artifacts, and public GitHub/CDN byte verification.
+  Tag v0.91.1 binds that exact SHA and is a non-prerelease. Public macOS CLI
+  beta -> stable upgrade/start/stop retained Workspace chat-stable-ivory-lantern;
+  real Settings reports 0.91.1 Stable and up-to-date. Homebrew sync 33957271180
+  passed, then a clean native Linux ARM64 container installed from the public
+  tap, resolved dependencies, started 0.91.1, and uninstalled successfully
+  (/tmp/openalice-0911-public-brew.log). Copy the two accepted version values
+  back to dev; source launcher identity remains dev, not stable.
 
 ### Implemented boundary
 

--- a/scripts/release-workflow.spec.ts
+++ b/scripts/release-workflow.spec.ts
@@ -138,6 +138,11 @@ describe('Release workflow critical path', () => {
       expect(job.steps?.find((entry) => entry.uses === 'actions/setup-node@v7')?.with)
         .toMatchObject({ 'node-version': '22.22.2', 'package-manager-cache': false })
       expect(step(job, 'Install OIDC-capable npm').run).toContain('npm@12.0.2')
+      const bootstrap = step(job, 'Install OIDC-capable npm').run ?? ''
+      expect(bootstrap).toContain('npm_prefix="$RUNNER_TEMP/openalice-release-npm"')
+      expect(bootstrap).toContain('npm install --global --prefix "$npm_prefix"')
+      expect(bootstrap).toContain('test "$("$npm_prefix/bin/npm" --version)" = 12.0.2')
+      expect(bootstrap).toContain('echo "$npm_prefix/bin" >> "$GITHUB_PATH"')
     }
     expect(workflow.jobs['preflight-public-cli-authority'].permissions?.['id-token']).toBe('write')
     expect(JSON.stringify(workflow)).not.toMatch(/NPM_TOKEN|NODE_AUTH_TOKEN/)


### PR DESCRIPTION
## Summary
- Repair the reproducible npm self-upgrade failure in both OIDC publishing jobs by installing pinned npm into a separate runner-temporary prefix.
- Preserve OIDC, integrity checks, platform-first publication, and accepted release bytes; no product rebuild or new tag.
- Sync the two accepted 0.91.1 version values to dev and record stable, Homebrew, and seven-package OIDC acceptance. Source launcher identity remains dev.

## Verification
- Clean pinned Node 22.22.2 Docker reproduces the original missing promise-retry failure.
- Isolated installation succeeds on native Linux ARM64 and emulated Linux x64; bootstrap npm remains unchanged and the new npm reads the public registry.
- Root typecheck; 45 focused release/OIDC/publisher tests; full suite: 719 files, 6425 passed, 3 expected skips (202.39s); git diff --check.
- Previous serial PR #1372 and its dev preview 33954332317 are green.

## Boundary
Release tooling only, plus accepted version bookkeeping. No credential values, signing changes, or package-byte changes. Publish run 33957962527 failed before uploading; seven-package OIDC verification 33957933624 passed. After integration, rerun only publish-npm for v0.91.1 from dev. Public npm installation acceptance remains pending.