### PR TITLE
fix: retain injected CLI precedence in Cursor shell snapshots

### DIFF
--- a/docs/alice-harness.md
+++ b/docs/alice-harness.md
@@ -153,6 +153,30 @@ The setting is a per-launch override, including resumes, not a user-config or
 Skill rewrite. Verify CLI discovery inside the agent's shell, not just its
 parent process environment.
 
+Cursor's Bash/Zsh snapshot has the same precedence hazard: the login profile
+can select a global `alice` even when Workspace routing variables survive.
+The Cursor adapter restores the composed PATH through
+`__CURSOR_SANDBOX_ENV_RESTORE`, evaluated after snapshot restoration in Cursor
+`2026.09.08-6caf4ff`. This is a vendor-internal integration, not a public Cursor
+configuration promise; revalidate it on runtime upgrades. Native Windows is
+excluded. No user shell profile is rewritten.
+
+### Headless CLI acceptance
+
+Exercise the actual Workspace headless API with default shell options. Check
+both the exact `command -v alice` path and a read such as
+`alice issue list --limit 1`; exit zero alone can hide a stale global binary.
+Do not supply PATH/login overrides in acceptance. Inspect normalized errors as
+well as process exit codes: Pi can exit zero after a provider authentication
+failure, and `headlessTaskStatus` correctly marks that outcome failed.
+
+The 2026-09-09 audit exercised Codex, Pi and OpenCode on the Linux SSH Runtime,
+and Grok, OMP and Cursor on macOS. Codex's non-login setting and Cursor's PATH
+restoration address the observed failures. Local Claude was unauthenticated;
+Antigravity returned an execution error before tool use. Those runs do not
+establish CLI acceptance and require working native access before retesting.
+This is dated acceptance evidence, not a permanent runtime compatibility claim.
+
 ## Optional sticker resources
 
 Chat sticker packs use a separate Project-owned projection and generated Skill.

--- a/src/workspaces/adapters/cursor.spec.ts
+++ b/src/workspaces/adapters/cursor.spec.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -42,6 +43,18 @@ describe('cursor session layout', () => {
 });
 
 describe('cursor composeCommand', () => {
+  it.skipIf(process.platform === 'win32')('restores injected PATH after a login snapshot without evaluating path contents', () => {
+    const path = `/tmp/alice tools/it's-$(echo BAD)-\`echo BAD\`:/usr/bin:/bin`;
+    const env = cursorAdapter.composeEnv!(ctx({ env: {
+      PATH: path,
+      __CURSOR_SANDBOX_ENV_RESTORE: 'export OA_TEST_EXISTING=kept',
+    } }));
+    const output = execFileSync('/bin/bash', ['-c',
+      'PATH=/usr/bin:/bin; eval "$__CURSOR_SANDBOX_ENV_RESTORE"; printf "%s\\n%s" "$PATH" "$OA_TEST_EXISTING"',
+    ], { env, encoding: 'utf8' });
+    expect(output).toBe(`${path}\nkept`);
+  });
+
   it('seeds a fresh TUI with a trailing `-- <prompt>` and never goes headless', () => {
     const argv = cursorAdapter.composeCommand(['claude'], ctx({ initialPrompt: PROMPT }));
     expect(argv[0]).toBe('cursor-agent');

--- a/src/workspaces/adapters/cursor.ts
+++ b/src/workspaces/adapters/cursor.ts
@@ -272,6 +272,20 @@ export const cursorAdapter: CliAdapter = {
     ];
   },
 
+  composeEnv(ctx: SpawnContext): Record<string, string> {
+    if (process.platform === 'win32' || !ctx.env['PATH']) return {};
+    // Cursor 2026.09.08 snapshots a login shell, then evaluates this hook
+    // after restoring that snapshot in Bash/Zsh (including print/ACP mode).
+    // Keep Alice's already-resolved CLI/toolchain precedence over host profiles.
+    // This is a vendor-internal seam; retain live shell acceptance on upgrades.
+    const path = `'${ctx.env['PATH'].replace(/'/g, `'"'"'`)}'`;
+    const inherited = ctx.env['__CURSOR_SANDBOX_ENV_RESTORE']?.trim();
+    return {
+      __CURSOR_SANDBOX_ENV_RESTORE: [inherited, `builtin export PATH=${path}`]
+        .filter(Boolean).join('; '),
+    };
+  },
+
   extractHeadlessSessionId(line: string): string | null {
     const evt = parseJsonRecord(line);
     return evt && typeof evt['session_id'] === 'string' ? evt['session_id'] : null;


### PR DESCRIPTION
Cursor builds a login-shell snapshot before executing tools. Host profiles can replace Alice's injected PATH, so `alice` resolves to a stale globally installed shim even while Workspace routing variables remain intact.

Restore the composed PATH after Cursor's Bash/Zsh snapshot through its existing `__CURSOR_SANDBOX_ENV_RESTORE` seam, preserving inherited restoration and safely quoting literal PATH contents. Native Windows is unchanged. This is a vendor-internal seam verified against Cursor 2026.09.08-6caf4ff, explicitly documented for revalidation on upgrades; no user shell files are edited.

Live audit: Linux Codex, Pi, and OpenCode successfully read the Issue CLI through the real Workspace headless API. macOS Grok and OMP passed; Cursor reproduced global-shim selection before the fix and resolved the injected shim and read JSON afterward. One Cursor startup timed out before any events; subsequent default-shell runs passed. Claude lacked native authentication and Antigravity returned an execution error before tools, so neither is claimed as passing. Pi's local expired-provider error was already correctly normalized despite its zero process exit code.

Validation: 451 changed tests, 1,655 Alice owner tests, and 1,763 Runtime/CLI owner tests passed (1 skipped); root typecheck and diff checks passed. Added a shell execution regression for PATH restoration and injection-safe quoting. No trading writes or connector messages.
