### PR TITLE
Expose Project CLI context and raw market bars

### DIFF
--- a/default/alice-harness.json
+++ b/default/alice-harness.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Alice Project-provided Skills file bundle"
 }

--- a/default/skills/alice-analysis/SKILL.md
+++ b/default/skills/alice-analysis/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: alice-analysis
 description: >
-  How to compute technical analysis with OpenAlice's Quant Calculator (v2) via
-  `alice analysis` — a small Python/pandas-subset scripting language over
-  K-lines, keyed by barId so you compute on a SPECIFIC source — prefer a
-  broker's bars (matches what you trade, realtime) over a free vendor like
-  yfinance (delayed fallback) — and can batch many
-  timeframes/symbols/indicators in ONE call. Use whenever the task is
-  technical/quantitative on price data: "RSI on BTC", "is AAPL above its
-  200-day", "50/200 golden cross check", "multi-timeframe momentum", "how
-  extended is X (z-score)", "does this track the sector (correlation)", "trend
-  strength", "compare 1h/4h/12h at once". Reach it with
-  `alice analysis search-bars` (find a barId) then `alice analysis quant`
-  (compute).
+  Optional technical-analysis formulas and snapshots through alice analysis.
+  Documents the bounded expression language, barId source selection and panels.
+  Raw K-lines for local scripts are available through alice market bars.
 ---
 
 # `alice analysis` — Quant Calculator (v2)
@@ -21,25 +12,22 @@ A bounded, side-effect-free expression language for technical analysis. You writ
 a short script; it fetches K-lines by **barId** and returns a value (or a panel
 of values). Get barIds from `alice analysis search-bars` first.
 
-## The loop
+## Example
 
 ```bash
-alice analysis search-bars --query AAPL
-# Pick a broker barId if one came back (realtime, matches your fills); fall back to a vendor only if not.
+alice market search-bars --query AAPL
 alice analysis quant --script $'s = bars("alpaca-paper|AAPL", "1d", count=250)\nsma(s.close, 50)'
 ```
 
 ## Choosing a source
 
-`search-bars` federates broker bars and vendor bars (freshest-first). Pick in
-this order:
+`search-bars` federates broker and vendor bars. Choose a source by the asset,
+coverage and entitlement needed for the task. A broker feed is not necessarily
+realtime or complete; metadata reports its advertised capability. Different
+sources for the same asset remain separate barIds.
 
-1. **A broker you actually trade** (`barCapability: "realtime"`) — freshest, and
-   the chart matches your fills. Always prefer this when it's in the results.
-2. **A paid vendor** (`fmp`, …) when no broker source exists.
-3. **`yfinance` — free fallback only.** Its end-of-day bars can lag a **day or
-   two**, so never use it for anything time-sensitive (a fresh signal, an entry
-   check) or to chart a live position when a broker source is available.
+For custom processing, `alice market bars ... --output bars.json` returns raw
+OHLCV and metadata for local scripts. The calculator is an optional shortcut.
 
 Vendor barIds (`yfinance|…`, `fmp|…`) need `asset=`; broker barIds infer it.
 Keyless exchange data sources such as `binance-readonly` are opt-in in

--- a/default/skills/alice/SKILL.md
+++ b/default/skills/alice/SKILL.md
@@ -51,11 +51,24 @@ If a search for a non-US name comes up empty, check `alice market vendors`
 `alice rss` is an optional quick scan of collected subscription articles,
 with limited coverage. Command parameters are available in `alice rss --help`.
 
-**Technical / quantitative analysis** lives in its own surface — `alice analysis
-search-bars` (find a K-line barId) then `alice analysis quant` (compute). It's a
-small scripting language with a full function catalog, multi-timeframe panels,
-and source selection. **See the `alice-analysis` skill** for the manual; don't
-hand-roll indicators here.
+**Raw K-lines** use the same BarService as the Market chart:
+
+```bash
+alice market search-bars --query AAPL
+alice market bars --bar-id 'yfinance|AAPL' --asset-class equity --interval 1d --count 250 --output bars.json
+```
+
+The JSON file contains `bars` and `meta`, suitable for local Python/JavaScript
+or shell pipelines. Omit `--output` for stdout. Existing files are preserved.
+Sources retain their own identity; inspect coverage and freshness metadata.
+`alice analysis quant` and `snapshot` remain optional conveniences; see the
+`alice-analysis` Skill for their formula syntax.
+
+Workspace shells inherit their Alice Project automatically. Outside a Workspace,
+use `openalice exec --project <key> alice <group> <verb> ...`; omitting the
+selector uses the configured Project context/default. Explicit Project selection
+clears inherited Workspace/Session scope. Workspace collaboration commands need
+Workspace context.
 
 ## Collaboration and durable assets
 

--- a/docs/alice-harness.md
+++ b/docs/alice-harness.md
@@ -131,3 +131,12 @@ apply supplies the same `{ skill, action }` as `projection`, plus the exact plan
 digest and conflict resolutions. Supported actions are `install`, `update`,
 `remove` and `restore`. Preview is read-only; stale files or config invalidate
 apply. Failures before commit restore both files and preferences.
+
+## CLI context injection
+
+Workspace launch supplies `OPENALICE_HOME`, `OPENALICE_PROJECT_ID`, its tool
+endpoint and `AQ_WS_ID`; Session/run identity remains separate. Ordinary shells
+can select that Project through `openalice exec --project <key> alice ...`.
+Project-only requests omit Workspace identity and expose only global registry
+commands. Workspace calls still enforce their CLI preferences. See
+[[docs/cli-supervisor.md]] for resolution and endpoint discovery.

--- a/docs/cli-supervisor.md
+++ b/docs/cli-supervisor.md
@@ -1328,3 +1328,29 @@ Verify the real `/api/auth/status` and root page after `up`, prove the Runtime
 survives the starting shell, and prove `down` leaves no Guardian/Alice child.
 When shared Runtime or dependency topology changes, add the matching Electron
 PTY/package smoke even though this CLI does not own Electron.
+
+## Project capability CLI
+
+`openalice exec [--project <key> | --home <path>] <alice|traderhub|alice-uta>
+[command flags]` invokes the running Project's manifest-driven CLI. For example:
+
+```bash
+openalice exec --project research alice market search-bars --query AAPL
+openalice exec --project research alice market bars --symbol AAPL --asset-class equity --count 250 --output bars.json
+```
+
+Selection uses the existing Supervisor Project resolver. An injected Workspace
+inherits its Project and Workspace policy; an explicit Project/home selection
+clears inherited Workspace, run and Session attribution. Project-only calls
+expose globally owned tools, never construct a synthetic Workspace, and cannot
+invoke scoped collaboration tools. UTA continues owning all trading writes.
+
+Alice publishes ephemeral `state/cli-endpoint.json` after startup, including
+Project identity and the actual loopback/socket tool endpoint. Shutdown removes
+only its own descriptor. Missing/stale endpoints fail; the client does not scan
+ports or start a Runtime. The gateway checks the selected Project identity on
+every Project request. This is local routing consistency, not authentication.
+
+The native executable dispatches the same bundled Workspace CLI payload;
+source mode loads the running Project's payload. `--output` saves successful
+responses to a new file, preserving existing files; diagnostics stay on stderr.

