### PR TITLE
Sync accepted v0.92.1 stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1-beta.2",
+  "version": "0.92.1",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1-beta.2",
+  "version": "0.92.1",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Copy only the two accepted stable version values to dev. Release 34390482383 completed successfully after retrying a documented unrelated test synchronization race (#1461); all source, platform, package-manager, upgrade, public-byte and npm publication gates passed. GitHub stable tag targets 7b9db356, CDN stable manifest reports 0.92.1, npm meta/platform dependencies report 0.92.1, and Homebrew sync 34395362676 passed. Beta2 remains a separate accepted prerelease. Version equality and diff whitespace checked; no runtime changes.