### PR TITLE
fix(workspaces): unify full-access agent launch policies

### DIFF
--- a/docs/model-semantics-and-runtime-injection.md
+++ b/docs/model-semantics-and-runtime-injection.md
@@ -559,3 +559,26 @@ is deliberately absent.
 When a provider changes a model in place, update the registry and its unit
 tests together. Existing Workspace files are not rewritten in the background;
 the new facts apply on the next explicit provider apply or Workspace creation.
+
+## Managed Session execution permissions
+
+Alice-managed interactive, headless, and Web Sessions launch with full host
+filesystem/network access and automatic tool approval. Apply the same policy
+to fresh Sessions and exact resumes; approval `never` alone does not disable
+a native sandbox. In particular, Codex workspace-write requires Linux
+namespaces that many remote containers cannot create.
+
+| Runtime | Process-local execution policy |
+| --- | --- |
+| Codex | `danger-full-access`, approval `never`; Web thread start/resume use the same wire values |
+| Claude | `--dangerously-skip-permissions`, injected `sandbox.enabled=false` |
+| Cursor | `--force --trust --sandbox disabled` |
+| Grok | `--always-approve`, `--sandbox off` |
+| Antigravity | `--dangerously-skip-permissions`; no sandbox opt-in |
+| Oh My Pi | `--auto-approve` on all surfaces |
+| opencode | Process-local `OPENCODE_CONFIG_CONTENT` with `permission: "allow"` |
+| Pi | Native tools have no per-tool sandbox/approval; existing Workspace resource trust bootstrap applies |
+
+Do not implement this by rewriting global user configuration. Native runtime
+enterprise policies and OS permissions remain authoritative. UTA still owns
+trading permissions; these launch settings do not change its trading mode.

--- a/docs/web-conversation-surface.md
+++ b/docs/web-conversation-surface.md
@@ -35,7 +35,7 @@ approval or cannot reopen an exact recorded conversation.
 | `pi-rpc` | `pi`, `omp` | `--mode rpc` JSONL; Pi additionally `--approve`, omp `--auto-approve` | none in RPC mode; launch-time approval | yes (RPC allocates the id) |
 | `acp` | `cursor`, `grok`, `opencode` | Agent Client Protocol JSON-RPC over stdio (`cursor-agent acp`, `grok agent --no-leader stdio`, `opencode acp`) | `session/request_permission` with the agent's own options | `session/new`; resume via `session/load` when advertised |
 | `claude-stream-json` | `claude` | `-p --input-format stream-json --output-format stream-json --include-partial-messages --permission-prompt-tool stdio` | `control_request` `can_use_tool`; answered with allow/deny | `--session-id <uuid>` chosen by the adapter |
-| `codex-app-server` | `codex` | `codex app-server --listen stdio://` with MCP registration, `approvalPolicy: on-request`, `sandbox: workspace-write` | `item/commandExecution/requestApproval`, `item/fileChange/requestApproval` (answered with a `decision` enum), `item/permissions/requestApproval` (answered with the granted `permissions` profile + `scope`), `item/tool/requestUserInput` | `thread/start`; resume via `thread/resume` |
+| `codex-app-server` | `codex` | `codex app-server --listen stdio://` with MCP registration, `approvalPolicy: never`, `sandbox: danger-full-access` | `item/commandExecution/requestApproval`, `item/fileChange/requestApproval` (answered with a `decision` enum), `item/permissions/requestApproval` (answered with the granted `permissions` profile + `scope`), `item/tool/requestUserInput` | `thread/start`; resume via `thread/resume` |
 
 If ACP does not advertise `loadSession`, opening an existing Session fails with
 terminal guidance and preserves its native ID. Never replace its transcript
@@ -152,3 +152,5 @@ an explicit model, a completed turn, errors, and exact-session restoration with
 the installed CLI. Keep login/provider/version failures distinct from parser
 or lifecycle defects, and never claim every runtime passed from one shared
 wire's fake-process fixture.
+
+Managed launch permissions follow [[docs/model-semantics-and-runtime-injection.md]]. Protocol permission handling remains available for native policy requests; normal managed tool execution is approved at launch.

--- a/src/workspaces/adapters/agy.spec.ts
+++ b/src/workspaces/adapters/agy.spec.ts
@@ -51,10 +51,10 @@ describe('agy session layout', () => {
 describe('agy composeCommand', () => {
   it('seeds a fresh TUI with --prompt-interactive and never goes headless', () => {
     const argv = agyAdapter.composeCommand(['claude'], ctx({ initialPrompt: PROMPT }));
-    expect(argv).toEqual(['agy', '--prompt-interactive', PROMPT]);
+    expect(argv).toEqual(['agy', '--dangerously-skip-permissions', '--prompt-interactive', PROMPT]);
     expect(argv).not.toContain('-p');
     expect(argv).not.toContain('--print');
-    expect(argv).not.toContain('--dangerously-skip-permissions');
+    expect(argv).toContain('--dangerously-skip-permissions');
     expect(argv).not.toContain('--agent');
     expect(argv).not.toContain('--resume');
     expect(argv).not.toContain('--session-id');
@@ -66,18 +66,18 @@ describe('agy composeCommand', () => {
     expect(agyAdapter.composeCommand(['agy'], ctx({
       resume: { sessionId: LIVE_CONVERSATION_ID },
       initialPrompt: PROMPT,
-    }))).toEqual(['agy', '--conversation', LIVE_CONVERSATION_ID]);
+    }))).toEqual(['agy', '--dangerously-skip-permissions', '--conversation', LIVE_CONVERSATION_ID]);
     expect(agyAdapter.composeCommand(['agy'], ctx({
       resume: 'last',
       initialPrompt: PROMPT,
-    }))).toEqual(['agy', '--continue']);
+    }))).toEqual(['agy', '--dangerously-skip-permissions', '--continue']);
   });
 
   it('ignores Alice skills and role prompts (no native flags)', () => {
     expect(agyAdapter.composeCommand(['agy'], ctx({
       appendSystemPrompt: 'Stay in the Workspace.',
       skills: ['/tmp/skill'],
-    }))).toEqual(['agy']);
+    }))).toEqual(['agy', '--dangerously-skip-permissions']);
   });
 });
 

