### PR TITLE
Prepare v0.92.1 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta.2",
+  "version": "0.92.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta.2",
+  "version": "0.92.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Prepare the separately requested stable release from accepted v0.92.1-beta.2 source. Only the root and CLI version fields change. Beta Release 34385616703 succeeded; public tag, 55 assets, beta manifest and unchanged stable aliases independently verified. Promotion #1456 records full source and real platform acceptance. All seven npm OIDC authority checks passed on retry after a GitHub HTTP 504; OPENALICE_PUBLISH_NPM=true. Stable retains its full PR gates and exact-dispatch Full Source Validation, package-manager lifecycle, N-1 desktop upgrade and public publication gates. No additional product code is included.