### PR TITLE
Prepare 0.92.0-beta.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.1",
+  "version": "0.92.0-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.1",
+  "version": "0.92.0-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Set the synchronized root and CLI package versions to 0.92.0-beta.1 for the accepted 0.92 product source. This PR changes only the two version fields and uses the exact-beta preparation gate.

Product acceptance is recorded in #1407: 6,751 passing tests, root/UI types, local packaged Workspace checks and native promotion/installer gates. After this PR's applicable checks pass and it merges, dispatch the beta Release on its exact master commit. Stable follows only after public beta acceptance through its separate version preparation and Release run.
