### PR TITLE
feat(workspaces): independently version Alice Harness CLI and Skills

### DIFF
--- a/default/alice-harness.json
+++ b/default/alice-harness.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "version": "1.0.0",
+  "description": "Alice Project-provided CLI contract and companion skills"
+}

--- a/default/skills/alice/references/collaboration.md
+++ b/default/skills/alice/references/collaboration.md
@@ -210,3 +210,18 @@ alice template upgrade --id <workspaceId>
 Applying to a live current Workspace is blocked. A headless run may preview a
 peer but cannot apply a cross-Workspace upgrade. Conflict resolution, lifecycle
 guards, and managed-file boundaries are reported by the live command.
+
+
+## Alice Harness injection
+
+The Alice Project supplies this CLI and its companion Skills independently of
+Chat, AutoQuant and Auto Prediction source versions. Inspect or update only this
+injection layer with `alice harness upgrade` (preview) and `alice harness upgrade
+--apply` (a paused Workspace is required; a manager may target a peer with `--id`).
+Use `alice template upgrade` only for template-owned instructions and skills.
+
+`.alice/alice-harness-version.json` records the accepted injection revision.
+`.alice/alice-harness-config.json` controls enabled CLIs and command groups;
+disabled commands are unavailable through the gateway, including old aliases.
+The live Project supplies execution, so the recorded revision does not pin an
+old binary. Always discover available commands with `alice --help`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ GitHub navigation.
 | [[docs/remote-access.md]] | [Remote Runtime and access](remote-access.md) | Server lifecycle, SSH transport, managed remote bootstrap, client authority, and staged Studio protocol |
 | [[docs/connector-service.md]] | [Connector Service](connector-service.md) | Optional Discord/Telegram Inbox projection, adapters, secrets, health, Guardian lifecycle |
 | [[docs/ui-interaction-and-motion.md]] | [UI interaction and motion](ui-interaction-and-motion.md) | Clickable affordances, shared motion tokens, entrances/disclosures, reduced-motion policy |
+| [[docs/alice-harness.md]] | [Alice Harness injection](alice-harness.md) | Independent Project-provided CLI/Skills versions, Workspace command switches and injection upgrades |
 | [[docs/workspace-agent-guidance.md]] | [Workspace agent guidance](workspace-agent-guidance.md) | Always-loaded prompt contract, skill ownership, Workspace capability browser, live CLI authority, guidance versioning |
 | [[docs/workspace-lifecycle.md]] | [Workspace and Session lifecycle](workspace-lifecycle.md) | Offboarding, departed directories, handoff, restore/purge, Session retirement |
 | [[docs/workspace-manager.md]] | [Workspace Manager](workspace-manager.md) | Launcher-owned control plane, Web quick start, active-desk inventory, and management boundaries |

--- a/docs/alice-harness.md
+++ b/docs/alice-harness.md
@@ -1,0 +1,80 @@
+# Alice Harness injection
+
+Alice Project provides Workspace CLI contracts and companion Skills independently
+of the Workspace Harness. Chat template versions, AutoQuant source pins, and
+Auto Prediction source pins do not version this injection layer.
+
+## Version authority
+
+`default/alice-harness.json` declares the Project's injection release version.
+Its effective revision appends a content fingerprint of the public CLI command
+registry and complete owned skill trees. Bump the declared version for behavior
+changes not represented in those assets. Updating these assets does not require
+bumping a Chat/AQ/AP template version.
+
+Each newly created Workspace records accepted state at
+`.alice/alice-harness-version.json` (schemaVersion, template=alice-harness,
+appliedVersion, appliedAt, source and optional upgrade commit). It is local
+bookkeeping excluded from Workspace Git, alongside the compressed three-way
+baseline and recovery journal under `.alice/alice-harness-upgrade/`.
+The actual executable/tool implementation remains provided by the running
+Project. The accepted revision does not pin an old binary. Status surfaces show
+accepted and available revisions separately.
+
+## Ownership
+
+Alice Harness owns complete trees for `alice`, `alice-analysis`, `alice-uta`,
+`traderhub`, and `self-scheduling`, plus removal/reconciliation of legacy
+`alice-workspace` copies. `.agents/skills` is primary and `.claude/skills` is its
+runtime mirror; old `.pi/skills` duplicates are included only for reconciliation.
+Template-declared instructions, README and other bundled Skills remain template
+owned. Existing template baselines may contain these trees, but template plans
+exclude Alice-owned paths. Source upgrades remain ordinary upstream Git merges
+and do not advance Alice injection metadata.
+
+## Workspace configuration
+
+`.alice/alice-harness-config.json` is Workspace-owned, tracked configuration.
+Omitted entries are enabled. A CLI-wide disable wins over group switches:
+
+```json
+{
+  "schemaVersion": 1,
+  "cli": {
+    "alice": { "groups": { "rss": false } },
+    "alice-uta": { "enabled": false }
+  }
+}
+```
+
+First-version granularity is CLI and command group. The gateway reads current
+configuration for both discovery and invocation, including the legacy Workspace
+export. Disabled tools return 403; malformed configuration fails closed with a
+configuration error. This is customization of Workspace capabilities, not a
+sandbox against an Agent allowed to edit its own files. UTA permission and
+trading-write authority remain unchanged.
+
+Saving configuration does not overwrite skill files. An independent injection
+preview reflects the current configuration; a wholly disabled CLI's companion
+Skills are omitted from Incoming. Group-level restrictions remain discoverable
+through live help even when a shared Skill discusses other groups. Customized
+Skills follow ordinary three-way conflict/preservation rules.
+
+## Independent upgrade
+
+Workspace details → CLI → Alice Harness → Manage offers status, command
+switches and a file review. The API is `/api/workspaces/:id/alice-harness`,
+`PUT .../alice-harness/config`, and `GET/POST .../alice-harness-upgrade`.
+The CLI offers `alice harness upgrade` and `alice harness upgrade --apply`, with
+`--id` for a peer and the same per-file conflict flags as template upgrades.
+
+The shared managed-file engine provides checkout serialization, active-Session
+and staged-index blockers, exact preview digests, atomic file replacements,
+Git commit, rollback and committed-transaction recovery. Configuration is part
+of the preview digest and never overwritten by upgrade. Both upgrade layers
+recover before scheduled work starts.
+
+Existing Workspaces are unversioned until explicitly adopted. First preview
+uses the legacy root-commit baseline; unknown or customized content is preserved
+or reviewed as a conflict. No startup rewrite or bulk migration changes user
+files. First successful adoption creates a missing default configuration through the same reviewed transaction and records the independent baseline and revision.

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -138,3 +138,11 @@ outside this browser's scope.
 - Was the template version bumped for a material injected-guidance change?
 - Were context injection, the affected tool, the CLI gateway, and the real shim
   tested together?
+
+
+## Independent injection releases
+
+Project-provided CLI and companion Skills are owned and independently versioned
+by [[docs/alice-harness.md]]. Workspace details → CLI → Alice Harness exposes
+accepted/available revisions, command switches and three-way injection upgrade.
+Changing those Skills no longer requires a Chat/AQ/AP template version bump.

--- a/docs/workspace-template-upgrade.md
+++ b/docs/workspace-template-upgrade.md
@@ -25,7 +25,8 @@ that a whole repository is a launcher-managed file set.
 The current managed set is intentionally narrow:
 
 - `README.md`, `AGENTS.md`, and `CLAUDE.md`;
-- `.agents/skills/**` and `.claude/skills/**`;
+- Template-owned `.agents/skills/**` and `.claude/skills/**`; Alice Harness CLI
+  companion skills are excluded and independently upgraded via [[docs/alice-harness.md]].
 - legacy `.pi/skills/**`, so an unchanged duplicate skill tree can be removed.
 
 Research, reports, Issues, Inbox records, credentials, Git history, runtime

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -245,6 +245,7 @@ export interface WorkspaceToolContext {
   }
   /** Safe current-Workspace template preview/apply surface. */
   templateUpgrades?: WorkspaceTemplateUpgradeControl
