### PR TITLE
fix: keep Telegram activity alive and honor automated no-reply

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -60,13 +60,19 @@ categories.
   one quoted comment on that Issue. Alice suppresses a desk comment only when
   its run carries the `connector-cron-issue` trigger metadata and its text
   contains the literal tag `[[no-reply]]`. Ordinary chat replies treat that
-  tag as text. Inbound owner comments are not echoed back to that connector.
+  tag as text. Agent-written `issue comment` carries its server-resolved run
+  provenance too: an Issue-triggered run consumes the tag, while an ordinary
+  conversation does not. Inbound owner comments are not echoed back to that connector.
   While a desk turn is running, Alice also
   projects an explicit `accepted | progress | final | failed` lifecycle.
   Telegram turns `accepted` into a native Bot API live draft immediately,
   refreshes that draft every 20 seconds, and replaces it with sealed mid-turn
   `text` blocks (a tool or error followed them). If live drafts are unavailable,
-  Telegram refreshes the ordinary typing action every four seconds. Final and
+  Telegram refreshes the ordinary typing action every four seconds. Typing also
+  continues alongside text drafts during tool calls, until the terminal event.
+  In-turn CLI comments update the same draft rather than marking it final. A
+  suppressed automated reply sends a textless final event to stop activity
+  without publishing a message. Final and
   failed replies are always persistent messages; ephemeral progress never
   suppresses an identical final answer. Tool names, status, and payloads stay
   off the owner chat. The trailing text still becomes today's reply comment.

--- a/packages/connector-protocol/src/types.spec.ts
+++ b/packages/connector-protocol/src/types.spec.ts
@@ -36,6 +36,7 @@ describe('owner chat messages', () => {
       ...base,
       phase: 'accepted',
     }).phase).toBe('accepted')
