### PR TITLE
fix: keep RSS and website adapters optional in research guidance

### DIFF
--- a/default/alice-harness.json
+++ b/default/alice-harness.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Alice Project-provided Skills file bundle"
 }

--- a/default/skills/alice/SKILL.md
+++ b/default/skills/alice/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: alice
 description: >
-  Research and Workspace collaboration through the `alice` CLI. Data surfaces: the collected-RSS archive (`alice rss`), cross-asset symbol
-  search (`alice market search` → barIds), and K-line quant analysis
-  (`alice analysis`). Use for: "grep the collected feeds for the Fed", "find
-  the barId for AAPL", "compute RSI on this chart", "I can't find a Taiwan/CN
-  stock — add a data vendor". Output is JSON; discover every flag with
-  `alice --help` / `alice <group> <verb> --help` — do NOT guess.
-  (Low-frequency market data — fundamentals, macro series, calendars, boards —
-  is the separate `traderhub` CLI; the quant scripting manual is the
-  `alice-analysis` skill.)
+  Research data and Workspace collaboration through the `alice` CLI:
+  symbol discovery, K-line analysis, optional subscribed-article lookup,
+  peer conversations, Inbox and Issues. Use CLI help for command parameters.
   Also use alice for Workspace collaboration: peer discovery, Agent conversations,
   Inbox delivery, Issues, Session identity, tracked assets and template upgrades.
   Read references/collaboration.md for these workflows.
@@ -54,28 +48,8 @@ If a search for a non-US name comes up empty, check `alice market vendors`
 **before giving up** — the covering source may just be off. Each vendor's
 `howToUse` flags its quirks (e.g. twse wants 繁体 `台積電`, not 简体 `台积电`).
 
-**Search the collected-RSS archive, then read one article by its stable id**
-(the `id` is stable — you do **not** need to repeat `--lookback` to read it):
-
-```bash
-alice rss grep --pattern "interest rate" --lookback 2d
-alice rss read --id <id-from-the-results>
-```
-
-**Metadata filters** (`--meta` is repeatable):
-
-```bash
-alice rss grep --pattern BTC --meta source=coindesk --meta category=crypto
-```
-
-Know what `rss` is: an archive of articles Alice's collector pulled from the
-user's **subscribed feeds** — coverage is exactly the feed list, nothing more.
-It is NOT a general news search. Empty results mean "not in the subscribed
-feeds", not "nothing happened" — so don't stop at "nothing found." For news
-beyond the feeds (frontpages, breaking, a specific outlet, social chatter),
-that's what `opencli` reaches (the `opencli-reader` skill, when this workspace
-has it — it'll ask to install if needed). Say what's missing rather than
-quietly returning thin.
+`alice rss` is an optional quick scan of collected subscription articles,
+with limited coverage. Command parameters are available in `alice rss --help`.
 
 **Technical / quantitative analysis** lives in its own surface — `alice analysis
 search-bars` (find a K-line barId) then `alice analysis quant` (compute). It's a

--- a/default/skills/build-thesis/SKILL.md
+++ b/default/skills/build-thesis/SKILL.md
@@ -27,8 +27,8 @@ favoring this?) is usually what drives realized P&L. Don't stop at "it's cheap."
 
 The tools: `traderhub equity` for valuation / estimates / consensus,
 `alice analysis quant` for relative strength, momentum, and z-score vs history,
-`traderhub board` for the sector/macro frame, `alice rss grep` for the
-narrative. (See the `traderhub`, `alice-analysis`, `alice` skills.)
+`traderhub board` for the sector/macro frame. Choose news sources to suit
+the question. (See the `traderhub`, `alice-analysis`, `alice` skills.)
 
 0. **Anchor the comparison set.** The right side is *relative* — "strong" only
    means something against peers. If a value-chain map for this name's theme

--- a/default/skills/opencli-reader/SKILL.md
+++ b/default/skills/opencli-reader/SKILL.md
@@ -1,168 +1,49 @@
 ---
 name: opencli-reader
 description: >
