### PR TITLE
Show Workspace primary sources and runtime mirror differences

### DIFF
--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -99,9 +99,17 @@ skills that a user deliberately preserves.
 
 The Workspace details page is a read-only capability browser. Skills are read
 through the existing Workspace file API from `.agents/skills`, `.claude/skills`,
-and `.pi/skills`; AGENTS.md and CLAUDE.md have a separate instruction view.
-Identical skill names and contents are grouped with their paths, while divergent
-copies remain separate. Supporting files and Markdown source are inspectable.
+and `.pi/skills`. Each skill has one identity: `.agents/skills` is the Workspace
+primary source, `.claude/skills` is its runtime mirror, and existing `.pi/skills`
+entries are legacy copies. Instructions similarly present AGENTS.md with its
+CLAUDE.md mirror. Missing primary sources retain inspectable runtime copies.
+
+Selecting an item compares its complete directory (including supporting files
+and empty folders). Missing, extra and changed entries have a side-by-side text
+view. Links, read failures, oversized or undecodable content and traversal limits
+are unverified, never equal. Traversal is bounded to 2,000 operations and 24 levels.
+This is a read-only snapshot, not a sync service. Template injection and upgrades
+still own writes; divergent content is never automatically overwritten.
 This inventory describes files on disk, not proof that a native runtime loaded
 them, and does not inventory user-level or other native skill directories.
 

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
@@ -26,6 +26,7 @@ import {
   stripFrontmatter,
   type ReadFileResult,
 } from '../workspace/api'
