### PR TITLE
feat: add alice issue run and retry commands

### DIFF
--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -305,3 +305,8 @@ otherwise do nothing and exit."
 - **Legacy:** the old single `.alice/issue.json` is retired. If you find one,
   split each issue into its own `.alice/issues/<id>.md` file with the
   frontmatter above.
+
+Run a scheduled Issue immediately with `alice issue run --id <id>`; add `--await`
+when its result is needed now. Retry its latest failed run with
+`alice issue retry --id <id> --run-id <taskId>`. Both use the current What and
+owner without moving the next scheduled occurrence.

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -352,8 +352,10 @@ Headless runs may overlap with interactive sessions or other runs in the same
 checkout. Agents must tolerate concurrent edits. The launcher currently admits
 at most eight headless processes globally and serializes registry persistence,
 but there is no per-Workspace exclusive lock. One small dispatch-start guard
-prevents a Run now / Retry now click and a schedule tick from launching the same
-Issue at the same instant; it is released as soon as the run is registered.
+prevents Run now / Retry now, CLI calls and a schedule tick from launching the
+same Issue at the same instant; it is released as soon as the run is registered.
+The shared dispatch path also rejects a new occurrence while that Issue still
+has a running task. Other Issues in the same Workspace remain independent.
 
 Offboarding is the lifecycle exception: a Workspace with a live headless run
 cannot depart. Once its Catalog row enters `offboarding`, new dispatch is
@@ -529,3 +531,18 @@ pnpm test
 For UI changes, run strict UI types and verify Issue board, issue detail,
 Activity comments/replies, the independent Runs section, schedule projection,
 and linked Inbox reports in the real browser surface.
+
+## Manual execution from CLI
+
+`alice issue run --id <id>` uses the same Run now dispatch as the Issue page.
+`alice issue retry --id <id> --run-id <taskId>` requires the latest failed or
+interrupted run of that Issue. Both resolve names on the global board; duplicate
+names require `--ws-id`. They return the exact dispatched `taskId`; `--await`
+waits for completion through the conversation reader. No prompt/runtime override
+is accepted. Current scheduled Issue semantics and next-fire markers are preserved.
+
+Retry persists `trigger.retryOfTaskId`, exposed by Issue run history as
+`retryOfTaskId`, independently of conversation `parentTaskId`. Existing records
+without that optional field have unknown retry lineage. Active Issue runs and
+dispatch-start races are rejected, including schedule ticks; there is no force
+override that launches concurrent turns against the same owner.

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -246,6 +246,7 @@ export interface WorkspaceToolContext {
     detail(wsId: string, id: string): Promise<IssueDetail | null>
     resolveByName(name: string): Promise<WikilinkIssueRef[]>
   }
