### PR TITLE
Promote Broker Pack fixes for v0.92.1-beta.2

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -126,8 +126,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+
       - name: Build optional Broker Packs on Windows
         run: pnpm broker-packs:build
+        timeout-minutes: 10
+
+      - name: Verify Broker Packs in compiled runtime
+        run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled
         timeout-minutes: 10
 
       - name: Prove previous-release Broker Pack upgrade on Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -867,8 +867,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+
       - name: Build optional Broker Packs
         run: pnpm broker-packs:build
+
+      - name: Verify Broker Packs in compiled runtime
+        run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled
 
       - name: Prove previous-release Broker Pack upgrade
         if: needs.release.outputs.channel == 'stable'

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -255,3 +255,18 @@ For desktop changes, follow [[docs/managed-workspace-runtime.md]] and require
 `pnpm electron:assert-package` plus the packaged Workspace smoke. For a broker
 implementation change, also follow the paper/demo scenarios in
 [[docs/uta-live-testing.md]]; never use a real-money account for acceptance.
+
+## Standalone CLI acceptance
+
+Bun standalone builds must enable `autoloadPackageJson` via the shared
+`scripts/bun-compile-options.ts`. Bun disables runtime package.json loading by
+default in compiled executables, preventing physical Pack SDK resolution even
+when the identical archive imports under Node. See [Bun executable configuration](https://bun.sh/docs/bundler/executables).
+
+After building the release archives, run
+`pnpm exec tsx scripts/verify-broker-packs.ts --compiled`. This extracts all five
+archives and uses a compiled probe with the release compile options to import
+and construct each broker, including Longbridge's platform-native binding.
+It uses synthetic configuration, never calls init, and does not connect or trade.
+Release pack jobs and Windows package smoke run this gate. Node-only archive
+verification remains available for environments without Bun.

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -42,7 +42,14 @@ createBroker(config): IBroker
 
 The wrapper workspaces live under `packages/uta-broker-*`. They bundle the
 OpenAlice-owned adapter/protocol code needed at runtime; third-party broker SDKs
-remain external within each deployed Pack. Release assembly removes workspace
+remain external within each deployed Pack, except Alpaca: its pure-JavaScript
+dependency closure is bundled into the entry for compiled Bun compatibility.
+Alpaca acceptance must import the built entry with a compiled Bun executable;
+a Node or interpreted Bun import alone does not exercise that resolver. Run
+`pnpm -F @traderalice/uta-broker-alpaca build` followed by
+`pnpm -F @traderalice/uta-broker-alpaca test:packaged` (requires Bun). The probe
+uses an isolated entry with no node_modules and never contacts a broker.
+Release assembly removes workspace
 links, pnpm lock/workspace metadata, and build-machine paths before archiving.
 `services/uta/src/domain/trading/brokers/registry.ts`
 statically imports only Mock, then loads one active Pack by file URL when an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta",
+  "version": "0.92.1-beta.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta",
+  "version": "0.92.1-beta.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {

--- a/packages/uta-broker-alpaca/package.json
+++ b/packages/uta-broker-alpaca/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "exports": { ".": { "openalice-source": "./src/index.ts", "import": "./dist/index.js" } },
   "files": ["dist"],
-  "scripts": { "build": "tsup", "typecheck": "tsc --noEmit" },
+  "scripts": { "build": "tsup", "typecheck": "tsc --noEmit", "test:packaged": "node smoke-compiled.mjs" },
   "dependencies": {
     "@alpacahq/alpaca-trade-api": "^3.1.3",
     "@traderalice/ibkr": "workspace:*",

--- a/packages/uta-broker-alpaca/smoke-compiled.mjs
+++ b/packages/uta-broker-alpaca/smoke-compiled.mjs
@@ -1,0 +1,33 @@
+// No credentials or network: exercise a detached pack through compiled Bun.
+import { mkdtemp, copyFile, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const root = await mkdtemp(join(tmpdir(), 'alpaca-compiled-smoke-'))
+const run = (command, args) => {
+  const result = spawnSync(command, args, { cwd: root, encoding: 'utf8', timeout: 120_000 })
+  if (result.error || result.status !== 0) throw new Error(`${command}: ${result.error ?? result.stderr ?? result.stdout}`)
+  return result.stdout
+}
+try {
+  const entry = join(root, 'pack.mjs')
+  await copyFile(fileURLToPath(new URL('./dist/index.js', import.meta.url)), entry)
+  const probe = join(root, 'probe.ts')
+  await writeFile(probe, `
+const pack = await import(process.argv[2]);
+if (pack.BROKER_ENGINE !== 'alpaca' || pack.BROKER_PACK_API_VERSION !== 1) throw new Error('Invalid pack exports');
+const broker = pack.createBroker({ id: 'offline-smoke', brokerConfig: { paper: true } });
+if (typeof broker.init !== 'function' || typeof broker.getAccount !== 'function') throw new Error('Invalid broker');
+await broker.close();
+console.log('ALPACA_COMPILED_IMPORT_OK');
+`)
+  const binary = join(root, process.platform === 'win32' ? 'probe.exe' : 'probe')
+  run('bun', ['build', probe, '--compile', '--outfile', binary])
+  const output = run(binary, [entry])
+  if (!output.includes('ALPACA_COMPILED_IMPORT_OK')) throw new Error('Missing acceptance receipt')
+  console.log(output.trim())
+} finally {
+  await rm(root, { recursive: true, force: true })
+}

--- a/packages/uta-broker-alpaca/tsup.config.ts
+++ b/packages/uta-broker-alpaca/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts' }, format: ['esm'], outDir: 'dist', target: 'node20',
-  clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: true,
-  noExternal: [/^@traderalice\//, /^@bufbuild\/protobuf(?:\/|$)/],
+  clean: true, sourcemap: true, splitting: false, skipNodeModulesBundle: false,
+  // Compiled Bun cannot resolve this deployed SDK tree reliably. Keep the
+  // pure-JS Alpaca dependency closure inside the pack, including CJS helpers.
+  noExternal: [/.*/],
+  banner: { js: "import { createRequire as __oaCreateRequire } from 'node:module'; const require = __oaCreateRequire(import.meta.url);" },
   esbuildOptions: (options) => { options.conditions = ['openalice-source', ...(options.conditions ?? [])] },
 })

--- a/scripts/build-bun-alice-feasibility.ts
+++ b/scripts/build-bun-alice-feasibility.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createServer } from 'node:net'
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
@@ -31,8 +32,7 @@ const result = await Bun.build({
   entrypoints: [join(repositoryRoot, 'src/main.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUN_STANDALONE__': 'true',
@@ -92,8 +92,7 @@ const ptyBuild = await Bun.build({
   entrypoints: [join(repositoryRoot, 'scripts/bun-native-pty-smoke.ts')],
   compile: {
     outfile: ptySmokePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   minify: true,
 })

--- a/scripts/build-bun-cli-feasibility.ts
+++ b/scripts/build-bun-cli-feasibility.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -32,8 +33,7 @@ const result = await Bun.build({
   entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(cliPackage.version),

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createHash } from 'node:crypto'
 import {
   chmod,
@@ -69,8 +70,7 @@ const build = await Bun.build({
   entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice-bun.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(product.version),

--- a/scripts/build-bun-runtime-feasibility.ts
+++ b/scripts/build-bun-runtime-feasibility.ts
@@ -1,3 +1,4 @@
+import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createServer } from 'node:net'
 import { mkdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
@@ -46,8 +47,7 @@ const build = await Bun.build({
   entrypoints: [join(repositoryRoot, 'packages/cli/bin/openalice-bun.ts')],
   compile: {
     outfile: executablePath,
-    autoloadBunfig: false,
-    autoloadDotenv: false,
+    ...runtimeCompileOptions,
   },
   define: {
     'globalThis.__OPENALICE_BUILD_VERSION__': JSON.stringify(product.version),

--- a/scripts/bun-compile-options.ts
+++ b/scripts/bun-compile-options.ts
@@ -1,0 +1,6 @@
+/** External Broker Packs resolve dependencies through their physical package.json. */
+export const runtimeCompileOptions = {
+  autoloadBunfig: false,
+  autoloadDotenv: false,
+  autoloadPackageJson: true,
+} as const

--- a/scripts/verify-broker-packs.ts
+++ b/scripts/verify-broker-packs.ts
@@ -3,7 +3,7 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { access, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat } from 'node:fs/promises'
+import { access, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -36,8 +36,34 @@ for (const engine of expectedEngines) {
   if (!actualEngines.has(engine)) throw new Error(`Broker Pack catalog is missing ${engine}`)
 }
 
+const compiled = process.argv.includes('--compiled')
+let compiledProbe: string | undefined
 const tempRoot = await mkdtemp(resolve(tmpdir(), 'openalice-broker-pack-verify-'))
 try {
+  if (compiled) {
+    const probe = resolve(tempRoot, 'probe.ts')
+    const options = pathToFileURL(resolve(repoRoot, 'scripts/bun-compile-options.ts')).href
+    const builder = resolve(tempRoot, 'build.ts')
+    compiledProbe = resolve(tempRoot, process.platform === 'win32' ? 'probe.exe' : 'probe')
+    await writeFile(probe, `
+const m = await import(process.argv[2]);
+const engine = process.argv[3];
+if (m.BROKER_ENGINE !== engine || m.BROKER_PACK_API_VERSION !== 1) throw new Error('Invalid pack');
+const configs = {
+  ccxt: {exchange:'binance', keyless:true}, alpaca:{paper:true}, ibkr:{},
+  leverup:{network:'testnet',privateKey:'0x'+'1'.repeat(64)},
+  longbridge:{appKey:'offline',appSecret:'offline',accessToken:'offline',paper:true},
+};
+const broker = m.createBroker({id:'offline-pack-smoke',brokerConfig:configs[engine]});
+if (typeof broker.getAccount !== 'function') throw new Error('Invalid broker');
+await broker.close();
+console.log('COMPILED_PACK_OK', engine);
+`)
+    await writeFile(builder, `import {runtimeCompileOptions} from ${JSON.stringify(options)};
+const r=await Bun.build({entrypoints:[${JSON.stringify(probe)}],compile:{...runtimeCompileOptions,outfile:${JSON.stringify(compiledProbe)}}}); if(!r.success) throw new Error(String(r.logs));`)
+    const result = spawnSync('bun', [builder], {cwd: tempRoot, encoding:'utf8', timeout:120_000})
+    if (result.error || result.status !== 0) throw new Error(`Compiled probe build failed: ${result.error ?? result.stderr}`)
+  }
   for (const asset of catalog.packs) await verifyAsset(asset, tempRoot)
 } finally {
   await rm(tempRoot, { recursive: true, force: true })
@@ -100,6 +126,13 @@ async function verifyAsset(asset: BrokerPackReleaseAsset, root: string): Promise
   }
 
   verifyModuleInCleanProcess(asset.engine, realEntry, packageRoot)
+  if (compiledProbe) {
+    const result = spawnSync(compiledProbe, [realEntry, asset.engine], {cwd:packageRoot, encoding:'utf8', timeout:60_000, env:{...process.env, NODE_PATH:''}})
+    if (result.error || result.status !== 0 || !result.stdout.includes('COMPILED_PACK_OK')) {
+      throw new Error(`${asset.engine} compiled import/construction failed: ${result.error ?? result.stderr}`)
+    }
+    console.log(result.stdout.trim())
+  }
   await rm(packageRoot, { recursive: true, force: true })
   console.log(`[broker-packs] verified ${asset.engine} (${formatBytes(asset.size)})`)
 }


### PR DESCRIPTION
Promote the Broker Pack runtime fixes for the requested v0.92.1-beta.2 checkpoint, followed by a separate v0.92.1 stable release of the accepted product source.

Alpaca now bundles its SDK closure. Standalone builds enable runtime package.json resolution so real external Broker Packs load, and release/Windows pack jobs verify actual archives through a compiled probe.

Validation: #1455 records the complete hermetic suite (774 files, 6880 passed, 3 skipped), root/UI types, all five macOS arm64 archive imports/construction including native Longbridge, and compiled multiprocess restart/recovery. Latest dev preview 34373214239 passed. Fresh local unsigned packaged Workspace acceptance passed with every receipt check true, including scheduled Pi CLI side effects and cleanup. All five real Pack archives passed the compiled import/construction verifier on macOS arm64. Required promotion checks must all pass.

No broker initialization or trading operations are performed. Longbridge Linux retains its documented glibc requirement.
