### PR TITLE
fix: one sticker per reply guidance

### DIFF
--- a/src/workspaces/sticker-packs.ts
+++ b/src/workspaces/sticker-packs.ts
@@ -203,7 +203,7 @@ export class StickerPacks {
 }
 
 export function renderStickerSkill(pack: StickerPack) {
-  return `---\nname: alice-stickers\ndescription: Optional expressive stickers for casual user conversation in a chat that supports image replies.\n---\n\n# Alice stickers\n\nUse a sticker when it adds to the conversation. No need to inspect images or use a sticker in every reply. Send a listed relative path as a double-bracket reference.\n\n${pack.stickers.map(item => `- [[sticker/${item.file}]] — ${item.description.replace(/[\r\n]/g, ' ')}`).join('\n')}\n`
+  return `---\nname: alice-stickers\ndescription: Optional expressive stickers for casual user conversation in a chat that supports image replies.\n---\n\n# Alice stickers\n\nUse a sticker when it adds to the conversation. Send at most one sticker per reply. No need to inspect images or use a sticker in every reply. Send a listed relative path as a double-bracket reference.\n\n${pack.stickers.map(item => `- [[sticker/${item.file}]] — ${item.description.replace(/[\r\n]/g, ' ')}`).join('\n')}\n`
 }
 function validateImage(name: string, bytes: Uint8Array) {
   filename.parse(name)


### PR DESCRIPTION
Add a concise English instruction to the generated Sticker Skill: send at most one sticker per reply. Verified the six projection tests, root typecheck, and local Chat preview/apply with identical canonical and Claude Skills.