--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -15,7 +15,7 @@ OpenAlice has three market-data layers with different jobs:
 | Layer | Primary consumers | Contract |
 |---|---|---|
 | TraderHub/reference data | Native agents, boards, low-frequency research | `traderhub` CLI and `/api/reference/*` |
-| Bar service | Charts, quant tools, snapshots, simulations | `barId`-keyed K-line provider federation through `/api/bars` |
+| Bar service | Charts, raw CLI exports, quant tools and snapshots | `barId`-keyed K-line provider federation through `/api/bars` |
 | Embedded provider compatibility | Remaining Alice fundamentals/search clients | Private `@traderalice/opentypebb` workspace package and `/api/market-data-v1` compatibility routes |
 
 The first two layers are the product architecture. The compatibility package is
@@ -35,14 +35,15 @@ low-frequency/reference research
   -> typed local fallback when supported
 
 K-lines and quantitative work
-  -> alice analysis search-bars/snapshot/quant
+  -> alice market search-bars/bars (raw data)
+  -> optional alice analysis snapshot/quant
   -> BarService
   -> vendor source or UTA broker source selected by barId
 ```
 
 `traderhub` is intentionally named after the hosted/reference domain. It owns
 boards, fundamentals, macro series, calendars, ETFs, and related slow-moving
-research data. `alice analysis` owns bar discovery and price-path analysis.
+research data. `alice market` owns bar discovery and raw history; `alice analysis` supplies optional price-path calculations.
 
 ## TraderHub and Reference Data
 
@@ -80,7 +81,7 @@ through the hub without copying the hub's upstream credential into OpenAlice.
 
 `src/domain/market-data/bars/` is the canonical price-history layer. A bar
 source is addressed by `barId`, so provider selection is explicit and stable
-across search, charting, snapshots, and simulations.
+across search, charting, snapshots, and raw exports.
 
 BarService federates:
 
@@ -163,3 +164,22 @@ This read path survives index eviction and restart without a persisted format
 change. It returns stored feed content, which may be only a summary, and does
 not fetch the publisher webpage. Empty search results establish only that no
 match exists in the available subscribed-feed index.
+
+## Raw history consumption
+
+`alice market bars --bar-id 'yfinance|AAPL' --asset-class equity --interval 1d
+--count 250 --output bars.json` returns `{ bars, meta }`. Without `--output`,
+JSON goes to stdout for pipelines. Chart `/api/bars` retains its existing
+`{ results, meta }` envelope over exactly the same service.
+
+`meta` carries source identity, interval, freshness, response ceiling and local
+`truncatedRows`. A zero truncation count does not prove upstream completeness.
+The service returns at most 5,000 bars and rejects invalid counts, unsupported
+intervals and invalid/conflicting dates. `asOf` anchors vendor requests as well
+as broker requests. Commodity vendor spot history supports daily bars only.
+Dates and OHLCV retain provider semantics: adjustment policy, exchange timezone
+and whether the latest candle is complete are not guaranteed by this envelope.
+Freshness is a date-level weekday estimate, not a live-market assertion.
+
+Outside a Workspace use `openalice exec --project <key> alice market bars ...`.
+No formula engine is needed to export data or process it with local code.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
     "src/ai-credential-copy.ts",
     "src/create-alice-project.ts",
     "src/project-command.ts",
+    "src/project-cli.ts",
     "src/project-transfer.ts",
     "src/project-transfer-files.ts",
     "src/project-transfer-secrets.ts",

--- a/packages/cli/src/lifecycle-command.mjs
+++ b/packages/cli/src/lifecycle-command.mjs
@@ -18,6 +18,7 @@ export const ROOT_COMMANDS = Object.freeze([
   { name: 'version', description: 'Print the OpenAlice product and install version' },
   { name: 'tui', description: 'Open the local Supervisor TUI' },
   { name: 'create', description: 'Create a named AliceProject (Trader or Nano)' },
+  { name: 'exec', description: 'Run a capability CLI in the selected AliceProject' },
   { name: 'project', description: 'List, select, or transfer AliceProjects' },
   { name: 'machine', description: 'Register SSH hosts and inspect their AliceProjects' },
   { name: 'up', description: 'Start a persistent local Runtime in the background' },

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,3 +1,4 @@
+import { runProjectCli } from './project-cli.ts'
 import { main as runLegacyCommand } from '../bin/openalice.mjs'
 import { isBunStandalone } from './bun-standalone.mjs'
 import { runDependencySetup } from './dependency-setup.mjs'
@@ -21,6 +22,7 @@ export async function main(
   dependencies: CliDependencies = {},
 ): Promise<number> {
   const [command, ...args] = argv
+  if (command === 'exec') return runProjectCli(args)
   const setup = async () => {
     if (!(dependencies.standalone ?? isBunStandalone())) return 0
     return (dependencies.runSetup ?? ((setupArgs: string[]) => runDependencySetup(setupArgs, { quietReady: true })))(args.includes('--json') ? ['--json'] : [])

--- a/packages/cli/src/project-cli.ts
+++ b/packages/cli/src/project-cli.ts
@@ -1,0 +1,62 @@
+import { readFile, access } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { spawn } from 'node:child_process'
+import { resolveStoredLaunchContext } from './supervisor-config.ts'
+import { isBunStandalone } from './bun-standalone.mjs'
+
+/** Invoke the same manifest-driven payload used by injected Workspace CLIs. */
+export async function runProjectCli(argv: string[]): Promise<number> {
+  const args = [...argv]
+  let project: string | undefined
+  let home: string | undefined
+  while (args[0] === '--project' || args[0] === '--home') {
+    const flag = args.shift()
+    const value = args.shift()
+    if (!value || value.startsWith('-')) throw new Error(`${flag} requires a value`)
+    if (flag === '--project') project = value
+    else home = value
+  }
+  if (!args.length || args[0] === '--help' || args[0] === '-h') {
+    process.stdout.write('Usage: openalice exec [--project <key> | --home <path>] <alice|traderhub|alice-uta> [command flags]\nExample: openalice exec --project research alice market bars --symbol AAPL --asset-class equity --count 250 --output bars.json\nWorkspace context is inherited unless an explicit Project/home is selected. Existing output files are never overwritten.\n')
+    return 0
+  }
+  const binary = args.shift()!
+  if (!['alice', 'traderhub', 'alice-uta'].includes(binary)) throw new Error(`Unsupported CLI: ${binary}`)
+  const env = { ...process.env }
+  const explicit = project !== undefined || home !== undefined
+  if (explicit) {
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('OPENALICE_PROJECT_') || ['OPENALICE_PROJECT', 'OPENALICE_INSTANCE', 'OPENALICE_HOME', 'AQ_WS_ID', 'AQ_RUN_ID', 'AQ_SESSION_ID', 'OPENALICE_TOOL_URL', 'OPENALICE_TOOL_SOCKET', 'OPENALICE_MCP_URL'].includes(key)) delete env[key]
+    }
+  }
+  const context = await resolveStoredLaunchContext({ ...(project ? { project } : {}), ...(home ? { home } : {}) }, { env })
+  const endpointPath = join(context.home, 'state', 'cli-endpoint.json')
+  let endpoint: { schemaVersion?: number; projectId?: string; home?: string; appRoot?: string; url?: string; socket?: string }
+  try { endpoint = JSON.parse(await readFile(endpointPath, 'utf8')) }
+  catch { throw new Error(`No CLI endpoint in ${context.home}. Start or restart this Project with the updated OpenAlice Runtime.`) }
+  if (endpoint.schemaVersion !== 1 || endpoint.projectId !== context.aliceProject.id || !endpoint.home || resolve(endpoint.home) !== resolve(context.home)) throw new Error('Project CLI endpoint identity does not match the selected Project')
+  if (!endpoint.url) throw new Error('Project CLI endpoint has no URL')
+  if (!endpoint.socket) {
+    const url = new URL(endpoint.url)
+    if (url.protocol !== 'http:' || !['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname) || url.username || url.password) throw new Error('Project CLI endpoint must use local HTTP')
+  }
+  env.OPENALICE_PROJECT_ID = context.aliceProject.id
+  env.OPENALICE_HOME = context.home
+  env.OPENALICE_TOOL_URL = endpoint.socket ? '/cli' : endpoint.url
+  delete env.OPENALICE_TOOL_SOCKET
+  if (endpoint.socket) env.OPENALICE_TOOL_SOCKET = endpoint.socket
+  env.OPENALICE_CLI_BIN = binary
+  let childArgs: string[]
+  if (isBunStandalone()) childArgs = ['--workspace-cli', binary, ...args]
+  else {
+    if (!endpoint.appRoot) throw new Error('Project endpoint is missing its runtime asset root')
+    const payload = join(endpoint.appRoot, 'src', 'workspaces', 'cli', 'bin', 'openalice-cli.cjs')
+    await access(payload)
+    childArgs = [payload, ...args]
+  }
+  return new Promise((done, reject) => {
+    const child = spawn(process.execPath, childArgs, { env, stdio: 'inherit' })
+    child.once('error', reject)
+    child.once('exit', code => done(code ?? 1))
+  })
+}

--- a/scripts/build-bun-runtime-feasibility.ts
+++ b/scripts/build-bun-runtime-feasibility.ts
@@ -122,6 +122,10 @@ try {
       && status.componentDetail?.connector?.state === 'ready'
   ))
   readyDurationMs = Math.round(performance.now() - runtimeStartedAt)
+  const projectBarsHelp = runProbe(['exec', '--home', smokeHome, 'alice', 'market', 'bars', '--help'], smokeEnvironment)
+  if (!projectBarsHelp.stdout.includes('--bar-id') || !projectBarsHelp.stdout.includes('--output')) {
+    throw new Error('Native Project CLI did not discover raw market bars through the running Alice gateway')
+  }
   const initialPids = runtimePids(initialStatus)
   if (new Set(initialPids).size !== 4) {
     throw new Error(`Guardian/Alice/UTA/Connector did not have four distinct PIDs: ${initialPids}`)

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -383,3 +383,23 @@ describe('searchBarSources — federated candidates', () => {
     expect(out.some((c) => c.source === 'uta')).toBe(false)
   })
 })
+
+describe('raw bar contract', () => {
+  it.each([
+    { interval: '2h' }, { interval: '1d', count: 0 }, { interval: '1d', count: 5001 },
+    { interval: '1d', start: '2024-02-30' }, { interval: '1d', start: '2024-02-01', end: '2024-01-01' },
+    { interval: '1d', asOf: '2024-01-01', end: '2024-01-02' },
+  ])('rejects invalid windows before contacting providers: %j', async opts => {
+    const deps = makeDeps()
+    await expect(createBarService(deps).getBars({ symbol: 'AAPL', assetClass: 'equity' }, opts)).rejects.toThrow()
+    expect(deps.equityClient.getHistorical).not.toHaveBeenCalled()
+  })
+  it('honors asOf and explicit lower bounds even when a vendor ignores them', async () => {
+    const result = await createBarService(makeDeps()).getBars({ symbol: 'AAPL', assetClass: 'equity' }, { interval: '1d', start: '2024-01-02', asOf: '2024-01-02' })
+    expect(result.bars.map(bar => bar.date)).toEqual(['2024-01-02'])
+    expect(result.meta).toMatchObject({ interval: '1d', limit: 5000, truncatedRows: 0, asOf: '2024-01-02' })
+  })
+  it('does not label daily commodity vendor prices as intraday', async () => {
+    await expect(createBarService(makeDeps()).getBars({ symbol: 'gold', assetClass: 'commodity' }, { interval: '1h' })).rejects.toThrow('only 1d')
+  })
+})

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -39,9 +39,8 @@ const VENDOR_CAPABILITY: Record<string, BarCapability> = {
 const BAR_INTERVALS: readonly BarInterval[] = ['1m', '5m', '15m', '30m', '1h', '4h', '1d', '1w']
 
 function toBarInterval(interval: string): BarInterval {
-  return (BAR_INTERVALS as readonly string[]).includes(interval)
-    ? (interval as BarInterval)
-    : '1d'
+  if (!(BAR_INTERVALS as readonly string[]).includes(interval)) throw new Error(`Unsupported bar interval: ${interval}`)
+  return interval as BarInterval
 }
 
 /** Map a broker secType to the data-vendor asset class (for candidate display
@@ -201,7 +200,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
     const start_date = startDateFor(opts)
     // Upper bound: the provider compatibility models apply end_date;
     // we also post-filter defensively in case a provider ignores it.
-    const end_date = opts.end
+    const end_date = opts.end ?? opts.asOf
     const p = (extra?: Record<string, unknown>) => ({ symbol, start_date, provider, ...(end_date ? { end_date } : {}), ...extra })
     let raw: Array<Record<string, unknown>>
     switch (assetClass) {
@@ -215,15 +214,20 @@ export function createBarService(deps: BarServiceDeps): BarService {
         raw = await deps.currencyClient.getHistorical(p({ interval: opts.interval }))
         break
       case 'commodity':
+        if (opts.interval !== '1d') throw new Error('Commodity vendor bars support only 1d; choose an explicit broker source for other intervals')
         raw = await deps.commodityClient.getSpotPrices(p())
         break
     }
     let bars = raw.filter(isFullBar) as OhlcvBar[]
+    if (opts.start) bars = bars.filter((b) => b.date.slice(0, 10) >= opts.start!)
     if (end_date) bars = bars.filter((b) => b.date.slice(0, 10) <= end_date)
     const filtered = finalize(bars, opts.count)
     return {
       bars: filtered,
       meta: buildMeta(symbol, filtered, {
+        interval: opts.interval,
+        limit: MAX_BARS,
+        truncatedRows: Math.max(0, bars.length - MAX_BARS),
         source: 'vendor',
         sourceId: provider,
         barId: formatBarId(provider, symbol),
@@ -265,6 +269,9 @@ export function createBarService(deps: BarServiceDeps): BarService {
     return {
       bars,
       meta: buildMeta(symbol, bars, {
+        interval: opts.interval,
+        limit: MAX_BARS,
+        truncatedRows: Math.max(0, wireBars.length - MAX_BARS),
         source: 'uta',
         sourceId,
         barId,
@@ -369,6 +376,19 @@ export function createBarService(deps: BarServiceDeps): BarService {
     },
 
     async getBars(ref, opts) {
+      toBarInterval(opts.interval)
+      if (opts.count != null && (!Number.isInteger(opts.count) || opts.count < 1 || opts.count > MAX_BARS)) {
+        throw new Error(`count must be an integer between 1 and ${MAX_BARS}`)
+      }
+      for (const key of ['start', 'end', 'asOf'] as const) {
+        const value = opts[key]
+        if (value != null && (!/^\d{4}-\d{2}-\d{2}$/.test(value) || !Number.isFinite(Date.parse(value)) || new Date(value).toISOString().slice(0, 10) !== value)) {
+          throw new Error(`${key} must be a valid YYYY-MM-DD date`)
+        }
+      }
+      if (opts.end && opts.asOf && opts.end !== opts.asOf) throw new Error('end and asOf must agree')
+      const end = opts.end ?? opts.asOf
+      if (opts.start && end && opts.start > end) throw new Error('start must not follow end')
       if ('symbol' in ref) {
         const provider = deps.vendorProviders[ref.assetClass]
         return getVendorBars(provider, ref.assetClass, ref.symbol, opts)

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -78,6 +78,12 @@ export interface BarMeta {
   barId?: string
   provider?: string
   barCapability?: BarCapability
+  /** Requested interval. Sources may reject unsupported intervals. */
+  interval?: string
+  /** Local response ceiling; not a guarantee of upstream history completeness. */
+  limit?: number
+  /** Rows omitted by this service's hard ceiling, before count selection. */
+  truncatedRows?: number
   // ---- freshness contract ----
   // The point-in-time the request was anchored to (opts.end ?? asOf ?? today),
   // and whether the data actually REACHES it. A delayed vendor silently

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { publishCliEndpoint } from './server/cli-endpoint.js'
+import { createMarketBarsTools } from './tool/market-bars.js'
 import {
   acquireOpenAliceRuntimeLocks,
   takeoverRequested,
@@ -264,6 +266,7 @@ async function main() {
   // v1 calculateIndicator (createAnalysisTools) is retired from the tool surface
   // — calculateQuant (v2, barId-keyed) supersedes it and the two descriptions
   // confused the model / bloated context. The code remains for now.
+  toolCenter.register(createMarketBarsTools({ barService }), 'market-bars')
   toolCenter.register(createQuantTools({ barService }), 'quant')
   toolCenter.register(createSnapshotTools(barService), 'snapshot')
   toolCenter.register(createSimulateTools(barService), 'simulate')
@@ -408,6 +411,8 @@ async function main() {
     console.log(`plugin started: ${plugin.name}`)
   }
 
+  const removeCliEndpoint = await publishCliEndpoint(toolBaseUrl, process.env['OPENALICE_TOOL_SOCKET'])
+
   // Optional products actively install their own journal producer after the
   // shared Workspace service is ready. NanoAlice can omit News entirely; the
   // journal core never imports or starts the collector.
@@ -450,6 +455,7 @@ async function main() {
   let stopped = false
   const shutdown = async () => {
     stopped = true
+    await removeCliEndpoint()
     newsCollector?.stop()
     for (const plugin of [...corePlugins, ...optionalPlugins.values()]) {
       await plugin.stop()

--- a/src/server/cli-commands.spec.ts
+++ b/src/server/cli-commands.spec.ts
@@ -1,3 +1,4 @@
+import { createMarketBarsTools } from '../tool/market-bars.js'
 import { describe, it, expect } from 'vitest'
 import { ToolCenter } from '../core/tool-center.js'
 import { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
@@ -48,6 +49,7 @@ describe('CLI_EXPORTS — data export (global tools)', () => {
   tc.register(createVendorTools(any), 'market-vendors')
   tc.register(createEquityTools(any), 'equity')
   tc.register(createNewsArchiveTools(any), 'rss')
+  tc.register(createMarketBarsTools(any), 'market-bars')
   tc.register(createQuantTools(any), 'quant')
   tc.register(createSnapshotTools(any), 'snapshot')
   tc.register(createSimulateTools(any), 'simulate')
@@ -149,16 +151,23 @@ describe('CLI_EXPORTS — structure', () => {
     }
   })
 
-  it('no export maps the same tool from two verbs', () => {
+  it('keeps mapping targets unique except the shipped analysis search-bars alias', () => {
     for (const [key, exp] of Object.entries(CLI_EXPORTS)) {
       const seen = new Set<string>()
       for (const verbs of Object.values(exp.commands)) {
         for (const toolName of Object.values(verbs)) {
-          expect(seen.has(toolName), `${key}: duplicate mapping target: ${toolName}`).toBe(false)
+          if (!(key === 'data' && toolName === 'searchBars')) {
+            expect(seen.has(toolName), `${key}: duplicate mapping target: ${toolName}`).toBe(false)
+          }
           seen.add(toolName)
         }
       }
     }
+  })
+
+  it('keeps the old bar discovery command as an exact alias', () => {
+    expect(CLI_EXPORTS.data.commands.market['search-bars']).toBe('searchBars')
+    expect(CLI_EXPORTS.data.commands.analysis['search-bars']).toBe('searchBars')
   })
 
   it('unions sibling exports without crossing registry scopes', () => {

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -41,6 +41,8 @@ const BASE_EXPORTS: Record<string, CliExport> = {
       },
       market: {
         search: 'marketSearchForResearch',
+        'search-bars': 'searchBars',
+        bars: 'getMarketBars',
         // Discover data sources + drive them: `vendors` lists what's available,
         // each with on/off state and a usage note (symbol convention, search
         // language); `vendor-set` flips one on/off, live on the next search.
@@ -48,6 +50,7 @@ const BASE_EXPORTS: Record<string, CliExport> = {
         'vendor-set': 'setMarketVendor',
       },
       analysis: {
+        // Shipped alias; new raw-data workflows use market search-bars.
         'search-bars': 'searchBars',
         quant: 'calculateQuant',
         // Dated as-of read with a freshness contract for retrospective analysis.

--- a/src/server/cli-endpoint.spec.ts
+++ b/src/server/cli-endpoint.spec.ts
@@ -1,0 +1,26 @@
+import { it, expect } from 'vitest'
+import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { publishCliEndpoint } from './cli-endpoint.js'
+
+it('old owners cannot remove a replacement endpoint; current owner cleans up', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'oa-cli-endpoint-'))
+  try {
+    const old = await publishCliEndpoint('http://127.0.0.1:1/cli', undefined, home)
+    const current = await publishCliEndpoint('http://127.0.0.1:2/cli', undefined, home)
+    const path = join(home, 'state', 'cli-endpoint.json')
+    await old()
+    expect(JSON.parse(await readFile(path, 'utf8')).url).toBe('http://127.0.0.1:2/cli')
+    await current()
+    await expect(readFile(path)).rejects.toThrow()
+  } finally { await rm(home, { recursive: true, force: true }) }
+})
+it('damaged discovery state cannot stop Runtime shutdown', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'oa-cli-endpoint-'))
+  try {
+    const cleanup = await publishCliEndpoint('/cli', '/tmp/fixture.sock', home)
+    await writeFile(join(home, 'state', 'cli-endpoint.json'), 'broken')
+    await expect(cleanup()).resolves.toBeUndefined()
+  } finally { await rm(home, { recursive: true, force: true }) }
+})

--- a/src/server/cli-endpoint.ts
+++ b/src/server/cli-endpoint.ts
@@ -1,0 +1,24 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { resolveAliceProjectIdentity } from '@traderalice/guardian-runtime'
+import { appResourcesHome, userDataHome } from '../core/paths.js'
+
+/** Ephemeral discovery only. Callers must also verify the live Project header. */
+export async function publishCliEndpoint(url: string, socket?: string, home = userDataHome): Promise<() => Promise<void>> {
+  const project = resolveAliceProjectIdentity({ home, appRoot: appResourcesHome })
+  const path = join(home, 'state', 'cli-endpoint.json')
+  const nonce = randomUUID()
+  const payload = { schemaVersion: 1, projectId: project.id, home: project.home, appRoot: appResourcesHome, pid: process.pid, nonce, url, ...(socket ? { socket } : {}) }
+  await mkdir(join(home, 'state'), { recursive: true })
+  const temp = `${path}.${nonce}.tmp`
+  await writeFile(temp, JSON.stringify(payload), { mode: 0o600 })
+  await rename(temp, path)
+  return async () => {
+    // Discovery is disposable; a damaged cache must not interrupt shutdown.
+    try {
+      const current = JSON.parse(await readFile(path, 'utf8')) as { nonce?: string }
+      if (current.nonce === nonce) await rm(path, { force: true })
+    } catch { /* Missing or damaged discovery state can be replaced on startup. */ }
+  }
+}

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -1,3 +1,4 @@
+import { registerProjectCliRoutes } from './project-cli.js'
 /**
  * CLI gateway — the third adapter over the tool registry.
  *
@@ -64,6 +65,7 @@ type WsMeta = { id: string; tag: string; dir?: string }
 /** Mount /cli/:wsId/:export/* onto an existing Hono app (the MCP server's app). */
 export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly = false): void {
   const { toolCenter, workspaceToolCenter, inboxStore, entityStore, getWorkspaceService } = deps
+  if (!manifestOnly) registerProjectCliRoutes(app, toolCenter)
 
   /** Resolve + validate the workspace from the URL path. */
   const resolveWs = (wsId: string): { meta: WsMeta } | { error: 'unavailable' | 'unknown' } => {

--- a/src/server/project-cli.spec.ts
+++ b/src/server/project-cli.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Hono } from 'hono'
+import { tool } from 'ai'
+import { z } from 'zod'
+import { resolveAliceProjectIdentity } from '@traderalice/guardian-runtime'
+import { userDataHome } from '../core/paths.js'
+import { ToolCenter } from '../core/tool-center.js'
+import { registerProjectCliRoutes } from './project-cli.js'
+
+const projectId = resolveAliceProjectIdentity({ home: userDataHome }).id
+function fixture() {
+  const app = new Hono()
+  const center = new ToolCenter()
+  const execute = vi.fn(({ query }: { query: string }) => ({ query }))
+  center.register({
+    marketSearchForResearch: tool({ inputSchema: z.object({ query: z.string() }), execute }),
+    workspace_path: tool({ inputSchema: z.object({}), execute: (): { path: string } => { throw new Error('scoped tool leaked') } }),
+  }, 'fixture')
+  registerProjectCliRoutes(app, center)
+  return { app, execute }
+}
+describe('Project CLI boundary', () => {
+  it('requires selected Project identity on discovery and invocation', async () => {
+    const { app, execute } = fixture()
+    for (const path of ['manifest', 'invoke']) {
+      const response = await app.request(`/cli/project/data/${path}`, { method: path === 'manifest' ? 'GET' : 'POST', headers: { 'x-openalice-project': 'wrong-project' } })
+      expect(response.status).toBe(409)
+    }
+    expect(execute).not.toHaveBeenCalled()
+  })
+  it('exposes global commands without creating a Workspace', async () => {
+    const { app } = fixture()
+    const response = await app.request('/cli/project/data/manifest', { headers: { 'x-openalice-project': projectId } })
+    const manifest = await response.json()
+    expect(manifest.groups.market.search.tool).toBe('marketSearchForResearch')
+    expect(manifest.groups.workspace).toBeUndefined()
+  })
+  it('rejects scoped commands and unknown arguments, even with forged Session headers', async () => {
+    const { app, execute } = fixture()
+    const request = (body: unknown) => app.request('/cli/project/data/invoke', { method: 'POST', headers: { 'x-openalice-project': projectId, 'content-type': 'application/json', 'x-openalice-session': 'forged' }, body: JSON.stringify(body) })
+    expect((await request({ tool: 'workspace_path', args: {} })).status).toBe(404)
+    expect((await request({ tool: 'marketSearchForResearch', args: { query: 'AAPL', extra: true } })).status).toBe(400)
+    expect(execute).not.toHaveBeenCalled()
+    expect((await request({ tool: 'marketSearchForResearch', args: { query: 'AAPL' } })).status).toBe(200)
+    expect(execute).toHaveBeenCalledOnce()
+  })
+})

--- a/src/server/project-cli.ts
+++ b/src/server/project-cli.ts
@@ -1,0 +1,53 @@
+import type { Hono } from 'hono'
+import { z } from 'zod'
+import { resolveAliceProjectIdentity } from '@traderalice/guardian-runtime'
+import { appResourcesHome, userDataHome } from '../core/paths.js'
+import type { ToolCenter } from '../core/tool-center.js'
+import { extractMcpShape, wrapToolExecute } from '../core/mcp-export.js'
+import { getExport, toolRegistryScope } from './cli-commands.js'
+
+/** Project calls have no Workspace identity and cannot construct scoped tools. */
+export function registerProjectCliRoutes(app: Hono, toolCenter: ToolCenter, project = resolveAliceProjectIdentity({ home: userDataHome, appRoot: appResourcesHome })): void {
+  app.use('/cli/project/*', async (c, next) => {
+    if (c.req.header('x-openalice-project') !== project.id) {
+      return c.json({ error: 'Project identity mismatch; reconnect to the selected Project' }, 409)
+    }
+    await next()
+  })
+  const catalog = (key: string) => {
+    const exp = getExport(key)
+    if (!exp) return null
+    const groups: Record<string, Record<string, { tool: string; description: string; schema: unknown }>> = {}
+    for (const [group, verbs] of Object.entries(exp.commands)) {
+      for (const [verb, name] of Object.entries(verbs)) {
+        if (toolRegistryScope(exp, name) !== 'global') continue
+        const tool = toolCenter.get(name)
+        if (!tool) continue
+        ;(groups[group] ??= {})[verb] = {
+          tool: name, description: tool.description ?? '',
+          schema: z.toJSONSchema(tool.inputSchema as z.ZodType, { io: 'input', unrepresentable: 'any' }),
+        }
+      }
+    }
+    return { export: key, projectId: project.id, description: exp.description, groupDescriptions: exp.groupDescriptions, groups, unmapped: [] }
+  }
+  app.get('/cli/project/:export/manifest', c => {
+    const result = catalog(c.req.param('export'))
+    return result ? c.json(result) : c.json({ error: 'Unknown CLI export' }, 404)
+  })
+  app.post('/cli/project/:export/invoke', async c => {
+    const exp = catalog(c.req.param('export'))
+    if (!exp) return c.json({ error: 'Unknown CLI export' }, 404)
+    const body = await c.req.json().catch(() => ({})) as { tool?: unknown; args?: unknown }
+    const name = typeof body.tool === 'string' ? body.tool : ''
+    const allowed = Object.values(exp.groups).some(verbs => Object.values(verbs).some(command => command.tool === name))
+    const tool = allowed ? toolCenter.get(name) : null
+    if (!tool) return c.json({ error: 'Command unavailable at Project scope; Workspace commands require Workspace context' }, 404)
+    const schema = z.strictObject(extractMcpShape(tool))
+    const args = await schema.safeParseAsync(body.args ?? {})
+    if (!args.success) return c.json({ error: 'Validation failed', details: args.error.message }, 400)
+    const result = await wrapToolExecute(tool)(args.data)
+    if (result.isError) return c.json({ error: result.content.filter(b => b.type === 'text').map(b => b.text).join('\n') }, 500)
+    return c.json({ content: result.content })
+  })
+}

--- a/src/server/project-market-cli.spec.ts
+++ b/src/server/project-market-cli.spec.ts
@@ -1,0 +1,83 @@
+import { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
+import { registerCliRoutes } from './cli.js'
+import { it, expect } from 'vitest'
+import { Hono } from 'hono'
+import { serve } from '@hono/node-server'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveAliceProjectIdentity } from '@traderalice/guardian-runtime'
+import { ToolCenter } from '../core/tool-center.js'
+import { createBarService } from '../domain/market-data/bars/index.js'
+import type { BarServiceDeps } from '../domain/market-data/bars/types.js'
+import { createMarketBarsTools } from '../tool/market-bars.js'
+import { createBarsRoutes } from '../webui/routes/bars.js'
+import { registerProjectCliRoutes } from './project-cli.js'
+
+const exec = promisify(execFile)
+const executable = process.env['OPENALICE_CLI_ACCEPTANCE_EXECUTABLE'] ?? process.execPath
+const entryArgs = process.env['OPENALICE_CLI_ACCEPTANCE_EXECUTABLE'] ? [] : ['packages/cli/bin/openalice.ts']
+it('public Project CLI exports the same bars as the chart, clears inherited Workspace scope and preserves files', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'oa-project-bars-'))
+  const identity = resolveAliceProjectIdentity({ home, env: {} })
+  const rows = [{ date: '2024-01-02', open: 1, high: 3, low: 1, close: 2, volume: 100 }]
+  const barService = createBarService({
+    equityClient: { getHistorical: async () => rows },
+    vendorProviders: { equity: 'yfinance' },
+    utaManager: { has: async () => false },
+  } as unknown as BarServiceDeps)
+  const center = new ToolCenter()
+  center.register(createMarketBarsTools({ barService }), 'bars')
+  const app = new Hono()
+  const headers: Array<{ session?: string; path: string }> = []
+  app.use('*', async (c, next) => { headers.push({ path: c.req.path, session: c.req.header('x-openalice-session') }); await next() })
+  registerProjectCliRoutes(app, center, identity)
+  registerCliRoutes(app, {
+    toolCenter: center, workspaceToolCenter: new WorkspaceToolCenter(), inboxStore: {} as never, entityStore: {} as never,
+    getWorkspaceService: () => ({ registry: { get: (id: string) => id === 'local-ws' ? { id, tag: 'Local', dir: home } : undefined } }) as never,
+  })
+  app.route('/api/bars', createBarsRoutes({ barService } as never))
+  const server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 })
+  await new Promise<void>(resolve => server.listening ? resolve() : server.once('listening', resolve))
+  const port = (server.address() as { port: number }).port
+  try {
+    await mkdir(join(home, 'state'))
+    await writeFile(join(home, 'state', 'cli-endpoint.json'), JSON.stringify({ schemaVersion: 1, projectId: identity.id, home, appRoot: process.cwd(), url: `http://127.0.0.1:${port}/cli` }))
+    const env = { ...process.env, OPENALICE_SUPERVISOR_HOME: join(home, 'supervisor'), AQ_WS_ID: 'foreign-workspace', AQ_SESSION_ID: 'foreign-session', OPENALICE_PROJECT_ID: 'foreign-project' }
+    const args = [...entryArgs, 'exec', '--home', home, 'alice', 'market', 'bars', '--symbol', 'AAPL', '--asset-class', 'equity', '--end', '2024-01-02', '--count', '1']
+    const result = await exec(executable, args, { env, timeout: 20_000 })
+    const cli = JSON.parse(result.stdout)
+    const chart = await (await app.request('/api/bars?symbol=AAPL&assetClass=equity&end=2024-01-02&count=1')).json()
+    expect(cli).toEqual({ bars: chart.results, meta: chart.meta })
+    expect(headers.filter(h => h.path.startsWith('/cli')).every(h => h.path.startsWith('/cli/project/') && !h.session)).toBe(true)
+    await mkdir(join(home, 'supervisor'))
+    await writeFile(join(home, 'supervisor', 'config.json'), JSON.stringify({ schemaVersion: 2, defaultProject: 'research', projects: { research: { home } } }))
+    const commandArgs = args.slice(args.indexOf('alice'))
+    const named = await exec(executable, [...entryArgs, 'exec', '--project', 'research', ...commandArgs], { env })
+    expect(JSON.parse(named.stdout)).toEqual(cli)
+    await expect(exec(executable, [...entryArgs, 'exec', '--project', 'missing', ...commandArgs], { env })).rejects.toThrow()
+    const workspaceEnv = { ...env, OPENALICE_HOME: home, OPENALICE_PROJECT_ID: identity.id, AQ_WS_ID: 'local-ws', AQ_SESSION_ID: '' }
+    const inherited = await exec(executable, [...entryArgs, 'exec', ...commandArgs], { env: workspaceEnv })
+    expect(JSON.parse(inherited.stdout)).toEqual(cli)
+    expect(headers.some(h => h.path === '/cli/local-ws/data/invoke')).toBe(true)
+    await mkdir(join(home, '.alice'))
+    await writeFile(join(home, '.alice', 'alice-harness-config.json'), JSON.stringify({ schemaVersion: 1, cli: { alice: { groups: { market: false } } } }))
+    await expect(exec(executable, [...entryArgs, 'exec', ...commandArgs], { env: workspaceEnv })).rejects.toThrow()
+    // Explicit Project scope remains independent of Workspace preferences.
+    const projectOnly = await exec(executable, [...entryArgs, 'exec', '--project', 'research', ...commandArgs], { env: workspaceEnv })
+    expect(JSON.parse(projectOnly.stdout)).toEqual(cli)
+    const output = join(home, 'bars.json')
+    const saved = await exec(executable, [...args, '--output', output], { env, timeout: 20_000 })
+    expect(saved.stdout).toBe('')
+    expect(JSON.parse(await readFile(output, 'utf8'))).toEqual(cli)
+    await expect(exec(executable, [...args, '--output', output], { env })).rejects.toThrow()
+    expect(JSON.parse(await readFile(output, 'utf8'))).toEqual(cli)
+    await expect(exec(executable, [...args, '--interval', '2h', '--output', join(home, 'bad.json')], { env })).rejects.toThrow()
+    await expect(readFile(join(home, 'bad.json'))).rejects.toThrow()
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()))
+    await rm(home, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/src/tool/market-bars.ts
+++ b/src/tool/market-bars.ts
@@ -1,0 +1,28 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { BarService } from '../domain/market-data/bars/types.js'
+
+/** Raw market data; the chart and optional calculators use this same service. */
+export function createMarketBarsTools({ barService }: { barService: BarService }) {
+  return {
+    getMarketBars: tool({
+      description: 'Read normalized OHLCV bars with source and window metadata. Use the returned bars in local Python, JavaScript or other pipelines. barId selects an explicit source; symbol plus assetClass uses the configured vendor. No calculation is required.',
+      inputSchema: z.object({
+        barId: z.string().min(1).optional().describe('Explicit sourceId|nativeSymbol from market search-bars'),
+        symbol: z.string().min(1).optional(),
+        assetClass: z.enum(['equity', 'crypto', 'currency', 'commodity']).optional(),
+        interval: z.enum(['1m', '5m', '15m', '30m', '1h', '4h', '1d', '1w']).default('1d'),
+        count: z.number().int().min(1).max(5000).optional(),
+        start: z.string().optional().describe('Inclusive start date, YYYY-MM-DD'),
+        end: z.string().optional().describe('End date, YYYY-MM-DD'),
+        asOf: z.string().optional().describe('Count anchor date, YYYY-MM-DD; cannot conflict with end'),
+      }),
+      execute: async ({ barId, symbol, assetClass, ...window }) => {
+        if (barId && symbol) throw new Error('Choose barId or symbol, not both')
+        if (!barId && (!symbol || !assetClass)) throw new Error('Supply barId, or symbol and assetClass')
+        const ref = barId ? { barId, ...(assetClass ? { assetClass } : {}) } : { symbol: symbol!, assetClass: assetClass! }
+        return barService.getBars(ref, window)
+      },
+    }),
+  }
+}

--- a/src/tool/quant.ts
+++ b/src/tool/quant.ts
@@ -15,20 +15,7 @@ import { runScript, type CalcDeps } from '@/domain/analysis/calc-v2/index'
 export function createQuantTools(deps: CalcDeps) {
   return {
     searchBars: tool({
-      description: `Find K-line sources for a symbol — returns barIds to paste into calculateQuant's bars(...).
-
-Federates connected brokers, user-enabled keyless data sources (binance-readonly, …), AND vendors (fmp, yfinance).
-Candidates come back relevance-first, then freshest within the same match quality. Each carries:
-  - barId: use directly, e.g. bars("<barId>", "1d", count=250).
-    · broker barIds ("accountId|symbol") need NO asset= in bars().
-    · vendor barIds ("provider|symbol") need asset="equity|crypto|currency|commodity".
-  - source: "uta" (broker) | "vendor"
-  - barCapability: "realtime" | "delayed" | "iex" | "subscription".
-Source preference: a broker you actually trade (realtime, and the chart matches your fills) >
-a paid vendor (fmp, …) > yfinance. yfinance is a FREE FALLBACK only — its end-of-day bars can
-lag a day or two, so don't use it for anything time-sensitive or to chart a live position when
-a broker source exists. The same asset appears from multiple sources (redundancy is expected);
-default to the freshest broker candidate.`,
+      description: `Find K-line sources for a symbol. Returns explicit barIds for market bars, charting or optional calculateQuant calls. Each source retains its own identity, asset class and advertised capability. Vendor barIds require assetClass when fetching; broker barIds do not. Sources can differ in coverage, freshness and entitlement.`,
       inputSchema: z.object({
         query: z.string().describe('Symbol or keyword, e.g. "AAPL", "BTC", "bitcoin"'),
         limit: z.number().int().positive().optional().describe('Max candidates (default 20)'),

--- a/src/workspaces/cli/bin/openalice-cli.cjs
+++ b/src/workspaces/cli/bin/openalice-cli.cjs
@@ -28,6 +28,13 @@ let BIN = 'alice'
 
 async function main() {
   const argv = process.argv.slice(2)
+  let outputPath
+  const outputIndex = argv.indexOf('--output')
+  if (outputIndex >= 0) {
+    outputPath = argv[outputIndex + 1]
+    if (!outputPath || outputPath.startsWith('-')) fail('--output requires a file path')
+    argv.splice(outputIndex, 2)
+  }
 
   // Launchers provide the public command name because argv[1] now points to
   // this shared payload. Keep argv fallback for direct diagnostics/tests.
@@ -46,9 +53,11 @@ async function main() {
   const toolUrl = process.env.OPENALICE_TOOL_URL
   const legacyMcpUrl = process.env.OPENALICE_MCP_URL || 'http://127.0.0.1:47332/mcp'
   const wsId = process.env.AQ_WS_ID
-  if (!wsId) {
-    fail('AQ_WS_ID is not set — run from inside an OpenAlice workspace.')
+  const projectId = process.env.OPENALICE_PROJECT_ID
+  if (!wsId && !projectId) {
+    fail('No Project context — use openalice exec --project <key> alice ... or run inside a Workspace.')
   }
+  if (!wsId && !toolUrl && !toolSocket) fail('No Project endpoint — use openalice exec --project <key> alice ...')
   // Prefer the dedicated CLI base. Fall back to legacy MCP-derived config so
   // older workspace envs keep working: .../mcp -> .../cli/<wsId>/<export>.
   const gateway = toolSocket
@@ -56,7 +65,7 @@ async function main() {
     : toolUrl
       ? toolUrl.replace(/\/+$/, '')
       : legacyMcpUrl.replace(/\/+$/, '').replace(/\/mcp$/, '/cli')
-  const base = gateway + '/' + wsId + '/' + exportKey
+  const base = gateway + '/' + (wsId ? encodeURIComponent(wsId) : 'project') + '/' + exportKey
   debug('runtime', { bin: BIN, wsId, toolSocket, toolUrl, base })
 
   const wantsHelp = argv.includes('--help') || argv.includes('-h')
@@ -96,8 +105,19 @@ async function main() {
 
   // Run it.
   const args = await parseFlags(argv.slice(argv.indexOf(verb) + 1), cmd.schema, { group, verb })
+  if (outputPath) {
+    const fs = await import('node:fs/promises')
+    try { await fs.lstat(outputPath); fail(`Output already exists: ${outputPath}`) }
+    catch (error) { if (error.code !== 'ENOENT') throw error }
+  }
   const res = await invoke(base, cmd.tool, args)
-  process.stdout.write(res.endsWith('\n') ? res : res + '\n')
+  const output = res.endsWith('\n') ? res : res + '\n'
+  if (outputPath) {
+    // Exclusive creation avoids destroying an existing dataset on a typo.
+    const fs = await import('node:fs/promises')
+    await fs.writeFile(outputPath, output, { flag: 'wx' })
+    process.stderr.write(`Saved ${outputPath}\n`)
+  } else process.stdout.write(output)
 }
 
 // ---- HTTP -----------------------------------------------------------------
@@ -132,9 +152,9 @@ async function invoke(base, tool, args) {
   // one. So at most one of these headers is ever sent.
   const headers = { 'Content-Type': 'application/json' }
   const runId = process.env.AQ_RUN_ID
-  if (runId) headers['x-openalice-run'] = runId
+  if (runId && process.env.AQ_WS_ID) headers['x-openalice-run'] = runId
   const sessionId = process.env.AQ_SESSION_ID
-  if (sessionId) headers['x-openalice-session'] = sessionId
+  if (sessionId && process.env.AQ_WS_ID) headers['x-openalice-session'] = sessionId
   const r = await fetchJson(base + '/invoke', {
     method: 'POST',
     headers,
@@ -154,6 +174,7 @@ async function invoke(base, tool, args) {
 }
 
 async function fetchJson(url, opts) {
+  opts = { ...opts, headers: { ...opts.headers, ...(process.env.OPENALICE_PROJECT_ID ? { 'x-openalice-project': process.env.OPENALICE_PROJECT_ID } : {}) } }
   if (process.env.OPENALICE_TOOL_SOCKET && url.startsWith('/')) {
     return fetchSocketJson(process.env.OPENALICE_TOOL_SOCKET, url, opts)
   }
@@ -337,6 +358,7 @@ function printVerbs(group, cmds, description) {
 }
 
 function printVerbHelp(group, verb, cmd) {
+  out('Use --output <file> to save the response without filling stdout (existing files are preserved).')
   out(`${BIN} ${group} ${verb} [--flags]\n`)
   if (cmd.description) out(cmd.description + '\n')
   const props = (cmd.schema && cmd.schema.properties) || {}
@@ -410,7 +432,7 @@ function out(s) {
 }
 function debug(label, value) {
   if (process.env.OPENALICE_CLI_DEBUG !== '1') return
-  out('[openalice-cli-debug] ' + label + ' ' + JSON.stringify(value))
+  process.stderr.write('[openalice-cli-debug] ' + label + ' ' + JSON.stringify(value) + '\n')
 }
 function fail(msg) {
   process.stderr.write(BIN + ': ' + msg + '\n')

--- a/src/workspaces/cli/shim.spec.ts
+++ b/src/workspaces/cli/shim.spec.ts
@@ -93,15 +93,15 @@ describe('CLI launchers and payload', () => {
       server.listen(socketPath, resolve)
     })
     try {
-      const { stdout } = await runCli('alice', [], {
+      const { stdout, stderr } = await runCli('alice', [], {
           ...process.env,
           AQ_WS_ID: 'ws1',
           OPENALICE_TOOL_SOCKET: socketPath,
           OPENALICE_TOOL_URL: '/cli',
           OPENALICE_CLI_DEBUG: '1',
       })
-      expect(stdout).toContain('[openalice-cli-debug] runtime')
-      expect(stdout).toContain('[openalice-cli-debug] socket.response')
+      expect(stderr).toContain('[openalice-cli-debug] runtime')
+      expect(stderr).toContain('[openalice-cli-debug] socket.response')
       expect(stdout).toContain('OpenAlice CLI')
       expect(stdout).toContain('market')
       expect(stdout).toContain('Discover symbols and bar sources')

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -1,3 +1,5 @@
+import { userDataHome } from '../core/paths.js';
+import { resolveAliceProjectIdentity } from '@traderalice/guardian-runtime';
 /**
  * Composition root for the Workspaces feature.
  *
@@ -1195,6 +1197,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   } => {
     const baseEnv = buildSpawnEnv(process.env, {
       AQ_WS_ID: ws.id,
+      OPENALICE_HOME: userDataHome,
+      OPENALICE_PROJECT_ID: resolveAliceProjectIdentity({ home: userDataHome }).id,
       AQ_LAUNCHER_REPO_ROOT: config.launcherRepoRoot,
       // Local tool gateway for the injected `alice*` CLI shims. Electron/dev
       // can point this at the web listener's `/cli`; Docker/public-web can keep


### PR DESCRIPTION
Native agents could obtain K-lines through calculations, but ordinary terminals could not use the Project's capability CLI without inventing a Workspace. Add `openalice exec --project <key> alice market bars ...` and retain direct `alice ...` use inside injected Workspace shells.

- Resolve external calls through the existing Project selector and an ephemeral, identity-checked Runtime endpoint. Explicit Project/home selection clears inherited Workspace/Session attribution. Project routes expose global tools only; Workspace routes retain their preferences and scoped tools.
- Expose raw `{ bars, meta }` from the same BarService used by charts. Add exclusive `--output` file export and keep diagnostics on stderr. Preserve `analysis search-bars` as the existing alias while introducing `market search-bars`.
- Reject invalid windows and unsupported intervals instead of silently falling back to daily bars. Honor vendor `asOf`, report interval/local truncation metadata, and reject intraday requests against daily-only commodity spot history.
- Update companion Skills to make raw data/local scripting first-class and calculations optional. Skill bundle becomes 1.0.2; existing Workspace files are still upgraded independently.

Validation: full hermetic suite (757 files, 6,765 passed, 3 skipped), root/CLI/UI typechecks, Skill validation, and final endpoint-cleanup/Project CLI tests. Source and native CLI tests cover chart/export parity, explicit Project selection, inherited Workspace preferences, wrong identity, invalid input and output-file preservation. The macOS arm64 Bun multiprocess smoke also discovers `market bars` through a real running Alice gateway without host Node/Bun on PATH. No live broker orders or public-provider requests were needed.

Scope: this exposes the existing provider federation; it does not introduce a historical-data warehouse or promise upstream completeness, adjustment policy, timezone normalization or closed-candle status. Freshness remains the existing date-level estimate. Windows and Electron release acceptance are not claimed by the local macOS native smoke.
