### PR TITLE
Show candle record freshness without confusing it with feed delay

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -223,3 +223,17 @@ secids remain on the bar request; broker discovery receives the security code
 as a heuristic query, not a claimed canonical trading identity. The chart
 displays its forward-adjustment policy beside the source and keeps full candle
 timestamps available on the condensed date-range label.
+
+### Bar record freshness
+
+Bar responses expose `meta.freshness` identically through HTTP and the Project
+CLI: fetch completion time, latest returned record timestamp, timestamp precision,
+record age in seconds (only for explicit timezone-bearing instants), and whether
+the caller supplied a historical anchor. Age is not measured feed latency.
+Date-only, timezone-less and future records have no inferred age. Existing
+`isLatestActual`/`staleTradingDays` are legacy weekday comparisons, not realtime
+guarantees or exchange-calendar checks.
+
+Charts show latest record time separately from fetch time; source-declared
+`delayed` does not imply a known number of delayed minutes. Board refresh labels
+say “Fetched” because successful polling does not establish underlying freshness.

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -1,3 +1,4 @@
+import { describeBarFreshness } from './freshness.js'
 /**
  * Federated bar layer — service.
  *
@@ -163,18 +164,18 @@ function tradingDaysBetween(fromISO: string, toISO: string): number {
   return days
 }
 
-/** Freshness contract — did the data actually reach the requested point-in-time?
- *  Anchor = explicit end/asOf, else today. The point is to make a delayed source
- *  that silently stopped a day behind "now" LOUD, not to mask it as current. */
+/** Add record timestamps alongside the legacy weekday comparison. */
 function computeFreshness(
   lastBarDate: string,
   opts: GetBarsOpts,
   now: () => Date,
-): Pick<BarMeta, 'asOf' | 'isLatestActual' | 'staleTradingDays'> {
-  if (!lastBarDate) return {}
-  const anchor = (opts.end ?? opts.asOf ?? now().toISOString().slice(0, 10)).slice(0, 10)
+): Pick<BarMeta, 'asOf' | 'isLatestActual' | 'staleTradingDays' | 'freshness'> {
+  const observed = now()
+  const freshness = describeBarFreshness(lastBarDate, Boolean(opts.end || opts.asOf), observed)
+  if (!lastBarDate) return { freshness }
+  const anchor = (opts.end ?? opts.asOf ?? observed.toISOString().slice(0, 10)).slice(0, 10)
   const gap = tradingDaysBetween(lastBarDate.slice(0, 10), anchor)
-  return { asOf: anchor, isLatestActual: gap === 0, staleTradingDays: gap }
+  return { asOf: anchor, isLatestActual: gap === 0, staleTradingDays: gap, freshness }
 }
 
 /** Sort ascending, cap to MAX_BARS (keep most-recent), then truncate to `count`. */

--- a/src/domain/market-data/bars/freshness.spec.ts
+++ b/src/domain/market-data/bars/freshness.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { describeBarFreshness } from './freshness.js'
+const now = new Date('2026-09-08T08:00:00Z')
+describe('bar record freshness', () => {
+  it('measures timestamp age with explicit offsets, without claiming latency', () => {
+    expect(describeBarFreshness('2026-09-08T15:45:00+08:00', false, now)).toEqual({
+      fetchedAt: now.toISOString(), latestRecordAt: '2026-09-08T15:45:00+08:00',
+      timestampKind: 'instant', recordAgeSeconds: 900, historical: false,
+    })
+  })
+  it('does not manufacture intraday ages from dates or timezone-less records', () => {
+    for (const date of ['2026-09-07', '2026-09-08T07:00:00', '', 'invalid']) {
+      expect(describeBarFreshness(date, false, now).recordAgeSeconds).toBeNull()
+    }
+  })
+  it('does not clamp future records into an apparently current age', () => {
+    expect(describeBarFreshness('2026-09-09T08:00:00Z', false, now).recordAgeSeconds).toBeNull()
+  })
+  it('identifies explicit historical requests independently of record age', () => {
+    expect(describeBarFreshness('2025-01-01T08:00:00Z', true, now).historical).toBe(true)
+  })
+})

