### PR TITLE
Explain incomplete candle exclusions in bars CLI and charts

### DIFF
--- a/docs/market-data-architecture.md
+++ b/docs/market-data-architecture.md
@@ -246,3 +246,14 @@ otherwise `unknown`; `basis` distinguishes this heuristic from historical
 requests, empty results and insufficient evidence. `estimatedSeconds` remains
 null until actual latency evidence is available. The explanation travels with
 the CLI JSON; neither fresh timestamps nor `realtime` capability certify latency.
+
+### Incomplete bar diagnostics
+
+`meta.quality` reports inspected and excluded row counts within the fetched date
+window, before count/ceiling selection, plus the latest excluded record and its
+invalid OHLC fields. Null, non-number and non-finite OHLC values are excluded;
+zero and negative prices remain valid. Yahoo's nullable provider models preserve
+incomplete rows until this boundary so a missing latest close is observable.
+The chart displays exclusions separately from freshness; neither CLI nor UI
+substitutes a quote or switches sources to manufacture a complete candle.
+Diagnostics describe rows reaching the bar service, not invisible upstream gaps.

--- a/packages/opentypebb/src/providers/yfinance/models/commodity-spot-price.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/commodity-spot-price.ts
@@ -71,6 +71,7 @@ export class YFinanceCommoditySpotPriceFetcher extends Fetcher {
     const results = await Promise.allSettled(
       symbols.map(async (sym) => {
         const data = await getHistoricalData(sym, {
+          preserveIncomplete: true,
           startDate: query.start_date ?? undefined,
           endDate: query.end_date ?? undefined,
           interval: '1d',

--- a/packages/opentypebb/src/providers/yfinance/models/crypto-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/crypto-historical.ts
@@ -50,6 +50,7 @@ export class YFinanceCryptoHistoricalFetcher extends Fetcher {
     const results = await Promise.allSettled(
       yahooTickers.map(async (sym) => {
         return getHistoricalData(sym, {
+          preserveIncomplete: true,
           startDate: query.start_date,
           endDate: query.end_date,
           interval,

--- a/packages/opentypebb/src/providers/yfinance/models/currency-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/currency-historical.ts
@@ -14,7 +14,7 @@ export const YFinanceCurrencyHistoricalQueryParamsSchema = CurrencyHistoricalQue
 })
 export type YFinanceCurrencyHistoricalQueryParams = z.infer<typeof YFinanceCurrencyHistoricalQueryParamsSchema>
 
-export const YFinanceCurrencyHistoricalDataSchema = CurrencyHistoricalDataSchema
+export const YFinanceCurrencyHistoricalDataSchema = CurrencyHistoricalDataSchema.extend({ close: z.number().nullable() })
 export type YFinanceCurrencyHistoricalData = z.infer<typeof YFinanceCurrencyHistoricalDataSchema>
 
 export class YFinanceCurrencyHistoricalFetcher extends Fetcher {
@@ -50,6 +50,7 @@ export class YFinanceCurrencyHistoricalFetcher extends Fetcher {
     const results = await Promise.allSettled(
       symbols.map(async (sym) => {
         return getHistoricalData(sym, {
+          preserveIncomplete: true,
           startDate: query.start_date,
           endDate: query.end_date,
           interval,

--- a/packages/opentypebb/src/providers/yfinance/models/equity-historical.ts
+++ b/packages/opentypebb/src/providers/yfinance/models/equity-historical.ts
@@ -48,6 +48,7 @@ export class YFinanceEquityHistoricalFetcher extends Fetcher {
     const results = await Promise.allSettled(
       symbols.map(async (sym) => {
         const data = await getHistoricalData(sym, {
+          preserveIncomplete: true,
           startDate: query.start_date,
           endDate: query.end_date,
           interval,

--- a/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/helpers.ts
@@ -286,6 +286,7 @@ export async function getHistoricalData(
     endDate?: string | null
     interval?: string
     extendedHours?: boolean
+    preserveIncomplete?: boolean
   } = {},
 ): Promise<Record<string, unknown>[]> {
   const yf = getYF()
@@ -338,9 +339,9 @@ export async function getHistoricalData(
   }
   const records: Record<string, unknown>[] = []
   for (const q of quotes) {
-    // A missing candle must not invalidate the entire series. Zero/negative
-    // prices are real observations for some contracts (e.g. oil futures).
-    if (![q.open, q.high, q.low, q.close].every(value => typeof value === 'number' && Number.isFinite(value))) continue
+    if (!options.preserveIncomplete && ![q.open, q.high, q.low, q.close].every(value => typeof value === 'number' && Number.isFinite(value))) continue
+    // Preserve incomplete OHLC as null in the nullable provider model. The bar
+    // service excludes these records and reports quality diagnostics to callers.
 
     const date = q.date instanceof Date ? q.date : new Date(q.date as any)
     const dateStr = isIntraday
@@ -349,10 +350,10 @@ export async function getHistoricalData(
 
     records.push({
       date: dateStr,
-      open: q.open ?? null,
-      high: q.high ?? null,
-      low: q.low ?? null,
-      close: q.close ?? null,
+      open: typeof q.open === 'number' && Number.isFinite(q.open) ? q.open : null,
+      high: typeof q.high === 'number' && Number.isFinite(q.high) ? q.high : null,
+      low: typeof q.low === 'number' && Number.isFinite(q.low) ? q.low : null,
+      close: typeof q.close === 'number' && Number.isFinite(q.close) ? q.close : null,
       volume: q.volume ?? null,
       ...(q.adjclose != null ? { adj_close: q.adjclose } : {}),
     })

--- a/packages/opentypebb/src/providers/yfinance/utils/historical-contract.spec.ts
+++ b/packages/opentypebb/src/providers/yfinance/utils/historical-contract.spec.ts
@@ -39,19 +39,32 @@ describe('Yahoo historical time contract', () => {
 })
 
 
-it('skips incomplete FX candles while retaining zero and negative futures prices', async () => {
+it('preserves incomplete FX candles for diagnostics alongside valid zero and negative prices', async () => {
   chart.mockResolvedValue({ quotes: [
     { ...quote('2024-01-01'), close: null },
     { ...quote('2024-01-02'), open: 0, high: 0, low: -2, close: -1 },
     quote('2024-01-03'),
   ] })
-  const rows = await getHistoricalData('USDJPY=X')
-  expect(rows.map(r => r.date)).toEqual(['2024-01-02', '2024-01-03'])
-  expect(rows[0].close).toBe(-1)
+  const rows = await getHistoricalData('USDJPY=X', { preserveIncomplete: true })
+  expect(rows.map(r => r.date)).toEqual(['2024-01-01', '2024-01-02', '2024-01-03'])
+  expect(rows[0].close).toBeNull()
+  expect(rows[1].close).toBe(-1)
 })
 
 it.each([['oats', 'ZO=F'], ['rice', 'ZR=F'], ['orange_juice', 'OJ=F'], ['feeder_cattle', 'GF=F'], ['lumber', 'LBR=F']])('resolves the advertised commodity %s', async (symbol, native) => {
   chart.mockResolvedValue({ quotes: [quote('2024-01-02')] })
   await YFinanceCommoditySpotPriceFetcher.extractData(YFinanceCommoditySpotPriceFetcher.transformQuery({ symbol }), null)
   expect(chart.mock.calls[0][0]).toBe(native)
+})
+
+it('carries incomplete currency rows through schema transformation for bar-service diagnostics', async () => {
+  chart.mockResolvedValue({ quotes: [{ ...quote('2024-01-01'), close: null }, quote('2024-01-02')] })
+  const query = YFinanceCurrencyHistoricalFetcher.transformQuery({ symbol: 'EURUSD', interval: '1m' })
+  const raw = await YFinanceCurrencyHistoricalFetcher.extractData(query, null)
+  expect(YFinanceCurrencyHistoricalFetcher.transformData(query, raw)[0].close).toBeNull()
+})
+
+it('keeps unrelated historical consumers on the existing complete-row contract', async () => {
+  chart.mockResolvedValue({ quotes: [{ ...quote('2024-01-01'), close: null }, quote('2024-01-02')] })
+  expect((await getHistoricalData('GC=F')).map(row => row.date)).toEqual(['2024-01-02'])
 })

--- a/src/domain/market-data/bars/bar-service.spec.ts
+++ b/src/domain/market-data/bars/bar-service.spec.ts
@@ -424,3 +424,12 @@ describe('real-use bar window regressions', () => {
     expect(getHistorical.mock.calls[0]).toEqual([{ aliceId: 'test|AAPL' }, expect.objectContaining({ end: new Date('2024-01-02T23:59:59.999Z') })])
   })
 })
+
+it('explains excluded OHLC rows before count selection and respects the requested window', async () => {
+  const service = createBarService(makeDeps())
+  const result = await service.getBars({ symbol: 'AAPL', assetClass: 'equity' }, { interval: '1d', count: 1 })
+  expect(result.bars).toHaveLength(1)
+  expect(result.meta.quality).toMatchObject({ inspectedRows: 4, excludedRows: 1, latestExcludedRecordAt: '2024-01-04', latestExcludedFields: ['open', 'close'] })
+  const historical = await service.getBars({ symbol: 'AAPL', assetClass: 'equity' }, { interval: '1d', end: '2024-01-03' })
+  expect(historical.meta.quality?.excludedRows).toBe(0)
+})

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -1,3 +1,4 @@
+import { inspectBarQuality, invalidOhlcFields } from './quality.js'
 import { describeBarFreshness } from './freshness.js'
 /**
  * Federated bar layer — service.
@@ -111,7 +112,7 @@ function startDateFor(opts: GetBarsOpts): string {
 // ---- bar shaping ----
 
 function isFullBar(d: Record<string, unknown>): boolean {
-  return d.close != null && d.open != null && d.high != null && d.low != null
+  return invalidOhlcFields(d).length === 0
 }
 
 function dateOf(bar: Bar, interval?: string): string {
@@ -235,13 +236,16 @@ export function createBarService(deps: BarServiceDeps): BarService {
         raw = await deps.commodityClient.getSpotPrices(p())
         break
     }
-    let bars = raw.filter(isFullBar) as OhlcvBar[]
-    if (opts.start) bars = bars.filter((b) => b.date.slice(0, 10) >= opts.start!)
-    if (end_date) bars = bars.filter((b) => b.date.slice(0, 10) <= end_date)
+    const boundedRaw = raw.filter(row =>
+      (!opts.start || String(row.date).slice(0, 10) >= opts.start) &&
+      (!end_date || String(row.date).slice(0, 10) <= end_date))
+    const quality = inspectBarQuality(boundedRaw)
+    const bars = boundedRaw.filter(isFullBar) as OhlcvBar[]
     const filtered = finalize(bars, opts.count)
     return {
       bars: filtered,
       meta: buildMeta(symbol, filtered, {
+        quality,
         interval: opts.interval,
         limit: MAX_BARS,
         truncatedRows: Math.max(0, bars.length - MAX_BARS),
@@ -284,11 +288,13 @@ export function createBarService(deps: BarServiceDeps): BarService {
     const bounded = wireBars.map((b) => barToOhlcv(b, params.interval)).filter((bar) =>
       (!opts.start || bar.date.slice(0, 10) >= opts.start) &&
       (!(opts.end ?? opts.asOf) || bar.date.slice(0, 10) <= (opts.end ?? opts.asOf)!))
-    const bars = finalize(bounded, opts.count)
+    const quality = inspectBarQuality(bounded as unknown as Array<Record<string, unknown>>)
+    const bars = finalize(bounded.filter(row => isFullBar(row as unknown as Record<string, unknown>)), opts.count)
     const symbol = parseBarId(barId)?.nativeSymbol ?? barId
     return {
       bars,
       meta: buildMeta(symbol, bars, {
+        quality,
         interval: opts.interval,
         limit: MAX_BARS,
         truncatedRows: Math.max(0, wireBars.length - MAX_BARS),

--- a/src/domain/market-data/bars/quality.spec.ts
+++ b/src/domain/market-data/bars/quality.spec.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest'
+import { inspectBarQuality, invalidOhlcFields } from './quality.js'
+it('retains zero and negative prices but diagnoses null, non-finite and non-number values', () => {
+  expect(invalidOhlcFields({ open: 0, high: 0, low: -2, close: -1 })).toEqual([])
+  expect(invalidOhlcFields({ open: null, high: Infinity, low: '1', close: NaN })).toEqual(['open', 'high', 'low', 'close'])
+})
+it('reports the latest excluded record even when input is unsorted or entirely invalid', () => {
+  expect(inspectBarQuality([{ date: '2026-09-08', open: 1, high: 2, low: 1, close: null }, { date: '2026-09-07' }])).toMatchObject({ excludedRows: 2, latestExcludedRecordAt: '2026-09-08', latestExcludedFields: ['close'] })
+  expect(inspectBarQuality([])).toMatchObject({ inspectedRows: 0, excludedRows: 0, latestExcludedRecordAt: null, reason: null })
+})

--- a/src/domain/market-data/bars/quality.ts
+++ b/src/domain/market-data/bars/quality.ts
@@ -1,0 +1,22 @@
+export interface BarQuality {
+  scope: 'fetched_window_before_count'
+  inspectedRows: number
+  excludedRows: number
+  latestExcludedRecordAt: string | null
+  latestExcludedFields: string[]
+  reason: 'missing_or_non_finite_ohlc' | null
+}
+const fields = ['open', 'high', 'low', 'close'] as const
+export function invalidOhlcFields(row: Record<string, unknown>): string[] {
+  return fields.filter(field => typeof row[field] !== 'number' || !Number.isFinite(row[field]))
+}
+export function inspectBarQuality(rows: Array<Record<string, unknown>>): BarQuality {
+  const excluded = rows.filter(row => invalidOhlcFields(row).length > 0)
+  const latest = excluded.filter(row => typeof row.date === 'string').sort((a, b) => String(a.date).localeCompare(String(b.date))).at(-1)
+  return {
+    scope: 'fetched_window_before_count', inspectedRows: rows.length, excludedRows: excluded.length,
+    latestExcludedRecordAt: latest ? String(latest.date) : null,
+    latestExcludedFields: latest ? invalidOhlcFields(latest) : [],
+    reason: excluded.length ? 'missing_or_non_finite_ohlc' : null,
+  }
+}

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -1,3 +1,4 @@
+import type { BarQuality } from './quality.js'
 import type { BarFreshness } from './freshness.js'
 /**
  * Federated bar layer — types.
@@ -70,6 +71,7 @@ export type BarCapability = 'free' | 'delayed' | 'subscription' | 'iex' | 'realt
 
 /** Data-source metadata — structurally a superset of `DataSourceMeta`. */
 export interface BarMeta {
+  quality?: BarQuality
   freshness?: BarFreshness
   symbol: string
   from: string

--- a/src/tool/market-bars.ts
+++ b/src/tool/market-bars.ts
@@ -6,7 +6,7 @@ import type { BarService } from '../domain/market-data/bars/types.js'
 export function createMarketBarsTools({ barService }: { barService: BarService }) {
   return {
     getMarketBars: tool({
-      description: 'Read normalized OHLCV bars with source, returned-window timestamps and freshness metadata. freshness.delay describes possible delay and its basis; recordAgeSeconds is not measured feed latency. Use the returned bars in local Python, JavaScript or other pipelines. barId selects an explicit source; symbol plus assetClass uses the configured vendor. No calculation is required.',
+      description: 'Read normalized OHLCV bars with source, returned-window timestamps and freshness metadata. freshness.delay describes possible delay and its basis; recordAgeSeconds is not measured feed latency. Use the returned bars in local Python, JavaScript or other pipelines. barId selects an explicit source; symbol plus assetClass uses the configured vendor. meta.quality reports incomplete OHLC records excluded from the fetched window before count selection. No calculation is required.',
       inputSchema: z.object({
         barId: z.string().min(1).optional().describe('Explicit sourceId|nativeSymbol from market search-bars'),
         symbol: z.string().min(1).optional(),

--- a/ui/src/api/market.ts
+++ b/ui/src/api/market.ts
@@ -158,6 +158,14 @@ export interface BarSourceCandidate {
 
 /** Provenance of the bars currently shown — the explicit "who provided this". */
 export interface BarMeta {
+  quality?: {
+    scope: 'fetched_window_before_count'
+    inspectedRows: number
+    excludedRows: number
+    latestExcludedRecordAt: string | null
+    latestExcludedFields: string[]
+    reason: 'missing_or_non_finite_ohlc' | null
+  }
   freshness?: {
     earliestRecordAt?: string | null
     earliestTimestampKind?: 'instant' | 'date' | 'unknown'

--- a/ui/src/components/market/KlinePanel.spec.tsx
+++ b/ui/src/components/market/KlinePanel.spec.tsx
@@ -250,3 +250,12 @@ it('switches to a usable minute window from a stale workspace route', async () =
   expect(screen.getByRole('button', { name: '1M' }).getAttribute('aria-pressed')).toBe('true')
   expect(screen.getByTestId('route').textContent).toBe('/market/equity/AAPL')
 })
+
+it('explains a newer rejected candle without substituting it into the chart', async () => {
+  const data = response('AAPL', 'yfinance|AAPL')
+  data.meta!.quality = { scope: 'fetched_window_before_count', inspectedRows: 2, excludedRows: 1, latestExcludedRecordAt: '2026-07-18', latestExcludedFields: ['close'], reason: 'missing_or_non_finite_ohlc' }
+  mocks.bars.mockResolvedValue(data)
+  render(<MemoryRouter><KlinePanel selection={{ symbol: 'AAPL', assetClass: 'equity' }} source="yfinance|AAPL" /></MemoryRouter>)
+  expect((await screen.findByRole('status')).textContent).toContain('2026-07-18 (close missing or invalid)')
+  expect(screen.getByText('Latest record: 2026-07-17')).toBeTruthy()
+})

--- a/ui/src/components/market/KlinePanel.tsx
+++ b/ui/src/components/market/KlinePanel.tsx
@@ -344,6 +344,10 @@ export function KlinePanel({ selection, source, onSnapshot, displayTitle }: Prop
           )}
         </div>
         {meta && <BarFreshness meta={meta} />}
+        {meta?.quality && meta.quality.excludedRows > 0 && <p className="text-[11px] leading-5 text-warning" role="status">
+          {meta.quality.excludedRows} incomplete {meta.quality.excludedRows === 1 ? 'record' : 'records'} excluded from fetched window.
+          {meta.quality.latestExcludedRecordAt && ` Latest: ${meta.quality.latestExcludedRecordAt} (${meta.quality.latestExcludedFields.join(', ')} missing or invalid).`}
+        </p>}
         <div className="flex items-center gap-x-5 gap-y-2 flex-wrap">
           {sourceOptions.length > 1 && (
             <label className="flex items-center gap-2">

--- a/ui/src/demo/handlers/market.ts
+++ b/ui/src/demo/handlers/market.ts
@@ -138,6 +138,8 @@ export const marketHandlers = [
       source: sourceId === 'alpaca-paper' ? 'uta' : 'vendor', sourceId, barId: barId ?? `${sourceId}|${selected.symbol}`,
       provider: sourceId, barCapability: sourceId === 'alpaca-paper' ? 'iex' : 'delayed',
     }
+    meta.quality = { scope: 'fetched_window_before_count', inspectedRows: results.length,
+      excludedRows: 0, latestExcludedRecordAt: null, latestExcludedFields: [], reason: null }
     meta.freshness = {
       earliestRecordAt: meta.from || null,
       delay: { status: 'unknown', estimatedSeconds: null, basis: 'insufficient_evidence', explanation: 'Demo snapshot; actual feed delay cannot be assessed.' },


### PR DESCRIPTION
Yahoo can return a latest daily candle with a null close: the chart previously stopped at the prior day without explaining why. Nullable Yahoo bar models now preserve incomplete records until the bar-service validation boundary. `meta.quality` exposes inspected/excluded counts, the latest excluded timestamp and invalid OHLC fields. Charts display a compact warning beside freshness; agents receive the same diagnostics through the raw bars CLI.

The validation excludes missing/non-finite OHLC while retaining zero/negative prices and zero volume. Diagnostics describe the fetched date window before count selection, including all-invalid results. Historical bounds exclude unrelated invalid records. Yahoo's other historical consumers retain the existing complete-row default. The currency-specific schema permits missing close so one incomplete candle cannot abort the entire bars request.

Validation: root, UI and provider-package typechecks; complete hermetic suite and targeted provider/service/UI specs. Real default Project CLI checked Yahoo Maotai daily (missing latest close), Yahoo FX/BTC minute bars, gold daily and OKX hourly bars. Browser verified the real missing-close warning and the normal Demo chart. No orders or data-source substitution.
