### PR TITLE
Fix RSS candidate truncation and durable article reads

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -148,3 +148,18 @@ When changing bars or reference contracts, also run their focused suites and
 exercise the corresponding `traderhub` or `alice analysis` CLI path. Keyed or
 network tests require explicit test credentials and must not become a silent
 prerequisite of the normal unit suite.
+
+## Collected RSS archive
+
+`alice rss glob` and `grep` search all available items in the collector's recent
+index within the requested lookback before applying the output limit (default
+500 matching items, oldest-first). `window` likewise filters the available
+index before applying its output cap. The index is bounded by collector
+`maxInMemory` and recovery `retentionDays`; it is not a full-history disk search.
+
+`alice rss read --id` resolves the durable JSONL sequence ID. Recent entries use
+the memory index; evicted entries are read by streaming the archive on disk.
+This read path survives index eviction and restart without a persisted format
+change. It returns stored feed content, which may be only a summary, and does
+not fetch the publisher webpage. Empty search results establish only that no
+match exists in the available subscribed-feed index.

--- a/src/domain/news/query/archive.spec.ts
+++ b/src/domain/news/query/archive.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { globRss, grepRss, readRss, windowRss, type NewsToolContext } from './archive'
+import { createNewsArchiveTools, globRss, grepRss, readRss, windowRss, type NewsToolContext } from './archive'
 import type { NewsItem } from '../types'
 
 describe('news tools (pure functions)', () => {
@@ -311,5 +311,36 @@ describe('news tools (pure functions)', () => {
       expect(out.map((r) => r.id)).toEqual([10, 30]) // both mention Bitcoin, oldest-first
       expect(out[0].matchedText).toMatch(/Bitcoin/)
     })
+  })
+})
+
+
+describe('archive tool provider boundary', () => {
+  const articles = Array.from({ length: 501 }, (_, index) => ({
+    id: index + 1, time: new Date(Date.now() - (502 - index) * 1000),
+    title: index === 0 ? 'rare catalyst' : 'routine update',
+    content: index === 0 ? 'rare catalyst evidence' : 'routine', metadata: {},
+  }))
+  const provider = {
+    getNewsV2: async ({ limit }: { limit?: number }) => limit ? articles.slice(-limit) : articles,
+  }
+  it('matches before limiting results, including articles older than the newest 500', async () => {
+    const tools = createNewsArchiveTools(provider)
+    for (const name of ['globRss', 'grepRss'] as const) {
+      const result = await tools[name].execute!({ pattern: 'rare catalyst', limit: 1 }, { toolCallId: 'test', messages: [] })
+      expect(result).toMatchObject([{ id: 1 }])
+    }
+    expect(await tools.readRss.execute!({ id: 1 }, { toolCallId: 'test', messages: [] })).toMatchObject({ id: 1 })
+  })
+  it('counts the complete indexed window before applying its output cap', async () => {
+    const many = Array.from({ length: 5001 }, (_, index) => ({ ...articles[0], id: index + 1 }))
+    const tools = createNewsArchiveTools({ getNewsV2: async ({ limit }) => limit ? many.slice(-limit) : many })
+    const result = await tools.windowRss.execute!({ from: '2020-01-01', limit: 1 }, { toolCallId: 'test', messages: [] })
+    expect(result).toMatchObject({ total: 5001, shown: 1, omitted: 5000, results: [{ id: 1 }] })
+  })
+  it('reads by durable id when the provider supports it', async () => {
+    const tools = createNewsArchiveTools({ getNewsV2: async () => [], getNewsById: async (id) => id === 1 ? articles[0] : null })
+    expect(await tools.readRss.execute!({ id: 1 }, { toolCallId: 'test', messages: [] })).toMatchObject({ id: 1 })
+    expect(await tools.readRss.execute!({ id: 9999 }, { toolCallId: 'test', messages: [] })).toMatchObject({ error: expect.any(String) })
   })
 })

--- a/src/domain/news/query/archive.ts
+++ b/src/domain/news/query/archive.ts
@@ -9,7 +9,7 @@ import { tool } from 'ai'
 import { z } from 'zod'
 import type { INewsProvider, NewsItem } from '../types.js'
 
