### PR TITLE
fix(alpaca): support crypto trading and read-only options research

### DIFF
--- a/default/skills/alice-uta/SKILL.md
+++ b/default/skills/alice-uta/SKILL.md
@@ -66,6 +66,19 @@ alice-uta contract expand --help       # expand a directory-style result (chains
 - **Resolve the contract before any order** (`contract search` →
   `contract details`) — never guess a symbol's broker-native identity.
 
+## Broker research
+
+`contract option-contracts` returns paginated option definitions and dated open
+interest; `contract option-chain` returns paginated snapshots with IV/Greeks
+when supplied. Currently Alpaca supports these reads. Keep the same filters
+when following `nextPageToken`. The default indicative feed contains modified
+quotes and delayed trades; use observation timestamps and do not treat it as
+executable OPRA. Options reads do not imply options trading permission.
+`contract order-book` provides depth on Alpaca crypto and CCXT.
+
+Alpaca crypto uses `CRYPTO` contracts, with GTC or IOC orders. Its equity
+market clock does not describe the 24/7 crypto session.
+
 ## Place / modify / cancel orders
 
 ```bash

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -270,3 +270,33 @@ and construct each broker, including Longbridge's platform-native binding.
 It uses synthetic configuration, never calls init, and does not connect or trade.
 Release pack jobs and Windows package smoke run this gate. Node-only archive
 verification remains available for environments without Bun.
+
+## Alpaca multi-asset boundary
+
+The Alpaca pack handles stock/ETF and spot-crypto trading. Crypto catalog rows,
+positions and orders retain `CRYPTO` identity; canonical Alice native keys use
+slash pairs (`BTC/USD`). The upstream positions endpoint alone uses compact
+symbols (`BTCUSD`). Do not send slash paths there, including encoded slashes.
+Crypto orders accept MKT/LMT/STP LMT with GTC/IOC; attached exits and stock
+extended-hours flags are rejected. Venue minimums and increments still apply.
+Contract details expose the asset's minimum size and increments when supplied.
+Notional orders retain cash quantity separately from filled base quantity.
+
+Options are a **read-only** capability in this pack. `alice-uta contract
+option-contracts` exposes paginated definitions and dated open interest;
+`option-chain` exposes paginated snapshots with feed provenance and individual
+trade/quote timestamps. `contract expand` requires an expiry for concrete
+Alpaca option leaves. Option place/modify/close operations remain refused.
+The default snapshot feed is `indicative`: trades are delayed and quotes are
+modified, not executable OPRA. Explicit OPRA requests preserve entitlement
+errors instead of silently changing feeds. Missing IV/Greeks/OI stay missing.
+
+`contract order-book` shares the optional broker read boundary with CCXT.
+Requests carry an account-owned aliceId; credentials stay in UTA. Old packs
+without these optional methods remain loadable and return unsupported errors.
+`historicalBars.qualityBySecType` lets mixed-asset packs distinguish crypto
+history from equity-only IEX entitlement in BarService and charts.
+
+Upstream contracts: [Crypto](https://docs.alpaca.markets/us/docs/crypto-trading),
+[option contracts](https://docs.alpaca.markets/us/reference/get-options-contracts),
+[option snapshots](https://docs.alpaca.markets/us/reference/optionchain).

--- a/packages/uta-protocol/src/broker-research.ts
+++ b/packages/uta-protocol/src/broker-research.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+import type { Contract } from '@traderalice/ibkr'
+
+const date = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
+export const optionResearchSchema = z.object({
+  aliceId: z.string().min(1).describe('Underlying stock aliceId from contract search'),
+  expiration: date.optional(), expirationFrom: date.optional(), expirationTo: date.optional(),
+  right: z.enum(['call', 'put']).optional(),
+  strikeMin: z.number().nonnegative().optional(), strikeMax: z.number().nonnegative().optional(),
+  limit: z.number().int().min(1).max(1000).optional(),
+  pageToken: z.string().optional().describe('Continue with the returned nextPageToken and the same filters'),
+  feed: z.enum(['indicative', 'opra']).optional().describe('Snapshots only; defaults to indicative (modified quotes, delayed trades). OPRA needs entitlement.'),
+})
+export const orderBookSchema = z.object({
+  aliceId: z.string().min(1), limit: z.number().int().min(1).max(100).optional(),
+})
+export type OptionResearchRequest = z.infer<typeof optionResearchSchema>
+export type OptionResearchFilters = Omit<OptionResearchRequest, 'aliceId'>
+
+/** Optional structural capabilities: old broker packs continue to load. */
+export interface BrokerResearch {
+  getOptionContracts?(underlying: string, filters: OptionResearchFilters): Promise<Record<string, unknown>>
+  getOptionChain?(underlying: string, filters: OptionResearchFilters): Promise<Record<string, unknown>>
+  getOrderBook?(contract: Contract, limit?: number): Promise<unknown>
+}

--- a/packages/uta-protocol/src/brokers/preset-catalog.ts
+++ b/packages/uta-protocol/src/brokers/preset-catalog.ts
@@ -336,8 +336,8 @@ export const CCXT_CUSTOM_PRESET: BrokerPresetDef = {
 
 export const ALPACA_PRESET: BrokerPresetDef = {
   id: 'alpaca',
-  label: 'Alpaca (US Equities)',
-  description: 'Commission-free US stocks and ETFs with fractional shares.',
+  label: 'Alpaca (Stocks & Crypto)',
+  description: 'US stocks, ETFs and spot crypto trading; read-only option contracts and snapshots.',
   category: 'recommended',
   hint: 'Paper and Live use **separate** API keys — generate from the matching dashboard at alpaca.markets. Paper is free and unlimited; Live places real orders on real money.',
   defaultName: 'alpaca-paper',

--- a/packages/uta-protocol/src/index.ts
+++ b/packages/uta-protocol/src/index.ts
@@ -18,3 +18,5 @@ export * from './client/UTAClient.js'
 export * from './brokers/preset-catalog.js'
 export * from './brokers/presets.js'
 export * from './brokers/search-rules.js'
+
+export * from './broker-research.js'

--- a/packages/uta-protocol/src/types/broker.ts
+++ b/packages/uta-protocol/src/types/broker.ts
@@ -438,6 +438,8 @@ export interface BrokerConnectionStateEvent {
 export interface HistoricalBarsCapability {
   supported: boolean
   quality?: 'realtime' | 'iex' | 'delayed' | 'subscription'
+  /** Overrides for mixed-asset brokers (e.g. Alpaca equities vs crypto). */
+  qualityBySecType?: Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'>
   /** Subset of BarInterval this broker actually maps to a native bar size. */
   supportedBarSizes?: BarInterval[]
 }

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.spec.ts
@@ -366,7 +366,7 @@ describe('AlpacaBroker — modifyOrder()', () => {
     const replaceOrder = vi.fn().mockResolvedValue({
       id: 'ord-modified', status: 'accepted',
     })
-    ;(acc as any).client = { replaceOrder }
+    ;(acc as any).client = { replaceOrder, getOrder: vi.fn().mockResolvedValue({ symbol: 'AAPL' }) }
 
     const changes = new Order()
     changes.totalQuantity = new Decimal(20)
@@ -388,6 +388,7 @@ describe('AlpacaBroker — modifyOrder()', () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     ;(acc as any).client = {
       replaceOrder: vi.fn().mockRejectedValue(new Error('Order not found')),
+      getOrder: vi.fn().mockRejectedValue(new Error('Order not found')),
     }
 
     const changes = new Order()
@@ -409,7 +410,7 @@ describe('AlpacaBroker — modifyOrder null-check', () => {
   it('does not send undefined lmtPrice/auxPrice/trailingPercent when only qty changes', async () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     const replaceOrder = vi.fn().mockResolvedValue({ id: 'ord-mod', status: 'accepted' })
-    ;(acc as any).client = { replaceOrder }
+    ;(acc as any).client = { replaceOrder, getOrder: vi.fn().mockResolvedValue({ symbol: 'AAPL' }) }
 
     // Partial<Order> — only totalQuantity set, everything else is undefined
     const changes: Partial<Order> = { totalQuantity: new Decimal(20) }
@@ -427,7 +428,7 @@ describe('AlpacaBroker — modifyOrder null-check', () => {
   it('sends lmtPrice when explicitly set in changes', async () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     const replaceOrder = vi.fn().mockResolvedValue({ id: 'ord-mod', status: 'accepted' })
-    ;(acc as any).client = { replaceOrder }
+    ;(acc as any).client = { replaceOrder, getOrder: vi.fn().mockResolvedValue({ symbol: 'AAPL' }) }
 
     const changes: Partial<Order> = { lmtPrice: new Decimal('155.50') }
 
@@ -442,7 +443,7 @@ describe('AlpacaBroker — modifyOrder null-check', () => {
   it('sends auxPrice as stop_price when explicitly set', async () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     const replaceOrder = vi.fn().mockResolvedValue({ id: 'ord-mod', status: 'accepted' })
-    ;(acc as any).client = { replaceOrder }
+    ;(acc as any).client = { replaceOrder, getOrder: vi.fn().mockResolvedValue({ symbol: 'AAPL' }) }
 
     const changes: Partial<Order> = { auxPrice: new Decimal(140) }
 
@@ -827,7 +828,7 @@ describe('AlpacaBroker — getHistorical()', () => {
       { timestamp: new Date('2025-01-02T00:00:00Z'), open: '101', high: '103', low: '100', close: '102.5', volume: '6000' },
     ])
     expect(getBarsV2).toHaveBeenCalledWith('AAPL', expect.objectContaining({ timeframe: '1Day', adjustment: 'all', limit: 2 }))
-    expect(acc.getCapabilities().historicalBars).toEqual({ supported: true, quality: 'iex' })
+    expect(acc.getCapabilities().historicalBars).toEqual({ supported: true, quality: 'iex', qualityBySecType: { CRYPTO: 'realtime' } })
   })
 
   it('tail-slices a bounded window instead of forwarding Alpaca first-N limit semantics', async () => {
@@ -898,7 +899,7 @@ describe('AlpacaBroker — getCapabilities()', () => {
   it('returns correct supportedSecTypes and supportedOrderTypes', () => {
     const acc = new AlpacaBroker({ apiKey: 'k', secretKey: 's', paper: true })
     const caps = acc.getCapabilities()
-    expect(caps.supportedSecTypes).toEqual(['STK'])
+    expect(caps.supportedSecTypes).toEqual(['STK', 'CRYPTO'])
     expect(caps.supportedOrderTypes).toEqual(['MKT', 'LMT', 'STP', 'STP LMT', 'TRAIL'])
   })
 })

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -2,13 +2,14 @@
  * AlpacaBroker — IBroker adapter for Alpaca
  *
  * Direct implementation against @alpacahq/alpaca-trade-api SDK.
- * Supports US equities (STK). Contract resolution uses Alpaca's ticker
- * as nativeId — unambiguous for stocks, extensible when options arrive.
+ * Supports equities and spot crypto trading, plus read-only options research.
+ * Native keys are stock tickers, slash crypto pairs, or OCC option symbols.
  *
  * Takes IBKR Order objects, reads relevant fields, ignores the rest.
  */
 
 import { z } from 'zod'
+import { AlpacaData, type OptionFilters, type SnapshotRaw } from './alpaca-data.js'
 import Alpaca from '@alpacahq/alpaca-trade-api'
 import Decimal from 'decimal.js'
 import { Contract, ContractDescription, ContractDetails, Order, OrderState, UNSET_DECIMAL } from '@traderalice/ibkr'
@@ -26,6 +27,8 @@ import {
   type TpSlParams,
   type Bar,
   type BarParams,
+  type ExpandContractFilters,
+  type ContractExpansion,
 } from '../types.js'
 import '../../contract-ext.js'
 import type {
@@ -47,6 +50,9 @@ interface AlpacaAssetRaw {
   name?: string
   class?: string         // 'us_equity' | 'crypto'
   exchange?: string
+  min_order_size?: string
+  min_trade_increment?: string
+  price_increment?: string
   tradable?: boolean
   status?: string        // 'active' | 'inactive'
 }
@@ -245,7 +251,7 @@ export class AlpacaBroker implements IBroker {
     }
 
     const entries: FuzzyRankInput[] = this.catalog.map((a) => {
-      const c = makeContract(a.symbol)
+      const c = makeContract(a.symbol, a.class)
       // Stash the asset name in `description` so panels that render it
       // (e.g. TradeableContractsPanel) can show "Teucrium Commodity Trust"
       // alongside the ticker.
@@ -253,7 +259,10 @@ export class AlpacaBroker implements IBroker {
       if (a.exchange) c.primaryExchange = a.exchange
       return { contract: c, name: a.name }
     })
-    return fuzzyRankContracts(entries, pattern)
+    return fuzzyRankContracts(entries, pattern).map(desc => {
+      desc.derivativeSecTypes = desc.contract.secType === 'STK' ? ['OPT'] : []
+      return desc
+    })
   }
 
   async getContractDetails(query: Contract): Promise<ContractDetails | null> {
@@ -261,19 +270,34 @@ export class AlpacaBroker implements IBroker {
     if (!symbol) return null
 
     const details = new ContractDetails()
-    details.contract = makeContract(symbol)
+    details.contract = this.contractFor(symbol)
     details.validExchanges = 'SMART,NYSE,NASDAQ,ARCA'
     details.orderTypes = 'MKT,LMT,STP,STP LMT,TRAIL'
-    details.stockType = 'COMMON'
+    details.stockType = details.contract.secType === 'STK' ? 'COMMON' : ''
+    if (details.contract.secType === 'CRYPTO') {
+      details.validExchanges = 'ALPACA'
+      details.orderTypes = 'MKT,LMT,STP LMT'
+      const asset = this.catalogBySymbol?.get(symbol)
+      if (asset?.price_increment) details.minTick = Number(asset.price_increment)
+      if (asset?.min_order_size) details.minSize = new Decimal(asset.min_order_size)
+      if (asset?.min_trade_increment) details.sizeIncrement = new Decimal(asset.min_trade_increment)
+    } else if (details.contract.secType === 'OPT') details.orderTypes = ''
     return details
   }
 
   // ---- Trading operations ----
 
   async placeOrder(contract: Contract, order: Order, tpsl?: TpSlParams): Promise<PlaceOrderResult> {
-    const symbol = resolveSymbol(contract)
+    const symbol = this.canonicalSymbol(contract)
     if (!symbol) {
       return { success: false, error: 'Cannot resolve contract to Alpaca symbol' }
+    }
+
+    if (this.contractFor(symbol).secType === 'OPT') return { success: false, error: 'Alpaca options are read-only; options orders are not enabled.' }
+    if (this.contractFor(symbol).secType === 'CRYPTO') {
+      if (!['MKT', 'LMT', 'STP LMT'].includes(order.orderType)) return { success: false, error: 'Alpaca crypto supports MKT, LMT and STP LMT only.' }
+      if (!['GTC', 'IOC'].includes(order.tif)) return { success: false, error: 'Alpaca crypto requires GTC or IOC time in force.' }
+      if (tpsl || order.outsideRth) return { success: false, error: 'Alpaca crypto does not support attached TP/SL or extended-hours flags.' }
     }
 
     try {
@@ -348,6 +372,13 @@ export class AlpacaBroker implements IBroker {
 
   async modifyOrder(orderId: string, changes: Partial<Order>): Promise<PlaceOrderResult> {
     try {
+      const existing = await this.client.getOrder(orderId) as AlpacaOrderRaw
+      const contract = this.contractFor(existing.symbol, existing.asset_class)
+      if (contract.secType === 'OPT') return { success: false, error: 'Alpaca options are read-only.' }
+      if (contract.secType === 'CRYPTO') {
+        if (changes.tif && !['GTC', 'IOC'].includes(changes.tif)) return { success: false, error: 'Alpaca crypto requires GTC or IOC time in force.' }
+        if (changes.trailingPercent != null && !changes.trailingPercent.equals(UNSET_DECIMAL)) return { success: false, error: 'Alpaca crypto does not support trailing orders.' }
+      }
       const patch: Record<string, unknown> = {}
       if (changes.totalQuantity != null && !changes.totalQuantity.equals(UNSET_DECIMAL)) patch.qty = changes.totalQuantity.toFixed()
       if (changes.lmtPrice != null && !changes.lmtPrice.equals(UNSET_DECIMAL)) patch.limit_price = changes.lmtPrice.toFixed()
@@ -379,10 +410,12 @@ export class AlpacaBroker implements IBroker {
   }
 
   async closePosition(contract: Contract, quantity?: Decimal): Promise<PlaceOrderResult> {
-    const symbol = resolveSymbol(contract)
+    const symbol = this.canonicalSymbol(contract)
     if (!symbol) {
       return { success: false, error: 'Cannot resolve contract to Alpaca symbol' }
     }
+
+    if (this.contractFor(symbol).secType === 'OPT') return { success: false, error: 'Alpaca options are read-only.' }
 
     // Partial close → reverse market order
     if (quantity != null) {
@@ -394,14 +427,15 @@ export class AlpacaBroker implements IBroker {
       order.action = pos.side === 'long' ? 'SELL' : 'BUY'
       order.orderType = 'MKT'
       order.totalQuantity = quantity
-      order.tif = 'DAY'
+      order.tif = pos.contract.secType === 'CRYPTO' ? 'GTC' : 'DAY'
 
       return this.placeOrder(contract, order)
     }
 
-    // Full close → native Alpaca API
+    // Positions API uses compact crypto symbols (BTCUSD), unlike data/orders
+    // which use BTC/USD. Even percent-encoded slash paths return 404.
     try {
-      const result = await this.client.closePosition(symbol) as AlpacaOrderRaw
+      const result = await this.client.closePosition(this.contractFor(symbol).secType === 'CRYPTO' ? symbol.replace('/', '') : symbol) as AlpacaOrderRaw
       return {
         success: true,
         orderId: result.id,
@@ -446,9 +480,14 @@ export class AlpacaBroker implements IBroker {
    * position / order / trade rows can render them (issue #340). Falls back to a
    * bare contract before the catalog has loaded.
    */
-  private contractFor(symbol: string): Contract {
-    const contract = makeContract(symbol)
-    const asset = this.catalogBySymbol?.get(symbol)
+  private canonicalSymbol(contract: Contract): string | null {
+    const symbol = resolveSymbol(contract)
+    return symbol ? resolveSymbol(this.contractFor(symbol, contract.secType === 'CRYPTO' ? 'crypto' : undefined)) : null
+  }
+
+  private contractFor(symbol: string, assetClass?: string): Contract {
+    const asset = this.catalogBySymbol?.get(symbol) ?? this.catalog?.find(a => a.class === 'crypto' && a.symbol.replace('/', '') === symbol)
+    const contract = makeContract(asset?.symbol ?? symbol, assetClass ?? asset?.class)
     if (asset?.name) contract.description = asset.name
     if (asset?.exchange) contract.primaryExchange = asset.exchange
     return contract
@@ -459,7 +498,7 @@ export class AlpacaBroker implements IBroker {
       const raw = await this.client.getPositions() as AlpacaPositionRaw[]
 
       return raw.map(p => buildPosition({
-        contract: this.contractFor(p.symbol),
+        contract: this.contractFor(p.symbol, p.asset_class),
         currency: 'USD',
         side: p.side === 'long' ? 'long' as const : 'short' as const,
         quantity: new Decimal(p.qty),
@@ -471,8 +510,7 @@ export class AlpacaBroker implements IBroker {
         marketValue: new Decimal(p.market_value).abs().toString(),
         unrealizedPnL: new Decimal(p.unrealized_pl).toString(),
         realizedPnL: '0',
-        // Alpaca is STK-only — canonical multiplier is always '1'.
-        multiplier: '1',
+        multiplier: this.contractFor(p.symbol, p.asset_class).multiplier || '1',
       }))
     } catch (err) {
       throw BrokerError.from(err)
@@ -509,14 +547,36 @@ export class AlpacaBroker implements IBroker {
   }
 
   async getQuote(contract: Contract): Promise<Quote> {
-    const symbol = resolveSymbol(contract)
+    const symbol = this.canonicalSymbol(contract)
     if (!symbol) throw new BrokerError('EXCHANGE', 'Cannot resolve contract to Alpaca symbol')
 
     try {
+      const resolved = this.contractFor(symbol)
+      if (resolved.secType === 'CRYPTO') {
+        const result = await this.data.read<{ snapshots: Record<string, SnapshotRaw> }>(
+          '/v1beta3/crypto/us/snapshots', { symbols: resolved.symbol },
+        )
+        const snapshot = result.snapshots?.[resolved.symbol]
+        if (!snapshot?.latestTrade || !snapshot.latestQuote) {
+          throw new Error(`No complete Alpaca crypto snapshot for ${resolved.symbol}`)
+        }
+        return {
+          contract: resolved,
+          last: String(snapshot.latestTrade.p),
+          bid: String(snapshot.latestQuote.bp),
+          ask: String(snapshot.latestQuote.ap),
+          volume: String(snapshot.dailyBar?.v ?? 0),
+          ...(snapshot.dailyBar && { high: String(snapshot.dailyBar.h), low: String(snapshot.dailyBar.l) }),
+          timestamp: new Date(snapshot.latestQuote.t),
+        }
+      }
+      if (resolved.secType === 'OPT') {
+        throw new BrokerError('CONFIG', 'Use option-chain snapshots with explicit feed metadata for Alpaca options.')
+      }
       const snapshot = await this.client.getSnapshot(symbol) as AlpacaSnapshotRaw
 
       return {
-        contract: makeContract(symbol),
+        contract: this.contractFor(symbol),
         last: String(snapshot.LatestTrade.Price),
         bid: String(snapshot.LatestQuote.BidPrice),
         ask: String(snapshot.LatestQuote.AskPrice),
@@ -535,8 +595,11 @@ export class AlpacaBroker implements IBroker {
    * capability quality 'iex'; full SIP needs a paid data subscription.
    */
   async getHistorical(contract: Contract, params: BarParams): Promise<Bar[]> {
-    const symbol = resolveSymbol(contract)
+    const symbol = this.canonicalSymbol(contract)
     if (!symbol) throw new BrokerError('EXCHANGE', 'Cannot resolve contract to Alpaca symbol')
+    const resolved = this.contractFor(symbol)
+    if (resolved.secType === 'CRYPTO') return this.cryptoHistory(resolved.symbol, params)
+    if (resolved.secType === 'OPT') throw new BrokerError('CONFIG', 'Alpaca option history is not enabled; use option-chain snapshots.')
     const timeframe = ALPACA_TIMEFRAME[params.interval]
     const limit = params.limit == null ? undefined : Math.max(1, Math.floor(params.limit))
     const baseOpts: Record<string, unknown> = { timeframe, adjustment: 'all' }
@@ -594,9 +657,9 @@ export class AlpacaBroker implements IBroker {
 
   getCapabilities(): AccountCapabilities {
     return {
-      supportedSecTypes: ['STK'],
+      supportedSecTypes: ['STK', 'CRYPTO'],
       supportedOrderTypes: ['MKT', 'LMT', 'STP', 'STP LMT', 'TRAIL'],
-      historicalBars: { supported: true, quality: 'iex' },
+      historicalBars: { supported: true, quality: 'iex', qualityBySecType: { CRYPTO: 'realtime' } },
     }
   }
 
@@ -618,22 +681,88 @@ export class AlpacaBroker implements IBroker {
   // ---- Contract identity ----
 
   getNativeKey(contract: Contract): string {
-    return contract.symbol
+    return resolveSymbol(contract) ?? contract.symbol
   }
 
   resolveNativeKey(nativeKey: string): Contract {
-    return makeContract(nativeKey)
+    return this.contractFor(nativeKey)
+  }
+
+  private get data(): AlpacaData {
+    return new AlpacaData(this.config)
+  }
+
+  async getOptionContracts(underlying: string, filters: OptionFilters = {}) {
+    return this.data.optionContracts(underlying, filters)
+  }
+  async getOptionChain(underlying: string, filters: OptionFilters = {}) {
+    return this.data.optionSnapshots(underlying, filters)
+  }
+
+  async expandContract(nativeKey: string, filters: ExpandContractFilters = {}): Promise<ContractExpansion> {
+    if (this.contractFor(nativeKey).secType !== 'STK' || (filters.secType && filters.secType !== 'OPT')) throw new Error('Alpaca expands stock option contracts only.')
+    if (!filters.expiry || !/^\d{8}$/.test(filters.expiry)) throw new Error('Alpaca option expansion requires expiry YYYYMMDD. Use option-contracts for paginated expiration discovery.')
+    const rows = []
+    const seenTokens = new Set<string>()
+    let pageToken: string | undefined
+    do {
+      const page = await this.getOptionContracts(nativeKey, { expiration: filters.expiry?.replace(/^(\d{4})(\d{2})(\d{2})$/, '$1-$2-$3'),
+        right: filters.right === 'C' ? 'call' : filters.right === 'P' ? 'put' : undefined,
+        strikeMin: filters.strikeMin, strikeMax: filters.strikeMax, limit: 1000, pageToken })
+      rows.push(...page.contracts)
+      pageToken = page.nextPageToken ?? undefined
+      if (pageToken && seenTokens.has(pageToken)) throw new Error('Alpaca repeated an option pagination token.')
+      if (pageToken) seenTokens.add(pageToken)
+    } while (pageToken)
+    return { kind: 'contracts', total: rows.length, contracts: rows.slice(0, Math.min(filters.limit ?? 60, 200)).map(row => {
+      const contract = makeContract(row.symbol, 'us_option')
+      contract.multiplier = row.multiplier ?? row.size
+      return contract
+    }), hint: 'Alpaca options are read-only. Use option-chain for feed-labelled snapshots and option-contracts for open interest with observation dates.' }
+  }
+
+  async getOrderBook(contract: Contract, limit = 20): Promise<Record<string, unknown>> {
+    const resolved = this.contractFor(this.canonicalSymbol(contract) ?? '')
+    if (resolved.secType !== 'CRYPTO') throw new Error('Alpaca order books are available for crypto only.')
+    const result = await this.data.read<{ orderbooks: Record<string, { t: string; b: { p: number; s: number }[]; a: { p: number; s: number }[] }> }>('/v1beta3/crypto/us/latest/orderbooks', { symbols: resolved.symbol })
+    const book = result.orderbooks?.[resolved.symbol]
+    if (!book) throw new Error(`No Alpaca order book for ${resolved.symbol}`)
+    return { symbol: resolved.symbol, timestamp: book.t, bids: book.b.slice(0, limit).map(l => [String(l.p), String(l.s)]), asks: book.a.slice(0, limit).map(l => [String(l.p), String(l.s)]) }
+  }
+
+  private async cryptoHistory(symbol: string, params: BarParams): Promise<Bar[]> {
+    type RawBar = { t: string; o: number; h: number; l: number; c: number; v: number }
+    const rows: RawBar[] = []
+    let pageToken: string | undefined
+    // Descending pagination selects the most recent N bars, not the first N
+    // after start. Always return chronological data to UTA/BarService.
+    const count = params.limit == null ? undefined : Math.max(1, Math.floor(params.limit))
+    const intervalMs = ({ '1m': 60000, '5m': 300000, '15m': 900000, '30m': 1800000, '1h': 3600000, '4h': 14400000, '1d': 86400000, '1w': 604800000 })[params.interval]
+    const start = params.start ?? new Date((params.end?.getTime() ?? Date.now()) - intervalMs * (count ?? 1000) * 2)
+    const seenTokens = new Set<string>()
+    do {
+      const page = await this.data.read<{ bars: Record<string, RawBar[]>; next_page_token?: string | null }>('/v1beta3/crypto/us/bars', {
+        symbols: symbol, timeframe: ALPACA_TIMEFRAME[params.interval], start: start.toISOString(), end: params.end?.toISOString(),
+        sort: 'desc', limit: Math.min(count == null ? 10000 : count - rows.length, 10000), page_token: pageToken,
+      })
+      rows.push(...(page.bars?.[symbol] ?? []))
+      pageToken = page.next_page_token ?? undefined
+      if (pageToken && seenTokens.has(pageToken)) throw new Error('Alpaca repeated a bars pagination token.')
+      if (pageToken) seenTokens.add(pageToken)
+    } while (pageToken && (count == null || rows.length < count))
+    return rows.slice(0, count).sort((a, b) => a.t.localeCompare(b.t)).map(b => ({ timestamp: new Date(b.t), open: String(b.o), high: String(b.h), low: String(b.l), close: String(b.c), volume: String(b.v) }))
   }
 
   // ---- Internal ----
 
   private mapOpenOrder(o: AlpacaOrderRaw): OpenOrder {
-    const contract = this.contractFor(o.symbol)
+    const contract = this.contractFor(o.symbol, o.asset_class)
 
     const order = new Order()
     order.action = o.side.toUpperCase() // buy → BUY
-    order.totalQuantity = new Decimal(o.qty ?? o.notional ?? '0')
-    order.orderType = (o.type ?? 'market').toUpperCase()
+    order.totalQuantity = o.qty != null ? new Decimal(o.qty) : UNSET_DECIMAL
+    if (o.notional != null) order.cashQty = new Decimal(o.notional)
+    order.orderType = ({ market: 'MKT', limit: 'LMT', stop: 'STP', stop_limit: 'STP LMT', trailing_stop: 'TRAIL' } as Record<string, string>)[o.type] ?? o.type.toUpperCase()
     if (o.limit_price) order.lmtPrice = new Decimal(o.limit_price)
     if (o.stop_price) order.auxPrice = new Decimal(o.stop_price)
     if (o.time_in_force) order.tif = o.time_in_force.toUpperCase()

--- a/services/uta/src/domain/trading/brokers/alpaca/alpaca-contracts.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/alpaca-contracts.ts
@@ -16,27 +16,31 @@ export const ALPACA_TIMEFRAME: Record<BarInterval, string> = {
   '1h': '1Hour', '4h': '4Hour', '1d': '1Day', '1w': '1Week',
 }
 
-/** Build a fully qualified IBKR Contract for an Alpaca ticker. */
-export function makeContract(ticker: string): Contract {
-  return buildContract({
-    symbol: ticker,
-    secType: 'STK',
-    exchange: 'SMART',
-    currency: 'USD',
-  })
+/** Build venue identity without treating crypto pairs or OCC options as stocks. */
+export function makeContract(ticker: string, assetClass?: string): Contract {
+  ticker = ticker.toUpperCase()
+  const option = /^([A-Z0-9.]+)(\d{6})([CP])(\d{8})$/.exec(ticker)
+  if (option && assetClass !== 'us_equity') {
+    return buildContract({
+      symbol: option[1], localSymbol: ticker, secType: 'OPT', exchange: 'SMART', currency: 'USD',
+      lastTradeDateOrContractMonth: `20${option[2]}`, right: option[3] as 'C' | 'P',
+      strike: Number(option[4]) / 1000, multiplier: '100',
+    })
+  }
+  if (assetClass === 'crypto' || ticker.includes('/')) {
+    // Position/order APIs can return the legacy compact symbol. Only split it
+    // when the venue explicitly identifies it as crypto.
+    const symbol = ticker.includes('/') ? ticker : ticker.replace(/(USDT|USDC|USD|BTC)$/, '/$1')
+    if (!symbol.includes('/')) throw new Error(`Unrecognized Alpaca crypto pair: ${ticker}`)
+    return buildContract({ symbol, secType: 'CRYPTO', exchange: 'ALPACA', currency: symbol.split('/')[1] })
+  }
+  return buildContract({ symbol: ticker, secType: 'STK', exchange: 'SMART', currency: 'USD' })
 }
 
-/**
- * Resolve a Contract to an Alpaca ticker symbol.
- * Uses symbol directly. aliceId is managed by UTA layer, not broker.
- */
 export function resolveSymbol(contract: Contract): string | null {
-  if (contract.symbol) {
-    // If secType is specified and not STK, not our domain
-    if (contract.secType && contract.secType !== 'STK') return null
-    return contract.symbol.toUpperCase()
-  }
-  return null
+  if (contract.secType === 'OPT') return contract.localSymbol || null
+  if (contract.secType && !['STK', 'CRYPTO'].includes(contract.secType)) return null
+  return contract.symbol?.toUpperCase() || null
 }
 
 /** Map Alpaca order status string to IBKR-style OrderState status. */

--- a/services/uta/src/domain/trading/brokers/alpaca/alpaca-data.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/alpaca-data.ts
@@ -1,0 +1,85 @@
+import type { AlpacaBrokerConfig } from './alpaca-types.js'
+
+export type { OptionResearchFilters as OptionFilters } from '@traderalice/uta-protocol'
+import type { OptionResearchFilters as OptionFilters } from '@traderalice/uta-protocol'
+
+export interface OptionContractRaw {
+  symbol: string
+  underlying_symbol: string
+  expiration_date: string
+  type: 'call' | 'put'
+  strike_price: string
+  size: string
+  multiplier?: string
+  status: string
+  tradable: boolean
+  open_interest?: string | null
+  open_interest_date?: string | null
+  close_price?: string | null
+  close_price_date?: string | null
+}
+
+export interface SnapshotRaw {
+  dailyBar?: { v: number; h: number; l: number; t: string }
+  latestTrade?: { p: number; t: string; s?: number }
+  latestQuote?: { bp: number; ap: number; bs?: number; as?: number; t: string }
+  impliedVolatility?: number
+  greeks?: { delta?: number; gamma?: number; theta?: number; vega?: number; rho?: number }
+}
+
+/** SDK v3 predates current crypto/options endpoints. Keep authenticated reads
+ * in the broker pack; callers cannot choose an arbitrary credential destination. */
+export class AlpacaData {
+  constructor(private readonly config: AlpacaBrokerConfig) {}
+
+  async read<T>(path: string, query: Record<string, string | number | undefined> = {}, trading = false): Promise<T> {
+    const origin = trading
+      ? (this.config.paper ? 'https://paper-api.alpaca.markets' : 'https://api.alpaca.markets')
+      : 'https://data.alpaca.markets'
+    const url = new URL(path, origin)
+    for (const [key, value] of Object.entries(query)) if (value !== undefined) url.searchParams.set(key, String(value))
+    const response = await fetch(url, {
+      headers: { 'APCA-API-KEY-ID': this.config.apiKey, 'APCA-API-SECRET-KEY': this.config.secretKey },
+      signal: AbortSignal.timeout(30_000), redirect: 'error',
+    })
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`Alpaca ${response.status} ${path}: ${body.slice(0, 1000)}`)
+    }
+    return await response.json() as T
+  }
+
+  optionQuery(filters: OptionFilters) {
+    return {
+      expiration_date: filters.expiration,
+      expiration_date_gte: filters.expirationFrom,
+      expiration_date_lte: filters.expirationTo,
+      type: filters.right, strike_price_gte: filters.strikeMin, strike_price_lte: filters.strikeMax,
+      limit: filters.limit ?? 100, page_token: filters.pageToken,
+    }
+  }
+
+  async optionContracts(underlying: string, filters: OptionFilters = {}) {
+    const result = await this.read<{ option_contracts: OptionContractRaw[]; next_page_token?: string | null }>(
+      '/v2/options/contracts', {
+        underlying_symbols: underlying, status: 'active', ...this.optionQuery(filters),
+        // Override Alpaca's implicit next-weekend cutoff. Omitted upper bound
+        // must allow later expirations instead of silently hiding the chain.
+        expiration_date_lte: filters.expirationTo ?? filters.expiration ?? '2099-12-31',
+      }, true)
+    return { contracts: result.option_contracts ?? [], nextPageToken: result.next_page_token ?? null,
+      metadata: { retrievedAt: new Date().toISOString(), openInterest: 'Daily observation; use open_interest_date per contract.' } }
+  }
+
+  async optionSnapshots(underlying: string, filters: OptionFilters = {}) {
+    const feed = filters.feed ?? 'indicative'
+    const result = await this.read<{ snapshots: Record<string, SnapshotRaw>; next_page_token?: string | null }>(
+      `/v1beta1/options/snapshots/${encodeURIComponent(underlying)}`, { ...this.optionQuery(filters), feed })
+    return { snapshots: result.snapshots ?? {}, nextPageToken: result.next_page_token ?? null,
+      metadata: {
+        feed, retrievedAt: new Date().toISOString(),
+        indicative: feed === 'indicative', possiblyDelayed: feed === 'indicative',
+        note: feed === 'indicative' ? 'Trades are delayed and quotes are modified. Not executable OPRA quotes. Use each trade/quote timestamp; delay is not inferred from retrieval time.' : 'OPRA subscription required. Use each trade/quote timestamp.',
+      } }
+  }
+}

--- a/services/uta/src/domain/trading/brokers/alpaca/alpaca-multi-asset.spec.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/alpaca-multi-asset.spec.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import Decimal from 'decimal.js'
+import { Order, UNSET_DECIMAL } from '@traderalice/ibkr'
+import { AlpacaBroker } from './AlpacaBroker.js'
+import { makeContract } from './alpaca-contracts.js'
+import { AlpacaData } from './alpaca-data.js'
+
+const config = { apiKey: 'fixture', secretKey: 'fixture', paper: true }
+afterEach(() => vi.unstubAllGlobals())
+function respond(...bodies: unknown[]) {
+  const fetcher = vi.fn()
+  bodies.forEach(body => fetcher.mockResolvedValueOnce(new Response(JSON.stringify(body))))
+  vi.stubGlobal('fetch', fetcher)
+  return fetcher
+}
+
+describe('Alpaca multi-asset identities and writes', () => {
+  it('preserves crypto identity from catalog, compact position symbols and restart keys', async () => {
+    const broker = new AlpacaBroker(config)
+    const raw = { symbol: 'BTCUSD', asset_class: 'crypto', qty: '0.001', side: 'long', avg_entry_price: '50000', current_price: '60000', market_value: '60', unrealized_pl: '10' }
+    Object.assign(broker, { client: { getAssets: async () => [{ symbol: 'BTC/USD', class: 'crypto', tradable: true }], getPositions: async () => [raw] } })
+    await broker.refreshCatalog()
+    const [found] = await broker.searchContracts('BTC')
+    expect(found.contract.secType).toBe('CRYPTO')
+    expect(broker.resolveNativeKey('BTC/USD').secType).toBe('CRYPTO')
+    expect(broker.resolveNativeKey('BTCUSD').symbol).toBe('BTC/USD')
+    expect((await broker.getPositions())[0]).toMatchObject({ contract: { secType: 'CRYPTO', symbol: 'BTC/USD' }, marketValue: '60', unrealizedPnL: '10' })
+  })
+  it('does not turn cash-notional into quantity when reading an order', async () => {
+    const broker = new AlpacaBroker(config)
+    Object.assign(broker, { client: { getOrder: async () => ({ id: 'uuid', symbol: 'BTCUSD', asset_class: 'crypto', side: 'buy', qty: null, notional: '100', type: 'market', status: 'new' }) } })
+    const result = await broker.getOrder('uuid')
+    expect(result?.contract.secType).toBe('CRYPTO')
+    expect(result?.order.totalQuantity.equals(UNSET_DECIMAL)).toBe(true)
+    expect(result?.order.cashQty.toString()).toBe('100')
+    expect(result?.order.orderType).toBe('MKT')
+  })
+  it('rejects crypto stock-only order flags before sending and preserves fractional quantities', async () => {
+    const broker = new AlpacaBroker(config)
+    const createOrder = vi.fn().mockResolvedValue({ id: 'crypto-order', status: 'new' })
+    Object.assign(broker, { client: { createOrder } })
+    const order = Object.assign(new Order(), { action: 'BUY', orderType: 'MKT', tif: 'DAY', totalQuantity: new Decimal('0.00012345') })
+    const contract = makeContract('BTC/USD')
+    expect((await broker.placeOrder(contract, order)).error).toMatch(/GTC or IOC/)
+    order.tif = 'GTC'
+    expect((await broker.placeOrder(contract, order, { takeProfit: { price: '100000' } })).success).toBe(false)
+    expect(createOrder).not.toHaveBeenCalled()
+    expect((await broker.placeOrder(contract, order)).success).toBe(true)
+    expect(createOrder).toHaveBeenCalledWith(expect.objectContaining({ symbol: 'BTC/USD', qty: '0.00012345', time_in_force: 'gtc' }))
+  })
+  it('keeps option local identity and multiplier while rejecting trading', async () => {
+    const broker = new AlpacaBroker(config)
+    const contract = broker.resolveNativeKey('SPY260918C00600000')
+    expect(contract).toMatchObject({ symbol: 'SPY', localSymbol: 'SPY260918C00600000', secType: 'OPT', strike: 600, multiplier: '100', right: 'C', lastTradeDateOrContractMonth: '20260918' })
+    expect(broker.getNativeKey(contract)).toBe('SPY260918C00600000')
+    expect((await broker.placeOrder(contract, new Order())).error).toMatch(/read-only/)
+    expect((await broker.closePosition(contract)).error).toMatch(/read-only/)
+  })
+})
+
+describe('Alpaca read-only data endpoints', () => {
+  it('uses crypto snapshots rather than stock snapshots', async () => {
+    const fetcher = respond({ snapshots: { 'BTC/USD': { latestTrade: { p: 60000, t: '2026-09-10T00:00:00Z' }, latestQuote: { bp: 59999, ap: 60001, t: '2026-09-10T00:00:01Z' } } } })
+    const quote = await new AlpacaBroker(config).getQuote(makeContract('BTC/USD'))
+    expect(String(fetcher.mock.calls[0][0])).toContain('/v1beta3/crypto/us/snapshots?symbols=BTC%2FUSD')
+    expect(quote).toMatchObject({ last: '60000', bid: '59999', ask: '60001', contract: { secType: 'CRYPTO' } })
+  })
+  it('paginates descending crypto bars and returns the latest N chronologically', async () => {
+    const bar = (day: number) => ({ t: `2026-09-0${day}T00:00:00Z`, o: day, h: day, l: day, c: day, v: 2 })
+    const fetcher = respond({ bars: { 'BTC/USD': [bar(3), bar(2)] }, next_page_token: 'next' }, { bars: { 'BTC/USD': [bar(1)] } })
+    const bars = await new AlpacaBroker(config).getHistorical(makeContract('BTC/USD'), { interval: '1d', limit: 3 })
+    expect(bars.map(b => b.close)).toEqual(['1', '2', '3'])
+    expect(String(fetcher.mock.calls[1][0])).toContain('page_token=next')
+    expect(String(fetcher.mock.calls[0][0])).not.toContain('adjustment')
+  })
+  it('retains snapshot provenance, explicit feed and continuation token', async () => {
+    const fetcher = respond({ snapshots: { SPY260918C00600000: { impliedVolatility: 0.2, greeks: { delta: 0.5 }, latestQuote: { t: '2026-09-10T00:00:00Z', bp: 2, ap: 3 } } }, next_page_token: 'page2' })
+    const result = await new AlpacaData(config).optionSnapshots('SPY', { expiration: '2026-09-18', limit: 1 })
+    expect(result.nextPageToken).toBe('page2')
+    expect(result.metadata).toMatchObject({ feed: 'indicative', indicative: true, possiblyDelayed: true })
+    expect(result.snapshots.SPY260918C00600000.greeks?.delta).toBe(0.5)
+    expect(String(fetcher.mock.calls[0][0])).toContain('expiration_date=2026-09-18')
+  })
+  it('does not silently cap contracts at the next weekend or omit OI dates', async () => {
+    const fetcher = respond({ option_contracts: [{ symbol: 'SPY260918C00600000', open_interest: '500', open_interest_date: '2026-09-09' }] })
+    const result = await new AlpacaData(config).optionContracts('SPY')
+    expect(String(fetcher.mock.calls[0][0])).toContain('paper-api.alpaca.markets')
+    expect(String(fetcher.mock.calls[0][0])).toContain('expiration_date_lte=2099-12-31')
+    expect(result.contracts[0].open_interest_date).toBe('2026-09-09')
+  })
+  it('propagates entitlement failures without silently switching feeds', async () => {
+    const fetcher = vi.fn().mockResolvedValue(new Response('{"message":"subscription required"}', { status: 403 }))
+    vi.stubGlobal('fetch', fetcher)
+    await expect(new AlpacaData(config).optionSnapshots('SPY', { feed: 'opra' })).rejects.toThrow(/403.*subscription required/)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Alpaca close and amendment boundaries', () => {
+  it('uses the positions endpoint compact symbol instead of a slash path', async () => {
+    const broker = new AlpacaBroker(config)
+    const closePosition = vi.fn().mockResolvedValue({ id: 'close', status: 'new' })
+    Object.assign(broker, { client: { closePosition } })
+    await broker.closePosition(makeContract('BTC/USD'))
+    expect(closePosition).toHaveBeenCalledWith('BTCUSD')
+  })
+  it('blocks option amendments and invalid crypto TIF before replacement', async () => {
+    const broker = new AlpacaBroker(config)
+    const replaceOrder = vi.fn()
+    const getOrder = vi.fn().mockResolvedValueOnce({ symbol: 'SPY260918C00600000', asset_class: 'us_option' }).mockResolvedValueOnce({ symbol: 'BTCUSD', asset_class: 'crypto' })
+    Object.assign(broker, { client: { getOrder, replaceOrder } })
+    expect((await broker.modifyOrder('option', { tif: 'DAY' })).error).toMatch(/read-only/)
+    expect((await broker.modifyOrder('crypto', { tif: 'DAY' })).error).toMatch(/GTC or IOC/)
+    expect(replaceOrder).not.toHaveBeenCalled()
+  })
+})

--- a/services/uta/src/domain/trading/brokers/alpaca/alpaca-types.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/alpaca-types.ts
@@ -18,6 +18,7 @@ export interface AlpacaBrokerRaw {
 }
 
 export interface AlpacaPositionRaw {
+  asset_class?: string
   symbol: string
   side: string
   qty: string
@@ -30,6 +31,7 @@ export interface AlpacaPositionRaw {
 }
 
 export interface AlpacaOrderRaw {
+  asset_class?: string
   id: string
   symbol: string
   side: string

--- a/services/uta/src/http/broker-research.spec.ts
+++ b/services/uta/src/http/broker-research.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createTradingRoutes } from './routes-trading.js'
+import type { UTAEngineContext } from '../types.js'
+
+function setup() {
+  const read = vi.fn().mockResolvedValue({ snapshots: {}, nextPageToken: 'next', metadata: { feed: 'indicative' } })
+  const account = {
+    id: 'alpaca', health: 'healthy', broker: { getOptionChain: read, getOptionContracts: read, getOrderBook: read },
+    contractFromAliceId: (id: string) => {
+      if (!id.startsWith('alpaca|')) throw new Error('Wrong account')
+      return { secType: id.includes('BTC') ? 'CRYPTO' : 'STK', symbol: id.split('|')[1] }
+    },
+  }
+  const routes = createTradingRoutes({ utaManager: { get: () => account } } as unknown as UTAEngineContext)
+  const post = (route: string, body: unknown) => routes.request(`/uta/alpaca/contract/${route}`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+  return { read, post }
+}
+describe('Broker research HTTP boundary', () => {
+  it('passes filters/feed/pagination unchanged without losing metadata', async () => {
+    const { read, post } = setup()
+    const res = await post('option-chain', { aliceId: 'alpaca|SPY', expiration: '2026-09-18', feed: 'opra', pageToken: 'cursor' })
+    expect(res.status).toBe(200)
+    expect(read).toHaveBeenCalledWith('SPY', { expiration: '2026-09-18', feed: 'opra', pageToken: 'cursor' })
+    expect(await res.json()).toMatchObject({ nextPageToken: 'next', metadata: { feed: 'indicative' } })
+  })
+  it('rejects invalid limits before touching the broker', async () => {
+    const { read, post } = setup()
+    expect((await post('option-contracts', { aliceId: 'alpaca|SPY', limit: 1001 })).status).toBe(400)
+    expect(read).not.toHaveBeenCalled()
+  })
+  it('does not accept a cross-account aliceId or a crypto underlying', async () => {
+    const { read, post } = setup()
+    expect((await post('option-chain', { aliceId: 'other|SPY' })).status).not.toBe(200)
+    expect((await post('option-chain', { aliceId: 'alpaca|BTC/USD' })).status).not.toBe(200)
+    expect(read).not.toHaveBeenCalled()
+  })
+  it('resolves depth contracts through the account and bounds requested levels', async () => {
+    const { read, post } = setup()
+    expect((await post('order-book', { aliceId: 'alpaca|BTC/USD', limit: 2 })).status).toBe(200)
+    expect(read).toHaveBeenCalledWith({ symbol: 'BTC/USD', secType: 'CRYPTO' }, 2)
+  })
+})

--- a/services/uta/src/http/routes-trading.ts
+++ b/services/uta/src/http/routes-trading.ts
@@ -1,3 +1,4 @@
+import { optionResearchSchema, orderBookSchema, type BrokerResearch } from '@traderalice/uta-protocol'
 import { Hono } from 'hono'
 import type { Context } from 'hono'
 import { z } from 'zod'
@@ -325,6 +326,36 @@ export function createTradingRoutes(ctx: UTAEngineContext) {
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
     }
+  })
+
+  for (const [route, method] of [['option-contracts', 'getOptionContracts'], ['option-chain', 'getOptionChain']] as const) {
+    app.post(`/uta/:id/contract/${route}`, async c => {
+      const account = resolveAccount(ctx, c)
+      if (!account) return c.json({ error: 'Account not found' }, 404)
+      const parsed = optionResearchSchema.safeParse(await c.req.json().catch(() => null))
+      if (!parsed.success) return c.json({ error: parsed.error.message }, 400)
+      return queryAccount(c, account, async () => {
+        const { aliceId, ...filters } = parsed.data
+        const contract = account.contractFromAliceId(aliceId)
+        if (contract.secType !== 'STK') throw new Error('Option research requires an underlying stock aliceId.')
+        const broker = account.broker as typeof account.broker & BrokerResearch
+        const read = broker[method]
+        if (!read) throw new Error(`${method} is not supported by this broker pack.`)
+        return read.call(broker, contract.symbol, filters)
+      })
+    })
+  }
+  app.post('/uta/:id/contract/order-book', async c => {
+    const account = resolveAccount(ctx, c)
+    if (!account) return c.json({ error: 'Account not found' }, 404)
+    const parsed = orderBookSchema.safeParse(await c.req.json().catch(() => null))
+    if (!parsed.success) return c.json({ error: parsed.error.message }, 400)
+    return queryAccount(c, account, async () => {
+      const contract = account.contractFromAliceId(parsed.data.aliceId)
+      const broker = account.broker as typeof account.broker & BrokerResearch
+      if (!broker.getOrderBook) throw new Error('Order books are not supported by this broker pack.')
+      return broker.getOrderBook(contract, parsed.data.limit ?? 20)
+    })
   })
 
   // Hub → leaves expansion (bond issuers, option chains, futures months).

--- a/src/domain/market-data/bars/bar-service.ts
+++ b/src/domain/market-data/bars/bar-service.ts
@@ -266,7 +266,7 @@ export function createBarService(deps: BarServiceDeps): BarService {
     // The broker's HONEST entitlement (Alpaca free = 'iex', CCXT = 'realtime'),
     // not a blanket 'realtime'. Falls back to 'realtime' when the gateway can't
     // surface it (mocks / brokers that declare no quality).
-    const caps: Record<string, BarCapability> = (await deps.utaManager.getBarCapabilities?.()) ?? {}
+    const caps: Record<string, BarCapability> = (await deps.utaManager.getBarCapabilities?.(barId)) ?? {}
     const cap = caps[sourceId]
     if (deps.utaManager.getBarCapabilities && !cap) {
       throw new Error(`UTA source "${sourceId}" does not advertise historical-bar support.`)

--- a/src/domain/market-data/bars/types.ts
+++ b/src/domain/market-data/bars/types.ts
@@ -161,7 +161,7 @@ export interface UtaBarGateway {
    *  the BROKER's honest entitlement (Alpaca free = 'iex', CCXT = 'realtime')
    *  instead of blanket-labeling every broker source 'realtime'. Optional: a
    *  gateway that can't surface it falls back to 'realtime'. */
-  getBarCapabilities?(): Promise<Record<string, BarCapability>>
+  getBarCapabilities?(aliceId?: string): Promise<Record<string, BarCapability>>
 }
 
 export interface BarServiceDeps {

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -235,6 +235,9 @@ const BASE_EXPORTS: Record<string, CliExport> = {
         details: 'getContractDetails',
         quote: 'getQuote',
         expand: 'expandContract',
+        'option-contracts': 'getOptionContracts',
+        'option-chain': 'getOptionChain',
+        'order-book': 'getOrderBook',
       },
       order: {
         list: 'getOrders',

--- a/src/services/uta-client/UTAAccountSDK.ts
+++ b/src/services/uta-client/UTAAccountSDK.ts
@@ -12,6 +12,7 @@
 
 import type {
   UTAClient,
+  OptionResearchRequest,
   AccountInfo,
   SubAccountRef,
   OrderHistoryEntry,
@@ -160,6 +161,18 @@ export class UTAAccountSDK {
       `/api/trading/uta/${encodeURIComponent(this.id)}/quote`,
       query,
     )
+  }
+
+  getOptionContracts(request: OptionResearchRequest): Promise<Record<string, unknown>> {
+    return this.client.post(`/api/trading/uta/${encodeURIComponent(this.id)}/contract/option-contracts`, request)
+  }
+
+  getOptionChain(request: OptionResearchRequest): Promise<Record<string, unknown>> {
+    return this.client.post(`/api/trading/uta/${encodeURIComponent(this.id)}/contract/option-chain`, request)
+  }
+
+  getOrderBook(request: { aliceId: string; limit?: number }): Promise<Record<string, unknown>> {
+    return this.client.post(`/api/trading/uta/${encodeURIComponent(this.id)}/contract/order-book`, request)
   }
 
   getMarketClock(): Promise<MarketClock> {

--- a/src/services/uta-client/UTAManagerSDK.spec.ts
+++ b/src/services/uta-client/UTAManagerSDK.spec.ts
@@ -126,3 +126,19 @@ describe('UTAManagerSDK — readonly product mode', () => {
     await expect(account.push('abc12345')).rejects.toThrow('Trading mode is readonly')
   })
 })
+
+describe('mixed-asset historical quality', () => {
+  it('uses the resolved contract type instead of labelling crypto as IEX', async () => {
+    const calls: string[] = []
+    const client = {
+      get: async () => ({ utas: [summary('alpaca', 'trading', {
+        capabilities: { supportedSecTypes: ['STK', 'CRYPTO'], supportedOrderTypes: [], historicalBars: { supported: true, quality: 'iex', qualityBySecType: { CRYPTO: 'realtime' } } },
+      })] }),
+      post: async (path: string) => { calls.push(path); return { contract: { secType: 'CRYPTO' } } },
+    } as never
+    const m = new UTAManagerSDK({ client })
+    expect(await m.getBarCapabilities('alpaca|BTC/USD')).toEqual({ alpaca: 'realtime' })
+    expect(calls[0]).toContain('/contracts/details')
+    expect(await m.getBarCapabilities()).toEqual({ alpaca: 'iex' })
+  })
+})

--- a/src/services/uta-client/UTAManagerSDK.ts
+++ b/src/services/uta-client/UTAManagerSDK.ts
@@ -132,7 +132,7 @@ export class UTAManagerSDK {
   /** sourceId → declared historical-bar quality, for the federated bar layer to
    *  report each broker's honest entitlement (Alpaca free = 'iex', CCXT =
    *  'realtime') rather than blanket-labeling broker sources 'realtime'. */
-  async getBarCapabilities(): Promise<Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'>> {
+  async getBarCapabilities(aliceId?: string): Promise<Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'>> {
     if (this.getUnavailableReason()) return {}
     const all = await this.listUTAs()
     const out: Record<string, 'realtime' | 'iex' | 'delayed' | 'subscription'> = {}
@@ -141,6 +141,11 @@ export class UTAManagerSDK {
       const historical = u.capabilities.historicalBars
       if (!historical?.supported) continue
       out[u.id] = historical.quality ?? 'realtime'
+      if (aliceId?.startsWith(`${u.id}|`) && historical.qualityBySecType) {
+        const account = await this.get(u.id)
+        const details = await account?.getContractDetails({ aliceId })
+        if (details) out[u.id] = historical.qualityBySecType[details.contract.secType] ?? out[u.id]
+      }
     }
     return out
   }

--- a/src/tool/trading.ts
+++ b/src/tool/trading.ts
@@ -1,3 +1,4 @@
+import { optionResearchSchema, orderBookSchema } from '@traderalice/uta-protocol'
 /**
  * AI Trading Tool Factory — pure tool shell layer
  *
@@ -470,6 +471,43 @@ If the result is an object with a \`degraded\` array, one or more accounts could
       },
     }),
 
+    getOptionContracts: tool({
+      description: 'Read one page of option contracts, including open interest and its observation date when supplied. Currently Alpaca. Returns nextPageToken; reuse filters to continue. Read-only; does not enable options trading.',
+      inputSchema: optionResearchSchema,
+      execute: async request => {
+        try {
+          const parsed = parseAliceId(request.aliceId)
+          if (!parsed) return { error: 'Invalid aliceId. Use contract search first.' }
+          const uta = await manager.resolveOne(parsed.utaId)
+          return { source: uta.id, ...await uta.getOptionContracts(request) }
+        } catch (err) { return handleBrokerError(err) }
+      },
+    }),
+    getOptionChain: tool({
+      description: 'Read one page of option snapshots: latest trade, quote, IV and Greeks when available. Currently Alpaca. Indicative feed has modified quotes and delayed trades; not executable OPRA. Inspect metadata and per-observation timestamps. Follow nextPageToken for more contracts.',
+      inputSchema: optionResearchSchema,
+      execute: async request => {
+        try {
+          const parsed = parseAliceId(request.aliceId)
+          if (!parsed) return { error: 'Invalid aliceId. Use contract search first.' }
+          const uta = await manager.resolveOne(parsed.utaId)
+          return { source: uta.id, ...await uta.getOptionChain(request) }
+        } catch (err) { return handleBrokerError(err) }
+      },
+    }),
+    getOrderBook: tool({
+      description: 'Read broker order-book depth for a contract. Available on Alpaca crypto and CCXT. Bids/asks are [price, quantity] levels; inspect the observation timestamp.',
+      inputSchema: orderBookSchema,
+      execute: async request => {
+        try {
+          const parsed = parseAliceId(request.aliceId)
+          if (!parsed) return { error: 'Invalid aliceId. Use contract search first.' }
+          const uta = await manager.resolveOne(parsed.utaId)
+          return { source: uta.id, ...await uta.getOrderBook(request) }
+        } catch (err) { return handleBrokerError(err) }
+      },
+    }),
+
     getQuote: tool({
       description: `Query the latest quote/price for a contract.
 If this tool returns an error with transient=true, wait a few seconds and retry once before reporting to the user.`,
@@ -506,7 +544,7 @@ Venue search returns two species: LEAVES (tradeable, with conId-style aliceId) a
 - Bond issuer hub (aliceId like "ibkr-x|issuer:e1400789"): expands to the issuer's individual bonds.
 - Stock underlying (numeric aliceId): no expiry → option-chain parameter grid (expirations × strikes); with expiry → concrete option contracts for that expiry.
 - secType=FUT on an underlying: futures contract months.
-Every returned leaf carries its own aliceId usable with getQuote / placeOrder.`,
+Returned leaves carry aliceId. Broker capabilities still govern trading; Alpaca options are read-only (use option-chain for snapshots).`,
       inputSchema: z.object({
         aliceId: z.string().describe('Hub or underlying contract ID (format: accountId|nativeKey, from searchContracts)'),
         expiry: z.string().optional().describe('Expiry YYYYMMDD or YYYYMM — switches option expansion from the grid to concrete contracts'),


### PR DESCRIPTION
Alpaca crypto assets were treated as stocks, sending quotes and bars to equity endpoints and losing asset identity in orders and positions. Route crypto through native data endpoints, preserve CRYPTO identity, enforce supported order types and time-in-force, and close positions using the compact symbol required by Alpaca. Historical bars now report quality by security type instead of applying IEX to crypto.

Add paginated, read-only option contracts and chain snapshots plus crypto order books through UTA, SDK, tools and CLI. Preserve individual observation timestamps, feed, Greeks and dated open interest; indicative data is explicitly marked. Options orders remain disabled. Update the injected Skill and broker guide.

Validation:
- Full hermetic suite: 6,920 passed, 3 skipped, zero failures (778 files).
- Final targeted regression suite: 120 passed; UTA integration: 15 passed.
- Root, protocol, UTA service and Alpaca package typechecks passed.
- Packaged Alpaca build and compiled import smoke passed.
- Real CLI and browser: BTC/ETH quotes, bars, order books and SPY contracts/chain pagination.
- Verified paper account: limit placement, modification, cancellation, $12 notional buy and full close. Final BTC position absent, no open orders or pending approval/staged writes; pre-existing stock quantities unchanged.
