### PR TITLE
Remove analysis simulate from Workspace CLI

### DIFF
--- a/default/skills/alice-analysis/SKILL.md
+++ b/default/skills/alice-analysis/SKILL.md
@@ -90,10 +90,10 @@ d1 = bars("yfinance|BTC-USD", "1d", count=250, asset="crypto")
 ```
 → `{ "1h": 53.2, "4h": 48.9, "1d": 61.4 }`
 
-## Sibling verbs — dated reads & backtests
+## Sibling verbs — dated reads
 
 `quant` returns latest scalars with no dates. When you need the time axis or a
-hypothetical trade, reach for these instead (see the `retrospective` skill for
+dated research input, reach for these instead (see the `retrospective` skill for
 the full workflow):
 
 - **`alice analysis snapshot --query XLE [--asOf YYYY-MM-DD]`** — the honest
@@ -101,9 +101,6 @@ the full workflow):
   (close + vs-prevClose + day high/low + amplitude), compact levels, and a
   **freshness contract** (`isLatestActual` / `staleTradingDays`). Use this for
   "what does/did X look like", not a hand-rolled quant dump.
-- **`alice analysis simulate --query XLE --entryDate … --exitRule …`** —
-  backtest one entry + one exit (`trailing_stop`/`ma_break`/`stop`/`target`/
-  `hold`); returns entry/exit, returnPct, MFE/MAE.
 - **`alice analysis quant … --dates`** — opt-in date axis on a quant result
   (`dates[barId]` for one interval; `dates["barId@interval"]` when the same
   barId is used at multiple intervals), to map a dumped series back to days.

--- a/default/skills/retrospective/SKILL.md
+++ b/default/skills/retrospective/SKILL.md
@@ -10,7 +10,7 @@ description: >
   money?", "replay the SMH spike — policy or earnings?", "was there an entry
   signal at the time", "would an 8% trailing stop have saved me", "event study
   on the Hormuz escalation". It strings together the as-of snapshot, the
-  date-windowed news, and the backtest into one honest replay — and it is
+  date-windowed news, and Workspace research code into one honest replay — and it is
   ruthless about data freshness, because a retro built on a stale or
   future-leaking price is worse than no retro.
 ---
@@ -23,7 +23,7 @@ is honesty: **no lookahead** (never use a price the moment didn't yet know) and
 **no stale data** (never report yesterday's close as "now").
 
 The tools (run them — don't answer from memory):
-`alice analysis snapshot`, `alice analysis simulate`, `alice rss window`,
+`alice analysis snapshot`, `alice rss window`,
 `alice rss grep` / `read`. (See the `alice`, `alice-analysis` skills for the
 quant scripting language.)
 
@@ -71,20 +71,14 @@ it.**
    Barchart options flow, Reddit sentiment — are unreachable from a headless
    run; if the call needs them, flag the gap rather than imply full coverage.)
 
-3. **Test the entry (backtest the hypothesis).** "If I'd bought at the anchor,
-   would a stop/exit have worked?"
-   ```bash
-   alice analysis simulate --query XLE --entryDate 2026-04-03 \
-     --exitRule trailing_stop --exitPct 8
-   # also try: --exitRule ma_break --exitPeriod 50   (trend exit)
-   #           --exitRule hold                        (just measure to now)
-   ```
-   Read `entry`/`exit` (date·price·reason), `returnPct`, and **MFE/MAE** (the
-   best and worst it went while you held — the round trip a single end-number
-   hides). `open: true` means it never triggered the exit; the return is
-   mark-to-market, not realized. Compare a couple of exit rules — the
-   interesting finding is usually "the move was real but giving it back to a
-   loose stop ate most of it", or vice-versa.
+3. **Test the hypothesis in Workspace research code.** If the question needs
+   a hypothetical trade, save the dated inputs and write an inspectable script
+   with the native Coding Agent. Pin the source and evaluation window. State
+   signal timing, executable entry/exit prices, position sizing, fees and
+   slippage explicitly. Do not use a closing-price signal to assume an
+   executable fill at that same close. Exclude pre-entry price extremes from
+   holding-period MFE/MAE. Save the script, inputs and results together so the
+   assumptions can be changed and the calculation reproduced.
 
 4. **Map the index to dates when you need the path in a quant script.** Most
    reads are covered by snapshot; when you must compute over the series and want

--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -35,7 +35,7 @@ low-frequency/reference research
   -> typed local fallback when supported
 
 K-lines and quantitative work
-  -> alice analysis search-bars/snapshot/quant/simulate
+  -> alice analysis search-bars/snapshot/quant
   -> BarService
   -> vendor source or UTA broker source selected by barId
 ```

--- a/src/domain/news/query/archive.ts
+++ b/src/domain/news/query/archive.ts
@@ -253,7 +253,7 @@ Example: grepRss({ pattern: "interest rate", lookback: "2d" })`,
     windowRss: tool({
       description: `Articles within a DATE WINDOW (event study), oldest-first — for aligning news against a price path ("what hit between the gap-up and the fade").
 
