### PR TITLE
fix(market): report socket failures without blaming local networking

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -206,3 +206,12 @@ venue's per-page cap must not silently turn a large request into an old first
 page. Pagination deduplicates timestamps and stops if the provider no longer
 advances; short results can still reflect upstream availability. Validate the
 installed Broker Pack as well as source code when changing this adapter.
+
+Eastmoney history can close a connection without an HTTP response while its
+quote endpoint still works. A transport error alone does not establish a DNS,
+proxy, or provider fault. In live acceptance (#1417), the official chart showed
+a human-verification challenge; after the user completed it, unchanged CLI
+requests for Shanghai/Shenzhen minute bars and daily history succeeded. Treat
+that as a diagnostic possibility, not a guaranteed recovery procedure. Do not
+automate the challenge, import browser cookies, or silently substitute another
+vendor under an Eastmoney bar ID.

--- a/packages/opentypebb/src/core/provider/utils/__tests__/helpers.spec.ts
+++ b/packages/opentypebb/src/core/provider/utils/__tests__/helpers.spec.ts
@@ -1,12 +1,4 @@
-/**
- * amakeRequest network-error classification.
- *
- * The point of these tests: when fetch fails at the network layer (DNS,
- * TLS, routing, refused), the helper must throw a NetworkUnreachableError
- * with a "do not retry" hint that surfaces verbatim to AI agents — NOT
- * the generic "Request failed (TypeError: fetch failed)" string that
- * looks indistinguishable from a transient flake.
- */
+/** Transport failures preserve diagnostic causes without assigning blame. */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { amakeRequest } from '../helpers.js'
@@ -28,7 +20,7 @@ describe('amakeRequest — network failure classification', () => {
     await expect(amakeRequest(URL_OK)).rejects.toThrowError(NetworkUnreachableError)
   })
 
-  it('the thrown error message contains NETWORK_UNREACHABLE + the host + a "do not retry" instruction', async () => {
+  it('preserves the host and error code without prescribing an agent workflow', async () => {
     fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'))
     try {
       await amakeRequest(URL_OK)
@@ -37,7 +29,8 @@ describe('amakeRequest — network failure classification', () => {
       const err = e as Error
       expect(err.message).toMatch(/NETWORK_UNREACHABLE/)
       expect(err.message).toMatch(/api\.example\.com/)
-      expect(err.message.toLowerCase()).toMatch(/do not retry/i)
+      expect(err.message).toContain('no HTTP response')
+      expect(err.message).not.toMatch(/do not retry|ask the user|not a provider error/i)
     }
   })
 
@@ -53,6 +46,19 @@ describe('amakeRequest — network failure classification', () => {
       expect(err).toBeInstanceOf(NetworkUnreachableError)
       expect(err.message).toContain('ENOTFOUND')
     }
+  })
+
+  it('does not misdiagnose a remote socket closure as a proven local-network failure', async () => {
+    const cause = Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' })
+    const wrapped = Object.assign(new TypeError('fetch failed'), { cause })
+    fetchMock.mockRejectedValueOnce(wrapped)
+    const error = await amakeRequest(URL_OK).catch(e => e)
+    expect(error).toBeInstanceOf(NetworkUnreachableError)
+    if (!(error instanceof NetworkUnreachableError)) throw new Error('Expected transport failure')
+    expect(error.original).toBe(wrapped)
+    expect(error.message).toContain('UND_ERR_SOCKET: other side closed')
+    expect(error.message).toContain('remote service closing the connection')
+    expect(error.message).toContain('does not identify which')
   })
 
   it('still uses generic OpenBBError for non-network failures (e.g. unhandled non-TypeError throws)', async () => {

--- a/packages/opentypebb/src/core/provider/utils/errors.ts
+++ b/packages/opentypebb/src/core/provider/utils/errors.ts
@@ -32,25 +32,18 @@ export class UnauthorizedError extends OpenBBError {
 }
 
 /**
- * Raised when the request never reached the provider — DNS failure, TLS
- * failure, connection refused, host unreachable, etc. Distinct from
- * provider-side errors (HTTP 4xx/5xx, malformed JSON) because the fix
- * is on the user's network/proxy, not on the provider, and retrying
- * with the same network state is futile.
- *
- * Surfaced to AI agents with a "do not retry" hint so they don't burn
- * tokens on silent re-attempts that all fail the same way.
+ * No HTTP response was received. The legacy error code is retained, but a
+ * connection closing does not establish whether the network or provider is
+ * responsible: servers and intermediaries can also close requests.
  */
 export class NetworkUnreachableError extends OpenBBError {
   readonly host: string
 
   constructor(host: string, cause: string, original?: unknown) {
     super(
-      `NETWORK_UNREACHABLE: cannot reach ${host} from this machine (${cause}). ` +
-      `This is a network-layer failure (DNS / routing / TLS / proxy), not a provider error — ` +
-      `the provider's API may well be operational, the connection from this network cannot complete. ` +
-      `Do NOT retry the same call; ask the user to check their VPN / proxy routing for this hostname, ` +
-      `or fall back to a different data source.`,
+      `NETWORK_UNREACHABLE: no HTTP response from ${host} (${cause}). ` +
+      `The cause may be the network/proxy or the remote service closing the connection; ` +
+      `this error alone does not identify which.`,
       original,
     )
     this.name = 'NetworkUnreachableError'

--- a/packages/opentypebb/src/core/provider/utils/helpers.ts
+++ b/packages/opentypebb/src/core/provider/utils/helpers.ts
@@ -6,8 +6,8 @@
 import { OpenBBError, NetworkUnreachableError } from './errors.js'
 
 /**
- * Identify a fetch failure that never reached the provider — network
- * layer (DNS, routing, TLS, proxy) rather than HTTP-level.
+ * Identify a fetch failure before an HTTP response was received. This
+ * includes network failures and connections closed by the remote service.
  *
  * Node 18+ wraps low-level network errors in TypeError("fetch failed")
  * with the underlying cause attached as `.cause`. Common cause codes


### PR DESCRIPTION
A socket closure was reported to agents as a proven local-network problem, explicitly excluding provider faults. During Eastmoney diagnosis, the official chart required human verification and unchanged CLI reads recovered immediately after the maintainer completed it. That error guidance was misleading.

Preserve the existing error class/code and low-level cause, but describe a missing HTTP response without assigning blame or prescribing a workflow. Document the observed Eastmoney recovery and add a socket-closure regression.

Validation: provider suite 45 tests passed; focused helper suite 7 passed after type narrowing; provider typecheck and diff check passed. Live unchanged CLI reads returned 30 bars for Shanghai 1m/5m/1h/1d and Shenzhen 5m after manual verification. OpenAlice five-minute chart checked with explicit Eastmoney source.

Closes #1417. This does not bypass provider verification or guarantee future availability.
