### PR TITLE
Unify workspace collaboration commands and skills under alice

### DIFF
--- a/default/skills/alice-uta/SKILL.md
+++ b/default/skills/alice-uta/SKILL.md
@@ -125,5 +125,5 @@ alice-uta sim price-change --help      # MockBroker only — move a mock price f
 ## Not here
 
 - **Scheduling is not in `alice-uta`.** Recurring/headless workspace work is
-  issue-backed: use `alice-workspace issue create` or write
+  issue-backed: use `alice issue create` or write
   `.alice/issues/<id>.md` with a `when` field (see the `self-scheduling` skill).

--- a/default/skills/alice/SKILL.md
+++ b/default/skills/alice/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: alice
 description: >
-  Research & data on your shell PATH via the `alice` CLI — THIS WORKBENCH's
-  read surfaces: the collected-RSS archive (`alice rss`), cross-asset symbol
+  Research and Workspace collaboration through the `alice` CLI. Data surfaces: the collected-RSS archive (`alice rss`), cross-asset symbol
   search (`alice market search` → barIds), and K-line quant analysis
   (`alice analysis`). Use for: "grep the collected feeds for the Fed", "find
   the barId for AAPL", "compute RSI on this chart", "I can't find a Taiwan/CN
@@ -11,18 +10,21 @@ description: >
   (Low-frequency market data — fundamentals, macro series, calendars, boards —
   is the separate `traderhub` CLI; the quant scripting manual is the
   `alice-analysis` skill.)
+  Also use alice for Workspace collaboration: peer discovery, Agent conversations,
+  Inbox delivery, Issues, Session identity, tracked assets and template upgrades.
+  Read references/collaboration.md for these workflows.
 ---
 
-# Research & data — `alice`
+# Research & collaboration — `alice`
 
-`alice` is OpenAlice's read surface on your PATH. Output is JSON on stdout
+`alice` is OpenAlice's research and collaboration interface on your PATH. Output is JSON on stdout
 (pipe it: `alice market search --query AAPL | jq '.results[0]'`); a non-zero
 exit means it failed, with the reason on stderr.
 
 ## Discover, don't guess
 
 ```bash
-alice --help                       # the groups: rss, market, analysis
+alice --help                       # discover research and collaboration groups
 alice <group> <verb> --help        # a verb's flags (which are required)
 ```
 
@@ -80,3 +82,14 @@ search-bars` (find a K-line barId) then `alice analysis quant` (compute). It's a
 small scripting language with a full function catalog, multi-timeframe panels,
 and source selection. **See the `alice-analysis` skill** for the manual; don't
 hand-roll indicators here.
+
+## Collaboration and durable assets
+
+The same `alice` CLI also owns `peer`, `conversation`, `inbox`, `issue`,
+`provenance`, `signature`, `session`, `track`, and `template`. These are top-level
+groups, not an `alice workspace` subcommand.
+
+Read [the collaboration reference](references/collaboration.md) before sending
+messages, delivering reports or managing durable work. Workspace and Session
+identity are supplied by the launch context. Use live `alice --help` to discover
+commands and flags.

--- a/default/skills/alice/references/collaboration.md
+++ b/default/skills/alice/references/collaboration.md
@@ -1,14 +1,4 @@
----
-name: alice-workspace
-description: >
-  Use the `alice-workspace` CLI for collaboration between durable OpenAlice
-  Workspaces: find peers, send ordinary Agent messages, deliver reports to the
-  human Inbox, coordinate Issues, and trace artifacts to attributable product
-  Sessions. Load it when work must cross a Workspace boundary or remain
-  recoverable. Read live help instead of guessing flags.
----
-
-# Workspace collaboration — `alice-workspace`
+# Workspace collaboration — `alice`
 
 OpenAlice owns addresses, delivery, durable work, and provenance. Coding Agents
 keep using their native file, search, and Git tools inside any resolved path.
@@ -30,9 +20,9 @@ keep using their native file, search, and Git tools inside any resolved path.
 Start with live intent help whenever the route is unclear:
 
 ```bash
-alice-workspace
-alice-workspace <group>
-alice-workspace <group> <verb> --help
+alice
+alice <group>
+alice <group> <verb> --help
 ```
 
 ## Talk to another Agent
@@ -41,22 +31,22 @@ Use `conversation`, not Inbox, for ordinary coworker communication.
 
 ```bash
 # Discover the active office floor and choose a desk.
-alice-workspace peer list
+alice peer list
 
 # Recruit a fresh Session at that Workspace for new work.
-alice-workspace conversation ask --ws-id <workspaceId> \
+alice conversation ask --ws-id <workspaceId> \
   --prompt 'Investigate this bounded question and report back.'
 
 # Continue one exact attributable product Session.
-alice-workspace conversation ask --resume-id <resumeId> \
+alice conversation ask --resume-id <resumeId> \
   --prompt 'Explain the missing context.' --await
 
 # Ask the attributable sender of one Inbox delivery.
-alice-workspace conversation ask --inbox-id <entryId> \
+alice conversation ask --inbox-id <entryId> \
   --prompt 'What did you send, and what should I inspect first?' --await
 
 # Recruit a fresh Session in a Harness default Workspace.
-alice-workspace conversation ask --harness autoquant \
+alice conversation ask --harness autoquant \
   --prompt 'Start a new quantitative research assignment.'
 ```
 
@@ -78,9 +68,9 @@ Choose the waiting rhythm from the work:
 - Several independent peers: dispatch first, then collect the task ids together.
 
 ```bash
-alice-workspace conversation await --task-id <taskId>
-alice-workspace conversation read --task-id <taskId>
-alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
+alice conversation await --task-id <taskId>
+alice conversation read --task-id <taskId>
+alice conversation collect --task-id <taskA> --task-id <taskB>
 ```
 
 Conversation work has no implicit execution deadline. `--await`, `conversation
@@ -101,7 +91,7 @@ already reaches the user; scheduled/headless work must push explicitly when its
 result deserves human attention.
 
 ```bash
-alice-workspace inbox push \
+alice inbox push \
   --doc research/report.md \
   --comments 'Finished — the report contains the evidence and conclusion.'
 ```
@@ -113,8 +103,8 @@ recover what was sent even if the path later changes.
 Read recent deliveries with:
 
 ```bash
-alice-workspace inbox read --limit 5
-alice-workspace inbox read --self
+alice inbox read --limit 5
+alice inbox read --self
 ```
 
 Each attachment is returned in `files[]` with a directly usable `absolutePath`,
@@ -126,7 +116,7 @@ path is unsafe, do not guess it. For broader inspection of an available peer
 desk, resolve its root explicitly:
 
 ```bash
-alice-workspace peer path --id <workspaceId>
+alice peer path --id <workspaceId>
 # Then use the Coding Agent's native Read/Search/Glob/Git capabilities.
 ```
 
@@ -145,14 +135,14 @@ only delivers the exact committed files and stamps their origin.
 Prefer the business object when one already identifies the responsible work:
 
 ```bash
-alice-workspace inbox ask --id <entryId> \
+alice inbox ask --id <entryId> \
   --prompt 'Why did you send this result?' --await
 
-alice-workspace issue ask --id <issueName> --creator \
+alice issue ask --id <issueName> --creator \
   --prompt 'Why was this Issue created?' --await
-alice-workspace issue ask --id <issueName> --owner \
+alice issue ask --id <issueName> --owner \
   --prompt 'What is the current state and next decision?' --await
-alice-workspace issue ask --id <issueName> --run-id <taskId> \
+alice issue ask --id <issueName> --run-id <taskId> \
   --prompt 'What happened in this execution?' --await
 ```
 
@@ -168,13 +158,13 @@ Resolution means:
 ## Trace provenance
 
 ```bash
-alice-workspace provenance show --kind inbox --inbox-entry-id <entryId>
-alice-workspace provenance show --kind issue --issue-id <id>
-alice-workspace provenance show --kind report --workspace-id <workspaceId> \
+alice provenance show --kind inbox --inbox-entry-id <entryId>
+alice provenance show --kind issue --issue-id <id>
+alice provenance show --kind report --workspace-id <workspaceId> \
   --path research/report.md --revision <sha256:...>
-alice-workspace provenance show --resume-id <resumeId>
-alice-workspace signature show
-alice-workspace session rename --resume-id <resumeId> --display-name 'AAPL desk'
+alice provenance show --resume-id <resumeId>
+alice signature show
+alice session rename --resume-id <resumeId> --display-name 'AAPL desk'
 ```
 
 `resumeId` is the product follow-up handle; `taskId` is one execution. Native
@@ -186,12 +176,12 @@ delivery, which may differ from whoever last edited its live document.
 Issue reads span the shared board; writes belong to this Workspace:
 
 ```bash
-alice-workspace issue list
-alice-workspace issue list --mode detailed
-alice-workspace issue show --id <name>
-alice-workspace issue create --title 'Investigate the anomaly'
-alice-workspace issue update --id <id> --status in_progress
-alice-workspace issue comment --id <id> --text 'Evidence collected; review next.'
+alice issue list
+alice issue list --mode detailed
+alice issue show --id <name>
+alice issue create --title 'Investigate the anomaly'
+alice issue update --id <id> --status in_progress
+alice issue comment --id <id> --text 'Evidence collected; review next.'
 ```
 
 Use `issue comment` for durable discussion on this Workspace's Issue. Use
@@ -202,8 +192,8 @@ Scheduling and the complete Issue file/assignee contract belong to the
 Tracked entities are the durable cross-Workspace subject index, not tasks:
 
 ```bash
-alice-workspace track search --query uranium
-alice-workspace track add --name uranium-ccj --description 'Cameco — uranium miner'
+alice track search --query uranium
+alice track add --name uranium-ccj --description 'Cameco — uranium miner'
 ```
 
 ## Upgrade managed Workspace guidance
