### PR TITLE
docs(release): record accepted 0.91.1 public channels

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -46,8 +46,8 @@ the durable truth after it changes. Git history is the archive.
   coordination across CLI installers/package managers; Electron stays separate.
   Stable `0.91.1` and its Homebrew formula are publicly accepted after the
   separate beta checkpoint. Windows x64 npm first publication is complete;
-  all seven OIDC exchanges pass. npm/Bun activation is repairing an npm
-  self-upgrade failure before uploading the accepted stable packages.
+  all seven OIDC exchanges and complete npm/Bun publication now pass.
+  Public macOS npm/Bun and Linux npm 12 lifecycle acceptance passed.
   Native Intel acceptance passed; renderer latency remains tracked in #1350.
   AUR registration remains deferred.
   The CLI package owns OpenAlice only: Agent Runtime installation and Electron

--- a/docs/cli-package-managers.md
+++ b/docs/cli-package-managers.md
@@ -8,9 +8,19 @@ owned by [[docs/cli-supervisor.md]] and [[docs/local-runtime.md]].
 The native target set is macOS, glibc Linux, and Windows on arm64 and x64.
 Windows direct installation lives in [[docs/cli-installer.md]]. Generated Windows
 packages have completed first publication and Trusted Publisher enrollment.
-The complete seven-package stable npm activation still requires publication
-and public-install acceptance; the historical four-platform meta package is
-not evidence of Windows availability through `npm install openalice`.
+The seven-package stable npm channel is active at `0.91.1`: the meta package
+declares all six platform dependencies, including Windows x64 and ARM64.
+
+On 2026-09-05 [OIDC publication](https://github.com/TraderAlice/OpenAlice/actions/runs/33958504645)
+completed for `0.91.1`. All seven registry SHA-1/SHA-512 values match the
+release-owned manifest. Fresh public npm/Bun installs on macOS ARM64 and npm
+12.0.2 on clean Linux ARM64 passed startup, stable version discovery, stop,
+and removal while preserving project data. Native Windows package mechanics
+passed release acceptance; a separate Windows public-registry install was not
+repeated on a maintainer-owned Windows machine.
+The [Homebrew sync](https://github.com/TraderAlice/homebrew-tap/actions/runs/33957271180)
+also activated `0.91.1`; a fresh public tap install, startup, and removal passed
+inside a clean native Linux ARM64 Homebrew container.
 
 Public npm activation: `openalice` and its four platform packages were first
 published as `0.90.2` on 2026-09-04 under maintainer `jiaran258`. The registry
@@ -247,8 +257,8 @@ For each of `openalice`, `openalice-darwin-arm64`, `openalice-darwin-x64`,
 
 On 2026-09-05 both Windows packages completed first publication and enrollment.
 The [seven-package exchange](https://github.com/TraderAlice/OpenAlice/actions/runs/33957933624)
-passed from `master`, including the new Windows x64 connection. This proves
-authority, not completion of the all-platform meta-package publication.
+passed from `master`, including the new Windows x64 connection. The later
+publication and public-install receipts above prove activation separately.
 
 Publication runs on GitHub-hosted Ubuntu with `id-token: write`, Node 22.22.2,
 and pinned npm 12.0.2 installed in an isolated runner-temporary prefix. Verify

--- a/plans/bun-cli-distribution.md
+++ b/plans/bun-cli-distribution.md
@@ -39,7 +39,7 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
 - [x] Enroll Windows x64 OIDC and verify all seven identities. npm confirmed
   TraderAlice/OpenAlice / release.yml with direct publishing permission;
   real exchange run 33957933624 passed for the complete seven-package set.
-- [ ] Publish and accept the complete public npm/Bun channel. Run 33957962527
+- [x] Publish and accept the complete public npm/Bun channel. Run 33957962527
   failed twice before publication while globally upgrading npm in place:
   the running npm could no longer resolve its own promise-retry dependency.
   Isolate pinned npm 12.0.2 in RUNNER_TEMP, verify its version, and prepend that
@@ -57,6 +57,16 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   Node 22.22.2/npm 12.0.2 reproduces that exact response. Accept one string or
   exactly one string entry, while rejecting ambiguous/malformed reports; retry
   must preserve integrity verification and keep the meta package last.
+  Parser repair #1375 merged as b2c12ba9; 50 focused tests and root types passed.
+  Publication run 33958504645 succeeded: identical platform packages were
+  skipped and openalice@0.91.1 was published last through OIDC. Independent
+  registry reads verify all seven SHA-1/SHA-512 values and all six exact-version
+  optional dependencies. Public macOS ARM64 npm/Bun and clean Linux ARM64 npm
+  12.0.2 installation, system dependency checks, Runtime start, stable version
+  API/update probe, stop, uninstall and data preservation passed. Receipts:
+  /tmp/openalice-0911-public-npm-macos.log,
+  /tmp/openalice-0911-public-bun-macos.log,
+  /tmp/openalice-0911-public-npm12-linux.log.
 - [x] Prepare and publish 0.91.1 independently after beta acceptance; verify
   public release, direct upgrade, and Homebrew. AUR registration remains deferred.
   Stable preparation #1371 and full source run 33952791151 passed on f1ac9ece.
@@ -80,8 +90,8 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   real Settings reports 0.91.1 Stable and up-to-date. Homebrew sync 33957271180
   passed, then a clean native Linux ARM64 container installed from the public
   tap, resolved dependencies, started 0.91.1, and uninstalled successfully
-  (/tmp/openalice-0911-public-brew.log). Copy the two accepted version values
-  back to dev; source launcher identity remains dev, not stable.
+  (/tmp/openalice-0911-public-brew.log). The two accepted version values were
+  copied back to dev in #1374; source launcher identity remains dev, not stable.
 
 ### Implemented boundary
 
@@ -152,9 +162,10 @@ was accepted and merged to dev as 9d592d18. The maintainer authorized a serial
   exercised. Other Linux manager plans are likewise not all live-installed.
 - Real agent/provider credentials, broker operations, signing/notarization, and
   network Git are separate opt-in release/product checks, not exercised here.
-- Public npm/AUR activation and release promotion remain separate actions.
-  The previously accepted `openalice-windows-arm64@0.91.0` is not overwritten;
-  this new topology requires a newly accepted version for publication.
+- Public npm activation completed at 0.91.1 without overwriting the previous
+  openalice-windows-arm64@0.91.0. AUR registration remains externally deferred.
+  Windows native candidate mechanics passed; public-registry installation was
+  not repeated on a maintainer-owned Windows machine.
 
 Owner guides: [[docs/cli-installer.md]], [[docs/cli-package-managers.md]],
 [[docs/local-runtime.md]], [[docs/managed-workspace-runtime.md]].


### PR DESCRIPTION
## Summary
- Record the completed separate beta-to-stable journey and seven-package npm OIDC activation.
- Record exact registry integrity and six-platform dependency verification, public npm/Bun runtime lifecycle acceptance, Homebrew activation, and accepted version sync to dev.
- Keep AUR registration deferred and disclose that native Windows candidate acceptance is not a separate maintainer-machine public-registry test.

## Verification
- Stable release 33955286757 and npm publication 33958504645: success.
- Stable/beta public CDN versions match their respective release tags; npm latest is 0.91.1.
- All seven registry SHA-1/SHA-512 values match release manifest; main package declares six exact 0.91.1 platform dependencies.
- Fresh macOS ARM64 npm/Bun and clean Linux ARM64 npm 12: install, setup check, Runtime start, version/update read, stop, uninstall, retained user data.
- Homebrew sync 33957271180 and clean public Linuxbrew lifecycle passed.
- Docs-only diff; git diff --check passes. Previous #1375 clean-build passed; newer dev preview remains trailing feedback.

## Boundary
Documentation and acceptance receipts only; no package bytes, release tags, credentials, or production state changed.