-  Read-only access to the long tail of sites Alice's own tools do NOT cover,
-  via the community `opencli` CLI (~160 site adapters): social sentiment
-  (Reddit, HackerNews, Twitter/X, Bluesky, Xueqiu 雪球, Weibo), options flow
-  (Barchart), crypto long-tail (CoinGecko, DeFiLlama, Binance), global news
-  frontpages (Bloomberg, Reuters, BBC), CN money-flow (Eastmoney 东方财富
-  northbound / longhu / money-flow / hot-rank), research (arXiv, PubMed,
-  Google Scholar), and a generic `web read` fallback. Triggers: "what's
-  reddit / 雪球 saying about X", "unusual options flow on Y", "TVL of Z",
-  "Bloomberg headlines", "northbound flow today", "search arXiv for…", any
-  read from a site Alice has no tool for. READ-ONLY — never invoke write
-  commands. opencli is NOT bundled with OpenAlice: if it's missing and a task
-  would benefit, you MUST say so and ask the user — never install silently,
-  never silently work with thinner data.
+  Use the optional community opencli CLI for read-only website access when
+  the user requests it or an available adapter fits the task. Covers command
+  discovery and browser-backed adapters. OpenAlice does not bundle opencli.
 ---
 
-# `opencli` — read the sites Alice doesn't ship (optional, read-only)
+# opencli (optional, read-only)
 