@@ -211,10 +201,10 @@ alice-workspace track add --name uranium-ccj --description 'Cameco — uranium m
 Preview first; apply only after reviewing the plan:
 
 ```bash
-alice-workspace template upgrade
-alice-workspace template upgrade --mode detailed
-alice-workspace template upgrade --apply
-alice-workspace template upgrade --id <workspaceId>
+alice template upgrade
+alice template upgrade --mode detailed
+alice template upgrade --apply
+alice template upgrade --id <workspaceId>
 ```
 
 Applying to a live current Workspace is blocked. A headless run may preview a

--- a/default/skills/delegate-autoquant/SKILL.md
+++ b/default/skills/delegate-autoquant/SKILL.md
@@ -32,10 +32,10 @@ correct handoff.
 
 ## Recruit the default desk
 
-Use the `alice-workspace` collaboration surface:
+Use the `alice` collaboration surface:
 
 ```bash
-alice-workspace conversation ask --harness autoquant --await --prompt '
+alice conversation ask --harness autoquant --await --prompt '
 Research question: <question>
 Decision this supports: <decision>
 Caller-owned scope and constraints: <assets, direction, horizon, cadence, benchmark, costs, limits>
@@ -47,7 +47,7 @@ Ask before proceeding if a missing caller-owned fact would materially change the
 
 Add `--await` when the current turn needs the answer. For longer delegation,
 omit it, retain the returned `taskId`, and use `conversation await`, `read`, or
-`collect` as described by the `alice-workspace` skill. There is no unsolicited
+`collect` as described by the `alice` skill. There is no unsolicited
 Agent-to-Agent completion notification bus. AutoQuant assignments deliberately
 have no default runtime deadline; add `--timeout-ms` only when the caller has
 chosen a real hard stop for that particular study.
@@ -84,13 +84,13 @@ OpenAlice Inbox.
    worker:
 
    ```bash
-   alice-workspace conversation ask --resume-id <resumeId> --await \
+   alice conversation ask --resume-id <resumeId> --await \
      --prompt 'Please provide the absolute directory path of the primary Report, Dossier, or Project evidence from your completed assignment. Do not rerun the research.'
    ```
 
 3. Use native Read/Search/Git capabilities directly on the returned directory
    and only the named artifacts. Use
-   `alice-workspace peer path --id <workspaceId>` only as an addressing fallback
+   `alice peer path --id <workspaceId>` only as an addressing fallback
    when the reported absolute path is unavailable.
 4. If the answer needs substantive clarification, continue that same
    `resumeId`; do not recruit a new AutoQuant Session and discard its context.

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -5,7 +5,7 @@ description: >
   `.alice/issues/<id>.md`: structured ownership and optional `when` frontmatter
   plus one canonical markdown What. Use for creating or editing an Issue,
   choosing its assignee, schedule, prompt, delivery behavior, or health state.
-  Use the `alice-workspace` skill instead when the goal is to ask another
+  Use the `alice` skill instead when the goal is to ask another
   Session for an answer.
 ---
 
@@ -34,7 +34,7 @@ The filename stem **is** the issue id (`morning-scan.md` → id `morning-scan`).
 You have two equivalent paths, and both write the **same**
 `.alice/issues/<id>.md` files:
 
-1. **`alice-workspace issue …` — the convenient agent surface, and what you
+1. **`alice issue …` — the convenient agent surface, and what you
    should reach for first.** A small set of verbs does the read-modify-write for
    you: id slug derivation, frontmatter validation against the allowed
    status/priority enums, structured comment sidecars, and not clobbering an
@@ -51,42 +51,42 @@ You have two equivalent paths, and both write the **same**
 
 ```bash
 # list — scan the WHOLE board: every workspace's issues as compact title rows
-alice-workspace issue list
+alice issue list
 
 # show — one issue in full, resolved by its (global) name: frontmatter + What + comments +
 # run history + inbox reports. --id takes a name OR id and resolves across the
 # board; a name two workspaces share returns the candidates to pick from.
-alice-workspace issue show --id morning-scan
+alice issue show --id morning-scan
 
 # create — a new issue. --title is required; --id is derived as a kebab slug
 # from the title when omitted. Creating over an existing id is refused.
-alice-workspace issue create --title "Split the data fetcher" \
+alice issue create --title "Split the data fetcher" \
   --priority medium \
   --what "src/fetch.ts mixes the HTTP call with the normalization step."
 
 # update — patch board fields, canonical What, or the optional run timeout;
 # scheduling cadence (`when`) is left untouched. Setting status done|canceled is how
 # you silence a self-scheduled issue (there is no separate enabled flag).
-alice-workspace issue update --id morning-scan --status done
-alice-workspace issue update --id morning-scan --timeout 30m
+alice issue update --id morning-scan --status done
+alice issue update --id morning-scan --timeout 30m
 
 # comment — append markdown to the structured `<id>.comments.json` sidecar. An
 # attributable Session signs with @resumeId. If somebody else comments on an
 # For a fixed @resumeId owner, OpenAlice asks that owner in the background.
 # Human comments without one ask the creator or a reconstructed Workspace Agent.
 # Agent-authored comments without a fixed owner remain timeline notes.
-alice-workspace issue comment --id morning-scan --text "Brief pushed; SPY gapped +0.4%."
+alice issue comment --id morning-scan --text "Brief pushed; SPY gapped +0.4%."
 ```
 
-Run `alice-workspace issue <verb> --help` for a verb's flags. Object-valued flags
+Run `alice issue <verb> --help` for a verb's flags. Object-valued flags
 take JSON — e.g. to create a self-scheduled issue in one call, pass the schedule
 as `--when`:
 
 ```bash
-alice-workspace issue create --title "Pre-market brief" --priority high \
+alice issue create --title "Pre-market brief" --priority high \
   --when '{"kind":"cron","cron":"30 8 * * 1-5","timezone":"America/New_York"}' \
   --assignee @me \
-  --what "Pull pre-market movers and overnight news for my watchlist, write a short brief to research/premarket.md, then run: alice-workspace inbox push --doc research/premarket.md --comments 'Pre-market brief'." \
+  --what "Pull pre-market movers and overnight news for my watchlist, write a short brief to research/premarket.md, then run: alice inbox push --doc research/premarket.md --comments 'Pre-market brief'." \
   --agent codex \
   --credential openai-primary \
   --model gpt-5.6 \
@@ -263,8 +263,8 @@ work and surfaces nothing has vanished. So:
 
 - If the run produces something the user should see — a brief, a finding, a
   result — **push it to the Inbox**, the only channel a headless run has:
-  `alice-workspace inbox push --comments "…"` (attach files with repeatable
-  `--doc <path>`; run `alice-workspace --help` for the flags). A report pushed
+  `alice inbox push --comments "…"` (attach files with repeatable
+  `--doc <path>`; run `alice --help` for the flags). A report pushed
   during a scheduled run is automatically linked back to the issue that
   triggered it — you don't pass any id.
 - If the run is a **check that didn't trigger** (condition not met, nothing

--- a/default/skills/workspace-manager/SKILL.md
+++ b/default/skills/workspace-manager/SKILL.md
@@ -11,8 +11,8 @@ the desks currently in service; departed desks have already moved elsewhere.
 Start with product indexes, not an unbounded filesystem crawl:
 
 ```bash
-alice-workspace peer list
-alice-workspace issue list --mode detailed
+alice peer list
+alice issue list --mode detailed
 ```
 
 `peer list` already includes recent attributable Session titles. Use those to
@@ -25,13 +25,13 @@ crawl.
 For one desk or coworker:
 
 ```bash
-alice-workspace peer path --id <workspaceId>
-alice-workspace peer sessions --id <workspaceId>
-alice-workspace conversation ask --resume-id <resumeId> --prompt "..." --await
+alice peer path --id <workspaceId>
+alice peer sessions --id <workspaceId>
+alice conversation ask --resume-id <resumeId> --prompt "..." --await
 # Recruit a fresh coworker for new work:
-alice-workspace conversation ask --ws-id <workspaceId> --prompt "..."
+alice conversation ask --ws-id <workspaceId> --prompt "..."
 # Explicit historical reconstruction when no attributable Session exists:
-alice-workspace conversation ask --ws-id <workspaceId> --prompt "..." --reconstruct --await
+alice conversation ask --ws-id <workspaceId> --prompt "..." --reconstruct --await
 ```
 
 This distinction is not cosmetic. `--resume-id` continues the exact coworker
@@ -41,7 +41,7 @@ missing historical intent; either way it must not impersonate an absent owner.
 Preserve and report `resolution.mode` (`exact` versus `reconstructed`) when the
 difference affects the answer.
 
-Use `alice-workspace <group> <verb> --help` whenever a flag is uncertain. The
+Use `alice <group> <verb> --help` whenever a flag is uncertain. The
 live manifest is authoritative even when an older Workspace carries stale
 instructions.
 
