### PR TITLE
Expose record boundaries and delay assessment in raw bars metadata

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -234,6 +234,15 @@ Date-only, timezone-less and future records have no inferred age. Existing
 `isLatestActual`/`staleTradingDays` are legacy weekday comparisons, not realtime
 guarantees or exchange-calendar checks.
 
-Charts show latest record time separately from fetch time; source-declared
+Charts show latest record time separately from fetch time; OpenAlice-classified
 `delayed` does not imply a known number of delayed minutes. Board refresh labels
 say “Fetched” because successful polling does not establish underlying freshness.
+
+Freshness also names the earliest returned record, each endpoint's precision and
+explicit timezone offset (null when unknown), and `timestampMeaning` as the
+provider bar timestamp, without assuming open/close boundary semantics.
+`delay.status` is `possible` for an OpenAlice delayed-source classification,
+otherwise `unknown`; `basis` distinguishes this heuristic from historical
+requests, empty results and insufficient evidence. `estimatedSeconds` remains
+null until actual latency evidence is available. The explanation travels with
+the CLI JSON; neither fresh timestamps nor `realtime` capability certify latency.

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -169,9 +169,11 @@ function computeFreshness(
   lastBarDate: string,
   opts: GetBarsOpts,
   now: () => Date,
+  earliest: string,
+  capability?: string,
 ): Pick<BarMeta, 'asOf' | 'isLatestActual' | 'staleTradingDays' | 'freshness'> {
   const observed = now()
-  const freshness = describeBarFreshness(lastBarDate, Boolean(opts.end || opts.asOf), observed)
+  const freshness = describeBarFreshness(lastBarDate, Boolean(opts.end || opts.asOf), observed, { earliest, capability })
   if (!lastBarDate) return { freshness }
   const anchor = (opts.end ?? opts.asOf ?? observed.toISOString().slice(0, 10)).slice(0, 10)
   const gap = tradingDaysBetween(lastBarDate.slice(0, 10), anchor)
@@ -248,7 +250,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
         barId: formatBarId(provider, symbol),
         provider,
         barCapability: VENDOR_CAPABILITY[provider],
-        ...computeFreshness(filtered[filtered.length - 1]?.date ?? '', opts, () => new Date()),
+        ...computeFreshness(filtered[filtered.length - 1]?.date ?? '', opts, () => new Date(), filtered[0]?.date ?? '', VENDOR_CAPABILITY[provider]),
       }),
     }
   }
@@ -294,7 +296,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
         sourceId,
         barId,
         barCapability: effectiveCap,
-        ...computeFreshness(bars[bars.length - 1]?.date ?? '', opts, () => new Date()),
+        ...computeFreshness(bars[bars.length - 1]?.date ?? '', opts, () => new Date(), bars[0]?.date ?? '', effectiveCap),
       }),
     }
   }