--- a/src/workspaces/adapters/agy.ts
+++ b/src/workspaces/adapters/agy.ts
@@ -213,6 +213,7 @@ export const agyAdapter: CliAdapter = {
     // Ignore the workspace default command (usually `claude`).
     const cmd = [
       'agy',
+      '--dangerously-skip-permissions',
       ...(ctx.sessionRuntime?.interactiveArgs ?? []),
     ];
     if (ctx.resume === undefined) {

--- a/src/workspaces/adapters/ai-config.spec.ts
+++ b/src/workspaces/adapters/ai-config.spec.ts
@@ -50,7 +50,7 @@ describe('claudeAdapter AI-config', () => {
   // Project-scoped `.mcp.json` servers park at "Pending approval" until the
   // user approves — and each workspace dir is a fresh project key, so every
   // spawn carries the auto-trust setting (see AUTOTRUST_SETTINGS in claude.ts).
-  const SETTINGS_FLAG = ['--settings', '{"enableAllProjectMcpServers":true}'];
+  const SETTINGS_FLAG = ['--settings', '{"enableAllProjectMcpServers":true,"sandbox":{"enabled":false}}', '--dangerously-skip-permissions'];
 
   it('composeCommand: fresh spawn injects the MCP auto-trust settings', () => {
     expect(claudeAdapter.composeCommand(['claude'], { cwd: dir, env: {} })).toEqual([
@@ -766,9 +766,8 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
     expect(claudeAdapter.composeHeadlessCommand!(['claude'], ctx(), 'do x')).toEqual([
       'claude',
       '--settings',
-      '{"enableAllProjectMcpServers":true}',
-      '--allowedTools',
-      'Bash(alice:*),Bash(alice-workspace:*),Bash(alice-uta:*),Bash(traderhub:*)',
+      '{"enableAllProjectMcpServers":true,"sandbox":{"enabled":false}}',
+      '--dangerously-skip-permissions',
       '-p',
       '--output-format',
       'stream-json',
@@ -784,9 +783,7 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
       '-c',
       'approval_policy="never"',
       '-c',
-      'sandbox_mode="workspace-write"',
-      '-c',
-      'sandbox_workspace_write.network_access=true',
+      'sandbox_mode="danger-full-access"',
       'exec',
       '--json',
       '--',
@@ -811,7 +808,7 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
       '-p',
       '--output-format',
       'stream-json',
-      '--force',
+      '--force', '--sandbox', 'disabled',
       '--trust',
       '--',
       'do x',
@@ -820,9 +817,8 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
 
   it('grok: streaming-json --always-approve --single=<prompt>', () => {
     expect(grokAdapter.composeHeadlessCommand!(['grok'], ctx(), 'do x')).toEqual([
-      'grok',
-      '--no-leader',
-      '--always-approve',
+      'grok', '--sandbox', 'off',
+      '--no-leader', '--always-approve',
       '--output-format',
       'streaming-json',
       '--single=do x',
@@ -866,7 +862,7 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
       'opencode', 'run', '--format', 'json', '--session', 'native-session-1', '--', 'next',
     ]);
     expect(cursorAdapter.composeHeadlessCommand!(['cursor-agent'], { ...ctx(), resume }, 'next')).toEqual([
-      'cursor-agent', '-p', '--output-format', 'stream-json', '--force', '--trust',
+      'cursor-agent', '-p', '--output-format', 'stream-json', '--force', '--sandbox', 'disabled', '--trust',
       '--resume', 'native-session-1', '--', 'next',
     ]);
     expect(agyAdapter.composeHeadlessCommand!(['agy'], { ...ctx(), resume }, 'next')).toEqual([
@@ -874,7 +870,7 @@ describe('composeHeadlessCommand (one-shot headless argv, prompt placed per-CLI)
       '--conversation', 'native-session-1', '-p', 'next',
     ]);
     expect(grokAdapter.composeHeadlessCommand!(['grok'], { ...ctx(), resume }, 'next')).toEqual([
-      'grok', '--no-leader', '--always-approve', '--resume', 'native-session-1',
+      'grok', '--sandbox', 'off', '--no-leader', '--always-approve', '--resume', 'native-session-1',
       '--output-format', 'streaming-json', '--single=next',
     ]);
     expect(piAdapter.composeHeadlessCommand!(['pi'], { ...ctx(), resume }, 'next')).toEqual([

--- a/src/workspaces/adapters/claude.ts
+++ b/src/workspaces/adapters/claude.ts
@@ -76,19 +76,7 @@ function claudeProjectEffort(value: unknown): ModelReasoningEffort | null {
  * same flag so automation doesn't silently lose MCP if a future version
  * closes that gap.
  */
-const AUTOTRUST_SETTINGS = '{"enableAllProjectMcpServers":true}';
-
-// `claude -p` has nobody available to answer a permission prompt. Keep its
-// autonomous Bash surface limited to the four launcher-owned CLI shims rather
-// than bypassing every Claude Code permission. The gateway still validates the
-// Workspace/run identity and each command's argument schema server-side.
-// Syntax follows Claude Code's documented command-prefix permission rules.
-const HEADLESS_ALLOWED_TOOLS = [
-  'Bash(alice:*)',
-  'Bash(alice-workspace:*)',
-  'Bash(alice-uta:*)',
-  'Bash(traderhub:*)',
-].join(',');
+const AUTOTRUST_SETTINGS = '{"enableAllProjectMcpServers":true,"sandbox":{"enabled":false}}';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -243,7 +231,7 @@ export const claudeAdapter: CliAdapter = {
   readInteractiveSetupStatus: readClaudeInteractiveSetupStatus,
 
   composeCommand(base: readonly string[], ctx: SpawnContext): readonly string[] {
-    const cmd = [...base, '--settings', AUTOTRUST_SETTINGS, ...(ctx.sessionRuntime?.interactiveArgs ?? [])];
+    const cmd = [...base, '--settings', AUTOTRUST_SETTINGS, '--dangerously-skip-permissions', ...(ctx.sessionRuntime?.interactiveArgs ?? [])];
     if (ctx.resume === undefined) {
       // Quick-chat seed: `claude [flags] -- <prompt>` opens the interactive TUI
       // and auto-submits the prompt. The `--` end-of-options terminator (same as
@@ -281,8 +269,7 @@ export const claudeAdapter: CliAdapter = {
     }
     return [
       ...base,
-      '--settings', AUTOTRUST_SETTINGS,
-      '--allowedTools', HEADLESS_ALLOWED_TOOLS,
+      '--settings', AUTOTRUST_SETTINGS, '--dangerously-skip-permissions',
       ...(ctx.sessionRuntime?.headlessArgs ?? []),
       ...(ctx.resume ? ['--resume', ctx.resume.sessionId] : []),
       '-p', '--output-format', 'stream-json', '--verbose',
@@ -294,7 +281,7 @@ export const claudeAdapter: CliAdapter = {
   // the process alive between turns, `--include-partial-messages` streams text
   // deltas, and `--permission-prompt-tool stdio` turns tool permission prompts
   // into `control_request` frames the transport can present in the browser
-  // (no `--allowedTools` here: a human is attached). A fresh Session mints its
+  // (managed launches bypass tool approvals). A fresh Session mints its
   // uuid up front so `--resume <id>` reopens the identical conversation in the
   // TUI afterwards. MCP still rides the workspace `.mcp.json` via the same
   // autotrust settings as the TUI.
@@ -302,7 +289,7 @@ export const claudeAdapter: CliAdapter = {
     if (ctx.resume === 'last') throw new Error('the Web surface requires a concrete Claude session id or a fresh Session');
     return [
       ...base,
-      '--settings', AUTOTRUST_SETTINGS,
+      '--settings', AUTOTRUST_SETTINGS, '--dangerously-skip-permissions',
       ...(ctx.sessionRuntime?.webArgs ?? ctx.sessionRuntime?.interactiveArgs ?? []),
       ...(ctx.appendSystemPrompt ? ['--append-system-prompt', ctx.appendSystemPrompt] : []),
       ...(ctx.resume ? ['--resume', ctx.resume.sessionId] : ['--session-id', randomUUID()]),

--- a/src/workspaces/adapters/codex.ts
+++ b/src/workspaces/adapters/codex.ts
@@ -189,8 +189,7 @@ export const codexAdapter: CliAdapter = {
     transcriptDiscovery: 'subprocess',
     headless: true,
     // `codex app-server` speaks JSON-RPC over stdio; threads are created or
-    // resumed in-band, and command/file-change approvals round-trip to the
-    // browser under `approvalPolicy: onRequest`.
+    // resumed in-band with the same full-access policy as TUI/headless.
     web: { wire: 'codex-app-server', permissionPrompts: true, freshSession: true },
     aiProvider: {
       credentialSource: 'runtime-or-workspace',
@@ -253,12 +252,8 @@ export const codexAdapter: CliAdapter = {
   // call when there's no human to approve — even under approval_policy=never
   // (verified: "user cancelled MCP tool call") — so MCP is dead weight here.
   // Instead the agent reads data and reports via the unified `alice` CLI
-  // (shell commands codex runs autonomously). Three GLOBAL `-c` (before `exec`)
-  // make that work:
-  //   approval_policy=never                        — don't block on approval
-  //   sandbox_mode=workspace-write                 — let it write the workspace
-  //   sandbox_workspace_write.network_access=true  — let `alice*` reach the
-  //                       loopback CLI gateway (else: "...fetch failed").
+  // (shell commands codex runs autonomously). Full host access and no approval
+  // match the interactive launch, including resumed runs on container hosts.
   // No mcp_servers head (interactive composeCommand keeps it — MCP works there
   // with a human approver). `--` terminates options before the trailing prompt.
   composeHeadlessCommand(
@@ -280,9 +275,7 @@ export const codexAdapter: CliAdapter = {
       '-c',
       'approval_policy="never"',
       '-c',
-      'sandbox_mode="workspace-write"',
-      '-c',
-      'sandbox_workspace_write.network_access=true',
+      'sandbox_mode="danger-full-access"',
       'exec',
     ];
     if (ctx.resume === 'last') return [...head, 'resume', '--json', '--last', prompt];
@@ -297,18 +290,14 @@ export const codexAdapter: CliAdapter = {
 
   // Web surface: `codex app-server --listen stdio://`. Session identity,
   // approval policy, and sandbox are selected in-band by the transport
-  // (`thread/start` / `thread/resume` with `approvalPolicy: onRequest` and a
-  // workspace-write sandbox), so no TUI permission flags belong here. The
-  // network override keeps the injected `alice*` CLIs reachable from inside
-  // that sandbox, same as headless. MCP registration mirrors the TUI.
+  // (`thread/start` / `thread/resume` with never/danger-full-access).
+  // MCP registration mirrors the TUI.
   composeWebCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     if (ctx.resume === 'last') throw new Error('the Web surface requires a concrete Codex thread id or a fresh Session');
     return [
       'codex',
       ...(ctx.sessionRuntime?.webArgs ?? ctx.sessionRuntime?.interactiveArgs ?? []),
       ...codexMcpConfigArgs(ctx),
-      '-c',
-      'sandbox_workspace_write.network_access=true',
       'app-server',
       '--listen',
       'stdio://',

--- a/src/workspaces/adapters/cursor.spec.ts
+++ b/src/workspaces/adapters/cursor.spec.ts
@@ -60,24 +60,24 @@ describe('cursor composeCommand', () => {
     expect(cursorAdapter.composeCommand(['cursor-agent'], ctx({
       resume: { sessionId: LIVE_SESSION_ID },
       initialPrompt: PROMPT,
-    }))).toEqual(['cursor-agent', '--resume', LIVE_SESSION_ID]);
+    }))).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled', '--resume', LIVE_SESSION_ID]);
     expect(cursorAdapter.composeCommand(['cursor-agent'], ctx({
       resume: 'last',
       initialPrompt: PROMPT,
-    }))).toEqual(['cursor-agent', '--continue']);
+    }))).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled', '--continue']);
   });
 
-  it('passes --trust only after an explicit project approval', () => {
+  it('trusts Alice-managed workspaces and enables unrestricted execution', () => {
     expect(cursorAdapter.composeCommand(['cursor-agent'], ctx({ approveProject: true })))
-      .toEqual(['cursor-agent', '--trust']);
-    expect(cursorAdapter.composeCommand(['cursor-agent'], ctx())).toEqual(['cursor-agent']);
+      .toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled', ]);
+    expect(cursorAdapter.composeCommand(['cursor-agent'], ctx())).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled']);
   });
 
   it('ignores Alice skills and role prompts (no native flags)', () => {
     expect(cursorAdapter.composeCommand(['cursor-agent'], ctx({
       appendSystemPrompt: 'Stay in the Workspace.',
       skills: ['/tmp/skill'],
-    }))).toEqual(['cursor-agent']);
+    }))).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled']);
   });
 });
 
@@ -88,7 +88,7 @@ describe('cursor composeHeadlessCommand', () => {
       '-p',
       '--output-format',
       'stream-json',
-      '--force',
+      '--force', '--sandbox', 'disabled',
       '--trust',
       '--',
       'do x',
@@ -105,7 +105,7 @@ describe('cursor composeHeadlessCommand', () => {
       '-p',
       '--output-format',
       'stream-json',
-      '--force',
+      '--force', '--sandbox', 'disabled',
       '--trust',
       '--resume',
       'native-session-1',
@@ -121,7 +121,7 @@ describe('cursor composeHeadlessCommand', () => {
         '-p',
         '--output-format',
         'stream-json',
-        '--force',
+        '--force', '--sandbox', 'disabled',
         '--trust',
         '--continue',
         '--',
@@ -166,7 +166,7 @@ describe('cursor sessionRuntime', () => {
     });
     expect(argv.join(' ')).not.toContain(SECRET);
     expect(argv.join(' ')).not.toContain('[effort=');
-    expect(argv).toEqual(['cursor-agent', '--model', 'gpt-5']);
+    expect(argv).toEqual(['cursor-agent', '--model', 'gpt-5', '--trust', '--force', '--sandbox', 'disabled']);
   });
 
   it('ignores Session effort, including ultra, and leaves native login env empty', () => {

--- a/src/workspaces/adapters/cursor.ts
+++ b/src/workspaces/adapters/cursor.ts
@@ -229,7 +229,7 @@ export const cursorAdapter: CliAdapter = {
     const cmd = [
       'cursor-agent',
       ...(ctx.sessionRuntime?.interactiveArgs ?? []),
-      ...(ctx.approveProject ? ['--trust'] : []),
+      '--trust', '--force', '--sandbox', 'disabled',
     ];
     if (ctx.resume === undefined) {
       if (ctx.initialPrompt) return [...cmd, '--', ctx.initialPrompt];
@@ -247,7 +247,7 @@ export const cursorAdapter: CliAdapter = {
     return [
       'cursor-agent',
       ...(ctx.sessionRuntime?.webArgs ?? ctx.sessionRuntime?.interactiveArgs ?? []),
-      ...(ctx.approveProject ? ['--trust'] : []),
+      '--trust', '--force', '--sandbox', 'disabled',
       'acp',
     ];
   },
@@ -263,6 +263,7 @@ export const cursorAdapter: CliAdapter = {
       '--output-format',
       'stream-json',
       '--force',
+      '--sandbox', 'disabled',
       '--trust',
       ...(ctx.sessionRuntime?.headlessArgs ?? []),
       ...cursorResumeArgs(ctx.resume),

--- a/src/workspaces/adapters/grok.spec.ts
+++ b/src/workspaces/adapters/grok.spec.ts
@@ -45,7 +45,7 @@ describe('grok session layout', () => {
 describe('grok composeCommand', () => {
   it('seeds a fresh TUI with a trailing `-- <prompt>` and never goes headless', () => {
     const argv = grokAdapter.composeCommand(['grok'], ctx({ initialPrompt: PROMPT }));
-    expect(argv.slice(0, 2)).toEqual(['grok', '--no-leader']);
+    expect(argv.slice(0, 5)).toEqual(['grok', '--sandbox', 'off', '--no-leader', '--always-approve']);
     expect(argv.slice(-2)).toEqual(['--', PROMPT]);
     expect(argv).not.toContain('-p');
     expect(argv).not.toContain('--worktree');
@@ -57,19 +57,18 @@ describe('grok composeCommand', () => {
       resume: { sessionId: '019ff963-4d80-7650-a109-efd64717a05d' },
       initialPrompt: PROMPT,
     }))).toEqual([
-      'grok', '--no-leader', '--resume', '019ff963-4d80-7650-a109-efd64717a05d',
+      'grok', '--sandbox', 'off', '--no-leader', '--always-approve', '--resume', '019ff963-4d80-7650-a109-efd64717a05d',
     ]);
     expect(grokAdapter.composeCommand(['grok'], ctx({ resume: 'last', initialPrompt: PROMPT })))
-      .toEqual(['grok', '--no-leader', '--continue']);
+      .toEqual(['grok', '--sandbox', 'off', '--no-leader', '--always-approve', '--continue']);
   });
 });
 
 describe('grok composeHeadlessCommand', () => {
   it('uses streaming-json and binds the prompt with --single=', () => {
     expect(grokAdapter.composeHeadlessCommand!(['grok'], ctx(), 'do x')).toEqual([
-      'grok',
-      '--no-leader',
-      '--always-approve',
+      'grok', '--sandbox', 'off',
+      '--no-leader', '--always-approve',
       '--output-format',
       'streaming-json',
       '--single=do x',
@@ -82,9 +81,8 @@ describe('grok composeHeadlessCommand', () => {
       ctx({ resume: { sessionId: 'native-session-1' } }),
       'next',
     )).toEqual([
-      'grok',
-      '--no-leader',
-      '--always-approve',
+      'grok', '--sandbox', 'off',
+      '--no-leader', '--always-approve',
       '--resume',
       'native-session-1',
       '--output-format',
@@ -101,15 +99,14 @@ describe('grok composeHeadlessCommand', () => {
   });
 
   it('uses the grok binary even when the workspace default command is claude', () => {
-    expect(grokAdapter.composeCommand(['claude'], ctx())).toEqual(['grok', '--no-leader']);
+    expect(grokAdapter.composeCommand(['claude'], ctx())).toEqual(['grok', '--sandbox', 'off', '--no-leader', '--always-approve']);
     expect(grokAdapter.composeHeadlessCommand!(['claude'], ctx(), 'do x')[0]).toBe('grok');
   });
 
   it('resumes the last headless session with --continue', () => {
     expect(grokAdapter.composeHeadlessCommand!(['grok'], ctx({ resume: 'last' }), 'next')).toEqual([
-      'grok',
-      '--no-leader',
-      '--always-approve',
+      'grok', '--sandbox', 'off',
+      '--no-leader', '--always-approve',
       '--continue',
       '--output-format',
       'streaming-json',
@@ -123,16 +120,15 @@ describe('grok composeHeadlessCommand', () => {
       initialPrompt: PROMPT,
     }));
     expect(seeded).toEqual([
-      'grok', '--no-leader', '--rules', 'Stay in the Workspace.', '--', PROMPT,
+      'grok', '--sandbox', 'off', '--no-leader', '--always-approve', '--rules', 'Stay in the Workspace.', '--', PROMPT,
     ]);
     expect(grokAdapter.composeHeadlessCommand!(
       ['grok'],
       ctx({ appendSystemPrompt: 'Stay in the Workspace.' }),
       'do x',
     )).toEqual([
-      'grok',
-      '--no-leader',
-      '--always-approve',
+      'grok', '--sandbox', 'off',
+      '--no-leader', '--always-approve',
       '--rules',
       'Stay in the Workspace.',
       '--output-format',
@@ -168,7 +164,7 @@ describe('grok sessionRuntime', () => {
       sessionRuntime: projected,
     });
     expect(argv.join(' ')).not.toContain(SECRET);
-    expect(argv).toEqual(['grok', '--no-leader', '--model', 'grok-4.6', '--effort', 'high']);
+    expect(argv).toEqual(['grok', '--sandbox', 'off', '--no-leader', '--always-approve', '--model', 'grok-4.6', '--effort', 'high']);
   });
 
   it('points custom OpenAI-compatible endpoints at GROK_MODELS_BASE_URL', () => {

--- a/src/workspaces/adapters/grok.ts
+++ b/src/workspaces/adapters/grok.ts
@@ -342,7 +342,9 @@ export const grokAdapter: CliAdapter = {
     // do the same; spreading `base` here launched `claude --no-leader`.
     const cmd = [
       'grok',
+      '--sandbox', 'off',
       '--no-leader',
+      '--always-approve',
       ...(ctx.sessionRuntime?.interactiveArgs ?? []),
       ...grokRulesArgs(ctx),
     ];
@@ -359,9 +361,11 @@ export const grokAdapter: CliAdapter = {
     if (ctx.resume === 'last') throw new Error('the Web surface requires a concrete Grok session id or a fresh Session');
     return [
       'grok',
+      '--sandbox', 'off',
       ...grokRulesArgs(ctx),
       'agent',
       '--no-leader',
+      '--always-approve',
       ...(ctx.sessionRuntime?.webArgs ?? ctx.sessionRuntime?.interactiveArgs ?? []),
       'stdio',
     ];
@@ -374,6 +378,7 @@ export const grokAdapter: CliAdapter = {
   ): readonly string[] {
     return [
       'grok',
+      '--sandbox', 'off',
       '--no-leader',
       '--always-approve',
       ...(ctx.sessionRuntime?.headlessArgs ?? []),

--- a/src/workspaces/adapters/interactive-seed.spec.ts
+++ b/src/workspaces/adapters/interactive-seed.spec.ts
@@ -79,14 +79,14 @@ describe('interactive seed — composeCommand initialPrompt', () => {
 
     it('cursor: trailing `-- <prompt>`', () => {
       const argv = cursorAdapter.composeCommand(['claude'], ctx({ initialPrompt: PROMPT }));
-      expect(argv).toEqual(['cursor-agent', '--', PROMPT]);
+      expect(argv).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled', '--', PROMPT]);
       expect(argv).not.toContain('-p');
       expect(argv).not.toContain('agent');
     });
 
     it('agy: `--prompt-interactive <prompt>`', () => {
       const argv = agyAdapter.composeCommand(['claude'], ctx({ initialPrompt: PROMPT }));
-      expect(argv).toEqual(['agy', '--prompt-interactive', PROMPT]);
+      expect(argv).toEqual(['agy', '--dangerously-skip-permissions', '--prompt-interactive', PROMPT]);
       expect(argv).not.toContain('-p');
       expect(argv).not.toContain('antigravity');
     });
@@ -100,7 +100,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
 
     it('omp: trailing `-- <prompt>`', () => {
       const argv = ompAdapter.composeCommand(['claude'], ctx({ initialPrompt: PROMPT }));
-      expect(argv).toEqual(['omp', '--', PROMPT]);
+      expect(argv).toEqual(['omp', '--auto-approve', '--', PROMPT]);
       expect(argv).not.toContain('-p');
       expect(argv).not.toContain('--session-id');
     });
@@ -117,13 +117,13 @@ describe('interactive seed — composeCommand initialPrompt', () => {
       expect(piAdapter.composeCommand([], ctx())).toEqual(['pi']);
     });
     it('cursor', () => {
-      expect(cursorAdapter.composeCommand([], ctx())).toEqual(['cursor-agent']);
+      expect(cursorAdapter.composeCommand([], ctx())).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled']);
     });
     it('agy', () => {
-      expect(agyAdapter.composeCommand([], ctx())).toEqual(['agy']);
+      expect(agyAdapter.composeCommand([], ctx())).toEqual(['agy', '--dangerously-skip-permissions']);
     });
     it('omp', () => {
-      expect(ompAdapter.composeCommand([], ctx())).toEqual(['omp']);
+      expect(ompAdapter.composeCommand([], ctx())).toEqual(['omp', '--auto-approve']);
     });
   });
 
@@ -153,12 +153,12 @@ describe('interactive seed — composeCommand initialPrompt', () => {
     });
     it('cursor resume ignores the prompt', () => {
       const argv = cursorAdapter.composeCommand(['cursor-agent'], ctx({ resume: RESUME, initialPrompt: PROMPT }));
-      expect(argv).toEqual(['cursor-agent', '--resume', 'sess-1234abcd']);
+      expect(argv).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled', '--resume', 'sess-1234abcd']);
       expect(argv).not.toContain(PROMPT);
     });
     it('agy resume ignores the prompt', () => {
       const argv = agyAdapter.composeCommand(['agy'], ctx({ resume: RESUME, initialPrompt: PROMPT }));
-      expect(argv).toEqual(['agy', '--conversation', 'sess-1234abcd']);
+      expect(argv).toEqual(['agy', '--dangerously-skip-permissions', '--conversation', 'sess-1234abcd']);
       expect(argv).not.toContain(PROMPT);
     });
     it('grok resume ignores the prompt', () => {
@@ -168,7 +168,7 @@ describe('interactive seed — composeCommand initialPrompt', () => {
     });
     it('omp resume ignores the prompt', () => {
       const argv = ompAdapter.composeCommand(['omp'], ctx({ resume: RESUME, initialPrompt: PROMPT }));
-      expect(argv).toEqual(['omp', '--resume', 'sess-1234abcd']);
+      expect(argv).toEqual(['omp', '--auto-approve', '--resume', 'sess-1234abcd']);
       expect(argv).not.toContain(PROMPT);
     });
   });

--- a/src/workspaces/adapters/omp.spec.ts
+++ b/src/workspaces/adapters/omp.spec.ts
@@ -93,15 +93,15 @@ describe('omp composeCommand', () => {
     expect(ompAdapter.composeCommand(['omp'], ctx({
       resume: { sessionId: LIVE_SESSION_ID },
       initialPrompt: PROMPT,
-    }))).toEqual(['omp', '--resume', LIVE_SESSION_ID]);
+    }))).toEqual(['omp', '--auto-approve', '--resume', LIVE_SESSION_ID]);
     expect(ompAdapter.composeCommand(['omp'], ctx({ resume: 'last', initialPrompt: PROMPT })))
-      .toEqual(['omp', '--continue']);
+      .toEqual(['omp', '--auto-approve', '--continue']);
   });
 
   it('maps launcher-owned role guidance to --append-system-prompt', () => {
     expect(ompAdapter.composeCommand(['omp'], ctx({
       appendSystemPrompt: 'You are the desk closer.',
-    }))).toEqual(['omp', '--append-system-prompt', 'You are the desk closer.']);
+    }))).toEqual(['omp', '--auto-approve', '--append-system-prompt', 'You are the desk closer.']);
   });
 });
 

--- a/src/workspaces/adapters/omp.ts
+++ b/src/workspaces/adapters/omp.ts
@@ -265,6 +265,7 @@ export const ompAdapter: CliAdapter = {
   composeCommand(_base: readonly string[], ctx: SpawnContext): readonly string[] {
     const cmd = [
       'omp',
+      '--auto-approve',
       ...(ctx.sessionRuntime?.interactiveArgs ?? []),
       ...ompRoleArgs(ctx),
     ];

--- a/src/workspaces/adapters/opencode-runtime-flags.spec.ts
+++ b/src/workspaces/adapters/opencode-runtime-flags.spec.ts
@@ -25,7 +25,7 @@ describe('opencode runtime flags', () => {
 
     expect(projected.interactiveArgs).toEqual(['--model', 'openai/gpt-5.6-sol']);
     expect(projected.webArgs).toEqual([]);
-    expect(JSON.parse(projected.env['OPENCODE_CONFIG_CONTENT']!)).toEqual({ model: 'openai/gpt-5.6-sol' });
+    expect(JSON.parse(projected.env['OPENCODE_CONFIG_CONTENT']!)).toEqual({ model: 'openai/gpt-5.6-sol', permission: 'allow' });
     expect(projected.headlessArgs).toEqual([
       '--model', 'openai/gpt-5.6-sol',
       '--variant', 'high',
@@ -48,6 +48,15 @@ describe('opencode runtime flags', () => {
 
 it('preserves process config while selecting the ACP model without unsupported flags', () => {
   const projected = opencodeAdapter.sessionRuntime!.project({ cwd: '/workspace', env: { OPENCODE_CONFIG_CONTENT: '{"theme":"system"}' } }, runtime);
-  expect(JSON.parse(projected.env['OPENCODE_CONFIG_CONTENT']!)).toEqual({ theme: 'system', model: 'openai/gpt-5.6-sol' });
+  expect(JSON.parse(projected.env['OPENCODE_CONFIG_CONTENT']!)).toEqual({ theme: 'system', model: 'openai/gpt-5.6-sol', permission: 'allow' });
   expect(opencodeAdapter.composeWebCommand!([], { cwd: '/workspace', env: projected.env, sessionRuntime: projected })).toEqual(['opencode', 'acp']);
+});
+
+
+it('applies full access even without a model override, preserving other process config', () => {
+  const projected = opencodeAdapter.sessionRuntime!.project(
+    { cwd: '/workspace', env: { OPENCODE_CONFIG_CONTENT: '{"theme":"system","permission":"ask"}' } },
+    { binding: { version: 1, credential: { source: 'native' } }, ai: null },
+  );
+  expect(JSON.parse(projected.env['OPENCODE_CONFIG_CONTENT']!)).toEqual({ theme: 'system', permission: 'allow' });
 });

--- a/src/workspaces/adapters/opencode.ts
+++ b/src/workspaces/adapters/opencode.ts
@@ -352,6 +352,11 @@ export const opencodeAdapter: CliAdapter = {
         }
         env['OPENCODE_CONFIG_CONTENT'] = JSON.stringify({ ...inherited, model: selectedModel });
       }
+      const config: unknown = JSON.parse(env['OPENCODE_CONFIG_CONTENT'] ?? _ctx.env['OPENCODE_CONFIG_CONTENT'] ?? '{}');
+      if (!config || typeof config !== 'object' || Array.isArray(config)) {
+        throw new Error('OPENCODE_CONFIG_CONTENT must contain a JSON object');
+      }
+      env['OPENCODE_CONFIG_CONTENT'] = JSON.stringify({ ...config, permission: 'allow' });
       return { env, interactiveArgs, headlessArgs, webArgs: [] };
     },
   },

--- a/src/workspaces/adapters/web-command.spec.ts
+++ b/src/workspaces/adapters/web-command.spec.ts
@@ -44,7 +44,7 @@ describe('Web surface command composition', () => {
   it('composes Claude bidirectional stream-json with stdio permission prompts', () => {
     const resumed = claudeAdapter.composeWebCommand!(['claude'], ctx({ resume: { sessionId: 'c-1' } }))
     expect(resumed).toEqual([
-      'claude', '--settings', '{"enableAllProjectMcpServers":true}', '--resume', 'c-1',
+      'claude', '--settings', '{"enableAllProjectMcpServers":true,"sandbox":{"enabled":false}}', '--dangerously-skip-permissions', '--resume', 'c-1',
       '-p', '--input-format', 'stream-json', '--output-format', 'stream-json', '--verbose',
       '--include-partial-messages', '--permission-prompt-tool', 'stdio',
     ])
@@ -58,14 +58,14 @@ describe('Web surface command composition', () => {
     const argv = codexAdapter.composeWebCommand!([], ctx({ env: { AQ_WS_ID: 'ws-1', OPENALICE_MCP_URL: 'http://127.0.0.1:1/mcp' } }))
     expect(argv.slice(-3)).toEqual(['app-server', '--listen', 'stdio://'])
     expect(argv).toContain('mcp_servers.openalice.url="http://127.0.0.1:1/mcp"')
-    expect(argv).toContain('sandbox_workspace_write.network_access=true')
+    expect(argv).not.toContain('sandbox_workspace_write.network_access=true')
     expect(argv).not.toContain('--ask-for-approval')
     expect(argv).not.toContain('--sandbox')
   })
 
   it('composes the three native ACP agents', () => {
-    expect(cursorAdapter.composeWebCommand!([], ctx({ approveProject: true }))).toEqual(['cursor-agent', '--trust', 'acp'])
-    expect(grokAdapter.composeWebCommand!([], ctx())).toEqual(['grok', 'agent', '--no-leader', 'stdio'])
+    expect(cursorAdapter.composeWebCommand!([], ctx({ approveProject: true }))).toEqual(['cursor-agent', '--trust', '--force', '--sandbox', 'disabled',  'acp'])
+    expect(grokAdapter.composeWebCommand!([], ctx())).toEqual(['grok', '--sandbox', 'off', 'agent', '--no-leader', '--always-approve', 'stdio'])
     expect(opencodeAdapter.composeWebCommand!([], ctx())).toEqual(['opencode', 'acp'])
   })
 })

--- a/src/workspaces/web-session-host.spec.ts
+++ b/src/workspaces/web-session-host.spec.ts
@@ -518,7 +518,7 @@ describe('WebSessionHost with the codex-app-server transport', () => {
     expect(started.nativeSessionId).toBe('thr_new')
     expect(onNativeSessionId).toHaveBeenCalledWith('record-1', 'thr_new')
     expect(process.received.map((c) => c['method'])).toEqual(['initialize', 'initialized', 'thread/start'])
-    expect(process.received[2]).toMatchObject({ params: { cwd: '/tmp/workspace', approvalPolicy: 'on-request', sandbox: 'workspace-write' } })
+    expect(process.received[2]).toMatchObject({ params: { cwd: '/tmp/workspace', approvalPolicy: 'never', sandbox: 'danger-full-access' } })
 
     await host.prompt('record-1', 'run the tests')
     await settle()

--- a/src/workspaces/web-session/codex-app-server-transport.ts
+++ b/src/workspaces/web-session/codex-app-server-transport.ts
@@ -63,8 +63,8 @@ export class CodexAppServerTransport implements WebSessionTransport {
     // against `codex app-server generate-json-schema`, 0.153.x).
     const options = {
       cwd: this.ctx.input.cwd,
-      approvalPolicy: 'on-request',
-      sandbox: 'workspace-write',
+      approvalPolicy: 'never',
+      sandbox: 'danger-full-access',
       ...(this.ctx.input.model ? { model: this.ctx.input.model } : {}),
     }
     const result = this.threadId


### PR DESCRIPTION
## Problem and change

Codex background runs used workspace-write despite interactive Sessions already using full access. On container hosts without namespace permissions, even a shell command failed with `bwrap: Creating new namespace failed: Permission denied`. Other adapters also had different approval policies between interactive and background launches.

Unify Alice-managed execution across fresh and resumed launches: Codex headless and Web use danger-full-access/never; Claude bypasses tool checks and disables its sandbox; Cursor uses force/trust with sandbox disabled; Grok disables its sandbox and always approves; Antigravity and OMP approve interactive execution as they already did headlessly. opencode gets process-local permission=allow, including native bindings without model overrides. Pi has no per-tool sandbox; its existing resource-trust bootstrap remains intact.

Global user configuration and UTA trading mode are unchanged. Native enterprise restrictions and OS permissions remain authoritative.

## Validation

- Adapter and Web transport regression tests, including fresh/resume argument placement.
- Root TypeScript check and full hermetic suite.
- Installed runtime CLI help verified Cursor sandbox/force, Grok sandbox/approval, Claude, Antigravity, and OMP flags.
- Remote Codex using the new policy executed shell and fetched the Alice loopback API successfully, without bwrap errors.
- Other providers were not live-model tested on the remote host.