@@ -65,7 +65,7 @@ instructions.
 Template reconciliation is preview-first:
 
 ```bash
-alice-workspace template upgrade --id <workspaceId>
+alice template upgrade --id <workspaceId>
 ```
 
 Only add `--apply` after the user has asked to perform the reviewed mutation.

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -119,7 +119,7 @@ categories.
 
 ```text
 Workspace agent
-  -> alice-workspace inbox push (CLI)
+  -> alice inbox push (CLI)
   -> InboxStore durable JSONL append
   -> non-blocking Alice bridge
   -> Connector Service on loopback

--- a/docs/conversation-provenance.md
+++ b/docs/conversation-provenance.md
@@ -10,7 +10,7 @@ trade decisions. It is the design spine for features such as “ask the sender,�
 `resumeId` is OpenAlice's unique Session identity; `@resumeId` is its visible
 signature. Every live interactive/headless Agent receives
 `OPENALICE_RESUME_ID` and `OPENALICE_SIGNATURE`, while
-`alice-workspace signature show` resolves the same identity through the
+`alice signature show` resolves the same identity through the
 authoritative request origin. Environment values help the Agent remember its
 name; server-side origin resolution remains the authority for structured
 Inbox, Issue, and trade actions.
@@ -127,7 +127,7 @@ This is the coworker's nametag:
 - changing the nametag is metadata, not Session activity, and must not update
   recency or reorder the Session roster;
 - empty or `null` clears the field; the maximum is 120 characters after trim;
-- agents rename only through `alice-workspace session rename` or
+- agents rename only through `alice session rename` or
   `PATCH /api/workspaces/:id/resumes/:resumeId/metadata`;
 - the Ask Alice / Quant Session row overflow menu exposes **Settings** for the
   nametag plus paused credential/model/effort editing (same dialog as the
@@ -349,7 +349,7 @@ An Issue has two independent identity questions:
 `assignee` is the single answer to the second question; schedule is an intrinsic
 capability of that Work item, not a second ownership object.
 
-Issue detail and `alice-workspace issue show` expose creation/update provenance
+Issue detail and `alice issue show` expose creation/update provenance
 plus structured comments. Adjacent updates from the same origin are projected
 as one editing activity, including historical autosave records written before
 store-side coalescing existed. Session origins carry a product
@@ -496,7 +496,7 @@ records a `decided` occurrence. A call without an authoritative Session header
 remains unattributed rather than being guessed. Query it with:
 
 ```bash
-alice-workspace provenance show --kind trade-decision \
+alice provenance show --kind trade-decision \
   --account-id <account> --decision-id <uta-commit-hash>
 ```
 
@@ -569,7 +569,7 @@ useful without starting or messaging an agent.
 Phase 1 answers “what produced or changed this, and which Session was
 responsible?” It owns:
 
-- a safe Workspace Session directory (`alice-workspace peer sessions`) whose
+- a safe Workspace Session directory (`alice peer sessions`) whose
   only conversation handle is `resumeId`; it is an audit/addressing surface,
   not permission to choose an arbitrary old Session when provenance is absent;
 - the standard `SessionOrigin` envelope;
@@ -581,7 +581,7 @@ responsible?” It owns:
 - report revision/write attribution where observable;
 - trade-decision correlation across the Alice -> UTA boundary;
 - read-only artifact and reverse-Session queries through
-  `alice-workspace provenance show`;
+  `alice provenance show`;
 - honest `unknown`/`unavailable` records for legacy, human, or external changes;
 - read-only provenance queries and diagnostics.
 
@@ -605,25 +605,25 @@ Phase 2 consumes Phase 1; it does not infer provenance independently. It owns:
 The embedded generic entry point is:
 
 ```bash
-alice-workspace conversation ask --resume-id <resumeId> --prompt '<question>'
-alice-workspace conversation ask --inbox-id <entryId> --prompt '<question>'
-alice-workspace conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
-alice-workspace conversation ask --ws-id <workspaceId> --prompt '<question>'
-alice-workspace conversation ask --harness chat --prompt '<new assignment>'
-alice-workspace conversation ask --harness autoquant --prompt '<new assignment>'
-alice-workspace conversation ask --ws-id <workspaceId> --prompt '<reconstruction request>' --reconstruct
-alice-workspace conversation await --task-id <taskId>
-alice-workspace conversation collect --task-id <taskA> --task-id <taskB>
-alice-workspace conversation read --task-id <taskId>
+alice conversation ask --resume-id <resumeId> --prompt '<question>'
+alice conversation ask --inbox-id <entryId> --prompt '<question>'
+alice conversation ask --issue-id <issueId> [--ws-id <workspaceId>] --prompt '<question>'
+alice conversation ask --ws-id <workspaceId> --prompt '<question>'
+alice conversation ask --harness chat --prompt '<new assignment>'
+alice conversation ask --harness autoquant --prompt '<new assignment>'
+alice conversation ask --ws-id <workspaceId> --prompt '<reconstruction request>' --reconstruct
+alice conversation await --task-id <taskId>
+alice conversation collect --task-id <taskA> --task-id <taskB>
+alice conversation read --task-id <taskId>
 ```
 
 Inbox and Issue callers normally use the business-level wrappers instead:
 
 ```bash
-alice-workspace inbox ask --id <entryId> --prompt '<question>' --await
-alice-workspace issue ask --id <issueName> --creator --prompt '<question>' --await
-alice-workspace issue ask --id <issueName> --owner --prompt '<question>' --await
-alice-workspace issue ask --id <issueName> --run-id <taskId> --prompt '<question>' --await
+alice inbox ask --id <entryId> --prompt '<question>' --await
+alice issue ask --id <issueName> --creator --prompt '<question>' --await
+alice issue ask --id <issueName> --owner --prompt '<question>' --await
+alice issue ask --id <issueName> --run-id <taskId> --prompt '<question>' --await
 ```
 
 The public CLI accepts only flat identity flags. `resumeId` addresses one exact

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -146,7 +146,7 @@ specifically requires `openai-responses`). It writes only the selected
 credential into the temporary runtime volume over stdin, asks the agent to
 remember a generated codeword, resumes the same OpenAlice `resumeId`, and
 requires the second turn to recall it. A final turn requires the agent to use
-`alice-workspace` to create and read back marker-bearing Issue data; the smoke
+`alice` to create and read back marker-bearing Issue data; the smoke
 requires both a normalized tool block containing the marker and the agent's
 confirmation. The credential check then requires a completed
 `traderhub board get --board macro` call and a metric summary from its live,

--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -571,11 +571,11 @@ contract:
    the production-composed Workspace environment. It resolves `alice`,
    `alice-workspace`, `traderhub`, and `alice-uta`, loads every CLI manifest over
    the Electron tool socket, verifies Git, and creates then reads an issue with
-   the real `alice-workspace` shim.
+   the real `alice` shim (with `alice-workspace` retained as a compatibility alias).
 2. The shell creates a one-shot scheduled Issue containing metacharacters in
    its visible What. The real `ScheduleScanner` dispatches the packaged managed
    Pi runtime, which performs a deterministic `bash` tool call that invokes
-   `alice-workspace issue create`. The smoke accepts the run only when it is
+   `alice issue create`. The smoke accepts the run only when it is
    process-backed, structured assistant output is decoded, the one-shot Issue
    auto-completes, and the created side-effect Issue is visible from the
    external `/api/issues` surface.

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -37,7 +37,7 @@ One concept has one primary owner:
 
 | Concept | Owner |
 |---|---|
-| Inbox, Issue collaboration, provenance, peer questions, Session nametags | `alice-workspace` |
+| Inbox, Issue collaboration, provenance, peer questions, Session nametags | `alice` (collaboration reference) |
 | Delegating quantitative research from Chat to AutoQuant | `delegate-autoquant` |
 | Issue file shape, ownership, schedules, headless delivery | `self-scheduling` |
 | Low-frequency market/fundamental/macro data | `traderhub` |
@@ -59,22 +59,27 @@ product bug.
 Use the real shim in the verification loop; direct tool calls do not exercise
 argv parsing or manifest help.
 
-The four public CLI names are deliberate authority boundaries rather than one
+The three public CLI names are deliberate authority boundaries rather than one
 flat command bag:
 
 | CLI | Boundary |
 |---|---|
-| `alice` | Workspace research data, subscribed-feed archive, symbols, and bounded K-line analysis |
+| `alice` | Research data, subscribed-feed archive, symbols, K-lines, Workspace collaboration, Inbox, Issues, Sessions and tracked assets |
 | `traderhub` | Low-frequency boards, fundamentals, macro, and calendars |
-| `alice-workspace` | Peer addressing, Agent conversation, human Inbox delivery, durable work, provenance, and Session coworker names |
 | `alice-uta` | Broker reads plus explicit trading mutations and approval flow |
+
+`alice-workspace` remains a compatibility alias for existing scripts. New
+Workspace guidance uses `alice` and its bundled collaboration reference. The
+legacy `/workspace` gateway remains available to older shims; the unified
+`/data` gateway routes each mapped tool to its owning registry, preserving
+Workspace and Session provenance.
 
 Every export manifest supplies intent-first descriptions for its command
 groups. Top-level and group help must explain which namespace owns an action
 before listing verbs. Skills may teach workflows, but an old copied skill must
 be able to recover from current live help.
 
-`alice-workspace inbox read` projects each attached document with a directly
+`alice inbox read` projects each attached document with a directly
 usable absolute path when its source Workspace is available. `peer path` is the
 lower-level addressing primitive for inspecting that desk. In both cases,
 native Coding Agent file, search, and Git capabilities own the read flow. Do

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -233,12 +233,12 @@ ordinary coworkers.
 Agents normally use:
 
 ```bash
-alice-workspace issue list
-alice-workspace issue show --id <id-or-title>
-alice-workspace issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @new-each-run --agent codex --credential openai-primary --model gpt-5.6-sol --effort high --timeout 30m
-alice-workspace issue update --id <id> --credential openai-primary --model gpt-5.6-sol --effort high
-alice-workspace issue update --id <id> --timeout 45m
-alice-workspace issue comment --id <id> --text "..."
+alice issue list
+alice issue show --id <id-or-title>
+alice issue create --title "..." --what "..." --when '{"kind":"every","every":"1h"}' --assignee @new-each-run --agent codex --credential openai-primary --model gpt-5.6-sol --effort high --timeout 30m
+alice issue update --id <id> --credential openai-primary --model gpt-5.6-sol --effort high
+alice issue update --id <id> --timeout 45m
+alice issue comment --id <id> --text "..."
 ```
 
 The CLI and MCP tools use the same implementation and write the same files.
@@ -400,14 +400,14 @@ Structured headless output is the live control-plane result, while Inbox is the
 durable user-delivery channel. A run with a meaningful report or artifact calls:
 
 ```bash
