### PR TITLE
Prepare v0.92.1-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta.1",
+  "version": "0.92.1-beta.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta.1",
+  "version": "0.92.1-beta.2",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Synchronize only the root and CLI version values for the requested beta checkpoint. Promotion #1456 passed all platform, installer, compiled Broker Pack, Workspace, and upgrade gates; local packaged Workspace and five real compiled Pack checks passed. After this bounded version gate, publish beta2 and verify channel isolation before the separately authorized v0.92.1 stable release.