### PR TITLE
Fix packaged CLI transport smoke diagnostic stream

### DIFF
--- a/scripts/smoke-packaged-toolchain.mjs
+++ b/scripts/smoke-packaged-toolchain.mjs
@@ -213,7 +213,7 @@ const run = async (args) => {
         OPENALICE_CLI_DEBUG: '1',
       },
       expectStatus: 1,
-      expectStdout: /"toolUrl":"\/cli"/,
+      expectStderr: /"toolUrl":"\/cli"/,
     })
   }
 

--- a/scripts/smoke-packaged-toolchain.spec.ts
+++ b/scripts/smoke-packaged-toolchain.spec.ts
@@ -128,7 +128,22 @@ describe('buildPackagedToolchainSmokePlan', () => {
       expect(plan.commands[9].env?.PATH.replaceAll('\\', '/')).toContain('vendor/tools/win32-x64/bin')
       expect(plan.commands[10].env?.OPENALICE_MANAGED_PI_NODE_PATH.replaceAll('\\', '/'))
         .toContain('win-unpacked/OpenAlice.exe')
-      expect(plan.commands[11].env?.OPENALICE_TOOL_URL).toBe('/cli')
+      const transport = plan.commands[11]
+      expect(transport.env?.OPENALICE_TOOL_URL).toBe('/cli')
+      const result = spawnSync(process.execPath, ['src/workspaces/cli/bin/openalice-cli.cjs', '--help'], {
+        encoding: 'utf8',
+        timeout: 10_000,
+        env: {
+          ...process.env,
+          ...transport.env,
+          OPENALICE_PROJECT_ID: '',
+          OPENALICE_TOOL_SOCKET: join(root, 'missing.sock'),
+          ELECTRON_RUN_AS_NODE: '',
+        },
+      })
+      expect(result.status).toBe(transport.expectStatus)
+      expect(result.stderr).toMatch(transport.expectStderr)
+      expect(result.stdout).toBe('')
     } finally {
       rmSync(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
The Windows packaged transport probe expected CLI debug metadata on stdout, but the CLI emits diagnostics on stderr. Match the actual stream and exercise the CLI payload in the smoke-plan regression so this mismatch is caught locally.

Validation: 3 smoke-plan tests passed, root typecheck passed, and the retained unsigned macOS package toolchain smoke passed. Windows Git Bash transport remains covered by promotion CI.