-alice-workspace inbox push --doc <path> --comments "<summary>"
+alice inbox push --doc <path> --comments "<summary>"
 ```
 
 The launcher binds the run/issue origin; the agent does not pass its own
 identity. Attached reports also receive a publication-time SHA-256 revision;
 the Inbox still renders the live file, but provenance can distinguish the sent
 revision from later edits. A no-change check should exit silently rather than
-generating Inbox noise. `alice-workspace inbox read` returns this safe provenance to internal
+generating Inbox noise. `alice inbox read` returns this safe provenance to internal
 agents as `origin` (`runId` / `sessionId`, `resumeId`, `issueId`, and `agent`
 when available). For append-only entries created before `resumeId` was stamped,
 the read path joins the stored run/session handle against the live registries;
@@ -426,12 +426,12 @@ remain valid and are never renamed. `taskId` remains one execution, while
 rather than silently pruned.
 
 Internal agents use the same product handle through the embedded collaboration
-path. `alice-workspace issue ask --id <name> --creator --prompt '<question>'`
+path. `alice issue ask --id <name> --creator --prompt '<question>'`
 queries Issue provenance first without making the caller extract a Workspace or
 resume id: it resumes the exact attributable Session,
 reconstructs with a fresh worker only when the Workspace is known and no
 Session origin exists, or returns unavailable without substituting another
-agent. `alice-workspace conversation read --task-id <id>` returns the latest
+agent. `alice conversation read --task-id <id>` returns the latest
 assistant reply by default; diagnostic tool/message blocks require
 `--mode detailed`. New task ids are short `run-xxxxxxxx` codes; existing UUID
 task ids remain readable.

--- a/docs/workspace-manager.md
+++ b/docs/workspace-manager.md
@@ -82,7 +82,7 @@ prompt flag; their durable native transcript carries it across later resumes.
 The contract says:
 
 - inspect and coordinate the active floor;
-- use the embedded `alice-workspace` CLI instead of raw localhost APIs;
+- use the embedded `alice` CLI instead of raw localhost APIs;
 - ask attributable existing Sessions before reconstructing intent;
 - preview lifecycle/template mutations before applying them;
 - never write reports, research, Issues, or other business artifacts at the
@@ -107,8 +107,8 @@ native runtimes retain the WebGL default.
 Start a floor audit from product indexes:
 
 ```bash
-alice-workspace peer list
-alice-workspace issue list --mode detailed
+alice peer list
+alice issue list --mode detailed
 ```
 
 `peer list` returns active Workspace ids, tags, templates, configured runtimes,
@@ -124,14 +124,14 @@ and the durable cached projection.
 Drill into one selected desk with:
 
 ```bash
-alice-workspace peer path --id <workspaceId>
-alice-workspace peer sessions --id <workspaceId>
-alice-workspace conversation ask --resume-id <resumeId> --prompt "..." --await
+alice peer path --id <workspaceId>
+alice peer sessions --id <workspaceId>
+alice conversation ask --resume-id <resumeId> --prompt "..." --await
 # Recruit a fresh coworker for new work:
-alice-workspace conversation ask --ws-id <workspaceId> --prompt "..."
+alice conversation ask --ws-id <workspaceId> --prompt "..."
 # Reconstruct missing historical intent explicitly:
-alice-workspace conversation ask --ws-id <workspaceId> --prompt "..." --reconstruct --await
-alice-workspace template upgrade --id <workspaceId>
+alice conversation ask --ws-id <workspaceId> --prompt "..." --reconstruct --await
+alice template upgrade --id <workspaceId>
 ```
 
 `--resume-id` continues the exact coworker and should report

--- a/docs/workspace-template-upgrade.md
+++ b/docs/workspace-template-upgrade.md
@@ -117,10 +117,10 @@ The same transaction is available from inside the current Workspace without
 hand-authoring API calls:
 
 ```bash