-const NEWS_LIMIT = 500
+const SEARCH_DEFAULT_LIMIT = 500
 /** Default cap on windowRss OUTPUT — a wide date window can match hundreds; we
  *  bound what's returned and report how many were omitted, rather than wall the
  *  caller's context. */
@@ -199,26 +199,25 @@ coverage is exactly the feed list, not the news at large. Empty results mean
 "not in the subscribed feeds", not "nothing happened".
 
 Returns matching headlines with a stable \`id\`, title, content length, and metadata preview.
-Pass an \`id\` to readRss to read the full article — the id is stable across calls,
+Pass an \`id\` to readRss to read the stored feed content — the id is stable across calls,
 so you do NOT need to repeat your \`lookback\`.
 Use this to quickly scan what the subscribed feeds picked up.
 
-Search pool: the most recent ${NEWS_LIMIT} items within \`lookback\` (or the
-most recent ${NEWS_LIMIT} overall when \`lookback\` is omitted). Older items
-within the lookback window are NOT searched. Your \`limit\` then bounds the
-match count returned from that pool.
+Searches the complete available recent index within \`lookback\`, then applies
+\`limit\` to matching results (default ${SEARCH_DEFAULT_LIMIT}, oldest-first). The collector
+index is bounded by its memory/retention settings; it is not the full disk archive.
 
 Example: globRss({ pattern: "BTC|Bitcoin", lookback: "1d" })`,
       inputSchema: z.object({
         pattern: z.string().describe('Regex to match against article titles'),
-        lookback: z.string().optional().describe(`Time range: "1h", "12h", "1d", "7d" (searches up to ${NEWS_LIMIT} most recent items in the window)`),
+        lookback: z.string().optional().describe('Time range: "1h", "12h", "1d", "7d" within the available recent index'),
         metadataFilter: z.record(z.string(), z.string()).optional().describe('Filter by metadata key-value'),
-        limit: z.number().int().positive().optional().describe('Max results'),
+        limit: z.number().int().positive().optional().describe(`Max matching results, oldest-first (default ${SEARCH_DEFAULT_LIMIT})`),
       }).meta({ examples: [{ pattern: 'BTC|Bitcoin', lookback: '1d' }] }),
       execute: async ({ pattern, lookback, metadataFilter, limit }) => {
         return globRss(
-          { getNews: () => provider.getNewsV2({ endTime: new Date(), lookback, limit: NEWS_LIMIT }) },
-          { pattern, metadataFilter, limit },
+          { getNews: () => provider.getNewsV2({ endTime: new Date(), lookback }) },
+          { pattern, metadataFilter, limit: limit ?? SEARCH_DEFAULT_LIMIT },
         )
       },
     }),
@@ -230,22 +229,22 @@ Searches articles pulled from the user's SUBSCRIBED RSS feeds (coverage = the
 feed list). Returns matched text with surrounding context.
 Use this to find specific mentions in the collected articles.
 
-Search pool: the most recent ${NEWS_LIMIT} items within \`lookback\` (or the
-most recent ${NEWS_LIMIT} overall when \`lookback\` is omitted). Older items
-within the lookback window are NOT searched.
+Searches the complete available recent index within \`lookback\`, then applies
+\`limit\` to matching results (default ${SEARCH_DEFAULT_LIMIT}, oldest-first). The collector
+index is bounded by its memory/retention settings; it is not the full disk archive.
 
 Example: grepRss({ pattern: "interest rate", lookback: "2d" })`,
       inputSchema: z.object({
         pattern: z.string().describe('Regex to search in title and content'),
-        lookback: z.string().optional().describe(`Time range: "1h", "12h", "1d", "7d" (searches up to ${NEWS_LIMIT} most recent items in the window)`),
+        lookback: z.string().optional().describe('Time range: "1h", "12h", "1d", "7d" within the available recent index'),
         contextChars: z.number().int().positive().optional().describe('Context chars around match (default: 50)'),
         metadataFilter: z.record(z.string(), z.string()).optional().describe('Filter by metadata key-value'),
-        limit: z.number().int().positive().optional().describe('Max results'),
+        limit: z.number().int().positive().optional().describe(`Max matching results, oldest-first (default ${SEARCH_DEFAULT_LIMIT})`),
       }).meta({ examples: [{ pattern: 'interest rate', lookback: '2d' }] }),
       execute: async ({ pattern, lookback, contextChars, metadataFilter, limit }) => {
         return grepRss(
-          { getNews: () => provider.getNewsV2({ endTime: new Date(), lookback, limit: NEWS_LIMIT }) },
-          { pattern, contextChars, metadataFilter, limit },
+          { getNews: () => provider.getNewsV2({ endTime: new Date(), lookback }) },
+          { pattern, contextChars, metadataFilter, limit: limit ?? SEARCH_DEFAULT_LIMIT },
         )
       },
     }),