+  aliceHarnessUpgrades?: WorkspaceTemplateUpgradeControl
   /** Rename a product Session in this Workspace. Empty/null clears the nametag. */
   setSessionDisplayName?: (input: {
     readonly resumeId: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ import { inboxReadFactory } from './tool/inbox-read.js'
 import { workspacePathFactory } from './tool/workspace-path.js'
 import { workspaceSessionsFactory } from './tool/workspace-sessions.js'
 import { workspaceListFactory } from './tool/workspace-list.js'
-import { workspaceTemplateUpgradeFactory } from './tool/workspace-template-upgrade.js'
+import { workspaceTemplateUpgradeFactory, aliceHarnessUpgradeFactory } from './tool/workspace-template-upgrade.js'
 import { createEntityStore } from './core/entity-store.js'
 import { entityUpsertFactory } from './tool/entity-upsert.js'
 import { entitySearchFactory } from './tool/entity-search.js'
@@ -108,6 +108,7 @@ async function main() {
   workspaceToolCenter.register(workspaceSessionsFactory)
   workspaceToolCenter.register(workspaceListFactory)
   workspaceToolCenter.register(workspaceTemplateUpgradeFactory)
+  workspaceToolCenter.register(aliceHarnessUpgradeFactory)
   workspaceToolCenter.register(entityUpsertFactory)
   workspaceToolCenter.register(entitySearchFactory)
   for (const f of issueToolFactories) workspaceToolCenter.register(f)

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -22,7 +22,7 @@ import { inboxReadFactory } from '../tool/inbox-read.js'
 import { workspacePathFactory } from '../tool/workspace-path.js'
 import { workspaceSessionsFactory } from '../tool/workspace-sessions.js'
 import { workspaceListFactory } from '../tool/workspace-list.js'
-import { workspaceTemplateUpgradeFactory } from '../tool/workspace-template-upgrade.js'
+import { workspaceTemplateUpgradeFactory, aliceHarnessUpgradeFactory } from '../tool/workspace-template-upgrade.js'
 import { entityUpsertFactory } from '../tool/entity-upsert.js'
 import { entitySearchFactory } from '../tool/entity-search.js'
 import { issueToolFactories } from '../tool/issue-tools.js'
@@ -110,6 +110,7 @@ describe('CLI_EXPORTS — workspace export (scoped collaboration tools)', () => 
   wtc.register(workspaceSessionsFactory)
   wtc.register(workspaceListFactory)
   wtc.register(workspaceTemplateUpgradeFactory)
+  wtc.register(aliceHarnessUpgradeFactory)
   wtc.register(entityUpsertFactory)
   wtc.register(entitySearchFactory)
   for (const f of issueToolFactories) wtc.register(f)

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -141,6 +141,7 @@ const BASE_EXPORTS: Record<string, CliExport> = {
       signature: 'Show this Session\'s safe product identity',
       session: 'Rename or inspect this Workspace\'s product Sessions',
       track: 'Maintain the shared index of durable assets and topics',
+      harness: 'Manage independently versioned Alice Project CLI and Skills injection',
       template: 'Preview or apply managed Workspace-template updates',
     },
     commands: {
@@ -198,6 +199,7 @@ const BASE_EXPORTS: Record<string, CliExport> = {
       },
       // Current-Workspace managed template reconciliation. Preview is the
       // default; `--apply` explicitly performs the reviewed safe operation.
+      harness: { upgrade: 'alice_harness_upgrade' },
       template: {
         upgrade: 'workspace_template_upgrade',
       },

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { Hono } from 'hono'
 import { tool } from 'ai'
 import { z } from 'zod'
-import { resolve } from 'node:path'
+import { resolve, join } from 'node:path'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { ToolCenter } from '../core/tool-center.js'
 import { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
 import { createThinkingTools } from '../tool/thinking.js'
@@ -498,5 +500,34 @@ describe('Workspace CLI documentation', () => {
     expect((await docs.request('/api/workspaces/missing/cli/data/manifest')).status).toBe(404)
     expect((await docs.request('/api/workspaces/ws1/cli/data/invoke', { method: 'POST' })).status).toBe(404)
     expect((await docs.request('/cli/ws1/data/invoke', { method: 'POST' })).status).toBe(404)
+  })
+})
+
+
+describe('Workspace CLI configuration', () => {
+  it('filters discovery and rejects direct invocation through both canonical and legacy exports', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'alice-cli-policy-'))
+    try {
+      await mkdir(join(dir, '.alice'))
+      const wtc = new WorkspaceToolCenter()
+      const execute = vi.fn(async () => ({ ok: true }))
+      wtc.register({ name: 'workspace_list', build: () => tool({ inputSchema: z.object({}), execute }) })
+      const server = new Hono()
+      registerCliRoutes(server, {
+        toolCenter: new ToolCenter(), workspaceToolCenter: wtc, inboxStore: {} as never, entityStore: {} as never,
+        getWorkspaceService: () => ({ registry: { get: () => ({ id: 'one', tag: 'one', dir }) } }) as never,
+      })
+      await writeFile(join(dir, '.alice/alice-harness-config.json'), JSON.stringify({ schemaVersion: 1, cli: { alice: { groups: { peer: false } } } }))
+      for (const exp of ['data', 'workspace']) {
+        const manifest = await (await server.request(`/cli/one/${exp}/manifest`)).json() as { groups: object }
+        expect(manifest.groups).not.toHaveProperty('peer')
+        const response = await server.request(`/cli/one/${exp}/invoke`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ tool: 'workspace_list', args: {} }) })
+        expect(response.status).toBe(403)
+      }
+      expect(execute).not.toHaveBeenCalled()
+      await writeFile(join(dir, '.alice/alice-harness-config.json'), '{broken')
+      expect((await server.request('/cli/one/data/manifest')).status).toBe(503)
+      expect((await server.request('/cli/one/workspace/invoke', { method: 'POST', body: JSON.stringify({ tool: 'workspace_list' }) })).status).toBe(503)
+    } finally { await rm(dir, { recursive: true, force: true }) }
   })
 })

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Hono } from 'hono'
+import { readAliceHarnessConfig, cliGroupEnabled, DEFAULT_ALICE_HARNESS_CONFIG } from '../workspaces/alice-harness-policy.js'
 import { z } from 'zod'
 import type { Tool } from 'ai'
 import type { ToolCenter } from '../core/tool-center.js'
@@ -58,7 +59,7 @@ export interface CliGatewayDeps {
   getWorkspaceService: () => WorkspaceService | null
 }
 
-type WsMeta = { id: string; tag: string }
+type WsMeta = { id: string; tag: string; dir?: string }
 
 /** Mount /cli/:wsId/:export/* onto an existing Hono app (the MCP server's app). */
 export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly = false): void {
@@ -73,7 +74,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
     // identity can share the CLI without entering the business registry.
     const meta = svc.resolveRuntimeWorkspace?.(wsId) ?? svc.registry.get(wsId)
     if (!meta) return { error: 'unknown' }
-    return { meta: { id: meta.id, tag: meta.tag } }
+    return { meta: { id: meta.id, tag: meta.tag, dir: meta.dir } }
   }
 
   /**
@@ -105,7 +106,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
         entityStore,
         ...(svc ? { provenanceStore: svc.provenanceStore } : {}),
         ...(svc ? { conversation: createWorkspaceConversationControl(svc) } : {}),
-        ...(svc ? { templateUpgrades: svc.templateUpgrades } : {}),
+        ...(svc ? { templateUpgrades: svc.templateUpgrades, aliceHarnessUpgrades: svc.aliceHarnessUpgrades } : {}),
         ...(svc ? {
           setSessionDisplayName: async (input) => {
             const identity = await svc.setSessionDisplayName({
@@ -213,9 +214,12 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
     return { ok: true, exp, ws: ws.meta }
   }
 
-  app.get(manifestOnly ? '/api/workspaces/:wsId/cli/:export/manifest' : '/cli/:wsId/:export/manifest', (c) => {
+  app.get(manifestOnly ? '/api/workspaces/:wsId/cli/:export/manifest' : '/cli/:wsId/:export/manifest', async (c) => {
     const r = resolveCtx(c.req.param('wsId'), c.req.param('export'))
     if (!r.ok) return c.json({ error: r.error }, r.status)
+    let policy
+    try { policy = r.ws.dir ? await readAliceHarnessConfig(r.ws.dir) : DEFAULT_ALICE_HARNESS_CONFIG }
+    catch (error) { return c.json({ error: (error as Error).message }, 503) }
     const cat = exportCatalog(r.exp, r.ws)
 
     const groups: Record<
@@ -223,6 +227,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
       Record<string, { tool: string; description: string; schema: unknown }>
     > = {}
     for (const [group, verbs] of Object.entries(r.exp.commands)) {
+      if (!cliGroupEnabled(policy, r.exp.binary, group)) continue
       for (const [verb, toolName] of Object.entries(verbs)) {
         const tool = cat.resolve(toolName)
         if (!tool) continue
@@ -273,6 +278,12 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
     if (!mappedToolNames(c.req.param('export')).has(toolName)) {
       return c.json({ error: `Unknown CLI command tool: ${toolName || '(none)'}` }, 404)
     }
+    let policy
+    try { policy = r.ws.dir ? await readAliceHarnessConfig(r.ws.dir) : DEFAULT_ALICE_HARNESS_CONFIG }
+    catch (error) { return c.json({ error: (error as Error).message }, 503) }
+    const enabled = Object.entries(r.exp.commands).some(([group, verbs]) =>
+      cliGroupEnabled(policy, r.exp.binary, group) && Object.values(verbs).includes(toolName))
+    if (!enabled) return c.json({ error: `CLI command disabled by Workspace configuration: ${toolName}` }, 403)
     // Out-of-band identity (agent never sees it): the `alice` shim forwards the
     // spawn-injected AQ_RUN_ID (headless) / AQ_SESSION_ID (interactive) here as
     // mutually-exclusive headers, resolved server-side to an authoritative origin

--- a/src/tool/workspace-template-upgrade.spec.ts
+++ b/src/tool/workspace-template-upgrade.spec.ts
@@ -59,6 +59,13 @@ function setup(currentPlan = plan()) {
 }
 
 describe('workspace_template_upgrade', () => {
+  it('applies Alice Harness configuration changes at the same source version', async () => {
+    const { tool, templateUpgrades } = setup(plan({ template: 'alice-harness', fromVersion: '1.0.0', toVersion: '1.0.0' }))
+    const result = await run(tool, { apply: true, mode: 'summary' })
+    expect(result.action).toBe('applied')
+    expect(templateUpgrades.apply).toHaveBeenCalledOnce()
+  })
+
   it('previews by default without dumping file bodies', async () => {
     const { tool, templateUpgrades } = setup()
     const result = await run(tool, { apply: false, mode: 'summary' })

--- a/src/tool/workspace-template-upgrade.ts
+++ b/src/tool/workspace-template-upgrade.ts
@@ -33,8 +33,8 @@ function previewPayload(plan: TemplateUpgradePlan, mode: OutputMode, explicitTar
   const preserved = plan.files.filter((file) => file.status === 'preserved')
   const conflicts = plan.files.filter((file) => file.status === 'conflict')
   const sameVersion = plan.fromVersion === plan.toVersion
-  const versionMismatch = sameVersion && (changes.length > 0 || conflicts.length > 0)
-  const current = sameVersion && !versionMismatch
+  const versionMismatch = plan.template !== 'alice-harness' && sameVersion && (changes.length > 0 || conflicts.length > 0)
+  const current = sameVersion && changes.length === 0 && conflicts.length === 0
   const status = plan.blocked
     ? 'blocked'
     : versionMismatch
@@ -66,7 +66,7 @@ function previewPayload(plan: TemplateUpgradePlan, mode: OutputMode, explicitTar
       ? null
       : conflicts.length > 0
         ? 'Resolve every conflict with repeatable --keep-workspace <path> or --use-template <path>, then add --apply.'
-        : `alice template upgrade${explicitTarget ? ` --id ${plan.workspaceId}` : ''} --apply`,
+        : `alice ${plan.template === 'alice-harness' ? 'harness' : 'template'} upgrade${explicitTarget ? ` --id ${plan.workspaceId}` : ''} --apply`,
   }
 }
 
@@ -159,7 +159,7 @@ export const workspaceTemplateUpgradeFactory: WorkspaceToolFactory = {
               preview,
             }
           }
-          const changedAtSameVersion = plan.fromVersion === plan.toVersion
+          const changedAtSameVersion = plan.template !== 'alice-harness' && plan.fromVersion === plan.toVersion
             && plan.files.some((file) => file.status === 'ready' || file.status === 'conflict')
           if (changedAtSameVersion) {
             return {
@@ -171,7 +171,7 @@ export const workspaceTemplateUpgradeFactory: WorkspaceToolFactory = {
               preview,
             }
           }
-          if (plan.fromVersion === plan.toVersion) {
+          if (plan.fromVersion === plan.toVersion && !plan.files.some((file) => file.status === 'ready' || file.status === 'conflict')) {
             return { ok: true as const, action: 'noop' as const, preview }
           }
 
@@ -213,5 +213,14 @@ export const workspaceTemplateUpgradeFactory: WorkspaceToolFactory = {
         }
       },
     })
+  },
+}
+
+/** Same reconciliation contract, independently versioned Project injection layer. */
+export const aliceHarnessUpgradeFactory: WorkspaceToolFactory = {
+  name: 'alice_harness_upgrade',
+  build(ctx) {
+    const result = workspaceTemplateUpgradeFactory.build({ ...ctx, templateUpgrades: ctx.aliceHarnessUpgrades })
+    return { ...result, description: result.description?.replace('managed template upgrade', 'Alice Harness CLI/Skills injection upgrade (independent of the Workspace template/source version)') }
   },
 }

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1400,11 +1400,23 @@ export function createWorkspaceRoutes(
     }
   });
 
