### PR TITLE
fix(runtime): enable external broker package resolution in standalone builds

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -126,8 +126,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+
       - name: Build optional Broker Packs on Windows
         run: pnpm broker-packs:build
+        timeout-minutes: 10
+
+      - name: Verify Broker Packs in compiled runtime
+        run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled
         timeout-minutes: 10
 
       - name: Prove previous-release Broker Pack upgrade on Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -867,8 +867,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+
       - name: Build optional Broker Packs
         run: pnpm broker-packs:build
+
+      - name: Verify Broker Packs in compiled runtime
+        run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled
 
       - name: Prove previous-release Broker Pack upgrade
         if: needs.release.outputs.channel == 'stable'

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -255,3 +255,18 @@ For desktop changes, follow [[docs/managed-workspace-runtime.md]] and require
 `pnpm electron:assert-package` plus the packaged Workspace smoke. For a broker
 implementation change, also follow the paper/demo scenarios in
 [[docs/uta-live-testing.md]]; never use a real-money account for acceptance.
+
+## Standalone CLI acceptance
+
+Bun standalone builds must enable `autoloadPackageJson` via the shared
+`scripts/bun-compile-options.ts`. Bun disables runtime package.json loading by
+default in compiled executables, preventing physical Pack SDK resolution even
+when the identical archive imports under Node. See [Bun executable configuration](https://bun.sh/docs/bundler/executables).
+
+After building the release archives, run
+`pnpm exec tsx scripts/verify-broker-packs.ts --compiled`. This extracts all five
+archives and uses a compiled probe with the release compile options to import
+and construct each broker, including Longbridge's platform-native binding.
+It uses synthetic configuration, never calls init, and does not connect or trade.
+Release pack jobs and Windows package smoke run this gate. Node-only archive
+verification remains available for environments without Bun.

--- a/scripts/build-bun-alice-feasibility.ts
+++ b/scripts/build-bun-alice-feasibility.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createServer } from 'node:net'
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
@@ -31,8 +32,7 @@ const result = await Bun.build({
   entrypoints: [join(repositoryRoot, 'src/main.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUN_STANDALONE__': 'true',
@@ -92,8 +92,7 @@ const ptyBuild = await Bun.build({
   entrypoints: [join(repositoryRoot, 'scripts/bun-native-pty-smoke.ts')],
   compile: {
     outfile: ptySmokePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   minify: true,
 })

--- a/scripts/build-bun-cli-feasibility.ts
+++ b/scripts/build-bun-cli-feasibility.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -32,8 +33,7 @@ const result = await Bun.build({
   entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(cliPackage.version),

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createHash } from 'node:crypto'
 import {
   chmod,
@@ -69,8 +70,7 @@ const build = await Bun.build({
   entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice-bun.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(product.version),

--- a/scripts/build-bun-runtime-feasibility.ts
+++ b/scripts/build-bun-runtime-feasibility.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createServer } from 'node:net'
 import { mkdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
@@ -46,8 +47,7 @@ const build = await Bun.build({
   entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice-bun.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(product.version),

--- a/scripts/bun-compile-options.ts
+++ b/scripts/bun-compile-options.ts
@@ -1,0 +1,6 @@
+/** External Broker Packs resolve dependencies through their physical package.json. */
+export const runtimeCompileOptions = {
+  autoloadBunfig: false,
+  autoloadDotenv: false,
+  autoloadPackageJson: true,
+} as const

--- a/scripts/verify-broker-packs.ts
+++ b/scripts/verify-broker-packs.ts
@@ -3,7 +3,7 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { access, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from 'node:fs/promises'
+import { access, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -36,8 +36,34 @@ for (const engine of expectedEngines) {
   if (!actualEngines.has(engine)) throw new Error(`Broker Pack catalog is missing ${engine}`)
 }
 
+const compiled = process.argv.includes('--compiled')
+let compiledProbe: string | undefined
 const tempRoot = await mkdtemp(resolve(tmpdir(), 'openalice-broker-pack-verify-'))
 try {
+  if (compiled) {
+    const probe = resolve(tempRoot, 'probe.ts')
+    const options = pathToFileURL(resolve(repoRoot, 'scripts/bun-compile-options.ts')).href
+    const builder = resolve(tempRoot, 'build.ts')
+    compiledProbe = resolve(tempRoot, process.platform === 'win32' ? 'probe.exe' : 'probe')
+    await writeFile(probe, `
+const m = await import(process.argv[2]);
+const engine = process.argv[3];
+if (m.BROKER_ENGINE !== engine || m.BROKER_PACK_API_VERSION !== 1) throw new Error('Invalid pack');
+const configs = {
+  ccxt: {exchange:'binance', keyless:true}, alpaca:{paper:true}, ibkr:{},
+  leverup:{network:'testnet',privateKey:'0x'+'1'.repeat(64)},
+  longbridge:{appKey:'offline',appSecret:'offline',accessToken:'offline',paper:true},
+};
+const broker = m.createBroker({id:'offline-pack-smoke',brokerConfig:configs[engine]});
+if (typeof broker.getAccount !== 'function') throw new Error('Invalid broker');
+await broker.close();
+console.log('COMPILED_PACK_OK', engine);
+`)
+    await writeFile(builder, `import {runtimeCompileOptions} from ${JSON.stringify(options)};
+const r=await Bun.build({entrypoints:[${JSON.stringify(probe)}],compile:{...runtimeCompileOptions,outfile:${JSON.stringify(compiledProbe)}}}); if(!r.success) throw new Error(String(r.logs));`)
+    const result = spawnSync('bun', [builder], {cwd: tempRoot, encoding:'utf8', timeout:120_000})
+    if (result.error || result.status !== 0) throw new Error(`Compiled probe build failed: ${result.error ?? result.stderr}`)
+  }
   for (const asset of catalog.packs) await verifyAsset(asset, tempRoot)
 } finally {
   await rm(tempRoot, { recursive: true, force: true })
@@ -100,6 +126,13 @@ async function verifyAsset(asset: BrokerPackReleaseAsset, root: string): Promise
   }
 
   verifyModuleInCleanProcess(asset.engine, realEntry, packageRoot)
+  if (compiledProbe) {
+    const result = spawnSync(compiledProbe, [realEntry, asset.engine], {cwd:packageRoot, encoding:'utf8', timeout:60_000, env:{...process.env, NODE_PATH:''}})
+    if (result.error || result.status !== 0 || !result.stdout.includes('COMPILED_PACK_OK')) {
+      throw new Error(`${asset.engine} compiled import/construction failed: ${result.error ?? result.stderr}`)
+    }
+    console.log(result.stdout.trim())
+  }
   await rm(packageRoot, { recursive: true, force: true })
   console.log(`[broker-packs] verified ${asset.engine} (${formatBytes(asset.size)})`)
 }


### PR DESCRIPTION
## Problem
Standalone Bun builds disable runtime package.json loading by default. Actual external Broker Packs therefore fail dependency resolution despite passing Node-based artifact verification. Reproduced with CCXT, IBKR, LeverUp and Longbridge, and the previous unbundled Alpaca release.

## Change
Enable autoloadPackageJson in shared standalone compile options used by release and feasibility builds. Keep dotenv and bunfig autoload disabled. Add `verify-broker-packs.ts --compiled`, which verifies each real archive and imports/constructs its broker with a compiled probe using the same options. Wire this gate into release pack jobs and Windows pack smoke.

## Acceptance
- Five current macOS arm64 release archives pass both Node verification and compiled import/construction, including Longbridge's native binding.
- Linux x64 probe tested the checksum-verified v0.92.1-beta release archives on the remote Debian host: CCXT, original unbundled Alpaca, IBKR and LeverUp pass.
- Longbridge Linux correctly remains incompatible with that host: SDK requires glibc 2.39, host provides 2.36. Existing catalog requirements and installer rejection cover this limitation; this is not counted as a pass.
- Full compiled multiprocess runtime feasibility passed, including physical SDK/native-addon fixture, isolated UTA restart and recovery.
- Root/UI typechecks passed. Full hermetic suite result recorded below.

No credentials, broker init, network trading operations or orders in probes. No remote production runtime upgrade or artifact publication performed; prior Alpaca repair remains active. Windows execution is delegated to the updated CI gate and is not claimed as locally verified.

Full hermetic suite: 774 files passed; 6880 tests passed, 3 skipped.