-[opencli](https://github.com/jackwener/opencli) is an independent community
-CLI that turns ~160 websites and desktop apps into a uniform
-`opencli <site> <command>` surface. OpenAlice does not bundle or install it —
-this skill teaches you to use it **when the user has it**, and to **ask for
-it** when a task needs data only it can reach.
+[opencli](https://github.com/jackwener/opencli) provides website adapters through
+`opencli <site> <command>`. It is one source-access option alongside the Coding
+Agent's browser, search and other available tools; no research task requires it.
 
-## Where it sits next to Alice's own tools
+## Command discovery
 
-The boundary is capability-based, not site-based: **if Alice ships the
-number, use Alice's tool** — that keeps data 口径 consistent with what the
-trading engine sees.
-
-| You need… | Use |
-|---|---|
-| Quotes, K-lines, fundamentals, macro series, calendars, boards | `traderhub` / `alice` — never opencli, even when it has a similar command |
-| Articles already pulled by Alice's RSS collector (subscribed feeds only) | `alice rss grep` / `alice rss read` |
-| Social sentiment, forum chatter (Reddit, HN, X, 雪球, Weibo) | opencli |
-| Options flow / greeks beyond Alice's surface (Barchart) | opencli |
-| Crypto long-tail: TVL, small caps (DeFiLlama, CoinGecko) | opencli |
-| Global news frontpages (Bloomberg, Reuters, BBC) | opencli |
-| CN money-flow: northbound, 龙虎榜, hot-rank (Eastmoney) | opencli |
-| Papers (arXiv, PubMed, Scholar), any uncovered site (`web read`) | opencli |
-
-When unsure whether Alice covers something, check `traderhub --help` and
-`alice --help` first — that boundary moves as Alice grows; the CLIs are the
-source of truth, not this table.
-
-**Hard rule: opencli data never directly feeds a trading decision.** Don't
-size a position, route an order, or set a limit price off an opencli number.
-Use it for narrative, sentiment, screening leads, and research context; when
-a lead matters, re-anchor the actual numbers through Alice's tools before
-acting.
-
-## Behavior contract (read this even if you skip the rest)
-
-1. **Never install silently.** Installation touches the user's machine
-   globally (`npm install -g`). Propose it; the user decides.
-2. **Never silently lack data.** If the task would materially benefit from a
-   source opencli covers and it isn't installed (or the needed login isn't
-   set up), say exactly what's missing, what it would unlock, and how to set
-   it up — then ask. Proceeding quietly with thinner data is a failure mode.
-3. **Read-only, always.** Never invoke commands that mutate state: `post`,
-   `reply`, `comment`, `like`, `unlike`, `upvote`, `downvote`, `save`,
-   `subscribe`, `unsubscribe`, `follow`, `unfollow`, `block`, `delete`,
-   `bookmark`, `send`, `create-draft`, `reply-dm`, `accept`, and anything
-   whose `description` suggests a mutation. Unsure → don't run it.
-
-## Step 1 — Is it installed?
+When using opencli, check the installed command's help for current capabilities
+and parameters:
 
 ```bash
 command -v opencli
+opencli <site> --help
+opencli <site> <command> --help
 ```
 
-**Not installed?** Don't stop at "I can't." Tell the user:
+`opencli list -f json` lists available adapters. See
+[discovery.md](references/discovery.md) for registry fields and browser setup.
+Browser-backed adapters may need an extension and an authenticated browser;
+public adapters do not necessarily need that setup.
 
-> This question would benefit from <source> (e.g. Reddit sentiment, Eastmoney
-> northbound flow), which Alice's own tools don't cover. The community
-> `opencli` CLI can read it. Install with:
-> `npm install -g @jackwener/opencli` (needs Node ≥ 20)
-> Want me to proceed without it, or will you install it?
+If an adapter is unavailable, another suitable source may serve the task.
+Installation or account setup needs user authorization; missing opencli alone
+is not a reason to interrupt research. Report material evidence gaps, rather
+than treating a particular tool as a prerequisite.
 
-Then respect the answer. If they decline, note in your output which angle is
-missing — don't let the gap disappear.
+This Skill covers reading only. Do not use adapter actions that post, send,
+subscribe or otherwise mutate external state. Keep credentials and browser
+session details out of output. Execution prices and trading writes remain
+owned by the configured broker/UTA surface.
 
-## Step 2 — Discover the command. Never guess.
-
-The registry has 500+ commands across ~160 sites and changes weekly. Flags
-and names must come from live discovery, not memory:
-
-```bash
-opencli list -f json            # full registry, machine-readable
-opencli list | grep -i <site>   # filter to a site
-opencli <site> --help           # a site's commands
-opencli <site> <command> --help # args, flags, defaults
-```
-
-Each `opencli list -f json` entry carries `site`, `name`, `description`,
-`strategy`, `args`, `columns` — see `references/discovery.md` for the schema
-and for telling read from write commands.
-
-## Step 3 — Check `strategy` before running
-
-| Strategy | Needs |
-|---|---|
-| `PUBLIC` / `LOCAL` | Nothing — works bare |
-| `COOKIE` / `HEADER` | Chrome logged into the site + the OpenCLI extension ([Chrome Web Store](https://chromewebstore.google.com/detail/opencli/ildkmabpimmkaediidaifkhjpohdnifk)) |
-| `INTERCEPT` / `UI` | Same as COOKIE; slower (opens an automation window) |
-
-If a browser-backed adapter is needed and the user isn't set up, that's a
-Behavior-contract-#2 moment: explain (install extension from the Web Store,
-log into the site in Chrome, `opencli doctor` to verify the bridge) and ask.
-`opencli doctor` diagnoses the browser bridge only — `PUBLIC`/`LOCAL`
-adapters don't need it green.
-
-## Step 4 — Execute
-
-```bash
-opencli <site> <command> [args] [flags] -f json
-```
-
-- Always `-f json` for processing; `-v` for debug logs.
-- Start with a small `--limit` (10–20) to validate the shape before pulling
-  more. Command-specific flags are not universal — check `--help`.
-
-```bash
-opencli reddit subreddit wallstreetbets --limit 20 -f json
-opencli hackernews top --limit 20 -f json
-opencli eastmoney hot-rank -f json
-opencli xueqiu hot-stock -f json
-opencli barchart flow AAPL -f json
-opencli defillama --help          # discover before first use
-opencli arxiv search "volatility surface" --limit 10 -f json
-opencli web read "https://example.com/article" -f json
-```
-
-## Step 5 — When it fails
-
-Sites change; adapters break. There's a built-in repair loop:
-
-```bash
-OPENCLI_DIAGNOSTIC=1 opencli <site> <command> <args>
-```
-
-This emits a structured `RepairContext`. Suggest the user file it at
-https://github.com/jackwener/opencli/issues. **Never fall back to hand-rolled
-curl/fetch scraping** — that hides the breakage from the registry and gives
-you a parser that rots in a week. Empty results can also just be rate
-limits; wait and retry once before declaring breakage.
-
-## Step 6 — Present, don't dump
-
-- Summarize for the user's actual question; don't paste raw JSON.
-- Attribute each item (site + URL where available).
-- Posts/news: headline, timestamp, key quotes. Papers: title, authors,
-  abstract, link.
-- Label the provenance honestly: "Reddit sentiment via opencli", not "the
-  market thinks". And per the hard rule above — if a finding should drive a
-  trade, re-anchor through `traderhub`/`alice` first.
-- Browser sessions are private: never echo cookies, CDP endpoints, or auth
-  tokens into output.
+For an adapter failure, `OPENCLI_DIAGNOSTIC=1` can help diagnose the problem.
+Check diagnostic output for private data before sharing it. Research can
+continue through other available tools.
 
 ---
 
-*Maintained by OpenAlice. Doctrine follows the official
-[jackwener/opencli](https://github.com/jackwener/opencli) skills; structure
-informed by `opencli-reader` in
-[himself65/finance-skills](https://github.com/himself65/finance-skills)
-(MIT). opencli itself is an independent project — adapter bugs go upstream.*
+*Adapted from the [jackwener/opencli](https://github.com/jackwener/opencli)
+skills and [himself65/finance-skills](https://github.com/himself65/finance-skills)
+(MIT). opencli is an independent project.*

--- a/default/skills/opencli-reader/references/discovery.md
+++ b/default/skills/opencli-reader/references/discovery.md
@@ -85,9 +85,8 @@ opencli barchart flow NVDA -f json
 
 ## Don'ts
 
-- Don't paste a hand-maintained adapter list into a plan — it rots. Run
-  `opencli list -f json` at task start.
+- Don't paste a hand-maintained adapter list into a plan — it rots. Use live command help when selecting an adapter.
 - Don't assume every adapter needs a browser — `strategy: PUBLIC` doesn't.
-- Don't fall back from a failing adapter to raw curl/fetch. Re-run with
-  `OPENCLI_DIAGNOSTIC=1`, hand the `RepairContext` upstream.
+- `OPENCLI_DIAGNOSTIC=1` can help diagnose a failing adapter. Other available
+  tools remain options for accessing the source.
 - Don't invoke anything whose name or description suggests mutation.

--- a/default/skills/retrospective/SKILL.md
+++ b/default/skills/retrospective/SKILL.md
@@ -22,10 +22,9 @@ catalysts, and test whether a tradeable edge actually existed. The whole value
 is honesty: **no lookahead** (never use a price the moment didn't yet know) and
 **no stale data** (never report yesterday's close as "now").
 
-The tools (run them — don't answer from memory):
-`alice analysis snapshot`, `alice rss window`,
-`alice rss grep` / `read`. (See the `alice`, `alice-analysis` skills for the
-quant scripting language.)
+`alice analysis snapshot` provides dated market summaries; the `alice-analysis`
+skill describes quantitative queries. Choose historical news sources with
+coverage of the period being studied.
 
 ## The freshness gate — DO THIS FIRST, every time
 
@@ -59,17 +58,9 @@ it.**
    can be large); add `--bars N` when you actually need the per-day series.
    `windowBars` tells you how many are available.
 
-2. **Align the catalysts to the price.** Pull the news IN the window,
-   oldest-first, and lay the timestamps against the bars.
-   ```bash
-   alice rss window --from 2026-04-01 --to 2026-04-10 --pattern "Iran|oil|OPEC"
-   ```
-   Each hit has an ISO `time` — put it next to the bar it moved. This is how you
-   answer "was the spike policy or earnings". Coverage is the user's SUBSCRIBED
-   feeds only: an empty window means "not in the feeds", NOT "nothing happened"
-   — say so, and don't pretend you saw everything. (Cookie-gated sources —
-   Barchart options flow, Reddit sentiment — are unreachable from a headless
-   run; if the call needs them, flag the gap rather than imply full coverage.)
+2. **Align the catalysts to the price.** Build a dated event timeline from
+   relevant sources and compare it with the bars. Distinguish evidence of a
+   catalyst from a coincident headline, and note material gaps in coverage.
 
 3. **Test the hypothesis in Workspace research code.** If the question needs
    a hypothetical trade, save the dated inputs and write an inspectable script

--- a/default/skills/scan-value-chain/SKILL.md
+++ b/default/skills/scan-value-chain/SKILL.md
@@ -22,8 +22,8 @@ thing, and why."
 
 The data is on your CLIs: `alice market search` to turn a name into a barId,
 `traderhub equity` / `traderhub board` for valuation snapshots & macro,
-`alice analysis quant` for where each trades vs its own trend, `alice rss grep`
-for the news cluster. (See the `alice`, `alice-analysis`, `traderhub` skills.)
+`alice analysis quant` for where each trades vs its own trend. Choose news
+sources to suit the question. (See the `alice`, `alice-analysis`, `traderhub` skills.)
 
 1. **Decompose the chain, not a flat list.** Break the theme into structural
    layers — upstream (inputs, equipment, IP) → midstream (manufacture, core

--- a/default/skills/sector-rotation/SKILL.md
+++ b/default/skills/sector-rotation/SKILL.md
@@ -22,8 +22,8 @@ together."
 ## Procedure (don't answer from memory — go to the data)
 
 The data is on your CLIs: `traderhub board` / `traderhub etf` for sector & theme
-performance, `alice analysis quant` for momentum across timeframes and breadth,
-`alice rss grep` for the news narrative. (See the `traderhub`, `alice-analysis`
+performance, `alice analysis quant` for momentum across timeframes and breadth.
+Choose news sources to suit the question. (See the `traderhub`, `alice-analysis`
 skills.)
 
 1. **Rank the field across timeframes.** Look at sector/theme performance and

--- a/src/workspaces/templates/chat/README.md
+++ b/src/workspaces/templates/chat/README.md
@@ -1,5 +1,5 @@
 ---
-version: 1.8.8
+version: 1.8.9
 ---
 
 # Chat
@@ -18,7 +18,8 @@ archive, run indicators, write research files, track entities with `[[name]]`,
 and turn follow-up into `.alice/issues/<id>.md` work items. The bundled
 `opencli-reader` skill additionally teaches it to reach long-tail sources
 (social sentiment, options flow, global news frontpages) through the optional
-community `opencli` CLI — it will ask before assuming you have it.
+community `opencli` CLI when installed. Research can also use the Coding
+Agent’s other available tools.
 
 When an Inbox result or Issue is hard to interpret, the workspace can ask its
 attributable product Session directly. It can also dispatch several peer

--- a/src/workspaces/templates/chat/files/instruction.md
+++ b/src/workspaces/templates/chat/files/instruction.md
@@ -47,9 +47,9 @@ files, Issues, Inbox reports, tracked entities, and attributable Sessions.
 
 ## Choose the right surface
 
-OpenAlice places four boundary-specific CLIs on PATH. Their live top-level help
-explains each group; their skills own procedures and exact examples. Read the
-relevant skill before the first domain command and never guess flags.
+OpenAlice provides the CLIs below. Use their help for current parameters and
+the relevant skills for domain-specific guidance. Choose sources and tools to
+fit the task.
 
 | Need | Surface | Skill |
 |---|---|---|
@@ -58,7 +58,7 @@ relevant skill before the first domain command and never guess flags.
 | Peer addressing, Agent conversation, Inbox, Issues and provenance | `alice` | `alice` |
 | Issue files, schedules, headless delivery contracts | `.alice/issues/` + `alice issue` | `self-scheduling` |
 | Accounts, positions, orders, trading-as-git | `alice-uta` | `alice-uta` |
-| Optional sources Alice does not ship | `opencli` | `opencli-reader` |
+| Optional website adapters, if installed separately | `opencli` | `opencli-reader` |
 
 Use the bundled research skills (`build-thesis`, `sector-rotation`,
 `scan-value-chain`, `retrospective`) when their workflow matches the request.


### PR DESCRIPTION
Research Skills currently assign news narratives and historical catalysts to RSS commands, while the fallback guidance makes opencli a prerequisite. This steers agents toward a fixed tool sequence even when other sources fit the question better.

Remove RSS-specific research steps from thesis building, sector rotation, value-chain scans and retrospectives. Keep a brief optional archive description in the alice Skill. Shorten opencli guidance to optional adapter discovery and relevant read-only/credential boundaries; remove mandatory installation prompts, fixed source routing and the prohibition on alternative access tools. Preserve dated evidence, coverage gaps and broker execution authority.

Bump the Alice Harness Skill bundle to 1.0.1 and the Chat template to 1.8.9 so both owners expose updates. Existing Workspace copies are left for their normal reviewed updates.

Validation: root typecheck; template upgrade/registry/creator suites (43 tests); Alice Harness asset suite; validation of all six changed Skills. Ran the real context injector into a temporary directory and verified the six source files, their Claude mirrors and the AGENTS/CLAUDE instruction pair; cleaned up afterward. No runtime command behavior changed. No model-behavior benchmark was run.