-  app.get('/:id/template-upgrade', async (c) => {
+  app.get('/:id/alice-harness', async (c) => {
+    try { return c.json(await svc.aliceHarnessUpgrades.harnessStatus(c.req.param('id'))); }
+    catch (error) { return c.json({ error: (error as Error).message }, error instanceof TemplateUpgradeError && error.code === 'not_found' ? 404 : 400); }
+  });
+  app.put('/:id/alice-harness/config', async (c) => {
+    try {
+      await svc.aliceHarnessUpgrades.configureHarness(c.req.param('id'), await c.req.json());
+      return c.json({ ok: true });
+    } catch (error) { return c.json({ error: (error as Error).message }, error instanceof TemplateUpgradeError && error.code === 'busy' ? 409 : 400); }
+  });
+
+  for (const [route, manager] of [['template-upgrade', svc.templateUpgrades], ['alice-harness-upgrade', svc.aliceHarnessUpgrades]] as const) {
+  app.get(`/:id/${route}`, async (c) => {
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
     try {
-      return c.json({ plan: await svc.templateUpgrades.plan(id) });
+      return c.json({ plan: await manager.plan(id) });
     } catch (err) {
       if (err instanceof TemplateUpgradeError) {
         const status = err.code === 'not_found' ? 404
@@ -1417,7 +1429,7 @@ export function createWorkspaceRoutes(
     }
   });
 
-  app.post('/:id/template-upgrade', async (c) => {
+  app.post(`/:id/${route}`, async (c) => {
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
     const body = await safeJson(c);
@@ -1432,7 +1444,7 @@ export function createWorkspaceRoutes(
             entry[1] === 'workspace' || entry[1] === 'template'))
       : undefined;
     try {
-      const result = await svc.templateUpgrades.apply(id, {
+      const result = await manager.apply(id, {
         planDigest: fields['planDigest'],
         ...(resolutions ? { resolutions } : {}),
       });
@@ -1449,6 +1461,8 @@ export function createWorkspaceRoutes(
       return c.json({ error: 'upgrade_apply_failed', message: (err as Error).message }, 500);
     }
   });
+
+  }
 
   app.get('/:id/source-upgrade', async (c) => {
     const id = c.req.param('id');

--- a/src/workspaces/alice-harness-assets.ts
+++ b/src/workspaces/alice-harness-assets.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto'
+import { cp, mkdir, readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { defaultPath } from '../core/paths.js'
+import { CLI_EXPORTS } from '../server/cli-commands.js'
+import { ALICE_HARNESS_SKILLS, cliGroupEnabled, type AliceHarnessConfig, DEFAULT_ALICE_HARNESS_CONFIG } from './alice-harness-policy.js'
+
+/** The Project supplies this revision; it is independent of Workspace template pins. */
+export async function aliceHarnessSourceVersion(): Promise<string> {
+  const manifest = JSON.parse(await readFile(defaultPath('alice-harness.json'), 'utf8')) as { version: string }
+  const hash = createHash('sha256').update(JSON.stringify(CLI_EXPORTS))
+  async function walk(dir: string, relative: string) {
+    for (const entry of (await readdir(dir, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name))) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) await walk(path, `${relative}/${entry.name}`)
+      else if (entry.isFile()) hash.update(`${relative}/${entry.name}\0`).update(await readFile(path))
+    }
+  }
+  for (const skill of ALICE_HARNESS_SKILLS) await walk(defaultPath('skills', skill), skill)
+  return `${manifest.version}+${hash.digest('hex').slice(0, 16)}`
+}
+
+export async function injectAliceHarnessSkills(dir: string, injectTools: boolean, config: AliceHarnessConfig = DEFAULT_ALICE_HARNESS_CONFIG): Promise<void> {
+  const skills = ALICE_HARNESS_SKILLS.filter((skill) => {
+    if (!injectTools && skill !== 'self-scheduling') return false
+    const binary = ['self-scheduling', 'alice-analysis'].includes(skill) ? 'alice' : skill
+    const exp = Object.values(CLI_EXPORTS).find((candidate) => candidate.binary === binary)!
+    return Object.keys(exp.commands).some((group) => cliGroupEnabled(config, binary, group))
+  })
+  for (const root of ['.agents/skills', '.claude/skills']) {
+    await mkdir(join(dir, root), { recursive: true })
+    for (const skill of skills) await cp(defaultPath('skills', skill), join(dir, root, skill), { recursive: true })
+  }
+}

--- a/src/workspaces/alice-harness-policy.ts
+++ b/src/workspaces/alice-harness-policy.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { z } from 'zod'
+import { CLI_EXPORTS } from '../server/cli-commands.js'
+
+export const ALICE_HARNESS_CONFIG_PATH = '.alice/alice-harness-config.json'
+export const ALICE_HARNESS_VERSION_PATH = '.alice/alice-harness-version.json'
+export const ALICE_HARNESS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'self-scheduling'] as const
+export const LEGACY_ALICE_HARNESS_SKILLS = [...ALICE_HARNESS_SKILLS, 'alice-workspace']
+export const aliceHarnessConfigSchema = z.object({
+  schemaVersion: z.literal(1),
+  cli: z.record(z.string(), z.object({
+    enabled: z.boolean().optional(),
+    groups: z.record(z.string(), z.boolean()).optional(),
+  }).strict()).default({}),
+}).strict()
+export type AliceHarnessConfig = z.infer<typeof aliceHarnessConfigSchema>
+export const DEFAULT_ALICE_HARNESS_CONFIG: AliceHarnessConfig = { schemaVersion: 1, cli: {} }
+
+export function parseAliceHarnessConfig(value: unknown): AliceHarnessConfig {
+  const config = aliceHarnessConfigSchema.parse(value)
+  for (const [binary, policy] of Object.entries(config.cli)) {
+    const exp = Object.values(CLI_EXPORTS).find((candidate) => candidate.binary === binary && binary !== 'alice-workspace')
+    if (!exp || Object.keys(policy.groups ?? {}).some((group) => !Object.hasOwn(exp.commands, group))) throw new Error(`Unknown CLI or command group in ${binary}`)
+  }
+  return config
+}
+export async function readAliceHarnessConfig(dir: string): Promise<AliceHarnessConfig> {
+  try {
+    return parseAliceHarnessConfig(JSON.parse(await readFile(join(dir, ALICE_HARNESS_CONFIG_PATH), 'utf8')))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return DEFAULT_ALICE_HARNESS_CONFIG
+    throw new Error('Invalid .alice/alice-harness-config.json; fix the configuration before using Workspace CLI commands', { cause: error })
+  }
+}
+export function cliGroupEnabled(config: AliceHarnessConfig, binary: string, group: string): boolean {
+  const canonical = binary === 'alice-workspace' ? 'alice' : binary
+  const policy = config.cli[canonical]
+  return policy?.enabled !== false && policy?.groups?.[group] !== false
+}
+export function isAliceHarnessSkillPath(path: string): boolean {
+  const parts = path.replaceAll('\\', '/').split('/')
+  return ['.agents', '.claude', '.pi'].includes(parts[0]) && parts[1] === 'skills'
+    && LEGACY_ALICE_HARNESS_SKILLS.includes(parts[2] as typeof LEGACY_ALICE_HARNESS_SKILLS[number])
+}

--- a/src/workspaces/context-injector.ts
+++ b/src/workspaces/context-injector.ts
@@ -14,30 +14,16 @@ import { join } from 'node:path';
 
 import { defaultPath } from '@/core/paths.js';
 
+import { injectAliceHarnessSkills } from './alice-harness-assets.js';
+import { ALICE_HARNESS_SKILLS, ALICE_HARNESS_CONFIG_PATH, DEFAULT_ALICE_HARNESS_CONFIG } from './alice-harness-policy.js';
 import { writeWorkspaceFile } from './file-service.js';
 import type { TemplateMeta } from './template-registry.js';
-
-/**
- * Skills teaching the `alice*` + `traderhub` CLIs — injected into every
- * tool-bearing template (`injectTools` truthy). The launcher injects NO MCP into
- * workspaces at all (no `.mcp.json`, no Pi bridge); these skills are how the
- * agent learns the CLI surface that is now its ONLY path to OpenAlice's tools.
- */
-const CLI_TOOLS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'traderhub'];
-
-/**
- * Skills injected into EVERY new workspace, regardless of template — generic
- * launcher capabilities every agent should know about. Unlike CLI_TOOLS_SKILLS
- * (gated on `injectTools`), these are UNGATED: self-scheduling works in any
- * workspace because the `alice` CLI is on PATH everywhere (so even an untooled
- * template's headless run can report back to the Inbox).
- */
-const ALWAYS_SKILLS = ['self-scheduling'];
 
 export async function injectWorkspaceContext(opts: {
   readonly template: TemplateMeta;
   readonly wsId: string;
   readonly dir: string;
+  readonly templateOnly?: boolean;
 }): Promise<void> {
   const { template, dir } = opts;
 
@@ -52,17 +38,17 @@ export async function injectWorkspaceContext(opts: {
     await writeWorkspaceFile(dir, 'AGENTS.md', instruction);
   }
 
-  // Every workspace gets ALWAYS_SKILLS (generic launcher capabilities). Tool-
-  // bearing templates additionally get the per-CLI playbooks (alice / alice-uta
-  // / traderhub) so the agent knows the CLI surface — its ONLY
-  // path to OpenAlice tools, since the launcher injects no MCP. All de-duped.
+  // Template-owned skills remain separate from Project-provided Alice Harness skills.
   const skills = [
     ...new Set([
-      ...ALWAYS_SKILLS,
-      ...template.bundledSkills,
-      ...(template.injectTools ? CLI_TOOLS_SKILLS : []),
+      ...template.bundledSkills.filter((skill) => !ALICE_HARNESS_SKILLS.includes(skill as typeof ALICE_HARNESS_SKILLS[number])),
     ]),
   ];
+  if (!opts.templateOnly) {
+    await injectAliceHarnessSkills(dir, template.injectTools);
+    await writeWorkspaceFile(dir, ALICE_HARNESS_CONFIG_PATH, JSON.stringify(DEFAULT_ALICE_HARNESS_CONFIG, null, 2) + '\n');
+  }
+
   if (skills.length > 0) {
     // Claude Code reads `.claude/skills`; Codex and current Pi both read the
     // shared `.agents/skills` path. Do not also copy into `.pi/skills`: Pi

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -419,6 +419,7 @@ export interface WorkspaceService {
   readonly catalog: WorkspaceCatalog;
   readonly lifecycle: WorkspaceLifecycleManager;
   readonly templateUpgrades: TemplateUpgradeManager;
+  readonly aliceHarnessUpgrades: TemplateUpgradeManager;
   readonly sourceUpgrades: HarnessSourceUpgradeManager;
   readonly workspaceAbsorbs: WorkspaceAbsorbManager;
   /** Coordinates runtime starts with directory-wide lifecycle operations. */
@@ -3040,6 +3041,13 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     logger: launcherLogger.child({ scope: 'template-upgrade' }),
   });
   await templateUpgrades.recover();
+  const aliceHarnessUpgrades = new TemplateUpgradeManager({
+    aliceHarness: true, registry, templates,
+    workspaceRuntimeActivity: workspaceRuntimeActivityMethod,
+    operationGuard: workspaceOperationGuard,
+    logger: launcherLogger.child({ scope: 'alice-harness-upgrade' }),
+  });
+  await aliceHarnessUpgrades.recover();
   const sourceUpgrades = new HarnessSourceUpgradeManager({
     registry,
     templates,
@@ -3266,6 +3274,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     catalog,
     lifecycle,
     templateUpgrades,
+    aliceHarnessUpgrades,
     sourceUpgrades,
     workspaceAbsorbs,
     operationGuard: workspaceOperationGuard,

--- a/src/workspaces/template-upgrade.spec.ts
+++ b/src/workspaces/template-upgrade.spec.ts
@@ -30,11 +30,11 @@ let incoming: TemplateSnapshot;
 beforeEach(async () => {
   root = await mkdtemp(join(tmpdir(), 'template-upgrade-'));
   const dir = join(root, 'workspaces', 'chat-old');
-  await mkdir(join(dir, '.agents', 'skills', 'alice'), { recursive: true });
+  await mkdir(join(dir, '.agents', 'skills', 'template-skill'), { recursive: true });
   await writeFile(join(dir, 'README.md'), 'template readme v1\n');
   await writeFile(join(dir, 'AGENTS.md'), 'template agents v1\n');
   await writeFile(join(dir, 'CLAUDE.md'), 'template claude v1\n');
-  await writeFile(join(dir, '.agents', 'skills', 'alice', 'SKILL.md'), 'skill v1\n');
+  await writeFile(join(dir, '.agents', 'skills', 'template-skill', 'SKILL.md'), 'skill v1\n');
   await git(dir, ['init', '-q']);
   await git(dir, ['add', '.']);
   await git(dir, ['-c', 'user.email=test@local', '-c', 'user.name=test', 'commit', '-q', '-m', 'root']);
@@ -65,7 +65,7 @@ beforeEach(async () => {
     'README.md': file('template readme v2\n'),
     'AGENTS.md': file('template agents v2\n'),
     'CLAUDE.md': file('template claude v1\n'),
-    '.agents/skills/alice/SKILL.md': file('skill v2\n'),
+    '.agents/skills/template-skill/SKILL.md': file('skill v2\n'),
     '.agents/skills/new/SKILL.md': file('new skill\n'),
   };
 });
@@ -78,6 +78,54 @@ afterEach(async () => rm(root, {
 }));
 
 describe('TemplateUpgradeManager', () => {
+  it('adopts missing policy transactionally and reconciles a disable at the same revision', async () => {
+    const upgrade = new TemplateUpgradeManager({ registry, templates: { get: () => template } as unknown as TemplateRegistry, logger, aliceHarness: true });
+    const preview = await upgrade.plan(workspace.id);
+    expect(preview.files.find((entry) => entry.path === '.alice/alice-harness-config.json')?.operation).toBe('add');
+    await expect(readFile(join(workspace.dir, '.alice/alice-harness-config.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await upgrade.apply(workspace.id, { planDigest: preview.planDigest });
+    expect(JSON.parse(await readFile(join(workspace.dir, '.alice/alice-harness-config.json'), 'utf8'))).toEqual({ schemaVersion: 1, cli: {} });
+    await upgrade.configureHarness(workspace.id, { schemaVersion: 1, cli: { alice: { enabled: false } } });
+    const disabled = await upgrade.plan(workspace.id);
+    expect(disabled.fromVersion).toBe(disabled.toVersion);
+    expect(disabled.files.find((entry) => entry.path === '.agents/skills/alice/SKILL.md')?.operation).toBe('remove');
+    await upgrade.apply(workspace.id, { planDigest: disabled.planDigest });
+    await expect(readFile(join(workspace.dir, '.agents/skills/alice/SKILL.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(JSON.parse(await readFile(join(workspace.dir, '.alice/alice-harness-config.json'), 'utf8')).cli.alice.enabled).toBe(false);
+    expect(await upgrade.currentVersion(workspace)).toBe(preview.toVersion);
+  });
+
+  it('upgrades Alice skills without changing a source-owned Harness or local config', async () => {
+    template = { ...template, upgradeStrategy: undefined };
+    await mkdir(join(workspace.dir, '.agents/skills/alice'), { recursive: true });
+    await writeFile(join(workspace.dir, '.agents/skills/alice/SKILL.md'), 'alice v1');
+    await initializeWorkspaceTemplateState(workspace, template);
+    await manager(false, true).configureHarness(workspace.id, { schemaVersion: 1, cli: { alice: { groups: { rss: false } } } });
+    incoming = { '.agents/skills/alice/SKILL.md': file('alice v2'), 'AGENTS.md': file('must not replace') };
+    const plan = await manager(false, true).plan(workspace.id);
+    expect(plan.template).toBe('alice-harness');
+    expect(plan.files.map((file) => file.path)).toEqual(['.agents/skills/alice/SKILL.md']);
+    const result = await manager(false, true).apply(workspace.id, { planDigest: plan.planDigest });
+    expect(result.changedPaths).toEqual(['.agents/skills/alice/SKILL.md']);
+    expect(await readFile(join(workspace.dir, 'AGENTS.md'), 'utf8')).toBe('template agents v1\n');
+    expect(JSON.parse(await readFile(join(workspace.dir, '.alice/alice-harness-config.json'), 'utf8')).cli.alice.groups.rss).toBe(false);
+    expect(JSON.parse(await readFile(join(workspace.dir, '.alice/alice-harness-version.json'), 'utf8')).template).toBe('alice-harness');
+    expect(await manager().currentVersion(workspace)).toBe('1.0.0');
+  });
+
+  it('keeps Alice skills outside template upgrade and blocks busy config writes', async () => {
+    incoming = { ...incoming, '.agents/skills/alice/SKILL.md': file('not template-owned') };
+    expect((await manager().plan(workspace.id)).files.some((file) => file.path.includes('/alice/'))).toBe(false);
+    await expect(manager(true, true).configureHarness(workspace.id, { schemaVersion: 1, cli: {} })).rejects.toMatchObject({ code: 'busy' });
+  });
+
+  it('invalidates an injection preview when config changes', async () => {
+    incoming = { '.agents/skills/alice/SKILL.md': file('alice v2') };
+    const plan = await manager(false, true).plan(workspace.id);
+    await manager(false, true).configureHarness(workspace.id, { schemaVersion: 1, cli: { alice: { groups: { rss: false } } } });
+    await expect(manager(false, true).apply(workspace.id, { planDigest: plan.planDigest })).rejects.toMatchObject({ code: 'stale_plan' });
+  });
+
   it('classifies incoming updates, local customizations, dual edits, and additions', async () => {
     await writeFile(join(workspace.dir, 'AGENTS.md'), 'workspace agents\n');
     await writeFile(join(workspace.dir, 'CLAUDE.md'), 'workspace claude\n');
@@ -122,11 +170,11 @@ describe('TemplateUpgradeManager', () => {
     }
 
     const plan = await manager().plan(workspace.id);
-    const skill = plan.files.find((entry) => entry.path === '.agents/skills/alice/SKILL.md');
+    const skill = plan.files.find((entry) => entry.path === '.agents/skills/template-skill/SKILL.md');
     expect(skill).toMatchObject({ status: 'conflict', canUseTemplate: false });
     await expect(manager().apply(workspace.id, {
       planDigest: plan.planDigest,
-      resolutions: { '.agents/skills/alice/SKILL.md': 'template' },
+      resolutions: Object.fromEntries(plan.files.filter((file) => file.status === 'conflict').map((file) => [file.path, 'template' as const])),
     })).rejects.toMatchObject({ code: 'invalid_resolution' } satisfies Partial<TemplateUpgradeError>);
   });
 
@@ -242,20 +290,21 @@ describe('TemplateUpgradeManager', () => {
 describe('isManagedTemplatePath', () => {
   it('accepts only canonical managed paths', () => {
     expect(isManagedTemplatePath('README.md')).toBe(true);
-    expect(isManagedTemplatePath('.agents/skills/alice/SKILL.md')).toBe(true);
+    expect(isManagedTemplatePath('.agents/skills/template-skill/SKILL.md')).toBe(true);
     expect(isManagedTemplatePath('.agents/skills/../../AGENTS.md')).toBe(false);
-    expect(isManagedTemplatePath('.agents//skills/alice/SKILL.md')).toBe(false);
+    expect(isManagedTemplatePath('.agents//skills/template-skill/SKILL.md')).toBe(false);
     expect(isManagedTemplatePath('/tmp/AGENTS.md')).toBe(false);
   });
 });
 
-function manager(busy = false): TemplateUpgradeManager {
+function manager(busy = false, aliceHarness = false): TemplateUpgradeManager {
   const templates = {
     get: (name: string) => name === template.name ? template : undefined,
   } as unknown as TemplateRegistry;
   return new TemplateUpgradeManager({
     registry,
     templates,
+    aliceHarness,
     workspaceRuntimeActivity: () => busy
       ? {
           busy: true,

--- a/src/workspaces/template-upgrade.ts
+++ b/src/workspaces/template-upgrade.ts
@@ -18,6 +18,9 @@ import { gzip, gunzip } from 'node:zlib';
 
 import { exec as gitExec, type IGitStringExecutionOptions } from './git-execution.js';
 
+import { CLI_EXPORTS } from '../server/cli-commands.js';
+import { aliceHarnessSourceVersion, injectAliceHarnessSkills } from './alice-harness-assets.js';
+import { ALICE_HARNESS_VERSION_PATH, ALICE_HARNESS_CONFIG_PATH, parseAliceHarnessConfig, isAliceHarnessSkillPath, readAliceHarnessConfig } from './alice-harness-policy.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import type { Logger } from './logger.js';
 import type { TemplateMeta, TemplateRegistry } from './template-registry.js';
@@ -29,13 +32,18 @@ const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
 
 const STATE_SCHEMA_VERSION = 1 as const;
-const STATE_REL = '.alice/template-upgrade/state.json';
-const BASELINE_REL = '.alice/template-upgrade/baseline.json.gz';
-const TRANSACTION_DIR_REL = '.alice/template-upgrade/transaction';
-const JOURNAL_REL = `${TRANSACTION_DIR_REL}/journal.json`;
-const BEFORE_REL = `${TRANSACTION_DIR_REL}/before.json.gz`;
-const INCOMING_REL = `${TRANSACTION_DIR_REL}/incoming.json.gz`;
-const EXCLUDE_LINE = '/.alice/template-upgrade/';
+function upgradePaths(aliceHarness = false) {
+  const root = aliceHarness ? '.alice/alice-harness-upgrade' : '.alice/template-upgrade';
+  const transaction = `${root}/transaction`;
+  return {
+    state: aliceHarness ? ALICE_HARNESS_VERSION_PATH : `${root}/state.json`,
+    baseline: `${root}/baseline.json.gz`, transaction,
+    journal: `${transaction}/journal.json`, before: `${transaction}/before.json.gz`, incoming: `${transaction}/incoming.json.gz`,
+    exclude: `/${root}/`,
+  };
+}
+type UpgradePaths = ReturnType<typeof upgradePaths>;
+const TEMPLATE_PATHS = upgradePaths();
 const MAX_PREVIEW_CHARS = 24_000;
 const GIT_TIMEOUT_MS = 15_000;
 const MAX_GIT_BUFFER = 16 * 1024 * 1024;
@@ -148,6 +156,7 @@ export class TemplateUpgradeError extends Error {
 }
 
 export interface TemplateUpgradeManagerOptions {
+  readonly aliceHarness?: boolean;
   readonly registry: WorkspaceRegistry;
   readonly templates: TemplateRegistry;
   readonly workspaceRuntimeActivity?: (workspaceId: string) => WorkspaceRuntimeActivity;
@@ -172,14 +181,16 @@ export interface TemplateUpgradeManagerOptions {
  */
 export class TemplateUpgradeManager {
   private readonly operationGuard: WorkspaceOperationGuard;
+  private readonly paths: UpgradePaths;
 
   constructor(private readonly opts: TemplateUpgradeManagerOptions) {
+    this.paths = upgradePaths(opts.aliceHarness);
     this.operationGuard = opts.operationGuard ?? new WorkspaceOperationGuard();
   }
 
   async recover(): Promise<void> {
     for (const workspace of this.opts.registry.list()) {
-      if (!existsSync(join(workspace.dir, JOURNAL_REL))) continue;
+      if (!existsSync(join(workspace.dir, this.paths.journal))) continue;
       await this.recoverWorkspace(workspace).catch((err) =>
         this.opts.logger.error('template_upgrade.recovery_failed', {
           workspaceId: workspace.id,
@@ -189,10 +200,36 @@ export class TemplateUpgradeManager {
     }
   }
 
+  async harnessStatus(workspaceId: string) {
+    const workspace = this.opts.registry.get(workspaceId);
+    if (!workspace) throw new TemplateUpgradeError('not_found', 'Workspace not found');
+    return {
+      appliedVersion: await this.currentVersion(workspace) ?? null,
+      availableVersion: await aliceHarnessSourceVersion(),
+      runtimeAuthority: 'alice-project' as const,
+      config: await readAliceHarnessConfig(workspace.dir),
+      commands: Object.fromEntries(Object.values(CLI_EXPORTS).filter((exp) => exp.binary !== 'alice-workspace').map((exp) => [exp.binary, Object.keys(exp.commands)])),
+    };
+  }
+
+  async configureHarness(workspaceId: string, value: unknown): Promise<void> {
+    const config = parseAliceHarnessConfig(value);
+    const lease = this.operationGuard.acquire(workspaceId, 'alice-harness-config');
+    if (!lease) throw new TemplateUpgradeError('busy', 'Workspace has another checkout operation');
+    try {
+      const workspace = this.opts.registry.get(workspaceId);
+      if (!workspace) throw new TemplateUpgradeError('not_found', 'Workspace not found');
+      if (this.opts.workspaceRuntimeActivity?.(workspaceId).busy) throw new TemplateUpgradeError('busy', 'Pause Workspace Sessions before changing CLI configuration');
+      const unsafeParent = await parentPathIssue(workspace.dir, ALICE_HARNESS_CONFIG_PATH);
+      if (unsafeParent) throw new Error(`Unsafe config path: ${unsafeParent}`);
+      await atomicWriteJson(join(workspace.dir, ALICE_HARNESS_CONFIG_PATH), config);
+    } finally { lease.release(); }
+  }
+
   async currentVersion(workspace: WorkspaceMeta): Promise<string | undefined> {
-    const state = await readState(workspace.dir);
-    if (state && state.template === workspace.template) return state.appliedVersion;
-    return workspace.spawnedFromVersion;
+    const state = await readState(workspace.dir, this.paths);
+    if (state && state.template === (this.opts.aliceHarness ? 'alice-harness' : workspace.template)) return state.appliedVersion;
+    return this.opts.aliceHarness ? undefined : workspace.spawnedFromVersion;
   }
 
   async plan(workspaceId: string): Promise<TemplateUpgradePlan> {
@@ -200,7 +237,7 @@ export class TemplateUpgradeManager {
     try {
       const workspace = this.opts.registry.get(workspaceId);
       if (!workspace) throw new TemplateUpgradeError('not_found', 'Workspace not found');
-      const template = resolveUpgradeableTemplate(workspace, this.opts.templates);
+      const template = await this.resolveTemplate(workspace);
       await this.recoverWorkspace(workspace);
       const incoming = await this.materializeTemplate(template, workspace.id);
       return this.buildPlan(workspace, template, incoming);
@@ -234,7 +271,7 @@ export class TemplateUpgradeManager {
   ): Promise<TemplateUpgradeResult> {
     const workspace = this.opts.registry.get(workspaceId);
     if (!workspace) throw new TemplateUpgradeError('not_found', 'Workspace not found');
-    const template = resolveUpgradeableTemplate(workspace, this.opts.templates);
+    const template = await this.resolveTemplate(workspace);
     await this.recoverWorkspace(workspace);
 
     // Materialize once: the exact Incoming snapshot included in the reviewed
@@ -253,7 +290,7 @@ export class TemplateUpgradeManager {
         plan,
       );
     }
-    if (plan.fromVersion === plan.toVersion) {
+    if (plan.fromVersion === plan.toVersion && (!this.opts.aliceHarness || !plan.files.some((file) => file.status === 'ready' || file.status === 'conflict'))) {
       throw new TemplateUpgradeError('already_current', 'Workspace is already on this template version', plan);
     }
 
@@ -305,16 +342,16 @@ export class TemplateUpgradeManager {
       preparedAt: new Date().toISOString(),
     };
 
-    await ensureStateExcluded(workspace.dir);
-    await writeCompressedJson(join(workspace.dir, BEFORE_REL), {
+    await ensureStateExcluded(workspace.dir, this.paths);
+    await writeCompressedJson(join(workspace.dir, this.paths.before), {
       schemaVersion: STATE_SCHEMA_VERSION,
       files: before,
     } satisfies StoredBaseline);
-    await writeCompressedJson(join(workspace.dir, INCOMING_REL), {
+    await writeCompressedJson(join(workspace.dir, this.paths.incoming), {
       schemaVersion: STATE_SCHEMA_VERSION,
       files: incoming,
     } satisfies StoredBaseline);
-    await atomicWriteJson(join(workspace.dir, JOURNAL_REL), journal);
+    await atomicWriteJson(join(workspace.dir, this.paths.journal), journal);
 
     try {
       for (const path of changedPaths) {
@@ -334,8 +371,8 @@ export class TemplateUpgradeManager {
         'commit', '--allow-empty', '-q', '-m', message,
       ]);
       const commit = (await runGit(workspace.dir, ['rev-parse', 'HEAD'])).trim();
-      await persistAppliedState(workspace.dir, template, incoming, 'upgrade', commit);
-      await rm(join(workspace.dir, TRANSACTION_DIR_REL), { recursive: true, force: true });
+      await persistAppliedState(workspace.dir, template, incoming, 'upgrade', commit, this.paths);
+      await rm(join(workspace.dir, this.paths.transaction), { recursive: true, force: true });
       this.opts.logger.info('template_upgrade.applied', {
         workspaceId: workspace.id,
         fromVersion: plan.fromVersion,
@@ -368,8 +405,8 @@ export class TemplateUpgradeManager {
     template: TemplateMeta,
     incoming: Snapshot,
   ): Promise<TemplateUpgradePlan> {
-    const state = await readState(workspace.dir);
-    const stored = state?.template === template.name ? await readBaseline(workspace.dir) : null;
+    const state = await readState(workspace.dir, this.paths);
+    const stored = state?.template === template.name ? await readBaseline(workspace.dir, this.paths) : null;
     const baseline = stored?.files ?? await readLegacyRootBaseline(workspace.dir);
     const source: TemplateUpgradePlan['source'] = stored
       ? 'recorded-baseline'
@@ -383,7 +420,7 @@ export class TemplateUpgradeManager {
       ...Object.keys(localSnapshot),
       ...Object.keys(incoming),
     ])]
-      .filter(isManagedTemplatePath)
+      .filter((path) => isManagedTemplatePath(path) && (this.opts.aliceHarness ? (isAliceHarnessSkillPath(path) || path === ALICE_HARNESS_CONFIG_PATH) : (!isAliceHarnessSkillPath(path) && path !== ALICE_HARNESS_CONFIG_PATH)))
       .sort();
     const localEntries = await Promise.all(paths.map((path) => readLocalFile(workspace.dir, path)));
     const files = paths.map((path, index) => classifyFile(
@@ -402,13 +439,14 @@ export class TemplateUpgradeManager {
     if ((await stagedPaths(workspace.dir)).length > 0) blockers.push('staged_changes');
     const fromVersion = state?.template === template.name
       ? state.appliedVersion
-      : workspace.spawnedFromVersion ?? 'unknown';
+      : this.opts.aliceHarness ? 'unversioned' : workspace.spawnedFromVersion ?? 'unknown';
     const planDigest = digestPlan({
       workspaceId: workspace.id,
       template: template.name,
       fromVersion,
       toVersion: template.version,
       baseline,
+      ...(this.opts.aliceHarness ? { config: await readAliceHarnessConfig(workspace.dir) } : {}),
       incoming,
       local: Object.fromEntries(paths.map((path, index) => [path, localEntries[index] ?? missingFile()])),
     });
@@ -433,33 +471,54 @@ export class TemplateUpgradeManager {
     };
   }
 
-  private materializeTemplate(template: TemplateMeta, workspaceId: string): Promise<Snapshot> {
-    return this.opts.materializeTemplate
-      ? this.opts.materializeTemplate(template, workspaceId)
-      : materializeTemplateSnapshot(template, workspaceId);
+  private async resolveTemplate(workspace: WorkspaceMeta): Promise<TemplateMeta> {
+    if (!this.opts.aliceHarness) return resolveUpgradeableTemplate(workspace, this.opts.templates);
+    const template = workspace.template ? this.opts.templates.get(workspace.template) : undefined;
+    if (!template) throw new TemplateUpgradeError('unsupported', 'Workspace template is unavailable');
+    return { ...template, name: 'alice-harness', version: await aliceHarnessSourceVersion(), upgradeStrategy: 'managed-context' };
+  }
+
+  private async materializeTemplate(template: TemplateMeta, workspaceId: string): Promise<Snapshot> {
+    if (this.opts.materializeTemplate) return this.opts.materializeTemplate(template, workspaceId);
+    if (!this.opts.aliceHarness) return materializeTemplateSnapshot(template, workspaceId);
+    const workspace = this.opts.registry.get(workspaceId)!;
+    const config = await readAliceHarnessConfig(workspace.dir);
+    const dir = await mkdtemp(join(tmpdir(), 'alice-harness-'));
+    try {
+      await injectAliceHarnessSkills(dir, template.injectTools, config);
+      const snapshot = { ...await readManagedWorkspaceSnapshot(dir) };
+      // Adopt legacy Workspaces through the same reviewed, recoverable transaction.
+      // Existing policy bytes are Workspace-owned and are never regenerated.
+      const existingConfig = await readLocalFile(workspace.dir, ALICE_HARNESS_CONFIG_PATH);
+      if (existingConfig.kind === 'missing') {
+        await atomicWriteJson(join(dir, ALICE_HARNESS_CONFIG_PATH), config);
+        snapshot[ALICE_HARNESS_CONFIG_PATH] = await readLocalFile(dir, ALICE_HARNESS_CONFIG_PATH);
+      } else snapshot[ALICE_HARNESS_CONFIG_PATH] = existingConfig;
+      return snapshot;
+    } finally { await rm(dir, { recursive: true, force: true }); }
   }
 
   private async recoverWorkspace(workspace: WorkspaceMeta): Promise<void> {
-    const journal = await readJson<UpgradeJournal>(join(workspace.dir, JOURNAL_REL));
+    const journal = await readJson<UpgradeJournal>(join(workspace.dir, this.paths.journal));
     if (!journal) return;
-    const incoming = await readCompressedJson<StoredBaseline>(join(workspace.dir, INCOMING_REL));
+    const incoming = await readCompressedJson<StoredBaseline>(join(workspace.dir, this.paths.incoming));
     const headMessage = await runGit(workspace.dir, ['log', '-1', '--pretty=%B']).catch(() => '');
     if (headMessage.includes(`OpenAlice-Template-Upgrade: ${journal.planDigest}`) && incoming) {
-      const template = this.opts.templates.get(journal.template);
+      const template = this.opts.aliceHarness ? await this.resolveTemplate(workspace) : this.opts.templates.get(journal.template);
       if (!template) throw new Error(`cannot recover missing template: ${journal.template}`);
       const commit = (await runGit(workspace.dir, ['rev-parse', 'HEAD'])).trim();
       await persistAppliedState(workspace.dir, {
         ...template,
         version: journal.toVersion,
-      }, incoming.files, 'upgrade', commit);
-      await rm(join(workspace.dir, TRANSACTION_DIR_REL), { recursive: true, force: true });
+      }, incoming.files, 'upgrade', commit, this.paths);
+      await rm(join(workspace.dir, this.paths.transaction), { recursive: true, force: true });
       this.opts.logger.info('template_upgrade.recovered_committed', {
         workspaceId: workspace.id,
         commit,
       });
       return;
     }
-    const before = await readCompressedJson<StoredBaseline>(join(workspace.dir, BEFORE_REL));
+    const before = await readCompressedJson<StoredBaseline>(join(workspace.dir, this.paths.before));
     if (!before) throw new Error('template upgrade recovery snapshot is missing');
     for (const path of journal.touchedPaths) {
       await writeSnapshotFile(workspace.dir, path, before.files[path] ?? missingFile());
@@ -467,7 +526,7 @@ export class TemplateUpgradeManager {
     if (journal.touchedPaths.length > 0) {
       await runGit(workspace.dir, ['reset', '-q', '--', ...journal.touchedPaths]).catch(() => '');
     }
-    await rm(join(workspace.dir, TRANSACTION_DIR_REL), { recursive: true, force: true });
+    await rm(join(workspace.dir, this.paths.transaction), { recursive: true, force: true });
     this.opts.logger.warn('template_upgrade.recovered_rollback', {
       workspaceId: workspace.id,
       preparedAt: journal.preparedAt,
@@ -480,10 +539,12 @@ export async function initializeWorkspaceTemplateState(
   workspace: WorkspaceMeta,
   template: TemplateMeta,
 ): Promise<void> {
-  if (template.upgradeStrategy !== 'managed-context') return;
   const snapshot = await readManagedWorkspaceSnapshot(workspace.dir);
+  const injected = Object.fromEntries(Object.entries(snapshot).filter(([path]) => isAliceHarnessSkillPath(path)));
+  await persistAppliedState(workspace.dir, { ...template, name: 'alice-harness', version: await aliceHarnessSourceVersion() }, injected, 'creation', undefined, upgradePaths(true));
+  if (template.upgradeStrategy !== 'managed-context') return;
   await ensureStateExcluded(workspace.dir);
-  await persistAppliedState(workspace.dir, template, snapshot, 'creation');
+  await persistAppliedState(workspace.dir, template, Object.fromEntries(Object.entries(snapshot).filter(([path]) => !isAliceHarnessSkillPath(path))), 'creation');
 }
 
 export function isManagedTemplatePath(path: string): boolean {
@@ -493,7 +554,7 @@ export function isManagedTemplatePath(path: string): boolean {
     || normalized.includes('\0')
     || normalized.split('/').some((part) => part === '' || part === '.' || part === '..')
   ) return false;
-  return MANAGED_ROOT_FILES.some((candidate) => normalized === candidate)
+  return normalized === ALICE_HARNESS_CONFIG_PATH || MANAGED_ROOT_FILES.some((candidate) => normalized === candidate)
     || normalized.startsWith('.agents/skills/')
     || normalized.startsWith('.claude/skills/')
     // Old Pi injection duplicated the shared skill tree. Treat it as legacy
@@ -648,7 +709,7 @@ async function materializeTemplateSnapshot(
       await mkdir(dir, { recursive: true });
       await writeFile(join(dir, 'README.md'), await readFile(template.readmePath, 'utf8'), 'utf8');
     }
-    await injectWorkspaceContext({ template, wsId: workspaceId, dir });
+    await injectWorkspaceContext({ template, wsId: workspaceId, dir, templateOnly: true });
     // Await inside the try. Returning the unresolved Promise would enter the
     // finally block first and delete the materialization while its recursive
     // reader is still walking — producing nondeterministic partial snapshots.
@@ -767,7 +828,7 @@ async function stagedPaths(workspaceDir: string): Promise<string[]> {
   return output.split(/\r?\n/).filter(Boolean);
 }
 
-async function ensureStateExcluded(workspaceDir: string): Promise<void> {
+async function ensureStateExcluded(workspaceDir: string, paths = TEMPLATE_PATHS): Promise<void> {
   const path = join(workspaceDir, '.git', 'info', 'exclude');
   await mkdir(dirname(path), { recursive: true });
   let current = '';
@@ -776,9 +837,11 @@ async function ensureStateExcluded(workspaceDir: string): Promise<void> {
   } catch (err) {
     if (!isENOENT(err)) throw err;
   }
-  if (current.split(/\r?\n/).includes(EXCLUDE_LINE)) return;
+  const excludes = [paths.exclude, ...(paths.state === ALICE_HARNESS_VERSION_PATH ? [`/${ALICE_HARNESS_VERSION_PATH}`] : [])];
+  const missing = excludes.filter((line) => !current.split(/\r?\n/).includes(line));
+  if (!missing.length) return;
   const separator = current.length === 0 || current.endsWith('\n') ? '' : '\n';
-  await writeFile(path, `${current}${separator}${EXCLUDE_LINE}\n`, 'utf8');
+  await writeFile(path, `${current}${separator}${missing.join('\n')}\n`, 'utf8');
 }
 
 async function persistAppliedState(
@@ -787,13 +850,14 @@ async function persistAppliedState(
   baseline: Snapshot,
   source: TemplateUpgradeState['source'],
   commit?: string,
+  paths = TEMPLATE_PATHS,
 ): Promise<void> {
-  await ensureStateExcluded(workspaceDir);
-  await writeCompressedJson(join(workspaceDir, BASELINE_REL), {
+  await ensureStateExcluded(workspaceDir, paths);
+  await writeCompressedJson(join(workspaceDir, paths.baseline), {
     schemaVersion: STATE_SCHEMA_VERSION,
     files: baseline,
   } satisfies StoredBaseline);
-  await atomicWriteJson(join(workspaceDir, STATE_REL), {
+  await atomicWriteJson(join(workspaceDir, paths.state), {
     schemaVersion: STATE_SCHEMA_VERSION,
     template: template.name,
     appliedVersion: template.version,
@@ -803,15 +867,15 @@ async function persistAppliedState(
   } satisfies TemplateUpgradeState);
 }
 
-async function readState(workspaceDir: string): Promise<TemplateUpgradeState | null> {
-  const parsed = await readJson<TemplateUpgradeState>(join(workspaceDir, STATE_REL));
+async function readState(workspaceDir: string, paths = TEMPLATE_PATHS): Promise<TemplateUpgradeState | null> {
+  const parsed = await readJson<TemplateUpgradeState>(join(workspaceDir, paths.state));
   if (!parsed || parsed.schemaVersion !== STATE_SCHEMA_VERSION) return null;
   if (typeof parsed.template !== 'string' || typeof parsed.appliedVersion !== 'string') return null;
   return parsed;
 }
 
-async function readBaseline(workspaceDir: string): Promise<StoredBaseline | null> {
-  const parsed = await readCompressedJson<StoredBaseline>(join(workspaceDir, BASELINE_REL));
+async function readBaseline(workspaceDir: string, paths = TEMPLATE_PATHS): Promise<StoredBaseline | null> {
+  const parsed = await readCompressedJson<StoredBaseline>(join(workspaceDir, paths.baseline));
   return parsed?.schemaVersion === STATE_SCHEMA_VERSION ? parsed : null;
 }
 

--- a/src/workspaces/workspace-creation.e2e.spec.ts
+++ b/src/workspaces/workspace-creation.e2e.spec.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { initializeWorkspaceTemplateState } from './template-upgrade.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import type { TemplateMeta } from './template-registry.js';
 import { commitInitial } from './workspace-creator.js';
@@ -119,6 +120,10 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
     await injectWorkspaceContext({ template: chatMeta(), wsId: 'ws-e2e-1', dir });
     // 3. launcher-owned initial commit
     await commitInitial(dir, 'chat: testtag');
+    await initializeWorkspaceTemplateState({ id: 'ws-e2e-1', tag: 'testtag', dir, createdAt: new Date().toISOString(), template: 'chat', spawnedFromVersion: '1.0.0' }, chatMeta());
+    const injection = JSON.parse(await readFile(join(dir, '.alice/alice-harness-version.json'), 'utf8'));
+    expect(injection.appliedVersion).toMatch(/^1\.0\.0\+/);
+    expect(injection.template).toBe('alice-harness');
 
     // injected files all present
     for (const rel of [
@@ -131,7 +136,8 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
       '.claude/skills/alice/SKILL.md',
       '.claude/skills/alice-analysis/SKILL.md',
       '.claude/skills/alice-uta/SKILL.md',
-      '.claude/skills/alice-workspace/SKILL.md',
+      '.claude/skills/alice/references/collaboration.md',
+      '.alice/alice-harness-config.json',
       '.claude/skills/traderhub/SKILL.md',
     ]) {
       expect(existsSync(join(dir, rel)), rel).toBe(true);

--- a/ui/src/components/workspace-capabilities/AliceHarnessPanel.tsx
+++ b/ui/src/components/workspace-capabilities/AliceHarnessPanel.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAliceHarness, type AliceHarnessConfig } from '../../hooks/useAliceHarness'
+import { Button } from '../ui/button'
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '../ui/dialog'
+import { WorkspaceTemplateUpgradePanel } from '../workspace/WorkspaceTemplateUpgradePanel'
+
+export function AliceHarnessPanel({ wsId, onChange }: { wsId: string; onChange(): void }) {
+  const { t } = useTranslation()
+  const state = useAliceHarness(wsId)
+  const [open, setOpen] = useState(false)
+  const [review, setReview] = useState(false)
+  const [draft, setDraft] = useState<AliceHarnessConfig | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  useEffect(() => { setDraft(state.data?.config ?? null) }, [state.data])
+  return <>
+    <div className="flex flex-wrap items-center gap-3 border-b border-border py-3 text-xs">
+      <strong>Alice Harness</strong>
+      <span className="min-w-0 flex-1 break-all text-muted-foreground">{state.error ?? (state.data ? state.data.appliedVersion ?? t('aliceHarness.unversioned') : t('common.loading'))}</span>
+      <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>{t('aliceHarness.manage')}</Button>
+    </div>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-h-[85vh] overflow-auto sm:max-w-3xl" closeLabel={t('common.close')}>
+        <DialogTitle>Alice Harness</DialogTitle>
+        <DialogDescription>{t('aliceHarness.description')}</DialogDescription>
+        {state.error && <Button variant="outline" onClick={state.refresh}>{t('common.retry')}</Button>}
+        {(!state.data && !state.error) && <p role="status">{t('common.loading')}</p>}
+        {(state.error || error) && <p role="alert">{state.error || error}</p>}
+        {state.data && draft && <>
+          <div className="space-y-1 break-all text-xs text-muted-foreground">
+            <p>{t('aliceHarness.applied')}: {state.data.appliedVersion ?? t('aliceHarness.unversioned')}</p>
+            <p>{t('aliceHarness.available')}: {state.data.availableVersion}</p>
+          </div>
+          {Object.entries(state.data.commands).map(([binary, groups]) => <fieldset key={binary} className="border-t border-border py-3">
+            <legend className="px-1 font-mono text-sm">{binary}</legend>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={draft.cli[binary]?.enabled !== false} onChange={(event) => setDraft({ ...draft, cli: { ...draft.cli, [binary]: { ...draft.cli[binary], enabled: event.target.checked } } })} />
+              {t('aliceHarness.enabled')}
+            </label>
+            <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {groups.map((group) => <label key={group} className="flex items-center gap-2 font-mono text-xs">
+                <input type="checkbox" disabled={draft.cli[binary]?.enabled === false} checked={draft.cli[binary]?.groups?.[group] !== false} onChange={(event) => setDraft({ ...draft, cli: { ...draft.cli, [binary]: { ...draft.cli[binary], groups: { ...draft.cli[binary]?.groups, [group]: event.target.checked } } } })} />
+                {group}
+              </label>)}
+            </div>
+          </fieldset>)}
+          <p className="text-xs text-muted-foreground">{t('aliceHarness.configHint')}</p>
+          <div className="flex flex-wrap gap-2">
+            <Button disabled={saving} onClick={() => { setSaving(true); setError(null); void state.save(draft).then(onChange).catch((err) => setError((err as Error).message)).finally(() => setSaving(false)) }}>{t('common.save')}</Button>
+            <Button variant="outline" onClick={() => setReview((value) => !value)}>{t('aliceHarness.review')}</Button>
+          </div>
+          {review && <WorkspaceTemplateUpgradePanel wsId={wsId} layer="alice-harness" onWorkspaceChanged={() => { state.refresh(); onChange() }} onClose={() => setReview(false)} />}
+        </>}
+      </DialogContent>
+    </Dialog>
+  </>
+}

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.spec.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.spec.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { i18n } from '../../i18n'
 import { CapabilityBrowser, CliBrowser } from './CapabilityBrowser'
+vi.mock('./AliceHarnessPanel', () => ({ AliceHarnessPanel: () => null }))
 vi.mock('../../hooks/useWorkspaceCapabilities', async (importOriginal) => ({
   ...(await importOriginal<
     typeof import('../../hooks/useWorkspaceCapabilities')

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
@@ -26,6 +26,7 @@ import {
   stripFrontmatter,
   type ReadFileResult,
 } from '../workspace/api'
+import { AliceHarnessPanel } from './AliceHarnessPanel'
 import { MirrorDetails } from './MirrorDetails'
 import './capabilities.css'
 
@@ -437,6 +438,7 @@ export function CliBrowser({ wsId }: { wsId: string }) {
   const current = filtered.find((c) => c.name === selected) ?? filtered[0]
   return (
     <>
+      <AliceHarnessPanel wsId={wsId} onChange={() => setAttempt((value) => value + 1)} />
       <div className="cap-section-intro">
         <div>
           <h2>{t('capabilities.cli')}</h2>

--- a/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.tsx
+++ b/ui/src/components/workspace/WorkspaceTemplateUpgradePanel.tsx
@@ -27,6 +27,7 @@ import {
 } from './api'
 
 interface Props {
+  readonly layer?: 'template' | 'alice-harness'
   readonly wsId: string
   readonly onWorkspaceChanged: () => void
   readonly onClose: () => void
@@ -39,6 +40,7 @@ interface Props {
  */
 export function WorkspaceTemplateUpgradePanel({
   wsId,
+  layer = 'template',
   onWorkspaceChanged,
   onClose,
 }: Props): ReactElement {
@@ -56,7 +58,7 @@ export function WorkspaceTemplateUpgradePanel({
     setError(null)
     setUnsupported(false)
     try {
-      const next = await getTemplateUpgradePlan(wsId)
+      const next = await (layer === 'template' ? getTemplateUpgradePlan(wsId) : getTemplateUpgradePlan(wsId, layer))
       setPlan(next)
       setResolutions((current) => Object.fromEntries(
         Object.entries(current).filter(([path]) =>
@@ -70,7 +72,7 @@ export function WorkspaceTemplateUpgradePanel({
     } finally {
       setLoading(false)
     }
-  }, [wsId])
+  }, [wsId, layer])
 
   useEffect(() => { void load() }, [load])
 
@@ -79,7 +81,7 @@ export function WorkspaceTemplateUpgradePanel({
     [plan],
   )
   const unresolved = conflicts.filter((file) => !resolutions[file.path]).length
-  const current = plan?.fromVersion === plan?.toVersion
+  const current = plan?.fromVersion === plan?.toVersion && (layer === 'template' || !plan?.files.some((file) => file.status === 'ready' || file.status === 'conflict'))
   const canApply = !!plan && !current && !plan.blocked && unresolved === 0 && !applying
 
   const apply = async (): Promise<void> => {
@@ -87,7 +89,7 @@ export function WorkspaceTemplateUpgradePanel({
     setApplying(true)
     setError(null)
     try {
-      const next = await applyTemplateUpgrade(wsId, plan.planDigest, resolutions)
+      const next = await (layer === 'template' ? applyTemplateUpgrade(wsId, plan.planDigest, resolutions) : applyTemplateUpgrade(wsId, plan.planDigest, resolutions, layer))
       setResult(next)
       onWorkspaceChanged()
       await load()
@@ -125,12 +127,12 @@ export function WorkspaceTemplateUpgradePanel({
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 text-[12px] font-semibold text-muted-foreground">
                     <FileDiff size={14} />
-                    {t('workspace.upgradeManagedAssets')}
+                    {layer === 'alice-harness' ? 'Alice Harness' : t('workspace.upgradeManagedAssets')}
                   </div>
                   <div className="mt-2 flex flex-wrap items-center gap-2 text-[18px] font-semibold text-foreground">
-                    <span>v{plan.fromVersion}</span>
+                    <span className="break-all">{plan.fromVersion === 'unversioned' ? t('aliceHarness.unversioned') : `v${plan.fromVersion}`}</span>
                     <ArrowRight size={17} className="text-muted-foreground" />
-                    <span className={current ? '' : 'text-primary'}>v{plan.toVersion}</span>
+                    <span className={`break-all ${current ? '' : 'text-primary'}`}>v{plan.toVersion}</span>
                   </div>
                   <p className="mt-1 max-w-xl text-[12px] leading-relaxed text-muted-foreground">
                     {current

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -188,8 +188,8 @@ export class TemplateUpgradeApiError extends Error {
   }
 }
 
-export async function getTemplateUpgradePlan(wsId: string): Promise<TemplateUpgradePlan> {
-  const res = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/template-upgrade`)
+export async function getTemplateUpgradePlan(wsId: string, layer: 'template' | 'alice-harness' = 'template'): Promise<TemplateUpgradePlan> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/${layer}-upgrade`)
   const body = await res.json().catch(() => ({})) as {
     plan?: TemplateUpgradePlan
     error?: string
@@ -210,8 +210,9 @@ export async function applyTemplateUpgrade(
   wsId: string,
   planDigest: string,
   resolutions: Readonly<Record<string, TemplateUpgradeResolution>>,
+  layer: 'template' | 'alice-harness' = 'template',
 ): Promise<TemplateUpgradeResult> {
-  const res = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/template-upgrade`, {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(wsId)}/${layer}-upgrade`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ planDigest, resolutions }),

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw'
+import type { AliceHarnessConfig } from '../../hooks/useAliceHarness'
 import {
   DEMO_AUTO_QUANT_WORKSPACE_ID,
   DEMO_AUTO_PREDICTION_WORKSPACE_ID,
@@ -388,7 +389,7 @@ const demoTemplateUpgradePlan = (workspaceId: string) => ({
       currentTruncated: false, templateTruncated: false,
     },
     {
-      path: '.agents/skills/alice/SKILL.md', status: 'ready', operation: 'update', canUseTemplate: true,
+      path: '.agents/skills/template-research/SKILL.md', status: 'ready', operation: 'update', canUseTemplate: true,
       currentPreview: 'Old collaboration guidance.', templatePreview: 'Current collaboration guidance.',
       currentTruncated: false, templateTruncated: false,
     },
@@ -399,7 +400,7 @@ const demoTemplateUpgradePlan = (workspaceId: string) => ({
       note: 'Changed only in this Workspace; it will stay as-is.',
     },
     {
-      path: '.claude/skills/self-scheduling/SKILL.md', status: 'conflict', operation: 'update', canUseTemplate: true,
+      path: '.claude/skills/template-research/SKILL.md', status: 'conflict', operation: 'update', canUseTemplate: true,
       currentPreview: 'Report scheduled work to the owner with the local checklist.',
       templatePreview: 'Report scheduled work to Inbox with a signed artifact.',
       currentTruncated: false, templateTruncated: false,
@@ -408,6 +409,9 @@ const demoTemplateUpgradePlan = (workspaceId: string) => ({
   ],
   summary: { ready: 2, preserved: 1, conflicts: 1, unchanged: 0 },
 })
+
+const demoHarnessConfigs = new Map<string, AliceHarnessConfig>()
+const demoHarnessCommands = { alice: ['rss', 'market', 'analysis', 'peer', 'inbox', 'issue', 'harness'], traderhub: ['equity', 'economy'], 'alice-uta': ['account', 'order'] }
 
 export const workspacesHandlers = [
   http.get('/api/workspaces/auto-quant/default-workspace', () => {
@@ -658,6 +662,22 @@ export const workspacesHandlers = [
     })
     return HttpResponse.json({ ok: true })
   }),
+  http.get('/api/workspaces/:id/alice-harness', ({ params }) => HttpResponse.json({
+    appliedVersion: '1.0.0+demo', availableVersion: '1.1.0+demo', runtimeAuthority: 'alice-project',
+    config: demoHarnessConfigs.get(String(params.id)) ?? { schemaVersion: 1, cli: {} },
+    commands: demoHarnessCommands,
+  })),
+  http.put('/api/workspaces/:id/alice-harness/config', async ({ params, request }) => {
+    demoHarnessConfigs.set(String(params.id), await request.json() as AliceHarnessConfig)
+    return HttpResponse.json({ ok: true })
+  }),
+  http.get('/api/workspaces/:id/alice-harness-upgrade', ({ params }) => HttpResponse.json({ plan: {
+    ...demoTemplateUpgradePlan(String(params.id)), template: 'alice-harness',
+    fromVersion: '1.0.0+demo', toVersion: '1.1.0+demo',
+    files: demoTemplateUpgradePlan(String(params.id)).files.filter((file) => file.path.includes('/skills/')).map((file) => ({ ...file, path: file.path.replace('template-research', 'alice') })),
+    summary: { ready: 1, preserved: 0, conflicts: 1, unchanged: 0 },
+  } })),
+  http.post('/api/workspaces/:id/alice-harness-upgrade', () => HttpResponse.json({ error: 'demo_read_only', message: 'This recorded preview does not modify Workspace files.' }, { status: 409 })),
   http.get('/api/workspaces/:id/template-upgrade', ({ params }) => {
     const workspace = demoWorkspaces.find((candidate) => candidate.id === String(params.id))
     if (!workspace) return HttpResponse.json({ error: 'not_found' }, { status: 404 })
@@ -999,10 +1019,15 @@ export const workspacesHandlers = [
   http.get('/api/workspaces/:id/git/status', () =>
     HttpResponse.json({ branch: 'main', clean: true, files: [] }),
   ),
-  http.get('/api/workspaces/:id/cli/:export/manifest', ({ params }) => HttpResponse.json({
-    export: params.export, description: 'Demonstration command catalog', groupDescriptions: { help: 'Discover this CLI' },
-    groups: { help: { show: { description: 'Demonstration command. Production uses the live registry.', schema: { type: 'object', properties: { topic: { type: 'string', description: 'Topic to inspect' } }, required: ['topic'] } } } },
-  })),
+  http.get('/api/workspaces/:id/cli/:export/manifest', ({ params }) => {
+    const binary = params.export === 'data' ? 'alice' : params.export === 'traderhub' ? 'traderhub' : 'alice-uta'
+    const policy = demoHarnessConfigs.get(String(params.id))?.cli[binary]
+    const groups = policy?.enabled === false ? [] : demoHarnessCommands[binary].filter((group) => policy?.groups?.[group] !== false)
+    return HttpResponse.json({
+      export: params.export, description: 'Demonstration command catalog',
+      groups: Object.fromEntries(groups.map((group) => [group, { show: { description: 'Demonstration command. Production uses the live registry.', schema: { type: 'object', properties: {} } } }])),
+    })
+  }),
   http.get('/api/workspaces/:id/files', ({ params, request }) => {
     const path = new URL(request.url).searchParams.get('path') ?? ''
     const listing = demoDirectoryListing(String(params.id), path)

--- a/ui/src/hooks/useAliceHarness.spec.ts
+++ b/ui/src/hooks/useAliceHarness.spec.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { fetchJson } from '../api/client'
+import { useAliceHarness } from './useAliceHarness'
+vi.mock('../api/client', () => ({ fetchJson: vi.fn() }))
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+it('loads the selected Workspace and reloads after saving configuration', async () => {
+  const data = { appliedVersion: null, availableVersion: '1.0.0', config: { schemaVersion: 1 as const, cli: {} }, commands: { alice: ['rss'] } }
+  vi.mocked(fetchJson).mockResolvedValue(data)
+  const { result, rerender } = renderHook(({ id }) => useAliceHarness(id), { initialProps: { id: 'one' } })
+  expect(result.current.data).toBeNull()
+  await waitFor(() => expect(result.current.data).toEqual(data))
+  await act(async () => { await result.current.save(data.config) })
+  expect(fetchJson).toHaveBeenCalledWith('/api/workspaces/one/alice-harness/config', expect.objectContaining({ method: 'PUT', body: JSON.stringify(data.config) }))
+  rerender({ id: 'two' })
+  await waitFor(() => expect(fetchJson).toHaveBeenCalledWith('/api/workspaces/two/alice-harness', expect.anything()))
+})
+it('surfaces read failures instead of inventing a version', async () => {
+  vi.mocked(fetchJson).mockRejectedValue(new Error('invalid config'))
+  const { result } = renderHook(() => useAliceHarness('one'))
+  await waitFor(() => expect(result.current.error).toBe('invalid config'))
+  expect(result.current.data).toBeNull()
+})

--- a/ui/src/hooks/useAliceHarness.ts
+++ b/ui/src/hooks/useAliceHarness.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react'
+import { fetchJson } from '../api/client'
+export interface AliceHarnessConfig {
+  schemaVersion: 1
+  cli: Record<string, { enabled?: boolean; groups?: Record<string, boolean> }>
+}
+export interface AliceHarnessStatus {
+  appliedVersion: string | null
+  availableVersion: string
+  config: AliceHarnessConfig
+  commands: Record<string, string[]>
+}
+export function useAliceHarness(wsId: string) {
+  const [data, setData] = useState<AliceHarnessStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [revision, setRevision] = useState(0)
+  const refresh = useCallback(() => setRevision((value) => value + 1), [])
+  useEffect(() => {
+    const controller = new AbortController()
+    setData(null)
+    setError(null)
+    void fetchJson<AliceHarnessStatus>(`/api/workspaces/${encodeURIComponent(wsId)}/alice-harness`, { signal: controller.signal })
+      .then((value) => { if (!controller.signal.aborted) setData(value) })
+      .catch((err) => { if (!controller.signal.aborted) setError((err as Error).message) })
+    return () => controller.abort()
+  }, [wsId, revision])
+  const save = async (config: AliceHarnessConfig) => {
+    await fetchJson(`/api/workspaces/${encodeURIComponent(wsId)}/alice-harness/config`, {
+      method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(config),
+    })
+    refresh()
+  }
+  return { data, error, refresh, save }
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -13,6 +13,17 @@
  */
 
 export const en = {
+  aliceHarness: {
+    "unversioned": "Not recorded",
+    "manage": "Manage",
+    "description": "Alice Project supplies CLI and companion Skills. Upgrade this layer independently of Chat, AutoQuant or Auto Prediction. Commands run on the current Project runtime; the recorded revision does not pin an older executable.",
+    "applied": "Injected revision",
+    "available": "Available from Project",
+    "enabled": "Enable CLI",
+    "configHint": "Save command switches first, then preview the skill update. Pause active Sessions before saving or upgrading. Local file customizations are reviewed, not overwritten.",
+    "review": "Review injection update"
+},
+
   mirrors: {
     "canonical": "Primary source",
     "mirror-only": "Mirror only",

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -2,6 +2,17 @@ import type { Resources } from './en'
 
 /** 日本語. Typed as `Resources` → must match en's key structure exactly. */
 export const ja: Resources = {
+  aliceHarness: {
+    "unversioned": "未記録",
+    "manage": "管理",
+    "description": "CLI と付属 Skills は Alice Project が提供し、Chat、AutoQuant、Auto Prediction とは独立して更新できます。コマンドは現在の Project ランタイムで実行され、記録された版は古い実行ファイルを固定しません。",
+    "applied": "注入済みバージョン",
+    "available": "Project の提供バージョン",
+    "enabled": "CLI を有効化",
+    "configHint": "コマンド設定を保存してからスキル更新を確認してください。保存・更新前に実行中のセッションを停止します。ローカル変更は比較され、自動で上書きされません。",
+    "review": "注入更新を確認"
+},
+
   mirrors: {
     "canonical": "正本",
     "mirror-only": "ミラーのみ",

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -10,6 +10,17 @@ import type { Resources } from './en'
  * Content is UI chrome only — no geographic or other non-technical terms.
  */
 export const zhHant: Resources = {
+  aliceHarness: {
+    "unversioned": "尚未記錄",
+    "manage": "管理",
+    "description": "CLI 與配套 Skills 由 Alice Project 提供，可獨立於 Chat、AutoQuant 和 Auto Prediction 升級。命令由目前 Project 執行環境執行，記錄版本不代表鎖定舊版執行檔。",
+    "applied": "已注入版本",
+    "available": "Project 可用版本",
+    "enabled": "啟用 CLI",
+    "configHint": "先儲存命令開關，再預覽技能更新。儲存或升級前需暫停使用中的會話；本機檔案修改會進入比較，不會直接覆寫。",
+    "review": "預覽注入升級"
+},
+
   mirrors: {
     "canonical": "主源",
     "mirror-only": "僅有鏡像",

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -2,6 +2,17 @@ import type { Resources } from './en'
 
 /** 简体中文. Typed as `Resources` → must match en's key structure exactly. */
 export const zh: Resources = {
+  aliceHarness: {
+    "unversioned": "尚未记录",
+    "manage": "管理",
+    "description": "CLI 和配套 Skills 由 Alice Project 提供，可独立于 Chat、AutoQuant 和 Auto Prediction 升级。命令由当前 Project 运行时执行，已记录版本不代表锁定旧版可执行程序。",
+    "applied": "已注入版本",
+    "available": "Project 可用版本",
+    "enabled": "启用 CLI",
+    "configHint": "先保存命令开关，再预览技能更新。保存或升级前需暂停活跃会话；本地文件改动会进入比较，不会直接覆盖。",
+    "review": "预览注入升级"
+},
+
   mirrors: {
     "canonical": "主源",
     "mirror-only": "仅有镜像",


### PR DESCRIPTION
Workspace CLI and companion Skills previously shared template injection without an independently reviewable revision or command policy. This change makes Alice Project the source of an Alice Harness injection release, with separate `.alice/alice-harness-version.json` and `.alice/alice-harness-config.json` in each Workspace.

- Separate Alice-owned Skills from Chat/AQ/AP template upgrades. Reuse three-way preview, conflict handling, checkout guards and transactional recovery for independent updates, including legacy adoption and configuration-only reconciliation.
- Enforce CLI and command-group switches in both manifests and invocation, including the legacy alias. Expose configuration and upgrade review in Workspace details and `alice harness upgrade`.
- Keep the running Project authoritative for executable behavior: the recorded injection revision does not pin an older runtime. Config is customization, not an agent sandbox.

Validation: complete hermetic suite (750 files, 6,715 passed, 3 skipped); root and UI typechecks; Workspace creation integration (4 passed); final affected gateway/tool/UI closure (47 passed); packaged Electron Workspace acceptance including shell CLI, managed Pi and scheduled work. Walked the real details route, actual shell preview, AQ/AP independent previews, and demo configuration save/filter behavior. Existing user Workspaces were previewed without applying their upgrades.
