### PR TITLE
feat(ui): distinguish Alice Harness injection from Workspace content

### DIFF
--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -109,6 +109,16 @@ primary source, `.claude/skills` is its runtime mirror, and existing `.pi/skills
 entries are legacy copies. Instructions similarly present AGENTS.md with its
 CLAUDE.md mirror. Missing primary sources retain inspectable runtime copies.
 
+The browser separately groups ownership into Alice Harness injection and
+Workspace-supplied content. The Project exposes its managed Skill names,
+including legacy injection names; the frontend does not maintain a second
+allowlist. Workspace-supplied includes template content and local additions,
+not proof of upstream provenance. AGENTS.md/CLAUDE.md belong to the Workspace
+instruction layer. Mirror location and divergence do not change ownership.
+A failed ownership lookup leaves files readable under an unknown-source group.
+The CLI tab inventories Alice Harness exports only, not arbitrary executables
+installed by a Workspace.
+
 Selecting an item compares its complete directory (including supporting files
 and empty folders). Missing, extra and changed entries have a side-by-side text
 view. Links, read failures, oversized or undecodable content and traversal limits

--- a/src/workspaces/template-upgrade.spec.ts
+++ b/src/workspaces/template-upgrade.spec.ts
@@ -78,6 +78,12 @@ afterEach(async () => rm(root, {
 }));
 
 describe('TemplateUpgradeManager', () => {
+  it('exposes the injection-owned Skill inventory including legacy names', async () => {
+    const status = await manager(false, true).harnessStatus(workspace.id);
+    expect(status.managedSkillNames).toEqual(expect.arrayContaining(['alice', 'traderhub', 'alice-workspace']));
+    expect(status.managedSkillNames).not.toContain('template-skill');
+  });
+
   it('adopts missing policy transactionally and reconciles a disable at the same revision', async () => {
     const upgrade = new TemplateUpgradeManager({ registry, templates: { get: () => template } as unknown as TemplateRegistry, logger, aliceHarness: true });
     const preview = await upgrade.plan(workspace.id);

--- a/src/workspaces/template-upgrade.ts
+++ b/src/workspaces/template-upgrade.ts
@@ -20,7 +20,7 @@ import { exec as gitExec, type IGitStringExecutionOptions } from './git-executio
 
 import { CLI_EXPORTS } from '../server/cli-commands.js';
 import { aliceHarnessSourceVersion, injectAliceHarnessSkills } from './alice-harness-assets.js';
-import { ALICE_HARNESS_VERSION_PATH, ALICE_HARNESS_CONFIG_PATH, parseAliceHarnessConfig, isAliceHarnessSkillPath, readAliceHarnessConfig } from './alice-harness-policy.js';
+import { ALICE_HARNESS_VERSION_PATH, ALICE_HARNESS_CONFIG_PATH, LEGACY_ALICE_HARNESS_SKILLS, parseAliceHarnessConfig, isAliceHarnessSkillPath, readAliceHarnessConfig } from './alice-harness-policy.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import type { Logger } from './logger.js';
 import type { TemplateMeta, TemplateRegistry } from './template-registry.js';
@@ -207,6 +207,7 @@ export class TemplateUpgradeManager {
       appliedVersion: await this.currentVersion(workspace) ?? null,
       availableVersion: await aliceHarnessSourceVersion(),
       runtimeAuthority: 'alice-project' as const,
+      managedSkillNames: [...LEGACY_ALICE_HARNESS_SKILLS],
       config: await readAliceHarnessConfig(workspace.dir),
       commands: Object.fromEntries(Object.values(CLI_EXPORTS).filter((exp) => exp.binary !== 'alice-workspace').map((exp) => [exp.binary, Object.keys(exp.commands)])),
     };

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.spec.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.spec.tsx
@@ -16,6 +16,7 @@ vi.mock('../../hooks/useWorkspaceCapabilities', async (importOriginal) => ({
       skills: [
         {
           name: 'alpha',
+          owner: 'alice-harness',
           path: '.agents/skills/alpha/SKILL.md',
           locations: ['.agents/skills/alpha/SKILL.md'],
           content: {
@@ -25,6 +26,7 @@ vi.mock('../../hooks/useWorkspaceCapabilities', async (importOriginal) => ({
         },
         {
           name: 'beta',
+          owner: 'workspace',
           path: '.agents/skills/beta/SKILL.md',
           locations: ['.agents/skills/beta/SKILL.md'],
           content: { kind: 'ok', content: '# Beta method' },
@@ -92,4 +94,14 @@ it('collapses command groups without losing the reader and reveals search matche
   expect(group.getAttribute('aria-expanded')).toBe('false')
   fireEvent.click(group)
   expect(screen.getByRole('button', { name: 'inspect' })).toBeTruthy()
+})
+
+it('separates ownership groups while keeping source/mirror identity independent', () => {
+  render(<CapabilityBrowser wsId="one" view="skills" resolvePath={(p) => p} />)
+  expect(screen.getByRole('heading', { name: 'Alice Harness injected 1' })).toBeTruthy()
+  expect(screen.getByRole('heading', { name: 'Workspace supplied 1' })).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: /beta/ }))
+  expect(screen.getByText(/Supplied by the Workspace template or added locally/)).toBeTruthy()
+  fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'beta' } })
+  expect(screen.queryByRole('heading', { name: /Alice Harness injected 1/ })).toBeNull()
 })

--- a/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
+++ b/ui/src/components/workspace-capabilities/CapabilityBrowser.tsx
@@ -17,6 +17,7 @@ import { FileContentView } from '../FileContentView'
 import { CenteredLoading } from '../StateViews'
 import {
   cliExports,
+  type CapabilityOwner,
   useWorkspaceCapabilities,
   useWorkspaceCli,
 } from '../../hooks/useWorkspaceCapabilities'
@@ -203,6 +204,13 @@ function SkillFiles({
   )
 }
 
+const capabilityOwners: CapabilityOwner[] = ['alice-harness', 'workspace', 'unknown']
+const ownerKeys = {
+  'alice-harness': 'ownerAlice',
+  workspace: 'ownerWorkspace',
+  unknown: 'ownerUnknown',
+} as const
+
 export function CapabilityBrowser({
   wsId,
   view,
@@ -228,11 +236,13 @@ export function CapabilityBrowser({
       !data ? [] : view === 'instructions' ? data.instructions : data.skills,
     [data, view],
   )
-  const filtered = items.filter((i) =>
-    `${i.name} ${i.path} ${i.content.kind === 'ok' ? i.content.content : ''}`
-      .toLowerCase()
-      .includes(query.toLowerCase()),
-  )
+  const filtered = [...items]
+    .sort((a, b) => capabilityOwners.indexOf(a.owner ?? 'unknown') - capabilityOwners.indexOf(b.owner ?? 'unknown'))
+    .filter((i) =>
+      `${i.name} ${i.path} ${i.content.kind === 'ok' ? i.content.content : ''}`
+        .toLowerCase()
+        .includes(query.toLowerCase()),
+    )
   const current = filtered.find((i) => i.path === selected) ?? filtered[0]
   const attachment =
     attachmentChoice?.owner === current?.path
@@ -283,7 +293,8 @@ export function CapabilityBrowser({
         <div>
           <span className="cap-eyebrow">03 · LIFECYCLE</span>
           <h2>{t('capabilities.upgrades')}</h2>
-          <p>{t('capabilities.upgradesHint')}</p>
+          <p>{t('capabilities.ownerAliceHint')}</p>
+          <p>{t('capabilities.ownerWorkspaceHint')}</p>
         </div>
         {data.errors.map((e) => (
           <p key={e} role="alert">
@@ -324,25 +335,34 @@ export function CapabilityBrowser({
         <aside className="cap-directory">
           <SearchBox value={query} onChange={setQuery} />
           <nav aria-label={t(`capabilities.${view}`)}>
-            {filtered.map((i) => (
-              <button
-                className="cap-row"
-                aria-current={current?.path === i.path ? 'page' : undefined}
-                key={i.path}
-                onClick={() => {
-                  setSelected(i.path)
-                  setAttachment(undefined)
-                  setMobileDetail(true)
-                }}
-              >
-                <BookOpen size={15} aria-hidden />
-                <span>
-                  <strong>{i.name}</strong>
-                  <small>{t(`mirrors.${i.source ?? 'canonical'}`)}</small>
-                </span>
-                <ChevronRight size={13} aria-hidden />
-              </button>
-            ))}
+            {capabilityOwners.map((owner) => {
+              const owned = filtered.filter((item) => (item.owner ?? 'unknown') === owner)
+              if (!owned.length) return null
+              return (
+                <section className="cap-origin-group" key={owner} aria-label={t(`capabilities.${ownerKeys[owner]}`)}>
+                  <h3>{t(`capabilities.${ownerKeys[owner]}`)} <span>{owned.length}</span></h3>
+                  {owned.map((i) => (
+                    <button
+                      className="cap-row"
+                      aria-current={current?.path === i.path ? 'page' : undefined}
+                      key={i.path}
+                      onClick={() => {
+                        setSelected(i.path)
+                        setAttachment(undefined)
+                        setMobileDetail(true)
+                      }}
+                    >
+                      <BookOpen size={15} aria-hidden />
+                      <span>
+                        <strong>{i.name}</strong>
+                        <small>{t(`mirrors.${i.source ?? 'canonical'}`)}</small>
+                      </span>
+                      <ChevronRight size={13} aria-hidden />
+                    </button>
+                  ))}
+                </section>
+              )
+            })}
           </nav>
           {!filtered.length && (
             <p className="cap-empty">{t('capabilities.empty')}</p>
@@ -362,9 +382,10 @@ export function CapabilityBrowser({
             <>
               <div className="cap-reader-heading">
                 <span className="cap-eyebrow">
-                  {t('capabilities.workspaceFile')}
+                  {t(`capabilities.${ownerKeys[current.owner ?? 'unknown']}`)}
                 </span>
                 <h2>{current.name}</h2>
+                <p>{t(`capabilities.${ownerKeys[current.owner ?? 'unknown']}Hint`)}</p>
                 {current.description && <p>{current.description}</p>}
                 <code className="cap-path">{current.path}</code>
               </div>
@@ -442,7 +463,7 @@ export function CliBrowser({ wsId }: { wsId: string }) {
       <div className="cap-section-intro">
         <div>
           <h2>{t('capabilities.cli')}</h2>
-          <p>{t('capabilities.cliHint')}</p>
+          <p>{t('capabilities.cliOwnerHint')}</p>
         </div>
         <span className="cap-live">{t('capabilities.live')}</span>
       </div>

--- a/ui/src/components/workspace-capabilities/capabilities.css
+++ b/ui/src/components/workspace-capabilities/capabilities.css
@@ -425,3 +425,21 @@
 @media (prefers-reduced-motion: reduce) {
   .cap-cli-group-trigger svg { transition: none; }
 }
+
+.cap-origin-group h3 {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 13px; font-weight: 600; color: var(--foreground);
+  padding: 16px 9px 6px;
+}
+.cap-origin-group h3 span { font-size: 11px; font-weight: 400; color: var(--muted-foreground); }
+.cap-origin-group .cap-row {
+  margin-left: 8px;
+  width: calc(100% - 8px);
+  min-height: 36px;
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+.cap-origin-group .cap-row > span { display: flex; align-items: baseline; gap: 8px; }
+.cap-origin-group .cap-row strong { flex: 1; }
+.cap-origin-group .cap-row small { margin-top: 0; white-space: nowrap; }
+@media (pointer: coarse) { .cap-origin-group .cap-row { min-height: 44px; } }

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -664,6 +664,7 @@ export const workspacesHandlers = [
   }),
   http.get('/api/workspaces/:id/alice-harness', ({ params }) => HttpResponse.json({
     appliedVersion: '1.0.0+demo', availableVersion: '1.1.0+demo', runtimeAuthority: 'alice-project',
+    managedSkillNames: ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'self-scheduling', 'alice-workspace'],
     config: demoHarnessConfigs.get(String(params.id)) ?? { schemaVersion: 1, cli: {} },
     commands: demoHarnessCommands,
   })),

--- a/ui/src/hooks/useAliceHarness.ts
+++ b/ui/src/hooks/useAliceHarness.ts
@@ -5,6 +5,7 @@ export interface AliceHarnessConfig {
   cli: Record<string, { enabled?: boolean; groups?: Record<string, boolean> }>
 }
 export interface AliceHarnessStatus {
+  managedSkillNames: string[]
   appliedVersion: string | null
   availableVersion: string
   config: AliceHarnessConfig

--- a/ui/src/hooks/useWorkspaceCapabilities.spec.ts
+++ b/ui/src/hooks/useWorkspaceCapabilities.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   loadWorkspaceCapabilities,
   useWorkspaceCapabilities,
@@ -16,6 +16,7 @@ vi.mock('../components/workspace/api', () => ({
   readWorkspaceFile: mocks.read,
 }))
 vi.mock('../api/client', () => ({ fetchJson: mocks.json }))
+beforeEach(() => { mocks.json.mockResolvedValue({ managedSkillNames: ['same', 'alice-workspace'] }) })
 afterEach(() => {
   cleanup()
   vi.resetAllMocks()
@@ -42,6 +43,9 @@ describe('Workspace capability inventory', () => {
     }))
     const data = await loadWorkspaceCapabilities('one')
     expect(data.skills).toHaveLength(2)
+    expect(data.skills.find((s) => s.name === 'same')?.owner).toBe('alice-harness')
+    expect(data.skills.find((s) => s.name === 'changed')?.owner).toBe('workspace')
+    expect(data.instructions[0]?.owner).toBe('workspace')
     expect(data.skills.find((s) => s.name === 'same')?.locations).toHaveLength(
       2,
     )
@@ -118,4 +122,13 @@ it('keeps an orphan Claude skill inspectable under one identity', async () => {
     source: 'mirror-only',
     path: 'CLAUDE.md',
   })
+})
+
+it('keeps files readable with unknown ownership when the Project inventory fails', async () => {
+  mocks.json.mockRejectedValue(new Error('offline'))
+  mocks.list.mockImplementation(async (_id, path) => path === '' ? listing('.agents') : path === '.agents' ? listing('skills') : listing('same'))
+  mocks.read.mockResolvedValue({ kind: 'ok', content: 'local text' })
+  const data = await loadWorkspaceCapabilities('one')
+  expect(data.skills[0]).toMatchObject({ owner: 'unknown', content: { kind: 'ok' } })
+  expect(data.errors).toContain('Alice Harness: offline')
 })

--- a/ui/src/hooks/useWorkspaceCapabilities.ts
+++ b/ui/src/hooks/useWorkspaceCapabilities.ts
@@ -37,7 +37,9 @@ export interface CliManifest {
     >
   >
 }
+export type CapabilityOwner = 'alice-harness' | 'workspace' | 'unknown'
 export interface WorkspaceSkill {
+  owner?: CapabilityOwner
   name: string
   description?: string
   path: string
@@ -60,7 +62,15 @@ export async function loadWorkspaceCapabilities(
   const roots: string[] = []
   const errors: string[] = []
   const skills: WorkspaceSkill[] = []
-  const root = await listFiles(wsId, '')
+  const [root, ownership] = await Promise.all([
+    listFiles(wsId, ''),
+    fetchJson<{ managedSkillNames: string[] }>(`/api/workspaces/${encodeURIComponent(wsId)}/alice-harness`)
+      .then((value) => {
+        if (!value || !Array.isArray(value.managedSkillNames) || !value.managedSkillNames.every((name) => typeof name === 'string')) throw new Error('Alice Harness ownership inventory unavailable')
+        return new Set(value.managedSkillNames)
+      })
+      .catch((error) => { errors.push(`Alice Harness: ${error instanceof Error ? error.message : String(error)}`); return null }),
+  ])
   await Promise.all(
     ['.agents', '.claude', '.pi'].map(async (parent) => {
       if (
@@ -105,6 +115,7 @@ export async function loadWorkspaceCapabilities(
     const chosen = primary ?? claude ?? pi!
     grouped.push({
       ...chosen,
+      owner: ownership ? ownership.has(name) ? 'alice-harness' : 'workspace' : 'unknown',
       locations: copies.map((s) => s.path),
       source: primary
         ? 'canonical'
@@ -133,6 +144,7 @@ export async function loadWorkspaceCapabilities(
   const instructions: WorkspaceSkill[] = [
     {
       name: 'AGENTS.md',
+      owner: 'workspace',
       path:
         agents.kind === 'file_missing' && claude.kind === 'ok'
           ? 'CLAUDE.md'

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -43,6 +43,14 @@ export const en = {
     "directory": "Directory"
 },
   capabilities: {
+    ownerAlice: "Alice Harness injected",
+    ownerWorkspace: "Workspace supplied",
+    ownerUnknown: "Source unavailable",
+    ownerAliceHint: "Managed by the Alice Project injection layer. Local edits remain part of this Workspace; upgrades review them before replacement.",
+    ownerWorkspaceHint: "Supplied by the Workspace template or added locally. This content follows the Workspace lifecycle, independently of Alice Harness injection.",
+    ownerUnknownHint: "The ownership inventory could not be loaded. Files remain readable; no source is assumed.",
+    cliOwnerHint: "These CLIs are supplied by Alice Harness. The live registry reflects this Workspace’s switches; commands installed by the Workspace itself are not inventoried here.",
+
     "search": "Search names and content…",
     "copy": "Copy command",
     "copyFailed": "Copy failed. Select the command to copy it.",

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -32,6 +32,14 @@ export const ja: Resources = {
     "directory": "ディレクトリ"
 },
   capabilities: {
+    ownerAlice: "Alice Harness が注入",
+    ownerWorkspace: "Workspace が提供",
+    ownerUnknown: "提供元を確認できません",
+    ownerAliceHint: "Alice Project の注入層が管理します。ローカルの変更は保持され、更新前に差分を確認します。",
+    ownerWorkspaceHint: "Workspace テンプレートまたはローカルで追加された内容です。Alice Harness の注入とは独立して管理されます。",
+    ownerUnknownHint: "提供元の一覧を読み込めません。ファイルは閲覧できますが、提供元は推測しません。",
+    cliOwnerHint: "Alice Harness が提供する CLI を表示します。一覧はこの Workspace の設定を反映し、Workspace 独自のコマンドは含みません。",
+
     "search": "名前と内容を検索…",
     "copy": "コマンドをコピー",
     "copyFailed": "コピーできませんでした。コマンドを選択してコピーしてください。",

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -40,6 +40,14 @@ export const zhHant: Resources = {
     "directory": "目錄"
 },
   capabilities: {
+    ownerAlice: "Alice Harness 注入",
+    ownerWorkspace: "Workspace 自帶",
+    ownerUnknown: "來源待確認",
+    ownerAliceHint: "由 Alice Project 注入層管理。本地修改仍屬於此工作區，升級時會先比較再處理。",
+    ownerWorkspaceHint: "來自工作區範本或後續本地新增，隨 Workspace 自身維護，與 Alice Harness 注入層獨立。",
+    ownerUnknownHint: "來源清單暫時無法讀取。仍可查閱檔案內容，暫不推斷歸屬。",
+    cliOwnerHint: "這裡展示 Alice Harness 提供的 CLI，即時清單反映此工作區的開關設定；不包含工作區自行安裝的其他命令。",
+
     "search": "搜尋名稱與內容…",
     "copy": "複製命令",
     "copyFailed": "複製失敗，請選取命令手動複製。",

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -32,6 +32,14 @@ export const zh: Resources = {
     "directory": "目录"
 },
   capabilities: {
+    ownerAlice: "Alice Harness 注入",
+    ownerWorkspace: "Workspace 自带",
+    ownerUnknown: "来源待确认",
+    ownerAliceHint: "由 Alice Project 注入层管理。本地修改仍属于此工作区，升级时会先比较再处理。",
+    ownerWorkspaceHint: "来自工作区模板或后续本地新增，随 Workspace 自身维护，与 Alice Harness 注入层独立。",
+    ownerUnknownHint: "来源清单暂时无法读取。仍可查阅文件内容，暂不推断归属。",
+    cliOwnerHint: "这里展示 Alice Harness 提供的 CLI，实时清单反映此工作区的开关配置；不包含工作区自行安装的其他命令。",
+
     "search": "搜索名称与内容…",
     "copy": "复制命令",
     "copyFailed": "复制失败，请选中命令手动复制。",


### PR DESCRIPTION
Workspace details mixed Project-injected capabilities and Workspace-owned content in one undifferentiated directory. Skills now group into Alice Harness injection and Workspace-supplied content, with counts and matching ownership explanations in the reader. Runtime mirrors remain copies of one Skill rather than a separate source.

The Project supplies the managed Skill names, including legacy injection names. Instructions remain Workspace-owned; the CLI reference explicitly scopes itself to Alice Harness exports. If ownership lookup fails, files remain readable under an unknown-source group. Workspace-supplied includes both template content and local additions, not proven upstream provenance.

The existing tabs, search, mobile list/detail transition and keyboard controls remain the interaction model. Compact neutral directory rows retain touch-sized targets; no new panel or custom focus primitive is introduced. Verified actual Chat Skills and Instructions routes and the demo route, including divergent mirrors. Root/UI typechecks and ownership/search/failure tests pass.

Complete hermetic suite: 750 files, 6,718 passed, 3 skipped.