--- a/src/domain/market-data/bars/freshness.ts
+++ b/src/domain/market-data/bars/freshness.ts
@@ -1,0 +1,19 @@
+/** Record age is not feed latency: sessions, bar boundaries and publication rules differ. */
+export interface BarFreshness {
+  fetchedAt: string
+  latestRecordAt: string | null
+  timestampKind: 'instant' | 'date' | 'unknown'
+  recordAgeSeconds: number | null
+  historical: boolean
+}
+
+export function describeBarFreshness(latest: string, historical: boolean, now = new Date()): BarFreshness {
+  const instant = /T.*(?:Z|[+-]\d{2}:?\d{2})$/i.test(latest) && Number.isFinite(Date.parse(latest))
+  const timestampKind = instant ? 'instant' : /^\d{4}-\d{2}-\d{2}$/.test(latest) ? 'date' : 'unknown'
+  const age = instant ? (now.getTime() - Date.parse(latest)) / 1000 : null
+  return {
+    fetchedAt: now.toISOString(), latestRecordAt: latest || null, timestampKind,
+    recordAgeSeconds: age !== null && age >= 0 ? Math.floor(age) : null,
+    historical,
+  }
+}

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -1,3 +1,4 @@
+import type { BarFreshness } from './freshness.js'
 /**
  * Federated bar layer — types.
  *
@@ -69,6 +70,7 @@ export type BarCapability = 'free' | 'delayed' | 'subscription' | 'iex' | 'realt
 
 /** Data-source metadata — structurally a superset of `DataSourceMeta`. */
 export interface BarMeta {
+  freshness?: BarFreshness
   symbol: string
   from: string
   to: string
@@ -84,16 +86,13 @@ export interface BarMeta {
   limit?: number
   /** Rows omitted by this service's hard ceiling, before count selection. */
   truncatedRows?: number
-  // ---- freshness contract ----
-  // The point-in-time the request was anchored to (opts.end ?? asOf ?? today),
-  // and whether the data actually REACHES it. A delayed vendor silently
-  // stopping a day behind "now" is the failure mode this makes loud: never let
-  // a stale `to` masquerade as the current price.
+  // Legacy weekday comparisons retained for existing consumers.
+  // Use freshness for record timestamps; neither establishes measured feed latency.
   /** Effective anchor of the request (YYYY-MM-DD): explicit end/asOf, else today. */
   asOf?: string
-  /** True when the last bar reaches `asOf` (no trading-day gap); false = stale. */
+  /** Legacy weekday comparison only; does not establish realtime freshness. */
   isLatestActual?: boolean
-  /** Trading-day gap between the last bar and `asOf` (0 when current). */
+  /** Weekday gap to `asOf`, ignoring exchange holidays and session hours. */
   staleTradingDays?: number
 }
 

--- a/src/server/project-market-cli.spec.ts
+++ b/src/server/project-market-cli.spec.ts
@@ -1,6 +1,7 @@
 import { WorkspaceToolCenter } from '../core/workspace-tool-center.js'
 import { registerCliRoutes } from './cli.js'
-import { it, expect } from 'vitest'
+import { it, expect, vi, afterEach } from 'vitest'
+afterEach(() => vi.useRealTimers())
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import { execFile } from 'node:child_process'
@@ -20,6 +21,8 @@ const exec = promisify(execFile)
 const executable = process.env['OPENALICE_CLI_ACCEPTANCE_EXECUTABLE'] ?? process.execPath
 const entryArgs = process.env['OPENALICE_CLI_ACCEPTANCE_EXECUTABLE'] ? [] : ['packages/cli/bin/openalice.ts']
 it('public Project CLI exports the same bars as the chart, clears inherited Workspace scope and preserves files', async () => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2026-09-08T08:00:00Z'))
   const home = await mkdtemp(join(tmpdir(), 'oa-project-bars-'))
   const identity = resolveAliceProjectIdentity({ home, env: {} })
   const rows = [{ date: '2024-01-02', open: 1, high: 3, low: 1, close: 2, volume: 100 }]

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -158,6 +158,13 @@ export interface BarSourceCandidate {
 
 /** Provenance of the bars currently shown — the explicit "who provided this". */
 export interface BarMeta {
+  freshness?: {
+    fetchedAt: string
+    latestRecordAt: string | null
+    timestampKind: 'instant' | 'date' | 'unknown'
+    recordAgeSeconds: number | null
+    historical: boolean
+  }
   symbol: string
   from: string
   to: string

--- a/ui/src/components/LiveIndicator.tsx
+++ b/ui/src/components/LiveIndicator.tsx
@@ -7,6 +7,7 @@ interface LiveIndicatorProps {
   lastUpdated: Date | null
   /** Hide the breathing dot — only show "updated Xs ago" microcopy. */
   hideDot?: boolean
+  label?: string
   className?: string
 }
 
@@ -19,7 +20,7 @@ interface LiveIndicatorProps {
  * without taking real estate. Drop it next to a PageHeader title or any
  * place a user might wonder "is this live?".
  */
-export function LiveIndicator({ lastUpdated, hideDot, className }: LiveIndicatorProps) {
+export function LiveIndicator({ lastUpdated, hideDot, className, label = 'updated' }: LiveIndicatorProps) {
   // Tick once every 5s so "Xs ago" doesn't go stale visually.
   const [, force] = useState(0)
   useEffect(() => {
@@ -34,7 +35,7 @@ export function LiveIndicator({ lastUpdated, hideDot, className }: LiveIndicator
       {!hideDot && (
         <span className="relative inline-block w-1.5 h-1.5 rounded-full bg-success live-pulse" aria-hidden />
       )}
-      <span className="tabular-nums">updated {ago}</span>
+      <span className="tabular-nums">{label} {ago}</span>
     </span>
   )
 }

--- a/ui/src/components/PageHeader.tsx
+++ b/ui/src/components/PageHeader.tsx
@@ -10,7 +10,7 @@ interface PageHeaderProps {
    *  ("updated 14s ago") in the description row below the toolbar.
    *  Pass the timestamp of the last successful refresh. `null` keeps the live
    *  state visible before the first refresh completes. */
-  live?: { lastUpdated: Date | null }
+  live?: { lastUpdated: Date | null; label?: string; hideDot?: boolean }
 }
 
 export function PageHeader({
@@ -25,7 +25,7 @@ export function PageHeader({
       {(description || live) && (
         <div data-slot="page-description" className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 px-4 pb-1 pt-3 text-xs leading-4 text-muted-foreground md:px-6">
           {description && <span className="min-w-0">{description}</span>}
-          {live && <LiveIndicator lastUpdated={live.lastUpdated} />}
+          {live && <LiveIndicator lastUpdated={live.lastUpdated} label={live.label} hideDot={live.hideDot} />}
         </div>
       )}
     </>

--- a/ui/src/components/market/BarFreshness.spec.tsx
+++ b/ui/src/components/market/BarFreshness.spec.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { BarFreshness } from './BarFreshness'
+import type { BarMeta } from '../../api/market'
+afterEach(() => { cleanup(); vi.useRealTimers() })
+it('shows an absolute UTC record and an age, without calling age delay', () => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2026-09-08T08:00:00Z'))
+  render(<BarFreshness meta={{ to: '2026-09-08T07:45:00Z', freshness: {
+    fetchedAt: '2026-09-08T08:00:00Z', latestRecordAt: '2026-09-08T07:45:00Z',
+    timestampKind: 'instant', recordAgeSeconds: 900, historical: false,
+  } } as BarMeta} />)
+  expect(screen.getByText(/Latest record:/).textContent).toContain('07:45:00 UTC')
+  expect(screen.getByText(/Latest record:/).textContent).not.toContain('delay')
+})
+it('keeps legacy date-only responses readable without inventing midnight freshness', () => {
+  render(<BarFreshness meta={{ to: '2026-09-08' } as BarMeta} />)
+  expect(screen.getByText('Latest record: 2026-09-08')).toBeTruthy()
+})
+it('marks historical windows without presenting their age as a live signal', () => {
+  render(<BarFreshness meta={{ freshness: {
+    fetchedAt: '2026-09-08T08:00:00Z', latestRecordAt: '2024-01-02',
+    timestampKind: 'date', recordAgeSeconds: null, historical: true,
+  } } as BarMeta} />)
+  expect(screen.getByText('Historical · Latest record: 2024-01-02')).toBeTruthy()
+})

--- a/ui/src/components/market/BarFreshness.tsx
+++ b/ui/src/components/market/BarFreshness.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import type { BarMeta } from '../../api/market'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { formatRelativeTime } from '../../lib/intl'
+
+/** Deliberately describes record age, never guesses an exchange's trading calendar. */
+export function BarFreshness({ meta }: { meta: BarMeta }) {
+  const [, tick] = useState(0)
+  useEffect(() => {
+    const timer = setInterval(() => tick(n => n + 1), 30_000)
+    return () => clearInterval(timer)
+  }, [])
+  const freshness = meta.freshness
+  const latest = freshness?.latestRecordAt ?? meta.to
+  if (!latest) return null
+  const instant = freshness?.timestampKind === 'instant'
+  const age = instant && freshness.recordAgeSeconds !== null && !freshness.historical
+    ? formatRelativeTime(new Date(latest)) : null
+  const explanation = [
+    'Time since the latest bar timestamp is not measured feed delay. Bar intervals, market closures and publication schedules affect this gap.',
+    freshness?.fetchedAt ? `Fetched: ${freshness.fetchedAt}` : null,
+    meta.barCapability === 'delayed' ? 'Source declares delayed data; exact delay is not provided.' : null,
+    freshness?.timestampKind === 'date' ? 'Daily record: intraday delay cannot be inferred.' : null,
+  ].filter(Boolean).join(' ')
+  return <Tooltip>
+    <TooltipTrigger render={<span tabIndex={0} className="block w-fit max-w-full text-[11px] leading-5 text-muted-foreground tabular-nums outline-none focus-visible:ring-2 focus-visible:ring-ring" />}>
+      {freshness?.historical ? 'Historical · ' : ''}Latest record: {instant ? new Date(latest).toISOString().replace('T', ' ').replace('.000Z', ' UTC') : latest}
+      {age && ` · ${age}`}
+    </TooltipTrigger>
+    <TooltipContent className="max-w-sm">{explanation}</TooltipContent>
+  </Tooltip>
+}

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -1,3 +1,4 @@
+import { BarFreshness } from './BarFreshness'
 import { WatchlistButton } from './WatchlistButton'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -342,6 +343,7 @@ export function KlinePanel({ selection, source, onSnapshot, displayTitle }: Prop
             </span>
           )}
         </div>
+        {meta && <BarFreshness meta={meta} />}
         <div className="flex items-center gap-x-5 gap-y-2 flex-wrap">
           {sourceOptions.length > 1 && (
             <label className="flex items-center gap-2">

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -138,6 +138,12 @@ export const marketHandlers = [
       source: sourceId === 'alpaca-paper' ? 'uta' : 'vendor', sourceId, barId: barId ?? `${sourceId}|${selected.symbol}`,
       provider: sourceId, barCapability: sourceId === 'alpaca-paper' ? 'iex' : 'delayed',
     }
+    meta.freshness = {
+      fetchedAt: new Date().toISOString(), latestRecordAt: meta.to || null,
+      timestampKind: /T.*Z$/.test(meta.to) ? 'instant' : 'date',
+      recordAgeSeconds: /T.*Z$/.test(meta.to) ? Math.max(0, Math.floor((Date.now() - Date.parse(meta.to)) / 1000)) : null,
+      historical: false,
+    }
     return HttpResponse.json({ results, meta })
   }),
 

--- a/ui/src/pages/MarketBoardPage.tsx
+++ b/ui/src/pages/MarketBoardPage.tsx
@@ -68,7 +68,7 @@ function MoversBoardView() {
             {data && <BoardMeta meta={data.meta} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-4 min-h-0">
         <div
@@ -202,7 +202,7 @@ function CalendarBoardView() {
             {data && <BoardMeta meta={data.meta} extra={`${data.window.start} → ${data.window.end}`} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-4 min-h-0">
         <div
@@ -576,7 +576,7 @@ function MacroBoardView() {
             {data && <BoardMeta meta={data.meta} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
@@ -633,7 +633,7 @@ function TermStructureBoardView() {
             {data && <BoardMeta meta={data.meta} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-6 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
@@ -753,7 +753,7 @@ function GlobalMacroBoardView() {
             {data && <BoardMeta meta={data.meta} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
@@ -906,7 +906,7 @@ function ShippingBoardView() {
             {data && <BoardMeta meta={data.meta} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}
@@ -987,7 +987,7 @@ function FedBoardView() {
             {data && <BoardMeta meta={data.meta} />}
           </span>
         }
-        live={{ lastUpdated: updatedAt }}
+        live={{ lastUpdated: updatedAt, label: 'Fetched', hideDot: true }}
       />
       <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 flex flex-col gap-5 min-h-0">
         {loading && !data && <CenteredLoading label={t('common.loading')} />}


### PR DESCRIPTION
Charts now show the latest returned candle timestamp and its age separately from fetch completion time. HTTP and Project CLI responses share additive `meta.freshness` fields. Board headers say “Fetched” and omit the live pulse so polling cannot imply realtime underlying prices.

Record age is deliberately not called feed latency: date-only or ambiguous timestamps have no inferred age, future timestamps are not clamped to current, and explicit historical windows are identified. Exact source delay remains unknown without provider timing and market-session evidence. Existing legacy weekday comparison fields remain compatible.

The UI adds one wrapping metadata line using the shared keyboard-accessible tooltip, without another card or toolbar action. Demo metadata and the market architecture guide are updated.

Validation: root and UI typechecks; full suite completed with 6,799 passing and one timestamp-equality failure, then fixed that test with a deterministic clock and reran all affected specs (12 passing). Real default Project CLI checked Eastmoney 5m, historical daily bars and OKX hourly bars; inspected the real chart daily/minute layouts, board fetch label, and Demo chart in the browser. Previous dev integration CI was green.
