### PR TITLE
Sync accepted 0.92.0 stable version to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.0-beta.1",
+  "version": "0.92.0",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.0-beta.1",
+  "version": "0.92.0",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Synchronize only the root and CLI version values to the accepted 0.92.0 stable release. Keep the integrated Windows ASAR upgrade-verifier fix on dev; no unrelated master implementation is merged back.

Stable Release 34207190294 passed all source, signed desktop/previous-stable upgrade, CLI, package-manager and public-byte gates. Product e85aa1bc and its preserved candidates were accepted with integrated verifier f8fc32df after #1411 repaired obsolete loose-manifest polling. Public stable manifest, desktop feeds and fresh temporary CLI install resolve 0.92.0; beta remains 0.92.0-beta.1. npm/Homebrew/AUR publication switches remain disabled.
