### PR TITLE
refactor(ui): consolidate workspace and automation navigation

### DIFF
--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -58,6 +58,37 @@ chatbot filler. Their visible titles should stay scannable while the inserted
 prompt carries the evidence, freshness, persistence, and permission boundaries
 needed for the real task. Prefer a small rotating set over a wall of commands.
 
+### Background execution surfaces
+
+The Automation activity entry and its dedicated navigator are retired. Runs
+and API remain unchanged under Settings → Developer, at
+`/settings/developer/runs` and `/settings/developer/api`. Old Automation links
+and saved tabs use this Settings destination; saved activity layouts cannot
+restore the retired entry. Developer expands for either page and uses the
+existing Settings scroll and mobile navigation behavior. This is an entry-point
+move, not a change to scheduling, run ownership, or an additional Issues view.
+
+### Current Workspace details
+
+The global Workspaces activity, overview, template catalog, and management
+navigator are retired. Saved layout entries cannot restore them. Old inventory
+links return to Ask Alice; legacy Session/file links resolve the Workspace's
+actual Harness and preserve their target identity without mounting a global
+Workspace interface. Missing or unsupported membership is an explicit recovery
+state, not permission to guess a Harness from a tag or show the old manager.
+
+The Harness footer identity opens the current Workspace's details in the same
+Harness shell (`/<harness>/workspaces/:wsId/details`); the adjacent chevron is an
+independent Workspace switcher. Keep configuration and conversation browsing
+as separate actions below it. Do not make the identity click switch Workspaces,
+open agent configuration, or navigate to the global Workspace catalog.
+
+Details distinguish the Workspace-owned README and recorded applied/source
+versions from the current catalog's Harness guide. Catalog documentation is
+reference material, not proof of the installed version or current Workspace
+configuration. Keep document loading/errors independent, retain the sessions
+sidebar, and use the shared reading renderer rather than a new Markdown stack.
+
 ### Long-form Markdown
 
 `MarkdownContent` owns one parser and interaction contract with two deliberate

