### PR TITLE
feat(news): add RSSHub presets for CLS, Gelonghui and Jin10

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -114,6 +114,52 @@ combines credential access, model selection, and those semantics before each
 adapter projects the result into one target CLI process. Follow
 [[docs/model-semantics-and-runtime-injection.md]] for that boundary.
 
+## Optional RSSHub News Sources
+
+Alice owns RSS collection and the JSONL archive in `src/domain/news/`.
+Settings → News Sources (`/settings/news-collector`) offers opt-in presets
+for 财联社 (CLS), 格隆汇 (Gelonghui), and 金十数据 (Jin10). Enter an RSSHub
+instance URL and add each wanted source. Existing subscriptions are preserved.
+A source already configured, even if disabled, cannot be added again by a preset.
+
+RSSHub is an independently operated service, not an Alice-managed process or a
+mandatory Docker dependency. For a native Alice backend on the same machine,
+this verified, pinned RSSHub image can run on loopback:
+
+```bash
+docker run -d --name openalice-news-rsshub --restart unless-stopped -p 127.0.0.1:1200:1200 -e CACHE_TYPE=memory -e CACHE_EXPIRE=600 diygod/rsshub@sha256:0c36f939df98144fc2cbba1c5d7feefbc1675cc6ad5e99544fa1c77ac84a4e0d
+```
+
+Use `http://127.0.0.1:1200` in the preset form. Docker must remain running;
+`docker stop openalice-news-rsshub` stops the service, and
+`docker start openalice-news-rsshub` starts it again. Operators own RSSHub
+updates and should recheck routes before replacing the pinned image.
+
+The address is resolved by the **Alice backend**, not the browser. With a remote
+backend, a browser-local RSSHub is not sufficient. For separate Alice and RSSHub
+containers, use a private shared Docker network and RSSHub's service name
+(for example `http://rsshub:1200`), not loopback. Do not expose an unauthenticated
+RSSHub publicly merely to make it reachable.
+
+HTTP(S) base URLs may include a reverse-proxy prefix, such as
+`https://news.example.com/rsshub/`. Presets preserve the prefix and append
+their route. Credentials, query strings, and fragments are rejected; do not put
+secrets in feed URLs, which can appear in collection errors. Public instances
+may rate-limit or return challenge pages. Adding a preset does not test connectivity.
+
+The form writes ordinary `news.feeds` entries through the existing config API.
+No new persisted shape or migration is needed. Existing installations see the
+presets without resetting config. The instance field is an add-time input, not a
+global setting: changing it does not rewrite saved feeds. Remove and re-add a
+preset to change its instance. Restart Alice after saving, when no Workspace
+session needs to remain running: the collector reads its feed list at startup.
+Then open News and filter by the saved source tag to verify reception.
+
+RSSHub owns provider adaptation; Alice owns parsing, deduplication, storage, and
+queries. Entries may lack an article link or body. Preserve available fields
+without inventing URLs or substituting headlines as full articles. Feed access
+does not grant redistribution rights or access to paid content.
+
 ## Workspace Architecture
 
 A Workspace is the primary capability boundary. It is a persistent directory

--- a/ui/src/pages/NewsCollectorPage.spec.tsx
+++ b/ui/src/pages/NewsCollectorPage.spec.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
+import { useState } from 'react'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
+import type { NewsCollectorFeed } from '../api/types'
 import { FeedsSection } from './NewsCollectorPage'
 
 afterEach(cleanup)
@@ -93,5 +94,61 @@ describe('NewsCollectorPage feed editor', () => {
       source: 'example-markets',
       enabled: true,
     }])