+    expect(ownerChatMessageSchema.parse({ ...base, phase: 'final' })).not.toHaveProperty('text')
     expect(() => ownerChatMessageSchema.parse({
       ...base,
       phase: 'progress',

--- a/packages/connector-protocol/src/types.ts
+++ b/packages/connector-protocol/src/types.ts
@@ -195,7 +195,7 @@ export type OwnerChatPhase = z.infer<typeof ownerChatPhaseSchema>
 
 /** Lifecycle event for one owner-private Agent turn.
  * `accepted` starts transport-native activity without requiring model text.
- * `progress` is ephemeral; `final` and `failed` must remain visible. */
+ * `progress` is ephemeral; final without text silently ends activity. */
 export const ownerChatMessageSchema = z.object({
   id: z.string().min(1),
   adapterId: z.string().min(1),
@@ -203,7 +203,7 @@ export const ownerChatMessageSchema = z.object({
   phase: ownerChatPhaseSchema,
   text: z.string().min(1).max(OWNER_CHAT_TEXT_MAX).optional(),
 }).superRefine((message, ctx) => {
-  if (message.phase !== 'accepted' && !message.text) {
+  if (message.phase !== 'accepted' && message.phase !== 'final' && !message.text) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['text'],

--- a/services/connector/src/adapters/telegram.spec.ts
+++ b/services/connector/src/adapters/telegram.spec.ts
@@ -334,6 +334,30 @@ describe('Telegram rich outbound text', () => {
     await adapter.stop()
   })
 
+  it('keeps working activity through multiple text/tool pauses and ends silently', async () => {
+    const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })
+    await startUntilReady(adapter, { botToken: 'token', ownerUserId: '42', chatId: '99' })
+    vi.useFakeTimers()
+    try {
+      await adapter.sendOwnerChat({ id: 'a', adapterId: 'telegram', conversationId: 'turn', phase: 'accepted' })
+      await adapter.sendOwnerChat({ id: 'p1', adapterId: 'telegram', conversationId: 'turn', phase: 'progress', text: 'Reading.' })
+      const count = sendChatAction.mock.calls.length
+      await vi.advanceTimersByTimeAsync(12_000)
+      expect(sendChatAction.mock.calls.length).toBeGreaterThan(count)
+      await adapter.sendOwnerChat({ id: 'p2', adapterId: 'telegram', conversationId: 'turn', phase: 'progress', text: 'Checking.' })
+      await vi.advanceTimersByTimeAsync(24_000)
+      expect(sendRichMessageDraft).toHaveBeenLastCalledWith(99, expect.any(Number), { markdown: 'Checking.' })
+      await adapter.sendOwnerChat({ id: 'end', adapterId: 'telegram', conversationId: 'turn', phase: 'final' })
+      const stopped = sendChatAction.mock.calls.length
+      await vi.advanceTimersByTimeAsync(24_000)
+      expect(sendChatAction).toHaveBeenCalledTimes(stopped)
+      expect(sendRichMessage).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+      await adapter.stop()
+    }
+  })
+
   it('falls back to Telegram typing when live drafts are unavailable', async () => {
     sendMessageDraft.mockRejectedValueOnce(new Error('method unavailable'))
     const adapter = new TelegramConnectorAdapter({ attemptTimeoutMs: 200, reconnectDelayMs: 20 })

--- a/services/connector/src/adapters/telegram.ts
+++ b/services/connector/src/adapters/telegram.ts
@@ -61,6 +61,7 @@ const MAX_FINISHED_DRAFTS = 128
 interface TelegramDraftSession {
   draftId: number
   markdown?: string
+  refreshedAt?: number
   typingFallback: boolean
   stopped: boolean
   pending: Promise<void>
@@ -723,6 +724,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       this.drafts.set(conversationId, session)
     }
     session.markdown = markdown
+    session.refreshedAt = undefined
     try {
       await this.queueDraftRefresh(conversationId, session)
     } finally {
@@ -742,10 +744,12 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   private async refreshDraft(session: TelegramDraftSession): Promise<void> {
     if (!this.bot || !this.sessionReady) throw new Error('Telegram bot is not ready')
     const chatId = telegramNumericChatId(this.chatId)
-    if (session.typingFallback) {
-      await this.bot.api.sendChatAction(chatId, 'typing')
-      return
-    }
+    // A text draft is content, not a durable working indicator. Keep typing alive
+    // through tool calls and long pauses until the authoritative terminal event.
+    await this.bot.api.sendChatAction(chatId, 'typing')
+    if (session.refreshedAt !== undefined && Date.now() - session.refreshedAt < TELEGRAM_DRAFT_HEARTBEAT_MS) return
+    session.refreshedAt = Date.now()
+    if (session.typingFallback) return
     try {
       if (session.markdown) {
         await this.bot.api.sendRichMessageDraft(chatId, session.draftId, { markdown: session.markdown })
@@ -768,7 +772,6 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
       }
       console.warn('[connector] Telegram live draft fell back to typing:', formatAdapterError(error))
       session.typingFallback = true
-      await this.bot.api.sendChatAction(chatId, 'typing')
     }
   }
 
@@ -796,7 +799,7 @@ export class TelegramConnectorAdapter implements ConnectorAdapter {
   private armDraftHeartbeat(conversationId: string, session: TelegramDraftSession): void {
     if (session.stopped || this.drafts.get(conversationId) !== session) return
     if (session.timer) clearTimeout(session.timer)
-    const delay = session.typingFallback ? TELEGRAM_TYPING_HEARTBEAT_MS : TELEGRAM_DRAFT_HEARTBEAT_MS
+    const delay = TELEGRAM_TYPING_HEARTBEAT_MS
     session.timer = setTimeout(() => {
       void this.queueDraftRefresh(conversationId, session).catch((error) => {
         this.tracker.degraded(error)

--- a/src/core/workspace-tool-center.ts
+++ b/src/core/workspace-tool-center.ts
@@ -35,7 +35,7 @@ import type { ArtifactRef, SessionOrigin } from './provenance-store.js'
 import type { IssuesSnapshot, IssueDetail, WikilinkIssueRef } from '../workspaces/issues/board.js'
 import type { WorkspaceSessionDirectory } from '../workspaces/session-directory.js'
 import type { HeadlessStructuredOutput } from '../workspaces/headless-output.js'
-import type { HeadlessInquirySubject, HeadlessTaskStatus } from '../workspaces/headless-task-registry.js'
+import type { HeadlessTaskRecord, HeadlessInquirySubject, HeadlessTaskStatus } from '../workspaces/headless-task-registry.js'
 import type {
   ApplyTemplateUpgradeInput,
   TemplateUpgradePlan,
@@ -233,6 +233,7 @@ export interface WorkspaceToolContext {
    *  agent). Factories pass it through to call sites (e.g. inbox_push →
    *  inboxStore.append) so a pushed entry self-links to its originating run /
    *  issue. Absent (interactive session, or no header) → undefined. */
+  callerRun?: Pick<HeadlessTaskRecord, 'taskId' | 'status' | 'trigger' | 'inquiry'>
   origin?: InboxOrigin
   /** GLOBAL issue-board reader — the cross-workspace board the
    *  `alice` CLI surfaces (issue_list / issue_show read EVERY

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -187,6 +187,7 @@ export function registerCliRoutes(app: Hono, deps: CliGatewayDeps, manifestOnly 
         // (resolved server-side). Only the invoke path passes it; manifest omits
         // it (no execution, no push). Absent → undefined.
         ...(origin ? { origin } : {}),
+        ...(origin?.kind === 'headless' && origin.runId && svc ? { callerRun: svc.headlessTasks.get(origin.runId) ?? undefined } : {}),
       })
       return {
         resolve: (name) => wsTools[name] ?? null,

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -183,6 +183,7 @@ export class McpPlugin implements Plugin {
         // Agent-invisible run provenance from the out-of-band header (resolved
         // server-side from the authoritative registry). Absent → undefined.
         ...(origin ? { origin } : {}),
+        ...(origin?.kind === 'headless' && origin.runId && svc ? { callerRun: svc.headlessTasks.get(origin.runId) ?? undefined } : {}),
       })
       const mcp = new McpServer({ name: 'open-alice-workspace', version: '1.0.0' })
       for (const [name, t] of Object.entries(tools)) {

--- a/src/tool/issue-tools.spec.ts
+++ b/src/tool/issue-tools.spec.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import * as deskProjection from '../workspaces/issues/telegram-desk-project.js'
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -683,4 +684,20 @@ describe('Issue execution tools', () => {
     start.mockRejectedValue(Object.assign(new Error('Already running'), { code: 'already_running' }))
     expect(await run(issueRunNowFactory.build(context), { id: 'daily' })).toMatchObject({ ok: false, code: 'already_running' })
   })
+})
+
+
+it('carries trusted run scope into in-turn desk comments', async () => {
+  await run(issueCreateFactory.build(ctx()), { id: 'desk', title: 'Desk', what: 'Talk' })
+  const path = join(dir, '.alice/issues/desk.md')
+  await writeFile(path, (await readFile(path, 'utf8')).replace('---\n', '---\nconnectorDesk: telegram\n'))
+  const project = vi.spyOn(deskProjection, 'projectDeskComment').mockResolvedValue()
+  try {
+    await run(issueCommentFactory.build(ctx({ callerRun: {
+      taskId: 'run-live', status: 'running', trigger: { kind: 'issue', workspaceId: 'ws-self', issueId: 'desk' },
+    } })), { id: 'desk', text: '[[no-reply]] quiet' })
+    expect(project).toHaveBeenCalledWith(expect.anything(), expect.anything(), undefined, {
+      progressScopeId: 'run-live', phase: 'progress', automated: true,
+    })
+  } finally { project.mockRestore() }
 })

--- a/src/tool/issue-tools.ts
+++ b/src/tool/issue-tools.ts
@@ -58,7 +58,7 @@ import {
   type IssueComment,
 } from '../workspaces/issues/comments.js'
 import { dispatchIssueCommentReply } from '../workspaces/issues/comment-delivery.js'
-import { projectDeskComment } from '../workspaces/issues/telegram-desk-project.js'
+import { deskProgressScope, projectDeskComment } from '../workspaces/issues/telegram-desk-project.js'
 import { issueMutation, issueMutationFingerprint } from '../workspaces/issues/change-tracker.js'
 import {
   NEW_THEN_RESUME_ASSIGNEE,
@@ -434,7 +434,15 @@ export const issueCommentFactory: WorkspaceToolFactory = {
             ...(origin ? { authorResumeId: origin.resumeId } : {}),
             source: origin ?? { kind: 'workspace', workspaceId: ctx.workspaceId },
           })
-          await projectDeskComment(res.issue, res.comment).catch(() => undefined)
+          const run = ctx.callerRun
+          const scope = run ? deskProgressScope(run) : null
+          await projectDeskComment(res.issue, res.comment, undefined, {
+            ...(scope?.workspaceId === ctx.workspaceId && scope.issueId === id
+              ? { progressScopeId: scope.scopeId } : {}),
+            automated: run?.trigger?.kind === 'issue',
+            ...(run?.status === 'running' && scope?.workspaceId === ctx.workspaceId && scope.issueId === id
+              ? { phase: 'progress' as const } : {}),
+          }).catch(() => undefined)
           if (dispatched.status !== 'not_requested') {
             const updated = await updateIssueCommentDelivery(
               dir.dir,

--- a/src/workspaces/issues/telegram-desk-chat.spec.ts
+++ b/src/workspaces/issues/telegram-desk-chat.spec.ts
@@ -175,7 +175,8 @@ describe('telegram desk ingest and stamp', () => {
     })
     expect(comment?.markdown).toContain('[[no-reply]]')
     expect(comment?.id).toBe('comment-fire-run-1')
-    expect(sent).toEqual([])
+    expect(sent).toEqual([expect.objectContaining({ phase: 'final', conversationId: 'run-1' })])
+    expect(sent[0]).not.toHaveProperty('text')
     if (!comment) return
     expect(shouldProjectDeskComment(created.issue, comment, {
       triggerMetadata: { kind: 'connector-cron-issue', connectorId: 'telegram' },

--- a/src/workspaces/issues/telegram-desk-project.spec.ts
+++ b/src/workspaces/issues/telegram-desk-project.spec.ts
@@ -255,6 +255,18 @@ describe('final comment projection', () => {
     })).toBe(false)
   })
 
+  it('projects an in-turn comment as progress and suppresses automated no-reply without ending the turn', async () => {
+    const { client, sent } = mockClient()
+    const issue = { connectorDesk: 'telegram' }
+    const comment = { id: 'note', author: '@agent', at: 'now', markdown: 'Still checking.' }
+    await projectDeskComment(issue, comment, client, { phase: 'progress', progressScopeId: 'run' })
+    expect(sent[0]).toMatchObject({ phase: 'progress', conversationId: 'run', text: 'Still checking.' })
+    await projectDeskComment(issue, { ...comment, markdown: '[[no-reply]] quiet' }, client, {
+      phase: 'progress', progressScopeId: 'run', automated: true,
+    })
+    expect(sent).toHaveLength(1)
+  })
+
   it('persists a final comment even when the same text was shown in an ephemeral draft', async () => {
     const { client, sent } = mockClient()
     const issue = { connectorDesk: 'telegram' }

--- a/src/workspaces/issues/telegram-desk-project.ts
+++ b/src/workspaces/issues/telegram-desk-project.ts
@@ -123,13 +123,16 @@ export function shouldProjectDeskComment(
   issue: { connectorDesk?: string },
   comment: IssueComment,
   opts?: {
+    /** Derived from the caller's server-owned Issue run, never tool arguments. */
+    automated?: boolean
+    phase?: 'progress' | 'final'
     progressScopeId?: string
     triggerMetadata?: HeadlessTaskTriggerMetadata
   },
 ): boolean {
   if (!isConnectorDeskIssue(issue) || comment.via) return false
   if (
-    consumesConnectorNoReply(opts?.triggerMetadata)
+    (opts?.automated === true || consumesConnectorNoReply(opts?.triggerMetadata))
     && containsTelegramNoReply(comment.markdown)
   ) return false
   return true
@@ -140,25 +143,32 @@ export async function projectDeskComment(
   comment: IssueComment,
   client: ConnectorClient = new ConnectorClient(resolveConnectorUrl()),
   opts?: {
+    /** Derived from the caller's server-owned Issue run, never tool arguments. */
+    automated?: boolean
+    phase?: 'progress' | 'final'
     progressScopeId?: string
     triggerMetadata?: HeadlessTaskTriggerMetadata
   },
 ): Promise<void> {
   const scope = opts?.progressScopeId ?? comment.replyTo
   try {
-    if (!shouldProjectDeskComment(issue, comment, {
+    if (!isConnectorDeskIssue(issue) || comment.via || !issue.connectorDesk) return
+    const phase = opts?.phase ?? 'final'
+    const visible = shouldProjectDeskComment(issue, comment, {
       progressScopeId: scope,
       triggerMetadata: opts?.triggerMetadata,
-    }) || !issue.connectorDesk) return
+      automated: opts?.automated,
+    })
+    if (!visible && phase === 'progress') return
     await client.sendOwnerMessage({
       id: `desk-${comment.id}`,
       adapterId: issue.connectorDesk,
       conversationId: scope ?? comment.id,
-      phase: 'final',
-      text: normalizeDeskText(comment.markdown),
+      phase,
+      ...(visible ? { text: normalizeDeskText(comment.markdown) } : {}),
     }, AbortSignal.timeout(5_000))
   } finally {
-    if (scope) forgetProjectedDeskTexts(scope)
+    if (scope && opts?.phase !== 'progress') forgetProjectedDeskTexts(scope)
   }
 }
 


### PR DESCRIPTION
Keep Telegram working activity alive through text/tool alternation: refresh typing every four seconds alongside the existing live draft, and stop only on the terminal event. CLI issue comments now inherit the server-resolved caller run: in-turn desk comments use progress on the same conversation instead of emitting final; automated Issue comments suppress [[no-reply]], while ordinary chat retains the literal text. Suppressed completion sends a textless final lifecycle event so it can stop activity without publishing a message.

Validation: related regression tests passed (including multiple progress/tool pauses, silent final, normal-chat literal tag, automated comment provenance); root/service types, protocol build, 16 replay/journal tests and isolated built Connector process smoke passed. Full suite: 765/766 files passed, 6828 tests passed; unrelated NewsPage IntersectionObserver callback timing failed once and its isolated 12 tests passed on rerun, recorded separately. No real Telegram message was sent and remote deployment was not changed; native client appearance remains to verify after deployment.
