### PR TITLE
fix(release): accept npm 12 singleton integrity reports

### DIFF
--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -51,6 +51,12 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   Focused release/OIDC/publisher contracts pass 45 tests.
   Root typecheck and all 719 files / 6,425 tests pass (3 expected skips,
   202.39 seconds); /tmp/openalice-0911-npm-bootstrap-tests.log.
+  Bootstrap repair #1374 merged as 3fc3b966. Publication run 33958315820 then
+  successfully uploaded five platform packages through OIDC; the existing
+  Windows x64 check exposed npm 12's singleton-array JSON response. Clean
+  Node 22.22.2/npm 12.0.2 reproduces that exact response. Accept one string or
+  exactly one string entry, while rejecting ambiguous/malformed reports; retry
+  must preserve integrity verification and keep the meta package last.
 - [x] Prepare and publish 0.91.1 independently after beta acceptance; verify
   public release, direct upgrade, and Homebrew. AUR registration remains deferred.
   Stable preparation #1371 and full source run 33952791151 passed on f1ac9ece.

--- a/scripts/publish-cli-npm-packages.mjs
+++ b/scripts/publish-cli-npm-packages.mjs
@@ -121,7 +121,9 @@ function readPublishedIntegrity(runNpm, entry) {
   if (result.error) throw result.error
   if (result.status === 0) {
     try {
-      const integrity = JSON.parse(result.stdout.trim())
+      const report = JSON.parse(result.stdout.trim())
+      // npm 12 wraps even an exact-version field query in a one-entry array.
+      const integrity = Array.isArray(report) && report.length === 1 ? report[0] : report
       if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) throw new Error()
       return integrity
     } catch {

--- a/scripts/publish-cli-npm-packages.spec.mjs
+++ b/scripts/publish-cli-npm-packages.spec.mjs
@@ -64,6 +64,25 @@ describe('publish CLI npm packages', () => {
       .toThrow('openalice-darwin-arm64@0.90.2 is already published with different integrity')
   })
 
+  it('accepts npm 12 singleton arrays when retrying an already-published version', () => {
+    const root = fixture()
+    const manifest = JSON.parse(readFixture(root))
+    const integrity = new Map(manifest.packages.map((entry) => [`${entry.name}@${entry.version}`, entry.integrity]))
+    const runNpm = vi.fn((args) => result(0, JSON.stringify([integrity.get(args[1])])))
+    publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() })
+    expect(runNpm.mock.calls.every(([args]) => args[0] === 'view')).toBe(true)
+  })
+
+  it.each([[], ['sha512-one', 'sha512-two'], [null], { integrity: 'sha512-one' }].map((report) => [report]))(
+    'rejects ambiguous or malformed npm view output: %j', (report) => {
+      const root = fixture()
+      const runNpm = vi.fn(() => result(0, JSON.stringify(report)))
+      expect(() => publishCliNpmPackages({ packagesDir: root, runNpm, logger: silent() }))
+        .toThrow('npm returned invalid integrity')
+      expect(runNpm).toHaveBeenCalledTimes(1)
+    },
+  )
+
   it('accepts a successful publish that became visible after npm returned an error', () => {
     const root = fixture()
     const manifest = JSON.parse(readFixture(root))


### PR DESCRIPTION
## Summary
- Handle npm 12 exact-version field queries, which return a one-entry array rather than the older scalar string.
- Keep strict integrity equality, reject empty/multiple/malformed entries, and preserve platform-first/meta-last publication.
- Release run 33958315820 already published five platforms with OIDC; it stopped before the meta package when checking the previously published Windows x64 version. Retry will skip identical packages.

## Verification
- Reproduced exact array response using clean pinned Node 22.22.2 and npm 12.0.2 against openalice-windows-x64@0.91.1.
- 50 focused publisher, OIDC, and workflow tests pass; root typecheck and git diff --check pass.
- Previous #1374 clean-build is green; trailing dev preview 33958300719 is pending, not used as a synchronous lock.

## Boundary
Publication output parsing only. No artifact rebuild, new version, signing, token fallback, or relaxed integrity check. Existing stable bytes remain authoritative.