### PR TITLE
Remove alice think calc from Workspace CLI

### DIFF
--- a/default/skills/alice/SKILL.md
+++ b/default/skills/alice/SKILL.md
@@ -22,7 +22,7 @@ exit means it failed, with the reason on stderr.
 ## Discover, don't guess
 
 ```bash
-alice --help                       # the groups: rss, market, analysis, think
+alice --help                       # the groups: rss, market, analysis
 alice <group> <verb> --help        # a verb's flags (which are required)
 ```
 

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -59,6 +59,11 @@ describe('CLI_EXPORTS — data export (global tools)', () => {
     }
   })
 
+  it('does not export the calculator', () => {
+    expect(mappedToolNames('data')).not.toContain('calculate')
+    expect(getExport('data')?.groupDescriptions).not.toHaveProperty('think')
+  })
+
   it('is scope: global', () => {
     expect(getExport('data')?.scope).toBe('global')
   })

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -55,7 +55,6 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       rss: 'Search and read the user\'s collected subscribed-feed archive',
       market: 'Discover symbols, bar sources, and optional market-data vendors',
       analysis: 'Read dated K-lines, calculate indicators, and run bounded simulations',
-      think: 'Evaluate side-effect-free calculations',
     },
     commands: {
       // `rss`, not `news`: the backing store is the RSS collector's archive —
@@ -84,9 +83,6 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
         // path-dependent backtest. The Retrospective / Time-Machine primitives.
         snapshot: 'marketSnapshot',
         simulate: 'simulate',
-      },
-      think: {
-        calc: 'calculate',
       },
     },
   },

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -14,12 +14,17 @@ import { inboxPushFactory } from '../tool/inbox-push.js'
 import { registerCliRoutes, type CliGatewayDeps } from './cli.js'
 
 /**
- * End-to-end gateway test using the real `calculate` tool (no client deps), so
- * the validate -> execute -> unwrap path is exercised for real, not mocked.
+ * Exercise gateway validation, dispatch and response unwrapping with a local
+ * search fixture; no market provider is contacted.
  */
 function makeApp(manifestOnly = false): Hono {
   const toolCenter = new ToolCenter()
-  toolCenter.register(createThinkingTools(), 'thinking') // registers `calculate`
+  toolCenter.register(createThinkingTools(), 'thinking') // must remain unreachable from CLI
+  toolCenter.register({ marketSearchForResearch: tool({
+    description: 'Local search fixture',
+    inputSchema: z.object({ query: z.string() }),
+    execute: ({ query }) => ({ symbol: query }),
+  }) }, 'market-search')
 
   const fakeSvc = {
     registry: {
@@ -58,7 +63,13 @@ describe('CLI gateway — data export', () => {
       unmapped: string[]
     }
     expect(body.export).toBe('data')
-    expect(body.groups['think']?.['calc']?.tool).toBe('calculate')
+    expect(body.groups['market']?.['search']?.tool).toBe('marketSearchForResearch')
+    expect(body.groups).not.toHaveProperty('think')
+  })
+
+  it('rejects the removed calculator even when the tool remains registered', async () => {
+    const response = await post('/cli/ws1/data/invoke', { tool: 'calculate', args: { expression: '2 + 2' } })
+    expect(response.status).toBe(404)
   })
 
   it('manifest 404s on unknown workspace', async () => {
@@ -72,11 +83,11 @@ describe('CLI gateway — data export', () => {
   })
 
   it('invoke runs a mapped tool and returns its payload', async () => {
-    const res = await post('/cli/ws1/data/invoke', { tool: 'calculate', args: { expression: '2 + 2' } })
+    const res = await post('/cli/ws1/data/invoke', { tool: 'marketSearchForResearch', args: { query: 'AAPL' } })
     expect(res.status).toBe(200)
     const body = (await res.json()) as { content: Array<{ type: string; text?: string }> }
     const text = body.content.map((b) => b.text ?? '').join('')
-    expect(text).toContain('4')
+    expect(text).toContain('AAPL')
   })
 
   it('invoke rejects a tool name not on the CLI map (e.g. trading)', async () => {
@@ -85,7 +96,7 @@ describe('CLI gateway — data export', () => {
   })
 
   it('invoke 400s on invalid args', async () => {
-    const res = await post('/cli/ws1/data/invoke', { tool: 'calculate', args: {} })
+    const res = await post('/cli/ws1/data/invoke', { tool: 'marketSearchForResearch', args: {} })
     expect(res.status).toBe(400)
   })
 
@@ -94,16 +105,16 @@ describe('CLI gateway — data export', () => {
     // --totalQuantity) was stripped by non-strict parsing, staging a
     // quantity-less order that validated clean.
     const res = await post('/cli/ws1/data/invoke', {
-      tool: 'calculate',
-      args: { expression: '1 + 1', expresion: 'typo' },
+      tool: 'marketSearchForResearch',
+      args: { query: 'AAPL', qurey: 'typo' },
     })
     expect(res.status).toBe(400)
     const body = (await res.json()) as { error: string; details?: string }
-    expect(body.details).toMatch(/expresion/)
+    expect(body.details).toMatch(/qurey/)
   })
 
   it('invoke 404s on unknown workspace', async () => {
-    const res = await post('/cli/nope/data/invoke', { tool: 'calculate', args: { expression: '1' } })
+    const res = await post('/cli/nope/data/invoke', { tool: 'marketSearchForResearch', args: { query: 'AAPL' } })
     expect(res.status).toBe(404)
   })
 })
@@ -114,8 +125,8 @@ describe('CLI gateway — export scope isolation', () => {
     expect(res.status).toBe(404) // not in the data map → gated out
   })
 
-  it('the workspace export cannot reach a data tool (calculate)', async () => {
-    const res = await post('/cli/ws1/workspace/invoke', { tool: 'calculate', args: { expression: '1' } })
+  it('the workspace export cannot reach a data tool (marketSearchForResearch)', async () => {
+    const res = await post('/cli/ws1/workspace/invoke', { tool: 'marketSearchForResearch', args: { query: 'AAPL' } })
     expect(res.status).toBe(404) // not in the workspace map → gated out
   })
 

--- a/src/workspaces/templates/auto-prediction/README.md
+++ b/src/workspaces/templates/auto-prediction/README.md
@@ -1,5 +1,5 @@
 ---
-version: 0.1.2
+version: 0.1.3
 ---
 
 # Auto Prediction

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.5
+version: 1.1.6
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.8.5
+version: 1.8.6
 ---
 
 # Chat


### PR DESCRIPTION
Remove `alice think calc` and the now-empty `think` group from the Workspace CLI export. Both CLI help and the UI's live reference stop advertising it, and direct CLI gateway invocation of `calculate` is rejected even if the internal tool remains registered.

Update the bundled alice skill's group list and bump the three consuming template guidance versions so existing Workspaces can pick up the documentation correction through their explicit upgrade flow. Existing Workspace files are not overwritten.

Validation: `pnpm test:changed` (41 tests), CLI shim/context injection specs (22 tests), root `npx tsc --noEmit`, and `git diff --check` passed. Real CLI help against the UI Setup gateway lists only rss/market/analysis; the removed command returns unknown group.

Prior PR #1396 clean-build failed before compilation because Electron's binary download returned HTTP 504. The failed job was rerun; its post-merge installer smoke was queued at inspection. No product/test failure was identified in that run.
