### PR TITLE
Fix K-line date bounds, intervals and chart navigation

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -177,8 +177,19 @@ JSON goes to stdout for pipelines. Chart `/api/bars` retains its existing
 The service returns at most 5,000 bars and rejects invalid counts, unsupported
 intervals and invalid/conflicting dates. `asOf` anchors vendor requests as well
 as broker requests. Commodity vendor spot history supports daily bars only.
-Dates and OHLCV retain provider semantics: adjustment policy, exchange timezone
-and whether the latest candle is complete are not guaranteed by this envelope.
+Date bounds are inclusive calendar days (UTC days for intraday instants).
+Yahoo, Eastmoney and broker intraday timestamps retain explicit UTC offsets; daily/weekly
+bars remain calendar labels. Yahoo translates the inclusive end into its
+exclusive upstream bound and excludes an appended live-price tick from candle
+counts. The latest genuine candle may still be incomplete. Adjustment policy
+and session calendars remain provider-owned.
+
+Count-only requests use a bounded lookback rather than loading months of minute
+bars. Yahoo inferred windows respect recent-history retention; explicit older
+windows fail with a source-specific message. Yahoo accepts the common `1w`
+period. Unsupported 4h requests fail explicitly: callers can export 1h bars
+and aggregate locally. The chart switches to 5D/1M when selecting 1m/5m from a
+longer range and updates the focused asset route rather than a stale tab URL.
 Freshness is a date-level weekday estimate, not a live-market assertion.
 
 Outside a Workspace use `openalice exec --project <key> alice market bars ...`.

--- a/packages/opentypebb/src/providers/eastmoney/models/equity-historical.spec.ts
+++ b/packages/opentypebb/src/providers/eastmoney/models/equity-historical.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { EastmoneyEquityHistoricalFetcher as F } from './equity-historical.js'
+describe('Eastmoney bar contract', () => {
+  it('retains exchange timezone for minutes and calendar labels for daily bars', () => {
+    const q = F.transformQuery({ symbol: '1.600519', interval: '5m' })
+    const rows = F.transformData(q, ['2026-09-08 09:35,10,12,13,9,100,0', '2026-09-08,10,12,13,9,100,0'])
+    expect(rows[0]).toMatchObject({ date: '2026-09-08T01:35:00.000Z', open: 10, close: 12, high: 13, low: 9 })
+    expect(rows[1].date).toBe('2026-09-08')
+  })
+  it('does not silently substitute daily candles for unsupported intervals', async () => {
+    await expect(F.extractData(F.transformQuery({ symbol: '1.600519', interval: '4h' }), null)).rejects.toThrow('does not supply 4h')
+  })
+})

