### PR TITLE
fix(workspaces): release interactive ownership for issue replies

### DIFF
--- a/docs/web-conversation-surface.md
+++ b/docs/web-conversation-surface.md
@@ -154,3 +154,13 @@ or lifecycle defects, and never claim every runtime passed from one shared
 wire's fake-process fixture.
 
 Managed launch permissions follow [[docs/model-semantics-and-runtime-injection.md]]. Protocol permission handling remains available for native policy requests; normal managed tool execution is approved at launch.
+
+## Background ownership handoff
+
+Issue and Connector desk work can preempt a TUI/Web interactive connection on
+the same Session. Native context is retained. The shared resume lease excludes
+new interactive starts while the previous child is stopping and the background
+turn is running. A deliberate PTY disposal must not trigger browser reconnect.
+Web shutdown waits for child termination, including the SIGKILL fallback, before
+another writer may start. The UI renders background occupancy without attaching
+a terminal to a headless Session.

--- a/docs/workspace-issues-and-scheduling.md
+++ b/docs/workspace-issues-and-scheduling.md
@@ -262,6 +262,21 @@ Reads such as list/show aggregate all workspaces. Writes from an autonomous or
 headless run stay inside its own Workspace. Editing a peer Workspace requires
 an attended, human-approved path and a commit in the peer repository.
 