--- a/ui/src/components/ActivityBar.spec.ts
+++ b/ui/src/components/ActivityBar.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { defaultUiLayout, type UiLayout } from '../live/ui-layout'
-import { filterNavSections, joinNavLayout, NAV_SECTIONS, navSectionsForProduct } from './activity-navigation'
+import { editorGroupsFromLayout, filterNavSections, joinNavLayout, NAV_SECTIONS, navSectionsForProduct } from './activity-navigation'
 
 describe('ActivityBar navigation hierarchy', () => {
   it('keeps the primary workflow ordered with Quant below Issues', () => {
@@ -24,7 +24,7 @@ describe('ActivityBar navigation hierarchy', () => {
       'connectors',
     ])
     expect(beta?.items.find((item) => item.page === 'portfolio')?.labelKey).toBe('nav.item.trading')
-    expect(system?.items.map((item) => item.page)).toContain('workspaces')
+    expect(system?.items).toEqual([])
   })
 
   it('hides trading and market-data pages on NanoAlice', () => {
@@ -38,11 +38,19 @@ describe('ActivityBar navigation hierarchy', () => {
       'prediction',
       'office',
       'connectors',
-      'workspaces',
-      'automation',
     ])
     expect(pages).not.toContain('market')
     expect(pages).not.toContain('portfolio')
+  })
+
+  it('does not resurrect Workspaces or Automation from saved layouts or the editor', () => {
+    const layout = defaultUiLayout()
+    const pages = joinNavLayout(NAV_SECTIONS, layout, { office: true }).flatMap(s => s.items.map(i => i.page))
+    const editable = editorGroupsFromLayout(NAV_SECTIONS, layout).flatMap(g => g.items.map(i => i.page))
+    expect(pages).not.toContain('workspaces')
+    expect(editable).not.toContain('workspaces')
+    expect(pages).not.toContain('automation')
+    expect(editable).not.toContain('automation')
   })
 
   it('keeps Settings and Dev out of the default joined rail', () => {

--- a/ui/src/components/FileContentView.tsx
+++ b/ui/src/components/FileContentView.tsx
@@ -20,18 +20,20 @@ import type { ReadFileResult } from './workspace/api'
 export function FileContentView({
   path,
   result,
+  resolveRelativeHref,
 }: {
   path: string
   result: ReadFileResult
+  resolveRelativeHref?: (href: string) => string
 }): ReactElement {
-  if (result.kind === 'ok') return <DocBody path={path} content={result.content} />
+  if (result.kind === 'ok') return <DocBody path={path} content={result.content} resolveRelativeHref={resolveRelativeHref} />
   return <DocTombstone result={result} />
 }
 
-function DocBody({ path, content }: { path: string; content: string }): ReactElement {
+function DocBody({ path, content, resolveRelativeHref }: { path: string; content: string; resolveRelativeHref?: (href: string) => string }): ReactElement {
   const lower = path.toLowerCase()
   if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
-    return <MarkdownContent text={content} variant="reading" />
+    return <MarkdownContent text={content} variant="reading" resolveRelativeHref={resolveRelativeHref} />
   }
   if (lower.endsWith('.html')) {
     return <HtmlReportView path={path} content={content} />

--- a/ui/src/components/HarnessSetupPage.tsx
+++ b/ui/src/components/HarnessSetupPage.tsx
@@ -5,7 +5,6 @@ import { ArrowRight, Check, Loader2, PanelsTopLeft } from 'lucide-react'
 import { useWorkspaces } from '../contexts/workspaces-context'
 import { RecoverySurface, RefreshNotice } from './StateViews'
 import { workspaceDisplayTitle } from './workspace/display'
-import { useWorkspace } from '../tabs/store'
 
 export type HarnessSetupCopyPrefix = 'autoQuantSetup' | 'autoPredictionSetup' | 'chatSetup'
 
@@ -38,7 +37,6 @@ export function HarnessSetupPage({
 }: HarnessSetupPageProps) {
   const { t } = useTranslation()
   const ctx = useWorkspaces()
-  const openOrFocus = useWorkspace((state) => state.openOrFocus)
   const [pendingWorkspaceId, setPendingWorkspaceId] = useState<string | null>(null)
   const [initializing, setInitializing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -179,13 +177,6 @@ export function HarnessSetupPage({
                 </button>
               )
             })}
-            <button
-              type="button"
-              onClick={() => openOrFocus({ kind: 'workspace-list', params: {} })}
-              className="mx-auto mt-3 block text-xs text-muted-foreground hover:text-foreground"
-            >
-              {t(`${copyPrefix}.manageWorkspaces`)}
-            </button>
           </div>
         ) : (
           <div className="rounded-2xl border border-border/75 bg-secondary/70 p-5 shadow-[0_20px_60px_-48px_var(--foreground)]">

--- a/ui/src/components/MarkdownContent.spec.ts
+++ b/ui/src/components/MarkdownContent.spec.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from 'vitest'
 import { renderMarkdownHtml } from './MarkdownContent'
 
 describe('renderMarkdownHtml', () => {
+  it('lets the owning surface route relative document links without rewriting external links or anchors', () => {
+    const html = renderMarkdownHtml('[Guide](docs/guide.md) [Web](https://example.com) [Section](#section)', {
+      resolveRelativeHref: href => `/chat/workspaces/one/view/${encodeURIComponent(href)}`,
+    })
+    expect(html).toContain('href="/chat/workspaces/one/view/docs%2Fguide.md"')
+    expect(html).toContain('href="https://example.com"')
+    expect(html).toContain('href="#section"')
+  })
+
+  it('does not let a link resolver bypass URL sanitization', () => {
+    const html = renderMarkdownHtml('[Guide](guide.md)', { resolveRelativeHref: () => 'javascript:alert(1)' })
+    expect(html).not.toContain('javascript:')
+  })
+
   it('keeps GFM strikethrough enabled by default', () => {
     const html = renderMarkdownHtml('Keep ~~this~~ struck.')
 

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -153,11 +153,13 @@ interface MarkdownContentProps {
    * Pass an explicit handler to override (e.g. tests, alternate surfaces).
    */
   onWikilink?: (entityKey: string) => void
+  /** Optional owner-provided route for relative document links. */
+  resolveRelativeHref?: (href: string) => string
 }
 
 export function renderMarkdownHtml(
   text: string,
-  opts: { strikethrough?: boolean; codeSpanWikilinks?: boolean } = {},
+  opts: { strikethrough?: boolean; codeSpanWikilinks?: boolean; resolveRelativeHref?: (href: string) => string } = {},
 ): string {
   const parser = opts.codeSpanWikilinks
     ? opts.strikethrough === false
@@ -166,7 +168,20 @@ export function renderMarkdownHtml(
     : opts.strikethrough === false
       ? markedWithoutStrikethrough
       : markedWithStrikethrough
-  const raw = DOMPurify.sanitize(parser.parse(text) as string)
+  let raw = DOMPurify.sanitize(parser.parse(text) as string)
+  if (opts.resolveRelativeHref) {
+    // Parse inert, sanitized markup. Re-sanitize resolved URLs as well; an
+    // owner callback must not bypass the renderer's URL safety contract.
+    const fragment = document.createElement('template')
+    fragment.innerHTML = raw
+    for (const link of fragment.content.querySelectorAll('a[href]')) {
+      const href = link.getAttribute('href') ?? ''
+      if (href && !/^(?:[a-z][a-z\d+.-]*:|\/|#)/i.test(href)) {
+        link.setAttribute('href', opts.resolveRelativeHref(href))
+      }
+    }
+    raw = DOMPurify.sanitize(fragment.innerHTML)
+  }
   return addMarkdownStructure(addCodeBlockWrappers(raw))
 }
 
@@ -186,6 +201,7 @@ export function MarkdownContent({
   strikethrough = true,
   codeSpanWikilinks = false,
   onWikilink,
+  resolveRelativeHref,
 }: MarkdownContentProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const defaultWikilink = useWikilinkHandler()
@@ -193,8 +209,8 @@ export function MarkdownContent({
   const wikilink = onWikilink ?? defaultWikilink
 
   const html = useMemo(() => {
-    return renderMarkdownHtml(text, { strikethrough, codeSpanWikilinks })
-  }, [text, strikethrough, codeSpanWikilinks])
+    return renderMarkdownHtml(text, { strikethrough, codeSpanWikilinks, resolveRelativeHref })
+  }, [text, strikethrough, codeSpanWikilinks, resolveRelativeHref])
 
   const handleClick = useCallback(
     (e: MouseEvent) => {

--- a/ui/src/components/SettingsCategoryList.spec.tsx
+++ b/ui/src/components/SettingsCategoryList.spec.tsx
@@ -7,7 +7,8 @@ import { SettingsCategoryList } from './SettingsCategoryList'
 
 const mocks = vi.hoisted(() => ({
   product: 'trader' as 'trader' | 'nano' | undefined,
-  focused: null as null | { kind: 'dev'; params: { tab: 'logs' } },
+  focused: null as null | { kind: 'dev'; params: { tab: 'logs' | 'runs' | 'api' } }
+    | { kind: 'automation'; params: { section: 'runs' | 'api' } },
   openOrFocus: vi.fn(),
 }))
 
@@ -101,5 +102,22 @@ describe('SettingsCategoryList', () => {
 
     expect(screen.getByRole('button', { name: 'settings.group.developer' }).getAttribute('aria-expanded')).toBe('true')
     expect(screen.getByRole('button', { name: 'common.logs' })).toBeTruthy()
+  })
+
+  it.each(['runs', 'api'] as const)('opens %s inside Developer and closes mobile navigation', (tab) => {
+    const onSelect = vi.fn()
+    render(<SettingsCategoryList onSelect={onSelect} />)
+    expect(screen.queryByRole('button', { name: `automation.${tab}` })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'settings.group.developer' }))
+    fireEvent.click(screen.getByRole('button', { name: `automation.${tab}` }))
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind: 'dev', params: { tab } })
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+
+  it('expands Developer for a saved legacy Automation tab', () => {
+    mocks.focused = { kind: 'automation', params: { section: 'runs' } }
+    render(<SettingsCategoryList />)
+    expect(screen.getByRole('button', { name: 'settings.group.developer' }).getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('button', { name: 'automation.runs' })).toBeTruthy()
   })
 })

--- a/ui/src/components/SettingsCategoryList.tsx
+++ b/ui/src/components/SettingsCategoryList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  Activity,
   Bot,
   Camera,
   Cpu,
@@ -38,6 +39,8 @@ const DEVELOPER_ITEMS = [
   { labelKey: 'dev.onboarding', tab: 'onboarding', Icon: Compass },
   { labelKey: 'dev.snapshots', tab: 'snapshots', Icon: Camera },
   { labelKey: 'common.logs', tab: 'logs', Icon: ScrollText },
+  { labelKey: 'automation.runs', tab: 'runs', Icon: Activity },
+  { labelKey: 'automation.api', tab: 'api', Icon: Code2 },
   { labelKey: 'simulator.title', tab: 'simulator', Icon: FlaskConical },
 ] as const
 
@@ -107,7 +110,9 @@ export function SettingsCategoryList({ onSelect }: { onSelect?: () => void }) {
   const { project } = useAliceProject()
   const focused = useWorkspace((state) => getFocusedTab(state)?.spec)
   const openOrFocus = useWorkspace((state) => state.openOrFocus)
-  const developerActive = focused?.kind === 'dev'
+  const developerTab = focused?.kind === 'dev' ? focused.params.tab
+    : focused?.kind === 'automation' ? focused.params.section : null
+  const developerActive = developerTab !== null
   const [developerExpanded, setDeveloperExpanded] = useState(
     () => developerActive || readDeveloperDisclosure(),
   )
@@ -183,7 +188,7 @@ export function SettingsCategoryList({ onSelect }: { onSelect?: () => void }) {
             className="ml-5 border-l border-border/70 pl-1"
           >
             {DEVELOPER_ITEMS.map((item) => {
-              const active = focused?.kind === 'dev' && focused.params.tab === item.tab
+              const active = developerTab === item.tab
               return (
                 <SidebarRow
                   key={item.tab}

--- a/ui/src/components/activity-navigation.ts
+++ b/ui/src/components/activity-navigation.ts
@@ -9,8 +9,6 @@ import {
   Binary,
   Plug,
   Telescope,
-  TerminalSquare,
-  Zap,
   type LucideIcon,
 } from 'lucide-react'
 
@@ -108,10 +106,6 @@ export const NAV_SECTIONS: NavSection[] = [
     sectionLabel: 'System',
     labelKey: 'nav.section.system',
     items: [
-      // Workspace management remains available for project/container control
-      // and provenance debugging; conversation continuation belongs to Chat.
-      { page: 'workspaces', labelKey: 'nav.item.workspaces', icon: TerminalSquare, defaultTab: { kind: 'workspace-list', params: {} } },
-      { page: 'automation', labelKey: 'nav.item.automation', icon: Zap, defaultTab: { kind: 'automation', params: { section: 'runs' } } },
     ],
   },
 ]

--- a/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.spec.tsx
@@ -194,7 +194,7 @@ describe('ChatWorkspaceSection actions', () => {
     expect(onNavigate).toHaveBeenCalledOnce()
   })
 
-  it('combines the current Workspace metadata and switch action', async () => {
+  it('separates Workspace details and switching with keyboard-accessible actions', async () => {
     const user = userEvent.setup()
     renderSection([chatWorkspace], null, undefined, 'focused')
 
@@ -208,13 +208,25 @@ describe('ChatWorkspaceSection actions', () => {
     expect(currentWorkspace.textContent).toContain('0 conversations')
     expect(screen.queryByRole('menuitemradio', { name: 'Recent across Workspaces' })).toBeNull()
     expect(screen.queryByRole('menuitemradio', { name: 'Workspace tree' })).toBeNull()
-    expect(screen.queryByRole('menuitem', { name: 'Switch Workspace' })).toBeNull()
+    expect(screen.getByRole('menuitem', { name: 'Switch Workspace' })).toBeTruthy()
+
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Switch Workspace' }))
 
     await user.keyboard('{ArrowDown}')
     expect(document.activeElement).toBe(screen.getByRole('menuitem', { name: 'Configure this workspace' }))
 
     await user.keyboard('{Escape}')
     await waitFor(() => expect(document.activeElement).toBe(trigger))
+  })
+
+  it('opens details from the current identity without opening configuration or switching', () => {
+    renderSection([chatWorkspace], null, undefined, 'focused')
+    fireEvent.click(screen.getByRole('button', { name: 'Chat Workspace options' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Current Workspace: chat-jul11' }))
+    expect(openOrFocus).toHaveBeenCalledExactlyOnceWith({ kind: 'workspace-details', params: { wsId: 'chat-1', source: 'chat' } })
+    expect(actions.openAgentConfig).not.toHaveBeenCalled()
+    expect(screen.queryByRole('menu', { name: 'Chat Workspace options' })).toBeNull()
   })
 
   it('surfaces a template update from the bottom Workspace context', () => {
@@ -265,9 +277,9 @@ describe('ChatWorkspaceSection actions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Chat Workspace options' }))
     expect(screen.queryByRole('menuitem', { name: 'Workspace Manager' })).toBeNull()
     expect(screen.queryByRole('menuitem', { name: 'New workspace' })).toBeNull()
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Current Workspace: chat-aug3' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Switch Workspace' }))
 
-    const picker = within(screen.getByRole('menu', { name: 'Current Workspace: chat-aug3' }))
+    const picker = within(screen.getByRole('menu', { name: 'Switch Workspace' }))
     expect(picker.getByRole('menuitemradio', { name: 'chat-aug3' }).getAttribute('aria-checked')).toBe('true')
     expect(picker.getByRole('menuitem', { name: 'New workspace' })).toBeTruthy()
     fireEvent.click(picker.getByRole('menuitemradio', { name: 'chat-jul11' }))
@@ -323,7 +335,7 @@ describe('ChatWorkspaceSection actions', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Chat Workspace options' }))
     expect(screen.queryByRole('menuitem', { name: 'New workspace' })).toBeNull()
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Current Workspace: chat-jul11' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Switch Workspace' }))
     expect(screen.getByRole('menuitem', { name: 'New workspace' })).toBeTruthy()
   })
 

--- a/ui/src/components/workspace/ChatWorkspaceSection.tsx
+++ b/ui/src/components/workspace/ChatWorkspaceSection.tsx
@@ -127,7 +127,7 @@ export function ChatWorkspaceSection({
     ? { wsId: focused.params.wsId, sessionId: focused.params.sessionId ?? null }
     : null
   const landingOwnsStatus = focused?.kind === landingKind
-  const routeWorkspaceId = isWsFocus
+  const routeWorkspaceId = isWsFocus || (focused?.kind === 'workspace-details' && focused.params.source === source)
     ? focused.params.wsId
     : focused?.kind === landingKind
       ? focused.params.targetWsId ?? null
@@ -524,6 +524,7 @@ export function ChatWorkspaceSection({
           ? t('autoQuant.newWorkspace')
           : mode === 'prediction' ? t('autoPrediction.newWorkspace') : t('chat.newWorkspace')}
         onConfigure={() => focusedWorkspace && ctx.openAgentConfig(focusedWorkspace.id)}
+        onDetails={() => focusedWorkspace && navigate({ kind: 'workspace-details', params: { wsId: focusedWorkspace.id, source } })}
         onUpgrade={() => focusedWorkspace && ctx.openAgentConfig(focusedWorkspace.id, undefined, 'template')}
         onSelectWorkspace={(workspaceId) => {
           selectHarnessWorkspace(workspaceId, () => {
@@ -627,6 +628,7 @@ interface ChatWorkspaceContextFooterProps {
   createWorkspaceLabel: string
   onConfigure: () => void
   onUpgrade: () => void
+  onDetails: () => void
   onSelectWorkspace: (workspaceId: string) => void
   onBrowseSessions: (restoreFocus: HTMLElement | null) => void
   onCreateWorkspace: () => void
@@ -712,12 +714,15 @@ function ChatWorkspaceContextFooter(props: ChatWorkspaceContextFooterProps): Rea
             <DropdownMenuLabel className="text-micro px-2 py-1 font-medium text-muted-foreground/70">
               {t('settings.group.workspace')}
             </DropdownMenuLabel>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger
+            <div className="flex items-stretch gap-1">
+              <DropdownMenuItem
+                disabled={!props.workspace}
+                onClick={() => queueAction(props.onDetails)}
+                title={t('workspaceDetails.title')}
                 aria-label={props.workspace
                   ? t('chat.currentWorkspaceLabel', { workspace: workspaceDisplayTitle(props.workspace) })
-                  : t('chat.switchWorkspace')}
-                className="oa-workspace-context-item min-h-12 items-start gap-2 rounded-lg px-2 py-2 text-foreground focus:bg-muted focus:text-foreground"
+                  : t('chat.currentWorkspace')}
+                className="oa-workspace-context-item min-h-12 min-w-0 flex-1 cursor-pointer items-start gap-2 rounded-lg px-2 py-2 text-foreground focus:bg-muted focus:text-foreground"
               >
                 <LayoutGrid size={15} strokeWidth={2} className="mt-0.5 shrink-0" aria-hidden />
                 <span className="min-w-0 flex-1">
@@ -728,37 +733,43 @@ function ChatWorkspaceContextFooter(props: ChatWorkspaceContextFooterProps): Rea
                     </span>
                   )}
                 </span>
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent
-                sideOffset={6}
-                className="flex max-h-[min(24rem,var(--available-height))] w-60 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-border/70 p-1 shadow-lg ring-0"
-              >
-                <DropdownMenuGroup className="shrink-0">
-                  <DropdownMenuLabel className="text-micro px-2 py-1 font-medium text-muted-foreground/70">
-                    {t('chat.switchWorkspace')}
-                  </DropdownMenuLabel>
-                </DropdownMenuGroup>
-                <DropdownMenuRadioGroup value={props.workspace?.id ?? ''}
-                  className="min-h-0 overflow-y-auto overscroll-contain">
-                  {props.workspaces.map((workspace) => (
-                    <DropdownMenuRadioItem key={workspace.id} value={workspace.id} closeOnClick
-                      aria-label={workspaceDisplayTitle(workspace)}
-                      title={workspaceDisplayTitle(workspace)}
-                      onClick={() => queueAction(() => props.onSelectWorkspace(workspace.id))}
-                      className="oa-workspace-context-item min-h-8 gap-2 rounded-md py-1 pl-2 pr-8"
-                    >
-                      <span className="min-w-0 flex-1 truncate">{workspaceDisplayName(workspace)}</span>
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-                <DropdownMenuSeparator className="mx-0 shrink-0 bg-border/60" />
-                <DropdownMenuItem onClick={() => queueAction(props.onCreateWorkspace)}
-                  className={menuItemClass + ' shrink-0'}>
-                  <Plus size={14} strokeWidth={2} aria-hidden />
-                  <span className="min-w-0 flex-1 truncate">{props.createWorkspaceLabel}</span>
-                </DropdownMenuItem>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
+              </DropdownMenuItem>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger aria-label={t('chat.switchWorkspace')} title={t('chat.switchWorkspace')}
+                  className="oa-workspace-context-item min-h-12 w-8 shrink-0 justify-center rounded-lg px-1 text-muted-foreground focus:bg-muted focus:text-foreground [&>svg]:mx-auto">
+                  <span className="sr-only">{t('chat.switchWorkspace')}</span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent
+                  sideOffset={6}
+                  className="flex max-h-[min(24rem,var(--available-height))] w-60 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-border/70 p-1 shadow-lg ring-0"
+                >
+                  <DropdownMenuGroup className="shrink-0">
+                    <DropdownMenuLabel className="text-micro px-2 py-1 font-medium text-muted-foreground/70">
+                      {t('chat.switchWorkspace')}
+                    </DropdownMenuLabel>
+                  </DropdownMenuGroup>
+                  <DropdownMenuRadioGroup value={props.workspace?.id ?? ''}
+                    className="min-h-0 overflow-y-auto overscroll-contain">
+                    {props.workspaces.map((workspace) => (
+                      <DropdownMenuRadioItem key={workspace.id} value={workspace.id} closeOnClick
+                        aria-label={workspaceDisplayTitle(workspace)}
+                        title={workspaceDisplayTitle(workspace)}
+                        onClick={() => queueAction(() => props.onSelectWorkspace(workspace.id))}
+                        className="oa-workspace-context-item min-h-8 gap-2 rounded-md py-1 pl-2 pr-8"
+                      >
+                        <span className="min-w-0 flex-1 truncate">{workspaceDisplayName(workspace)}</span>
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                  <DropdownMenuSeparator className="mx-0 shrink-0 bg-border/60" />
+                  <DropdownMenuItem onClick={() => queueAction(props.onCreateWorkspace)}
+                    className={menuItemClass + ' shrink-0'}>
+                    <Plus size={14} strokeWidth={2} aria-hidden />
+                    <span className="min-w-0 flex-1 truncate">{props.createWorkspaceLabel}</span>
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            </div>
           </DropdownMenuGroup>
 
           <DropdownMenuSeparator className="mx-0 bg-border/60" />

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -521,7 +521,7 @@ export async function fetchTemplateReadme(name: string): Promise<string | null> 
  * README body doesn't show the metadata to the user. Conservative: only
  * strips when frontmatter is at column 0; anything else passes through.
  */
-function stripFrontmatter(raw: string): string {
+export function stripFrontmatter(raw: string): string {
   const text = raw.replace(/^﻿/, '');
   if (!text.startsWith('---')) return text;
   const closeMatch = /^---\s*$/m.exec(text.slice(3));

--- a/ui/src/hooks/useWorkspaceDetails.spec.ts
+++ b/ui/src/hooks/useWorkspaceDetails.spec.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReadFileResult, Workspace } from '../components/workspace/api'
+import { useWorkspaceDetails } from './useWorkspaceDetails'
+
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(), guide: vi.fn(),
+  context: { workspaces: [] as Workspace[], templates: [{ name: 'chat', version: '9.0' }], hasLoaded: true, listError: null as string | null, refresh: vi.fn() },
+}))
+vi.mock('../contexts/workspaces-context', () => ({ useWorkspaces: () => mocks.context }))
+vi.mock('./useHarnessPreferences', () => ({ useHarnessPreferences: () => ({ preferences: {} }) }))
+vi.mock('./useWorkspaceSessionDirectory', () => ({ useWorkspaceSessionDirectory: () => ({ directory: null, loading: false, error: null }) }))
+vi.mock('../components/workspace/api', async importOriginal => ({
+  ...await importOriginal<typeof import('../components/workspace/api')>(),
+  readWorkspaceFile: mocks.read, fetchTemplateReadme: mocks.guide,
+}))
+
+const workspace: Workspace = { id: 'one', tag: 'one', template: 'chat', dir: '/tmp/one', createdAt: '2026-09-05', sessions: [], currentVersion: '1.0' }
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.context.workspaces = [workspace, { ...workspace, id: 'two' }]
+  mocks.context.hasLoaded = true
+  mocks.context.listError = null
+  mocks.read.mockResolvedValue({ kind: 'ok', content: '---\nversion: 1.0\n---\n# My workspace' })
+  mocks.guide.mockResolvedValue('# Template guide')
+})
+afterEach(cleanup)
+
+describe('useWorkspaceDetails', () => {
+  it('keeps instance content and applied version separate from the catalog', async () => {
+    const { result } = renderHook(() => useWorkspaceDetails('one', 'chat'))
+    await waitFor(() => expect(result.current.readme).toEqual({ kind: 'ok', content: '# My workspace' }))
+    expect(result.current.guide?.content).toBe('# Template guide')
+    expect(result.current.workspace?.currentVersion).toBe('1.0')
+    expect(result.current.template?.version).toBe('9.0')
+    expect(mocks.read).toHaveBeenCalledWith('one', 'README.md')
+  })
+
+  it('does not fetch content for a Workspace belonging to a different Harness', () => {
+    const { result } = renderHook(() => useWorkspaceDetails('one', 'prediction'))
+    expect(result.current.workspace).toBeUndefined()
+    expect(mocks.read).not.toHaveBeenCalled()
+    expect(mocks.guide).not.toHaveBeenCalled()
+  })
+
+  it('keeps missing documents distinct from errors and allows retry', async () => {
+    mocks.read.mockResolvedValueOnce({ kind: 'file_missing' })
+    mocks.guide.mockRejectedValueOnce(new Error('offline'))
+    const { result } = renderHook(() => useWorkspaceDetails('one', 'chat'))
+    await waitFor(() => expect(result.current.guide?.error).toBe('offline'))
+    expect(result.current.readme?.kind).toBe('file_missing')
+    act(() => result.current.retryDocuments())
+    await waitFor(() => expect(result.current.guide?.content).toBe('# Template guide'))
+    expect(result.current.readme?.kind).toBe('ok')
+  })
+
+  it('ignores a late previous Workspace response', async () => {
+    let resolveOld!: (result: ReadFileResult) => void
+    mocks.read.mockImplementationOnce(() => new Promise<ReadFileResult>(resolve => { resolveOld = resolve }))
+    const { result, rerender } = renderHook(({ id }) => useWorkspaceDetails(id, 'chat'), { initialProps: { id: 'one' } })
+    rerender({ id: 'two' })
+    await waitFor(() => expect(result.current.readme?.kind).toBe('ok'))
+    await act(async () => { resolveOld({ kind: 'ok', content: 'OLD' }) })
+    expect(result.current.readme).toEqual({ kind: 'ok', content: '# My workspace' })
+  })
+
+  it('distinguishes initial loading from failed list retrieval', () => {
+    mocks.context.workspaces = []
+    mocks.context.hasLoaded = false
+    const { result, rerender } = renderHook(() => useWorkspaceDetails('one', 'chat'))
+    expect(result.current.loading).toBe(true)
+    mocks.context.listError = 'Backend unavailable'
+    rerender()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBe('Backend unavailable')
+  })
+})

--- a/ui/src/hooks/useWorkspaceDetails.ts
+++ b/ui/src/hooks/useWorkspaceDetails.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { fetchTemplateReadme, readWorkspaceFile, stripFrontmatter, type ReadFileResult } from '../components/workspace/api'
+import { useWorkspaces } from '../contexts/workspaces-context'
+import type { WorkspaceSource } from '../tabs/types'
+import { joinWorkspaceHarnessSessions } from '../components/workspace/harness-sessions'
+import { useHarnessPreferences } from './useHarnessPreferences'
+import { useWorkspaceSessionDirectory } from './useWorkspaceSessionDirectory'
+
+const templates: Record<WorkspaceSource, string> = {
+  chat: 'chat', 'auto-quant': 'auto-quant-v2', prediction: 'auto-prediction',
+}
+
+/** Instance content and catalog documentation are independent, read-only resources. */
+export function useWorkspaceDetails(wsId: string, source: WorkspaceSource) {
+  const context = useWorkspaces()
+  const workspace = context.workspaces.find(w => w.id === wsId && w.template === templates[source])
+  const template = context.templates.find(t => t.name === workspace?.template)
+  const [attempt, setAttempt] = useState(0)
+  const [readme, setReadme] = useState<{ id: string; result: ReadFileResult } | null>(null)
+  const [guide, setGuide] = useState<{ name: string; content: string | null; error: string | null } | null>(null)
+  const id = workspace?.id
+  const templateName = workspace?.template
+  const directory = useWorkspaceSessionDirectory(id ?? null)
+  const { preferences } = useHarnessPreferences()
+  const sessions = workspace ? joinWorkspaceHarnessSessions(workspace, directory.directory, {
+    includeHeadlessBornSessions: preferences.showHeadlessBornSessions,
+    includeIssueAttachedSessions: preferences.showIssueAttachedSessions,
+  }) : []
+
+  useEffect(() => {
+    let cancelled = false
+    setReadme(null)
+    if (id) void readWorkspaceFile(id, 'README.md').catch((error: unknown): ReadFileResult => ({
+      kind: 'error', message: error instanceof Error ? error.message : String(error),
+    })).then(result => {
+      if (!cancelled) setReadme({ id, result: result.kind === 'ok'
+        ? { ...result, content: stripFrontmatter(result.content) } : result })
+    })
+    return () => { cancelled = true }
+  }, [id, attempt])
+
+  useEffect(() => {
+    let cancelled = false
+    setGuide(null)
+    if (templateName) void fetchTemplateReadme(templateName).then(content => {
+      if (!cancelled) setGuide({ name: templateName, content, error: null })
+    }).catch((error: unknown) => {
+      if (!cancelled) setGuide({ name: templateName, content: null, error: error instanceof Error ? error.message : String(error) })
+    })
+    return () => { cancelled = true }
+  }, [templateName, attempt])
+
+  return {
+    workspace, template,
+    sessionCount: directory.loading || directory.error ? null : sessions.length,
+    loading: !context.hasLoaded && !context.listError,
+    error: context.listError,
+    refresh: context.refresh,
+    readme: readme?.id === id ? readme?.result ?? null : null,
+    guide: guide?.name === templateName ? guide : null,
+    retryDocuments: () => setAttempt(n => n + 1),
+  }
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -13,6 +13,24 @@
  */
 
 export const en = {
+  workspaceDetails: {
+    title: "Workspace details",
+    back: "Back to conversations",
+    notFound: "This Workspace is unavailable in this Harness.",
+    harness: "Harness",
+    created: "Created",
+    baseline: "Applied template",
+    sourceVersion: "Installed Harness source",
+    repository: "Source repository",
+    location: "Local folder",
+    documents: "Workspace documentation",
+    overview: "Workspace overview",
+    guide: "Harness guide",
+    overviewHint: "README.md in this Workspace. This content belongs to the Workspace and may change as you work.",
+    guideHint: "Reference documentation from the current template catalog, not your Workspace’s live configuration.",
+    noReadme: "There is no README.md in this Workspace yet. You can ask your agent to write an overview of its purpose and contents.",
+    noGuide: "No Harness guide is available.",
+  },
   nav: {
     item: {
       inbox: 'Inbox',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -2,6 +2,24 @@ import type { Resources } from './en'
 
 /** 日本語. Typed as `Resources` → must match en's key structure exactly. */
 export const ja: Resources = {
+  workspaceDetails: {
+    title: "ワークスペース詳細",
+    back: "会話に戻る",
+    notFound: "この Harness ではこのワークスペースを利用できません。",
+    harness: "Harness",
+    created: "作成日",
+    baseline: "適用済みテンプレート",
+    sourceVersion: "インストール済み Harness ソース",
+    repository: "ソースリポジトリ",
+    location: "ローカルフォルダー",
+    documents: "ワークスペースのドキュメント",
+    overview: "ワークスペース概要",
+    guide: "Harness ガイド",
+    overviewHint: "このワークスペース内の README.md です。内容はワークスペースが管理し、作業とともに変化します。",
+    guideHint: "現在のテンプレートカタログの参考資料です。このワークスペースの現在の設定ではありません。",
+    noReadme: "このワークスペースにはまだ README.md がありません。目的や内容の概要をエージェントに作成してもらえます。",
+    noGuide: "Harness ガイドはありません。",
+  },
   nav: {
     item: {
       inbox: '受信トレイ',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -10,6 +10,24 @@ import type { Resources } from './en'
  * Content is UI chrome only — no geographic or other non-technical terms.
  */
 export const zhHant: Resources = {
+  workspaceDetails: {
+    title: "工作區詳情",
+    back: "返回對話",
+    notFound: "此 Harness 中沒有可用的該工作區。",
+    harness: "Harness",
+    created: "建立時間",
+    baseline: "已套用的範本",
+    sourceVersion: "已安裝的 Harness 來源版本",
+    repository: "來源儲存庫",
+    location: "本機目錄",
+    documents: "工作區文件",
+    overview: "工作區概覽",
+    guide: "Harness 指南",
+    overviewHint: "此工作區內的 README.md。內容由工作區管理，會隨著你的使用而變化。",
+    guideHint: "目前範本目錄提供的參考說明，並非此工作區的即時設定。",
+    noReadme: "此工作區還沒有 README.md。你可以讓 Agent 撰寫一份說明，介紹它的用途和內容。",
+    noGuide: "暫無 Harness 指南。",
+  },
   nav: {
     item: {
       inbox: '收件匣',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -2,6 +2,24 @@ import type { Resources } from './en'
 
 /** 简体中文. Typed as `Resources` → must match en's key structure exactly. */
 export const zh: Resources = {
+  workspaceDetails: {
+    title: "工作区详情",
+    back: "返回会话",
+    notFound: "此 Harness 中没有可用的该工作区。",
+    harness: "Harness",
+    created: "创建时间",
+    baseline: "已应用的模板",
+    sourceVersion: "已安装的 Harness 来源版本",
+    repository: "来源仓库",
+    location: "本地目录",
+    documents: "工作区文档",
+    overview: "工作区概览",
+    guide: "Harness 指南",
+    overviewHint: "此工作区内的 README.md。内容由工作区管理，会随着你的使用而变化。",
+    guideHint: "当前模板目录提供的参考说明，并非此工作区的实时配置。",
+    noReadme: "此工作区还没有 README.md。你可以让 Agent 撰写一份说明，介绍它的用途和内容。",
+    noGuide: "暂无 Harness 指南。",
+  },
   nav: {
     item: {
       inbox: '收件箱',

--- a/ui/src/live/ui-layout.spec.ts
+++ b/ui/src/live/ui-layout.spec.ts
@@ -15,9 +15,11 @@ import {
 } from './ui-layout'
 
 describe('ui-layout document', () => {
-  it('covers every catalog page and starts with no hidden entries', () => {
+  it('covers every active catalog page while accepting retired layout ids', () => {
     const catalogPages = NAV_SECTIONS.flatMap((section) => section.items.map((item) => item.page))
-    expect(new Set(catalogPages)).toEqual(new Set(ACTIVITY_PAGE_IDS))
+    // Persisted layout validation stays compatible; the navigation catalog
+    // decides which accepted ids can actually appear or be configured.
+    expect(new Set(catalogPages)).toEqual(new Set(ACTIVITY_PAGE_IDS.filter(page => page !== 'workspaces' && page !== 'automation')))
     expect(defaultUiLayout().hidden).toEqual([])
     expect(defaultUiLayout().hidden).not.toContain(PINNED_ACTIVITY_PAGE)
   })

--- a/ui/src/pages/ActivityBarSettingsPage.spec.tsx
+++ b/ui/src/pages/ActivityBarSettingsPage.spec.tsx
@@ -60,12 +60,14 @@ describe('ActivityBarSettingsPage', () => {
   it('persists the first visibility edit instead of treating it as hydration', async () => {
     render(<ActivityBarSettingsPage />)
 
-    const toggle = screen.getByRole('switch', { name: 'Hide Workspaces' })
+    expect(screen.queryByRole('switch', { name: /Workspaces/ })).toBeNull()
+    expect(screen.queryByRole('switch', { name: /Automation/ })).toBeNull()
+    const toggle = screen.getByRole('switch', { name: 'Hide Inbox' })
     expect(toggle.getAttribute('aria-checked')).toBe('true')
     fireEvent.click(toggle)
-    expect(screen.getByRole('switch', { name: 'Show Workspaces' }).getAttribute('aria-checked')).toBe('false')
+    expect(screen.getByRole('switch', { name: 'Show Inbox' }).getAttribute('aria-checked')).toBe('false')
     await waitFor(() => expect(mocks.save).toHaveBeenCalledOnce(), { timeout: 1_500 })
-    expect(mocks.save.mock.calls[0]?.[0].hidden).toContain('workspaces')
+    expect(mocks.save.mock.calls[0]?.[0].hidden).toContain('inbox')
   })
 
   it('creates a custom group and can reset to the default document', () => {

--- a/ui/src/pages/AutoQuantSetupPage.spec.tsx
+++ b/ui/src/pages/AutoQuantSetupPage.spec.tsx
@@ -135,6 +135,7 @@ describe('AutoQuant setup', () => {
     render(<AutoQuantSetupPage />)
 
     expect(screen.getByRole('heading', { name: 'Choose your AutoQuant workspace' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /Manage workspaces/i })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Initialize AutoQuant' })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /Quant desk/ }))
     await waitFor(() => {

--- a/ui/src/pages/AutomationPage.tsx
+++ b/ui/src/pages/AutomationPage.tsx
@@ -11,8 +11,8 @@ interface AutomationPageProps {
 
 /**
  * Automation page is sub-section-driven — `spec.params.section` picks which
- * surface renders. The Automation sidebar holds one row per section so each
- * section is its own tab in the editor area. Occupancy lives on Office.
+ * surface renders. Both entries live under Settings → Developer, without a
+ * separate Automation navigator. Occupancy lives on Office.
  * Schedules live on self-described Workspace issues; the retired event-bus
  * surfaces are intentionally absent.
  */

--- a/ui/src/pages/DevPage.tsx
+++ b/ui/src/pages/DevPage.tsx
@@ -6,6 +6,7 @@ import { Spinner, EmptyState } from '../components/StateViews'
 import { getIntlLocale } from '../lib/intl'
 import { useToast } from '../components/Toast'
 import { LogsPage } from './LogsPage'
+import { AutomationPage } from './AutomationPage'
 import { SimulatorPage } from './SimulatorPage'
 import { FrontendLabPage } from './FrontendLabPage'
 import { OnboardingDesignPage } from './OnboardingDesignPage'
@@ -31,6 +32,8 @@ const TAB_TITLE_KEYS = {
   onboarding: 'dev.onboarding',
   snapshots: 'dev.snapshots',
   logs: 'common.logs',
+  runs: 'automation.runs',
+  api: 'automation.api',
   simulator: 'simulator.title',
 } as const satisfies Record<Tab, string>
 
@@ -46,6 +49,10 @@ interface DevPageProps {
 export function DevPage({ spec }: DevPageProps) {
   const tab = spec.params.tab
   const { t } = useTranslation()
+
+  if (tab === 'runs' || tab === 'api') {
+    return <AutomationPage spec={{ kind: 'automation', params: { section: tab } }} />
+  }
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/ui/src/pages/WorkspaceDetailsPage.spec.tsx
+++ b/ui/src/pages/WorkspaceDetailsPage.spec.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { i18n } from '../i18n'
+import { WorkspaceDetailsPage } from './WorkspaceDetailsPage'
+import type { useWorkspaceDetails } from '../hooks/useWorkspaceDetails'
+
+const mocks = vi.hoisted(() => ({ details: {} as ReturnType<typeof useWorkspaceDetails>, openOrFocus: vi.fn() }))
+vi.mock('../hooks/useWorkspaceDetails', () => ({ useWorkspaceDetails: () => mocks.details }))
+vi.mock('../tabs/store', () => ({ useWorkspace: (selector: (state: { openOrFocus: typeof mocks.openOrFocus }) => unknown) => selector(mocks) }))
+vi.mock('../components/FileContentView', () => ({ FileContentView: ({ result }: { result: { content?: string } }) => <article>{result.content}</article> }))
+vi.mock('../components/MarkdownContent', () => ({ MarkdownContent: ({ text }: { text: string }) => <article>{text}</article> }))
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+  vi.clearAllMocks()
+  mocks.details = {
+    workspace: { id: 'one', tag: 'desk', template: 'chat', dir: '/tmp/desk', createdAt: '2026-09-05', sessions: [], currentVersion: '1.0' },
+    template: { name: 'chat', version: '9.0', defaultAgents: [], hasReadme: true },
+    sessionCount: 2, loading: false, error: null,
+    refresh: vi.fn(async () => {}), retryDocuments: vi.fn(),
+    readme: { kind: 'ok', content: 'My customized workspace' },
+    guide: { name: 'chat', content: 'Current catalog guide', error: null },
+  }
+})
+afterEach(cleanup)
+
+describe('WorkspaceDetailsPage', () => {
+  it('shows instance content first, with a separate catalog guide and its own version', () => {
+    render(<WorkspaceDetailsPage spec={{ kind: 'workspace-details', params: { wsId: 'one', source: 'chat' } }} />)
+    expect(screen.getByRole('heading', { name: 'desk' })).toBeTruthy()
+    expect(screen.getByText('v1.0')).toBeTruthy()
+    expect(screen.getByText('My customized workspace')).toBeTruthy()
+    expect(screen.queryByText('Current catalog guide')).toBeNull()
+    fireEvent.click(screen.getByRole('tab', { name: 'Harness guide' }))
+    expect(screen.getByText('Current catalog guide')).toBeTruthy()
+    expect(screen.getByText(/v9.0/)).toBeTruthy()
+    expect(screen.queryByText('My customized workspace')).toBeNull()
+  })
+
+  it('shows an honest empty README state and keeps guide failures retryable', () => {
+    mocks.details.readme = { kind: 'file_missing' }
+    mocks.details.guide = { name: 'chat', content: null, error: 'Guide unavailable' }
+    render(<WorkspaceDetailsPage spec={{ kind: 'workspace-details', params: { wsId: 'one', source: 'chat' } }} />)
+    expect(screen.getByText(/There is no README.md/)).toBeTruthy()
+    fireEvent.click(screen.getByRole('tab', { name: 'Harness guide' }))
+    expect(screen.getByRole('alert').textContent).toContain('Guide unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(mocks.details.retryDocuments).toHaveBeenCalledOnce()
+  })
+
+  it('refreshes metadata and documentation without opening configuration', () => {
+    render(<WorkspaceDetailsPage spec={{ kind: 'workspace-details', params: { wsId: 'one', source: 'chat' } }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    expect(mocks.details.refresh).toHaveBeenCalledOnce()
+    expect(mocks.details.retryDocuments).toHaveBeenCalledOnce()
+    expect(mocks.openOrFocus).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['chat', 'chat-landing'], ['auto-quant', 'auto-quant-landing'], ['prediction', 'auto-prediction-landing'],
+  ] as const)('returns to the same Workspace in %s', (source, kind) => {
+    render(<WorkspaceDetailsPage spec={{ kind: 'workspace-details', params: { wsId: 'one', source } }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Back to conversations' }))
+    expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind, params: { targetWsId: 'one' } })
+  })
+})

--- a/ui/src/pages/WorkspaceDetailsPage.tsx
+++ b/ui/src/pages/WorkspaceDetailsPage.tsx
@@ -1,0 +1,102 @@
+import { useCallback, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ArrowLeft, Folder, Layers, RefreshCw } from 'lucide-react'
+import { PageTopBar } from '../components/PageTopBar'
+import { FileContentView } from '../components/FileContentView'
+import { MarkdownContent } from '../components/MarkdownContent'
+import { Button } from '../components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs'
+import { CenteredLoading } from '../components/StateViews'
+import { workspaceDisplayName } from '../components/workspace/display'
+import { useWorkspaceDetails } from '../hooks/useWorkspaceDetails'
+import { useWorkspace } from '../tabs/store'
+import type { ViewSpec } from '../tabs/types'
+
+export function WorkspaceDetailsPage({ spec }: { spec: Extract<ViewSpec, { kind: 'workspace-details' }> }) {
+  const { t, i18n } = useTranslation()
+  const { wsId, source } = spec.params
+  const details = useWorkspaceDetails(wsId, source)
+  const openOrFocus = useWorkspace(s => s.openOrFocus)
+  const { workspace, template, readme, guide } = details
+  const resolveRelativeHref = useCallback((href: string) => {
+    const file = new URL(href, 'https://workspace.invalid/')
+    let path = file.pathname.slice(1)
+    try { path = decodeURIComponent(path) } catch { /* A literal percent is a valid filename. */ }
+    return `/${source}/workspaces/${encodeURIComponent(wsId)}/view/${encodeURIComponent(path)}`
+  }, [source, wsId])
+  const back = () => openOrFocus({
+    kind: source === 'chat' ? 'chat-landing' : source === 'auto-quant' ? 'auto-quant-landing' : 'auto-prediction-landing',
+    params: { targetWsId: wsId },
+  })
+  const retry = <Button size="sm" variant="outline" onClick={details.retryDocuments}>{t('common.retry')}</Button>
+  const created = workspace ? new Date(workspace.createdAt) : null
+  const baseline = workspace?.currentVersion ?? workspace?.spawnedFromVersion
+
+  return (
+    <div className="h-full min-w-0 overflow-y-auto">
+      <PageTopBar title={t('workspaceDetails.title')} actions={
+        <>
+          <Button size="icon-sm" variant="ghost" aria-label={t('harnessSurface.refresh')} title={t('harnessSurface.refresh')} onClick={() => {
+            details.retryDocuments()
+            void details.refresh()
+          }}><RefreshCw size={14} aria-hidden /></Button>
+          <Button size="sm" variant="ghost" onClick={back}><ArrowLeft size={14} aria-hidden />{t('workspaceDetails.back')}</Button>
+        </>
+      } />
+      {details.loading ? <CenteredLoading label={t('common.loading')} /> : !workspace ? (
+        <div className="mx-auto max-w-3xl space-y-3 p-6" role="status">
+          <p>{details.error || t('workspaceDetails.notFound')}</p>
+          {details.error && <Button variant="outline" onClick={() => void details.refresh()}>{t('common.retry')}</Button>}
+        </div>
+      ) : (
+        <div className="mx-auto w-full max-w-4xl space-y-7 px-4 py-6 sm:px-7 sm:py-8">
+          <header className="flex items-start gap-3.5">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary"><Folder size={21} aria-hidden /></span>
+            <div className="min-w-0">
+              <p className="text-caption mb-1 text-muted-foreground">{t(`office.harness.${source}`)} · Workspace</p>
+              <h1 className="break-words text-xl font-semibold tracking-tight [overflow-wrap:anywhere]">{workspaceDisplayName(workspace)}</h1>
+              {workspace.description && <p className="text-body mt-2 max-w-2xl leading-relaxed text-muted-foreground">{workspace.description}</p>}
+            </div>
+          </header>
+
+          {workspace.metadataError && <p role="alert" className="text-body text-destructive">{workspace.metadataError}</p>}
+          <dl className="grid grid-cols-2 gap-x-5 gap-y-4 border-y border-border py-5 sm:gap-x-8">
+            <Metadata label={t('workspaceDetails.harness')}>{template?.displayName || workspace.template}</Metadata>
+            <Metadata label={source === 'chat' ? t('chat.recentConversations') : source === 'auto-quant' ? t('autoQuant.recentResearch') : t('autoPrediction.recentResearch')}>{details.sessionCount ?? '—'}</Metadata>
+            <Metadata label={t('workspaceDetails.created')}>{created && !Number.isNaN(created.getTime()) ? created.toLocaleDateString(i18n.language, { year: 'numeric', month: 'short', day: 'numeric' }) : '—'}</Metadata>
+            {baseline && <Metadata label={t('workspaceDetails.baseline')}>v{baseline.replace(/^v/, '')}</Metadata>}
+            {workspace.harnessSource && <Metadata label={t('workspaceDetails.sourceVersion')}>{workspace.harnessSource.version} · <span className="font-mono text-caption">{workspace.harnessSource.commit.slice(0, 12)}</span></Metadata>}
+            {workspace.harnessSource && <Metadata label={t('workspaceDetails.repository')} wide>{workspace.harnessSource.repository}</Metadata>}
+            <Metadata label={t('workspaceDetails.location')} wide><span className="font-mono text-caption">{workspace.dir}</span></Metadata>
+          </dl>
+
+          <Tabs defaultValue="workspace" key={wsId} className="min-w-0">
+            <TabsList aria-label={t('workspaceDetails.documents')} className="mb-4 max-w-full">
+              <TabsTrigger value="workspace" className="flex-none max-[380px]:px-2">{t('workspaceDetails.overview')}</TabsTrigger>
+              <TabsTrigger value="guide" className="flex-none max-[380px]:px-2"><Layers size={14} className="shrink-0" aria-hidden />{t('workspaceDetails.guide')}</TabsTrigger>
+            </TabsList>
+            <TabsContent value="workspace" className="min-w-0 space-y-5">
+              <p className="text-caption leading-relaxed text-muted-foreground">{t('workspaceDetails.overviewHint')}</p>
+              {!readme ? <CenteredLoading label={t('common.loading')} /> : readme.kind === 'file_missing' ? (
+                <p className="text-body rounded-lg bg-muted/40 p-5 leading-relaxed text-muted-foreground">{t('workspaceDetails.noReadme')}</p>
+              ) : <div className="min-w-0 break-words [overflow-wrap:anywhere]"><FileContentView path="README.md" result={readme} resolveRelativeHref={resolveRelativeHref} /></div>}
+              {readme?.kind === 'error' && retry}
+            </TabsContent>
+            <TabsContent value="guide" className="min-w-0 space-y-5">
+              <p className="text-caption leading-relaxed text-muted-foreground">{t('workspaceDetails.guideHint')}{template?.version ? ` · v${template.version}` : ''}</p>
+              {!guide ? <CenteredLoading label={t('common.loading')} /> : guide.error ? (
+                <div role="alert" className="text-body space-y-3"><p>{guide.error}</p>{retry}</div>
+              ) : guide.content ? (
+                <div className="min-w-0 break-words [overflow-wrap:anywhere]"><MarkdownContent text={guide.content} variant="reading" /></div>
+              ) : <p className="text-body text-muted-foreground">{t('workspaceDetails.noGuide')}</p>}
+            </TabsContent>
+          </Tabs>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Metadata({ label, children, wide }: { label: string; children: ReactNode; wide?: boolean }) {
+  return <div className={`min-w-0 ${wide ? 'col-span-2' : ''}`}><dt className="text-caption mb-1 text-muted-foreground">{label}</dt><dd className="text-body break-words [overflow-wrap:anywhere]">{children}</dd></div>
+}

--- a/ui/src/tabs/UrlAdopter.spec.tsx
+++ b/ui/src/tabs/UrlAdopter.spec.tsx
@@ -48,6 +48,20 @@ beforeEach(() => {
 
 afterEach(cleanup)
 
+it.each(['/workspaces', '/workspaces/templates', '/workspaces/templates/chat'])('retires %s into Ask Alice', async path => {
+  render(<MemoryRouter initialEntries={[path]}><UrlAdopter /></MemoryRouter>)
+  await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind: 'chat-landing', params: {} }))
+  expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
+})
+
+it.each(['chat', 'auto-quant', 'prediction'] as const)('adopts a %s Workspace details deep link', async source => {
+  render(<MemoryRouter initialEntries={[`/${source}/workspaces/my%20workspace/details`]}><UrlAdopter /></MemoryRouter>)
+  await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({
+    kind: 'workspace-details', params: { wsId: 'my workspace', source },
+  }))
+  expect(mocks.setSidebar).toHaveBeenCalledWith(source)
+})
+
 describe('UrlAdopter file provenance', () => {
   it('restores an Auto Prediction file deep link with its Session return context', async () => {
     render(
@@ -102,7 +116,7 @@ describe('UrlAdopter file provenance', () => {
       kind: 'file-viewer',
       params: { wsId: 'workspace-1', path: 'README.md' },
     }))
-    expect(mocks.setSidebar).toHaveBeenCalledWith('workspaces')
+    expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
   })
 
   it('restores a Tracked file deep link with its entity return context', async () => {
@@ -206,6 +220,19 @@ describe('UrlAdopter Settings Beta', () => {
 })
 
 describe('UrlAdopter Settings Developer', () => {
+  it.each([
+    ['/settings/developer/runs', 'runs'],
+    ['/settings/developer/api', 'api'],
+    ['/automation', 'runs'],
+    ['/automation/runs', 'runs'],
+    ['/automation/api', 'api'],
+  ])('adopts %s into Settings Developer', async (path, tab) => {
+    render(<MemoryRouter initialEntries={[path]}><UrlAdopter /></MemoryRouter>)
+    await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind: 'dev', params: { tab } }))
+    expect(mocks.setSidebar).toHaveBeenCalledWith('settings')
+    expect(mocks.setSidebar).not.toHaveBeenCalledWith('automation')
+  })
+
   it('adopts a Developer page under Settings and highlights Settings', async () => {
     render(
       <MemoryRouter initialEntries={['/settings/developer/logs']}>

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -44,22 +44,25 @@ export function UrlAdopter() {
         <Route path="/chat/manager/s/:sessionId" element={<AdoptWorkspaceManager />} />
         <Route path="/chat/workspaces/:wsId/view/:path" element={<AdoptChatFileViewer />} />
         <Route path="/chat/workspaces/:wsId" element={<AdoptChatWorkspace />} />
+        <Route path="/chat/workspaces/:wsId/details" element={<AdoptWorkspaceDetails source="chat" />} />
         <Route path="/chat/workspaces/:wsId/s/:sessionId" element={<AdoptChatWorkspace />} />
         <Route path="/chat/:channelId" element={<Navigate to="/inbox" replace />} />
         <Route path="/auto-quant" element={<AdoptStatic spec={{ kind: 'auto-quant-landing', params: {} }} />} />
         <Route path="/auto-quant/workspaces/:wsId/studio" element={<AdoptHarnessSurface source="auto-quant" />} />
         <Route path="/auto-quant/workspaces/:wsId/view/:path" element={<AdoptAutoQuantFileViewer />} />
         <Route path="/auto-quant/workspaces/:wsId" element={<AdoptAutoQuantWorkspace />} />
+        <Route path="/auto-quant/workspaces/:wsId/details" element={<AdoptWorkspaceDetails source="auto-quant" />} />
         <Route path="/auto-quant/workspaces/:wsId/s/:sessionId" element={<AdoptAutoQuantWorkspace />} />
         <Route path="/prediction" element={<AdoptStatic spec={{ kind: 'auto-prediction-landing', params: {} }} />} />
         <Route path="/prediction/workspaces/:wsId/studio" element={<AdoptHarnessSurface source="prediction" />} />
         <Route path="/prediction/workspaces/:wsId/view/:path" element={<AdoptAutoPredictionFileViewer />} />
         <Route path="/prediction/workspaces/:wsId" element={<AdoptAutoPredictionWorkspace />} />
+        <Route path="/prediction/workspaces/:wsId/details" element={<AdoptWorkspaceDetails source="prediction" />} />
         <Route path="/prediction/workspaces/:wsId/s/:sessionId" element={<AdoptAutoPredictionWorkspace />} />
         <Route path="/portfolio" element={<AdoptTraderStatic spec={{ kind: 'portfolio', params: {} }} />} />
         <Route path="/issues" element={<AdoptStatic spec={{ kind: 'issue', params: {} }} />} />
         <Route path="/issues/:wsId/:id" element={<AdoptIssueDetail />} />
-        <Route path="/automation" element={<Navigate to="/automation/runs" replace />} />
+        <Route path="/automation" element={<Navigate to="/settings/developer/runs" replace />} />
         <Route path="/automation/runtime" element={<Navigate to="/office" replace />} />
         <Route path="/automation/:section" element={<AdoptAutomation />} />
         <Route
@@ -119,12 +122,9 @@ export function UrlAdopter() {
         <Route path="/tracked/issues/:wsId/:id" element={<AdoptTrackedIssueDetail />} />
 
         {/* Workspaces */}
-        <Route path="/workspaces" element={<AdoptStatic spec={{ kind: 'workspace-list', params: {} }} />} />
-        {/* Template catalog routes must come before /workspaces/:wsId so the
-            static `templates` segment wins the match even if a workspace id is
-            a human-readable slug. */}
-        <Route path="/workspaces/templates" element={<AdoptStatic spec={{ kind: 'template-catalog', params: {} }} />} />
-        <Route path="/workspaces/templates/:name" element={<AdoptTemplateDetail />} />
+        {/* Retired global inventory; old bookmarks return to the workbench. */}
+        <Route path="/workspaces" element={<Navigate to="/chat" replace />} />
+        <Route path="/workspaces/templates/*" element={<Navigate to="/chat" replace />} />
         <Route path="/workspaces/:wsId/view/:path" element={<AdoptFileViewer />} />
         <Route path="/workspaces/:wsId" element={<AdoptWorkspace />} />
         <Route path="/workspaces/:wsId/s/:sessionId" element={<AdoptWorkspace />} />
@@ -295,15 +295,14 @@ function AdoptAutomation() {
   const { section } = useParams<{ section: string }>()
   if (section === 'runtime') return <Navigate to="/office" replace />
   const valid: ReadonlyArray<string> = ['runs', 'api']
-  if (!section || !valid.includes(section)) return <Navigate to="/automation/runs" replace />
-  return (
-    <AdoptStatic
-      spec={{
-        kind: 'automation',
-        params: { section: section as Extract<ViewSpec, { kind: 'automation' }>['params']['section'] },
-      }}
-    />
-  )
+  const tab = section && valid.includes(section) ? section : 'runs'
+  return <Navigate to={`/settings/developer/${tab}`} replace />
+}
+
+function AdoptWorkspaceDetails({ source }: { source: 'chat' | 'auto-quant' | 'prediction' }) {
+  const { wsId } = useParams<{ wsId: string }>()
+  if (!wsId) return <Navigate to={`/${source}`} replace />
+  return <AdoptStatic spec={{ kind: 'workspace-details', params: { wsId, source } }} />
 }
 
 function AdoptWorkspace() {
@@ -351,12 +350,6 @@ function AdoptWorkspaceManager() {
   const { sessionId } = useParams<{ sessionId: string }>()
   if (!sessionId) return <Navigate to="/chat/manager" replace />
   return <AdoptStatic spec={{ kind: 'workspace-manager', params: { sessionId } }} />
-}
-
-function AdoptTemplateDetail() {
-  const { name } = useParams<{ name: string }>()
-  if (!name) return <Navigate to="/workspaces/templates" replace />
-  return <AdoptStatic spec={{ kind: 'template-detail', params: { name } }} />
 }
 
 function AdoptFileViewer() {
@@ -483,12 +476,13 @@ function specToSection(spec: ViewSpec): ActivitySection {
     case 'auto-prediction-landing': return 'prediction'
     case 'harness-surface':    return spec.params.source
     case 'workspace-manager':  return 'chat'
+    case 'workspace-details': return spec.params.source
     case 'workspace':
       return spec.params.source === 'chat'
         ? 'chat'
         : spec.params.source === 'auto-quant'
           ? 'auto-quant'
-          : spec.params.source === 'prediction' ? 'prediction' : 'workspaces'
+          : spec.params.source === 'prediction' ? 'prediction' : 'chat'
     case 'file-viewer':
       return spec.params.source === 'chat'
         ? 'chat'
@@ -496,17 +490,17 @@ function specToSection(spec: ViewSpec): ActivitySection {
           ? 'auto-quant'
           : spec.params.source === 'prediction'
             ? 'prediction'
-            : spec.params.source === 'tracked' ? 'tracked' : 'workspaces'
+            : spec.params.source === 'tracked' ? 'tracked' : 'chat'
     case 'workspace-list':
     case 'template-catalog':
-    case 'template-detail':    return 'workspaces'
+    case 'template-detail':    return 'chat'
     case 'connectors':         return 'connectors'
     case 'trading-as-git':
     case 'portfolio':
     case 'uta-detail':         return 'portfolio'
     case 'issue':
     case 'issue-detail':       return 'issue'
-    case 'automation':         return 'automation'
+    case 'automation':         return 'settings'
     case 'office':             return 'office'
     case 'news':
     case 'market-list':

--- a/ui/src/tabs/WorkspaceHarnessRedirect.spec.tsx
+++ b/ui/src/tabs/WorkspaceHarnessRedirect.spec.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { i18n } from '../i18n'
+import { WorkspaceHarnessRedirect } from './WorkspaceHarnessRedirect'
+
+const mocks = vi.hoisted(() => ({
+  openOrFocus: vi.fn(), setSidebar: vi.fn(),
+  context: { workspaces: [{ id: 'opaque-id', tag: 'prediction-looking-name', template: 'chat' }], hasLoaded: true, listError: null as string | null, refresh: vi.fn() },
+}))
+vi.mock('../contexts/workspaces-context', () => ({ useWorkspaces: () => mocks.context }))
+vi.mock('./store', () => ({ useWorkspace: (selector: (state: typeof mocks) => unknown) => selector(mocks) }))
+beforeEach(async () => {
+  vi.clearAllMocks()
+  await i18n.changeLanguage('en')
+  mocks.context.workspaces = [{ id: 'opaque-id', tag: 'prediction-looking-name', template: 'chat' }]
+  mocks.context.hasLoaded = true
+  mocks.context.listError = null
+})
+afterEach(cleanup)
+
+it.each([['chat', 'chat'], ['auto-quant-v2', 'auto-quant'], ['auto-prediction', 'prediction']])('routes %s Sessions into their actual Harness', async (template, source) => {
+  mocks.context.workspaces[0]!.template = template
+  render(<WorkspaceHarnessRedirect spec={{ kind: 'workspace', params: { wsId: 'opaque-id', sessionId: 'native-session' } }} />)
+  await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind: 'workspace', params: { wsId: 'opaque-id', sessionId: 'native-session', source } }))
+  expect(mocks.setSidebar).toHaveBeenCalledWith(source)
+})
+
+it('preserves file and return-Session identity', async () => {
+  render(<WorkspaceHarnessRedirect spec={{ kind: 'file-viewer', params: { wsId: 'opaque-id', path: 'reports/one.md', returnSessionId: 'native-session' } }} />)
+  await waitFor(() => expect(mocks.openOrFocus).toHaveBeenCalledWith({ kind: 'file-viewer', params: { wsId: 'opaque-id', path: 'reports/one.md', returnSessionId: 'native-session', source: 'chat' } }))
+})
+
+it('does not guess a Harness from the tag or mount the old global desk', () => {
+  mocks.context.workspaces[0]!.template = 'unknown'
+  render(<WorkspaceHarnessRedirect spec={{ kind: 'workspace', params: { wsId: 'opaque-id', sessionId: 'native-session' } }} />)
+  expect(screen.getByRole('status').textContent).toContain('unavailable')
+  expect(mocks.openOrFocus).not.toHaveBeenCalled()
+  expect(mocks.setSidebar).not.toHaveBeenCalled()
+})
+
+it('waits for metadata and preserves errors instead of falling back to a global desk', () => {
+  mocks.context.workspaces = []
+  mocks.context.hasLoaded = false
+  const view = render(<WorkspaceHarnessRedirect spec={{ kind: 'workspace', params: { wsId: 'opaque-id' } }} />)
+  expect(screen.getByText('Loading…')).toBeTruthy()
+  mocks.context.listError = 'Backend offline'
+  view.rerender(<WorkspaceHarnessRedirect spec={{ kind: 'workspace', params: { wsId: 'opaque-id' } }} />)
+  expect(screen.getByText('Backend offline')).toBeTruthy()
+  expect(mocks.openOrFocus).not.toHaveBeenCalled()
+})

--- a/ui/src/tabs/WorkspaceHarnessRedirect.tsx
+++ b/ui/src/tabs/WorkspaceHarnessRedirect.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useWorkspaces } from '../contexts/workspaces-context'
+import { CenteredLoading } from '../components/StateViews'
+import { Button } from '../components/ui/button'
+import { useWorkspace } from './store'
+import type { ViewSpec, WorkspaceSource } from './types'
+
+const harnessForTemplate: Record<string, WorkspaceSource | undefined> = {
+  chat: 'chat', 'auto-quant-v2': 'auto-quant', 'auto-prediction': 'prediction',
+}
+
+/** Resolve old/unspecified destinations without ever mounting a global desk.
+ * Membership comes from Workspace metadata, never from its tag or Session id. */
+export function WorkspaceHarnessRedirect({ spec }: {
+  spec: Extract<ViewSpec, { kind: 'workspace' | 'file-viewer' }>
+}) {
+  const { t } = useTranslation()
+  const { workspaces, hasLoaded, listError, refresh } = useWorkspaces()
+  const openOrFocus = useWorkspace(s => s.openOrFocus)
+  const setSidebar = useWorkspace(s => s.setSidebar)
+  const workspace = workspaces.find(w => w.id === spec.params.wsId)
+  const source = workspace?.template ? harnessForTemplate[workspace.template] : undefined
+  useEffect(() => {
+    if (!source) return
+    setSidebar(source)
+    openOrFocus(spec.kind === 'workspace'
+      ? { kind: 'workspace', params: { ...spec.params, source } }
+      : { kind: 'file-viewer', params: { ...spec.params, source } })
+  }, [source, spec, openOrFocus, setSidebar])
+
+  if (source || (!hasLoaded && !listError)) return <CenteredLoading label={t('common.loading')} />
+  return <div className="space-y-3 p-6" role="status">
+    <p className="text-body text-muted-foreground">{listError || t('workspaceDetails.notFound')}</p>
+    {listError && <Button variant="outline" onClick={() => void refresh()}>{t('common.retry')}</Button>}
+    <Button variant="outline" onClick={() => {
+      setSidebar('chat')
+      openOrFocus({ kind: 'chat-landing', params: {} })
+    }}>{t('workspaceDetails.back')}</Button>
+  </div>
+}

--- a/ui/src/tabs/registry.spec.ts
+++ b/ui/src/tabs/registry.spec.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import { getView, getViewShell } from './registry'
 
+it.each(['chat', 'auto-quant', 'prediction'] as const)('keeps %s Workspace details inside its Harness shell', source => {
+  const spec = { kind: 'workspace-details', params: { wsId: 'workspace one', source } } as const
+  expect(getView('workspace-details').toUrl(spec)).toBe(`/${source}/workspaces/workspace%20one/details`)
+  expect(getViewShell(spec)).toBe(source)
+})
+
 describe('file-viewer URL projection', () => {
   it('projects Ask Alice artifacts into the chat route with Session context', () => {
     expect(getView('file-viewer').toUrl({
@@ -17,11 +23,11 @@ describe('file-viewer URL projection', () => {
     )
   })
 
-  it('preserves the existing Workspace file URL', () => {
+  it('never projects unresolved Workspace files into the retired global area', () => {
     expect(getView('file-viewer').toUrl({
       kind: 'file-viewer',
       params: { wsId: 'workspace-1', path: 'README.md' },
-    })).toBe('/workspaces/workspace-1/view/README.md')
+    })).toBe('/chat')
   })
 
   it('projects AutoQuant artifacts into its Harness route', () => {
@@ -72,6 +78,11 @@ describe('Market News URL projection', () => {
 })
 
 describe('Settings URL projection', () => {
+  it.each(['runs', 'api'] as const)('projects current and saved legacy %s tabs into Developer', (tab) => {
+    expect(getView('dev').toUrl({ kind: 'dev', params: { tab } })).toBe(`/settings/developer/${tab}`)
+    expect(getView('automation').toUrl({ kind: 'automation', params: { section: tab } })).toBe(`/settings/developer/${tab}`)
+  })
+
   it('projects the Beta category onto /settings/beta', () => {
     expect(getView('settings').toUrl({
       kind: 'settings',

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType, ReactNode } from 'react'
 import type { Workspace } from '../components/workspace/api'
 import type { ViewKind, ViewSpec } from './types'
+import { WorkspaceDetailsPage } from '../pages/WorkspaceDetailsPage'
 
 import { PortfolioPage } from '../pages/PortfolioPage'
 import { TradingAsGitPage } from '../pages/TradingAsGitPage'
@@ -9,7 +10,6 @@ import { IssueSettingsPage } from '../pages/IssueSettingsPage'
 import { HarnessSettingsPage } from '../pages/HarnessSettingsPage'
 import { IssueDetailPage } from '../pages/IssueDetailPage'
 import { TrackedIssueDetailPage } from '../pages/TrackedIssueDetailPage'
-import { AutomationPage } from '../pages/AutomationPage'
 import { OfficePage } from '../pages/OfficePage'
 import { NewsPage } from '../pages/NewsPage'
 import { MarketPage } from '../pages/MarketPage'
@@ -39,19 +39,15 @@ import { TrackedPage } from '../pages/TrackedPage'
 import { AutoPredictionLandingPage, AutoQuantLandingPage, ChatLandingPage } from '../pages/ChatLandingPage'
 import { WorkspaceManagerPage } from '../pages/WorkspaceManagerPage'
 import { PageSidebarShell } from '../pages/PageSidebarShell'
-import { WorkspaceListPage } from '../pages/WorkspaceListPage'
 import { WorkspacePage } from '../pages/WorkspacePage'
-import { TemplateCatalogPage } from '../pages/TemplateCatalogPage'
-import { TemplateDetailPage } from '../pages/TemplateDetailPage'
+import { WorkspaceHarnessRedirect } from './WorkspaceHarnessRedirect'
 import { FileViewerPage } from '../pages/FileViewerPage'
 import { HarnessSurfacePage } from '../pages/HarnessSurfacePage'
 import { TrackedSidebar } from '../components/TrackedSidebar'
-import { WorkspacesSidebar } from '../components/workspace/WorkspacesSidebar'
 import { SettingsCategoryList } from '../components/SettingsCategoryList'
 import { MarketSidebar } from '../components/MarketSidebar'
 import { PortfolioSidebar } from '../components/PortfolioSidebar'
 import { PageContentLayout } from '../components/PageTopBar'
-import { AutomationSidebar } from '../components/AutomationSidebar'
 import { getDesignProject } from '../design/projects'
 
 /**
@@ -190,16 +186,9 @@ const automationSectionTitle: Record<
 const automationModule: ViewModule<'automation'> = {
   kind: 'automation',
   title: (spec) => automationSectionTitle[spec.params.section],
-  toUrl: (spec) => `/automation/${spec.params.section}`,
+  toUrl: (spec) => `/settings/developer/${spec.params.section}`,
   Component: (props) => (
-    <PageSidebarShell
-      storageKey="automation"
-      titleKey="nav.item.automation"
-      defaultWidth={220}
-      sidebar={<AutomationSidebar />}
-    >
-      <AutomationPage {...props} />
-    </PageSidebarShell>
+    <devModule.Component {...props} spec={{ kind: 'dev', params: { tab: props.spec.params.section } }} />
   ),
 }
 
@@ -372,6 +361,8 @@ const devTabTitle: Record<Extract<ViewSpec, { kind: 'dev' }>['params']['tab'], s
   onboarding: 'Onboarding',
   snapshots: 'Snapshots',
   logs: 'Logs',
+  runs: 'Runs',
+  api: 'API',
   simulator: 'Simulator',
 }
 
@@ -487,20 +478,22 @@ const workspaceManagerModule: ViewModule<'workspace-manager'> = {
   Component: ({ spec }) => <WorkspaceManagerPage spec={spec} />,
 }
 
+const workspaceDetailsModule: ViewModule<'workspace-details'> = {
+  kind: 'workspace-details',
+  shell: (spec) => spec.params.source,
+  title: (spec, ctx) => ctx.workspaces?.find((w) => w.id === spec.params.wsId)?.displayName
+    || ctx.workspaces?.find((w) => w.id === spec.params.wsId)?.tag || 'Workspace',
+  toUrl: (spec) => `/${spec.params.source}/workspaces/${encodeURIComponent(spec.params.wsId)}/details`,
+  Component: ({ spec }) => <WorkspaceDetailsPage spec={spec} />,
+}
+
+// Retained only for saved tabs; this no longer mounts a global management UI.
 const workspaceListModule: ViewModule<'workspace-list'> = {
   kind: 'workspace-list',
-  title: () => 'Workspaces',
-  toUrl: () => '/workspaces',
-  Component: () => (
-    <PageSidebarShell
-      storageKey="workspaces"
-      titleKey="nav.item.workspaces"
-      defaultWidth={300}
-      sidebar={<WorkspacesSidebar />}
-    >
-      <WorkspaceListPage />
-    </PageSidebarShell>
-  ),
+  shell: 'chat',
+  title: () => 'Ask Alice',
+  toUrl: () => '/chat',
+  Component: () => <ChatLandingPage spec={{ params: {} }} />,
 }
 
 const workspaceModule: ViewModule<'workspace'> = {
@@ -527,57 +520,32 @@ const workspaceModule: ViewModule<'workspace'> = {
           ? `/auto-quant/workspaces/${encodeURIComponent(spec.params.wsId)}`
           : spec.params.source === 'prediction'
             ? `/prediction/workspaces/${encodeURIComponent(spec.params.wsId)}`
-            : `/workspaces/${encodeURIComponent(spec.params.wsId)}`
+            : '/chat'
+    if (!spec.params.source) return '/chat'
     const sid = spec.params.sessionId
     return sid ? `${base}/s/${encodeURIComponent(sid)}` : base
   },
-  Component: (props) =>
-    props.spec.params.source === 'chat'
-      || props.spec.params.source === 'auto-quant'
-      || props.spec.params.source === 'prediction'
-      ? <WorkspacePage {...props} />
-      : (
-        <PageSidebarShell
-          storageKey="workspaces"
-          titleKey="nav.item.workspaces"
-          defaultWidth={300}
-          sidebar={<WorkspacesSidebar />}
-        >
-          <WorkspacePage {...props} />
-        </PageSidebarShell>
-      ),
+  Component: (props) => props.spec.params.source
+    ? <WorkspacePage {...props} />
+    : <WorkspaceHarnessRedirect spec={props.spec} />,
 }
 
+// Retained only for saved tabs; this no longer mounts a global management UI.
 const templateCatalogModule: ViewModule<'template-catalog'> = {
   kind: 'template-catalog',
-  title: () => 'Templates',
-  toUrl: () => '/workspaces/templates',
-  Component: () => (
-    <PageSidebarShell
-      storageKey="workspaces"
-      titleKey="nav.item.workspaces"
-      defaultWidth={300}
-      sidebar={<WorkspacesSidebar />}
-    >
-      <TemplateCatalogPage />
-    </PageSidebarShell>
-  ),
+  shell: 'chat',
+  title: () => 'Ask Alice',
+  toUrl: () => '/chat',
+  Component: () => <ChatLandingPage spec={{ params: {} }} />,
 }
 
+// Retained only for saved tabs; this no longer mounts a global management UI.
 const templateDetailModule: ViewModule<'template-detail'> = {
   kind: 'template-detail',
-  title: (spec) => `Template · ${spec.params.name}`,
-  toUrl: (spec) => `/workspaces/templates/${encodeURIComponent(spec.params.name)}`,
-  Component: ({ spec }) => (
-    <PageSidebarShell
-      storageKey="workspaces"
-      titleKey="nav.item.workspaces"
-      defaultWidth={300}
-      sidebar={<WorkspacesSidebar />}
-    >
-      <TemplateDetailPage spec={spec} />
-    </PageSidebarShell>
-  ),
+  shell: 'chat',
+  title: () => 'Ask Alice',
+  toUrl: () => '/chat',
+  Component: () => <ChatLandingPage spec={{ params: {} }} />,
 }
 
 const fileViewerModule: ViewModule<'file-viewer'> = {
@@ -602,7 +570,8 @@ const fileViewerModule: ViewModule<'file-viewer'> = {
         ? `/auto-quant/workspaces/${encodeURIComponent(spec.params.wsId)}`
         : spec.params.source === 'prediction'
           ? `/prediction/workspaces/${encodeURIComponent(spec.params.wsId)}`
-          : `/workspaces/${encodeURIComponent(spec.params.wsId)}`
+          : '/chat'
+    if (!spec.params.source) return '/chat'
     const query = spec.params.returnSessionId
       ? `?sessionId=${encodeURIComponent(spec.params.returnSessionId)}`
       : ''
@@ -623,16 +592,7 @@ const fileViewerModule: ViewModule<'file-viewer'> = {
           <FileViewerPage spec={spec} />
         </PageSidebarShell>
       )
-    : (
-      <PageSidebarShell
-        storageKey="workspaces"
-        titleKey="nav.item.workspaces"
-        defaultWidth={300}
-        sidebar={<WorkspacesSidebar />}
-      >
-        <FileViewerPage spec={spec} />
-      </PageSidebarShell>
-    ),
+    : <WorkspaceHarnessRedirect spec={spec} />,
 }
 
 // ==================== Aggregate ====================
@@ -664,6 +624,7 @@ const VIEWS = {
   'harness-surface': harnessSurfaceModule,
   'workspace-manager': workspaceManagerModule,
   'workspace-list': workspaceListModule,
+  'workspace-details': workspaceDetailsModule,
   workspace: workspaceModule,
   'template-catalog': templateCatalogModule,
   'template-detail': templateDetailModule,

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -17,7 +17,7 @@ export type WorkspaceSource = 'chat' | 'auto-quant' | 'prediction'
 export type FileViewerSource = WorkspaceSource | 'tracked'
 
 /** One source of truth for the Developer section and its Settings URL contract. */
-export const DEV_TABS = ['frontend', 'tools', 'onboarding', 'snapshots', 'logs', 'simulator'] as const
+export const DEV_TABS = ['frontend', 'tools', 'onboarding', 'snapshots', 'logs', 'runs', 'api', 'simulator'] as const
 export type DevTab = typeof DEV_TABS[number]
 
 export function isDevTab(value: string): value is DevTab {
@@ -25,6 +25,7 @@ export function isDevTab(value: string): value is DevTab {
 }
 
 export type ViewSpec =
+  | { kind: 'workspace-details'; params: { wsId: string; source: WorkspaceSource } }
   | { kind: 'workspace-list'; params: Record<string, never> }
   | { kind: 'workspace';      params: { wsId: string; sessionId?: string; source?: WorkspaceSource } }
   | { kind: 'template-catalog'; params: Record<string, never> }


### PR DESCRIPTION
## Summary

Consolidate Workspace and background-run navigation around the existing Harness and Settings surfaces. This is the maintainer-reviewed UI iteration, not a new execution or scheduling model.

- Open current Workspace details from the Harness footer identity; keep the adjacent Workspace switcher and configuration actions distinct.
- Show Workspace-owned README content, recorded applied/source metadata, and a separate current-catalog Harness guide. Preserve shared Markdown sanitization for relative document links.
- Retire the global Workspaces activity and management UI. Old inventory links return to Chat; old Session/file links resolve the recorded Harness without mounting a second Workspace navigator.
- Retire the Automation activity. Move the existing Runs and API pages unchanged into Settings → Developer, including old-link and saved-tab handling.
- Prevent saved activity layouts or the activity editor from restoring retired entries, without changing persisted layout validation or deleting user data.

## Design and acceptance

- Session interaction stays in its owning Harness; Workspace details do not replace agent configuration.
- Developer reuses the existing disclosure, navigation rows, Settings scrolling and phone drawer. Runs/API links automatically reveal that group.
- Missing Workspace ownership and independent document failures remain explicit; no tag-based routing guesses.
- Existing themes, shared page headers, menus, tabs and reading renderer are reused. No new navigation primitive or Issues run browser is introduced.

## Verification

- `node scripts/run-tests.mjs --owner ui`: 287 files / 1716 tests passed.
- `cd ui && npx tsc -b`: passed.
- `git diff --check`: passed.
- Real local AliceProject browser acceptance: Chat and Quant Workspace details, overview/guide separation, footer details versus switcher, and responsive layout.
- Real legacy Session and README links land in the owning Chat Harness; no global Workspace sidebar. Retired inventory links return to Chat.
- Runs/API verified inside Settings Developer on desktop and at 390px; mobile selection closes the drawer and returns focus to its trigger. Activity navigation no longer exposes either retired entry.
- Isolated first-run browser entry checked after removing the obsolete Manage Workspaces setup link. No Session was started or resumed during read-only acceptance.
- Current dev integrated without conflicts; preceding PR #1377 checks and its dev installer run were successful.

## Boundary touch / non-goals

UI and UI-owner documentation only. No backend API, Workspace/Session data deletion, schedule semantics, trading, credentials, runtime lifecycle, migrations, packaging, or release changes. Runs remain all-source; no new Issues entry is added in this iteration. Native packaged Electron acceptance was not run; evidence is the real browser surface and UI owner suite, not a packaged-app claim.