-Returns id + ISO time + title (+ matched snippet when a pattern is given), sorted oldest→newest so the timeline lines up with bars. Pair with marketSnapshot/simulate to attribute a move to a catalyst.
+Returns id + ISO time + title (+ matched snippet when a pattern is given), sorted oldest→newest so the timeline lines up with bars. Pair with dated market snapshots to compare the price path with candidate catalysts.
 
 Coverage is the user's SUBSCRIBED RSS feeds only (not the news at large) — an empty window means "nothing in the subscribed feeds for that span", not "nothing happened". Pass a \`pattern\` to filter, or omit it to get everything in the window.
 

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -59,8 +59,9 @@ describe('CLI_EXPORTS — data export (global tools)', () => {
     }
   })
 
-  it('does not export the calculator', () => {
+  it('does not export generic calculation or fixed trade simulation', () => {
     expect(mappedToolNames('data')).not.toContain('calculate')
+    expect(mappedToolNames('data')).not.toContain('simulate')
     expect(getExport('data')?.groupDescriptions).not.toHaveProperty('think')
   })
 

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -54,7 +54,7 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
     groupDescriptions: {
       rss: 'Search and read the user\'s collected subscribed-feed archive',
       market: 'Discover symbols, bar sources, and optional market-data vendors',
-      analysis: 'Read dated K-lines, calculate indicators, and run bounded simulations',
+      analysis: 'Read dated K-lines and calculate indicators',
     },
     commands: {
       // `rss`, not `news`: the backing store is the RSS collector's archive —
@@ -79,10 +79,8 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
       analysis: {
         'search-bars': 'searchBars',
         quant: 'calculateQuant',
-        // Honest as-of read (dated bars, no-lookahead, freshness contract) + a
-        // path-dependent backtest. The Retrospective / Time-Machine primitives.
+        // Dated as-of read with a freshness contract for retrospective analysis.
         snapshot: 'marketSnapshot',
-        simulate: 'simulate',
       },
     },
   },

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -26,6 +26,12 @@ function makeApp(manifestOnly = false): Hono {
     execute: ({ query }) => ({ symbol: query }),
   }) }, 'market-search')
 
+  toolCenter.register({ simulate: tool({
+    description: 'Unexported simulation fixture',
+    inputSchema: z.object({}),
+    execute: (): { executed: boolean } => { throw new Error('Removed simulation must not execute') },
+  }) }, 'simulation')
+
   const fakeSvc = {
     registry: {
       get: (id: string) => (id === 'ws1' ? { id: 'ws1', tag: 'demo' } : undefined),
@@ -65,10 +71,16 @@ describe('CLI gateway — data export', () => {
     expect(body.export).toBe('data')
     expect(body.groups['market']?.['search']?.tool).toBe('marketSearchForResearch')
     expect(body.groups).not.toHaveProperty('think')
+    expect(body.groups['analysis'] ?? {}).not.toHaveProperty('simulate')
   })
 
   it('rejects the removed calculator even when the tool remains registered', async () => {
     const response = await post('/cli/ws1/data/invoke', { tool: 'calculate', args: { expression: '2 + 2' } })
+    expect(response.status).toBe(404)
+  })
+
+  it('rejects direct invocation of the removed simulator', async () => {
+    const response = await post('/cli/ws1/data/invoke', { tool: 'simulate', args: {} })
     expect(response.status).toBe(404)
   })
 

--- a/src/workspaces/templates/auto-prediction/README.md
+++ b/src/workspaces/templates/auto-prediction/README.md
@@ -1,5 +1,5 @@
 ---
-version: 0.1.3
+version: 0.1.4
 ---
 
 # Auto Prediction

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.6
+version: 1.1.7
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.8.6
+version: 1.8.7
 ---
 
 # Chat


### PR DESCRIPTION
Remove `alice analysis simulate` from the injected Workspace CLI. The live CLI/UI manifest no longer advertises fixed trade simulations, and direct gateway invocation is rejected even when the internal tool is registered.

Remove the obsolete examples from alice-analysis and retrospective skills, and the news tool's cross-reference. Retrospective guidance now asks the native agent to preserve dated inputs and inspectable research code with explicit execution assumptions. Bump the three consuming template guidance versions for the reviewed upgrade flow; existing Workspace files are not overwritten.

Validation:
- `pnpm test:changed`: 73 tests passed.
- CLI shim and context-injector specs: 22 tests passed.
- Gateway spec rerun after fixture type annotation: 29 tests passed.
- Root `npx tsc --noEmit` and `git diff --check` passed.
- Real CLI against the isolated UI Setup gateway lists search-bars/quant/snapshot; `analysis simulate` returns unknown command.
- Previous PR #1397 clean-build and post-merge dev installer smoke succeeded. The earlier #1396 download-timeout retry also succeeded.

This removes the Workspace CLI export and injected guidance; the internal simulation implementation is not changed in this increment.
