### PR TITLE
fix(market): repair FX, commodity and paginated broker history

### DIFF
--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -52,6 +52,10 @@ Development and tests may resolve the wrapper workspaces directly. Production
 launchers must use an activated downloaded Pack. Set
 `OPENALICE_BROKER_PACK_ALLOW_WORKSPACE=1` only for an intentional source-tree
 runtime; never use it to disguise a missing production artifact.
+For `pnpm dev`, `OPENALICE_BROKER_PACK_PREFER_WORKSPACE=1` explicitly prefers
+source wrappers over installed packs. This opt-in is ignored outside dev/tests
+and still requires workspace loading to be allowed. It changes no activated
+pack pointer and is useful when debugging adapters against an existing Project.
 
 Pack-local dependency copies cross a structural API boundary. Core code must
 not depend on class identity from a Pack's dependency tree; use structural

--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -194,3 +194,15 @@ Freshness is a date-level weekday estimate, not a live-market assertion.
 
 Outside a Workspace use `openalice exec --project <key> alice market bars ...`.
 No formula engine is needed to export data or process it with local code.
+
+FX discovery retains USD-base pairs and crosses; Yahoo's abbreviated `JPY=X`
+is normalized to `USDJPY`. Incomplete OHLC rows are omitted rather than failing
+the whole series; valid zero and negative prices remain valid. Commodity roots
+map to vendor futures symbols (including current lumber `LBR=F`), so these
+histories are not executable spot quotes or explicit delivery-month contracts.
+
+CCXT history walks exchange pages within the trailing requested window. A
+venue's per-page cap must not silently turn a large request into an old first
+page. Pagination deduplicates timestamps and stops if the provider no longer
+advances; short results can still reflect upstream availability. Validate the
+installed Broker Pack as well as source code when changing this adapter.

--- a/packages/opentypebb/src/providers/yfinance/models/commodity-spot-price.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/commodity-spot-price.ts
@@ -6,8 +6,7 @@
 import { z } from 'zod'
 import { Fetcher } from '../../../core/provider/abstract/fetcher.js'
 import { CommoditySpotPriceQueryParamsSchema, CommoditySpotPriceDataSchema } from '../../../standard-models/commodity-spot-price.js'
-import { EmptyDataError } from '../../../core/provider/utils/errors.js'
-import { getHistoricalData } from '../utils/helpers.js'
+import { getHistoricalData, emptyHistoricalError } from '../utils/helpers.js'
 
 export const YFinanceCommoditySpotPriceQueryParamsSchema = CommoditySpotPriceQueryParamsSchema
 export type YFinanceCommoditySpotPriceQueryParams = z.infer<typeof YFinanceCommoditySpotPriceQueryParamsSchema>
@@ -28,11 +27,15 @@ const COMMODITY_MAP: Record<string, string> = {
   corn: 'ZC=F',
   wheat: 'ZW=F',
   soybeans: 'ZS=F',
+  oats: 'ZO=F',
+  rice: 'ZR=F',
+  orange_juice: 'OJ=F',
+  feeder_cattle: 'GF=F',
   sugar: 'SB=F',
   coffee: 'KC=F',
   cocoa: 'CC=F',
   cotton: 'CT=F',
-  lumber: 'LBS=F',
+  lumber: 'LBR=F',
   live_cattle: 'LE=F',
   lean_hogs: 'HE=F',
 }
@@ -83,7 +86,7 @@ export class YFinanceCommoditySpotPriceFetcher extends Fetcher {
     }
 
     if (allData.length === 0) {
-      throw new EmptyDataError('No commodity spot price data found.')
+      throw emptyHistoricalError(results, 'No commodity history returned')
     }
     return allData
   }

--- a/packages/opentypebb/src/providers/yfinance/models/currency-search.spec.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/currency-search.spec.ts
@@ -1,0 +1,18 @@
+import { expect, it, vi } from 'vitest'
+import { YFinanceCurrencySearchFetcher } from './currency-search.js'
+
+vi.mock('../utils/helpers.js', () => ({
+  searchYahooFinance: vi.fn().mockResolvedValue([
+    { symbol: 'JPY=X', quoteType: 'CURRENCY', shortname: 'USD/JPY' },
+    { symbol: 'EURGBP=X', quoteType: 'CURRENCY', shortname: 'EUR/GBP' },
+    { symbol: 'EURUSD=X', quoteType: 'CURRENCY', shortname: 'EUR/USD' },
+    { symbol: 'JPY', quoteType: 'EQUITY' },
+  ]),
+}))
+
+it('normalizes abbreviated USD-base pairs without changing crosses or including equities', async () => {
+  const query = YFinanceCurrencySearchFetcher.transformQuery({ query: 'JPY' })
+  const raw = await YFinanceCurrencySearchFetcher.extractData(query, null)
+  const pairs = YFinanceCurrencySearchFetcher.transformData(query, raw)
+  expect(pairs.map(pair => pair.symbol)).toEqual(['USDJPY', 'EURGBP', 'EURUSD'])
+})

