### PR TITLE
fix(alpaca): bundle SDK for standalone runtime loading

### DIFF
--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -42,7 +42,14 @@ createBroker(config): IBroker
 
 The wrapper workspaces live under `packages/uta-broker-*`. They bundle the
 OpenAlice-owned adapter/protocol code needed at runtime; third-party broker SDKs
-remain external within each deployed Pack. Release assembly removes workspace
+remain external within each deployed Pack, except Alpaca: its pure-JavaScript
+dependency closure is bundled into the entry for compiled Bun compatibility.
+Alpaca acceptance must import the built entry with a compiled Bun executable;
+a Node or interpreted Bun import alone does not exercise that resolver. Run
+`pnpm -F @traderalice/uta-broker-alpaca build` followed by
+`pnpm -F @traderalice/uta-broker-alpaca test:packaged` (requires Bun). The probe
+uses an isolated entry with no node_modules and never contacts a broker.
+Release assembly removes workspace
 links, pnpm lock/workspace metadata, and build-machine paths before archiving.
 `services/uta/src/domain/trading/brokers/registry.ts`
 statically imports only Mock, then loads one active Pack by file URL when an

--- a/packages/uta-broker-alpaca/package.json
+++ b/packages/uta-broker-alpaca/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "exports": { ".": { "openalice-source": "./src/index.ts", "import": "./dist/index.js" } },
   "files": ["dist"],
-  "scripts": { "build": "tsup", "typecheck": "tsc --noEmit" },
+  "scripts": { "build": "tsup", "typecheck": "tsc --noEmit", "test:packaged": "node smoke-compiled.mjs" },
   "dependencies": {
     "@alpacahq/alpaca-trade-api": "^3.1.3",
     "@traderalice/ibkr": "workspace:*",

--- a/packages/uta-broker-alpaca/smoke-compiled.mjs
+++ b/packages/uta-broker-alpaca/smoke-compiled.mjs
@@ -1,0 +1,33 @@
+// No credentials or network: exercise a detached pack through compiled Bun.
+import { mkdtemp, copyFile, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const root = await mkdtemp(join(tmpdir(), 'alpaca-compiled-smoke-'))
+const run = (command, args) => {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8', timeout: 120_000 })
+  if (result.error || result.status !== 0) throw new Error(`${command}: ${result.error ?? result.stderr ?? result.stdout}`)
+  return result.stdout
+}
+try {
+  const entry = join(root, 'pack.mjs')
+  await copyFile(fileURLToPath(new URL('./dist/index.js', import.meta.url)), entry)
+  const probe = join(root, 'probe.ts')
+  await writeFile(probe, `
+const pack = await import(process.argv[2]);
+if (pack.BROKER_ENGINE !== 'alpaca' || pack.BROKER_PACK_API_VERSION !== 1) throw new Error('Invalid pack exports');
+const broker = pack.createBroker({ id: 'offline-smoke', brokerConfig: { paper: true } });
+if (typeof broker.init !== 'function' || typeof broker.getAccount !== 'function') throw new Error('Invalid broker');
+await broker.close();
+console.log('ALPACA_COMPILED_IMPORT_OK');
+`)
+  const binary = join(root, process.platform === 'win32' ? 'probe.exe' : 'probe')
+  run('bun', ['build', probe, '--compile', '--outfile', binary])
+  const output = run(binary, [entry])
+  if (!output.includes('ALPACA_COMPILED_IMPORT_OK')) throw new Error('Missing acceptance receipt')
+  console.log(output.trim())
+} finally {
+  await rm(root, { recursive: true, force: true })
+}

--- a/packages/uta-broker-alpaca/tsup.config.ts
+++ b/packages/uta-broker-alpaca/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts' }, format: ['esm'], outDir: 'dist', target: 'node20',
-  clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: true,
-  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
+  clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: false,
+  // Compiled Bun cannot resolve this deployed SDK tree reliably. Keep the
+  // pure-JS Alpaca dependency closure inside the pack, including CJS helpers.
+  noExternal: [/.*/],
+  banner: { js: "import { createRequire as __oaCreateRequire } from 'node:module'; const require = __oaCreateRequire(import.meta.url);" },
   esbuildOptions: (options) => { options.conditions = ['openalice-source', ...(options.conditions ?? [])] },
 })


### PR DESCRIPTION
## Problem
The installed Linux standalone runtime fails to load Alpaca with `Cannot find package '@alpacahq/alpaca-trade-api'`, despite the SDK being present and the identical pack importing successfully under Node and interpreted Bun. A minimal compiled Bun importer reproduces the failure locally.

## Change
Bundle Alpaca's pure-JavaScript dependency closure into its ESM entry, with a createRequire bridge for CommonJS built-in imports. Add an explicit offline compiled-Bun smoke that copies the entry outside the repository without node_modules and verifies import plus broker construction. Document the package-specific requirement.

## Validation
- Alpaca build and package typecheck passed.
- Compiled detached-pack smoke passed (`ALPACA_COMPILED_IMPORT_OK`).
- Alpaca adapter suite: 47 tests passed.
- Remote production-shaped pack repair passed the actual UTA test-connection loading boundary: deliberately invalid diagnostic credentials now return an authentication error instead of an import failure. No account was saved and no orders were sent.
- Remote repair uses a separate release directory and preserved original activation pointer; no release artifact was republished. Actual user credential validation remains for the user's retry.