+## Interactive handoff
+
+Opening a Connector desk or Issue-assigned Session in TUI/Web requires a UI
+acknowledgement. The shared Session actions menu offers **Disconnect interactive
+connection**; this stops the interactive process and preserves the native
+conversation. Closing a browser tab alone is not a disconnect.
+
+Issue dispatch (scheduled, manual, retry, and comment replies, including
+Connector desk messages) claims the same resume lease used by UI startup,
+stops any TUI/Web owner, and waits for process exit before starting the
+headless turn. Another background turn is never preempted. Capacity/busy
+admission still follows the existing scanner/Connector queue policy.
+The disconnected browser does not reconnect automatically and shows background
+occupancy until the turn finishes; returning to interactive mode is explicit.
+
 ## Execution Flow
 
 ```text

--- a/src/webui/routes/workspaces.spec.ts
+++ b/src/webui/routes/workspaces.spec.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createWorkspaceRoutes } from './workspaces.js';
-import { HeadlessCapacityError, type WorkspaceService } from '../../workspaces/service.js';
+import { HeadlessCapacityError, HeadlessResumeError, type WorkspaceService } from '../../workspaces/service.js';
 import { TemplateUpgradeError } from '../../workspaces/template-upgrade.js';
 import { WorkspaceAbsorbError } from '../../workspaces/workspace-absorb.js';
 import { HarnessSourceUpgradeError } from '../../workspaces/harness-source-upgrade.js';
@@ -1722,8 +1722,27 @@ describe('Web surface routes', () => {
     const result = await post(app, `/ws-1/sessions/${TOKEN}/web/open`);
     expect(result.status).toBe(200);
     expect(result.body.snapshot).toMatchObject({ resumeId: 'resume-web', phase: 'idle' });
-    expect(order).toEqual(['prepare-workspace', 'terminal-stopped', 'web-started']);
+    expect(order).toEqual(['prepare-workspace', 'web-started']);
     expect(svc.startWebSession).toHaveBeenCalledOnce();
+  });
+
+  it('disconnects a live interactive Session without deleting its identity', async () => {
+    const { app, svc } = buildWeb();
+    const disposeAndWait = vi.fn(async () => undefined);
+    vi.mocked(svc.pool.get).mockReturnValue({ disposeAndWait } as never);
+    const result = await post(app, `/ws-1/sessions/${TOKEN}/pause`);
+    expect(result.status).toBe(200);
+    expect(disposeAndWait).toHaveBeenCalledWith('paused');
+    expect(svc.sessionRegistry.update).toHaveBeenCalledWith('ws-1', TOKEN,
+      expect.objectContaining({ state: 'paused' }));
+  });
+
+  it('does not overwrite background occupancy when Web loses the launch race', async () => {
+    const { app, svc } = buildWeb();
+    vi.mocked(svc.startWebSession).mockRejectedValue(new HeadlessResumeError('busy', 'running turn'));
+    const result = await post(app, `/ws-1/sessions/${TOKEN}/web/open`);
+    expect(result.status).toBe(409);
+    expect(svc.sessionRegistry.update).not.toHaveBeenCalled();
   });
 
   it('opens any runtime that declares a Web capability, not only Pi', async () => {

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1716,7 +1716,8 @@ export function createWorkspaceRoutes(
   app.get('/:id/resumes', async (c) => {
     const id = c.req.param('id');
     if (!validId(id)) return c.json({ error: 'not_found' }, 404);
-    const directory = await svc.sessionDirectory(id, 100);
+    const resumeId = c.req.query('resumeId');
+    const directory = await svc.sessionDirectory(id, 100, resumeId || undefined);
     if (!directory) return c.json({ error: 'workspace_not_found' }, 404);
     return c.json(directory);
   });
@@ -2174,6 +2175,9 @@ export function createWorkspaceRoutes(
       const live = svc.pool.get(token);
       if (!record && !live) return c.json({ error: 'not_found' }, 404);
 
+      const claimed = record ? (svc.claimResume?.(record.resumeId) ?? true) : false;
+      if (record && !claimed) return c.json({ error: 'resume_busy', message: 'A background turn owns this Session' }, 409);
+      try {
       let scrollbackRel: string | null = null;
       if (record?.agent === 'shell' && live) {
         try {
@@ -2185,7 +2189,8 @@ export function createWorkspaceRoutes(
           launcherLogger.warn('scrollback.dump_failed', { id, token, err });
         }
       }
-      const wasTerminalRunning = svc.pool.disposeToken(token, action === 'pause' ? 'paused' : 'tab stop');
+      const wasTerminalRunning = Boolean(live);
+      if (live) await live.disposeAndWait(action === 'pause' ? 'paused' : 'tab stop');
       const wasWebRunning = await svc.web?.stop(token, action === 'pause' ? 'paused' : 'tab stop') ?? false;
       const wasRunning = wasTerminalRunning || wasWebRunning;
       if (record) {
@@ -2218,6 +2223,7 @@ export function createWorkspaceRoutes(
         })
       }
       return c.json({ ok: true, wasRunning });
+      } finally { if (claimed && record) svc.releaseResume?.(record.resumeId); }
     });
   }
 
@@ -2558,7 +2564,6 @@ export function createWorkspaceRoutes(
         cwd: meta.dir,
         launcherRepoRoot: svc.config.launcherRepoRoot,
       });
-      if (svc.pool.get(token)) svc.pool.disposeToken(token, 'switch to Web');
       const snapshot = await svc.startWebSession(
         meta,
         record,
@@ -2566,6 +2571,9 @@ export function createWorkspaceRoutes(
       );
       return c.json({ ok: true, snapshot, session: publicSession(record) });
     } catch (err) {
+      if (err instanceof HeadlessResumeError) {
+        return c.json({ error: 'resume_busy', message: err.message }, 409);
+      }
       await svc.sessionRegistry.update(id, token, {
         state: 'paused',
         surface: 'webpi',

--- a/src/workspaces/persistent-session.spec.ts
+++ b/src/workspaces/persistent-session.spec.ts
@@ -27,6 +27,7 @@ const mockSpawn = vi.mocked(pty.spawn);
 /** Minimal IPty stand-in that lets the test inject PTY output and observe
  *  pause/resume calls. */
 function makeFakeTerm() {
+  const exits = new Set<(event: { exitCode: number }) => void>();
   let dataCb: ((d: unknown) => void) | undefined;
   return {
     pid: 4321,
@@ -40,7 +41,11 @@ function makeFakeTerm() {
       dataCb = cb;
       return { dispose: () => {} };
     },
-    onExit: () => ({ dispose: () => {} }),
+    onExit: (cb: (event: { exitCode: number }) => void) => {
+      exits.add(cb);
+      return { dispose: () => { exits.delete(cb); } };
+    },
+    emitExit: () => { for (const cb of exits) cb({ exitCode: 0 }); },
     /** test helper — push bytes through the captured onData handler */
     emitData: (d: Buffer) => dataCb?.(d),
   };
@@ -110,6 +115,19 @@ describe('PersistentSession backpressure / socket-drop deadlock', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('waits for the disposed child to exit before handing off its transcript', async () => {
+    const session = new PersistentSession(makeOptions());
+    let complete = false;
+    const stop = session.disposeAndWait('background handoff').then(() => { complete = true; });
+    await Promise.resolve();
+    expect(term.kill).toHaveBeenCalled();
+    expect(complete).toBe(false);
+    term.emitExit();
+    await stop;
+    expect(complete).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 
   it('bounds a slow consumer without killing a ConPTY agent when pause is unavailable', () => {

--- a/src/workspaces/persistent-session.ts
+++ b/src/workspaces/persistent-session.ts
@@ -97,6 +97,7 @@ export class PersistentSession {
   private ws: WebSocket | null = null;
   private paused = false;
   private disposed = false;
+  private currentChildExited = false;
   private cursorTimer: NodeJS.Timeout | null = null;
   private lastCursorSeq = 0;
   private messageHandler: ((raw: unknown, isBinary: boolean) => void) | null = null;
@@ -189,6 +190,7 @@ export class PersistentSession {
       this.log.warn('session.pty_flow_control_unavailable', { backend: backend.name });
     }
 
+    this.currentChildExited = false;
     term.onData((data) => this.onPtyData(data as unknown as Buffer | string));
     term.onExit(({ exitCode, signal }) => this.onChildExit(term, exitCode, signal));
     return term;
@@ -208,6 +210,7 @@ export class PersistentSession {
     if (this.disposed) return;
     // Ignore exits from an already-replaced term (paranoia).
     if (exited !== this.term) return;
+    this.currentChildExited = true;
     const signal = typeof signalRaw === 'number' ? signalRaw : null;
     this.log.info('session.child_exit', {
       pid: exited.pid,
@@ -463,6 +466,28 @@ export class PersistentSession {
       this.cursorTimer = null;
     }
     this.log.event('session.detached');
+  }
+
+  /** Disable respawn and await the current child before another writer starts. */
+  async disposeAndWait(reason: string): Promise<void> {
+    if (this.disposed) return;
+    if (this.currentChildExited) { this.dispose(reason); return; }
+    const term = this.term;
+    let exited = false;
+    let resolveExit!: () => void;
+    const exit = new Promise<void>((resolve) => { resolveExit = resolve; });
+    const listener = term.onExit(() => { exited = true; resolveExit(); });
+    const wait = async (ms: number) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try { await Promise.race([exit, new Promise<void>((resolve) => { timer = setTimeout(resolve, ms); })]); }
+      finally { if (timer) clearTimeout(timer); }
+    };
+    try {
+      this.dispose(reason);
+      await wait(2_000);
+      if (!exited) { term.kill('SIGKILL'); await wait(2_000); }
+      if (!exited) throw new Error('Interactive process did not exit; background handoff was not started');
+    } finally { listener.dispose(); }
   }
 
   dispose(reason: string): void {

--- a/src/workspaces/service.issue-assignee-session.spec.ts
+++ b/src/workspaces/service.issue-assignee-session.spec.ts
@@ -130,3 +130,36 @@ it('hands a fresh-owner comment to the configured runtime and persists the new o
     }, { timeout: 10000 })
   } finally { command.mockRestore() }
 }, 20000)
+
+it.each(['terminal', 'webpi'] as const)('hands %s ownership to an Issue turn and excludes a racing dispatch', async (surface) => {
+  await service!.catalog.recordCreated(service!.registry.get('ws-1')!)
+  const resumeId = 'resume-handoff-owner'
+  const { session } = await service!.sessionCoordinator.ensure({
+    resumeId, wsId: 'ws-1', agent: 'codex', namePrefix: 'c',
+    agentSessionId: 'native-handoff-owner', state: 'running', surface,
+  })
+  const adapter = service!.adapters.get('codex')!
+  const command = vi.spyOn(adapter, 'composeHeadlessCommand').mockReturnValue([
+    process.execPath, '-e', `console.log(JSON.stringify({type:'item.completed',item:{type:'agent_message',text:'TAKEOVER_OK'}}));`,
+  ])
+  let release!: () => void
+  const stopped = new Promise<void>((resolve) => { release = resolve })
+  const stop = vi.fn(async () => { await stopped; return true })
+  const terminal = vi.spyOn(service!.pool, 'get').mockReturnValue(surface === 'terminal'
+    ? { disposeAndWait: stop } as never : undefined)
+  const web = vi.spyOn(service!.web, 'stop').mockImplementation(surface === 'webpi' ? stop : async () => false)
+  try {
+    const ws = service!.registry.get('ws-1')!
+    const trigger = { kind: 'issue' as const, workspaceId: ws.id, issueId: 'handoff' }
+    const pending = service!.dispatchHeadlessTask(ws, adapter, 'Reply', undefined, trigger, resumeId)
+    await vi.waitFor(() => expect(stop).toHaveBeenCalled())
+    expect(command).not.toHaveBeenCalled()
+    await expect(service!.dispatchHeadlessTask(ws, adapter, 'Duplicate', undefined, trigger, resumeId))
+      .rejects.toMatchObject({ code: 'busy' })
+    release()
+    const result = await pending
+    await vi.waitFor(() => expect(service!.headlessTasks.get(result.taskId)?.status).toBe('done'), { timeout: 10000 })
+    expect(service!.sessionRegistry.get(ws.id, session.id)?.state).toBe('paused')
+    expect(service!.isResumeActive(resumeId)).toBe(false)
+  } finally { release(); terminal.mockRestore(); web.mockRestore(); command.mockRestore() }
+})

--- a/src/workspaces/service.ts
+++ b/src/workspaces/service.ts
@@ -591,7 +591,7 @@ export interface WorkspaceService {
   }): Promise<ConnectorDesk>;
   disableTelegramConnectorDesk(): Promise<ConnectorDesk | null>;
   /** Safe Workspace Session index. resumeId is the only public conversation handle. */
-  sessionDirectory(wsId: string, limit?: number): Promise<WorkspaceSessionDirectory | null>;
+  sessionDirectory(wsId: string, limit?: number, resumeId?: string): Promise<WorkspaceSessionDirectory | null>;
   /** Change in-desk floor presence. Does not retire or delete the coworker. */
   setSessionPresence(input: {
     wsId: string
@@ -1870,23 +1870,43 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
         throw new HeadlessResumeError('not_ready', 'runtime session id has not been captured yet');
       }
       await sessionRegistry.ensureLoaded(ws.id);
-      const productSession = sessionRegistry.findByResumeId(ws.id, resumeId);
-      if (productSession?.state === 'running') {
-        throw new HeadlessResumeError('busy', 'this conversation already has a running execution');
-      }
-      // Reserve before the first await below. Without this, two HTTP requests
-      // can both pass the check and mutate one native transcript concurrently.
+      // Claim before stopping an interactive owner: no UI launch or second
+      // dispatch may enter the transcript during the handoff.
       if (!claimResume(resumeId)) {
         throw new HeadlessResumeError('busy', 'this conversation already has a running turn');
       }
-      nativeResume = { sessionId: identity.agentSessionId };
-      parentTaskId = identity.latestTaskId ?? headlessTasks.latestForResumeId(resumeId)?.taskId;
-      if (selection?.credentialSlug || selection?.model || selection?.reasoningEffort) {
-        throw new HeadlessResumeError('not_ready', 'a resumed Session reuses its persisted credential, model, and effort');
+      try {
+        const productSession = sessionRegistry.findByResumeId(ws.id, resumeId);
+        if (productSession?.state === 'running') {
+          const issueDispatch = trigger?.kind === 'issue' || inquiry?.subject.kind === 'issue';
+          if (!issueDispatch || productSession.surface === 'headless'
+            || headlessTasks.latestForResumeId(resumeId)?.status === 'running') {
+            throw new HeadlessResumeError('busy', 'this conversation already has a running execution');
+          }
+          const terminal = pool.get(productSession.id);
+          if (terminal) await terminal.disposeAndWait('background handoff');
+          await web.stop(productSession.id, 'background handoff');
+          await sessionRegistry.update(ws.id, productSession.id, {
+            state: 'paused', lastActiveAt: new Date().toISOString(),
+          });
+          await agentRuntimeLog.record('runtime.stopped', {
+            workspaceId: ws.id, resumeId, agent: adapter.id,
+            sessionRecordId: productSession.id,
+            surface: productSession.surface ?? 'terminal', status: 'paused',
+          });
+        }
+        nativeResume = { sessionId: identity.agentSessionId };
+        parentTaskId = identity.latestTaskId ?? headlessTasks.latestForResumeId(resumeId)?.taskId;
+        if (selection?.credentialSlug || selection?.model || selection?.reasoningEffort) {
+          throw new HeadlessResumeError('not_ready', 'a resumed Session reuses its persisted credential, model, and effort');
+        }
+        sessionRuntime = identity.runtimeBinding
+          ? await resolveSessionRuntimeBinding({ adapter, cwd: ws.dir, binding: identity.runtimeBinding })
+          : createNativeSessionRuntimeBinding({ adapter });
+      } catch (error) {
+        activeResumeIds.delete(resumeId);
+        throw error;
       }
-      sessionRuntime = identity.runtimeBinding
-        ? await resolveSessionRuntimeBinding({ adapter, cwd: ws.dir, binding: identity.runtimeBinding })
-        : createNativeSessionRuntimeBinding({ adapter });
     } else {
       const read = await readWorkspaceRuntimeSettings(ws.dir);
       if (!read.ok && read.reason === 'invalid') {
@@ -2701,6 +2721,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
   const sessionDirectory = async (
     wsId: string,
     limit = 50,
+    resumeId?: string,
   ): Promise<WorkspaceSessionDirectory | null> => {
     const ws = registry.get(wsId);
     if (!ws) return null;
@@ -2727,12 +2748,26 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
           }),
         })
       : new Set<string>();
+    // Activation reads target one identity, including assignments whose Issue
+    // lives in another Workspace. Ordinary roster polling remains local.
+    if (resumeId && !issueAttachments.has(resumeId)) {
+      for (const other of registry.list()) {
+        if (other.id === wsId) continue;
+        const read = await readWorkspaceIssues(other.dir);
+        if (read.ok && read.issues.some((issue) => issueAssigneeResumeId(issue.assignee) === resumeId)) {
+          issueAttachments.add(resumeId);
+          break;
+        }
+      }
+    }
     const issueTitles = issueRead.ok
       ? new Map(issueRead.issues.map((issue) => [issue.id, issue.title] as const))
       : new Map<string, string>();
     return buildWorkspaceSessionDirectory({
       workspace: { id: ws.id, tag: ws.tag },
-      identities: resumeRegistry.list({ wsId, limit }),
+      identities: resumeId
+        ? [resumeRegistry.get(resumeId)].filter((entry): entry is ResumeIdentityRecord => entry?.wsId === wsId)
+        : resumeRegistry.list({ wsId, limit }),
       interactiveFor: (resumeId) => sessionRegistry.findByResumeId(wsId, resumeId),
       latestExecutionFor: (resumeId) => headlessTasks.latestForResumeId(resumeId),
       isActive: (resumeId) => activeResumeIds.has(resumeId),
@@ -2925,8 +2960,12 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       approveProject?: boolean;
     } = {},
   ): Promise<WebSessionSnapshot> => {
+    if (!claimResume(record.resumeId)) throw new HeadlessResumeError('busy', 'this conversation already has a running turn');
     const operationLease = workspaceOperationGuard.acquire(meta.id, 'web-session-start');
-    if (!operationLease) throw new Error(`workspace is busy with ${workspaceOperationGuard.current(meta.id)}`);
+    if (!operationLease) {
+      activeResumeIds.delete(record.resumeId);
+      throw new Error(`workspace is busy with ${workspaceOperationGuard.current(meta.id)}`);
+    }
     try {
     const adapter = adapters.get(record.agent);
     if (!adapter) throw new Error(`unknown agent runtime: ${record.agent}`);
@@ -2981,6 +3020,8 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
       spawnCwd: cwd,
       composedCommand: command,
     });
+    const terminal = pool.get(record.id);
+    if (terminal) await terminal.disposeAndWait('switch to Web');
     const snapshot = await web.start({
       recordId: record.id,
       wsId: record.wsId,
@@ -3009,6 +3050,7 @@ export async function createWorkspaceService(opts: CreateWorkspaceServiceOptions
     });
     return snapshot;
     } finally {
+      activeResumeIds.delete(record.resumeId);
       operationLease.release();
     }
   };

--- a/src/workspaces/web-session-host.ts
+++ b/src/workspaces/web-session-host.ts
@@ -138,8 +138,8 @@ export class WebSessionHost {
   async stop(recordId: string, reason = 'stopped'): Promise<boolean> {
     const session = this.sessions.get(recordId)
     if (!session) return false
-    this.sessions.delete(recordId)
     await session.stop(reason)
+    if (this.sessions.get(recordId) === session) this.sessions.delete(recordId)
     return true
   }
 
@@ -265,7 +265,15 @@ class LiveWebSession {
       new Promise<void>((resolve) => this.child.once('exit', () => resolve())),
       new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
     ])
-    if (!this.exited) this.child.kill('SIGKILL')
+    if (!this.exited) {
+      const exit = new Promise<void>((resolve) => this.child.once('exit', () => resolve()))
+      this.child.kill('SIGKILL')
+      let timer: ReturnType<typeof setTimeout> | undefined
+      try {
+        await Promise.race([exit, new Promise<void>((resolve) => { timer = setTimeout(resolve, 2_000) })])
+      } finally { if (timer) clearTimeout(timer) }
+      if (!this.exited) throw new Error('Web process did not exit; background handoff was not started')
+    }
   }
 
   private assertLive(): void {

--- a/ui/src/components/workspace/ResumeCta.tsx
+++ b/ui/src/components/workspace/ResumeCta.tsx
@@ -64,6 +64,7 @@ export function ResumeCta(props: ResumeCtaProps): ReactElement {
       else await props.onResume();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
       setResuming(null);
     }
   };

--- a/ui/src/components/workspace/Terminal.tsx
+++ b/ui/src/components/workspace/Terminal.tsx
@@ -45,6 +45,7 @@ interface SocketMessageEventLike {
 
 interface SocketCloseEventLike {
   readonly code: number;
+  readonly reason?: string;
 }
 
 interface SocketLike {
@@ -93,7 +94,7 @@ class ElectronPtySocket implements SocketLike {
       }),
       bridge.onClose(this.connectionId, (msg) => {
         this.readyState = this.CLOSED;
-        for (const cb of this.listeners.close) cb({ code: msg.code });
+        for (const cb of this.listeners.close) cb({ code: msg.code, reason: msg.reason });
         this.cleanup();
       }),
     );
@@ -599,7 +600,7 @@ export function TerminalView(props: TerminalViewProps): ReactElement {
           setStatus('locked');
           return;
         }
-        if (ev.code === 4404) {
+        if (ev.code === 4404 || (ev.code === 1000 && ev.reason?.startsWith('disposed:'))) {
           recoverableTransportFailure = false;
           setClosedRecoverable(false);
           onSessionLostRef.current?.();

--- a/ui/src/components/workspace/WorkspaceView.tsx
+++ b/ui/src/components/workspace/WorkspaceView.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { ReactElement, ReactNode } from 'react';
 
 import type { AgentInfo, PausedSessionRuntimeUpdate, SessionRecord } from './api';
@@ -38,6 +39,7 @@ export interface WorkspaceViewProps {
 }
 
 export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
+  const { t } = useTranslation();
   // Mount ONLY this tab's own pinned session. Each session is its own tab with
   // its own WorkspaceView, and TabHost keeps every tab mounted (display:none
   // when inactive) — so a session's terminal already persists across tab
@@ -51,7 +53,7 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   // briefly occur before the post-spawn poll supplies it.
   const runningSlots = useMemo<readonly SessionRecord[]>(
     () =>
-      props.activeRecord !== null && props.activeRecord.state === 'running'
+      props.activeRecord !== null && props.activeRecord.state === 'running' && props.activeRecord.surface !== 'headless'
         ? [props.activeRecord]
         : [],
     [props.activeRecord],
@@ -77,6 +79,11 @@ export function WorkspaceView(props: WorkspaceViewProps): ReactElement {
   return (
     <div className={viewClass}>
       <div className="workspace-terminal">
+        {props.activeRecord?.state === 'running' && props.activeRecord.surface === 'headless' && (
+          <div role="status" className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+            {t('workspace.interactiveOwnership.background')}
+          </div>
+        )}
         {showPausedCta && props.activeRecord && (
           <ResumeCta
             record={props.activeRecord}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -986,8 +986,9 @@ export interface WorkspaceSessionDirectory {
   readonly sessions: readonly WorkspaceSessionDirectoryEntry[];
 }
 
-export async function getWorkspaceSessionDirectory(id: string): Promise<WorkspaceSessionDirectory> {
-  const res = await fetch(`/api/workspaces/${encodeURIComponent(id)}/resumes`);
+export async function getWorkspaceSessionDirectory(id: string, resumeId?: string): Promise<WorkspaceSessionDirectory> {
+  const query = resumeId ? `?resumeId=${encodeURIComponent(resumeId)}` : '';
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(id)}/resumes${query}`);
   if (!res.ok) throw new Error(`Failed to load Workspace Sessions (${res.status})`);
   return res.json() as Promise<WorkspaceSessionDirectory>;
 }

