### PR TITLE
Fix Windows ASAR upgrade version detection

### DIFF
--- a/docs/managed-workspace-runtime.md
+++ b/docs/managed-workspace-runtime.md
@@ -270,6 +270,13 @@ which would remove Electron's own application metadata. Packaging commands run
 through `pnpm -F @traderalice/desktop` (the configured hook is relative to that
 working directory).
 
+Windows installed-version polling reads the authoritative `app.asar/package.json`
+when an archive exists, and the loose `app/package.json` for older releases.
+Clear the ASAR header cache between polls because NSIS replaces the archive in
+place. A partial archive must remain retryable rather than falling back to a
+stale loose manifest. Final installer completion and version detection remain
+separate checks before the upgrade journey launches the candidate.
+
 `asarUnpack` explicitly retains node-pty and dugite's embedded Git under
 `app.asar.unpacked`, with other native dependencies handled by builder's
 native-module detection. The package assertion verifies archive contents,

--- a/scripts/desktop-upgrade-smoke-lib.mjs
+++ b/scripts/desktop-upgrade-smoke-lib.mjs
@@ -1,5 +1,18 @@
-import { existsSync, lstatSync, readlinkSync } from 'node:fs'
+import { existsSync, lstatSync, readFileSync, readlinkSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { extractFile, uncache } from '@electron/asar'
+
+export function readInstalledDesktopVersion(installRoot) {
+  const resources = join(installRoot, 'resources')
+  const archive = join(resources, 'app.asar')
+  if (existsSync(archive)) {
+    // NSIS replaces this path in place. Never retain the previous archive header
+    // between polls, or fall back to a stale loose tree during replacement.
+    uncache(archive)
+    return JSON.parse(extractFile(archive, 'package.json').toString()).version
+  }
+  return JSON.parse(readFileSync(join(resources, 'app', 'package.json'), 'utf8')).version
+}
 
 export const DESKTOP_UPGRADE_RECEIPT_SCHEMA_VERSION = 1
 export const CHROMIUM_PROFILE_SINGLETON_NAMES = Object.freeze([

--- a/scripts/desktop-upgrade-smoke-lib.spec.ts
+++ b/scripts/desktop-upgrade-smoke-lib.spec.ts
@@ -1,8 +1,9 @@
-import { mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
+import { createPackage, uncacheAll } from '@electron/asar'
 
 import {
   buildDesktopUpgradeSmokePlan,
@@ -14,10 +15,39 @@ import {
   desktopUpgradeWorkspaceTags,
   inspectChromiumProfileSingleton,
   previousDesktopAssetName,
+  readInstalledDesktopVersion,
   selectPreviousDesktopTag,
   waitForChromiumProfileRelease,
   windowsInstallerArgs,
 } from './desktop-upgrade-smoke-lib.mjs'
+
+describe('installed desktop version during NSIS replacement', () => {
+  it('observes loose-to-ASAR and subsequent in-place ASAR upgrades', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'desktop-version-'))
+    try {
+      const loose = join(root, 'resources', 'app')
+      const input = join(root, 'archive-input')
+      const archive = join(root, 'resources', 'app.asar')
+      mkdirSync(loose, { recursive: true })
+      mkdirSync(input)
+      writeFileSync(join(loose, 'package.json'), JSON.stringify({ version: '0.91.1' }))
+      expect(readInstalledDesktopVersion(root)).toBe('0.91.1')
+      writeFileSync(join(input, 'package.json'), JSON.stringify({ version: '0.92.0' }))
+      await createPackage(input, archive)
+      // The old loose manifest must not win over the newly installed archive.
+      expect(readInstalledDesktopVersion(root)).toBe('0.92.0')
+      writeFileSync(join(input, 'package.json'), JSON.stringify({ version: '0.93.0-beta.1', padding: 'changed archive header and entry size' }))
+      await createPackage(input, archive)
+      expect(readInstalledDesktopVersion(root)).toBe('0.93.0-beta.1')
+      // A partially replaced archive is retryable, never a stale loose success.
+      writeFileSync(archive, 'partial')
+      expect(() => readInstalledDesktopVersion(root)).toThrow()
+    } finally {
+      uncacheAll()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
 
 describe('desktop upgrade smoke planning', () => {
   it('keeps the Windows builder and legacy takeover aligned with the upgrade contract', () => {

--- a/scripts/desktop-upgrade-smoke.mjs
+++ b/scripts/desktop-upgrade-smoke.mjs
@@ -26,6 +26,7 @@ import {
   DESKTOP_UPGRADE_RECEIPT_SCHEMA_VERSION,
   desktopUpgradeWorkspaceTags,
   previousDesktopAssetName,
+  readInstalledDesktopVersion,
   selectPreviousDesktopTag,
   versionFromTag,
   waitForChromiumProfileRelease,
@@ -99,7 +100,6 @@ async function waitForPath(path, timeoutMs = 30_000) {
 }
 
 async function waitForInstalledVersion(installRoot, expectedVersion, timeoutMs = 20 * 60_000) {
-  const packageJson = join(installRoot, 'resources', 'app', 'package.json')
   const startedAt = Date.now()
   const deadline = Date.now() + timeoutMs
   let lastObservedVersion = null
@@ -107,7 +107,7 @@ async function waitForInstalledVersion(installRoot, expectedVersion, timeoutMs =
   while (Date.now() < deadline) {
     let observedVersion = '<replacing>'
     try {
-      observedVersion = JSON.parse(readFileSync(packageJson, 'utf8')).version ?? '<missing>'
+      observedVersion = readInstalledDesktopVersion(installRoot) ?? '<missing>'
       if (observedVersion === expectedVersion) return
     } catch {
       // NSIS replaces the package tree in place; partial reads are expected while it runs.


### PR DESCRIPTION
Windows final-installer acceptance polls `resources/app/package.json` after NSIS exits. An ASAR candidate no longer has that path, so the verifier waits up to 20 minutes even after installation completes.

Read authoritative `app.asar/package.json` when present, retaining loose-package support for shipped older releases. Clear ASAR's header cache between polls for in-place replacement, and never accept a stale loose manifest when an archive exists but is incomplete. Installer-exit waiting and the subsequent real state/restart journey remain intact.

Validation: 56 upgrade/workflow/candidate/verifier tests passed, including real loose-to-ASAR and subsequent archive replacement fixtures plus partial-archive rejection; Node syntax checks passed. Full hermetic suite passed: 755 files, 6,752 tests, 3 skipped. Clean-build CI passed. The original native Windows log confirms NSIS exited 0 at 08:35:31 UTC, followed by 15 minutes of `<replacing>` from the obsolete manifest path before cancellation. The 0.92.0 release's already preserved signed candidates will be verified through the integrated verifier override; product source and bytes remain unchanged.
