### PR TITLE
Compact CLI reference navigation and support group folding

### DIFF
--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -279,13 +279,13 @@ async function smokeRelease(options: {
     port: 0,
     fetch(request) {
       const url = new URL(request.url)
-      if (url.pathname === '/cli/ws-release/workspace/manifest') {
+      if (url.pathname === '/cli/ws-release/data/manifest') {
         return Response.json({
           groups: { issue: { list: { tool: 'workspace_issue_list', schema: { type: 'object', properties: {} } } } },
           groupDescriptions: { issue: 'Issue coordination' },
         })
       }
-      if (url.pathname === '/cli/ws-release/workspace/invoke' && request.method === 'POST') {
+      if (url.pathname === '/cli/ws-release/data/invoke' && request.method === 'POST') {
         return Response.json({ content: [{ type: 'text', text: 'BUN_WORKSPACE_CLI_OK' }] })
       }
       return Response.json({ error: 'not found' }, { status: 404 })

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.spec.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.spec.tsx
@@ -77,3 +77,18 @@ it('shows required flags and raw schema without offering execution', () => {
     screen.queryByRole('button', { name: /execute|run command/i }),
   ).toBeNull()
 })
+
+it('collapses command groups without losing the reader and reveals search matches', () => {
+  render(<CliBrowser wsId="one" />)
+  const group = screen.getByRole('button', { name: 'test' })
+  fireEvent.click(group)
+  expect(group.getAttribute('aria-expanded')).toBe('false')
+  expect(screen.getByText('alice test inspect --symbol <symbol>')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: 'inspect' })).toBeNull()
+  fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'inspect' } })
+  expect(screen.getByRole('button', { name: 'inspect' })).toBeTruthy()
+  fireEvent.change(screen.getByRole('searchbox'), { target: { value: '' } })
+  expect(group.getAttribute('aria-expanded')).toBe('false')
+  fireEvent.click(group)
+  expect(screen.getByRole('button', { name: 'inspect' })).toBeTruthy()
+})

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
@@ -4,7 +4,6 @@ import {
   ArrowLeft,
   BookOpen,
   ChevronRight,
-  Code2,
   Copy,
   FileText,
   Search,
@@ -12,6 +11,7 @@ import {
   Check,
 } from 'lucide-react'
 import { Button } from '../ui/button'
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible'
 import { Tabs, TabsList, TabsTrigger } from '../ui/tabs'
 import { FileContentView } from '../FileContentView'
 import { CenteredLoading } from '../StateViews'
@@ -417,6 +417,7 @@ export function CliBrowser({ wsId }: { wsId: string }) {
   const [attempt, setAttempt] = useState(0)
   const [query, setQuery] = useState('')
   const [selected, setSelected] = useState('')
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [mobileDetail, setMobileDetail] = useState(false)
   const state = useWorkspaceCli(wsId, exportKey, attempt)
   const manifest = state?.data
@@ -474,36 +475,43 @@ export function CliBrowser({ wsId }: { wsId: string }) {
           <aside className="cap-directory">
             <SearchBox value={query} onChange={setQuery} />
             <nav aria-label={t('capabilities.commands')}>
-              {Object.keys(manifest?.groups ?? {}).map((group) => (
-                <section key={group}>
-                  {filtered.some((c) => c.group === group) && (
-                    <h3 title={manifest?.groupDescriptions?.[group]}>
-                      {group}
+              {Object.keys(manifest?.groups ?? {}).map((group) => {
+                const items = filtered.filter((c) => c.group === group)
+                if (!items.length) return null
+                const key = `${exportKey}:${group}`
+                const open = Boolean(query.trim()) || !collapsed[key]
+                return (
+                  <Collapsible
+                    key={key}
+                    className="cap-cli-group"
+                    open={open}
+                    onOpenChange={(value) => setCollapsed((previous) => ({ ...previous, [key]: !value }))}
+                  >
+                    <h3>
+                      <CollapsibleTrigger className="cap-cli-group-trigger" title={manifest?.groupDescriptions?.[group]}>
+                        <ChevronRight size={13} aria-hidden className={open ? 'is-open' : ''} />
+                        <span>{group}</span>
+                        <small aria-hidden>{items.length}</small>
+                      </CollapsibleTrigger>
                     </h3>
-                  )}
-                  {filtered
-                    .filter((c) => c.group === group)
-                    .map((c) => (
-                      <button
-                        className="cap-row"
-                        key={c.name}
-                        aria-current={
-                          current?.name === c.name ? 'page' : undefined
-                        }
-                        onClick={() => {
-                          setSelected(c.name)
-                          setMobileDetail(true)
-                        }}
-                      >
-                        <Code2 size={14} />
-                        <span>
-                          <strong>{c.verb}</strong>
-                        </span>
-                        <ChevronRight size={13} />
-                      </button>
-                    ))}
-                </section>
-              ))}
+                    <CollapsibleContent inert={!open} aria-hidden={!open || undefined}>
+                      {items.map((c) => (
+                        <button
+                          className="cap-row cap-cli-row"
+                          key={c.name}
+                          aria-current={current?.name === c.name ? 'page' : undefined}
+                          onClick={() => {
+                            setSelected(c.name)
+                            setMobileDetail(true)
+                          }}
+                        >
+                          <span><strong>{c.verb}</strong></span>
+                        </button>
+                      ))}
+                    </CollapsibleContent>
+                  </Collapsible>
+                )
+              })}
             </nav>
             {!filtered.length && (
               <p className="cap-empty">{t('capabilities.empty')}</p>

--- a/ui/src/components/workspace-capabilities/capabilities.css
+++ b/ui/src/components/workspace-capabilities/capabilities.css
@@ -379,3 +379,49 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* CLI navigation is a compact directory; skill rows retain their summaries. */
+.cap-cli-group + .cap-cli-group { margin-top: 6px; }
+.cap-directory .cap-cli-group h3 { padding: 0; }
+.cap-cli-group-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 30px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  text-align: left;
+  font-size: 12px;
+  color: var(--foreground);
+}
+.cap-cli-group-trigger:hover { background: var(--accent); }
+.cap-cli-group-trigger:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+.cap-cli-group-trigger span { flex: 1; }
+.cap-cli-group-trigger small {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+.cap-cli-group-trigger svg {
+  stroke-width: 1.5;
+  color: var(--muted-foreground);
+  transition: transform var(--motion-fast);
+}
+.cap-cli-group-trigger svg.is-open { transform: rotate(90deg); }
+.cap-cli-row {
+  min-height: 28px;
+  padding: 4px 9px 4px 27px;
+  border-radius: 4px;
+}
+.cap-cli-row strong { font-weight: 400; line-height: 20px; }
+@media (pointer: coarse), (max-width: 640px) {
+  .cap-cli-row, .cap-cli-group-trigger { min-height: 40px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cap-cli-group-trigger svg { transition: none; }
+}


### PR DESCRIPTION
CLI reference navigation had oversized rows and group gaps, making the unified command catalog hard to scan. Use compact 28px desktop rows, clear group headings with counts, and independently collapsible groups. Search reveals matching groups and clearing it restores the previous disclosure state; collapsing leaves the reader intact.

Reuse the shared Base UI Collapsible, focus styles, theme tokens and reduced-motion handling. Narrow/coarse-pointer controls remain 40px; the existing directory/detail navigation remains unchanged. Skill rows retain their current layout.

Also repair the previous CLI merge’s native-package smoke fixture: the compatibility alias now requests the unified `data` endpoint, while the fixture still served `workspace`, producing a 404. The packaged legacy alias remains exercised.

Validation: changed-file closure (6 files, 63 tests passed), UI typecheck, real details-route visual/disclosure/search walkthrough, and native darwin-arm64 Bun archive smoke passed (no Node/Bun on PATH, Workspace CLI invocation, templates, PTYs). Narrow-screen and OS reduced-motion behavior rely on the existing shared primitive and CSS; not separately exercised in a browser this turn.