+  })
+})
+
+describe('RSSHub news presets', () => {
+  it('adds all sources under a reverse-proxy prefix without replacing existing feeds', () => {
+    function Editor() {
+      const [feeds, setFeeds] = useState<NewsCollectorFeed[]>([{
+        name: 'Existing feed', source: 'existing', url: 'https://example.com/rss', enabled: false,
+      }])
+      return <FeedsSection feeds={feeds} onChange={setFeeds} />
+    }
+    render(<Editor />)
+    fireEvent.change(screen.getByLabelText('RSSHub instance URL'), {
+      target: { value: ' https://news.example.com/rsshub/// ' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add 财联社 · 电报' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add 格隆汇 · 实时快讯' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add 金十数据 · 市场快讯' }))
+    expect(screen.getByText('https://news.example.com/rsshub/jin10')).toBeTruthy()
+    expect(screen.getByText('https://news.example.com/rsshub/cls/telegraph')).toBeTruthy()
+    expect(screen.getByText('https://news.example.com/rsshub/gelonghui/live')).toBeTruthy()
+    expect(screen.getByText('https://example.com/rss')).toBeTruthy()
+    expect(screen.getByRole('switch', { name: 'Existing feed' }).getAttribute('aria-checked')).toBe('false')
+    expect(screen.getByRole('button', { name: 'Added 财联社 · 电报' }).hasAttribute('disabled')).toBe(true)
+    fireEvent.change(screen.getByLabelText('RSSHub instance URL'), { target: { value: 'http://localhost:1200' } })
+    expect(screen.getByText('https://news.example.com/rsshub/cls/telegraph')).toBeTruthy()
+  })
+
+  it('requires an HTTP instance URL without embedded secrets or discarded URL components', () => {
+    const onChange = vi.fn()
+    render(<FeedsSection feeds={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('RSSHub instance URL')
+    const add = screen.getByRole('button', { name: 'Add 财联社 · 电报' })
+    expect(add.hasAttribute('disabled')).toBe(true)
+    for (const value of ['file:///tmp/rss', 'https://user:secret@example.com', 'https://example.com?key=secret', 'https://example.com#feed']) {
+      fireEvent.change(input, { target: { value } })
+      expect(input.getAttribute('aria-invalid')).toBe('true')
+      fireEvent.click(add)
+    }
+    expect(onChange).not.toHaveBeenCalled()
+    fireEvent.change(input, { target: { value: 'http://localhost:1200' } })
+    expect(add.hasAttribute('disabled')).toBe(false)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('does not duplicate or enable a previously configured source on another instance', () => {
+    const onChange = vi.fn()
+    render(<FeedsSection feeds={[{
+      name: 'My CLS', source: 'CLS', url: 'https://old.example.com/cls/telegraph', enabled: false,
+    }]} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText('RSSHub instance URL'), { target: { value: 'http://localhost:1200' } })
+    const add = screen.getByRole('button', { name: 'Added 财联社 · 电报' })
+    expect(add.hasAttribute('disabled')).toBe(true)
+    fireEvent.click(add)
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('switch', { name: 'My CLS' }).getAttribute('aria-checked')).toBe('false')
   })
 })

--- a/ui/src/pages/NewsCollectorPage.tsx
+++ b/ui/src/pages/NewsCollectorPage.tsx
@@ -105,6 +105,88 @@ export function isValidFeedUrl(value: string): boolean {
   }
 }
 
+const RSSHUB_PRESETS = [
+  { name: '财联社 · 电报', source: 'cls', route: 'cls/telegraph', description: 'CLS telegraph news via your RSSHub instance.' },
+  { name: '格隆汇 · 实时快讯', source: 'gelonghui', route: 'gelonghui/live', description: 'Gelonghui live news via your RSSHub instance.' },
+  { name: '金十数据 · 市场快讯', source: 'jin10', route: 'jin10', description: 'Jin10 market news via your RSSHub instance.' },
+]
+
+function rssHubBaseUrl(value: string): string | null {
+  try {
+    const url = new URL(value.trim())
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password || url.search || url.hash) return null
+    return url.href.replace(/\/+$/, '') + '/'
+  } catch {
+    return null
+  }
+}
+
+function RssHubPresets({ feeds, onChange }: {
+  feeds: NewsCollectorFeed[]
+  onChange: (feeds: NewsCollectorFeed[]) => void
+}) {
+  const [instance, setInstance] = useState('')
+  const baseUrl = rssHubBaseUrl(instance)
+  const invalid = instance.trim().length > 0 && !baseUrl
+
+  return (
+    <div className="mb-4 space-y-3 border-b border-border/60 pb-4">
+      <h4 className="text-[13px] font-medium">Chinese news via RSSHub</h4>
+      <p id="rsshub-help" className="text-[12px] leading-5 text-muted-foreground">
+        Use an RSSHub instance reachable from the OpenAlice backend, not just this browser.
+        OpenAlice does not install RSSHub. Public instances may block requests.
+        Restart Alice after saving to start collecting the new feeds.
+      </p>
+      <Field label="RSSHub instance URL" controlId="rsshub-instance">
+        <input
+          id="rsshub-instance"
+          type="url"
+          className={inputClass}
+          value={instance}
+          onChange={(event) => setInstance(event.target.value)}
+          placeholder="http://localhost:1200"
+          aria-invalid={invalid}
+          aria-describedby={invalid ? 'rsshub-help rsshub-error' : 'rsshub-help'}
+        />
+        {invalid && (
+          <p id="rsshub-error" role="alert" className="mt-1 text-[12px] text-destructive">
+            Enter an HTTP(S) instance URL without credentials, a query, or a fragment.
+          </p>
+        )}
+      </Field>
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        {RSSHUB_PRESETS.map((preset) => {
+          const added = feeds.some((feed) => feed.source.trim().toLowerCase() === preset.source)
+          return (
+            <Button
+              key={preset.source}
+              type="button"
+              variant="outline"
+              disabled={!baseUrl || added}
+              onClick={() => {
+                if (!baseUrl || added) return
+                onChange([...feeds, {
+                  name: preset.name,
+                  source: preset.source,
+                  url: new URL(preset.route, baseUrl).href,
+                  description: preset.description,
+                  enabled: true,
+                }])
+              }}
+            >
+              {added ? 'Added' : 'Add'} {preset.name}
+            </Button>
+          )
+        })}
+      </div>
+      <p className="text-[12px] leading-5 text-muted-foreground">
+        Each preset saves a normal feed URL. Changing this address does not modify existing feeds;
+        remove and re-add a preset to move it to another instance.
+      </p>
+    </div>
+  )
+}
+
 export function FeedsSection({
   feeds,
   onChange,
@@ -156,6 +238,7 @@ export function FeedsSection({
           : 'Add a feed to start collecting articles.'
       }
     >
+      <RssHubPresets feeds={feeds} onChange={onChange} />
       {/* Existing feeds */}
       {feeds.length > 0 && (
         <div className="space-y-2 mb-4">


### PR DESCRIPTION
## Summary

Add opt-in RSSHub presets for 财联社 (CLS telegraph), 格隆汇 (Gelonghui live news), and 金十数据 (Jin10 market news) to Settings → News Sources.

Users supply an RSSHub instance URL reachable from the Alice backend, then add any of the three presets as ordinary RSS subscriptions. OpenAlice does not install or supervise RSSHub, does not depend on a public instance, and does not enable these feeds by default.

## Behavior and boundaries

- Preserve reverse-proxy path prefixes and normalize trailing slashes when constructing feed URLs.
- Reject non-HTTP(S) URLs, embedded credentials, query strings, and fragments.
- Keep existing subscriptions and disabled-source choices; do not duplicate an existing source tag.
- Explain that the instance field is an add-time input, that changing it does not rewrite existing feeds, and that Alice needs a restart to load changed subscriptions.
- Reuse the existing feed schema, config API, collector, JSONL store, and query API. No persisted-shape change, migration, dependency, or backend endpoint.
- Reuse shared form/Button primitives with labeled fields, accessible validation, and narrow-screen stacked controls.
- Document pinned local RSSHub deployment, remote/container networking, lifecycle, and provider-content limits in the existing project structure guide.

## Verification

Executed against this isolated feature branch, based on dev commit 7fdf5ca5:

- `pnpm --package=node@22.23.2 dlx node scripts/run-tests.mjs --changed origin/dev` — 4 files, 59 tests passed.
- `pnpm --package=node@22.23.2 dlx node scripts/run-tests.mjs --owner ui --path ui/src/demo/handlers/configNews.spec.ts` — 3 tests passed; existing demo handlers round-trip the unchanged feed shape.
- `pnpm --package=node@22.23.2 dlx node node_modules/typescript/bin/tsc -b ui` — passed.
- `git diff --check` — passed before commit.
- Real `/settings/news-collector` route in `dev:demo`: invalid URL error, all three preset additions, saved config payload, existing-feed preservation, added-state buttons; desktop and 390px viewport checked, no document horizontal overflow.
- Passed the three URLs produced by the browser form into the real `NewsCollector` and `NewsCollectorStore`, using temporary isolated storage and a real self-hosted RSSHub. Received CLS 20, Gelonghui 15, Jin10 21 items (56 total). Source-filtered HTTP handlers returned the corresponding stored items. Second collection and collection after storage reload added zero duplicates. Temporary storage removed afterward.
- Live RSSHub image: `diygod/rsshub@sha256:0c36f939df98144fc2cbba1c5d7feefbc1675cc6ad5e99544fa1c77ac84a4e0d`.

## Limits and environment notes

- Live counts are point-in-time evidence, not fixtures or availability guarantees. During acceptance, CLS/Jin10 feeds omitted article links; one Jin10 item had a title but an empty body. The existing optional-field contract is preserved; no content or links are fabricated.
- Public `rsshub.app` endpoints returned HTTP 403 in the earlier local investigation; this is why no public instance is shipped as a default.
- System Node 26.3.1 caused the unchanged TabHost test to fail on unavailable global localStorage. The same changed-file closure passed on CI's Node 22 major; no unrelated runtime/test changes are included.
- The workstation-mandated `cargo test --workspace --no-fail-fast` was attempted from the feature checkout root and could not run because this TypeScript repository has no Cargo.toml. It is not reported as passing.
- Full monorepo tests were not run: this is a leaf UI change plus its owner documentation; the changed-file closure, demo contract, owning typecheck, and real feed acceptance were exercised.

RSSHub implementation references: [CLS](https://github.com/DIYgod/RSSHub/blob/master/lib/routes/cls/telegraph.tsx), [Gelonghui](https://github.com/DIYgod/RSSHub/blob/master/lib/routes/gelonghui/live.tsx), [Jin10](https://github.com/DIYgod/RSSHub/blob/master/lib/routes/jin10/index.ts).

This PR is independent of #1383 and contains none of the unrelated changes in the original local working tree.
