### PR TITLE
fix: remove fixed five-minute Issue reply timeout

### DIFF
--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -97,8 +97,9 @@ The filename stem is the stable issue id. Frontmatter:
 - `effort` — optional one-run reasoning effort:
   `none | minimal | low | medium | high | xhigh | max`. The chosen runtime must
   expose that level; omission inherits its Workspace/native default.
-- `timeout` — optional scheduled-run watchdog: `15m | 30m | 45m | 60m`. Omission
-  means no limit: the headless child runs until the agent exits. This is a run
+- `timeout` — optional scheduled-run and comment-reply watchdog: `15m | 30m | 45m | 60m`. Omission
+  means no limit: the headless child runs until the agent exits. Comment replies
+  have no separate fixed five-minute cap. This is a run
   budget, not Session birth, so an exact `@resumeId` owner may still set it.
 - `commentPrompt` — optional template for the Input Prompt sent when a comment
   needs a reply. Omission keeps the historical wrapper (Issue id, title, author,

--- a/src/workspaces/issues/comment-delivery.spec.ts
+++ b/src/workspaces/issues/comment-delivery.spec.ts
@@ -69,6 +69,18 @@ describe('issueCommentReplyPrompt', () => {
 })
 
 describe('dispatchIssueCommentReply', () => {
+  it.each([undefined, '15m', '60m'] as const)('uses the Issue timeout %s for owner replies', async (timeout) => {
+    const ask = vi.fn(async () => ({ status: 'dispatched', taskId: 'run-reply', resumeId: 'resume-owner' }))
+    await dispatchIssueCommentReply({
+      conversation: { ask } as unknown as WorkspaceConversationControl,
+      issueWorkspaceId: 'ws-home', issue: { ...issue('@resume-owner'), timeout }, comment,
+      source: { kind: 'human' },
+    })
+    expect(ask).toHaveBeenCalledWith(expect.objectContaining({
+      timeoutMs: timeout === undefined ? undefined : timeout === '15m' ? 900_000 : 3_600_000,
+    }))
+  })
+
   it('keeps agent-authored workspace-owned comments as notes', async () => {
     expect(await dispatchIssueCommentReply({
       issueWorkspaceId: 'ws-home',

--- a/src/workspaces/issues/comment-delivery.ts
+++ b/src/workspaces/issues/comment-delivery.ts
@@ -12,13 +12,11 @@ import {
   type IssueCommentDelivery,
 } from './comments.js'
 import { renderIssueCommentPrompt } from './comment-prompt.js'
-import { issueAssigneeResumeId, type IssueRecord } from './declaration.js'
+import { issueAssigneeResumeId, issueTimeoutMs, type IssueRecord } from './declaration.js'
 import {
   projectDeskComment,
   projectWorkspaceDeskFailure,
 } from './telegram-desk-project.js'
-
-const COMMENT_REPLY_TIMEOUT_MS = 300_000
 
 export type IssueCommentDispatchResult =
   | { status: 'not_requested'; reason: 'non_human_note' | 'owner_commented' }
@@ -100,7 +98,7 @@ export async function dispatchIssueCommentReply(input: {
     const result = await input.conversation.ask({
       prompt: issueCommentReplyPrompt(input),
       target,
-      timeoutMs: COMMENT_REPLY_TIMEOUT_MS,
+      timeoutMs: issueTimeoutMs(input.issue.timeout),
       ...(!targetResumeId ? { reconstruct: true } : {}),
       ...(input.source ? { source: input.source } : {}),
       subject: {


### PR DESCRIPTION
Issue comment replies to existing owners or creator fallback were forcibly killed after five minutes, even when the Issue had no timeout. Remove the separate fixed cap and use the Issue watchdog: omitted means unlimited, explicit timeout is honored. Fresh-owner recruitment already uses the same Issue setting.

Verified against remote run run-_t7baxDL: timeoutMs 300000, duration 300026 ms, killed true. Validation: 262 changed-closure tests passed and root TypeScript check passed; regression covers omitted, 15-minute and 60-minute settings. No remote replay or deployment performed.