--- a/ui/src/contexts/WorkspacesContext.spec.tsx
+++ b/ui/src/contexts/WorkspacesContext.spec.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   getIssueDefaultAgent: vi.fn(),
   openResumeSession: vi.fn(),
   getWorkspaceManager: vi.fn(),
+  getWorkspaceSessionDirectory: vi.fn(),
   pauseSession: vi.fn(),
   resumeSession: vi.fn(),
   openWebSession: vi.fn(),
@@ -57,6 +58,7 @@ vi.mock('../components/workspace/api', async (importOriginal) => {
     getIssueDefaultAgent: mocks.getIssueDefaultAgent,
     openResumeSession: mocks.openResumeSession,
     getWorkspaceManager: mocks.getWorkspaceManager,
+    getWorkspaceSessionDirectory: mocks.getWorkspaceSessionDirectory,
     pauseSession: mocks.pauseSession,
     resumeSession: mocks.resumeSession,
     openWebSession: mocks.openWebSession,
@@ -195,6 +197,7 @@ beforeEach(async () => {
   mocks.getWorkspaceDefaultAgent.mockResolvedValue(null)
   mocks.getIssueDefaultAgent.mockResolvedValue(null)
   mocks.openResumeSession.mockResolvedValue({ session: persistentSession() })
+  mocks.getWorkspaceSessionDirectory.mockResolvedValue({ sessions: [] })
   mocks.getWorkspaceManager.mockResolvedValue(managerSnapshot())
   mocks.pauseSession.mockResolvedValue(true)
   mocks.resumeSession.mockResolvedValue(null)
@@ -271,6 +274,22 @@ describe('WorkspacesProvider conversation routing', () => {
       },
     }))
     expect(mocks.setSidebar).toHaveBeenCalledWith('chat')
+  })
+
+  it('asks before activating an Issue owner and cancellation does not launch it', async () => {
+    mocks.getWorkspaceSessionDirectory.mockResolvedValue({ sessions: [
+      { resumeId: 'resume-headless', issueAttached: true },
+    ] })
+    render(<ToastProvider><WorkspacesProvider><Probe /></WorkspacesProvider></ToastProvider>)
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    const dialog = await screen.findByRole('alertdialog')
+    expect(dialog.textContent).toContain('Issue')
+    expect(mocks.openResumeSession).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mocks.openResumeSession).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Open connection' }))
+    await waitFor(() => expect(mocks.openResumeSession).toHaveBeenCalledOnce())
   })
 
   it('routes Manager lifecycle actions through the separate launcher-owned state', async () => {

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -42,6 +42,7 @@ import {
   getAutoQuantDefaultWorkspace,
   getAutoPredictionDefaultWorkspace,
   getWorkspaceManager,
+  getWorkspaceSessionDirectory,
   getWorkspaceDefaultAgent,
   listTemplates,
   listWorkspaces,
@@ -313,12 +314,27 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
     setDefaultAgentState(saved)
   }, [])
 
+  const [interactiveConsent, setInteractiveConsent] = useState<{ resolve: (confirmed: boolean) => void } | null>(null)
+  const confirmInteractiveSession = useCallback(async (wsId: string, resumeId: string): Promise<boolean> => {
+    if (wsId === MANAGER_WORKSPACE_ID) return true
+    const directory = await getWorkspaceSessionDirectory(wsId, resumeId)
+    const identity = directory.sessions.find((entry) => entry.resumeId === resumeId)
+    if (!identity?.issueAttached && identity?.rosterVisibility !== 'hidden') return true
+    return new Promise<boolean>((resolve) => {
+      setInteractiveConsent((previous) => {
+        previous?.resolve(false)
+        return { resolve }
+      })
+    })
+  }, [])
+
   const openHeadlessRun = useCallback(
     async (
       wsId: string,
       resumeId: string,
       opts: { title?: string } = {},
     ): Promise<void> => {
+      if (!await confirmInteractiveSession(wsId, resumeId)) return
       const { session } = await openResumeSession(wsId, resumeId, opts)
       let nextSession = session
       if (session.state === 'paused') {
@@ -359,7 +375,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
       })
       void refresh()
     },
-    [ensureTerminalAppearancePublished, openOrFocus, refresh, setSidebar],
+    [confirmInteractiveSession, ensureTerminalAppearancePublished, openOrFocus, refresh, setSidebar],
   )
 
   const setIssueDefaultAgent = useCallback(async (agent: string | null): Promise<void> => {
@@ -527,6 +543,8 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
 
   const resumeSession = useCallback(
     async (wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void> => {
+      const record = workspaces.find((ws) => ws.id === wsId)?.sessions.find((entry) => entry.id === sessionId)
+      if (record && !await confirmInteractiveSession(wsId, record.resumeId)) return
       await ensureTerminalAppearancePublished()
       const resp = await apiResumeSession(wsId, sessionId)
       const patch = {
@@ -552,11 +570,13 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         void refresh()
       }
     },
-    [ensureTerminalAppearancePublished, refresh, refreshWorkspaceManager, openOrFocus],
+    [confirmInteractiveSession, workspaces, ensureTerminalAppearancePublished, refresh, refreshWorkspaceManager, openOrFocus],
   )
 
   const openWebSession = useCallback(
     async (wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void> => {
+      const record = workspaces.find((ws) => ws.id === wsId)?.sessions.find((entry) => entry.id === sessionId)
+      if (record && !await confirmInteractiveSession(wsId, record.resumeId)) return
       const snapshot = await apiOpenWebSession(wsId, sessionId)
       const patch = {
         state: 'running' as const,
@@ -578,7 +598,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         void refresh()
       }
     },
-    [openOrFocus, refresh, refreshWorkspaceManager],
+    [confirmInteractiveSession, workspaces, openOrFocus, refresh, refreshWorkspaceManager],
   )
 
   const saveWorkspaceMetadata = useCallback(
@@ -886,6 +906,15 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
             onClose={() => setConfiguringAgentTarget(null)}
           />
         )}
+        {interactiveConsent && <ConfirmDialog
+          title={t('workspace.interactiveOwnership.title')}
+          message={t('workspace.interactiveOwnership.message')}
+          confirmLabel={t('workspace.interactiveOwnership.confirm')}
+          cancelLabel={t('common.cancel')}
+          variant="primary"
+          onConfirm={() => { interactiveConsent.resolve(true); setInteractiveConsent(null) }}
+          onClose={() => { interactiveConsent.resolve(false); setInteractiveConsent(null) }}
+        />}
         {pendingSessionDelete !== null && (
           <ConfirmDialog
             title={t('chat.deleteSessionTitle')}

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1163,13 +1163,14 @@ export const workspacesHandlers = [
     demoSessionPresence.set(resumeId, presence)
     return HttpResponse.json({ resumeId, presence, lifecycle: 'active' })
   }),
-  http.get('/api/workspaces/:id/resumes', ({ params }) => {
+  http.get('/api/workspaces/:id/resumes', ({ params, request }) => {
+    const requestedResume = new URL(request.url).searchParams.get('resumeId')
     const wsId = String(params.id)
     if (wsId === DEMO_AUTO_QUANT_WORKSPACE_ID) {
       return HttpResponse.json({
         workspace: { id: wsId, tag: 'auto-quant' },
         sessions: [{
-          resumeId: 'resume-demo-thesis-owner', agent: 'claude',
+          resumeId: 'resume-demo-thesis-owner', agent: 'claude', issueAttached: true,
           createdAt: Date.now() - 86_400_000, updatedAt: Date.now() - 60_000,
           lifecycle: 'active', resumable: true, active: false,
           runtime: demoResumeRuntimes.get('resume-demo-thesis-owner'),
@@ -1179,7 +1180,7 @@ export const workspacesHandlers = [
             finishedAt: Date.now() - 60_000,
             assistantPreview: 'Reviewed the active thesis invalidation rules.',
           },
-        }],
+        }].filter((session) => !requestedResume || session.resumeId === requestedResume),
       })
     }
     const workspace = demoWorkspaces.find((candidate) => candidate.id === wsId)
@@ -1282,7 +1283,7 @@ export const workspacesHandlers = [
     }
     return HttpResponse.json({
       workspace: { id: wsId, tag: workspace?.tag ?? wsId },
-      sessions: sessions.map((session) => {
+      sessions: sessions.filter((session) => !requestedResume || session.resumeId === requestedResume).map((session) => {
         const presence = demoSessionPresence.get(session.resumeId) ?? session.presence
         return presence && presence !== 'active' ? { ...session, presence } : session
       }),

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3164,6 +3164,14 @@ export const en = {
     notFoundBody: 'No template named {{name}}.',
   },
   workspace: {
+    interactiveOwnership: {
+      background: 'This Session is running in the background. The interactive connection has been released.',
+      title: 'Open an interactive connection?',
+      message: 'This Session handles Connector messages or assigned Issues. Opening it gives you interactive control. Incoming messages, Issue comments, and automation will disconnect this view and continue in the background. Conversation history is retained.',
+      confirm: 'Open connection',
+      actions: 'Session actions',
+      disconnect: 'Disconnect interactive connection',
+    },
     newWorkspace: 'New workspace',
     overview: 'Overview',
     templates: 'Templates',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -3133,6 +3133,14 @@ export const ja: Resources = {
     notFoundBody: '{{name}} という名前のテンプレートはありません。',
   },
   workspace: {
+    interactiveOwnership: {
+      background: 'このセッションはバックグラウンドで実行中です。対話接続は切断されました。',
+      title: '対話接続を開きますか？',
+      message: 'このセッションは Connector メッセージまたは Issue を担当しています。新着メッセージ、コメント、自動化の実行時には対話接続を切断し、バックグラウンド処理を優先します。会話履歴は保持されます。',
+      confirm: '接続を開く',
+      actions: 'セッション操作',
+      disconnect: '対話接続を切断',
+    },
     newWorkspace: '新しいワークスペース',
     overview: '概要',
     templates: 'テンプレート',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -3140,6 +3140,14 @@ export const zhHant: Resources = {
     notFoundBody: '沒有名為 {{name}} 的模板。',
   },
   workspace: {
+    interactiveOwnership: {
+      background: '此會話正在背景執行任務，互動連線已釋放。',
+      title: '開啟互動連線？',
+      message: '此會話負責 Connector 訊息或已指派的 Issue。開啟後你將接管互動；收到新訊息、Issue 評論或自動化觸發時，此連線會自動中斷，讓背景任務繼續。會話歷史會保留。',
+      confirm: '開啟連線',
+      actions: '會話操作',
+      disconnect: '中斷互動連線',
+    },
     newWorkspace: '新增工作區',
     overview: '總覽',
     templates: '範本',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -3131,6 +3131,14 @@ export const zh: Resources = {
     notFoundBody: '没有名为 {{name}} 的模板。',
   },
   workspace: {
+    interactiveOwnership: {
+      background: '此会话正在后台执行任务，交互连接已释放。',
+      title: '打开交互连接？',
+      message: '此会话负责 Connector 消息或已分配的 Issue。打开后你将接管交互；收到新消息、Issue 评论或自动化触发时，此连接会自动断开，让后台任务继续。会话历史会保留。',
+      confirm: '打开连接',
+      actions: '会话操作',
+      disconnect: '断开交互连接',
+    },
     newWorkspace: '新建工作区',
     overview: '总览',
     templates: '模板',

--- a/ui/src/pages/WorkspacePage.tsx
+++ b/ui/src/pages/WorkspacePage.tsx
@@ -18,7 +18,7 @@
 
 import { useHarnessWorkbenchContext } from '../components/harness/context'
 import { useEffect } from 'react'
-import { Monitor, Settings } from 'lucide-react'
+import { ChevronDown, Unplug, Monitor, Settings } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import '@xterm/xterm/css/xterm.css'
 
@@ -32,6 +32,7 @@ import { WorkspaceView } from '../components/workspace/WorkspaceView'
 import { PageTopBar } from '../components/PageTopBar'
 import { WorkspaceFilesToggle } from '../components/workspace/WorkspaceFilesToggle'
 import { Button } from '../components/ui/button'
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '../components/ui/dropdown-menu'
 import { AgentRuntimeIcon } from '../lib/agentRuntimeIcon'
 import type { ViewSpec } from '../tabs/types'
 
@@ -140,6 +141,14 @@ export function WorkspacePage({ spec, visible }: Props) {
           {webCanvas ? 'Open TUI' : 'Web Beta'}
         </Button>
       )}
+      {activeRecord && (terminalCanvas || webCanvas) && <DropdownMenu>
+        <DropdownMenuTrigger render={<Button variant="ghost" size="icon" aria-label={t('workspace.interactiveOwnership.actions')}><ChevronDown size={14} /></Button>} />
+        <DropdownMenuContent align="end" className="min-w-64">
+          <DropdownMenuItem onClick={() => void ctx.pauseSession(wsId, activeRecord.id)}>
+            <Unplug size={14} />{t('workspace.interactiveOwnership.disconnect')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>}
       <WorkspaceFilesToggle />
       {!workbench && <Button
         type="button"


### PR DESCRIPTION
## Problem and behavior
Opening an Issue or Connector conversation interactively kept its native process alive, blocking later comments and scheduled work with a running-execution error. Activation now warns users, and the session action menu offers Disconnect interactive connection.

Issue dispatch (scheduled, manual, retry, and comment/Connector replies) acquires the conversation lease, stops and awaits the TUI/Web process, then resumes the same native conversation headlessly. Other headless runs remain protected. Intentional disconnects do not auto-reconnect, and the UI displays background ownership before returning to the paused conversation.

## Validation
- Full hermetic suite: 773 files, 6860 passed, 3 skipped; root and UI typechecks passed.
- Real local browser: TUI and Web handoff, manual disconnect, model/effort access afterward, warning acceptance/cancellation and mobile layout.
- Demo route and exact session-directory query verified.
- Real Electron PTY smoke and packaged Workspace smoke passed, including managed Pi scheduled reply and CLI injection.
- The local Codex handoff started its headless process successfully, but that machine's old Codex rejected its configured gpt-6-astra model. Native Codex reply completion therefore remains unverified; the packaged Pi reply completed.

Rebased cleanly onto current dev; incoming changes concern UTA/CCXT and do not overlap this change. No remote deployment or trading operation performed.