-alice-workspace template upgrade          # read-only preview
-alice-workspace template upgrade --apply  # re-plan and apply the exact current plan
-alice-workspace template upgrade --id <workspaceId>          # preview a peer
-alice-workspace template upgrade --id <workspaceId> --apply  # upgrade a paused peer
+alice template upgrade          # read-only preview
+alice template upgrade --apply  # re-plan and apply the exact current plan
+alice template upgrade --id <workspaceId>          # preview a peer
+alice template upgrade --id <workspaceId> --apply  # upgrade a paused peer
 ```
 
 Conflicts require one repeatable `--keep-workspace <path>` or

--- a/scripts/bun-release-content-identity.spec.mjs
+++ b/scripts/bun-release-content-identity.spec.mjs
@@ -7,7 +7,7 @@ import { bunReleaseContentIdentity } from './bun-release-content-identity.mjs'
 describe('Bun native release content identity', () => {
   it.each([
     ['Web UI', 'share/openalice/ui/dist/index.html'],
-    ['default resources', 'share/openalice/default/skills/alice-workspace/SKILL.md'],
+    ['default resources', 'share/openalice/default/skills/alice/SKILL.md'],
     ['Workspace templates', 'share/openalice/src/workspaces/templates/chat/bootstrap.mjs'],
   ])('changes when %s changes while the executable stays byte-identical', (_label, changedPath) => {
     const original = releaseMetadata()
@@ -80,7 +80,7 @@ function releaseMetadata(overrides = {}) {
   const content = {
     'bin/openalice': '#!/bin/sh\nprintf openalice\\n\n',
     'share/openalice/ui/dist/index.html': '<main>OpenAlice</main>\n',
-    'share/openalice/default/skills/alice-workspace/SKILL.md': '# Alice Workspace\n',
+    'share/openalice/default/skills/alice/SKILL.md': '# Alice\n',
     'share/openalice/src/workspaces/templates/chat/bootstrap.mjs': 'export const chat = true\n',
     ...overrides,
   }

--- a/scripts/docker-runtime-smoke.mjs
+++ b/scripts/docker-runtime-smoke.mjs
@@ -224,8 +224,8 @@ async function runCredentialedConversation(baseUrl, workspaceId, agent, model) {
     resumeId: first.resumeId,
     prompt: [
       'Use the Bash tool to run these commands in order:',
-      `alice-workspace issue create --title "${issueId}" --what "Docker CLI marker ${dataMarker}"`,
-      `alice-workspace issue show --id "${issueId}"`,
+      `alice issue create --title "${issueId}" --what "Docker CLI marker ${dataMarker}"`,
+      `alice issue show --id "${issueId}"`,
       `Only if the second command output contains ${dataMarker}, reply exactly: CLI_DATA_OK ${dataMarker}`,
     ].join('\n'),
   })

--- a/scripts/workspace-acceptance-ai-mock.mjs
+++ b/scripts/workspace-acceptance-ai-mock.mjs
@@ -33,7 +33,7 @@ export function textCompletionStream(text, id = 'chatcmpl-openalice-smoke') {
 
 export function cliToolCallStream(id = 'chatcmpl-openalice-cli-tool') {
   const command = [
-    'alice-workspace issue create',
+    'alice issue create',
     `--id ${WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID}`,
     '--title "OpenAlice agent CLI acceptance"',
   ].join(' ')

--- a/scripts/workspace-acceptance-ai-mock.spec.ts
+++ b/scripts/workspace-acceptance-ai-mock.spec.ts
@@ -21,7 +21,7 @@ describe('workspace acceptance AI mock', () => {
 
     expect(call.function.name).toBe('bash')
     expect(JSON.parse(call.function.arguments).command).toContain(
-      `alice-workspace issue create --id ${WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID}`,
+      `alice issue create --id ${WORKSPACE_ACCEPTANCE_AGENT_ISSUE_ID}`,
     )
     expect(payloads.at(-1).choices[0].finish_reason).toBe('tool_calls')
   })

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -232,7 +232,7 @@ export interface WorkspaceToolContext {
    *  issue. Absent (interactive session, or no header) → undefined. */
   origin?: InboxOrigin
   /** GLOBAL issue-board reader — the cross-workspace board the
-   *  `alice-workspace` CLI surfaces (issue_list / issue_show read EVERY
+   *  `alice` CLI surfaces (issue_list / issue_show read EVERY
    *  workspace's issues, not just the caller's). Backed by the live
    *  WorkspaceService at the two build sites (cli.ts, mcp.ts). OPTIONAL: a
    *  context without a service (older callers, unit tests) omits it, and the

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -55,6 +55,7 @@ describe('CLI_EXPORTS — data export (global tools)', () => {
 
   it('every mapped verb resolves to a registered global tool', () => {
     for (const name of mappedToolNames('data')) {
+      if (mappedToolNames('workspace').has(name)) continue
       expect(tc.get(name), `data CLI maps to missing tool: ${name}`).not.toBeNull()
     }
   })
@@ -65,8 +66,15 @@ describe('CLI_EXPORTS — data export (global tools)', () => {
     expect(getExport('data')?.groupDescriptions).not.toHaveProperty('think')
   })
 
-  it('is scope: global', () => {
-    expect(getExport('data')?.scope).toBe('global')
+  it('includes every collaboration group at the top level without changing its map', () => {
+    for (const [group, verbs] of Object.entries(CLI_EXPORTS.workspace.commands)) {
+      expect(CLI_EXPORTS.data.commands[group]).toEqual(verbs)
+    }
+    expect(CLI_EXPORTS.data.commands).not.toHaveProperty('workspace')
+  })
+
+  it('combines registry scopes', () => {
+    expect(getExport('data')?.scope).toBe('mixed')
   })
 })
 
@@ -156,7 +164,7 @@ describe('CLI_EXPORTS — structure', () => {
     const global = mappedToolNamesForScope('global')
     const scoped = mappedToolNamesForScope('scoped')
     expect(global).toEqual(new Set([
-      ...mappedToolNames('data'),
+      ...[...mappedToolNames('data')].filter(n => !scoped.has(n)),
       ...mappedToolNames('traderhub'),
       ...mappedToolNames('uta'),
     ]))
@@ -166,11 +174,11 @@ describe('CLI_EXPORTS — structure', () => {
 
   it('maps a binary name to its export key (alice -> data, alice-<x> -> <x>)', () => {
     expect(exportKeyForBinary('alice')).toBe('data')
-    expect(exportKeyForBinary('alice-workspace')).toBe('workspace')
+    expect(exportKeyForBinary('alice-workspace')).toBe('data')
     expect(exportKeyForBinary('alice-uta')).toBe('uta')
     // round-trips: each export's declared binary resolves back to its key
     for (const [key, exp] of Object.entries(CLI_EXPORTS)) {
-      expect(exportKeyForBinary(exp.binary)).toBe(key)
+      expect(exportKeyForBinary(exp.binary)).toBe(key === 'workspace' ? 'data' : key)
     }
   })
 

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -1,42 +1,13 @@
-/**
- * CLI export registry — the public `alice* <group> <verb>` surface, split into
- * independently-exported binaries by tool CATEGORY.
- *
- * Each export is one PATH binary (the shim self-detects which via argv[0]) over
- * one tool-center scope:
- *   - `alice`           (key `data`)      → global ToolCenter — market/research
- *                                            DATA sources (finance-domain; swapped
- *                                            out when the workspace's domain changes).
- *   - `alice-workspace` (key `workspace`) → WorkspaceToolCenter — AGENT
- *                                            COLLABORATION (inbox push + entity
- *                                            tracking); scoped per workspace,
- *                                            launcher-universal (survives a domain swap).
- *   - `traderhub`       (key `traderhub`) → global ToolCenter — LOW-FREQUENCY
- *                                            market data via the TraderHub-first
- *                                            client chain (boards, fundamentals,
- *                                            macro series, calendars). Named after
- *                                            the hosted hub so the binary name IS
- *                                            the domain name.
- *   - `alice-uta`       (key `uta`)       → global ToolCenter — TRADING (accounts,
- *                                            portfolio, orders, trading-as-git approval
- *                                            flow). Boundary-reviewed 2026-06-11: broker
- *                                            mutations are deliberate product surface
- *                                            (users want agent trading); cron stays
- *                                            MCP-only — no scheduling from the CLI.
- *
- * The (group, verb) → internal-tool-name map IS each export's contract,
- * deliberately decoupled from internal tool names: a verb like `rss grep` maps
- * to `grepRss`, so internal renames don't break the CLI and vice-versa. Adding
- * a row makes the command reachable in every workspace with zero client change —
- * the `alice*` client is manifest-driven, and the gateway only lets an export
- * invoke tools listed in ITS map.
+/** Public CLI exports. alice combines research and Workspace collaboration;
+ * dispatch retains each tool's global or Workspace registry ownership.
+ * The workspace export remains a compatibility endpoint for old shims.
  */
 
 export interface CliExport {
   /** PATH binary name. The shim is one file; siblings are byte-identical copies. */
   readonly binary: string
   /** Which registry backs this export — global catalog vs per-workspace scoped. */
-  readonly scope: 'global' | 'scoped'
+  readonly scope: 'global' | 'scoped' | 'mixed'
   readonly description: string
   /** Short intent-first help for each command group. The live manifest exposes
    * this separately from verb descriptions so old Workspace skills can recover
@@ -46,7 +17,7 @@ export interface CliExport {
   readonly commands: Record<string, Record<string, string>>
 }
 
-export const CLI_EXPORTS: Record<string, CliExport> = {
+const BASE_EXPORTS: Record<string, CliExport> = {
   data: {
     binary: 'alice',
     scope: 'global',
@@ -291,13 +262,34 @@ export const CLI_EXPORTS: Record<string, CliExport> = {
   // cron: deliberately NOT exported — scheduling stays MCP-only.
 }
 
+// Fail loudly if future namespaces collide instead of silently hiding commands.
+for (const group of Object.keys(BASE_EXPORTS.workspace.commands)) {
+  if (group in BASE_EXPORTS.data.commands) throw new Error(`Duplicate alice command group: ${group}`)
+}
+export const CLI_EXPORTS: Record<string, CliExport> = {
+  ...BASE_EXPORTS,
+  data: {
+    ...BASE_EXPORTS.data,
+    scope: 'mixed',
+    description: 'OpenAlice research, assets and Workspace collaboration',
+    commands: { ...BASE_EXPORTS.data.commands, ...BASE_EXPORTS.workspace.commands },
+    groupDescriptions: { ...BASE_EXPORTS.data.groupDescriptions, ...BASE_EXPORTS.workspace.groupDescriptions },
+  },
+}
+
+export function toolRegistryScope(exp: CliExport, name: string): 'global' | 'scoped' {
+  if (exp.scope !== 'mixed') return exp.scope
+  return Object.values(BASE_EXPORTS.workspace.commands).some(verbs => Object.values(verbs).includes(name)) ? 'scoped' : 'global'
+}
+
 /**
- * Map a PATH binary name to its export key. `alice` → `data`; `alice-<x>` →
+ * Map a PATH binary name to its export key. `alice` and its legacy alias
+ * `alice-workspace` → `data`; other `alice-<x>` →
  * `<x>`; any other bare name (e.g. `traderhub`) is its own key. Mirrored in
  * the shim (bin/alice).
  */
 export function exportKeyForBinary(binary: string): string {
-  return binary === 'alice' ? 'data' : binary.replace(/^alice-/, '')
+  return (binary === 'alice' || binary === 'alice-workspace') ? 'data' : binary.replace(/^alice-/, '')
 }
 
 /** The export descriptor for a key, or null. */
@@ -322,8 +314,9 @@ export function mappedToolNames(exportKey: string): Set<string> {
 export function mappedToolNamesForScope(scope: CliExport['scope']): Set<string> {
   const names = new Set<string>()
   for (const [key, exp] of Object.entries(CLI_EXPORTS)) {
-    if (exp.scope !== scope) continue
-    for (const name of mappedToolNames(key)) names.add(name)
+    for (const name of mappedToolNames(key)) {
+      if (scope === 'mixed' || toolRegistryScope(exp, name) === scope) names.add(name)
+    }
   }
   return names
 }

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -132,9 +132,9 @@ describe('CLI gateway — data export', () => {
 })
 
 describe('CLI gateway — export scope isolation', () => {
-  it('the data export cannot reach a collaboration tool (inbox_push)', async () => {
+  it('unified alice reports an unavailable scoped tool instead of using a global fallback', async () => {
     const res = await post('/cli/ws1/data/invoke', { tool: 'inbox_push', args: {} })
-    expect(res.status).toBe(404) // not in the data map → gated out
+    expect(res.status).toBe(404) // mapped, but not registered in this fixture
   })
 
   it('the workspace export cannot reach a data tool (marketSearchForResearch)', async () => {
@@ -257,7 +257,7 @@ describe('CLI gateway — inbox read (scoped, string-arg coercion)', () => {
   }
 
   const invoke = async (app: Hono, args: Record<string, string>) => {
-    const res = await app.request('/cli/ws1/workspace/invoke', {
+    const res = await app.request('/cli/ws1/data/invoke', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tool: 'inbox_read', args }),
@@ -322,9 +322,11 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
     }
     const wtc = new WorkspaceToolCenter()
     wtc.register(inboxPushFactory)
+    const globals = new ToolCenter()
+    globals.register({ inbox_push: tool({ inputSchema: z.object({ comments: z.string() }), execute: (): string => { throw new Error('Global shadow must never run') } }) }, 'shadow')
     const app = new Hono()
     registerCliRoutes(app, {
-      toolCenter: new ToolCenter(),
+      toolCenter: globals,
       workspaceToolCenter: wtc,
       inboxStore,
       entityStore: {} as never,
@@ -333,16 +335,16 @@ describe('CLI gateway — agent-invisible origin (x-openalice-run → registry)'
     return { app, inboxStore }
   }
 
-  const pushWith = (app: Hono, headers: Record<string, string>) =>
-    app.request('/cli/ws1/workspace/invoke', {
+  const pushWith = (app: Hono, headers: Record<string, string>, exportKey = 'data') =>
+    app.request(`/cli/ws1/${exportKey}/invoke`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({ tool: 'inbox_push', args: { comments: 'report' } }),
     })
 
-  it('stamps origin from the registry record when the run header is present', async () => {
+  it.each(['data', 'workspace'])('stamps registry origin through the %s export', async (exportKey) => {
     const { app, inboxStore } = makeOriginApp()
-    const res = await pushWith(app, { 'x-openalice-run': 'run-7' })
+    const res = await pushWith(app, { 'x-openalice-run': 'run-7' }, exportKey)
     expect(res.status).toBe(200)
     const { entries } = await inboxStore.read({ workspaceId: 'ws1' })
     expect(entries[0].origin).toEqual({
@@ -446,7 +448,7 @@ describe('CLI gateway — peer path (cross-workspace resolution)', () => {
   }
 
   const invoke = async (app: Hono, args: Record<string, string>) => {
-    const res = await app.request('/cli/ws1/workspace/invoke', {
+    const res = await app.request('/cli/ws1/data/invoke', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tool: 'workspace_path', args }),

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -10,18 +10,15 @@
  * Mounted on the MCP server's Hono app (open posture, no admin-token gate — the
  * workspace CLI carries no secret). Identity rides the URL path (`:wsId`), like
  * `/mcp/:wsId`. The `:export` segment selects a CliExport (data / workspace /
- * …) — the binary the agent invoked (`alice` vs `alice-workspace`) maps to it.
+ * …) — the binary maps to its public export (`alice` and its legacy alias use `data`).
  *
  *   GET  /cli/:wsId/:export/manifest   grouped command tree + per-verb JSON
  *                                      schema (powers `--help`), plus the
  *                                      registered-but-unmapped tools in scope.
  *   POST /cli/:wsId/:export/invoke     { tool, args } -> validate + execute.
  *
- * Each export resolves tools from ONE scope (global ToolCenter for `data`,
- * the per-workspace WorkspaceToolCenter for `workspace`) and invoke is gated to
- * that export's own map — so `alice` can't reach a collaboration tool and
- * vice-versa. Trading has its own explicit `uta` export; cron remains off the
- * CLI surface and is available only through its owned scheduling paths.
+ * alice combines both registry scopes, selecting the owner per mapped tool.
+ * Legacy workspace requests stay scoped. Trading retains the separate uta map.
  */
 
 import type { Hono } from 'hono'
@@ -42,6 +39,7 @@ import { logger as launcherLogger } from '../workspaces/logger.js'
 import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
 import {
   type CliExport,
+  toolRegistryScope,
   getExport,
   mappedToolNames,
   mappedToolNamesForScope,
@@ -79,18 +77,24 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
   }
 
   /**
-   * A per-request lookup over ONE export's scope: global catalog for `data`,
-   * the (per-workspace) scoped catalog for `workspace`. Never crosses scopes —
-   * an export only sees the tools its category owns.
+   * Per-request dispatch preserves Workspace context when a mixed export
+   * resolves collaboration tools; global tools never shadow scoped tools.
    */
   const exportCatalog = (
     exp: CliExport,
     ws: WsMeta,
     origin?: InboxOrigin,
   ): { resolve: (name: string) => Tool | null; inventoryNames: () => string[] } => {
+    if (exp.scope === 'mixed') {
+      const scoped = exportCatalog(getExport('workspace')!, ws, origin)
+      return {
+        resolve: name => toolRegistryScope(exp, name) === 'scoped' ? scoped.resolve(name) : toolCenter.get(name),
+        inventoryNames: () => [...new Set([...toolCenter.getInventory().map(t => t.name), ...scoped.inventoryNames()])],
+      }
+    }
     if (exp.scope === 'scoped') {
       // GLOBAL issue-board reader, backed by the live WorkspaceService.
-      // Built here so issue_list / issue_show on `alice-workspace` read EVERY
+      // Built here so issue_list / issue_show on `alice` read EVERY
       // workspace's issues (reads global), while create/update/comment stay
       // caller-local. Absent when the service isn't up yet → tools self-read.
       const svc = getWorkspaceService()

--- a/src/tool/conversation-artifacts.spec.ts
+++ b/src/tool/conversation-artifacts.spec.ts
@@ -179,7 +179,7 @@ describe('issue_ask', () => {
       id: 'audit', runId: 'run-from-a-follow-up', prompt: 'what happened?',
     })).resolves.toMatchObject({
       ok: false,
-      error: expect.stringContaining('alice-workspace issue show --id audit'),
+      error: expect.stringContaining('alice issue show --id audit'),
     })
   })
 })

--- a/src/tool/conversation-artifacts.ts
+++ b/src/tool/conversation-artifacts.ts
@@ -129,7 +129,7 @@ export const issueAskFactory: WorkspaceToolFactory = {
             if (!run) {
               return {
                 ok: false as const,
-                error: `issue run not found: ${runId}; use alice-workspace issue show --id ${ref.id} to list this Issue's runs`,
+                error: `issue run not found: ${runId}; use alice issue show --id ${ref.id} to list this Issue's runs`,
               }
             }
             target = { kind: 'resume' as const, resumeId: run.resumeId }