--- a/packages/opentypebb/src/providers/eastmoney/models/equity-historical.ts
+++ b/packages/opentypebb/src/providers/eastmoney/models/equity-historical.ts
@@ -40,7 +40,8 @@ export class EastmoneyEquityHistoricalFetcher extends Fetcher {
     _credentials: Record<string, string> | null,
   ): Promise<string[]> {
     const secid = query.symbol // already "{MktNum}.{Code}"; toUpperCase is a no-op on digits
-    const klt = KLT[query.interval] ?? '101'
+    const klt = KLT[query.interval]
+    if (!klt) throw new Error(`eastmoney does not supply ${query.interval} bars`)
     const beg = query.start_date ? query.start_date.replace(/-/g, '') : '0'
     const end = query.end_date ? query.end_date.replace(/-/g, '') : '20500101'
     const url =
@@ -58,7 +59,8 @@ export class EastmoneyEquityHistoricalFetcher extends Fetcher {
       // OCHL: date, open, close, high, low, volume, amount
       const [date, open, close, high, low, volume] = line.split(',')
       return EquityHistoricalDataSchema.parse({
-        date,
+        // Mainland exchange timestamps are Asia/Shanghai wall time, not UTC.
+        date: date.includes(' ') ? new Date(date.replace(' ', 'T') + '+08:00').toISOString() : date,
         open: Number(open),
         high: Number(high),
         low: Number(low),

--- a/packages/opentypebb/src/providers/yfinance/models/crypto-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/crypto-historical.ts
@@ -10,7 +10,7 @@ import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT } from '../utils/references.js'
 
 export const YFinanceCryptoHistoricalQueryParamsSchema = CryptoHistoricalQueryParamsSchema.extend({
-  interval: z.enum(['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1W', '1M', '1Q']).default('1d').describe('Data granularity.'),
+  interval: z.enum(['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1w', '1W', '1M', '1Q']).default('1d').describe('Data granularity.'),
 })
 export type YFinanceCryptoHistoricalQueryParams = z.infer<typeof YFinanceCryptoHistoricalQueryParamsSchema>
 

--- a/packages/opentypebb/src/providers/yfinance/models/currency-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/currency-historical.ts
@@ -10,7 +10,7 @@ import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT } from '../utils/references.js'
 
 export const YFinanceCurrencyHistoricalQueryParamsSchema = CurrencyHistoricalQueryParamsSchema.extend({
-  interval: z.enum(['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1W', '1M', '1Q']).default('1d').describe('Data granularity.'),
+  interval: z.enum(['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1w', '1W', '1M', '1Q']).default('1d').describe('Data granularity.'),
 })
 export type YFinanceCurrencyHistoricalQueryParams = z.infer<typeof YFinanceCurrencyHistoricalQueryParamsSchema>
 

--- a/packages/opentypebb/src/providers/yfinance/models/equity-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/equity-historical.ts
@@ -10,7 +10,7 @@ import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 import { INTERVALS_DICT } from '../utils/references.js'
 
 export const YFinanceEquityHistoricalQueryParamsSchema = EquityHistoricalQueryParamsSchema.extend({
-  interval: z.enum(['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1W', '1M', '1Q']).default('1d').describe('Data granularity.'),
+  interval: z.enum(['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1w', '1W', '1M', '1Q']).default('1d').describe('Data granularity.'),
   extended_hours: z.boolean().default(false).describe('Include Pre and Post market data.'),
   include_actions: z.boolean().default(true).describe('Include dividends and stock splits in results.'),
   adjustment: z.enum(['splits_only', 'splits_and_dividends']).default('splits_only').describe('The adjustment factor to apply.'),
@@ -51,6 +51,7 @@ export class YFinanceEquityHistoricalFetcher extends Fetcher {
           startDate: query.start_date,
           endDate: query.end_date,
           interval,
+          extendedHours: query.extended_hours,
         })
         return data.map(d => ({ ...d, symbol: sym }))
       })

--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
@@ -285,6 +285,7 @@ export async function getHistoricalData(
     startDate?: string | null
     endDate?: string | null
     interval?: string
+    extendedHours?: boolean
   } = {},
 ): Promise<Record<string, unknown>[]> {
   const yf = getYF()
@@ -294,14 +295,17 @@ export async function getHistoricalData(
     ? new Date(options.startDate)
     : new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
 
-  const period2 = options.endDate
-    ? new Date(options.endDate)
-    : new Date()
+  // Public date bounds include the entire requested day; Yahoo period2 is
+  // exclusive. Never request a future instant for today's/live bars.
+  const end = options.endDate ? new Date(options.endDate) : new Date()
+  if (options.endDate && /^\d{4}-\d{2}-\d{2}$/.test(options.endDate)) end.setUTCDate(end.getUTCDate() + 1)
+  const period2 = new Date(Math.min(end.getTime(), Date.now()))
 
   const chartResult = await withRetry(() => yf.chart(symbol, {
     period1,
     period2,
     interval: interval as any,
+    includePrePost: options.extendedHours ?? false,
   })).catch((err: unknown) => {
     // A failed K-line fetch is almost always Yahoo throttling / blocking the
     // unofficial client (HTTP 429 / crumb auth), NOT a symbol with no history.
@@ -320,13 +324,25 @@ export async function getHistoricalData(
 
   const isIntraday = ['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h'].includes(interval)
 
+  // Yahoo appends a live price tick after the last intraday candle. It is
+  // flat, zero-volume, stamped at regularMarketTime and inside that candle.
+  // Returning it as another bar changes count, indicators and chart spacing.
+  const quotes = [...chartResult.quotes]
+  const last = quotes.at(-1)
+  const previous = quotes.at(-2)
+  const intervalMs = interval.endsWith('h') ? Number.parseInt(interval) * 3600000 : Number.parseInt(interval) * 60000
+  if (isIntraday && last && previous && last.volume === 0 && last.open === last.high && last.high === last.low && last.low === last.close) {
+    const time = new Date(last.date).getTime()
+    const gap = time - new Date(previous.date).getTime()
+    if (time === new Date(chartResult.meta?.regularMarketTime).getTime() && gap > 0 && gap < intervalMs) quotes.pop()
+  }
   const records: Record<string, unknown>[] = []
-  for (const q of chartResult.quotes) {
+  for (const q of quotes) {
     if (q.open == null || q.open <= 0) continue
 
     const date = q.date instanceof Date ? q.date : new Date(q.date as any)
     const dateStr = isIntraday
-      ? date.toISOString().replace('T', ' ').slice(0, 19)
+      ? date.toISOString()
       : date.toISOString().slice(0, 10)
 
     records.push({

--- a/packages/opentypebb/src/providers/yfinance/utils/historical-contract.spec.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/historical-contract.spec.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+const { chart } = vi.hoisted(() => ({ chart: vi.fn() }))
+vi.mock('yahoo-finance2', () => ({ default: class { chart = chart } }))
+import { getHistoricalData } from './helpers.js'
+import { YFinanceEquityHistoricalFetcher } from '../models/equity-historical.js'
+import { YFinanceCryptoHistoricalFetcher } from '../models/crypto-historical.js'
+import { YFinanceCurrencyHistoricalFetcher } from '../models/currency-historical.js'
+
+const quote = (date: string) => ({ date: new Date(date), open: 1, high: 2, low: 0.5, close: 1.5, volume: 10 })
+afterEach(() => { vi.useRealTimers(); chart.mockReset() })
+describe('Yahoo historical time contract', () => {
+  it('includes the end day and preserves intraday instants, including midnight', async () => {
+    chart.mockResolvedValue({ quotes: [quote('2024-01-02T00:00:00Z'), quote('2024-01-02T14:30:00Z')] })
+    const bars = await getHistoricalData('AAPL', { startDate: '2024-01-02', endDate: '2024-01-02', interval: '1h' })
+    expect(chart).toHaveBeenCalledWith('AAPL', expect.objectContaining({ period1: new Date('2024-01-02'), period2: new Date('2024-01-03'), includePrePost: false }))
+    expect(bars.map(b => b.date)).toEqual(['2024-01-02T00:00:00.000Z', '2024-01-02T14:30:00.000Z'])
+  })
+  it('does not count an appended live quote as another candle', async () => {
+    const live = new Date('2024-01-02T14:52:15Z')
+    chart.mockResolvedValue({ meta: { regularMarketTime: live }, quotes: [quote('2024-01-02T14:30:00Z'), { date: live, open: 2, high: 2, low: 2, close: 2, volume: 0 }] })
+    const bars = await getHistoricalData('AAPL', { interval: '1h' })
+    expect(bars).toHaveLength(1)
+    expect(bars[0].date).toBe('2024-01-02T14:30:00.000Z')
+  })
+  it('clamps the current end day to now and retains daily labels', async () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date('2024-01-02T16:00:00Z'))
+    chart.mockResolvedValue({ quotes: [quote('2024-01-02T14:30:00Z')] })
+    const bars = await getHistoricalData('AAPL', { endDate: '2024-01-02' })
+    expect(chart.mock.calls[0][1].period2).toEqual(new Date())
+    expect(bars[0].date).toBe('2024-01-02')
+  })
+  it.each([YFinanceEquityHistoricalFetcher, YFinanceCryptoHistoricalFetcher, YFinanceCurrencyHistoricalFetcher])('maps the product weekly period to Yahoo weekly data', async (Fetcher) => {
+    chart.mockResolvedValue({ quotes: [quote('2024-01-01T00:00:00Z')] })
+    const query = Fetcher.transformQuery({ symbol: 'AAPL', interval: '1w', start_date: '2024-01-01', end_date: '2024-01-07' })
+    await Fetcher.extractData(query, null)
+    expect(chart.mock.calls[0][1].interval).toBe('1wk')
+  })
+})

--- a/packages/opentypebb/src/providers/yfinance/utils/references.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/references.ts
@@ -18,6 +18,7 @@ export const INTERVALS_DICT: Record<string, string> = {
   '1h': '1h',
   '1d': '1d',
   '5d': '5d',
+  '1w': '1wk',
   '1W': '1wk',
   '1M': '1mo',
   '1Q': '3mo',

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -403,3 +403,24 @@ describe('raw bar contract', () => {
     await expect(createBarService(makeDeps()).getBars({ symbol: 'gold', assetClass: 'commodity' }, { interval: '1h' })).rejects.toThrow('only 1d')
   })
 })
+
+describe('real-use bar window regressions', () => {
+  it('does not ask for months of data for twenty five-minute candles', async () => {
+    const deps = makeDeps()
+    await createBarService(deps).getBars({ barId: 'yfinance|AAPL', assetClass: 'equity' }, { interval: '5m', count: 20 })
+    const call = vi.mocked(deps.equityClient.getHistorical).mock.calls[0][0]
+    expect(Date.now() - Date.parse(call.start_date as string)).toBeLessThan(12 * 86400000)
+  })
+  it('explains unsupported 4h instead of leaking enum errors or returning daily data', async () => {
+    for (const source of ['yfinance', 'eastmoney', 'twse']) {
+      await expect(createBarService(makeDeps()).getBars({ barId: `${source}|AAPL`, assetClass: 'equity' }, { interval: '4h' })).rejects.toThrow('does not supply 4h')
+    }
+  })
+  it('preserves the full broker end day, filters over-returned bars and keeps midnight timestamps', async () => {
+    const getHistorical = vi.fn(async () => ['2024-01-01T23:00:00Z', '2024-01-02T00:00:00Z', '2024-01-02T23:00:00Z', '2024-01-03T00:00:00Z'].map(timestamp => ({ timestamp, open: '1', high: '2', low: '0', close: '1', volume: '10' })) as unknown as Bar[])
+    const svc = createBarService(makeDeps({ utaManager: { has: async () => true, get: async () => ({ getHistorical }), searchContracts: async () => [] } }))
+    const result = await svc.getBars({ barId: 'test|AAPL' }, { interval: '1h', start: '2024-01-02', asOf: '2024-01-02' })
+    expect(result.bars.map(b => b.date)).toEqual(['2024-01-02T00:00:00.000Z', '2024-01-02T23:00:00.000Z'])
+    expect(getHistorical.mock.calls[0]).toEqual([{ aliceId: 'test|AAPL' }, expect.objectContaining({ end: new Date('2024-01-02T23:59:59.999Z') })])
+  })
+})

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -100,7 +100,7 @@ function startDateFor(opts: GetBarsOpts): string {
   const anchor = opts.asOf ?? opts.end
   const end = anchor ? new Date(anchor) : new Date()
   const days = opts.count != null
-    ? Math.max(getCalendarDays(opts.interval), Math.ceil(opts.count * perBarDays(opts.interval)) + 5)
+    ? Math.max(7, Math.ceil(opts.count * perBarDays(opts.interval)) + 5)
     : getCalendarDays(opts.interval)
   const start = new Date(end)
   start.setDate(start.getDate() - days)
@@ -120,10 +120,10 @@ function dateOf(bar: Bar, interval?: string): string {
   // A daily/weekly bar is a calendar day, not an instant — render date-only even
   // when a broker stamps it at the session open (e.g. Alpaca's 04:00/05:00 ET,
   // which also flips an hour across DST and looks like a bug). Intraday keeps
-  // its time; a UTC-midnight stamp is date-only regardless.
+  // its instant, including UTC-midnight candles.
   const daily = interval === '1d' || interval === '1w'
-  if (daily || iso.endsWith('T00:00:00.000Z')) return iso.slice(0, 10)
-  return iso.slice(0, 19).replace('T', ' ')
+  if (daily) return iso.slice(0, 10)
+  return iso
 }
 
 function barToOhlcv(bar: Bar, interval?: string): OhlcvBar {
@@ -197,7 +197,21 @@ export function createBarService(deps: BarServiceDeps): BarService {
     symbol: string,
     opts: GetBarsOpts,
   ): Promise<BarsResult> {
-    const start_date = startDateFor(opts)
+    if (opts.interval === '4h' && ['yfinance', 'eastmoney', 'twse'].includes(provider)) {
+      throw new Error(`${provider} does not supply 4h bars; request 1h and aggregate locally, or choose a source supporting 4h`)
+    }
+    if (provider === 'fmp' && opts.interval === '1w') throw new Error('fmp does not supply 1w bars; request 1d and aggregate locally')
+    let start_date = startDateFor(opts)
+    // Yahoo intraday retention is measured from now, not the requested anchor.
+    // Only inferred windows may shrink; explicit dates must remain truthful.
+    if (['yfinance', 'twse'].includes(provider) && ['1m', '5m', '15m', '30m', '1h'].includes(opts.interval)) {
+      const retention = opts.interval === '1m' ? 7 : opts.interval === '1h' ? 729 : 59
+      const earliest = new Date(Date.now() - retention * 86400000).toISOString().slice(0, 10)
+      if (!opts.start && start_date < earliest) start_date = earliest
+      if ((opts.start && opts.start < earliest) || (opts.end ?? opts.asOf ?? '9999') < earliest) {
+        throw new Error(`yfinance ${opts.interval} history is limited to recent ${retention} days; choose a later window, daily bars, or another source`)
+      }
+    }
     // Upper bound: the provider compatibility models apply end_date;
     // we also post-filter defensively in case a provider ignores it.
     const end_date = opts.end ?? opts.asOf
@@ -260,11 +274,14 @@ export function createBarService(deps: BarServiceDeps): BarService {
     const params: BarParams = {
       interval: toBarInterval(opts.interval),
       start: start ? new Date(start) : undefined,
-      end: (opts.end ?? opts.asOf) ? new Date((opts.end ?? opts.asOf)!) : undefined,
+      end: (opts.end ?? opts.asOf) ? new Date(`${opts.end ?? opts.asOf}T23:59:59.999Z`) : undefined,
       limit: opts.count,
     }
     const wireBars = await acct.getHistorical({ aliceId: barId }, params)
-    const bars = finalize(wireBars.map((b) => barToOhlcv(b, params.interval)), opts.count)
+    const bounded = wireBars.map((b) => barToOhlcv(b, params.interval)).filter((bar) =>
+      (!opts.start || bar.date.slice(0, 10) >= opts.start) &&
+      (!(opts.end ?? opts.asOf) || bar.date.slice(0, 10) <= (opts.end ?? opts.asOf)!))
+    const bars = finalize(bounded, opts.count)
     const symbol = parseBarId(barId)?.nativeSymbol ?? barId
     return {
       bars,
@@ -377,6 +394,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
 
     async getBars(ref, opts) {
       toBarInterval(opts.interval)
+      if (ref.assetClass != null && !['equity', 'crypto', 'currency', 'commodity'].includes(ref.assetClass)) throw new Error(`Unsupported asset class: ${ref.assetClass}`)
       if (opts.count != null && (!Number.isInteger(opts.count) || opts.count < 1 || opts.count > MAX_BARS)) {
         throw new Error(`count must be an integer between 1 and ${MAX_BARS}`)
       }

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -123,7 +123,7 @@ export interface GetBarsOpts {
   count?: number
   /** Explicit lower bound (YYYY-MM-DD). */
   start?: string
-  /** Explicit upper bound (YYYY-MM-DD); also the count anchor. */
+  /** Inclusive upper calendar-day bound (YYYY-MM-DD); also the count anchor. */
   end?: string
   /** Point-in-time anchor for `count` (alias of `end`; default now). */
   asOf?: string

--- a/src/webui/routes/bars.spec.ts
+++ b/src/webui/routes/bars.spec.ts
@@ -52,6 +52,13 @@ describe('bars routes', () => {
     )
   })
 
+  it('forwards an asOf date to the shared bar service', async () => {
+    const ctx = mkCtx()
+    const getBars = vi.spyOn(ctx.barService, 'getBars')
+    await createBarsRoutes(ctx).request('/?barId=yfinance|AAPL&assetClass=equity&asOf=2024-01-02')
+    expect(getBars).toHaveBeenCalledWith({ barId: 'yfinance|AAPL', assetClass: 'equity' }, { interval: '1d', asOf: '2024-01-02' })
+  })
+
   it('GET / without barId or symbol → 400', async () => {
     const res = await createBarsRoutes(mkCtx()).request('/?interval=1d')
     expect(res.status).toBe(400)

--- a/src/webui/routes/bars.ts
+++ b/src/webui/routes/bars.ts
@@ -38,6 +38,7 @@ export function createBarsRoutes(ctx: EngineContext): Hono {
     const count = c.req.query('count')
     const start = c.req.query('start')
     const end = c.req.query('end')
+    const asOf = c.req.query('asOf')
 
     let ref: BarSourceRef
     if (barId) ref = assetClass ? { barId, assetClass } : { barId }
@@ -48,6 +49,7 @@ export function createBarsRoutes(ctx: EngineContext): Hono {
     if (count) opts.count = Number(count)
     if (start) opts.start = start
     if (end) opts.end = end
+    if (asOf) opts.asOf = asOf
 
     try {
       const { bars, meta } = await ctx.barService.getBars(ref, opts)

--- a/ui/src/components/market/KlinePanel.spec.tsx
+++ b/ui/src/components/market/KlinePanel.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BarsResponse } from '../../api/market'
@@ -230,4 +230,23 @@ describe('KlinePanel chart controls', () => {
       expect(mocks.bars).toHaveBeenCalledWith(expect.objectContaining({ interval: '1h' }))
     })
   })
+})
+
+it('renders timezone-bearing intraday bars as finite chart timestamps', async () => {
+  const data = response('AAPL', 'yfinance|AAPL')
+  data.results![0].date = '2026-07-17T13:30:00.000Z'
+  mocks.bars.mockResolvedValue(data)
+  render(<MemoryRouter><KlinePanel selection={{ symbol: 'AAPL', assetClass: 'equity' }} /></MemoryRouter>)
+  await waitFor(() => expect(mocks.candleSetData).toHaveBeenCalledWith([expect.objectContaining({ time: Date.parse('2026-07-17T13:30:00Z') / 1000 })]))
+})
+
+function CurrentRoute() { const location = useLocation(); return <output data-testid="route">{location.pathname}</output> }
+
+it('switches to a usable minute window from a stale workspace route', async () => {
+  mocks.bars.mockResolvedValue(response('AAPL', 'yfinance|AAPL'))
+  render(<MemoryRouter initialEntries={['/chat/workspaces/old/details']}><CurrentRoute /><KlinePanel selection={{ symbol: 'AAPL', assetClass: 'equity' }} /></MemoryRouter>)
+  fireEvent.click(screen.getByRole('button', { name: '5m' }))
+  await waitFor(() => expect(mocks.bars).toHaveBeenLastCalledWith(expect.objectContaining({ interval: '5m', start: expect.any(String) })))
+  expect(screen.getByRole('button', { name: '1M' }).getAttribute('aria-pressed')).toBe('true')
+  expect(screen.getByTestId('route').textContent).toBe('/market/equity/AAPL')
 })

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
   createChart,
   CandlestickSeries,
@@ -53,8 +53,9 @@ function startDateFromToday(days: number): string {
 }
 
 function toUTCTimestamp(s: string): UTCTimestamp {
-  // Daily bars use `YYYY-MM-DD`; intraday uses `YYYY-MM-DD HH:MM:SS`.
-  const iso = s.includes(' ') ? s.replace(' ', 'T') + 'Z' : `${s}T00:00:00Z`
+  // Calendar dates and timezone-bearing intraday instants are both valid.
+  const iso = /^\d{4}-\d{2}-\d{2}$/.test(s) ? `${s}T00:00:00Z`
+    : s.includes(' ') ? s.replace(' ', 'T') + 'Z' : s
   return Math.floor(new Date(iso).getTime() / 1000) as UTCTimestamp
 }
 
@@ -81,7 +82,8 @@ interface Props {
 export function KlinePanel({ selection, source, onSnapshot }: Props) {
   const effectiveTheme = useEffectiveTheme()
   const effectivePalette = useEffectivePalette()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const interval = parseInterval(searchParams.get('interval'))
   const tf = parseTimeframe(searchParams.get('range'))
   // The provider picked at search time (a barId), if any — opens the chart on
@@ -93,21 +95,30 @@ export function KlinePanel({ selection, source, onSnapshot }: Props) {
 
   // Local setter named `selectInterval` rather than `setInterval` so it
   // doesn't shadow the global timer function we use for polling below.
+  const updateChartQuery = (update: (next: URLSearchParams) => void) => {
+    if (!selection) return
+    const next = new URLSearchParams(searchParams)
+    if (selectedBarId) next.set('source', selectedBarId)
+    else next.delete('source')
+    update(next)
+    // Focused market tabs may project their URL without updating Router state.
+    // Explicitly address this asset, never the router's previously visited page.
+    navigate({ pathname: `/market/${selection.assetClass}/${encodeURIComponent(selection.symbol)}`, search: next.toString() }, { replace: true })
+  }
   const selectInterval = (iv: KlineInterval) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev)
+    updateChartQuery((next) => {
       if (iv === DEFAULT_INTERVAL) next.delete('interval')
       else next.set('interval', iv)
-      return next
-    }, { replace: true })
+      const days = daysForTimeframe(tf)
+      if (iv === '1m' && (days == null || days > 5)) next.set('range', '5D')
+      if (iv === '5m' && (days == null || days > 30)) next.set('range', '1M')
+    })
   }
   const setTf = (t: KlineTimeframe) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev)
+    updateChartQuery((next) => {
       if (t === DEFAULT_RANGE) next.delete('range')
       else next.set('range', t)
-      return next
-    }, { replace: true })
+    })
   }
 
   const [bars, setBars] = useState<HistoricalBar[] | null>(null)

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -105,7 +105,8 @@ export const marketHandlers = [
     if (barId && !barId.startsWith('alpaca-paper|') && assetClass !== selected.assetClass) {
       return HttpResponse.json({ results: null, meta: null, error: `Vendor barId needs assetClass=${selected.assetClass}.` })
     }
-    const rawResults = demoMarketAAPL.historical.results ?? []
+    const end = url.searchParams.get('end') ?? url.searchParams.get('asOf')
+    const rawResults = (demoMarketAAPL.historical.results ?? []).filter(bar => !end || bar.date.slice(0, 10) <= end)
     const targetSpot = DEMO_FX[selected.symbol]?.spot
     const results = targetSpot == null
       ? rawResults


### PR DESCRIPTION
K-line requests now agree across the Project CLI, charts and calculator. Historical `asOf` dates include the requested day; intraday Yahoo, Eastmoney and broker bars retain timezone information. Yahoo weekly intervals resolve correctly, and count-only minute requests no longer load months of unavailable history. Unsupported intervals report source-specific errors instead of silently substituting daily candles or leaking enum dumps.

Yahoo live quote ticks are excluded from intraday candle counts, and the equity extended-hours option now reaches the upstream request. Chart controls address the focused asset rather than a stale Workspace route; selecting minute candles from a long range selects a usable default window. Existing segmented controls and keyboard behavior remain unchanged.

Validation:
- Full hermetic suite: 759 files, 6,778 tests passed, 3 skipped. Final UI/route/Eastmoney additions: 18 tests passed.
- Root, provider package and UI typechecks; diff check.
- Real Project CLI: AAPL 1m/5m/1h/1d/1w and historical anchor, BTC hourly, EURUSD hourly, gold daily, Taiwan equity daily, Eastmoney A-share daily.
- Fixed historical AAPL hourly CLI/API results and metadata match exactly; local SMA20 324.9355133056641 matches calculator 324.9355 at its displayed precision.
- Rendered AAPL minute and BTC hourly charts, plus Demo daily chart.

Limits: Yahoo 4h remains unsupported (export 1h and aggregate locally). Eastmoney minute live acceptance was blocked by an upstream socket disconnect; conversion is covered by deterministic tests. Broker boundary shaping was tested with fixtures, not live broker accounts. Latest candles may still be incomplete, and freshness remains a weekday estimate.

Fixes #1415
