### PR TITLE
Sync accepted 0.92.1-beta version to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.0",
+  "version": "0.92.1-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.0",
+  "version": "0.92.1-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Copy only the root and CLI version values from the accepted beta release. Runtime dev channel identity remains unchanged.

Release run 34258766715 passed after retrying a transient GitHub upload disconnect. Public beta install reports 0.92.1-beta; stable manifests/feeds are byte-identical and stable download aliases retain their ETags, sizes and modification dates. The installer still defaults to stable 0.92.0.