### PR TITLE
Sync accepted v0.92.1-beta.1 version to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta",
+  "version": "0.92.1-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta",
+  "version": "0.92.1-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Copy only the accepted 0.92.1-beta.1 version values into the root and CLI manifests. Runtime source identity remains dev.

Release run 34368987676 completed successfully; tag v0.92.1-beta.1 targets c3c4d7d5cc24b56fbeb95d29691f05c89f8b36e9 and the public GitHub release is a prerelease with 55 assets. The beta CDN manifest reports the accepted version. Independent comparison confirms stable manifest/feed bytes and all five desktop download alias ETags/sizes remain unchanged.

Validated JSON version equality and git diff --check. Product tests and surface acceptance are recorded in promotion #1451; this PR contains no runtime change.