--- a/src/domain/market-data/bars/freshness.spec.ts
+++ b/src/domain/market-data/bars/freshness.spec.ts
@@ -3,7 +3,7 @@ import { describeBarFreshness } from './freshness.js'
 const now = new Date('2026-09-08T08:00:00Z')
 describe('bar record freshness', () => {
   it('measures timestamp age with explicit offsets, without claiming latency', () => {
-    expect(describeBarFreshness('2026-09-08T15:45:00+08:00', false, now)).toEqual({
+    expect(describeBarFreshness('2026-09-08T15:45:00+08:00', false, now)).toMatchObject({
       fetchedAt: now.toISOString(), latestRecordAt: '2026-09-08T15:45:00+08:00',
       timestampKind: 'instant', recordAgeSeconds: 900, historical: false,
     })
@@ -19,4 +19,17 @@ describe('bar record freshness', () => {
   it('identifies explicit historical requests independently of record age', () => {
     expect(describeBarFreshness('2025-01-01T08:00:00Z', true, now).historical).toBe(true)
   })
+})
+
+it('reports source classification as possible delay, not measured or declared latency', () => {
+  const result = describeBarFreshness('2026-09-08T07:55:00Z', false, now, { earliest: '2026-09-07', capability: 'delayed' })
+  expect(result.earliestRecordAt).toBe('2026-09-07')
+  expect(result.earliestTimezone).toBeNull()
+  expect(result.latestTimezone).toBe('Z')
+  expect(result.delay).toMatchObject({ status: 'possible', basis: 'source_classification', estimatedSeconds: null })
+})
+it('never infers realtime from a fresh record or a realtime capability', () => {
+  expect(describeBarFreshness(now.toISOString(), false, now, { capability: 'realtime' }).delay.status).toBe('unknown')
+  expect(describeBarFreshness('2026-09-07', true, now, { capability: 'delayed' }).delay.basis).toBe('historical_request')
+  expect(describeBarFreshness('', false, now).delay.basis).toBe('no_records')
 })

--- a/src/domain/market-data/bars/freshness.ts
+++ b/src/domain/market-data/bars/freshness.ts
@@ -1,5 +1,16 @@
 /** Record age is not feed latency: sessions, bar boundaries and publication rules differ. */
 export interface BarFreshness {
+  earliestRecordAt: string | null
+  earliestTimestampKind: 'instant' | 'date' | 'unknown'
+  earliestTimezone: string | null
+  latestTimezone: string | null
+  timestampMeaning: 'provider_bar_timestamp'
+  delay: {
+    status: 'possible' | 'unknown'
+    estimatedSeconds: number | null
+    basis: 'source_classification' | 'insufficient_evidence' | 'historical_request' | 'no_records'
+    explanation: string
+  }
   fetchedAt: string
   latestRecordAt: string | null
   timestampKind: 'instant' | 'date' | 'unknown'
@@ -7,11 +18,27 @@ export interface BarFreshness {
   historical: boolean
 }
 
-export function describeBarFreshness(latest: string, historical: boolean, now = new Date()): BarFreshness {
+export function describeBarFreshness(latest: string, historical: boolean, now = new Date(), context: { earliest?: string; capability?: string } = {}): BarFreshness {
   const instant = /T.*(?:Z|[+-]\d{2}:?\d{2})$/i.test(latest) && Number.isFinite(Date.parse(latest))
   const timestampKind = instant ? 'instant' : /^\d{4}-\d{2}-\d{2}$/.test(latest) ? 'date' : 'unknown'
   const age = instant ? (now.getTime() - Date.parse(latest)) / 1000 : null
+  const earliest = context.earliest ?? latest
+  const kind = (value: string): BarFreshness['timestampKind'] =>
+    /T.*(?:Z|[+-]\d{2}:?\d{2})$/i.test(value) && Number.isFinite(Date.parse(value)) ? 'instant'
+      : /^\d{4}-\d{2}-\d{2}$/.test(value) ? 'date' : 'unknown'
+  const timezone = (value: string) => kind(value) === 'instant' ? value.match(/(Z|[+-]\d{2}:?\d{2})$/i)![1] : null
+  const basis = !latest ? 'no_records' : historical ? 'historical_request'
+    : context.capability === 'delayed' ? 'source_classification' : 'insufficient_evidence'
   return {
+    earliestRecordAt: earliest || null, earliestTimestampKind: kind(earliest),
+    earliestTimezone: timezone(earliest), latestTimezone: timezone(latest),
+    timestampMeaning: 'provider_bar_timestamp',
+    delay: {
+      status: basis === 'source_classification' ? 'possible' : 'unknown', estimatedSeconds: null, basis,
+      explanation: basis === 'historical_request' ? 'Historical request; record age is not a live delay signal.'
+        : basis === 'no_records' ? 'No returned records to assess.'
+        : `${basis === 'source_classification' ? 'OpenAlice classifies this source as potentially delayed; this is not a per-response provider declaration. ' : ''}Record age is not feed latency. Trading sessions and bar timestamp boundaries are not verified; actual delay is unknown.`,
+    },
     fetchedAt: now.toISOString(), latestRecordAt: latest || null, timestampKind,
     recordAgeSeconds: age !== null && age >= 0 ? Math.floor(age) : null,
     historical,

--- a/src/tool/market-bars.ts
+++ b/src/tool/market-bars.ts
@@ -6,7 +6,7 @@ import type { BarService } from '../domain/market-data/bars/types.js'
 export function createMarketBarsTools({ barService }: { barService: BarService }) {
   return {
     getMarketBars: tool({
-      description: 'Read normalized OHLCV bars with source and window metadata. Use the returned bars in local Python, JavaScript or other pipelines. barId selects an explicit source; symbol plus assetClass uses the configured vendor. No calculation is required.',
+      description: 'Read normalized OHLCV bars with source, returned-window timestamps and freshness metadata. freshness.delay describes possible delay and its basis; recordAgeSeconds is not measured feed latency. Use the returned bars in local Python, JavaScript or other pipelines. barId selects an explicit source; symbol plus assetClass uses the configured vendor. No calculation is required.',
       inputSchema: z.object({
         barId: z.string().min(1).optional().describe('Explicit sourceId|nativeSymbol from market search-bars'),
         symbol: z.string().min(1).optional(),

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -159,6 +159,17 @@ export interface BarSourceCandidate {
 /** Provenance of the bars currently shown — the explicit "who provided this". */
 export interface BarMeta {
   freshness?: {
+    earliestRecordAt?: string | null
+    earliestTimestampKind?: 'instant' | 'date' | 'unknown'
+    earliestTimezone?: string | null
+    latestTimezone?: string | null
+    timestampMeaning?: 'provider_bar_timestamp'
+    delay?: {
+      status: 'possible' | 'unknown'
+      estimatedSeconds: number | null
+      basis: 'source_classification' | 'insufficient_evidence' | 'historical_request' | 'no_records'
+      explanation: string
+    }
     fetchedAt: string
     latestRecordAt: string | null
     timestampKind: 'instant' | 'date' | 'unknown'

--- a/ui/src/components/market/BarFreshness.tsx
+++ b/ui/src/components/market/BarFreshness.tsx
@@ -19,7 +19,7 @@ export function BarFreshness({ meta }: { meta: BarMeta }) {
   const explanation = [
     'Time since the latest bar timestamp is not measured feed delay. Bar intervals, market closures and publication schedules affect this gap.',
     freshness?.fetchedAt ? `Fetched: ${freshness.fetchedAt}` : null,
-    meta.barCapability === 'delayed' ? 'Source declares delayed data; exact delay is not provided.' : null,
+    freshness?.delay?.explanation ?? (meta.barCapability === 'delayed' ? 'OpenAlice classifies this source as potentially delayed; actual delay is unknown.' : null),
     freshness?.timestampKind === 'date' ? 'Daily record: intraday delay cannot be inferred.' : null,
   ].filter(Boolean).join(' ')
   return <Tooltip>

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -139,6 +139,8 @@ export const marketHandlers = [
       provider: sourceId, barCapability: sourceId === 'alpaca-paper' ? 'iex' : 'delayed',
     }
     meta.freshness = {
+      earliestRecordAt: meta.from || null,
+      delay: { status: 'unknown', estimatedSeconds: null, basis: 'insufficient_evidence', explanation: 'Demo snapshot; actual feed delay cannot be assessed.' },
       fetchedAt: new Date().toISOString(), latestRecordAt: meta.to || null,
       timestampKind: /T.*Z$/.test(meta.to) ? 'instant' : 'date',
       recordAgeSeconds: /T.*Z$/.test(meta.to) ? Math.max(0, Math.floor((Date.now() - Date.parse(meta.to)) / 1000)) : null,


### PR DESCRIPTION
The raw bars CLI now carries explicit earliest/latest returned record timestamps, timestamp precision and timezone offsets, plus a structured delay assessment in `meta.freshness`. Agents can distinguish record age from actual feed latency without inspecting the OHLCV array.

The assessment reports `possible` only from OpenAlice's delayed-source classification and otherwise `unknown`, with a basis and short explanation. Historical requests and empty responses have distinct reasons. Estimated latency stays null because source classifications and candle timestamps do not establish measured delay. The chart consumes the same explanation, correcting the previous implication that Yahoo declared a delay in each response. Existing freshness fields remain compatible.

Validation: root/UI typechecks, full hermetic suite, targeted freshness/service/Project CLI parity tests; actual default Project CLI Yahoo minute and historical daily requests; real Yahoo chart and Demo chart browser inspection. Previous dev CI was green.