@@ -255,7 +254,8 @@ Example: grepRss({ pattern: "interest rate", lookback: "2d" })`,
 
 Returns id + ISO time + title (+ matched snippet when a pattern is given), sorted oldest→newest so the timeline lines up with bars. Pair with dated market snapshots to compare the price path with candidate catalysts.
 
-Coverage is the user's SUBSCRIBED RSS feeds only (not the news at large) — an empty window means "nothing in the subscribed feeds for that span", not "nothing happened". Pass a \`pattern\` to filter, or omit it to get everything in the window.
+Coverage is the available recent collector index, bounded by memory/retention settings,
+not the full disk archive. It contains the user's SUBSCRIBED RSS feeds only (not the news at large) — an empty window means "nothing in the subscribed feeds for that span", not "nothing happened". Pass a \`pattern\` to filter, or omit it to get everything in the window.
 
 Example: windowRss({ from: "2026-06-20", to: "2026-06-26", pattern: "Iran|oil" })`,
       inputSchema: z.object({
@@ -275,7 +275,7 @@ Example: windowRss({ from: "2026-06-20", to: "2026-06-26", pattern: "Iran|oil" }
         // Fetch ALL matches in the window, then bound the OUTPUT (a wide window can
         // be a wall of hundreds) — and say how many we left out, oldest-first.
         const all = await windowRss(
-          { getNews: () => provider.getNewsV2({ startTime, endTime, limit: 5000 }) },
+          { getNews: () => provider.getNewsV2({ startTime, endTime }) },
           { pattern, contextChars, metadataFilter },
         )
         const cap = limit ?? WINDOW_DEFAULT_LIMIT
@@ -293,17 +293,19 @@ Example: windowRss({ from: "2026-06-20", to: "2026-06-26", pattern: "Iran|oil" }
     }),
 
     readRss: tool({
-      description: `Read full content of a collected-RSS article by stable id (like "cat").
+      description: `Read stored feed content of a collected-RSS article by stable id (like "cat").
 
 Use after globRss/grepRss to read a specific article — pass the \`id\` from their
 results. The id is stable, so it resolves regardless of what \`lookback\` you used
-to find the item (no need to repeat it).`,
+to find the item (no need to repeat it). The collector can retrieve retained disk records
+even after they leave the recent search index. Content is what the feed supplied,
+which may be a summary; this does not fetch the publisher webpage.`,
       inputSchema: z.object({
         id: z.number().int().nonnegative().describe('Stable article id from globRss/grepRss results'),
       }).meta({ examples: [{ id: 0 }] }),
       execute: async ({ id }) => {
-        const result = await readRss(
-          { getNews: () => provider.getNewsV2({ endTime: new Date(), limit: NEWS_LIMIT }) },
+        const result = provider.getNewsById ? await provider.getNewsById(id) : await readRss(
+          { getNews: () => provider.getNewsV2({ endTime: new Date() }) },
           { id },
         )
         return result ?? { error: `Article id ${id} not found` }

--- a/src/domain/news/store.spec.ts
+++ b/src/domain/news/store.spec.ts
@@ -49,6 +49,25 @@ describe('NewsCollectorStore', () => {
     try { await unlink(TEST_LOG_PATH) } catch { /* ignore */ }
   })
 
+  it('reads evicted and retention-expired IDs from disk, including after restart', async () => {
+    const small = new NewsCollectorStore({ logPath: TEST_LOG_PATH, maxInMemory: 1, retentionDays: 1 })
+    await small.init()
+    const old = await small.ingestRecord({ title: 'old', content: 'original feed content', pubTime: new Date(0), dedupKey: 'old', metadata: {} })
+    await small.ingest({ title: 'new', content: 'new', pubTime: new Date(), dedupKey: 'new', metadata: {} })
+    expect((await small.getNewsV2({ endTime: new Date() })).map(item => item.id)).not.toContain(old!.seq)
+    expect(await small.getNewsById(old!.seq)).toMatchObject({ title: 'old', content: 'original feed content' })
+    await small.close()
+    const recovered = new NewsCollectorStore({ logPath: TEST_LOG_PATH, maxInMemory: 1, retentionDays: 1 })
+    await recovered.init()
+    expect(await recovered.getNewsById(old!.seq)).toMatchObject({ title: 'old' })
+    expect(await recovered.getNewsById(99999)).toBeNull()
+    await recovered.close()
+  })
+
+  it('returns no article for an empty archive', async () => {
+    expect(await store.getNewsById(1)).toBeNull()
+  })
+
   it('starts empty', () => {
     expect(store.count).toBe(0)
     expect(store.dedupCount).toBe(0)

--- a/src/domain/news/store.ts
+++ b/src/domain/news/store.ts
@@ -10,6 +10,8 @@
  * Implements INewsProvider so globRss/grepRss/readRss tools work.
  */
 
+import { createReadStream } from 'node:fs'
+import { createInterface } from 'node:readline'
 import { appendFile, readFile, mkdir } from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { dirname } from 'node:path'
@@ -252,6 +254,28 @@ export class NewsCollectorStore implements INewsProvider {
     }
 
     return filtered.map(recordToNewsItem)
+  }
+
+  /** Stable IDs address the durable archive, not just the recent memory index. */
+  async getNewsById(id: number): Promise<NewsItem | null> {
+    const cached = this.buffer.find((record) => record.seq === id)
+    if (cached) return recordToNewsItem(cached)
+    const input = createReadStream(this.logPath, { encoding: 'utf8' })
+    const lines = createInterface({ input, crlfDelay: Infinity })
+    try {
+      for await (const line of lines) {
+        let record: NewsRecord
+        try { record = JSON.parse(line) } catch { continue }
+        if (record?.seq === id) return recordToNewsItem(record)
+      }
+      return null
+    } catch (error) {
+      if (isENOENT(error)) return null
+      throw error
+    } finally {
+      lines.close()
+      input.destroy()
+    }
   }
 
   // ==================== Lifecycle ====================

--- a/src/domain/news/types.ts
+++ b/src/domain/news/types.ts
@@ -82,4 +82,6 @@ export interface INewsProvider {
    * @returns News list (ascending by time, newest last)
    */
   getNewsV2(options: GetNewsV2Options): Promise<NewsItem[]>
+  /** Resolve a durable id beyond the recent search index, when supported. */
+  getNewsById?(id: number): Promise<NewsItem | null>
 }


### PR DESCRIPTION
RSS glob/grep previously truncated candidates to the latest 500 articles before matching, so an older matching item could disappear even inside the requested lookback. Reading its stable ID also searched only that truncated list.

Search the full available recent index before applying the matching-result cap (default 500, preserving array output and oldest-first ordering). Window queries likewise apply output limits after matching. Read IDs through the collector’s durable lookup: memory first, then a streaming JSONL scan so evicted/retention-expired records remain readable across restarts. Providers without durable lookup retain the uncapped recent-index fallback.

Help and the owner guide explicitly distinguish the bounded recent search index from the full disk archive and stored feed content from publisher-page content. This does not redesign collection, retention, or news sourcing and changes no persisted format.

Validation: changed closure (67 tests), additional 5001-item window regression, gateway/shim tests, root typecheck. Fixtures cover the 501st article, output-after-match limits, stable-ID reads after eviction/restart, and missing IDs/files. Real alice rss glob/read verified an older disk article (ID 1) remains readable while the recent index starts at ID 76.