--- a/src/tool/conversation.spec.ts
+++ b/src/tool/conversation.spec.ts
@@ -284,7 +284,7 @@ describe('conversation_await', () => {
         ok: true,
         awaited: false,
         status: 'running',
-        next: 'alice-workspace conversation read --task-id task-1',
+        next: 'alice conversation read --task-id task-1',
       })
   })
 })

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -133,7 +133,7 @@ export async function askWorkspaceConversation(
       ...taskProjection(task, 'summary'),
       awaited: task.status !== 'running',
       ...(task.status === 'running'
-        ? { next: `alice-workspace conversation await --task-id ${task.taskId}` }
+        ? { next: `alice conversation await --task-id ${task.taskId}` }
         : {}),
     }
   } catch (err) {
@@ -283,7 +283,7 @@ export const conversationAwaitFactory: WorkspaceToolFactory = {
             ...taskProjection(task, 'summary'),
             awaited: task.status !== 'running',
             ...(task.status === 'running'
-              ? { next: `alice-workspace conversation read --task-id ${task.taskId}` }
+              ? { next: `alice conversation read --task-id ${task.taskId}` }
               : {}),
           }
         } catch (err) {

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -51,7 +51,7 @@ export const inboxReadFactory: WorkspaceToolFactory = {
         '',
         'Each attachment appears in `files` with its stored `relativePath`, a directly usable `absolutePath`, and the published `revision` when known. `absolutePath` is null only when the source Workspace is unavailable or the stored path is unsafe.',
         '',
-        'The legacy `docs` relative-path list and `docRevisions` map remain for compatibility. `workspaceId` can still be resolved with `workspace_path` (CLI: `alice-workspace peer path`) when inspecting the source desk itself.',
+        'The legacy `docs` relative-path list and `docRevisions` map remain for compatibility. `workspaceId` can still be resolved with `workspace_path` (CLI: `alice peer path`) when inspecting the source desk itself.',
         '',
         'When an entry came from an agent run/session, `origin` carries its safe OpenAlice provenance (`runId` / `sessionId`, `resumeId`, `issueId`, `agent`). Native runtime session ids are never exposed.',
         '',

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -5,7 +5,7 @@
  * entity_upsert): the agent sees a schema WITHOUT any `wsId`, and the workspace
  * identity is closed over by the factory from the gateway URL (`/cli/:wsId` or
  * `/mcp/:wsId`). Registering each factory once makes it reachable via BOTH the
- * `alice-workspace issue …` CLI (the primary agent surface) AND MCP (one
+ * `alice issue …` CLI (the primary agent surface) AND MCP (one
  * adapter) for free — the gateway builds and dispatches both through the same
  * WorkspaceToolCenter.
  *
@@ -300,7 +300,7 @@ function summarizeIssueRows(
       ...(row.error ? { error: row.error } : {}),
     })),
     hint:
-      'Summary shows local issues plus active urgent/high/medium rows. Use `alice-workspace issue list --mode detailed` for the full board, then `alice-workspace issue show --id <id>` before acting.',
+      'Summary shows local issues plus active urgent/high/medium rows. Use `alice issue list --mode detailed` for the full board, then `alice issue show --id <id>` before acting.',
   }
 }
 
