### PR TITLE
fix(issues): recruit fresh owners for comment replies

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -172,8 +172,12 @@ structured run log remain durable. Inbox inquiries expose the same shape on the 
 Issue Activity and Inbox reply threads render that same field as a compact
 live timeline: semantic text, tool name/status, and errors. They do not fetch
 `/output` or show tool payloads. The Telegram phone desk
-already projects sealed `text` blocks from that same field. A human comment without a fixed owner
-uses the same provenance-aware fallback as Inbox: OpenAlice asks the
+already projects sealed `text` blocks from that same field. A human comment on
+`@new-then-resume` recruits and claims the first Session using the Issue's
+Agent, credential, model, and effort, sharing dispatch exclusion with scheduled
+fires. `@new-each-run` comments recruit fresh workers without claiming ownership.
+These comments never fall back to an earlier creator, and do not advance the
+schedule marker. Ordinary unassigned/human-owned Issue comments use the same provenance-aware fallback as Inbox: OpenAlice asks the
 attributable creator, or recruits a reconstruction Agent in the Issue
 Workspace when no creator Session exists. The answer is recorded in Activity
 without changing `assignee`; a temporary answerer never becomes the scheduling

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -138,6 +138,9 @@ export type WorkspaceConversationAskResult =
     }
 
 export interface WorkspaceConversationControl {
+  /** Follow the live Issue ownership policy, including first-owner recruitment. */
+  replyToIssue?(input: { workspaceId: string; issueId: string; prompt: string; commentId: string }): Promise<{ taskId: string; resumeId: string }>
+
   ask(input: {
     readonly prompt: string
     /** Optional execution watchdog. Omit to let the Session run to completion. */

--- a/src/workspaces/conversation-control.ts
+++ b/src/workspaces/conversation-control.ts
@@ -272,6 +272,7 @@ export function createWorkspaceConversationControl(
   harnessDependencies: ConversationHarnessDependencies = defaultHarnessDependencies,
 ): WorkspaceConversationControl {
   return {
+    replyToIssue: (input) => svc.replyToIssue(input),
     async ask(input): Promise<WorkspaceConversationAskResult> {
       const resolution = input.target.kind === 'harness'
         ? await resolveHarnessConversationTarget(svc, input.target.harness, harnessDependencies)

--- a/src/workspaces/issues/comment-delivery.spec.ts
+++ b/src/workspaces/issues/comment-delivery.spec.ts
@@ -101,7 +101,7 @@ describe('dispatchIssueCommentReply', () => {
     expect(await dispatchIssueCommentReply({
       conversation: control,
       issueWorkspaceId: 'ws-home',
-      issue: issue('@new-each-run'),
+      issue: issue('@unassigned'),
       comment,
       source: { kind: 'human' },
     })).toEqual({
@@ -267,5 +267,28 @@ describe('recordIssueCommentReply', () => {
     expect(comments.ok && comments.comments[0]?.delivery).toEqual({
       state: 'failed', targetResumeId: 'resume-owner', taskId: 'run-reply', error: 'runtime unavailable',
     })
+  })
+})
+
+describe('fresh Issue owner comments', () => {
+  it.each(['@new-then-resume', '@new-each-run'])('does not ask the historical creator for %s', async (assignee) => {
+    const ask = vi.fn()
+    const replyToIssue = vi.fn(async () => ({ taskId: 'new-run', resumeId: 'resume-new' }))
+    const result = await dispatchIssueCommentReply({
+      conversation: { ask, read: vi.fn(), replyToIssue }, issueWorkspaceId: 'ws-home',
+      issue: issue(assignee), comment, source: { kind: 'human' },
+    })
+    expect(ask).not.toHaveBeenCalled()
+    expect(replyToIssue).toHaveBeenCalledWith(expect.objectContaining({ issueId: 'audit', commentId: comment.id }))
+    expect(result).toEqual({ status: 'scheduled', delivery: { state: 'pending', taskId: 'new-run', targetResumeId: 'resume-new' } })
+  })
+  it('fails explicitly rather than falling back to the old creator when recruitment fails', async () => {
+    const ask = vi.fn()
+    const result = await dispatchIssueCommentReply({
+      conversation: { ask, read: vi.fn(), replyToIssue: async () => { throw new Error('busy') } },
+      issueWorkspaceId: 'ws-home', issue: issue('@new-then-resume'), comment, source: { kind: 'human' },
+    })
+    expect(result).toEqual({ status: 'failed', delivery: { state: 'failed', error: 'busy' } })
+    expect(ask).not.toHaveBeenCalled()
   })
 })

--- a/src/workspaces/issues/comment-delivery.ts
+++ b/src/workspaces/issues/comment-delivery.ts
@@ -42,8 +42,9 @@ export function issueCommentReplyPrompt(input: {
 
 /**
  * A fixed Issue owner is a real colleague: comments from somebody else are
- * delivered to that exact product Session. Human comments on Issues without a
- * fixed owner use the same provenance-aware fallback as Inbox: continue the
+ * delivered to that exact product Session. Fresh-owner policies recruit via
+ * the shared Issue dispatcher. Human comments on ordinary unassigned Issues
+ * use the same provenance-aware fallback as Inbox: continue the
  * creator when attributable, otherwise recruit a reconstruction worker in the
  * Issue Workspace. That answering Session is a collaborator, not a new owner;
  * the Issue assignee and scheduling contract stay unchanged.
@@ -78,6 +79,16 @@ export async function dispatchIssueCommentReply(input: {
   }
 
   try {
+    if (input.issue.assignee === '@new-then-resume' || input.issue.assignee === '@new-each-run') {
+      if (!input.conversation.replyToIssue) throw new Error('Issue owner recruitment is unavailable in this runtime.')
+      const result = await input.conversation.replyToIssue({
+        workspaceId: input.issueWorkspaceId,
+        issueId: input.issue.id,
+        prompt: issueCommentReplyPrompt(input),
+        commentId: input.comment.id,
+      })
+      return { status: 'scheduled', delivery: { state: 'pending', targetResumeId: result.resumeId, taskId: result.taskId } }
+    }
     const target = targetResumeId
       ? { kind: 'resume' as const, resumeId: targetResumeId }
       : {

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -125,7 +125,7 @@ describe('telegram desk ingest and stamp', () => {
     const { client, sent } = mockClient()
     const result = await ingestTelegramOwnerMessage(host({
       conversation: () => ({
-        ask: async () => ({ status: 'accepted', taskId: 'run-1', resumeId: 'resume-1' }),
+        replyToIssue: async () => ({ taskId: 'run-1', resumeId: 'resume-1' }),
       } as unknown as NonNullable<ReturnType<TelegramDeskChatHost['conversation']>>),
     }), {
       connectorId: 'telegram',

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -132,14 +132,7 @@ async function makeWs(id: string, issues: IssueSpec[]): Promise<WorkspaceMeta> {
 function scannerFor(
   workspaces: WorkspaceMeta[],
   opts: {
-    dispatch?: (
-      m: WorkspaceMeta,
-      a: CliAdapter,
-      p: string,
-      t?: number,
-      trigger?: import('../headless-task-registry.js').HeadlessTaskTrigger,
-      resumeId?: string,
-    ) => Promise<{ taskId: string; resumeId: string }>
+    dispatch?: ScheduleScannerDeps['dispatch']
     markers?: MarkerStore
     now?: number
     adapter?: CliAdapter
@@ -149,7 +142,7 @@ function scannerFor(
     observeIssues?: ScheduleScannerDeps['observeIssues']
   } = {},
 ) {
-  const dispatch = opts.dispatch ?? vi.fn(async () => ({ taskId: 'run-1', resumeId: 'resume-new-worker-a1b2c3' }))
+  const dispatch = vi.fn(opts.dispatch ?? (async () => ({ taskId: 'run-1', resumeId: 'resume-new-worker-a1b2c3' })))
   const markers = opts.markers ?? new FakeMarkers()
   const scanner = new ScheduleScanner({
     registry: {
@@ -772,5 +765,46 @@ describe('ScheduleScanner', () => {
     const { scanner } = scannerFor([ws], { markers })
     await scanner.scan()
     expect(markers.get('w1', 'removed')).toBeUndefined()
+  })
+})
+
+describe('comment owner handoff', () => {
+  it('uses the Issue runtime, claims once, and preserves the schedule marker', async () => {
+    const spec: IssueSpec = { id: 'desk', title: 'Desk', when: { kind: 'every', every: '4h' },
+      assignee: '@new-then-resume', agent: 'codex', credentialSource: 'native', model: 'gpt-5.6-sol', effort: 'medium' }
+    const ws = await makeWs('w1', [spec])
+    const claimFreshSession = vi.fn(async ({ resumeId }: { resumeId: string }) => {
+      await writeFile(join(ws.dir, '.alice/issues/desk.md'), issueMd({ ...spec, assignee: '@' + resumeId, agent: undefined, credentialSource: undefined, model: undefined, effort: undefined }))
+    })
+    const { scanner, dispatch, markers } = scannerFor([ws], { claimFreshSession })
+    await scanner.runIssueComment({ workspaceId: 'w1', issueId: 'desk', prompt: 'Hello', commentId: 'c1' })
+    const first = dispatch.mock.calls[0]
+    expect(first[4]).toBeUndefined() // never a cron turn: no no-reply suppression
+    expect(first[5]).toBeUndefined()
+    expect(first[6]).toMatchObject({ subject: { relation: 'owner', commentId: 'c1' } })
+    expect(first[7]).toMatchObject({ credentialSource: 'native', model: 'gpt-5.6-sol', reasoningEffort: 'medium' })
+    expect(first[9]).toMatchObject({ kind: 'issue', fire: 'comment', policy: 'new-then-resume' })
+    expect(claimFreshSession).toHaveBeenCalledTimes(1)
+    expect(markers.get('w1', 'desk')).toBeUndefined()
+    await scanner.runIssueComment({ workspaceId: 'w1', issueId: 'desk', prompt: 'Again', commentId: 'c2' })
+    expect(dispatch.mock.calls[1][5]).toBe('resume-new-worker-a1b2c3')
+    expect(claimFreshSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('excludes a scheduled fire while the comment is creating the owner', async () => {
+    const ws = await makeWs('w1', [{ id: 'desk', title: 'Desk', when: { kind: 'every', every: '4h' }, assignee: '@new-then-resume' }])
+    let release!: () => void
+    let entered!: () => void
+    const started = new Promise<void>((resolve) => { entered = resolve })
+    const held = new Promise<void>((resolve) => { release = resolve })
+    const dispatch = vi.fn(async () => { entered(); await held; return { taskId: 'run-1', resumeId: 'resume-new' } })
+    const { scanner, markers } = scannerFor([ws], { dispatch, claimFreshSession: async () => undefined })
+    const comment = scanner.runIssueComment({ workspaceId: 'w1', issueId: 'desk', prompt: 'Hello', commentId: 'c1' })
+    await started
+    await scanner.scan()
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(markers.get('w1', 'desk')).toBeUndefined()
+    release()
+    await comment
   })
 })

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -30,7 +30,7 @@ import type { CliAdapter } from '../cli-adapter.js'
 import type { SessionRuntimeSelection } from '../session-runtime-binding.js'
 import type { Logger } from '../logger.js'
 import type { WorkspaceMeta, WorkspaceRegistry } from '../workspace-registry.js'
-import type { HeadlessTaskTrigger } from '../headless-task-registry.js'
+import type { HeadlessTaskInquiry, HeadlessTaskTrigger } from '../headless-task-registry.js'
 import type { SessionCreatedBy } from '../session-metadata.js'
 
 import {
@@ -101,7 +101,7 @@ export interface ScheduleScannerDeps {
     /** Product Session to continue. Omitted means allocate a fresh Session. */
     resumeId?: string,
     /** Optional reverse-link metadata; scheduler leaves this absent. */
-    inquiry?: undefined,
+    inquiry?: HeadlessTaskInquiry,
     /** Fresh-Session credential/model/effort selection inherited from Issue frontmatter. */
     selection?: SessionRuntimeSelection,
     conversation?: undefined,
@@ -200,7 +200,7 @@ export class ScheduleScanner {
       }
     }
 
-    return this.dispatchIssue(
+    const result = await this.dispatchIssue(
       ws,
       issue.id,
       issueFirePrompt(issue),
@@ -212,6 +212,15 @@ export class ScheduleScanner {
       issue.connectorDesk,
       true,
     )
+    return { taskId: result.taskId }
+  }
+
+  /** Comments share the scheduler's dispatch/claim exclusion, without advancing its clock. */
+  async runIssueComment(input: { workspaceId: string; issueId: string; prompt: string; commentId: string }): Promise<{ taskId: string; resumeId: string }> {
+    const ws = this.deps.registry.get(input.workspaceId)
+    if (!ws) throw new Error('Workspace not found.')
+    return this.dispatchIssue(ws, input.issueId, input.prompt, undefined, undefined, undefined,
+      false, undefined, undefined, true, input.commentId)
   }
 
   private arm(): void {
@@ -406,7 +415,8 @@ export class ScheduleScanner {
     timeoutMs?: number,
     connectorDesk?: string,
     manual = false,
-  ): Promise<{ taskId: string }> {
+    commentId?: string,
+  ): Promise<{ taskId: string; resumeId: string }> {
     const dispatchKey = `${issueWorkspace.id}:${issueId}`
     if (this.dispatchingIssues.has(dispatchKey)) {
       if (manual) {
@@ -419,6 +429,24 @@ export class ScheduleScanner {
     }
     this.dispatchingIssues.add(dispatchKey)
     try {
+      // A scan or comment may have read the file before another dispatch claimed it.
+      // Resolve ownership again while holding the shared dispatch exclusion.
+      if (claimFreshSession || commentId) {
+        const read = await readWorkspaceIssues(issueWorkspace.dir)
+        const live = read.ok ? read.issues.find((issue) => issue.id === issueId) : undefined
+        if (!live) throw new Error('Issue not found.')
+        resumeId = issueAssigneeResumeId(live.assignee) ?? undefined
+        claimFreshSession = issueAssigneeClaimsFirstSession(live.assignee)
+        if (!resumeId && !claimFreshSession && live.assignee !== '@new-each-run') {
+          throw new Error('Issue ownership changed; no Agent owner is selected.')
+        }
+        agentId = live.agent
+        selection = issueRunOverrides(live)
+        timeoutMs = issueTimeoutMs(live.timeout)
+        if (commentId && !resumeId) {
+          what = `Issue ${issueId}: ${live.title}\n${live.what}\n\nHistory: .alice/issues/${issueId}.comments.json\n\n${what}`
+        }
+      }
       const executionWorkspace = resumeId
         ? this.resolveResumeWorkspace(resumeId)
         : issueWorkspace
@@ -429,7 +457,7 @@ export class ScheduleScanner {
       if (!adapter.capabilities.headless || !adapter.composeHeadlessCommand) {
         throw new Error(`agent runtime does not support headless work: ${adapter.id}`)
       }
-      const trigger: HeadlessTaskTrigger = {
+      const trigger: HeadlessTaskTrigger | undefined = commentId ? undefined : {
         kind: 'issue',
         workspaceId: issueWorkspace.id,
         issueId,
@@ -450,9 +478,17 @@ export class ScheduleScanner {
             workspaceId: issueWorkspace.id,
             issueId,
             policy: claimFreshSession ? 'new-then-resume' : 'new-each-run',
-            fire: manual ? 'retry' : 'schedule',
+            fire: commentId ? 'comment' : manual ? 'retry' : 'schedule',
           }
-      const result = resumeId
+      const inquiry: HeadlessTaskInquiry | undefined = commentId ? {
+        subject: { kind: 'issue', workspaceId: issueWorkspace.id, issueId, relation: 'owner', commentId },
+        question: what,
+        resolution: { mode: resumeId ? 'exact' : 'reconstructed' },
+      } : undefined
+      const result = inquiry
+        ? await this.deps.dispatch(executionWorkspace, adapter, what, timeoutMs, undefined,
+            resumeId, inquiry, selection, undefined, createdBy)
+        : resumeId
         ? selection
           ? await this.deps.dispatch(
               executionWorkspace,
@@ -530,7 +566,7 @@ export class ScheduleScanner {
         runId: result.taskId,
         manual,
       })
-      return { taskId: result.taskId }
+      return result
     } finally {
       this.dispatchingIssues.delete(dispatchKey)
     }

--- a/src/workspaces/service.issue-assignee-session.spec.ts
+++ b/src/workspaces/service.issue-assignee-session.spec.ts
@@ -90,3 +90,43 @@ describe('WorkspaceService Issue assignee activity', () => {
     }
   })
 })
+
+it('hands a fresh-owner comment to the configured runtime and persists the new owner', async () => {
+  const { createWorkspaceConversationControl } = await import('./conversation-control.js')
+  const { appendIssueComment, readIssueComments, updateIssueCommentDelivery } = await import('./issues/comments.js')
+  const { dispatchIssueCommentReply } = await import('./issues/comment-delivery.js')
+  await service!.catalog.recordCreated(service!.registry.get('ws-1')!)
+  const adapter = service!.adapters.get('codex')!
+  const command = vi.spyOn(adapter, 'composeHeadlessCommand').mockReturnValue([
+    process.execPath, '-e', `console.log(JSON.stringify({type:'thread.started',thread_id:'native-handoff'}));console.log(JSON.stringify({type:'item.completed',item:{type:'agent_message',text:'HANDOFF_OK'}}));`,
+  ])
+  try {
+    const created = await createIssue(wsDir, { id: 'handoff', title: 'Handoff',
+      when: { kind: 'every', every: '4h' }, assignee: '@new-then-resume',
+      agent: 'codex', credentialSource: 'native', model: 'gpt-5.6-sol', effort: 'medium',
+    })
+    expect(created.ok).toBe(true)
+    if (!created.ok) return
+    await service!.provenanceStore.append({ artifact: { kind: 'issue', workspaceId: 'ws-1', issueId: 'handoff' },
+      action: 'created', origin: { kind: 'session', workspaceId: 'ws-1', resumeId: 'resume-old-pi', agent: 'pi' }, at: Date.now() })
+    const added = await appendIssueComment(wsDir, 'handoff', 'human', 'Hello')
+    if (!added.ok) throw new Error('Could not append fixture comment')
+    const result = await dispatchIssueCommentReply({ conversation: createWorkspaceConversationControl(service!),
+      issueWorkspaceId: 'ws-1', issue: created.issue, comment: added.comment, source: { kind: 'human' } })
+    expect(result, JSON.stringify(result)).toMatchObject({ status: 'scheduled' })
+    if (result.status !== 'scheduled') return
+    expect((await updateIssueCommentDelivery(wsDir, 'handoff', added.comment.id, result.delivery)).ok).toBe(true)
+    const taskId = result.delivery.taskId
+    await vi.waitFor(() => expect(service!.headlessTasks.get(taskId)?.status).toBe('done'), { timeout: 10000 })
+    const task = service!.headlessTasks.get(taskId)!
+    expect(task).toMatchObject({ agent: 'codex', model: 'gpt-5.6-sol', effort: 'medium' })
+    expect(task.resumeId).not.toBe('resume-old-pi')
+    expect((await service!.issueDetail('ws-1', 'handoff'))?.issue.assignee).toBe('@' + task.resumeId)
+    expect(command).toHaveBeenCalledTimes(1)
+    await vi.waitFor(async () => {
+      const comments = await readIssueComments(wsDir, 'handoff')
+      expect(comments.ok && comments.comments.some((entry) => entry.replyTo === added.comment.id && entry.markdown === 'HANDOFF_OK')).toBe(true)
+      expect(service!.isResumeActive(task.resumeId)).toBe(false)
+    }, { timeout: 10000 })
+  } finally { command.mockRestore() }
+}, 20000)

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -574,6 +574,7 @@ export interface WorkspaceService {
   /** Dispatch a scheduled Issue immediately without requiring a failed last
    * run and without advancing its next-fire marker. */
   runIssueNow(wsId: string, id: string): Promise<IssueDetail>;
+  replyToIssue(input: { workspaceId: string; issueId: string; prompt: string; commentId: string }): Promise<{ taskId: string; resumeId: string }>;
   connectorDesk(connectorId: string): Promise<ConnectorDesk | null>;
   createConnectorDesk(connectorId: string, wsId: string): Promise<ConnectorDesk>;
   updateConnectorDesk(connectorId: string, patch: {
@@ -3323,6 +3324,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     disableTelegramConnectorDesk: async () => disableConnectorDeskOp('telegram'),
     retryIssue,
     runIssueNow,
+    replyToIssue: (input) => scheduleScanner.runIssueComment(input),
     sessionDirectory,
     setSessionPresence,
     setSessionDisplayName,

--- a/src/workspaces/session-metadata.ts
+++ b/src/workspaces/session-metadata.ts
@@ -12,7 +12,7 @@ export type SessionInteractiveSurface = 'spawn' | 'quick-chat' | 'auto-quant' | 
 
 export type SessionIssueBirthPolicy = 'new-each-run' | 'new-then-resume'
 
-export type SessionIssueFire = 'schedule' | 'retry'
+export type SessionIssueFire = 'schedule' | 'retry' | 'comment'
 
 export type SessionConversationCaller =
   | { readonly kind: 'agent'; readonly resumeId: string; readonly workspaceId?: string }
@@ -96,7 +96,7 @@ export function parseSessionCreatedBy(value: unknown): SessionCreatedBy | null {
       && typeof issueId === 'string'
       && issueId.length > 0
       && (policy === 'new-each-run' || policy === 'new-then-resume')
-      && (fire === 'schedule' || fire === 'retry')
+      && (fire === 'schedule' || fire === 'retry' || fire === 'comment')
     ) {
       return { kind: 'issue', workspaceId, issueId, policy, fire }
     }

--- a/src/workspaces/workspace-creation.e2e.spec.ts
+++ b/src/workspaces/workspace-creation.e2e.spec.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { initializeWorkspaceTemplateState } from './template-upgrade.js';
+import { aliceHarnessSourceVersion } from './alice-harness-assets.js';
 import { injectWorkspaceContext } from './context-injector.js';
 import type { TemplateMeta } from './template-registry.js';
 import { commitInitial } from './workspace-creator.js';
@@ -122,7 +123,7 @@ describe('chat workspace create: bootstrap → inject → commit', () => {
     await commitInitial(dir, 'chat: testtag');
     await initializeWorkspaceTemplateState({ id: 'ws-e2e-1', tag: 'testtag', dir, createdAt: new Date().toISOString(), template: 'chat', spawnedFromVersion: '1.0.0' }, chatMeta());
     const injection = JSON.parse(await readFile(join(dir, '.alice/alice-harness-version.json'), 'utf8'));
-    expect(injection.appliedVersion).toMatch(/^1\.0\.0\+/);
+    expect(injection.appliedVersion).toBe(await aliceHarnessSourceVersion());
     expect(injection.template).toBe('alice-harness');
 
     // injected files all present

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -926,7 +926,7 @@ export type SessionCreatedBy =
       readonly workspaceId: string;
       readonly issueId: string;
       readonly policy: 'new-each-run' | 'new-then-resume';
-      readonly fire: 'schedule' | 'retry';
+      readonly fire: 'schedule' | 'retry' | 'comment';
     }
   | { readonly kind: 'headless'; readonly surface: 'api' }
   | {


### PR DESCRIPTION
## Problem and change

When an Issue switched to `@new-then-resume`, its next comment could resume the historical creator before a new owner existed. A Telegram desk configured for Codex could therefore keep dispatching to its old Pi Session.

Route fresh-owner comments through the shared Issue dispatcher and ownership claim. Re-read ownership under the same exclusion used by scheduled runs, apply the configured runtime/model/effort, and persist the new owner for subsequent comments. Fresh Sessions receive the Issue context and history location. Comment replies retain their inquiry completion path without advancing the schedule or applying scheduled no-reply behavior. Ordinary unassigned Issues keep their existing creator fallback.

## Validation

- Full hermetic test suite.
- Root and UI TypeScript checks.
- Workspace integration suite.
- Real WorkspaceService test with a spawned local CLI fixture: historical Pi provenance, new Codex selection, persisted owner and completed reply.
- Regression coverage for fresh policies, failed recruitment without fallback, subsequent resume, and concurrent comment/schedule dispatch.

The Workspace creation integration assertion now reads the current injection source version instead of hardcoding the obsolete 1.0.0 baseline.
