### PR TITLE
fix(ui): clarify Eastmoney equity identity and chart hierarchy

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -215,3 +215,11 @@ requests for Shanghai/Shenzhen minute bars and daily history succeeded. Treat
 that as a diagnostic possibility, not a guaranteed recovery procedure. Do not
 automate the challenge, import browser cookies, or silently substitute another
 vendor under an Eastmoney bar ID.
+
+The Eastmoney equity page resolves its display name by exact bar ID and shows
+the six-digit security code and SSE/SZSE market label. Name lookup failure
+leaves a usable code-based heading and does not block history. Provider-native
+secids remain on the bar request; broker discovery receives the security code
+as a heuristic query, not a claimed canonical trading identity. The chart
+displays its forward-adjustment policy beside the source and keeps full candle
+timestamps available on the condensed date-range label.

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -74,12 +74,13 @@ interface Props {
    * only on React Router state: tab switches project their URL with
    * history.replaceState, which intentionally does not notify the router. */
   source?: string
+  displayTitle?: string
   /** Read-only mirror of the displayed series for sibling analysis panels.
    *  This avoids a second bar request on bespoke detail pages. */
   onSnapshot?: (snapshot: KlineSnapshot) => void
 }
 
-export function KlinePanel({ selection, source, onSnapshot }: Props) {
+export function KlinePanel({ selection, source, onSnapshot, displayTitle }: Props) {
   const effectiveTheme = useEffectiveTheme()
   const effectivePalette = useEffectivePalette()
   const [searchParams] = useSearchParams()
@@ -319,24 +320,25 @@ export function KlinePanel({ selection, source, onSnapshot }: Props) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between py-2 px-1 gap-3 flex-wrap">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-[13px] font-medium text-foreground truncate">{title}</span>
+      <div className="flex flex-col py-2 px-1 gap-2">
+        <div className="flex items-center gap-x-3 gap-y-1 min-w-0 flex-wrap">
+          <span className="text-[13px] font-medium text-foreground truncate">{displayTitle ?? title}</span>
           {meta && (
             <span
               className="inline-flex items-center gap-1.5 text-[11px] leading-[15px] font-medium text-muted-foreground"
               title={`Provider: ${meta.barId}${meta.barCapability ? ` (${meta.barCapability})` : ''}`}
             >
-              <span>{meta.sourceId}</span>{meta.barCapability && <span>{meta.barCapability}</span>}
+              <span>{meta.sourceId === 'eastmoney' ? '东方财富 · 前复权' : meta.sourceId}</span>{meta.barCapability && <span>{meta.barCapability}</span>}
             </span>
           )}
           {bars && bars.length > 0 && (
-            <span className="text-[11px] text-muted-foreground/60 truncate">
-              {bars.length} bars, {bars[0].date} → {bars[bars.length - 1].date}
+            <span className="text-[11px] text-muted-foreground sm:ml-auto"
+              title={`${bars[0].date} → ${bars[bars.length - 1].date}`}>
+              {bars.length} bars · {bars[0].date.slice(0, 10)} — {bars[bars.length - 1].date.slice(0, 10)}
             </span>
           )}
         </div>
-        <div className="flex items-center gap-5 flex-wrap">
+        <div className="flex items-center gap-x-5 gap-y-2 flex-wrap">
           {sourceOptions.length > 1 && (
             <label className="flex items-center gap-2">
               <span className="text-[11px] font-medium text-muted-foreground/70">Source</span>

--- a/ui/src/components/market/useEastmoneyIdentity.spec.ts
+++ b/ui/src/components/market/useEastmoneyIdentity.spec.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest'
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { barsApi } from '../../api/market'
+import { useEastmoneyIdentity } from './useEastmoneyIdentity'
+vi.mock('../../api/market', () => ({ barsApi: { searchSources: vi.fn() } }))
+afterEach(() => { cleanup(); vi.resetAllMocks() })
+it('selects only the exact source identity and clears the previous name on navigation', async () => {
+  vi.mocked(barsApi.searchSources).mockResolvedValueOnce({ count: 2, candidates: [
+    { barId: 'yfinance|600519.SS', symbol: '600519.SS', source: 'vendor', sourceId: 'yfinance', assetClass: 'equity', name: 'Wrong source', label: '' },
+    { barId: 'eastmoney|1.600519', symbol: '1.600519', source: 'vendor', sourceId: 'eastmoney', assetClass: 'equity', name: '贵州茅台', label: '' },
+  ] }).mockRejectedValueOnce(new Error('offline'))
+  const { result, rerender } = renderHook(({ source }) => useEastmoneyIdentity(source), { initialProps: { source: 'eastmoney|1.600519' } })
+  expect(result.current?.loading).toBe(true)
+  await waitFor(() => expect(result.current?.name).toBe('贵州茅台'))
+  rerender({ source: 'eastmoney|0.000001' })
+  expect(result.current?.name).toBeUndefined()
+  expect(result.current?.code).toBe('000001')
+  await waitFor(() => expect(result.current?.error).toBe(true))
+  expect(result.current?.loading).toBe(false)
+})
+it('does not fetch metadata for other vendors or malformed identities', () => {
+  const { result, rerender } = renderHook(({ source }) => useEastmoneyIdentity(source), { initialProps: { source: 'yfinance|AAPL' } })
+  expect(result.current).toBeNull()
+  rerender({ source: 'eastmoney|bad' })
+  expect(result.current).toBeNull()
+  expect(barsApi.searchSources).not.toHaveBeenCalled()
+})

--- a/ui/src/components/market/useEastmoneyIdentity.ts
+++ b/ui/src/components/market/useEastmoneyIdentity.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { barsApi } from '../../api/market'
+
+/** Resolve display identity from the selected source, never a same-code vendor. */
+export function useEastmoneyIdentity(source?: string) {
+  const match = source?.match(/^eastmoney\|([01])\.(\d{6})$/)
+  const code = match?.[2]
+  const [resolved, setResolved] = useState<{ source: string; name?: string; error: boolean } | null>(null)
+  useEffect(() => {
+    if (!code || !source) return
+    let cancelled = false
+    barsApi.searchSources(code, 100).then(({ candidates }) => {
+      const exact = candidates.find(candidate => candidate.barId === source)
+      if (!cancelled) setResolved({ source, name: exact?.name, error: !exact?.name })
+    }).catch(() => { if (!cancelled) setResolved({ source, error: true }) })
+    return () => { cancelled = true }
+  }, [code, source])
+  if (!code) return null
+  const current = resolved?.source === source ? resolved : null
+  return { code, name: current?.name, market: match![1] === '1' ? 'SSE' : 'SZSE', loading: !current, error: current?.error ?? false }
+}

--- a/ui/src/pages/MarketDetailPage.tsx
+++ b/ui/src/pages/MarketDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useEastmoneyIdentity } from '../components/market/useEastmoneyIdentity'
 import { PageHeader } from '../components/PageHeader'
 import { SearchBox } from '../components/market/SearchBox'
 import { EquityDetail } from './market/EquityDetail'
@@ -13,12 +14,13 @@ interface MarketDetailPageProps {
 
 export function MarketDetailPage({ spec }: MarketDetailPageProps) {
   const { assetClass, symbol, source } = spec.params
+  const identity = useEastmoneyIdentity(assetClass === 'equity' ? source : undefined)
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <PageHeader
-        title={symbol}
-        description={assetClass === 'currency'
+        title={identity?.name ?? identity?.code ?? symbol}
+        description={identity ? `${identity.code} · ${identity.market}` : assetClass === 'currency'
           ? 'FX spot, carry, macro, and scenario analysis'
           : `${assetClass} price history`}
         right={<PinButton assetClass={assetClass} symbol={symbol} />}
@@ -26,7 +28,7 @@ export function MarketDetailPage({ spec }: MarketDetailPageProps) {
       <div className="flex-1 flex flex-col gap-3 px-4 md:px-8 py-4 min-h-0 overflow-y-auto">
         <SearchBox />
         {assetClass === 'equity' ? (
-          <EquityDetail symbol={symbol} source={source} />
+          <EquityDetail symbol={symbol} source={source} displayName={identity?.name} securityCode={identity?.code} />
         ) : assetClass === 'currency' ? (
           <CurrencyDetail symbol={symbol} source={source} />
         ) : (

--- a/ui/src/pages/market/EquityDetail.spec.tsx
+++ b/ui/src/pages/market/EquityDetail.spec.tsx
@@ -10,7 +10,7 @@ vi.mock('../../components/market/ProfilePanel', () => ({ ProfilePanel: () => <di
 vi.mock('../../components/market/KeyMetricsPanel', () => ({ KeyMetricsPanel: () => <div>metrics-panel</div> }))
 vi.mock('../../components/market/FinancialStatementsPanel', () => ({ FinancialStatementsPanel: () => <div>statements-panel</div> }))
 vi.mock('../../components/market/KlinePanel', () => ({ KlinePanel: () => <div>kline-panel</div> }))
-vi.mock('../../components/market/TradeableContractsPanel', () => ({ TradeableContractsPanel: () => <div>contracts-panel</div> }))
+vi.mock('../../components/market/TradeableContractsPanel', () => ({ TradeableContractsPanel: ({ symbol }: { symbol: string }) => <div>contracts-panel {symbol}</div> }))
 
 afterEach(cleanup)
 
@@ -18,9 +18,9 @@ describe('EquityDetail provider namespaces', () => {
   it('keeps Eastmoney native secids on the supported K-line-only surface', () => {
     render(<EquityDetail symbol="1.600519" source="eastmoney|1.600519" />)
 
-    expect(screen.getByText(/This Eastmoney view includes Chinese A-share discovery/)).toBeTruthy()
+    expect(screen.queryByText(/This Eastmoney view/)).toBeNull()
     expect(screen.getByText('kline-panel')).toBeTruthy()
-    expect(screen.getByText('contracts-panel')).toBeTruthy()
+    expect(screen.getByText('contracts-panel 600519')).toBeTruthy()
     expect(screen.queryByText('quote-panel')).toBeNull()
     expect(screen.queryByText('profile-panel')).toBeNull()
     expect(screen.queryByText('metrics-panel')).toBeNull()

--- a/ui/src/pages/market/EquityDetail.tsx
+++ b/ui/src/pages/market/EquityDetail.tsx
@@ -8,9 +8,11 @@ import { TradeableContractsPanel } from '../../components/market/TradeableContra
 interface Props {
   symbol: string
   source?: string
+  displayName?: string
+  securityCode?: string
 }
 
-export function EquityDetail({ symbol, source }: Props) {
+export function EquityDetail({ symbol, source, displayName, securityCode }: Props) {
   // Eastmoney intentionally owns only Chinese-name discovery + forward-adjusted
   // K-lines. Its native secid (`1.600519`) is not a Yahoo/FMP ticker, so feeding
   // it into the default quote/fundamental panels produces misleading failures.
@@ -18,16 +20,10 @@ export function EquityDetail({ symbol, source }: Props) {
 
   return (
     <div className="flex flex-col gap-3">
-      {klineOnly ? (
-        <div className="rounded-lg border border-border bg-card px-3 py-2 text-[12px] leading-relaxed text-muted-foreground">
-          This Eastmoney view includes Chinese A-share discovery and forward-adjusted price history.
-        </div>
-      ) : (
-        <QuoteHeader symbol={symbol} />
-      )}
+      {!klineOnly && <QuoteHeader symbol={symbol} />}
 
-      <div className="h-[360px] shrink-0">
-        <KlinePanel selection={{ symbol, assetClass: 'equity' }} source={source} />
+      <div className="h-[440px] shrink-0">
+        <KlinePanel selection={{ symbol, assetClass: 'equity' }} source={source} displayTitle={klineOnly ? (displayName ?? securityCode ?? symbol.replace(/^[01]\./, '')) : undefined} />
       </div>
 
       {!klineOnly && (
@@ -37,7 +33,7 @@ export function EquityDetail({ symbol, source }: Props) {
         </div>
       )}
 
-      <TradeableContractsPanel symbol={symbol} assetClass="equity" />
+      <TradeableContractsPanel symbol={klineOnly ? (securityCode ?? symbol.replace(/^[01]\./, '')) : symbol} assetClass="equity" />
 
       {!klineOnly && <FinancialStatementsPanel symbol={symbol} />}
     </div>


### PR DESCRIPTION
Eastmoney equity pages displayed a raw secid as their title, an implementation note instead of security identity, and crowded chart metadata. They also searched brokers using the vendor-only secid.

Resolve the display name from the exact selected bar source, with a code/market fallback that stays usable during loading or failure. Remove the explanatory card, separate chart metadata from controls, condense visible dates while retaining full timestamps on hover, and give equity charts more room. Broker discovery now uses the six-digit security code; matching remains heuristic and broker identities stay explicit.

The chosen layout keeps the existing page/header/chart primitives, wraps controls on narrow content widths, and adds no dialogs or motion. No provider namespaces or underlying bar requests change.

Validation: UI owner suite and UI typecheck; hook tests cover exact-source selection, navigation, failure and non-Eastmoney behavior. Real Default Project browser checked with Shanghai 贵州茅台 daily bars and Shenzhen 平安银行 five-minute bars.