@@ -496,7 +496,7 @@ export const issueCreateFactory: WorkspaceToolFactory = {
         'unscheduled board item defaults to `@unassigned`. An attributable',
         'resumable caller still owns the Issue as `@me`.',
         'A scheduled run is unattended: if its result is meant for the human,',
-        'What must explicitly tell it to use `alice-workspace inbox push`.',
+        'What must explicitly tell it to use `alice inbox push`.',
       ].join('\n'),
       inputSchema: z.object({
         title: z.string().min(1).describe('Short human title (required).'),
@@ -587,7 +587,7 @@ export const issueListFactory: WorkspaceToolFactory = {
       }),
       execute: async ({ mode, limit }) => {
         // GLOBAL board when the service-backed reader is wired (the
-        // `alice-workspace` surface). Reads EVERY workspace's issues.
+        // `alice` surface). Reads EVERY workspace's issues.
         if (ctx.board) {
           const snapshot = await ctx.board.snapshot()
           const { rows, invalid } = flattenBoardRows(snapshot)

--- a/src/tool/workspace-template-upgrade.spec.ts
+++ b/src/tool/workspace-template-upgrade.spec.ts
@@ -70,7 +70,7 @@ describe('workspace_template_upgrade', () => {
         status: 'ready',
         fromVersion: '1.5.0',
         toVersion: '1.6.1',
-        nextCommand: 'alice-workspace template upgrade --apply',
+        nextCommand: 'alice template upgrade --apply',
       },
     })
     expect(result.preview.changes[0]).not.toHaveProperty('currentPreview')

--- a/src/tool/workspace-template-upgrade.ts
+++ b/src/tool/workspace-template-upgrade.ts
@@ -66,7 +66,7 @@ function previewPayload(plan: TemplateUpgradePlan, mode: OutputMode, explicitTar
       ? null
       : conflicts.length > 0
         ? 'Resolve every conflict with repeatable --keep-workspace <path> or --use-template <path>, then add --apply.'
-        : `alice-workspace template upgrade${explicitTarget ? ` --id ${plan.workspaceId}` : ''} --apply`,
+        : `alice template upgrade${explicitTarget ? ` --id ${plan.workspaceId}` : ''} --apply`,
   }
 }
 

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -252,7 +252,7 @@ export const codexAdapter: CliAdapter = {
   // Headless codex is CLI-MODE, NOT MCP: `codex exec` cancels EVERY MCP tool
   // call when there's no human to approve — even under approval_policy=never
   // (verified: "user cancelled MCP tool call") — so MCP is dead weight here.
-  // Instead the agent reads data via `alice` and reports via `alice-workspace`
+  // Instead the agent reads data and reports via the unified `alice` CLI
   // (shell commands codex runs autonomously). Three GLOBAL `-c` (before `exec`)
   // make that work:
   //   approval_policy=never                        — don't block on approval

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -17,7 +17,7 @@
  * which works from this CommonJS payload on every supported Node runtime.
  *
  *   alice                              list command groups (data export)
- *   alice-workspace inbox push ...     collaboration export
+ *   alice inbox push ...     collaboration export
  *   <bin> <group> <verb> --help        show a verb's flags
  *   <bin> <group> <verb> [--flags]     run it; JSON to stdout
  */
@@ -36,7 +36,11 @@ async function main() {
     (process.argv[1] || 'alice').split(/[\\/]/).pop() ||
     'alice'
   ).split(/[\\/]/).pop() || 'alice'
-  const exportKey = BIN === 'alice' ? 'data' : BIN.replace(/^alice-/, '')
+  if (BIN === 'alice-workspace') {
+    console.error('alice-workspace is a compatibility alias; use alice <group> <verb>.')
+    BIN = 'alice'
+  }
+  const exportKey = (BIN === 'alice' || BIN === 'alice-workspace') ? 'data' : BIN.replace(/^alice-/, '')
 
   const toolSocket = process.env.OPENALICE_TOOL_SOCKET
   const toolUrl = process.env.OPENALICE_TOOL_URL

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -141,13 +141,14 @@ describe('CLI launchers and payload', () => {
       server.listen(socketPath, resolve)
     })
     try {
-      const { stdout } = await runCli('alice-workspace', ['inbox'], {
+      const { stdout, stderr } = await runCli('alice-workspace', ['inbox'], {
         ...process.env,
         AQ_WS_ID: 'ws1',
         OPENALICE_TOOL_SOCKET: socketPath,
         OPENALICE_TOOL_URL: '/cli',
       })
-      expect(stdout).toContain('alice-workspace inbox <verb>')
+      expect(stdout).toContain('alice inbox <verb>')
+      expect(stderr).toContain('compatibility alias')
       expect(stdout).toContain('Deliver reports to the human Inbox')
       expect(stdout).toContain('push')
     } finally {

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -85,9 +85,9 @@ describe('injectWorkspaceContext — instructions', () => {
     expect(instruction).toContain('Every price, return, date, ratio');
     expect(instruction).toContain('A comment is a board');
     expect(instruction).toContain('OpenAlice does not wrap');
-    expect(instruction).toContain('The `alice-workspace` skill contains the exact commands');
-    expect(instruction).not.toContain('alice-workspace issue comment --text');
-    expect(instruction).not.toContain('alice-workspace inbox push --doc');
+    expect(instruction).toContain('The `alice` skill contains the exact commands');
+    expect(instruction).not.toContain('alice issue comment --text');
+    expect(instruction).not.toContain('alice inbox push --doc');
     expect(instruction).not.toContain('--when');
   });
 });
@@ -113,7 +113,7 @@ describe('injectWorkspaceContext — skills', () => {
     });
     for (const root of ['.claude/skills', '.agents/skills']) {
       const skill = await read(`${root}/delegate-autoquant/SKILL.md`);
-      expect(skill).toContain('alice-workspace conversation ask --harness autoquant');
+      expect(skill).toContain('alice conversation ask --harness autoquant');
       expect(skill).toContain('The universal result is the Agent\'s ordinary `assistantText` handoff');
       expect(skill).toContain('does not automatically publish either artifact to the');
       expect(skill).toContain('Primary deliverable directory: <absolute path>');
@@ -127,7 +127,7 @@ describe('injectWorkspaceContext — skills', () => {
       wsId: 'ws-abc',
       dir,
     });
-    for (const name of ['alice', 'alice-analysis', 'alice-uta', 'alice-workspace', 'traderhub', 'scan-value-chain']) {
+    for (const name of ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'scan-value-chain']) {
       expect(existsSync(join(dir, '.claude/skills', name, 'SKILL.md')), name).toBe(true);
       expect(existsSync(join(dir, '.agents/skills', name, 'SKILL.md')), name).toBe(true);
     }
@@ -140,12 +140,12 @@ describe('injectWorkspaceContext — skills', () => {
       wsId: 'ws-abc',
       dir,
     });
-    const skill = await read('.agents/skills/alice-workspace/SKILL.md');
+    const skill = await read('.agents/skills/alice/references/collaboration.md');
     expect(skill).toContain('There is deliberately no Workspace-level file-read command');
-    expect(skill).toContain('alice-workspace peer path --id <workspaceId>');
+    expect(skill).toContain('alice peer path --id <workspaceId>');
     expect(skill).toContain("Coding Agent's native Read/Search/Glob/Git capabilities");
-    expect(skill).toContain('alice-workspace conversation ask --inbox-id <entryId>');
-    expect(skill).toContain('alice-workspace conversation ask --harness autoquant');
+    expect(skill).toContain('alice conversation ask --inbox-id <entryId>');
+    expect(skill).toContain('alice conversation ask --harness autoquant');
     expect(skill).not.toContain('peer file-read');
   });
 

--- a/src/workspaces/context-injector.ts
+++ b/src/workspaces/context-injector.ts
@@ -23,7 +23,7 @@ import type { TemplateMeta } from './template-registry.js';
  * workspaces at all (no `.mcp.json`, no Pi bridge); these skills are how the
  * agent learns the CLI surface that is now its ONLY path to OpenAlice's tools.
  */
-const CLI_TOOLS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'alice-workspace', 'traderhub'];
+const CLI_TOOLS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'traderhub'];
 
 /**
  * Skills injected into EVERY new workspace, regardless of template — generic
@@ -54,7 +54,7 @@ export async function injectWorkspaceContext(opts: {
 
   // Every workspace gets ALWAYS_SKILLS (generic launcher capabilities). Tool-
   // bearing templates additionally get the per-CLI playbooks (alice / alice-uta
-  // / alice-workspace / traderhub) so the agent knows the CLI surface — its ONLY
+  // / traderhub) so the agent knows the CLI surface — its ONLY
   // path to OpenAlice tools, since the launcher injects no MCP. All de-duped.
   const skills = [
     ...new Set([

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -133,7 +133,7 @@ export function annotateNameCollisions(workspaces: IssuesSnapshotWorkspace[]): s
 }
 
 // ==================== Flattened board rows (CLI / agent surface) ====================
-// The `alice-workspace issue list` (issue_list) agent surface wants the board as
+// The `alice issue list` (issue_list) agent surface wants the board as
 // ONE flat list of title rows tagged with their owning workspace — not the
 // per-workspace tree GET /api/issues returns. Each row keeps the snapshot's
 // display fields, replaces `when` with a plain `scheduled` boolean, and carries

--- a/src/workspaces/issues/comment-prompt.ts
+++ b/src/workspaces/issues/comment-prompt.ts
@@ -23,7 +23,7 @@ export const DEFAULT_ISSUE_COMMENT_PROMPT = [
   '{comment}',
   '',
   'Reply directly to this comment. Your final assistant response will be recorded automatically in the Issue Activity timeline.',
-  'Do not call `alice-workspace issue comment` for this reply; that would create a second notification loop.',
+  'Do not call `alice issue comment` for this reply; that would create a second notification loop.',
 ].join('\n')
 
 const TOKEN_RE = /\{([A-Za-z][A-Za-z0-9]*)\}/g

--- a/src/workspaces/manager-workspace.ts
+++ b/src/workspaces/manager-workspace.ts
@@ -35,7 +35,7 @@ Operating contract:
 - Inspect, compare, question, and coordinate active Workspaces for the user.
 - NEVER create reports, research files, Issues, or other business artifacts in this top-level directory.
 - When work needs a durable artifact, choose the responsible Workspace, resolve its path, and write or delegate the work there.
-- Prefer OpenAlice's alice-workspace CLI over raw HTTP. Start from live CLI help when a flag is uncertain.
+- Prefer OpenAlice's alice CLI over raw HTTP. Start from live CLI help when a flag is uncertain.
 - Use peer inventory, global Issue reads, Session provenance, and attributable conversation commands before guessing why a desk or coworker did something.
 - The first management pass MUST use structured product indexes only: peer list and, when relevant, issue list. Recent Session titles in peer list are the first-pass responsibility map.
 - Treat the identity hierarchy as load-bearing: when a relevant recent Session exposes a resumeId, continue that exact coworker with conversation ask --resume-id. Use --ws-id to recruit a fresh coworker for new work or when no attributable Session exists. Add --reconstruct only when missing historical intent must be reconstructed, and never present a fresh worker as the original author.

--- a/src/workspaces/template-registry.ts
+++ b/src/workspaces/template-registry.ts
@@ -99,7 +99,7 @@ export interface TemplateMeta {
    * Launcher-owned context injection, post-bootstrap, gated per template
    * (defaults preserve each template's pre-standardization behavior):
    *   injectTools   — inject the per-CLI playbooks (alice / alice-uta /
-   *                   alice-workspace / traderhub skills) so the agent knows the `alice*` CLI
+   *                   traderhub skills) so the agent knows the `alice*` CLI
    *                   surface. The launcher injects NO MCP into workspaces;
    *                   `false` = a template that ships its own tool docs
    *                   (e.g. auto-quant).

--- a/src/workspaces/templates/auto-prediction/README.md
+++ b/src/workspaces/templates/auto-prediction/README.md
@@ -1,5 +1,5 @@
 ---
-version: 0.1.4
+version: 0.1.5
 ---
 
 # Auto Prediction

--- a/src/workspaces/templates/auto-quant-v2/README.md
+++ b/src/workspaces/templates/auto-quant-v2/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.1.7
+version: 1.1.8
 ---
 
 # AutoQuant

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.8.7
+version: 1.8.8
 ---
 
 # Chat

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -55,8 +55,8 @@ relevant skill before the first domain command and never guess flags.
 |---|---|---|
 | Current market boards, fundamentals, macro, calendars | `traderhub` | `traderhub` |
 | Symbol discovery, collected RSS, K-lines and bounded analysis | `alice` | `alice`, `alice-analysis` |
-| Peer addressing, Agent conversation, Inbox, Issues and provenance | `alice-workspace` | `alice-workspace` |
-| Issue files, schedules, headless delivery contracts | `.alice/issues/` + `alice-workspace issue` | `self-scheduling` |
+| Peer addressing, Agent conversation, Inbox, Issues and provenance | `alice` | `alice` |
+| Issue files, schedules, headless delivery contracts | `.alice/issues/` + `alice issue` | `self-scheduling` |
 | Accounts, positions, orders, trading-as-git | `alice-uta` | `alice-uta` |
 | Optional sources Alice does not ship | `opencli` | `opencli-reader` |
 
@@ -80,7 +80,7 @@ For long delegation, let the peer manage its work locally and return an
 ordinary reply; when the result also deserves human attention, have it commit
 the report and push the exact file to Inbox.
 
-The `alice-workspace` skill contains the exact commands. It also owns waiting
+The `alice` skill contains the exact commands. It also owns waiting
 rhythms, reconstruction rules, and the report-reading flow.
 
 ## Durable objects

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -15,7 +15,7 @@ export const DEFAULT_ISSUE_COMMENT_PROMPT = [
   '{comment}',
   '',
   'Reply directly to this comment. Your final assistant response will be recorded automatically in the Issue Activity timeline.',
-  'Do not call `alice-workspace issue comment` for this reply; that would create a second notification loop.',
+  'Do not call `alice issue comment` for this reply; that would create a second notification loop.',
 ].join('\n')
 
 /**

--- a/ui/src/components/workspace/web-transcript.spec.ts
+++ b/ui/src/components/workspace/web-transcript.spec.ts
@@ -22,7 +22,7 @@ describe('groupWebTranscript', () => {
         role: 'assistant',
         content: [
           { type: 'thinking', thinking: 'Push the Inbox entry.' },
-          { type: 'toolCall', id: 'call-bash', name: 'bash', arguments: { command: 'alice-workspace inbox push --doc research/report.md' } },
+          { type: 'toolCall', id: 'call-bash', name: 'bash', arguments: { command: 'alice inbox push --doc research/report.md' } },
         ],
       },
       { role: 'toolResult', toolCallId: 'call-bash', toolName: 'bash', content: [{ type: 'text', text: 'ok' }] },

--- a/ui/src/demo/fixtures/inbox.ts
+++ b/ui/src/demo/fixtures/inbox.ts
@@ -125,9 +125,9 @@ export const demoInboxEntries: InboxEntry[] = [
 export const demoWorkspaceFiles: Record<string, string> = {
   'AGENTS.md': '# Research workspace\n\nUse evidence, preserve dates, and return useful reports. This is demo guidance.',
   'CLAUDE.md': '# Research workspace\n\nUse evidence, preserve dates, and return useful reports. This is demo guidance.',
-  '.agents/skills/alice-workspace/SKILL.md': '---\nname: alice-workspace\ndescription: Collaborate and deliver research reports.\n---\n\n# Workspace collaboration\n\nUse `alice-workspace inbox` to deliver committed research.\n\nRead [the example](examples/report.md) before preparing a report.',
-  '.claude/skills/alice-workspace/SKILL.md': '---\nname: alice-workspace\ndescription: Collaborate and deliver research reports.\n---\n\n# Workspace collaboration\n\nUse `alice-workspace inbox` to deliver committed research.\n\nRead [the example](examples/report.md) before preparing a report.',
-  '.agents/skills/alice-workspace/examples/report.md': '# Example report\n\nSummarize the evidence and its timestamp.',
+  '.agents/skills/alice/SKILL.md': '---\nname: alice\ndescription: Collaborate and deliver research reports.\n---\n\n# Workspace collaboration\n\nUse `alice inbox` to deliver committed research.\n\nRead [the example](examples/report.md) before preparing a report.',
+  '.claude/skills/alice/SKILL.md': '---\nname: alice\ndescription: Collaborate and deliver research reports.\n---\n\n# Workspace collaboration\n\nUse `alice inbox` to deliver committed research.\n\nRead [the example](examples/report.md) before preparing a report.',
+  '.agents/skills/alice/examples/report.md': '# Example report\n\nSummarize the evidence and its timestamp.',
 
   // Doc for demoMoversReport (auto-quant › morning-scan run).
   'reports/movers-2026-06-27.md': `# Pre-market movers — 2026-06-27
@@ -266,7 +266,7 @@ export const demoWorkspaceFilePaths: Readonly<Record<string, readonly string[]>>
     DEMO_REPORT_PATH,
   ],
   [DEMO_CHAT_WORKSPACE_ID]: [
-    'AGENTS.md', 'CLAUDE.md', '.agents/skills/alice-workspace/SKILL.md', '.claude/skills/alice-workspace/SKILL.md', '.agents/skills/alice-workspace/examples/report.md',
+    'AGENTS.md', 'CLAUDE.md', '.agents/skills/alice/SKILL.md', '.claude/skills/alice/SKILL.md', '.agents/skills/alice/examples/report.md',
     'power_buy_points_2026-06-02.md',
     'rotation/2026-06-02.md',
     'rotation/ai-chain-2026-06-02.md',

--- a/ui/src/demo/fixtures/web-session.ts
+++ b/ui/src/demo/fixtures/web-session.ts
@@ -101,7 +101,7 @@ const aaplResearchMessages: readonly WebConversationMessage[] = [
         id: 'aapl-inbox',
         name: 'bash',
         arguments: {
-          command: 'alice-workspace inbox push --doc research/AAPL-q1-hidden-deceleration.md',
+          command: 'alice inbox push --doc research/AAPL-q1-hidden-deceleration.md',
         },
       },
     ],

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -388,7 +388,7 @@ const demoTemplateUpgradePlan = (workspaceId: string) => ({
       currentTruncated: false, templateTruncated: false,
     },
     {
-      path: '.agents/skills/alice-workspace/SKILL.md', status: 'ready', operation: 'update', canUseTemplate: true,
+      path: '.agents/skills/alice/SKILL.md', status: 'ready', operation: 'update', canUseTemplate: true,
       currentPreview: 'Old collaboration guidance.', templatePreview: 'Current collaboration guidance.',
       currentTruncated: false, templateTruncated: false,
     },
@@ -696,7 +696,7 @@ export const workspacesHandlers = [
         fromVersion: '0.1.0',
         toVersion: '0.2.0',
         commit: 'd3m0c0de12345678',
-        changedPaths: ['README.md', '.agents/skills/alice-workspace/SKILL.md'],
+        changedPaths: ['README.md', '.agents/skills/alice/SKILL.md'],
         keptPaths: ['AGENTS.md'],
       },
       workspace,

--- a/ui/src/hooks/useWorkspaceCapabilities.ts
+++ b/ui/src/hooks/useWorkspaceCapabilities.ts
@@ -10,7 +10,6 @@ import { fetchJson } from '../api/client'
 export const cliExports = [
   { key: 'data', name: 'alice' },
   { key: 'traderhub', name: 'traderhub' },
-  { key: 'workspace', name: 'alice-workspace' },
   { key: 'uta', name: 'alice-uta' },
 ] as const
 export interface CliManifest {

--- a/ui/src/pages/AutomationApiSection.tsx
+++ b/ui/src/pages/AutomationApiSection.tsx
@@ -40,7 +40,7 @@ export function AutomationApiSection() {
           checkout (the filename stem is the issue id). Each file is YAML
           frontmatter plus one canonical markdown What. The file remains the
           source of truth whether it is managed from <span className="text-foreground">Issues</span>,{' '}
-          <code className={CODE}>alice-workspace issue</code>, or edited directly.
+          <code className={CODE}>alice issue</code>, or edited directly.
           An issue with a{' '}
           <code className={CODE}>when</code> field self-schedules: a launcher
           scanner reads the dir and fires each due issue as a headless run. An
@@ -59,7 +59,7 @@ agent: claude
 
 Every trading morning before the open, assemble the pre-market picture for
 the watchlist — movers, gaps, and overnight headlines that move the thesis.
-Write research/premarket.md, then run alice-workspace inbox push --doc
+Write research/premarket.md, then run alice inbox push --doc
 research/premarket.md --comments "Pre-market brief".`}</Block>
         <ul className="ml-4 list-disc space-y-1 text-muted-foreground">
           <li>
@@ -138,7 +138,7 @@ research/premarket.md --comments "Pre-market brief".`}</Block>
           Every headless run preserves its structured reply and tool activity under{' '}
           <span className="text-foreground">Runs</span>. For a durable handoff or
           report, publish to the Inbox with the{' '}
-          <code className={CODE}>alice-workspace inbox push</code> CLI available on
+          <code className={CODE}>alice inbox push</code> CLI available on
           every Workspace&apos;s PATH. A no-change check may deliberately exit
           without creating Inbox noise.
         </p>


### PR DESCRIPTION
Workspace collaboration previously required a separate `alice-workspace` command and skill. Merge its groups directly into `alice`, so research and collaboration share one discoverable command tree (`alice peer`, `alice inbox`, `alice issue`, and so on).

Keep the old binary as a warning-emitting compatibility alias and retain the old gateway endpoint for installed shims. Dispatch still selects each tool’s original registry, preserving Workspace/Session identity and invocation allowlists.

Unify the injected skill with a collaboration reference, bump Chat/AutoQuant/AutoPrediction templates, and update the capability browser, demo fixtures, scheduling prompts, documentation, and package smoke assets. Existing Workspace files update through the normal template upgrade flow.

Validation: complete hermetic suite (749 files, 6700 passed, 3 skipped); root and UI typechecks; additional gateway tests (30 passed) and package identity tests (6 passed); real HTTP CLI and compatibility-alias round trips; real Workspace details and demo walkthroughs; packaged Electron Workspace smoke including tool-socket CLI side effects, scheduled Issues, and cleanup.
