### PR TITLE
fix: preserve text and media order in connector replies

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -53,7 +53,8 @@ categories.
   by the current trading mode. Callback data carries only page-local
   indexes; account ids and pending hashes stay in the Connector session
   and the Alice-validated action request.
-- Connector Service owns outgoing reply syntax. Alice owns one phone-desk Issue
+- Connector Service owns outgoing reply syntax. Resolved file references are
+  delivered at their original position: text before, media, then text after. Alice owns one phone-desk Issue
   per `desk`-capable connector and forwards raw reply text with a Workspace id
   and server-derived `conversation | automation` source. Workspace/Issue
   projection does not parse delivery markers. Inbound owner comments are not

--- a/services/connector/src/core/delivery-manager.spec.ts
+++ b/services/connector/src/core/delivery-manager.spec.ts
@@ -79,7 +79,7 @@ class FakeThirdPartyAdapter implements ConnectorAdapter {
     this.delivered.push(notification)
   }
 
-  async sendOwnerText(): Promise<void> {}
+  async sendOwnerText(_text: string): Promise<void> {}
 
   health(): ConnectorAdapterHealth {
     return { id: this.id, enabled: true, status: this.status }
@@ -886,8 +886,14 @@ it('owns reply syntax, sends final files once, and preserves ordinary syntax dis
   read.mockClear()
   await manager.sendOwnerChat({ ...base, id: 'limit', phase: 'final', text: Array.from({ length: 6 }, (_, i) => `[[${i}.pdf]]`).join(' ') })
   expect(read).toHaveBeenCalledTimes(5)
-  expect(adapter.sendOwnerChat).toHaveBeenLastCalledWith(expect.objectContaining({ text: '[[5.pdf]]' }))
+  expect(warning).toHaveBeenLastCalledWith('[[5.pdf]]')
   await manager.sendOwnerChat({ ...base, id: 'sticker', phase: 'final', text: '[[sticker/hello.png]]' })
   expect(adapter.sendOwnerFile).toHaveBeenLastCalledWith(expect.any(Object), 'sticker')
+  const order: string[] = []
+  adapter.sendOwnerChat.mockImplementation(async message => { order.push(message.text ?? 'finish') })
+  adapter.sendOwnerFile.mockImplementation(async () => { order.push('sticker') })
+  warning.mockImplementation(async text => { order.push(text) })
+  await manager.sendOwnerChat({ ...base, id: 'interleaved', phase: 'final', text: 'Before [[sticker/hello.png]] After' })
+  expect(order).toEqual(['Before', 'sticker', 'After'])
   await manager.stop()
 })

--- a/services/connector/src/core/delivery-manager.ts
+++ b/services/connector/src/core/delivery-manager.ts
@@ -1,4 +1,4 @@
-import { parseReplyDirectives, renderReplyReferences, replyMedia } from './reply-directives.js'
+import { parseReplyDirectives, replyMedia } from './reply-directives.js'
 import type { ConnectorAttachment } from '@traderalice/connector-protocol'
 import { randomUUID } from 'node:crypto'
 import {
@@ -455,13 +455,37 @@ export class DeliveryManager {
           }
         }
       }
-      const text = silent ? '' : renderReplyReferences(message.text ?? '', parsed.references, new Set(resolved.keys()))
-      const outgoing = { ...message, text: text || undefined }
+      const parts: Array<{ text: string } | { path: string; attachment: ConnectorAttachment }> = []
+      let cursor = 0
+      const sent = new Set<string>()
+      const raw = silent ? '' : message.text ?? ''
+      for (const reference of parsed.references) {
+        const attachment = resolved.get(reference.path)
+        if (!attachment) continue
+        const text = raw.slice(cursor, reference.start).trim()
+        if (text) parts.push({ text })
+        if (!sent.has(reference.path)) {
+          parts.push({ path: reference.path, attachment })
+          sent.add(reference.path)
+        }
+        cursor = reference.end
+      }
+      const tail = raw.slice(cursor).trim()
+      if (tail) parts.push({ text: tail })
+      // Finish the transport's live reply once, then preserve the remaining media/text order.
+      const first = parts[0]
+      const text = first && 'text' in first ? first.text : ''
+      if (text) parts.shift()
       if (!silent || message.phase !== 'progress') {
-        if (adapter.sendOwnerChat) await adapter.sendOwnerChat(outgoing)
+        if (adapter.sendOwnerChat) await adapter.sendOwnerChat({ ...message, text: text || undefined })
         else if (message.phase !== 'accepted' && text) await adapter.sendOwnerText(text)
       }
-      for (const [path, attachment] of resolved) {
+      for (const part of parts) {
+        if ('text' in part) {
+          await adapter.sendOwnerText(part.text)
+          continue
+        }
+        const { path, attachment } = part
         try {
           const presentation = replyMedia(path)
           await adapter.sendOwnerFile!(attachment, presentation)


### PR DESCRIPTION
Replies containing text, a file reference, and more text now deliver in that order instead of combining all text before attachments. Retains one final transport completion, reference deduplication, unresolved literals and upload failure handling. Verified connector owner suite (129 tests), connector typecheck, and a real local Telegram three-part delivery.