### PR TITLE
Sync accepted v0.92.1-beta.2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta.1",
+  "version": "0.92.1-beta.2",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta.1",
+  "version": "0.92.1-beta.2",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Copy only the two accepted beta2 version fields. Release 34385616703 passed all gates; the public prerelease has 55 assets and tag 862805f3. Independently verified beta manifest and unchanged stable feeds/download alias ETags and sizes. JSON version values and diff whitespace checked. No runtime changes.