### PR TITLE
Fix packaged CLI smoke after Project scope promotion

### DIFF
--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -102,9 +102,11 @@ export function buildPackagedToolchainSmokePlan(packageResult) {
     env: {
       ELECTRON_RUN_AS_NODE: '1',
       OPENALICE_CLI_BIN: 'traderhub',
+      AQ_WS_ID: '',
+      OPENALICE_PROJECT_ID: '',
     },
     expectStatus: 1,
-    expectStderr: /traderhub: AQ_WS_ID is not set/,
+    expectStderr: /traderhub: No Project context/,
   })
 
   if (packageResult.platform === 'win32') {
@@ -195,9 +197,9 @@ const run = async (args) => {
       label: 'Workspace CLI launcher through managed Git Bash',
       command: bashExe,
       args: ['--noprofile', '--norc', '-c', 'alice --help'],
-      env: winEnv,
+      env: { ...winEnv, AQ_WS_ID: '', OPENALICE_PROJECT_ID: '' },
       expectStatus: 1,
-      expectStderr: /alice: AQ_WS_ID is not set/,
+      expectStderr: /alice: No Project context/,
     })
     commands.push({
       label: 'Workspace CLI transport env through managed Git Bash',

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -51,6 +52,12 @@ describe('buildPackagedToolchainSmokePlan', () => {
         'managed Pi resolves packaged fd/rg without download',
         'workspace CLI payload through packaged Electron Node',
       ])
+      const cli = plan.commands.at(-1)!
+      const result = spawnSync(process.execPath, ['src/workspaces/cli/bin/openalice-cli.cjs'], {
+        encoding: 'utf8', env: { ...process.env, ...cli.env, ELECTRON_RUN_AS_NODE: '' },
+      })
+      expect(result.status).toBe(cli.expectStatus)
+      expect(result.stderr).toMatch(cli.expectStderr)
       expect(plan.commands[1].expectStdout.test('0.83.0\n')).toBe(true)
       expect(plan.commands[1].expectStdout.test('0x83x0\n')).toBe(false)
       expect(packagedElectronExecutable(appRoot, 'darwin')?.replaceAll('\\', '/'))


### PR DESCRIPTION
Packaged toolchain smoke still expected the old Workspace-only missing-context error after CLI gained Project scope, rejecting a valid packaged CLI. Update macOS/direct and Windows Bash expectations and explicitly clear inherited Workspace/Project context for these negative probes.

Validation: three plan specs including a real CLI error check, root typecheck, rebuilt packaged Electron Workspace acceptance and the exact packaged toolchain smoke all passed locally. This repairs the promotion gate without changing runtime behavior.
