### PR TITLE
fix(ui): move market watchlist action beside asset name

### DIFF
--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -1,3 +1,4 @@
+import { WatchlistButton } from './WatchlistButton'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
@@ -322,7 +323,10 @@ export function KlinePanel({ selection, source, onSnapshot, displayTitle }: Prop
     <div className="flex flex-col h-full">
       <div className="flex flex-col py-2 px-1 gap-2">
         <div className="flex items-center gap-x-3 gap-y-1 min-w-0 flex-wrap">
-          <span className="text-[13px] font-medium text-foreground truncate">{displayTitle ?? title}</span>
+          <div className="flex min-w-0 items-center gap-1">
+            <span className="text-[13px] font-medium text-foreground truncate">{displayTitle ?? title}</span>
+            {selection && <WatchlistButton assetClass={selection.assetClass} symbol={selection.symbol} />}
+          </div>
           {meta && (
             <span
               className="inline-flex items-center gap-1.5 text-[11px] leading-[15px] font-medium text-muted-foreground"

--- a/ui/src/components/market/WatchlistButton.spec.tsx
+++ b/ui/src/components/market/WatchlistButton.spec.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useWatchlist } from '../../tabs/watchlist-store'
+import { WatchlistButton } from './WatchlistButton'
+afterEach(() => { cleanup(); useWatchlist.setState({ entries: [] }) })
+it('toggles the current asset and exposes its state without visible button text', () => {
+  const { rerender } = render(<WatchlistButton assetClass="equity" symbol="1.600519" />)
+  const button = screen.getByRole('button', { name: 'Add to watchlist' })
+  expect(button.textContent).toBe('')
+  fireEvent.click(button)
+  expect(screen.getByRole('button', { name: 'Remove from watchlist' }).getAttribute('aria-pressed')).toBe('true')
+  rerender(<WatchlistButton assetClass="equity" symbol="0.000001" />)
+  expect(screen.getByRole('button', { name: 'Add to watchlist' }).getAttribute('aria-pressed')).toBe('false')
+  rerender(<WatchlistButton assetClass="equity" symbol="1.600519" />)
+  fireEvent.click(screen.getByRole('button', { name: 'Remove from watchlist' }))
+  expect(useWatchlist.getState().entries).toEqual([])
+})

--- a/ui/src/components/market/WatchlistButton.tsx
+++ b/ui/src/components/market/WatchlistButton.tsx
@@ -1,0 +1,26 @@
+import { Star } from 'lucide-react'
+import { useWatchlist } from '../../tabs/watchlist-store'
+import type { AssetClass } from '../../api/market'
+import { Button } from '../ui/button'
+
+/** Asset-local action, shared by all chart detail surfaces. */
+export function WatchlistButton({ assetClass, symbol }: { assetClass: AssetClass; symbol: string }) {
+  const pinned = useWatchlist(s => s.entries.some(e => e.assetClass === assetClass && e.symbol === symbol))
+  const add = useWatchlist(s => s.add)
+  const remove = useWatchlist(s => s.remove)
+  const label = pinned ? 'Remove from watchlist' : 'Add to watchlist'
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      className={pinned ? 'shrink-0 text-warning' : 'shrink-0 text-muted-foreground'}
+      title={label}
+      aria-label={label}
+      aria-pressed={pinned}
+      onClick={() => pinned ? remove(assetClass, symbol) : add(assetClass, symbol)}
+    >
+      <Star aria-hidden="true" className="size-4" strokeWidth={1.5} fill={pinned ? 'currentColor' : 'none'} />
+    </Button>
+  )
+}

--- a/ui/src/pages/MarketDetailPage.tsx
+++ b/ui/src/pages/MarketDetailPage.tsx
@@ -4,9 +4,7 @@ import { SearchBox } from '../components/market/SearchBox'
 import { EquityDetail } from './market/EquityDetail'
 import { CurrencyDetail } from './market/CurrencyDetail'
 import { GenericDetail } from './market/GenericDetail'
-import { useWatchlist } from '../tabs/watchlist-store'
 import type { ViewSpec } from '../tabs/types'
-import { Button } from '../components/ui/button'
 
 interface MarketDetailPageProps {
   spec: Extract<ViewSpec, { kind: 'market-detail' }>
@@ -23,7 +21,6 @@ export function MarketDetailPage({ spec }: MarketDetailPageProps) {
         description={identity ? `${identity.code} · ${identity.market}` : assetClass === 'currency'
           ? 'FX spot, carry, macro, and scenario analysis'
           : `${assetClass} price history`}
-        right={<PinButton assetClass={assetClass} symbol={symbol} />}
       />
       <div className="flex-1 flex flex-col gap-3 px-4 md:px-8 py-4 min-h-0 overflow-y-auto">
         <SearchBox />
@@ -39,29 +36,3 @@ export function MarketDetailPage({ spec }: MarketDetailPageProps) {
   )
 }
 
-interface PinButtonProps {
-  assetClass: Extract<ViewSpec, { kind: 'market-detail' }>['params']['assetClass']
-  symbol: string
-}
-
-/** Pin / unpin from the Market sidebar's watchlist. */
-function PinButton({ assetClass, symbol }: PinButtonProps) {
-  const pinned = useWatchlist((s) => s.entries.some((e) => e.assetClass === assetClass && e.symbol === symbol))
-  const add = useWatchlist((s) => s.add)
-  const remove = useWatchlist((s) => s.remove)
-  return (
-    <Button
-      type="button"
-      onClick={() => (pinned ? remove(assetClass, symbol) : add(assetClass, symbol))}
-      title={pinned ? 'Remove from watchlist' : 'Add to watchlist'}
-      variant={pinned ? 'secondary' : 'outline'}
-      size="sm"
-      className={pinned ? 'text-warning' : 'text-muted-foreground'}
-    >
-      <svg width="13" height="13" viewBox="0 0 24 24" fill={pinned ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-      </svg>
-      {pinned ? 'Pinned' : 'Pin'}
-    </Button>
-  )
-}


### PR DESCRIPTION
Move the watchlist action out of the market detail top bar and beside the asset name in the shared chart header. Use a ghost star button with a filled selected state, accessible label, pressed state, native tooltip and the existing keyboard-focus treatment. The top bar keeps only its title; all chart detail asset classes share the same control.

Validation: UI owner suite and UI typecheck; toggle/navigation regression. Real Default Project browser verified placement, pin/unpin state and sidebar synchronization, then restored the original unpinned state.