--- a/packages/opentypebb/src/providers/yfinance/models/currency-search.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/currency-search.ts
@@ -32,7 +32,8 @@ export class YFinanceCurrencySearchFetcher extends Fetcher {
     return quotes
       .filter((q: any) => q.quoteType === 'CURRENCY')
       .map((q: any) => ({
-        symbol: (q.symbol ?? '').replace('=X', ''),
+        // Yahoo abbreviates USD-base pairs, e.g. JPY=X means USD/JPY.
+        symbol: (q.symbol ?? '').replace('=X', '').replace(/^([A-Z]{3})$/, 'USD$1'),
         name: q.longname ?? q.shortname ?? null,
         exchange: q.exchDisp ?? null,
         quote_type: q.quoteType ?? null,

--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
@@ -338,7 +338,9 @@ export async function getHistoricalData(
   }
   const records: Record<string, unknown>[] = []
   for (const q of quotes) {
-    if (q.open == null || q.open <= 0) continue
+    // A missing candle must not invalidate the entire series. Zero/negative
+    // prices are real observations for some contracts (e.g. oil futures).
+    if (![q.open, q.high, q.low, q.close].every(value => typeof value === 'number' && Number.isFinite(value))) continue
 
     const date = q.date instanceof Date ? q.date : new Date(q.date as any)
     const dateStr = isIntraday

--- a/packages/opentypebb/src/providers/yfinance/utils/historical-contract.spec.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/historical-contract.spec.ts
@@ -4,6 +4,7 @@ vi.mock('yahoo-finance2', () => ({ default: class { chart = chart } }))
 import { getHistoricalData } from './helpers.js'
 import { YFinanceEquityHistoricalFetcher } from '../models/equity-historical.js'
 import { YFinanceCryptoHistoricalFetcher } from '../models/crypto-historical.js'
+import { YFinanceCommoditySpotPriceFetcher } from '../models/commodity-spot-price.js'
 import { YFinanceCurrencyHistoricalFetcher } from '../models/currency-historical.js'
 
 const quote = (date: string) => ({ date: new Date(date), open: 1, high: 2, low: 0.5, close: 1.5, volume: 10 })
@@ -35,4 +36,22 @@ describe('Yahoo historical time contract', () => {
     await Fetcher.extractData(query, null)
     expect(chart.mock.calls[0][1].interval).toBe('1wk')
   })
+})
+
+
+it('skips incomplete FX candles while retaining zero and negative futures prices', async () => {
+  chart.mockResolvedValue({ quotes: [
+    { ...quote('2024-01-01'), close: null },
+    { ...quote('2024-01-02'), open: 0, high: 0, low: -2, close: -1 },
+    quote('2024-01-03'),
+  ] })
+  const rows = await getHistoricalData('USDJPY=X')
+  expect(rows.map(r => r.date)).toEqual(['2024-01-02', '2024-01-03'])
+  expect(rows[0].close).toBe(-1)
+})
+
+it.each([['oats', 'ZO=F'], ['rice', 'ZR=F'], ['orange_juice', 'OJ=F'], ['feeder_cattle', 'GF=F'], ['lumber', 'LBR=F']])('resolves the advertised commodity %s', async (symbol, native) => {
+  chart.mockResolvedValue({ quotes: [quote('2024-01-02')] })
+  await YFinanceCommoditySpotPriceFetcher.extractData(YFinanceCommoditySpotPriceFetcher.transformQuery({ symbol }), null)
+  expect(chart.mock.calls[0][0]).toBe(native)
 })

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.spec.ts
@@ -1641,6 +1641,25 @@ describe('CcxtBroker — getHistorical', () => {
     ])
   })
 
+  it('paginates a venue cap without returning a stale first page', async () => {
+    const acc = makeAccount()
+    setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })
+    const end = new Date('2026-07-20T12:00:00Z')
+    const step = 3600000
+    const fetch = vi.fn(async (_symbol: string, _timeframe: string, since: number) => {
+      const first = Math.ceil(since / step) * step
+      return Array.from({ length: 300 }, (_, i) => first + i * step)
+        .filter(ts => ts <= end.getTime()).map(ts => [ts, 1, 2, 0.5, 1.5, 10])
+    })
+    ;(acc as any).exchange.fetchOHLCV = fetch
+    const contract = new Contract(); contract.localSymbol = 'BTC/USDT:USDT'
+    const bars = await acc.getHistorical(contract, { interval: '1h', end, limit: 400 })
+    expect(bars).toHaveLength(400)
+    expect(bars.at(-1)?.timestamp).toEqual(end)
+    expect(new Set(bars.map(b => b.timestamp.getTime())).size).toBe(400)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
   it('loud-refuses an interval the exchange does not support', async () => {
     const acc = makeAccount()
     setInitialized(acc, { 'BTC/USDT:USDT': makeSwapMarket('BTC', 'USDT', 'BTC/USDT:USDT') })

--- a/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
+++ b/services/uta/src/domain/trading/brokers/ccxt/CcxtBroker.ts
@@ -1246,9 +1246,9 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       throw new BrokerError('EXCHANGE', `${this.exchangeName} does not support the ${params.interval} interval`)
     }
     try {
-      const limit = params.limit == null ? undefined : Math.max(1, Math.floor(params.limit))
+      const limit = Math.min(5000, params.limit == null ? 5000 : Math.max(1, Math.floor(params.limit)))
       const lowerBound = params.start?.getTime()
-      const upperBound = params.end?.getTime() ?? Date.now()
+      const upperBound = Math.min(params.end?.getTime() ?? Date.now(), Date.now())
       // CCXT exchanges return the FIRST `limit` rows at/after `since`. Alice's
       // BarParams contract is the opposite: limit truncates to the MOST RECENT
       // rows in the requested window. Anchor `since` immediately before that
@@ -1263,11 +1263,26 @@ export class CcxtBroker implements IBroker<CcxtBrokerMeta> {
       const since = trailingSince == null
         ? lowerBound
         : Math.max(lowerBound ?? Number.NEGATIVE_INFINITY, trailingSince)
-      const rows = await this.exchange.fetchOHLCV(ccxtSymbol, timeframe, since, queryLimit)
-      const bounded = (rows as number[][]).filter(([ts]) =>
-        (lowerBound == null || ts >= lowerBound) && ts <= upperBound,
-      )
-      const selected = limit == null ? bounded : bounded.slice(-limit)
+      // Venues cap page sizes independently of the requested limit (OKX:
+      // 300). Walk forward until the window ends, not just the first page.
+      // De-duplicate inclusive boundaries and stop on non-advancing responses.
+      const byTime = new Map<number, number[]>()
+      let cursor = since
+      for (let page = 0; page < 100; page++) {
+        const rows = await this.exchange.fetchOHLCV(ccxtSymbol, timeframe, cursor, queryLimit) as number[][]
+        let latest = Number.NEGATIVE_INFINITY
+        for (const row of rows) {
+          const ts = row[0]
+          if (!Number.isFinite(ts)) continue
+          latest = Math.max(latest, ts)
+          if ((lowerBound == null || ts >= lowerBound) && ts <= upperBound) byTime.set(ts, row)
+        }
+        if (!rows.length || latest < (cursor ?? Number.NEGATIVE_INFINITY) || latest >= upperBound || byTime.size >= queryLimit!) break
+        const next = latest + BAR_INTERVAL_MS[params.interval]
+        if (!Number.isFinite(next) || next > upperBound || (cursor != null && next <= cursor)) break
+        cursor = next
+      }
+      const selected = [...byTime.values()].sort((a, b) => a[0] - b[0]).slice(-limit)
       return selected.map(([ts, o, h, l, c, v]) => ({
         timestamp: new Date(ts),
         open: String(o), high: String(h), low: String(l), close: String(c),

--- a/services/uta/src/domain/trading/brokers/registry.spec.ts
+++ b/services/uta/src/domain/trading/brokers/registry.spec.ts
@@ -10,11 +10,13 @@ let savedEnv: Record<string, string | undefined>
 beforeEach(async () => {
   savedEnv = {
     OPENALICE_HOME: process.env['OPENALICE_HOME'],
+    OPENALICE_BROKER_PACK_PREFER_WORKSPACE: process.env['OPENALICE_BROKER_PACK_PREFER_WORKSPACE'],
     OPENALICE_BROKER_PACK_ALLOW_WORKSPACE: process.env['OPENALICE_BROKER_PACK_ALLOW_WORKSPACE'],
   }
   home = await mkdtemp(resolve(tmpdir(), 'openalice-broker-registry-'))
   process.env['OPENALICE_HOME'] = home
   process.env['OPENALICE_BROKER_PACK_ALLOW_WORKSPACE'] = '0'
+  delete process.env['OPENALICE_BROKER_PACK_PREFER_WORKSPACE']
   vi.resetModules()
 })
 
@@ -77,6 +79,18 @@ describe('broker engine registry', () => {
     const mock = await loadBrokerEngine('mock')
     expect(mock.configSchema).toBeTruthy()
     expect(mock.createBroker({ id: 'sim', brokerConfig: {} }).brokerEngine).toBe('mock')
+  })
+
+  it('uses source code only when explicitly preferred and workspace loading is allowed', async () => {
+    await activateCcxtModule('valid-release', validModuleSource())
+    process.env['OPENALICE_BROKER_PACK_PREFER_WORKSPACE'] = '1'
+    const { loadBrokerEngine, clearBrokerEngineCache } = await import('./registry.js')
+    const installed = await loadBrokerEngine('ccxt')
+    expect('safeParse' in installed.configSchema).toBe(false)
+    process.env['OPENALICE_BROKER_PACK_ALLOW_WORKSPACE'] = '1'
+    clearBrokerEngineCache()
+    const source = await loadBrokerEngine('ccxt')
+    expect(typeof source.configSchema.safeParse).toBe('function')
   })
 
   it('loads and validates an activated pack module', async () => {

--- a/services/uta/src/domain/trading/brokers/registry.ts
+++ b/services/uta/src/domain/trading/brokers/registry.ts
@@ -75,6 +75,12 @@ async function loadBrokerEngineUncached(engine: BrokerEngine): Promise<BrokerEng
   }
   if (!isInstallableBrokerEngine(engine)) throw new Error(`Unknown broker engine "${engine}"`)
 
+  if (process.env['OPENALICE_BROKER_PACK_PREFER_WORKSPACE'] === '1'
+      && (process.env['OPENALICE_LAUNCHER'] === 'dev' || process.env['NODE_ENV'] === 'test')
+      && workspacePacksAllowed()) {
+    return loadWorkspacePack(engine)
+  }
+
   let installed: ResolvedBrokerPack | null
   try {
     installed = await resolveActiveBrokerPack(engine)
@@ -95,19 +101,18 @@ async function loadBrokerEngineUncached(engine: BrokerEngine): Promise<BrokerEng
     }
   }
 
-  if (workspacePacksAllowed()) {
-    try {
-      const entry = resolve(appResourcesHome, workspaceEntries[engine])
-      return validateModule(engine, await import(pathToFileURL(entry).href))
-    } catch (err) {
-      throw new BrokerPackUnavailableError(
-        engine,
-        `Workspace broker pack "${engine}" failed to load: ${err instanceof Error ? err.message : String(err)}`,
-      )
-    }
-  }
+  if (workspacePacksAllowed()) return loadWorkspacePack(engine)
 
   throw new BrokerPackUnavailableError(engine)
+}
+
+async function loadWorkspacePack(engine: InstallableBrokerEngine): Promise<BrokerEngineEntry> {
+  try {
+    const entry = resolve(appResourcesHome, workspaceEntries[engine])
+    return validateModule(engine, await import(pathToFileURL(entry).href))
+  } catch (err) {
+    throw new BrokerPackUnavailableError(engine, `Workspace broker pack "${engine}" failed to load: ${err instanceof Error ? err.message : String(err)}`)
+  }
 }
 
 function validateModule(engine: InstallableBrokerEngine, raw: unknown): BrokerEngineEntry {

--- a/src/domain/market-data/aggregate-search.spec.ts
+++ b/src/domain/market-data/aggregate-search.spec.ts
@@ -35,3 +35,11 @@ describe('aggregateSymbolSearch limits', () => {
     expect(searchDeps.commodityCatalog.search).toHaveBeenCalledWith('EURUSD', 2)
   })
 })
+
+
+it('retains USD-base and cross-currency pairs in discovery', async () => {
+  const d = deps()
+  vi.mocked(d.currencyClient.search).mockResolvedValue([{ symbol: 'USDJPY' }, { symbol: 'EURGBP' }])
+  const results = await aggregateSymbolSearch(d, 'USDJPY', 20)
+  expect(results.filter(r => r.assetClass === 'currency').map(r => r.symbol)).toEqual(['USDJPY', 'EURGBP'])
+})

--- a/src/domain/market-data/aggregate-search.ts
+++ b/src/domain/market-data/aggregate-search.ts
@@ -8,7 +8,7 @@
  * equity    — SymbolIndex (SEC/TMX local cache, regex, zero-latency)
  * commodity — CommodityCatalog (canonical catalog, ~25 items)
  * crypto    — cryptoClient.search on yfinance (online fuzzy)
- * currency  — currencyClient.search on yfinance (online fuzzy, XXXUSD filter)
+ * currency  — currencyClient.search on yfinance (online fuzzy, including crosses)
  */
 import type { SymbolIndex } from './equity/symbol-index.js'
 import type { CommodityCatalog } from './commodity/commodity-catalog.js'
@@ -123,10 +123,6 @@ export async function aggregateSymbolSearch(
   )
 
   const currencyResults = (currencySettled.status === 'fulfilled' ? currencySettled.value : [])
-    .filter((r) => {
-      const sym = (r as Record<string, unknown>).symbol as string | undefined
-      return sym?.endsWith('USD')
-    })
     .map((r) => ({ ...r, assetClass: 'currency' as const }))
 
   // Merge equity online hits, de-duped WITHIN each vendor's namespace by

--- a/src/domain/market-data/commodity/commodity-catalog.ts
+++ b/src/domain/market-data/commodity/commodity-catalog.ts
@@ -100,7 +100,7 @@ const CATALOG: CommodityCatalogEntry[] = [
   { id: 'coffee',      name: 'Coffee',            category: 'softs', aliases: ['咖啡', 'KC=F', 'KCUSX'] },
   { id: 'cocoa',       name: 'Cocoa',             category: 'softs', aliases: ['可可', 'CC=F', 'CCUSX'] },
   { id: 'cotton',      name: 'Cotton',            category: 'softs', aliases: ['棉花', 'CT=F', 'CTUSX'] },
-  { id: 'lumber',      name: 'Lumber',            category: 'softs', aliases: ['木材', 'LBS=F'] },
+  { id: 'lumber',      name: 'Lumber',            category: 'softs', aliases: ['木材', 'LBR=F', 'LBS=F'] },
   { id: 'orange_juice', name: 'Orange Juice',     category: 'softs', aliases: ['橙汁', 'OJ=F'] },
 
   // Livestock

--- a/src/tool/market.ts
+++ b/src/tool/market.ts
@@ -22,7 +22,7 @@ export function createMarketSearchTools(deps: MarketSearchDeps) {
 Returns matching symbols with assetClass attribution ("equity", "crypto", "currency", or "commodity").
 Equity results come from SEC/TMX listings (~13k US/CA stocks); crypto and currency results
 come from Yahoo Finance fuzzy search; commodity results come from a canonical catalog (~25 items).
-Currency results are filtered to XXXUSD pairs only.
+Currency results include USD-base pairs and cross pairs.
 
 For commodities, use the canonical id (e.g. "gold", "crude_oil", "copper") with calculateIndicator
 and other tools — provider-specific tickers (GC=F, GCUSD) are resolved automatically.


### PR DESCRIPTION
Large OKX history requests previously succeeded with only an old 300-row first page. Page through venue caps so the requested trailing window reaches its actual end. FX discovery now keeps USD-base/cross pairs and normalizes Yahoo abbreviations; incomplete OHLC rows no longer invalidate whole histories. Fill missing commodity mappings and replace the stale lumber symbol.

Add an explicit dev/test-only source Broker Pack preference for adapter debugging; normal runtime still prefers activated installed packs. Document source semantics and regression coverage.

Validation:
- Full hermetic suite: 760 files, 6,790 passed, 3 skipped; additional currency-normalization regression passed.
- Root, UI, provider, UTA and CCXT typechecks; UTA integration 15 passed.
- Built and verified all five Broker Pack artifacts. Installed the fixed CCXT artifact into Default AliceProject and restarted in normal installed-pack mode.
- Real read-only CLI: CN/HK/US stocks, FX, commodities and three crypto exchanges; Binance/OKX/Bybit each returned 1,200 hourly bars. Historical OKX CLI/API comparison: 400 identical bars through the requested end date.
- Real Default browser: USDJPY, lumber, OKX BTC 3-month hourly chart (2,175 bars).

Follow-up: #1417.

Limitation: Eastmoney 5-minute history hit a transport-level socket closure on this machine; its intraday path is not accepted. Commodity vendor series remain futures proxies, not executable spot prices. No trading writes.
