### PR TITLE
Prepare v0.92.1-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta",
+  "version": "0.92.1-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta",
+  "version": "0.92.1-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Set root and CLI package versions to 0.92.1-beta.1 for the requested beta release. This changes only the two synchronized version values.

Source promotion #1451 passed all required checks, including three-platform desktop Workspace and previous-release upgrade acceptance, Windows Broker Pack upgrade, installer/remote acceptance, and the current dev publication. Local full suite: 774 files, 6880 passed, 3 skipped; root/UI/UTA types, UTA integration, and unsigned packaged Workspace acceptance passed.

After the bounded beta version gate, dispatch Release from the merged master SHA with channel=beta and tag=v0.92.1-beta.1. Verify public beta bytes and unchanged stable aliases before synchronizing these two values to dev.