+  issueRuns?: { start(wsId: string, id: string, retryRunId?: string): Promise<{ taskId: string }> }
   /** Safe current-Workspace template preview/apply surface. */
   templateUpgrades?: WorkspaceTemplateUpgradeControl
   aliceHarnessUpgrades?: WorkspaceTemplateUpgradeControl

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -185,6 +185,8 @@ const BASE_EXPORTS: Record<string, CliExport> = {
         list: 'issue_list',
         show: 'issue_show',
         ask: 'issue_ask',
+        run: 'issue_run',
+        retry: 'issue_retry',
       },
       provenance: {
         show: 'provenance_show',

--- a/src/server/cli.spec.ts
+++ b/src/server/cli.spec.ts
@@ -1,3 +1,7 @@
+import { serve } from '@hono/node-server'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { issueRunNowFactory, issueRetryFactory } from '../tool/issue-tools.js'
 import { describe, it, expect, vi } from 'vitest'
 import { Hono } from 'hono'
 import { tool } from 'ai'
@@ -529,5 +533,46 @@ describe('Workspace CLI configuration', () => {
       expect((await server.request('/cli/one/data/manifest')).status).toBe(503)
       expect((await server.request('/cli/one/workspace/invoke', { method: 'POST', body: JSON.stringify({ tool: 'workspace_list' }) })).status).toBe(503)
     } finally { await rm(dir, { recursive: true, force: true }) }
+  })
+})
+
+
+describe('Issue run CLI end to end', () => {
+  it('uses the actual launcher, manifest, schema and execution tool for run/retry', async () => {
+    const startIssueRun = vi.fn(async () => ({ taskId: 'run-new' }))
+    const workspaceToolCenter = new WorkspaceToolCenter()
+    workspaceToolCenter.register(issueRunNowFactory)
+    workspaceToolCenter.register(issueRetryFactory)
+    const app = new Hono()
+    registerCliRoutes(app, {
+      toolCenter: new ToolCenter(), workspaceToolCenter,
+      inboxStore: {} as never, entityStore: {} as never,
+      getWorkspaceService: () => ({
+        registry: { get: () => ({ id: 'ws1', tag: 'desk' }) },
+        resolveIssuesByName: async () => [{ wsId: 'ws1', wsTag: 'desk', id: 'daily', title: 'Daily' }],
+        startIssueRun,
+      }) as never,
+    })
+    const server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' })
+    if (!server.listening) await new Promise<void>((resolve) => server.once('listening', resolve))
+    const address = server.address() as { port: number }
+    const execute = (args: string[]) => promisify(execFile)(process.execPath,
+      [resolve('src/workspaces/cli/bin/openalice-cli.cjs'), ...args], {
+        env: { ...process.env, OPENALICE_CLI_BIN: 'alice', AQ_WS_ID: 'ws1',
+          OPENALICE_TOOL_SOCKET: '', OPENALICE_TOOL_URL: `http://127.0.0.1:${address.port}/cli` },
+        timeout: 10000,
+      })
+    try {
+      expect((await execute(['issue', 'run', '--id', 'daily'])).stdout).toContain('run-new')
+      expect(startIssueRun).toHaveBeenLastCalledWith('ws1', 'daily', undefined)
+      expect((await execute(['issue', 'retry', '--id', 'daily', '--run-id', 'run-old'])).stdout).toContain('run-new')
+      expect(startIssueRun).toHaveBeenLastCalledWith('ws1', 'daily', 'run-old')
+      const before = startIssueRun.mock.calls.length
+      await expect(execute(['issue', 'retry', '--id', 'daily'])).rejects.toThrow()
+      expect(startIssueRun).toHaveBeenCalledTimes(before)
+    } finally {
+      if ('closeAllConnections' in server) server.closeAllConnections()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
   })
 })

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -175,6 +175,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
         } : {}),
         ...(svc
           ? {
+              issueRuns: { start: (w: string, i: string, r?: string) => svc.startIssueRun(w, i, r) },
               board: {
                 snapshot: () => svc.issuesSnapshot(),
                 detail: (w: string, i: string) => svc.issueDetail(w, i),

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -172,6 +172,7 @@ export class McpPlugin implements Plugin {
         } : {}),
         ...(svc
           ? {
+              issueRuns: { start: (w: string, i: string, r?: string) => svc.startIssueRun(w, i, r) },
               board: {
                 snapshot: () => svc.issuesSnapshot(),
                 detail: (w: string, i: string) => svc.issueDetail(w, i),

--- a/src/tool/conversation.ts
+++ b/src/tool/conversation.ts
@@ -29,7 +29,7 @@ export const conversationAskCommonShape = {
     .describe('Explicitly add artifact-reconstruction guidance if OpenAlice must recruit a fallback worker.'),
 }
 
-function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'detailed') {
+export function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'detailed') {
   const structured = task.structured
   const tools = structured?.blocks
     .filter((block): block is Extract<HeadlessMessageBlock, { type: 'tool' }> => block.type === 'tool')
@@ -56,7 +56,7 @@ function taskProjection(task: WorkspaceConversationTask, mode: 'summary' | 'deta
   }
 }
 
-async function awaitConversationTask(
+export async function awaitConversationTask(
   conversation: WorkspaceConversationControl,
   taskId: string,
   timeoutMs?: number,

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -19,6 +19,8 @@ import {
   issueListFactory,
   issueShowFactory,
   issueUpdateFactory,
+  issueRunNowFactory,
+  issueRetryFactory,
 } from './issue-tools.js'
 
 let dir: string
@@ -641,5 +643,44 @@ describe('workspace resolution failures', () => {
     const res = await run(issueListFactory.build(ctx({ resolveWorkspace: () => null })), {})
     expect(res.ok).toBe(false)
     expect(res.error).toMatch(/cannot locate/)
+  })
+})
+
+
+describe('Issue execution tools', () => {
+  function executionContext() {
+    const start = vi.fn(async () => ({ taskId: 'run-new' }))
+    const resolveByName = vi.fn(async () => [{ wsId: 'peer', wsTag: 'desk', id: 'daily', title: 'Daily' }])
+    const read = vi.fn(async () => ({ taskId: 'run-new', status: 'done', resumeId: 'owner', assistantText: 'finished' }))
+    return { start, resolveByName, read, context: ctx({
+      board: { snapshot: vi.fn(), detail: vi.fn(), resolveByName },
+      issueRuns: { start },
+      conversation: { read } as unknown as NonNullable<WorkspaceToolContext['conversation']>,
+    }) }
+  }
+  it('dispatches asynchronously without asking a Session or polling', async () => {
+    const { context, start, read } = executionContext()
+    expect(await run(issueRunNowFactory.build(context), { id: 'daily' })).toMatchObject({ ok: true, taskId: 'run-new', issueId: 'daily' })
+    expect(start).toHaveBeenCalledWith('peer', 'daily', undefined)
+    expect(read).not.toHaveBeenCalled()
+  })
+  it('passes the exact retry occurrence and waits for the dispatched run', async () => {
+    const { context, start, read } = executionContext()
+    expect(await run(issueRetryFactory.build(context), { id: 'daily', runId: 'run-failed', await: true })).toMatchObject({ ok: true, taskId: 'run-new', status: 'done', awaited: true })
+    expect(start).toHaveBeenCalledWith('peer', 'daily', 'run-failed')
+    expect(read).toHaveBeenCalledWith('run-new')
+  })
+  it('rejects ambiguous names before dispatch', async () => {
+    const { context, resolveByName, start } = executionContext()
+    resolveByName.mockResolvedValue([{ wsId: 'a', wsTag: 'a', id: 'daily', title: 'Daily' }, { wsId: 'b', wsTag: 'b', id: 'daily', title: 'Daily' }])
+    expect(await run(issueRunNowFactory.build(context), { id: 'daily' })).toMatchObject({ ok: false })
+    expect(start).not.toHaveBeenCalled()
+    expect(await run(issueRunNowFactory.build(context), { id: 'daily', wsId: 'b' })).toMatchObject({ ok: true })
+    expect(start).toHaveBeenCalledWith('b', 'daily', undefined)
+  })
+  it('preserves scheduler conflict errors without falling back to ask', async () => {
+    const { context, start } = executionContext()
+    start.mockRejectedValue(Object.assign(new Error('Already running'), { code: 'already_running' }))
+    expect(await run(issueRunNowFactory.build(context), { id: 'daily' })).toMatchObject({ ok: false, code: 'already_running' })
   })
 })

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -22,6 +22,7 @@
  */
 
 import { join } from 'node:path'
+import { awaitConversationTask, taskProjection } from './conversation.js'
 
 import { tool } from 'ai'
 import { z } from 'zod'
@@ -739,6 +740,52 @@ async function readSelfIssue(
   return { ok: true, issue: parsed.issue, comments: comments.comments }
 }
 
+/** Dispatch through the same service as the Issue page, never through ask. */
+function issueRunFactory(retry: boolean): WorkspaceToolFactory {
+  return {
+    name: retry ? 'issue_retry' : 'issue_run',
+    build(ctx) {
+      return tool({
+        description: retry
+          ? 'Retry the latest failed or interrupted Issue run using its current canonical What and owner. Preserves schedule cadence and records retry lineage.'
+          : 'Run a live scheduled Issue now using its canonical What and configured owner/runtime. Preserves schedule cadence; rejects overlapping runs.',
+        inputSchema: z.object({
+          id: z.string().min(1).describe('Issue id or title on the global board.'),
+          wsId: z.string().min(1).optional().describe('Workspace id to disambiguate matching Issues.'),
+          ...(retry ? { runId: z.string().min(1).describe('Exact latest failed or interrupted taskId to retry.') } : {}),
+          await: z.boolean().optional().default(false).describe('Wait for completion; otherwise return taskId immediately.'),
+        }),
+        execute: async (input) => {
+          if (!ctx.board || !ctx.issueRuns) return { ok: false, error: 'Issue execution is unavailable' }
+          if (input.await && !ctx.conversation) return { ok: false, error: 'Conversation wait is unavailable' }
+          try {
+            const refs = (await ctx.board.resolveByName(input.id)).filter((ref) => !input.wsId || ref.wsId === input.wsId)
+            if (refs.length !== 1) return {
+              ok: false, error: refs.length ? 'Issue name is ambiguous; specify --ws-id' : 'Issue not found',
+              ...(refs.length ? { candidates: refs.map(({ wsId, id, title }) => ({ wsId, id, title })) } : {}),
+            }
+            const ref = refs[0]!
+            const result = await ctx.issueRuns.start(ref.wsId, ref.id, retry && typeof input.runId === 'string' ? input.runId : undefined)
+            const subject = { workspaceId: ref.wsId, issueId: ref.id }
+            if (input.await && ctx.conversation) {
+              const task = await awaitConversationTask(ctx.conversation, result.taskId)
+              if (!task) return { ok: false, ...result, error: 'Dispatched run is unavailable' }
+              return { ok: true, ...subject, ...taskProjection(task, 'summary'), awaited: task.status !== 'running' }
+            }
+            return { ok: true, ...subject, ...result, next: `alice conversation read --task-id ${result.taskId}` }
+          } catch (err) {
+            return { ok: false, error: err instanceof Error ? err.message : String(err),
+              ...((err && typeof err === 'object' && 'code' in err) ? { code: err.code } : {}) }
+          }
+        },
+      })
+    },
+  }
+}
+
+export const issueRunNowFactory = issueRunFactory(false)
+export const issueRetryFactory = issueRunFactory(true)
+
 /** All issue tool factories, in registration order. */
 export const issueToolFactories: WorkspaceToolFactory[] = [
   issueUpdateFactory,
@@ -746,4 +793,6 @@ export const issueToolFactories: WorkspaceToolFactory[] = [
   issueCreateFactory,
   issueListFactory,
   issueShowFactory,
+  issueRunNowFactory,
+  issueRetryFactory,
 ]

--- a/src/workspaces/headless-task-registry.spec.ts
+++ b/src/workspaces/headless-task-registry.spec.ts
@@ -115,6 +115,7 @@ describe('HeadlessTaskRegistry', () => {
         kind: 'issue',
         workspaceId: 'home',
         issueId: 'daily-scan',
+        retryOfTaskId: 'failed-occurrence',
         metadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
       },
     })
@@ -123,6 +124,7 @@ describe('HeadlessTaskRegistry', () => {
       kind: 'issue',
       workspaceId: 'home',
       issueId: 'daily-scan',
+      retryOfTaskId: 'failed-occurrence',
       metadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },
     })
     // Manual runs leave the field absent (not undefined-valued) so the JSON stays clean.

--- a/src/workspaces/headless-task-registry.ts
+++ b/src/workspaces/headless-task-registry.ts
@@ -47,6 +47,8 @@ export type HeadlessTaskTriggerMetadata = {
 }
 
 export type HeadlessTaskTrigger = {
+  /** Exact failed occurrence retried; independent of conversation parentTaskId. */
+  readonly retryOfTaskId?: string
   readonly kind: 'issue'
   readonly workspaceId: string
   readonly issueId: string

--- a/src/workspaces/issues/board.spec.ts
+++ b/src/workspaces/issues/board.spec.ts
@@ -104,7 +104,7 @@ describe('issueRunRecord', () => {
       taskId: 'task-1',
       resumeId: 'resume-gentle-otter-abc123',
       wsId: 'ws-1',
-      trigger: { kind: 'issue', workspaceId: 'ws-home', issueId: 'audit' },
+      trigger: { kind: 'issue', workspaceId: 'ws-home', issueId: 'audit', retryOfTaskId: 'failed-occurrence' },
       agent: 'codex',
       prompt: 'inspect it',
       status: 'done',
@@ -116,6 +116,7 @@ describe('issueRunRecord', () => {
       taskId: 'task-1',
       resumeId: 'resume-gentle-otter-abc123',
       resumable: true,
+      retryOfTaskId: 'failed-occurrence',
     })
     expect(projected).not.toHaveProperty('agentSessionId')
   })

--- a/src/workspaces/issues/board.ts
+++ b/src/workspaces/issues/board.ts
@@ -351,6 +351,7 @@ export interface IssueRunRecord {
   taskId: string
   resumeId: string
   parentTaskId?: string
+  retryOfTaskId?: string
   wsId: string
   issueId?: string
   agent: string
@@ -386,6 +387,7 @@ export function issueRunRecord(task: HeadlessTaskRecord, resumable: boolean): Is
     taskId: task.taskId,
     resumeId: task.resumeId,
     ...(task.parentTaskId ? { parentTaskId: task.parentTaskId } : {}),
+    ...(task.trigger?.retryOfTaskId ? { retryOfTaskId: task.trigger.retryOfTaskId } : {}),
     wsId: task.wsId,
     ...(task.trigger?.kind === 'issue' ? { issueId: task.trigger.issueId } : {}),
     agent: task.agent,

--- a/src/workspaces/schedule/scanner.spec.ts
+++ b/src/workspaces/schedule/scanner.spec.ts
@@ -139,12 +139,16 @@ function scannerFor(
     resolveAdapter?: ScheduleScannerDeps['resolveAdapter']
     resolveResumeWorkspace?: ScheduleScannerDeps['resolveResumeWorkspace']
     claimFreshSession?: ScheduleScannerDeps['claimFreshSession']
+    canRetryIssueRun?: ScheduleScannerDeps['canRetryIssueRun']
+    isIssueRunning?: ScheduleScannerDeps['isIssueRunning']
     observeIssues?: ScheduleScannerDeps['observeIssues']
   } = {},
 ) {
   const dispatch = vi.fn(opts.dispatch ?? (async () => ({ taskId: 'run-1', resumeId: 'resume-new-worker-a1b2c3' })))
   const markers = opts.markers ?? new FakeMarkers()
   const scanner = new ScheduleScanner({
+    canRetryIssueRun: opts.canRetryIssueRun,
+    isIssueRunning: opts.isIssueRunning,
     registry: {
       list: () => workspaces,
       get: (id: string) => workspaces.find((workspace) => workspace.id === id),
@@ -195,6 +199,21 @@ describe('ScheduleScanner', () => {
     })
   })
 
+  it('rejects a manual run while an occurrence is still running', async () => {
+    const ws = await makeWs('w1', [{ id: 'busy', title: 'Busy', when: { kind: 'every', every: '30m' } }])
+    const { scanner, dispatch, markers } = scannerFor([ws], { isIssueRunning: () => true })
+    await expect(scanner.runIssueNow('w1', 'busy')).rejects.toMatchObject({ code: 'already_running' })
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(markers.get('w1', 'busy')).toBeUndefined()
+  })
+
+  it('revalidates retry lineage under the dispatch guard', async () => {
+    const ws = await makeWs('w1', [{ id: 'daily', title: 'Daily', when: { kind: 'every', every: '30m' } }])
+    const { scanner, dispatch } = scannerFor([ws], { canRetryIssueRun: () => false })
+    await expect(scanner.runIssueNow('w1', 'daily', 'stale-run')).rejects.toMatchObject({ code: 'not_retryable' })
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
   it('manually retries with live Issue semantics without moving the schedule marker', async () => {
     const ws = await makeWs('w1', [{
       id: 'retry-me',
@@ -205,13 +224,13 @@ describe('ScheduleScanner', () => {
     }])
     const { scanner, dispatch, markers } = scannerFor([ws])
 
-    await expect(scanner.runIssueNow('w1', 'retry-me')).resolves.toEqual({ taskId: 'run-1' })
+    await expect(scanner.runIssueNow('w1', 'retry-me', 'run-failed')).resolves.toEqual({ taskId: 'run-1' })
     expect(dispatch).toHaveBeenCalledWith(
       ws,
       headlessAdapter,
       'same exact prompt',
       undefined,
-      { kind: 'issue', workspaceId: 'w1', issueId: 'retry-me' },
+      { kind: 'issue', workspaceId: 'w1', issueId: 'retry-me', retryOfTaskId: 'run-failed' },
       undefined,
       undefined,
       undefined,
@@ -299,7 +318,7 @@ describe('ScheduleScanner', () => {
         workspaceId: 'w1',
         issueId: 'limited',
         policy: 'new-each-run',
-        fire: 'retry',
+        fire: 'manual',
       },
     )
   })

--- a/src/workspaces/schedule/scanner.ts
+++ b/src/workspaces/schedule/scanner.ts
@@ -61,6 +61,7 @@ export const DEFAULT_INTERVAL_MS = 60_000
 export type ScheduledIssueRunNowErrorCode =
   | 'not_found'
   | 'not_scheduled'
+  | 'not_retryable'
   | 'not_fireable'
   | 'already_running'
 
@@ -90,6 +91,8 @@ export interface ScheduleScannerDeps {
   registry: WorkspaceRegistry
   /** Resolve the execution Workspace for an exact signed Session owner. */
   resolveResumeWorkspace?: (resumeId: string) => WorkspaceMeta | undefined
+  canRetryIssueRun?: (wsId: string, issueId: string, runId: string) => boolean
+  isIssueRunning?: (wsId: string, issueId: string) => boolean
   resolveAdapter: (meta: WorkspaceMeta, agentId?: string, resumeId?: string) => CliAdapter | Promise<CliAdapter>
   dispatch: (
     meta: WorkspaceMeta,
@@ -169,7 +172,7 @@ export class ScheduleScanner {
    * marker. This is the authoritative manual-run / retry path: it re-reads the
    * live Issue and reuses the exact prompt, owner, runtime, and optional timeout used by
    * the scanner, while preserving the next scheduled occurrence. */
-  async runIssueNow(wsId: string, issueId: string): Promise<{ taskId: string }> {
+  async runIssueNow(wsId: string, issueId: string, retryOfTaskId?: string): Promise<{ taskId: string }> {
     const ws = this.deps.registry.get(wsId)
     if (!ws) throw new ScheduledIssueRunNowError('not_found', 'Workspace not found.')
 
@@ -211,6 +214,8 @@ export class ScheduleScanner {
       issueTimeoutMs(issue.timeout),
       issue.connectorDesk,
       true,
+      undefined,
+      retryOfTaskId,
     )
     return { taskId: result.taskId }
   }
@@ -416,6 +421,7 @@ export class ScheduleScanner {
     connectorDesk?: string,
     manual = false,
     commentId?: string,
+    retryOfTaskId?: string,
   ): Promise<{ taskId: string; resumeId: string }> {
     const dispatchKey = `${issueWorkspace.id}:${issueId}`
     if (this.dispatchingIssues.has(dispatchKey)) {
@@ -429,6 +435,12 @@ export class ScheduleScanner {
     }
     this.dispatchingIssues.add(dispatchKey)
     try {
+      if (this.deps.isIssueRunning?.(issueWorkspace.id, issueId)) {
+        throw new ScheduledIssueRunNowError('already_running', 'This Issue already has a run in progress.')
+      }
+      if (retryOfTaskId && this.deps.canRetryIssueRun && !this.deps.canRetryIssueRun(issueWorkspace.id, issueId, retryOfTaskId)) {
+        throw new ScheduledIssueRunNowError('not_retryable', 'The failed run is no longer this Issue’s latest occurrence.')
+      }
       // A scan or comment may have read the file before another dispatch claimed it.
       // Resolve ownership again while holding the shared dispatch exclusion.
       if (claimFreshSession || commentId) {
@@ -459,6 +471,7 @@ export class ScheduleScanner {
       }
       const trigger: HeadlessTaskTrigger | undefined = commentId ? undefined : {
         kind: 'issue',
+        ...(retryOfTaskId ? { retryOfTaskId } : {}),
         workspaceId: issueWorkspace.id,
         issueId,
         ...(connectorDesk
@@ -478,7 +491,7 @@ export class ScheduleScanner {
             workspaceId: issueWorkspace.id,
             issueId,
             policy: claimFreshSession ? 'new-then-resume' : 'new-each-run',
-            fire: commentId ? 'comment' : manual ? 'retry' : 'schedule',
+            fire: commentId ? 'comment' : manual ? (retryOfTaskId ? 'retry' : 'manual') : 'schedule',
           }
       const inquiry: HeadlessTaskInquiry | undefined = commentId ? {
         subject: { kind: 'issue', workspaceId: issueWorkspace.id, issueId, relation: 'owner', commentId },

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -568,8 +568,9 @@ export interface WorkspaceService {
    *  headless run history, newest first). `null` when the workspace or the issue
    *  id is absent. Powers GET /api/issues/:wsId/:id. */
   issueDetail(wsId: string, id: string): Promise<IssueDetail | null>;
-  /** Retry the latest unsuccessful scheduled execution now. Reuses the live
-   * Issue prompt/owner/runtime and never advances its schedule marker. */
+  /** Start a manual run or retry an exact failed occurrence; return its task id. */
+  startIssueRun(wsId: string, id: string, retryRunId?: string): Promise<{ taskId: string }>;
+  /** Retry the latest unsuccessful scheduled execution without moving its marker. */
   retryIssue(wsId: string, id: string): Promise<IssueDetail>;
   /** Dispatch a scheduled Issue immediately without requiring a failed last
    * run and without advancing its next-fire marker. */
@@ -2251,6 +2252,11 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     launcherLogger.child({ scope: 'schedule-markers' }),
   );
   const scheduleScanner = new ScheduleScanner({
+    canRetryIssueRun: (workspaceId, issueId, runId) => {
+      const latest = headlessTasks.list({ issue: { workspaceId, issueId } })[0];
+      return latest?.taskId === runId && (latest.status === 'failed' || latest.status === 'interrupted');
+    },
+    isIssueRunning: (workspaceId, issueId) => headlessTasks.list({ issue: { workspaceId, issueId } }).some((run) => run.status === 'running'),
     registry,
     resolveResumeWorkspace: (resumeId) => {
       const identity = resumeRegistry.get(resumeId);
@@ -2549,7 +2555,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     wsId: string,
     id: string,
     kind: 'retry' | 'manual',
-  ): Promise<IssueDetail> => {
+    retryRunId?: string,
+  ): Promise<{ taskId: string }> => {
     const key = `${wsId}:${id}`;
     const ws = registry.get(wsId);
     if (!ws) throw new IssueRetryError('not_found', 'Workspace not found.');
@@ -2567,8 +2574,12 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         `This Issue is ${issue.status}; reopen it before running.`,
       );
     }
-    const latest = headlessTasks.list({ issue: { workspaceId: wsId, issueId: id } })[0];
-    if (latest?.status === 'running' || retryingIssueKeys.has(key)) {
+    const runs = headlessTasks.list({ issue: { workspaceId: wsId, issueId: id } });
+    const latest = runs[0];
+    if (retryRunId && latest?.taskId !== retryRunId) {
+      throw new IssueRetryError('not_retryable', 'Retry must target this Issue’s latest failed or interrupted run.');
+    }
+    if (runs.some((run) => run.status === 'running') || retryingIssueKeys.has(key)) {
       throw new IssueRetryError('already_running', 'This Issue already has a run in progress.');
     }
     if (kind === 'retry' && (!latest || (latest.status !== 'failed' && latest.status !== 'interrupted'))) {
@@ -2580,13 +2591,14 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
 
     retryingIssueKeys.add(key);
     try {
-      const { taskId } = await scheduleScanner.runIssueNow(wsId, id);
+      const { taskId } = await scheduleScanner.runIssueNow(wsId, id, kind === 'retry' ? latest?.taskId : undefined);
       launcherLogger.info(kind === 'retry' ? 'issue.retry_dispatched' : 'issue.manual_run_dispatched', {
         wsId,
         issueId: id,
         previousTaskId: latest?.taskId,
         taskId,
       });
+      return { taskId };
     } catch (err) {
       if (err instanceof ScheduledIssueRunNowError) {
         throw new IssueRetryError(err.code, err.message);
@@ -2596,14 +2608,17 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       retryingIssueKeys.delete(key);
     }
 
+  };
+  const startIssueRun = (wsId: string, id: string, retryRunId?: string) =>
+    dispatchScheduledIssueNow(wsId, id, retryRunId ? 'retry' : 'manual', retryRunId);
+  const issueRunDetail = async (wsId: string, id: string, kind: 'retry' | 'manual'): Promise<IssueDetail> => {
+    await dispatchScheduledIssueNow(wsId, id, kind);
     const detail = await issueDetail(wsId, id);
     if (!detail) throw new IssueRetryError('not_found', 'Issue not found.');
     return detail;
   };
-  const retryIssue = async (wsId: string, id: string): Promise<IssueDetail> =>
-    dispatchScheduledIssueNow(wsId, id, 'retry');
-  const runIssueNow = async (wsId: string, id: string): Promise<IssueDetail> =>
-    dispatchScheduledIssueNow(wsId, id, 'manual');
+  const retryIssue = (wsId: string, id: string) => issueRunDetail(wsId, id, 'retry');
+  const runIssueNow = (wsId: string, id: string) => issueRunDetail(wsId, id, 'manual');
 
   const setSessionPresence = async (input: {
     wsId: string
@@ -3322,6 +3337,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     createTelegramConnectorDesk: async (wsId: string) => createConnectorDeskOp('telegram', wsId),
     updateTelegramConnectorDesk: async (patch) => updateConnectorDeskOp('telegram', patch),
     disableTelegramConnectorDesk: async () => disableConnectorDeskOp('telegram'),
+    startIssueRun,
     retryIssue,
     runIssueNow,
     replyToIssue: (input) => scheduleScanner.runIssueComment(input),

--- a/src/workspaces/session-metadata.ts
+++ b/src/workspaces/session-metadata.ts
@@ -12,7 +12,7 @@ export type SessionInteractiveSurface = 'spawn' | 'quick-chat' | 'auto-quant' | 
 
 export type SessionIssueBirthPolicy = 'new-each-run' | 'new-then-resume'
 
-export type SessionIssueFire = 'schedule' | 'retry' | 'comment'
+export type SessionIssueFire = 'schedule' | 'manual' | 'retry' | 'comment'
 
 export type SessionConversationCaller =
   | { readonly kind: 'agent'; readonly resumeId: string; readonly workspaceId?: string }
@@ -96,7 +96,7 @@ export function parseSessionCreatedBy(value: unknown): SessionCreatedBy | null {
       && typeof issueId === 'string'
       && issueId.length > 0
       && (policy === 'new-each-run' || policy === 'new-then-resume')
-      && (fire === 'schedule' || fire === 'retry' || fire === 'comment')
+      && (fire === 'schedule' || fire === 'manual' || fire === 'retry' || fire === 'comment')
     ) {
       return { kind: 'issue', workspaceId, issueId, policy, fire }
     }

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -926,7 +926,7 @@ export type SessionCreatedBy =
       readonly workspaceId: string;
       readonly issueId: string;
       readonly policy: 'new-each-run' | 'new-then-resume';
-      readonly fire: 'schedule' | 'retry' | 'comment';
+      readonly fire: 'schedule' | 'manual' | 'retry' | 'comment';
     }
   | { readonly kind: 'headless'; readonly surface: 'api' }
   | {


### PR DESCRIPTION
Expose `alice issue run --id … [--await]` and `alice issue retry --id … --run-id … [--await]` through the existing scheduled Issue dispatch path. Commands resolve the global board (with `--ws-id` for ambiguity), use the current What and owner/runtime selections, and return the exact task ID without advancing the schedule marker.

Retry requires the latest failed/interrupted occurrence and persists `retryOfTaskId` separately from conversation lineage. The shared scanner rejects active Issue runs and revalidates retries under the dispatch guard. Manual Session births are labeled manual. MCP uses the same tools; concise Skill guidance is included. This first version retains the existing scheduled-Issue scope and has no concurrent force override.

Validation: full hermetic suite 766 files / 6825 passed, 3 skipped; final targeted tests 98 passed including retry persistence and race validation; root and UI typechecks passed. Actual CLI launcher exercised against the real local gateway with deterministic dispatch, including missing required run-id validation. No remote production Issue or trade was triggered; remote deployment remains unchanged.
