### PR TITLE
Prepare 0.92.1-beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.0",
+  "version": "0.92.1-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.0",
+  "version": "0.92.1-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Set root and native CLI versions to 0.92.1-beta after accepted dev promotion #1426. This is a beta-only publication metadata change; stable remains 0.92.0.

Source acceptance: full promotion checks, all three desktop package platforms, Windows Broker Pack upgrade, installer/Docker checks, and latest dev-channel publication and install all passed. Release candidate acceptance and public-byte verification follow the merge.