+import { MirrorDetails } from './MirrorDetails'
 import './capabilities.css'
 
 function SearchBox({
@@ -223,16 +224,7 @@ export function CapabilityBrowser({
   const data = state?.data
   const items = useMemo(
     () =>
-      !data
-        ? []
-        : view === 'instructions'
-          ? data.instructions.map((i) => ({
-              ...i,
-              name: i.path,
-              description: undefined as string | undefined,
-              locations: [i.path],
-            }))
-          : data.skills,
+      !data ? [] : view === 'instructions' ? data.instructions : data.skills,
     [data, view],
   )
   const filtered = items.filter((i) =>
@@ -345,12 +337,7 @@ export function CapabilityBrowser({
                 <BookOpen size={15} aria-hidden />
                 <span>
                   <strong>{i.name}</strong>
-                  <small>
-                    {i.locations.length > 1
-                      ? t('capabilities.copies', { count: i.locations.length })
-                      : i.path.split('/').slice(0, -1).join('/') ||
-                        t('capabilities.workspaceFile')}
-                  </small>
+                  <small>{t(`mirrors.${i.source ?? 'canonical'}`)}</small>
                 </span>
                 <ChevronRight size={13} aria-hidden />
               </button>
@@ -378,12 +365,14 @@ export function CapabilityBrowser({
                 </span>
                 <h2>{current.name}</h2>
                 {current.description && <p>{current.description}</p>}
-                {current.locations.map((p) => (
-                  <code className="cap-path" key={p}>
-                    {p}
-                  </code>
-                ))}
+                <code className="cap-path">{current.path}</code>
               </div>
+              <MirrorDetails
+                key={current.path}
+                wsId={wsId}
+                skill={current}
+                instructions={view === 'instructions'}
+              />
               {view === 'skills' && (
                 <SkillFiles
                   key={current.path}

--- a/ui/src/components/workspace-capabilities/MirrorDetails.spec.tsx
+++ b/ui/src/components/workspace-capabilities/MirrorDetails.spec.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { i18n } from '../../i18n'
+import { MirrorDetails } from './MirrorDetails'
+vi.mock('../../hooks/useWorkspaceMirrors', () => ({
+  useWorkspaceMirror: () => ({
+    differences: [
+      {
+        path: 'scripts/run.py',
+        status: 'changed',
+        source: { kind: 'text', content: 'primary code' },
+        mirror: { kind: 'text', content: 'runtime edit' },
+      },
+    ],
+  }),
+}))
+beforeEach(async () => {
+  await i18n.changeLanguage('en')
+})
+afterEach(cleanup)
+it('shows a divergent mirror under the source and opens both file contents', () => {
+  render(
+    <MirrorDetails
+      wsId="one"
+      instructions={false}
+      skill={{
+        name: 'test',
+        path: '.agents/skills/test/SKILL.md',
+        content: { kind: 'ok', content: 'same' },
+        locations: [],
+        source: 'canonical',
+        mirrors: [
+          { path: '.claude/skills/test', label: 'Claude', present: true },
+        ],
+      }}
+    />,
+  )
+  expect(
+    screen.getByText('Differences found', { selector: 'span' }),
+  ).toBeTruthy()
+  fireEvent.click(screen.getByText(/Claude/).closest('summary')!)
+  fireEvent.click(screen.getByRole('button', { name: /scripts\/run.py/ }))
+  expect(screen.getByText('primary code')).toBeTruthy()
+  expect(screen.getByText('runtime edit')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: /sync|overwrite/i })).toBeNull()
+})

--- a/ui/src/components/workspace-capabilities/MirrorDetails.tsx
+++ b/ui/src/components/workspace-capabilities/MirrorDetails.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { WorkspaceSkill } from '../../hooks/useWorkspaceCapabilities'
+import { useWorkspaceMirror } from '../../hooks/useWorkspaceMirrors'
+import { Button } from '../ui/button'
+
+function Comparison({
+  wsId,
+  source,
+  mirror,
+  label,
+  instructions,
+}: {
+  wsId: string
+  source: string
+  mirror: string
+  label: string
+  instructions: boolean
+}) {
+  const { t } = useTranslation()
+  const state = useWorkspaceMirror(wsId, source, mirror, instructions)
+  const [selected, select] = useState<string>()
+  const differences = state?.differences ?? []
+  const uncertain =
+    state?.failed || differences.some((d) => d.status === 'unchecked')
+  const status = !state
+    ? 'checking'
+    : uncertain
+      ? 'unchecked'
+      : differences.length
+        ? 'changed'
+        : 'equal'
+  const file = differences.find((d) => d.path === selected)
+  return (
+    <details className="cap-mirror">
+      <summary>
+        <span>
+          {label} {t('mirrors.mirror')}
+        </span>
+        <span className={`cap-mirror-status ${status}`} role="status">
+          {t(`mirrors.${status}`)}
+        </span>
+      </summary>
+      <code className="cap-path">{mirror}</code>
+      <p className="cap-note">{t('mirrors.scope')}</p>
+      {differences.map((d) => (
+        <Button
+          key={d.path}
+          variant="ghost"
+          size="sm"
+          onClick={() => select(d.path)}
+          aria-pressed={selected === d.path}
+        >
+          {d.path} · {t(`mirrors.${d.status}`)}
+        </Button>
+      ))}
+      {file && (
+        <div className="cap-mirror-diff">
+          {(['source', 'mirror'] as const).map((side) => (
+            <section key={side}>
+              <h3>{t(`mirrors.${side}`)}</h3>
+              <pre className="cap-source">
+                {file[side]?.kind === 'text'
+                  ? file[side]?.content
+                  : t(
+                      `mirrors.${!file[side] ? 'absent' : file[side]?.kind === 'directory' ? 'directory' : 'unchecked'}`,
+                    )}
+              </pre>
+            </section>
+          ))}
+        </div>
+      )}
+    </details>
+  )
+}
+
+export function MirrorDetails({
+  wsId,
+  skill,
+  instructions,
+}: {
+  wsId: string
+  skill: WorkspaceSkill
+  instructions: boolean
+}) {
+  const { t } = useTranslation()
+  const source = instructions ? 'AGENTS.md' : `.agents/skills/${skill.name}`
+  return (
+    <div className="cap-mirrors">
+      <p className="cap-note">
+        {t(
+          skill.source === 'mirror-only' || skill.source === 'legacy'
+            ? 'mirrors.noSource'
+            : skill.source === 'unchecked'
+              ? 'mirrors.unchecked'
+              : 'mirrors.primaryHint',
+        )}
+      </p>
+      {skill.mirrors?.map((m) =>
+        m.present === false ? (
+          <div className="cap-mirror-summary" key={m.path}>
+            <span>
+              {m.label} {t('mirrors.mirror')}
+            </span>
+            <span>{t('mirrors.absent')}</span>
+          </div>
+        ) : m.present === undefined ? (
+          <div key={m.path} role="status">
+            {m.label} · {t('mirrors.unchecked')}
+          </div>
+        ) : (
+          <Comparison
+            key={m.path}
+            wsId={wsId}
+            source={source}
+            mirror={m.path}
+            label={m.label === 'Pi' ? `Pi · ${t('mirrors.legacy')}` : m.label}
+            instructions={instructions}
+          />
+        ),
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/workspace-capabilities/capabilities.css
+++ b/ui/src/components/workspace-capabilities/capabilities.css
@@ -320,3 +320,62 @@
     transition: none;
   }
 }
+
+.cap-mirrors {
+  margin: 16px 0;
+  border-block: 1px solid var(--border);
+  padding: 12px 0;
+}
+.cap-mirrors > .cap-note {
+  margin: 0 0 10px;
+}
+.cap-mirror summary,
+.cap-mirror-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  font-size: 12px;
+}
+.cap-mirror summary {
+  cursor: pointer;
+}
+.cap-mirror summary::before {
+  content: '›';
+  color: var(--muted-foreground);
+}
+.cap-mirror[open] summary::before {
+  content: '⌄';
+}
+.cap-mirror summary > span:first-of-type {
+  flex: 1;
+}
+.cap-mirror-status {
+  color: var(--muted-foreground);
+}
+.cap-mirror-status.changed,
+.cap-mirror-status.unchecked {
+  font-weight: 600;
+  color: var(--foreground);
+}
+.cap-mirror-diff {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  padding: 16px 0;
+}
+.cap-mirror-diff h3 {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+.cap-mirror-diff pre {
+  max-height: 360px;
+  overflow: auto;
+}
+@media (max-width: 900px) {
+  .cap-mirror-diff {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ui/src/hooks/useWorkspaceCapabilities.spec.ts
+++ b/ui/src/hooks/useWorkspaceCapabilities.spec.ts
@@ -24,7 +24,7 @@ const listing = (...names: string[]) => ({
   entries: names.map((name) => ({ name, kind: 'dir' })),
 })
 describe('Workspace capability inventory', () => {
-  it('groups identical copies, retains divergent files and reports unavailable roots', async () => {
+  it('groups by skill identity with the agents source even when mirrors diverge', async () => {
     mocks.list.mockImplementation(async (_id, path) =>
       path === ''
         ? listing('.agents', '.claude', '.pi')
@@ -41,7 +41,7 @@ describe('Workspace capability inventory', () => {
         : path,
     }))
     const data = await loadWorkspaceCapabilities('one')
-    expect(data.skills).toHaveLength(3)
+    expect(data.skills).toHaveLength(2)
     expect(data.skills.find((s) => s.name === 'same')?.locations).toHaveLength(
       2,
     )
@@ -49,10 +49,15 @@ describe('Workspace capability inventory', () => {
       'A folded skill description',
     )
     expect(data.errors[0]).toContain('unreachable')
-    expect(data.instructions.map((i) => i.path)).toEqual([
-      'AGENTS.md',
-      'CLAUDE.md',
-    ])
+    expect(data.instructions.map((i) => i.path)).toEqual(['AGENTS.md'])
+    expect(
+      data.skills.every(
+        (s) => s.source === 'canonical' && s.path.startsWith('.agents/'),
+      ),
+    ).toBe(true)
+    expect(
+      data.skills.find((s) => s.name === 'changed')?.mirrors?.[0].present,
+    ).toBe(true)
   })
   it('never exposes a late inventory from the previous Workspace', async () => {
     let resolve!: (v: unknown) => void
@@ -87,5 +92,30 @@ describe('Workspace capability inventory', () => {
     await waitFor(() => expect(result.current?.error).toBe('offline'))
     rerender({ attempt: 1 })
     await waitFor(() => expect(result.current?.data?.groups).toEqual({}))
+  })
+})
+
+it('keeps an orphan Claude skill inspectable under one identity', async () => {
+  mocks.list.mockImplementation(async (_id, path) =>
+    path === ''
+      ? listing('.claude')
+      : path === '.claude'
+        ? listing('skills')
+        : listing('orphan'),
+  )
+  mocks.read.mockImplementation(async (_id, path) =>
+    path === 'AGENTS.md'
+      ? { kind: 'file_missing' }
+      : { kind: 'ok', content: 'local edit' },
+  )
+  const data = await loadWorkspaceCapabilities('orphan')
+  expect(data.skills).toHaveLength(1)
+  expect(data.skills[0]).toMatchObject({
+    source: 'mirror-only',
+    path: '.claude/skills/orphan/SKILL.md',
+  })
+  expect(data.instructions[0]).toMatchObject({
+    source: 'mirror-only',
+    path: 'CLAUDE.md',
   })
 })

--- a/ui/src/hooks/useWorkspaceCapabilities.ts
+++ b/ui/src/hooks/useWorkspaceCapabilities.ts
@@ -44,10 +44,12 @@ export interface WorkspaceSkill {
   path: string
   content: ReadFileResult
   locations: string[]
+  source?: 'canonical' | 'mirror-only' | 'legacy' | 'unchecked'
+  mirrors?: { path: string; label: string; present?: boolean }[]
 }
 export interface CapabilityInventory {
   skills: WorkspaceSkill[]
-  instructions: { path: string; content: ReadFileResult }[]
+  instructions: WorkspaceSkill[]
   errors: string[]
   roots: string[]
 }
@@ -96,23 +98,71 @@ export async function loadWorkspaceCapabilities(
     }),
   )
   const grouped: WorkspaceSkill[] = []
-  for (const skill of skills.sort((a, b) => a.path.localeCompare(b.path))) {
-    const same = grouped.find(
-      (other) =>
-        other.name === skill.name &&
-        other.content.kind === 'ok' &&
-        skill.content.kind === 'ok' &&
-        other.content.content === skill.content.content,
-    )
-    if (same) same.locations.push(skill.path)
-    else grouped.push(skill)
+  for (const name of [...new Set(skills.map((s) => s.name))]) {
+    const copies = skills.filter((s) => s.name === name)
+    const primary = copies.find((s) => s.path.startsWith('.agents/'))
+    const claude = copies.find((s) => s.path.startsWith('.claude/'))
+    const pi = copies.find((s) => s.path.startsWith('.pi/'))
+    const chosen = primary ?? claude ?? pi!
+    grouped.push({
+      ...chosen,
+      locations: copies.map((s) => s.path),
+      source: primary
+        ? 'canonical'
+        : errors.some((e) => e.startsWith('.agents:'))
+          ? 'unchecked'
+          : claude
+            ? 'mirror-only'
+            : 'legacy',
+      mirrors: [
+        {
+          path: `.claude/skills/${name}`,
+          label: 'Claude',
+          present: errors.some((e) => e.startsWith('.claude:'))
+            ? undefined
+            : Boolean(claude),
+        },
+        ...(pi
+          ? [{ path: `.pi/skills/${name}`, label: 'Pi', present: true }]
+          : []),
+      ],
+    })
   }
-  const instructions = await Promise.all(
-    ['AGENTS.md', 'CLAUDE.md'].map(async (path) => ({
-      path,
-      content: await readWorkspaceFile(wsId, path),
-    })),
+  const [agents, claude] = await Promise.all(
+    ['AGENTS.md', 'CLAUDE.md'].map((path) => readWorkspaceFile(wsId, path)),
   )
+  const instructions: WorkspaceSkill[] = [
+    {
+      name: 'AGENTS.md',
+      path:
+        agents.kind === 'file_missing' && claude.kind === 'ok'
+          ? 'CLAUDE.md'
+          : 'AGENTS.md',
+      content:
+        agents.kind === 'file_missing' && claude.kind === 'ok'
+          ? claude
+          : agents,
+      locations: ['AGENTS.md'],
+      source:
+        agents.kind === 'ok'
+          ? 'canonical'
+          : agents.kind === 'file_missing'
+            ? 'mirror-only'
+            : 'unchecked',
+      mirrors: [
+        {
+          path: 'CLAUDE.md',
+          label: 'Claude',
+          present:
+            claude.kind === 'file_missing'
+              ? false
+              : claude.kind === 'ok'
+                ? true
+                : undefined,
+        },
+      ],
+    },
+  ]
   for (const skill of grouped) {
     if (skill.content.kind !== 'ok') continue
     const header = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(

--- a/ui/src/hooks/useWorkspaceMirrors.spec.ts
+++ b/ui/src/hooks/useWorkspaceMirrors.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest'
+import { cleanup, renderHook, waitFor, act } from '@testing-library/react'
+import {
+  compareWorkspaceTrees,
+  snapshotWorkspaceTree,
+  useWorkspaceMirror,
+} from './useWorkspaceMirrors'
+const mocks = vi.hoisted(() => ({ list: vi.fn(), read: vi.fn() }))
+vi.mock('../components/workspace/api', () => ({
+  listFiles: mocks.list,
+  readWorkspaceFile: mocks.read,
+}))
+afterEach(() => {
+  cleanup()
+  vi.resetAllMocks()
+})
+it('finds supporting-file drift even when SKILL.md is identical', async () => {
+  mocks.list.mockImplementation(async (_id, path) => ({
+    entries: path.endsWith('scripts')
+      ? [{ name: 'run.py', kind: 'file' }]
+      : [
+          { name: 'SKILL.md', kind: 'file' },
+          { name: 'scripts', kind: 'dir' },
+          { name: 'empty', kind: 'dir' },
+        ].filter((e) => !path.endsWith('empty')),
+  }))
+  mocks.read.mockImplementation(async (_id, path) => ({
+    kind: 'ok',
+    content: path.endsWith('SKILL.md') ? 'same' : path,
+  }))
+  const a = await snapshotWorkspaceTree('ws', '.agents/skills/test')
+  const b = await snapshotWorkspaceTree('ws', '.claude/skills/test')
+  expect(compareWorkspaceTrees(a, b).map((d) => d.path)).toEqual([
+    'scripts/run.py',
+  ])
+  expect(a.empty).toEqual({ kind: 'directory' })
+})
+it('distinguishes missing, extra and unreadable entries without treating unverified data as equal', () => {
+  expect(
+    compareWorkspaceTrees(
+      { missing: { kind: 'text', content: 'x' }, bad: { kind: 'unchecked' } },
+      { extra: { kind: 'text', content: 'y' }, bad: { kind: 'unchecked' } },
+    ).map((d) => [d.path, d.status]),
+  ).toEqual([
+    ['bad', 'unchecked'],
+    ['extra', 'mirrorOnly'],
+    ['missing', 'sourceOnly'],
+  ])
+})
+it('does not follow links or claim undecodable and oversized files match', async () => {
+  mocks.list.mockResolvedValue({
+    entries: [
+      { name: 'loop', kind: 'symlink' },
+      { name: 'binary', kind: 'file' },
+      { name: 'large', kind: 'file' },
+    ],
+  })
+  mocks.read.mockImplementation(async (_id, path) =>
+    path.endsWith('large')
+      ? { kind: 'too_large', sizeBytes: 999999 }
+      : { kind: 'ok', content: '\ufffd' },
+  )
+  const tree = await snapshotWorkspaceTree('ws', 'root')
+  expect(mocks.list).toHaveBeenCalledTimes(1)
+  expect(Object.values(tree).every((e) => e.kind === 'unchecked')).toBe(true)
+})
+it('drops an old Workspace comparison after navigation', async () => {
+  let finish!: (value: unknown) => void
+  mocks.read.mockImplementation((id) =>
+    id === 'old'
+      ? new Promise((r) => {
+          finish = r
+        })
+      : Promise.resolve({ kind: 'ok', content: 'new' }),
+  )
+  const { result, rerender } = renderHook(
+    ({ id }) => useWorkspaceMirror(id, 'AGENTS.md', 'CLAUDE.md', true),
+    { initialProps: { id: 'old' } },
+  )
+  rerender({ id: 'new' })
+  await waitFor(() => expect(result.current?.differences).toEqual([]))
+  await act(async () => {
+    finish({ kind: 'ok', content: 'old' })
+  })
+  expect(result.current?.id).toContain('new')
+})

--- a/ui/src/hooks/useWorkspaceMirrors.ts
+++ b/ui/src/hooks/useWorkspaceMirrors.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import { listFiles, readWorkspaceFile } from '../components/workspace/api'
+
+export type SnapshotEntry = {
+  kind: 'directory' | 'text' | 'unchecked'
+  content?: string
+}
+export type Snapshot = Record<string, SnapshotEntry>
+export type MirrorDifference = {
+  path: string
+  status: 'changed' | 'sourceOnly' | 'mirrorOnly' | 'unchecked'
+  source?: SnapshotEntry
+  mirror?: SnapshotEntry
+}
+
+/** Bounded, read-only traversal. Never follow links or infer equality from size/mtime. */
+export async function snapshotWorkspaceTree(
+  wsId: string,
+  root: string,
+  singleFile = false,
+): Promise<Snapshot> {
+  const result: Snapshot = {}
+  let count = 0
+  async function read(path: string, key: string) {
+    const value = await readWorkspaceFile(wsId, path)
+    result[key] =
+      value.kind === 'ok' && !/[\u0000\ufffd]/.test(value.content)
+        ? { kind: 'text', content: value.content }
+        : { kind: 'unchecked' }
+  }
+  async function visit(path: string, relative: string, depth: number) {
+    if (depth > 24 || ++count > 2000) {
+      result[relative || '.'] = { kind: 'unchecked' }
+      return
+    }
+    try {
+      const files = await listFiles(wsId, path)
+      for (const entry of files.entries) {
+        const key = relative ? `${relative}/${entry.name}` : entry.name
+        if (++count > 2000) {
+          result[relative || '.'] = { kind: 'unchecked' }
+          break
+        }
+        if (entry.kind === 'dir') {
+          result[key] = { kind: 'directory' }
+          await visit(`${path}/${entry.name}`, key, depth + 1)
+        } else if (entry.kind === 'file') {
+          await read(`${path}/${entry.name}`, key)
+        } else result[key] = { kind: 'unchecked' }
+      }
+    } catch {
+      result[relative || '.'] = { kind: 'unchecked' }
+    }
+  }
+  if (singleFile) await read(root, 'Instructions')
+  else await visit(root, '', 0)
+  return result
+}
+
+export function compareWorkspaceTrees(
+  source: Snapshot,
+  mirror: Snapshot,
+): MirrorDifference[] {
+  return [...new Set([...Object.keys(source), ...Object.keys(mirror)])]
+    .sort()
+    .flatMap((path) => {
+      const a = source[path],
+        b = mirror[path]
+      const status =
+        a?.kind === 'unchecked' || b?.kind === 'unchecked'
+          ? 'unchecked'
+          : !a
+            ? 'mirrorOnly'
+            : !b
+              ? 'sourceOnly'
+              : a.kind !== b.kind || a.content !== b.content
+                ? 'changed'
+                : undefined
+      return status ? [{ path, status, source: a, mirror: b }] : []
+    })
+}
+
+export function useWorkspaceMirror(
+  wsId: string,
+  source: string,
+  mirror: string,
+  singleFile: boolean,
+) {
+  const id = JSON.stringify([wsId, source, mirror, singleFile])
+  const [state, setState] = useState<{
+    id: string
+    differences?: MirrorDifference[]
+    failed?: boolean
+  }>()
+  useEffect(() => {
+    let active = true
+    setState(undefined)
+    void Promise.all([
+      snapshotWorkspaceTree(wsId, source, singleFile),
+      snapshotWorkspaceTree(wsId, mirror, singleFile),
+    ]).then(
+      ([a, b]) => {
+        if (active) setState({ id, differences: compareWorkspaceTrees(a, b) })
+      },
+      () => {
+        if (active) setState({ id, failed: true })
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [id, wsId, source, mirror, singleFile])
+  return state?.id === id ? state : undefined
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -13,6 +13,24 @@
  */
 
 export const en = {
+  mirrors: {
+    "canonical": "Primary source",
+    "mirror-only": "Mirror only",
+    "legacy": "Legacy copy",
+    "mirror": "mirror",
+    "source": "Primary source",
+    "noSource": "The primary source is missing. This runtime copy remains available for inspection; nothing is overwritten.",
+    "primaryHint": "Read the primary source here. Runtime copies are compared below; differences do not create a second skill.",
+    "checking": "Checking directory…",
+    "unchecked": "Not fully verified",
+    "changed": "Differences found",
+    "equal": "Contents match",
+    "scope": "Compares the complete directory, including scripts, examples and empty folders. Links, unreadable or oversized files, undecodable content and traversal limits remain unverified. This is a read-only snapshot, not ongoing synchronization.",
+    "sourceOnly": "Missing from mirror",
+    "mirrorOnly": "Only in mirror",
+    "absent": "Missing",
+    "directory": "Directory"
+},
   capabilities: {
     "search": "Search names and content…",
     "copy": "Copy command",
@@ -29,7 +47,7 @@ export const en = {
     "copies": "{{count}} identical copies",
     "workspaceFile": "Workspace file",
     "actualHint": "Read directly from this Workspace. Origin and runtime loading are not inferred from the filename.",
-    "skillsHint": "Explore the procedures available on disk. Identical copies are grouped; divergent copies stay separate.",
+    "skillsHint": "Browse primary Workspace skills and inspect runtime mirrors.",
     "instructionsHint": "The current instruction files, exactly as they exist in this Workspace.",
     "empty": "No matching content.",
     "live": "Live manifest",

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -2,6 +2,24 @@ import type { Resources } from './en'
 
 /** 日本語. Typed as `Resources` → must match en's key structure exactly. */
 export const ja: Resources = {
+  mirrors: {
+    "canonical": "正本",
+    "mirror-only": "ミラーのみ",
+    "legacy": "旧形式のコピー",
+    "mirror": "ミラー",
+    "source": "正本",
+    "noSource": "正本がありません。ランタイム側のコピーを閲覧できます。内容は上書きしません。",
+    "primaryHint": "正本を表示しています。ランタイムのミラーとの差異は同じスキルの下で確認できます。",
+    "checking": "ディレクトリを確認中…",
+    "unchecked": "一部未確認",
+    "changed": "差異あり",
+    "equal": "内容が一致",
+    "scope": "スクリプト、例、空フォルダーを含む全体を比較します。リンク、読み取り不可、サイズ超過、文字化け、走査上限は未確認として扱います。読み取り専用のスナップショットであり、継続的な同期ではありません。",
+    "sourceOnly": "ミラーに欠落",
+    "mirrorOnly": "ミラーにのみ存在",
+    "absent": "欠落",
+    "directory": "ディレクトリ"
+},
   capabilities: {
     "search": "名前と内容を検索…",
     "copy": "コマンドをコピー",
@@ -18,7 +36,7 @@ export const ja: Resources = {
     "copies": "同一内容のコピー {{count}} 件",
     "workspaceFile": "Workspace ファイル",
     "actualHint": "この Workspace から直接読み取っています。名前から出所や読み込み状態は推定しません。",
-    "skillsHint": "ディスク上の手順を閲覧できます。同一内容はまとめ、異なる内容は個別に表示します。",
+    "skillsHint": "Workspace のスキル正本とランタイムのミラーを閲覧します。",
     "instructionsHint": "この Workspace に実際に存在する指示ファイルです。",
     "empty": "一致する内容がありません。",
     "live": "現在のマニフェスト",

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -10,6 +10,24 @@ import type { Resources } from './en'
  * Content is UI chrome only — no geographic or other non-technical terms.
  */
 export const zhHant: Resources = {
+  mirrors: {
+    "canonical": "主源",
+    "mirror-only": "僅有鏡像",
+    "legacy": "舊版副本",
+    "mirror": "鏡像",
+    "source": "主源",
+    "noSource": "主源缺失，仍可查閱此執行環境副本，不會覆寫其內容。",
+    "primaryHint": "預設閱讀主源，下方核對執行環境鏡像，內容不同仍屬同一項內容。",
+    "checking": "正在核對目錄…",
+    "unchecked": "未能完整核對",
+    "changed": "存在差異",
+    "equal": "內容一致",
+    "scope": "檢查整個目錄，包括腳本、範例與空目錄。連結、無法讀取、過大或無法解碼的檔案，以及超出遍歷上限的內容會標為未核對。這是唯讀快照，不是持續同步。",
+    "sourceOnly": "鏡像缺少",
+    "mirrorOnly": "僅鏡像存在",
+    "absent": "缺失",
+    "directory": "目錄"
+},
   capabilities: {
     "search": "搜尋名稱與內容…",
     "copy": "複製命令",
@@ -26,7 +44,7 @@ export const zhHant: Resources = {
     "copies": "{{count}} 份相同副本",
     "workspaceFile": "Workspace 檔案",
     "actualHint": "直接讀取此 Workspace，不根據檔名推斷來源或載入狀態。",
-    "skillsHint": "查閱磁碟上的操作流程。相同副本合併顯示，內容不同的副本分別保留。",
+    "skillsHint": "查閱 Workspace 技能主源與執行環境鏡像。",
     "instructionsHint": "此 Workspace 中實際存在的指令文件。",
     "empty": "沒有符合的內容。",
     "live": "即時命令清單",

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -2,6 +2,24 @@ import type { Resources } from './en'
 
 /** 简体中文. Typed as `Resources` → must match en's key structure exactly. */
 export const zh: Resources = {
+  mirrors: {
+    "canonical": "主源",
+    "mirror-only": "仅有镜像",
+    "legacy": "旧版副本",
+    "mirror": "镜像",
+    "source": "主源",
+    "noSource": "主源缺失。仍可查阅这个运行时副本，不会覆盖其内容。",
+    "primaryHint": "默认阅读主源。下方核对运行时镜像，内容偏离也只对应同一项内容。",
+    "checking": "正在核对目录…",
+    "unchecked": "未能完整核对",
+    "changed": "存在差异",
+    "equal": "内容一致",
+    "scope": "检查整个目录，包括脚本、示例和空目录。符号链接、无法读取、过大或无法解码的文件，以及超出遍历上限的内容会保留为未核对。这是只读快照，不是持续同步。",
+    "sourceOnly": "镜像缺少",
+    "mirrorOnly": "仅镜像存在",
+    "absent": "缺失",
+    "directory": "目录"
+},
   capabilities: {
     "search": "搜索名称与内容…",
     "copy": "复制命令",
@@ -18,7 +36,7 @@ export const zh: Resources = {
     "copies": "{{count}} 份相同副本",
     "workspaceFile": "工作区实际文件",
     "actualHint": "直接读取当前工作区。文件名不能证明来源，也不代表运行时已加载。",
-    "skillsHint": "浏览工作区里的技能与工作方法。相同内容合并展示，内容不同的副本分别保留。",
+    "skillsHint": "查阅 Workspace 技能主源与运行时镜像。",
     "instructionsHint": "查看这个工作区当前实际保存的指令文件。",
     "empty": "没有匹配的内容。",
     "live": "实时命令清单",


### PR DESCRIPTION
Workspace details treated agent-specific skill copies as separate libraries when they diverged. Skills now have one identity rooted at `.agents/skills`, with Claude runtime mirrors and existing Pi legacy copies beneath it. Instructions use AGENTS.md as the primary source and CLAUDE.md as its mirror; orphan runtime copies remain inspectable.

Selecting an item compares the directory tree, including scripts, examples and empty directories. Missing, extra and changed files can be opened in a side-by-side text view. Unreadable, undecodable, oversized, linked or traversal-limited entries remain unverified. The page performs no synchronization or file writes; existing initialization and template-upgrade behavior is unchanged.

Interaction: the existing directory/reader layout stays in place, with a compact native disclosure for mirror status and shared Buttons for file selection. Narrow layouts stack the comparison columns. Backend reads remain in domain hooks and reuse the existing browser/Electron Workspace file transport.

Validation:
- `pnpm test:owner:ui`: 305 files / 1834 tests passed.
- Additional MirrorDetails interaction test passed (added after owner suite discovery).
- Targeted tests cover divergent supporting files despite identical SKILL.md, orphan Claude copies, missing/extra files, links/unreadable content and stale Workspace responses.
- `npx tsc -b ui` and `git diff --check` passed.
- Real UI Setup Workspace: source/mirror Skills and instruction layout visually checked; current Claude mirrors report equal.
- Demo browser: identical SKILL.md with a missing supporting report correctly reports a difference and opens the comparison.
- Previous PR #1395 clean-build and post-merge dev installer smoke succeeded.

Packaged Electron and narrow viewport rendering were not exercised. Comparisons are bounded read-only snapshots, not atomic filesystem snapshots or runtime-loading evidence.
