### PR TITLE
Sync accepted 0.92.0-beta.1 version to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.91.1",
+  "version": "0.92.0-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.91.1",
+  "version": "0.92.0-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Synchronize only the root and CLI package version values to the accepted 0.92.0-beta.1 release. Runtime source remains on dev; no master implementation changes are merged back.

Beta Release 34199497260 passed. Public beta manifest and fresh temporary CLI install resolve 0.92.0-beta.1; stable manifests, three updater feeds and five desktop download aliases remain unchanged. The shared installer's default plan still resolves stable 0.91.1.
