### PR TITLE
fix: allow Alice Skill upgrades during active sessions

### DIFF
--- a/docs/alice-harness.md
+++ b/docs/alice-harness.md
@@ -71,7 +71,7 @@ revision and with its CLI disabled.
 
 Project Settings → Workspace injection owns the Project CLI catalog, source Skills
 browser, Workspace update inventory and batch updates. Batch updates use the
-displayed digests and skip busy/conflicting entries; each Workspace succeeds or
+displayed digests and skip checkout-blocked/conflicting entries; each Workspace succeeds or
 fails independently. Workspace details owns CLI/Skill preferences and a link to
 Project management. Unversioned matching files need only a baseline/version
 record; differing files enter the same update review. The Project catalog API is `/api/workspaces/alice-harness/catalog`. Per-Workspace
@@ -80,8 +80,13 @@ APIs are `/api/workspaces/:id/alice-harness`,
 The CLI offers `alice harness upgrade` and `alice harness upgrade --apply`, with
 `--id` for a peer and the same per-file conflict flags as template upgrades.
 
-The shared managed-file engine provides checkout serialization, active-Session
-and staged-index blockers, exact preview digests, atomic file replacements,
+Skill updates, including scoped install/remove/restore, are allowed during active
+interactive, Web and headless Sessions. Existing model context is not reloaded;
+an agent must reread changed Skills to use the new instructions. Template/source
+upgrades and CLI configuration writes retain their separate activity checks.
+
+The shared managed-file engine provides checkout serialization and staged-index
+blockers, exact preview digests, atomic file replacements,
 Git commit, rollback and committed-transaction recovery. Configuration is part
 of the preview digest and never overwritten by upgrade. Both upgrade layers
 recover before scheduled work starts.

--- a/src/workspaces/template-upgrade.spec.ts
+++ b/src/workspaces/template-upgrade.spec.ts
@@ -306,6 +306,24 @@ describe('TemplateUpgradeManager', () => {
     expect(await manager().currentVersion(workspace)).toBe('1.0.0');
   });
 
+  it('applies Alice Skill updates during an active Session', async () => {
+    incoming = { '.agents/skills/alice/SKILL.md': file('updated live skill') };
+    const upgrade = manager(true, true);
+    const plan = await upgrade.plan(workspace.id);
+    expect(plan.activity.busy).toBe(true);
+    expect(plan.blockers).toEqual([]);
+    await upgrade.apply(workspace.id, { planDigest: plan.planDigest });
+    expect(await readFile(join(workspace.dir, '.agents/skills/alice/SKILL.md'), 'utf8')).toBe('updated live skill');
+    expect(await upgrade.currentVersion(workspace)).toBe(plan.toVersion);
+
+    await writeFile(join(workspace.dir, 'staged.md'), 'user work');
+    await git(workspace.dir, ['add', 'staged.md']);
+    const blocked = await upgrade.plan(workspace.id);
+    expect(blocked.blockers).toEqual(['staged_changes']);
+    await expect(upgrade.apply(workspace.id, { planDigest: blocked.planDigest }))
+      .rejects.toMatchObject({ code: 'staged_changes' });
+  });
+
   it('keeps Alice skills outside template upgrade and blocks busy config writes', async () => {
     incoming = { ...incoming, '.agents/skills/alice/SKILL.md': file('not template-owned') };
     expect((await manager().plan(workspace.id)).files.some((file) => file.path.includes('/alice/'))).toBe(false);

--- a/src/workspaces/template-upgrade.ts
+++ b/src/workspaces/template-upgrade.ts
@@ -532,7 +532,8 @@ export class TemplateUpgradeManager {
       headless: [],
     };
     const blockers: string[] = [];
-    if (activity.busy) blockers.push('active_sessions');
+    // Skill projections are live documents; running agents do not lock their updates.
+    if (activity.busy && !this.opts.aliceHarness) blockers.push('active_sessions');
     if ((await stagedPaths(workspace.dir)).length > 0) blockers.push('staged_changes');
     const fromVersion = state?.template === template.name
       ? state.appliedVersion


### PR DESCRIPTION
Alice Harness Skill updates were blocked whenever a Workspace had an active Session, preventing long-lived agents from updating their own injected documentation. Allow injection updates and scoped Skill operations during active Sessions while retaining checkout serialization, staged-index protection, conflict review, and stale-preview validation. Template/source upgrades and CLI configuration checks are unchanged.

Validation: 193 changed-closure tests passed, including a real temporary Git checkout apply with active Session evidence and staged-index rejection; root TypeScript check passed. Remote deployment has not been updated in this change.
