### PR TITLE
fix: make dev runtime and broker upgrades content-aware

### DIFF
--- a/.github/workflows/cli-installer-smoke.yml
+++ b/.github/workflows/cli-installer-smoke.yml
@@ -261,8 +261,48 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  build-dev-broker-packs:
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14, platform: darwin, arch: arm64 }
+          - { os: macos-15-intel, platform: darwin, arch: x64 }
+          - { os: ubuntu-24.04, platform: linux, arch: x64 }
+          - { os: ubuntu-24.04-arm, platform: linux, arch: arm64 }
+          - { os: windows-latest, platform: win32, arch: x64 }
+          - { os: windows-11-arm, platform: win32, arch: arm64 }
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
+    env:
+      OPENALICE_DEV_COMMIT: ${{ github.sha }}
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+          architecture: ${{ matrix.arch }}
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+      - run: pnpm install --frozen-lockfile --filter='!@traderalice/desktop'
+      - run: pnpm broker-packs:build
+      - run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dev-broker-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            dist/broker-packs/*.json
+            dist/broker-packs/*.tgz
+          if-no-files-found: error
+          compression-level: 0
+
   build-dev-cli:
-    needs: build-dev-cli-neutral
+    needs: [build-dev-cli-neutral, build-dev-broker-packs]
     if: github.event_name == 'push'
     name: Build dev native CLI (${{ matrix.platform }}-${{ matrix.arch }})
     strategy:
@@ -318,7 +358,13 @@ jobs:
         if: matrix.platform == 'linux' && matrix.arch == 'x64'
         run: pnpm build:bun-runtime:feasibility
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: dev-broker-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/dev-broker-packs
       - name: Build native CLI
+        env:
+          OPENALICE_DEV_COMMIT: ${{ github.sha }}
         run: pnpm build:bun:release
 
       - name: Name the native acceptance report
@@ -340,13 +386,14 @@ jobs:
           retention-days: 7
 
   build-dev-cli-windows:
-    needs: build-dev-cli-neutral
+    needs: [build-dev-cli-neutral, build-dev-broker-packs]
     if: github.event_name == 'push'
     uses: ./.github/workflows/windows-cli-preview.yml
     with:
       channel_build: true
       artifact_prefix: dev-cli
       neutral_inputs: true
+      dev_broker_packs: true
       native_acceptance: false
 
   publish-dev-cli-candidate:
@@ -366,6 +413,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: dev-cli-*
+          path: dist/dev-cli-candidates
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dev-broker-*
           path: dist/dev-cli-candidates
           merge-multiple: true
 
@@ -427,7 +480,8 @@ jobs:
 
           for file in "dist/dev-cli-upload/releases/${GITHUB_SHA}"/*; do
             case "$file" in
-              *.tar.gz) content_type="application/gzip" ;;
+              *.tar.gz|*.tgz) content_type="application/gzip" ;;
+              *.json) content_type="application/json" ;;
               *.sha256) content_type="text/plain" ;;
               */install) content_type="text/x-shellscript" ;;
               */install.ps1) content_type="text/plain" ;;

--- a/.github/workflows/windows-cli-preview.yml
+++ b/.github/workflows/windows-cli-preview.yml
@@ -29,6 +29,9 @@ on:
       neutral_inputs:
         type: boolean
         default: false
+      dev_broker_packs:
+        type: boolean
+        default: false
       neutral_artifact:
         type: string
         default: rolling-dev-neutral-inputs
@@ -88,8 +91,15 @@ jobs:
       - name: Verify shared server inputs
         if: inputs.candidate_run == '' && inputs.neutral_inputs
         run: node scripts/prepare-cli-neutral-inputs.mjs verify --repository-root . --input-dir dist/dev-neutral-inputs --commit "${{ github.sha }}" --install
+      - uses: actions/download-artifact@v4
+        if: inputs.dev_broker_packs && inputs.candidate_run == ''
+        with:
+          name: dev-broker-win32-${{ matrix.arch }}
+          path: dist/dev-broker-packs
       - name: Assemble preview before native acceptance
         if: inputs.candidate_run == ''
+        env:
+          OPENALICE_DEV_COMMIT: ${{ inputs.dev_broker_packs && github.sha || '' }}
         run: bun scripts/build-windows-cli-preview.ts ${{ matrix.arch }}
       - name: Preserve complete candidate for reproduction
         id: preserve

--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -112,7 +112,7 @@ have open. Pack directories are replaceable machine/runtime state: backup
 incompatible machine.
 
 On production startup Alice reconciles only Packs that already have an active
-downloaded release. A Pack produced by another OpenAlice version continues
+downloaded release. A Pack produced by another OpenAlice version or a different bound dev content revision continues
 serving through the supported Pack API while Alice downloads the current
 platform artifact, validates it, atomically switches `active.json`, and asks
 Guardian to restart UTA. A prior Pack with an old API is not loaded, but its
@@ -125,6 +125,20 @@ development and test runtimes skip automatic network reconciliation.
 Linux catalogs may declare a minimum glibc version. The current Longbridge GNU
 artifact requires glibc 2.39, so older Ubuntu/WSL systems are rejected before
 the native module is loaded instead of crashing UTA with `ERR_DLOPEN_FAILED`.
+
+Rolling dev CLI releases bundle `share/openalice/broker-pack-source.json`.
+Its catalog is bound to the same full source commit and covered by the CLI
+content identity. Status compares the active Pack content ID with the expected
+archive SHA-256 prefix, even when both have the same product version. This
+check is local; installed dev versions never consult a mutable latest catalog.
+Archives are downloaded on demand from `cli/dev/releases/<commit>/`.
+Explicit catalog/base URL overrides remain available for controlled tests.
+Stable/legacy releases without a binding retain their versioned catalog lookup.
+
+The dev publisher builds and loads Packs on native hosts, validates all archive
+hashes and the embedded catalog agreement, and publishes immutable Pack assets
+before advancing the CLI channel receipt. Longbridge is omitted on Windows
+ARM64 because its upstream native binding is unavailable there.
 
 ## Release Assets
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -49,6 +49,14 @@ loop on a host with no Node, Bun, or Agent Runtime installed. Real long-latency
 Agent TUI measurements remain a separate release observation rather than a
 reason to invent a new terminal protocol preemptively.
 
+Native `server run/start` derives its content identity from the installed
+`release.json`, matching the interactive launcher. Readiness confirms pending
+activation only when the running identity matches the installed pointer.
+Ownership contention exits with code 75 and does not roll back the installed
+release; corrupted or non-starting releases retain the existing rollback path.
+On Linux, process identity prefers procfs start ticks plus boot time, with the
+existing conservative fallback when process metadata cannot be read.
+
 ## Product Decision
 
 OpenAlice has four first-class entry surfaces, not one replacement chain:

--- a/packages/cli/bin/openalice-bun.ts
+++ b/packages/cli/bin/openalice-bun.ts
@@ -77,6 +77,7 @@ main().then(
   (error: unknown) => {
     const message = error instanceof Error ? error.message : String(error)
     process.stderr.write(`openalice: ${message}\n`)
-    process.exitCode = 1
+    const exitCode = (error as { exitCode?: number } | null)?.exitCode
+    process.exitCode = Number.isInteger(exitCode) ? exitCode! : 1
   },
 )

--- a/packages/cli/src/lifecycle.mjs
+++ b/packages/cli/src/lifecycle.mjs
@@ -29,6 +29,7 @@ import {
   bunGuardianProcessSpec,
   isBunStandalone,
   resolveBunResourceRoot,
+  resolveBunContentIdentity,
 } from './bun-standalone.mjs'
 
 const NULL_OUTPUT = Object.freeze({ write: () => undefined })
@@ -173,8 +174,10 @@ export async function startRuntime(options, dependencies = {}) {
     const rejectExit = (code, signal) => {
       if (!ready) {
         reject(lifecycleError(
-          'EEARLYEXIT',
-          `OpenAlice Runtime exited before it was ready (code=${String(code)}, signal=${String(signal)})`,
+          code === 75 ? 'EOWNED' : 'EEARLYEXIT',
+          code === 75
+            ? 'OpenAlice Runtime could not acquire its writer lease; the installed release was preserved'
+            : `OpenAlice Runtime exited before it was ready (code=${String(code)}, signal=${String(signal)})`,
         ))
       }
     }
@@ -256,8 +259,7 @@ function resolveRuntimeProvider(explicit, appDir, env) {
     return {
       kind: 'bun',
       contentIdentity: explicit?.contentIdentity
-        ?? env['OPENALICE_RUNTIME_CONTENT_IDENTITY']?.trim()
-        ?? null,
+        ?? resolveBunContentIdentity(appDir, env),
     }
   }
   if (explicit?.kind === 'bundle') {

--- a/packages/cli/src/lifecycle.spec.mjs
+++ b/packages/cli/src/lifecycle.spec.mjs
@@ -151,6 +151,43 @@ describe('OpenAlice Runtime lifecycle core', () => {
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 
+  it.skipIf(process.platform === 'win32')('preserves pending installation when the writer lease is occupied', async () => {
+    const fixture = await makeActivationLayout()
+    await recordPendingActivation(fixture.layout, {
+      activeRelease: fixture.currentName,
+      previousRelease: fixture.previousName,
+      productVersion: '0.92.0',
+    })
+    const child = new FakeChild()
+    child.pid = 456
+    const spawnProcess = () => {
+      setImmediate(() => child.emit('exit', 75, null))
+      return child
+    }
+
+    await expect(startRuntime(startOptions(), {
+      activationLayout: fixture.layout,
+      installedContentIdentityImpl: () => 'bbbbbbbbbbbbbbbb',
+      detached: true,
+      env: {},
+      nodeBinary: '/test/node',
+      resolveRoot: async (path) => path,
+      prepareSource: async () => ({ prepared: false }),
+      spawnProcess,
+      openFile: async () => ({ fd: 9, close: async () => undefined }),
+      mkdirImpl: async () => undefined,
+      readStatus: async () => absentStatus(),
+      sleep: async () => new Promise(() => undefined),
+    })).rejects.toMatchObject({
+      code: 'EOWNED',
+    })
+    expect(await readlink(fixture.layout.currentPath)).toBe(join('releases', fixture.currentName))
+    expect(await readActivationReceipt(fixture.layout)).toMatchObject({
+      state: 'pending',
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
   it('does not race a live installer while handling readiness failure', async () => {
     const fixture = await makeActivationLayout()
     await recordPendingActivation(fixture.layout, {
@@ -284,6 +321,11 @@ describe('OpenAlice Runtime lifecycle core', () => {
   it('starts the Bun Guardian role without source preparation', async () => {
     vi.stubGlobal('__OPENALICE_BUN_STANDALONE__', true)
     try {
+      const root = await mkdtemp(join(tmpdir(), 'alice-native-identity-'))
+      temporaryPaths.push(root)
+      const resources = join(root, 'share/openalice')
+      await mkdir(resources, {recursive: true})
+      await writeFile(join(root, 'release.json'), JSON.stringify({contentIdentity: 'bbbbbbbbbbbbbbbb'}))
       const child = new FakeChild()
       const prepareSource = vi.fn()
       const resolveRoot = vi.fn()
@@ -295,11 +337,10 @@ describe('OpenAlice Runtime lifecycle core', () => {
       await startRuntime({
         ...startOptions(),
         appDir: null,
-        runtimeProvider: { kind: 'bun', contentIdentity: 'release-content-1' },
       }, {
         detached: true,
         env: {
-          OPENALICE_APP_HOME: '/opt/openalice/releases/v1/share/openalice',
+          OPENALICE_APP_HOME: resources,
           OPENALICE_MANAGED_PI_PATH: '/desktop/pi/cli.js',
           OPENALICE_MANAGED_PI_NODE_PATH: '/desktop/node',
           PI_CODING_AGENT_DIR: '/native/pi',
@@ -324,9 +365,10 @@ describe('OpenAlice Runtime lifecycle core', () => {
         '/opt/openalice/releases/v1/bin/openalice',
         ['--internal-role', 'guardian'],
         expect.objectContaining({
-          cwd: resolve('/opt/openalice/releases/v1/share/openalice'),
+          cwd: resources,
           env: expect.objectContaining({
             OPENALICE_RUNTIME_PROVIDER: 'bun',
+            OPENALICE_RUNTIME_CONTENT_IDENTITY: 'bbbbbbbbbbbbbbbb',
             OPENALICE_RUNTIME_EXECUTABLE: '/opt/openalice/releases/v1/bin/openalice',
             PI_CODING_AGENT_DIR: '/native/pi',
           }),

--- a/packages/guardian-runtime/src/process-control.spec.ts
+++ b/packages/guardian-runtime/src/process-control.spec.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import { once } from 'node:events'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { normalizeProcessExitCode, terminateProcessTree } from './process-control.js'
+import { linuxProcessStartedAt, readProcessStartedAt, normalizeProcessExitCode, terminateProcessTree } from './process-control.js'
 
 const cleanupPids = new Set<number>()
 
@@ -68,3 +68,19 @@ function isAlive(pid: number): boolean {
     return false
   }
 }
+
+
+describe('Linux process identity', () => {
+  it('reads start ticks despite spaces and parentheses in the process name', () => {
+    const fields = ['S', ...Array(18).fill('0'), '12345', '0']
+    expect(linuxProcessStartedAt(`42 (worker (alice)) ${fields.join(' ')}`, 'cpu 1 2\nbtime 1700000000\n', 100)).toBe(1700000123450)
+    expect(linuxProcessStartedAt('42 broken', 'btime 1700000000', 100)).toBeNull()
+    expect(linuxProcessStartedAt(`42 (x) ${fields.join(' ')}`, 'cpu 1', 100)).toBeNull()
+    expect(linuxProcessStartedAt(`42 (x) ${fields.join(' ')}`, 'btime 1700000000', 0)).toBeNull()
+  })
+  it.skipIf(process.platform !== 'linux')('reads the real process start without locale-dependent ps output', async () => {
+    const started = await readProcessStartedAt(process.pid)
+    expect(started).not.toBeNull()
+    expect(Math.abs(started! - (Date.now() - process.uptime() * 1000))).toBeLessThan(3000)
+  })
+})

--- a/packages/guardian-runtime/src/process-control.ts
+++ b/packages/guardian-runtime/src/process-control.ts
@@ -128,7 +128,22 @@ async function waitForProcessesExit(
   return pids.every((pid) => !controller.isAlive(pid))
 }
 
-async function readProcessStartedAt(pid: number): Promise<number | null> {
+export async function readProcessStartedAt(pid: number): Promise<number | null> {
+  try {
+    if (process.platform === 'linux') {
+      // procfs has stable machine-readable timestamps, independent of ps,
+      // locale and process-spawn contention during container startup.
+      const [processStat, bootStat, ticks] = await Promise.all([
+        readFile(`/proc/${pid}/stat`, 'utf8'),
+        readFile('/proc/stat', 'utf8'),
+        linuxClockTicks(),
+      ])
+      const started = linuxProcessStartedAt(processStat, bootStat, ticks)
+      if (started !== null) return started
+    }
+  } catch {
+    // Restricted procfs: retain the conservative cross-platform fallback.
+  }
   try {
     if (process.platform === 'win32') {
       const script = `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')`
@@ -235,4 +250,26 @@ export async function listDescendantPids(rootPid: number): Promise<number[]> {
   } catch {
     return []
   }
+}
+
+
+let clockTicks: Promise<number> | undefined
+function linuxClockTicks(): Promise<number> {
+  clockTicks ??= execFileAsync('getconf', ['CLK_TCK'], { timeout: 2_000 })
+    .then(({ stdout }) => {
+      const value = Number(stdout.trim())
+      if (!Number.isSafeInteger(value) || value <= 0) throw new Error('Invalid CLK_TCK')
+      return value
+    }).catch((error) => { clockTicks = undefined; throw error })
+  return clockTicks
+}
+
+/** /proc/<pid>/stat field 22; comm may itself contain spaces and parentheses. */
+export function linuxProcessStartedAt(processStat: string, bootStat: string, ticks: number): number | null {
+  const fields = processStat.slice(processStat.lastIndexOf(')') + 2).trim().split(/\s+/)
+  const startTicks = Number(fields[19])
+  const bootSeconds = Number(/^btime\s+(\d+)$/m.exec(bootStat)?.[1])
+  if (!Number.isFinite(startTicks) || startTicks < 0 || !Number.isFinite(bootSeconds)
+      || !Number.isFinite(ticks) || ticks <= 0 || !processStat.includes(')')) return null
+  return Math.floor((bootSeconds + startTicks / ticks) * 1_000)
 }

--- a/packages/guardian-runtime/src/runtime-lock.ts
+++ b/packages/guardian-runtime/src/runtime-lock.ts
@@ -86,6 +86,8 @@ export interface PrepareOpenAliceRuntimeOptions {
 }
 
 export class RuntimeAlreadyRunningError extends Error {
+  /** EX_TEMPFAIL: ownership contention must not roll back installed bytes. */
+  readonly exitCode = 75
   constructor(readonly inspection: RuntimeLockInspection) {
     const owner = inspection.owner
     super(owner

--- a/scripts/beta-release-prep-workflow.spec.ts
+++ b/scripts/beta-release-prep-workflow.spec.ts
@@ -115,7 +115,7 @@ describe('exact beta release-preparation workflow lane', () => {
     expect(jobs['checkout-install'].if).not.toContain("github.base_ref == 'master'")
     expect(jobs['build-dev-cli-neutral'].if).toBe("github.event_name == 'push'")
     expect(jobs['build-dev-cli'].if).toBe("github.event_name == 'push'")
-    expect(jobs['build-dev-cli'].needs).toBe('build-dev-cli-neutral')
+    expect(jobs['build-dev-cli'].needs).toEqual(['build-dev-cli-neutral', 'build-dev-broker-packs'])
     expect(jobs['publish-dev-cli-candidate'].needs).toEqual(['build-dev-cli', 'build-dev-cli-windows'])
     expect(jobs['activate-dev-cli'].needs).toBe('publish-dev-cli-candidate')
   })

--- a/scripts/build-broker-packs.ts
+++ b/scripts/build-broker-packs.ts
@@ -1,6 +1,7 @@
 /** Build platform-specific, self-contained broker-pack release archives. */
 
 import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
 import { createReadStream } from 'node:fs'
 import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -14,6 +15,7 @@ import {
 import {
   brokerPackArchiveFileName,
   brokerPackCatalogFileName,
+  supportedBrokerPackEngines,
   type BrokerPackReleaseAsset,
   type BrokerPackRequirement,
   type BrokerPackReleaseCatalog,
@@ -23,6 +25,7 @@ import { runPnpmSync } from './pnpm-command.mjs'
 const repoRoot = resolve(import.meta.dirname, '..')
 const packageJson = JSON.parse(await readFile(resolve(repoRoot, 'package.json'), 'utf8')) as { version: string }
 const outputArg = process.argv.indexOf('--out-dir')
+if (process.env['OPENALICE_DEV_COMMIT'] && !/^[a-f0-9]{40}$/.test(process.env['OPENALICE_DEV_COMMIT'])) throw new Error('Invalid dev commit')
 const outDir = resolve(repoRoot, outputArg >= 0 ? process.argv[outputArg + 1] : 'dist/broker-packs')
 
 const packageNames: Record<InstallableBrokerEngine, string> = {
@@ -39,7 +42,7 @@ await mkdir(outDir, { recursive: true })
 const tempRoot = await mkdtemp(resolve(tmpdir(), 'openalice-broker-packs-'))
 const packs: BrokerPackReleaseAsset[] = []
 try {
-  for (const engine of INSTALLABLE_BROKER_ENGINES) {
+  for (const engine of supportedBrokerPackEngines()) {
     const deployRoot = resolve(tempRoot, engine)
     deployPackage(packageNames[engine], deployRoot)
     await sanitizeDeployment(engine, deployRoot)
@@ -54,6 +57,7 @@ try {
       cwd: deployRoot,
       file: archivePath,
       portable: true,
+      noMtime: true,
       sync: true,
     }, ['.'])
     const archiveStat = await stat(archivePath)
@@ -75,7 +79,10 @@ try {
     openAliceVersion: packageJson.version,
     platform: process.platform,
     arch: process.arch,
-    generatedAt: new Date().toISOString(),
+    ...(process.env['OPENALICE_DEV_COMMIT'] ? { sourceCommit: process.env['OPENALICE_DEV_COMMIT'] } : {}),
+    generatedAt: process.env['OPENALICE_DEV_COMMIT']
+      ? new Date(execFileSync('git', ['show', '-s', '--format=%cI', process.env['OPENALICE_DEV_COMMIT']], {cwd: repoRoot, encoding: 'utf8'}).trim()).toISOString()
+      : new Date().toISOString(),
     packs,
   }
   const catalogPath = resolve(outDir, brokerPackCatalogFileName(packageJson.version))

--- a/scripts/build-bun-release.ts
+++ b/scripts/build-bun-release.ts
@@ -1,3 +1,5 @@
+import { acceptNativeUpgrade } from './native-upgrade-acceptance.mjs'
+import { writeDevBrokerBinding } from './dev-broker-binding.mjs'
 import { runtimeCompileOptions } from './bun-compile-options.js'
 import { createHash } from 'node:crypto'
 import {
@@ -95,6 +97,8 @@ await Promise.all([
 await mkdir(join(releaseRoot, 'licenses'), { recursive: true })
 await cp(join(repositoryRoot, 'node_modules/dugite/LICENSE'), join(releaseRoot, 'licenses/dugite-LICENSE'))
 await materializeWorkspaceCli()
+
+await writeDevBrokerBinding(resourceRoot, { commit: process.env['OPENALICE_DEV_COMMIT'], inputDir: join(repositoryRoot, 'dist/dev-broker-packs'), version: product.version, platform: platformName, arch: process.arch })
 
 const files = await releaseFiles(releaseRoot, new Set(['release.json']))
 const unsignedReleaseMetadata = {
@@ -593,6 +597,7 @@ printf '%s\\n' "${'$'}1" > "${'$'}OPENALICE_SMOKE_OPEN_RECEIPT"
   if (runtimeError || exitCode !== 0) {
     throw new Error(`installed release Runtime failed: ${String(runtimeError)}\n${stdout}\n${stderr}`)
   }
+  const upgrade = await acceptNativeUpgrade({executablePath: options.executablePath, scratch: options.smokeHome, env: runtimeEnv, home: runtimeHome})
   const workspaceSessionLog = await readFile(
     join(runtimeHome, 'logs', 'workspace-sessions.log'),
     'utf8',
@@ -601,6 +606,7 @@ printf '%s\\n' "${'$'}1" > "${'$'}OPENALICE_SMOKE_OPEN_RECEIPT"
     throw new Error('installed release did not persist Workspace session logs under the selected Project Home')
   }
   return {
+    upgrade,
     nodeOrBunOnPath: false,
     gitInitCommitClone: true,
     networkGit: process.env['OPENALICE_BUN_NETWORK_GIT'] === '1',

--- a/scripts/build-windows-cli-preview.ts
+++ b/scripts/build-windows-cli-preview.ts
@@ -1,3 +1,4 @@
+import { writeDevBrokerBinding } from './dev-broker-binding.mjs'
 import { createHash } from 'node:crypto'
 import { cp, mkdir, mkdtemp, readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, relative, resolve } from 'node:path'
@@ -66,6 +67,8 @@ export MSYS2_ENV_CONV_EXCL='OPENALICE_TOOL_URL;OPENALICE_TOOL_SOCKET'
 exec "$(cygpath -u "$OPENALICE_RUNTIME_EXECUTABLE")" --workspace-cli ${helper} "$@"
 `, { mode: 0o755 })
 }
+
+await writeDevBrokerBinding(resources, { commit: process.env.OPENALICE_DEV_COMMIT, inputDir: join(root, 'dist/dev-broker-packs'), version, platform: 'win32', arch })
 
 if (channelBuild) await cp(join(root, 'install.ps1'), join(resources, 'install.ps1'))
 if (!channelBuild) {

--- a/scripts/cli-installer-workflow.spec.ts
+++ b/scripts/cli-installer-workflow.spec.ts
@@ -89,7 +89,7 @@ describe('CLI installer dev publication workflow', () => {
       'retention-days': 7,
     })
     expect(String(neutralUpload?.name)).not.toMatch(/^dev-cli-/)
-    expect(build.needs).toBe('build-dev-cli-neutral')
+    expect(build.needs).toEqual(['build-dev-cli-neutral', 'build-dev-broker-packs'])
     expect(build.strategy?.matrix?.include).toEqual([
       { os: 'macos-14', platform: 'darwin', arch: 'arm64' },
       { os: 'macos-15-intel', platform: 'darwin', arch: 'x64' },

--- a/scripts/dev-broker-binding.mjs
+++ b/scripts/dev-broker-binding.mjs
@@ -1,0 +1,40 @@
+import { createHash } from 'node:crypto'
+import { readFileSync, copyFileSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export function readDevBrokerCatalog(inputDir, { commit, version, platform, arch }, outputDir) {
+  if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error('Invalid dev broker commit')
+  const name = `OpenAlice-Broker-Packs-${version}-${platform}-${arch}.json`
+  const catalog = JSON.parse(readFileSync(join(inputDir, name), 'utf8'))
+  const engines = ['ccxt', 'alpaca', 'ibkr', 'leverup', 'longbridge']
+    .filter(engine => !(engine === 'longbridge' && platform === 'win32' && arch === 'arm64'))
+  if (catalog.schemaVersion !== 1 || catalog.sourceCommit !== commit || catalog.openAliceVersion !== version
+      || catalog.platform !== platform || catalog.arch !== arch || !Array.isArray(catalog.packs)
+      || catalog.packs.map(p => p.engine).sort().join() !== engines.sort().join()) {
+    throw new Error('Dev broker catalog does not match CLI candidate')
+  }
+  for (const asset of catalog.packs) {
+    const expectedFile = `OpenAlice-Broker-${asset.engine}-${version}-${platform}-${arch}.tgz`
+    if (asset.file !== expectedFile || asset.version !== version || asset.apiVersion !== 1
+        || asset.entry !== 'dist/index.js' || !/^[a-f0-9]{64}$/.test(asset.sha256)) {
+      throw new Error('Invalid dev broker asset metadata')
+    }
+    const bytes = readFileSync(join(inputDir, expectedFile))
+    if (bytes.length !== asset.size || createHash('sha256').update(bytes).digest('hex') !== asset.sha256) {
+      throw new Error(`Dev broker checksum mismatch: ${expectedFile}`)
+    }
+    if (outputDir) copyFileSync(join(inputDir, expectedFile), join(outputDir, expectedFile))
+  }
+  if (outputDir) copyFileSync(join(inputDir, name), join(outputDir, name))
+  return catalog
+}
+
+/** The catalog is covered by the CLI archive checksum/content identity. */
+export async function writeDevBrokerBinding(resourceRoot, options) {
+  if (!options.commit) return
+  const catalog = readDevBrokerCatalog(options.inputDir, options)
+  await writeFile(join(resourceRoot, 'broker-pack-source.json'), JSON.stringify({
+    schemaVersion: 1, commit: options.commit, catalog,
+  }, null, 2) + '\n')
+}

--- a/scripts/guardian/prod.mjs
+++ b/scripts/guardian/prod.mjs
@@ -699,6 +699,6 @@ export async function startGuardianRuntime() {
 if (!globalThis.__OPENALICE_INTERNAL_ROLE_DISPATCH__) {
   startGuardianRuntime().catch((err) => {
     console.error('[guardian/prod] fatal:', err)
-    shutdown(1)
+    shutdown(Number.isInteger(err?.exitCode) ? err.exitCode : 1)
   })
 }

--- a/scripts/native-upgrade-acceptance.mjs
+++ b/scripts/native-upgrade-acceptance.mjs
@@ -1,0 +1,52 @@
+import { cp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { bunReleaseContentIdentity } from './bun-release-content-identity.mjs'
+
+const execute = promisify(execFile)
+
+/** Real server lifecycle across two same-version resource revisions, isolated from user state. */
+export async function acceptNativeUpgrade({ executablePath, scratch, env, home }) {
+  const source = dirname(dirname(executablePath))
+  const original = JSON.parse(await readFile(join(source, 'release.json'), 'utf8'))
+  const root = join(scratch, 'upgrade-install')
+  const releases = join(root, 'cli/releases')
+  await mkdir(releases, { recursive: true })
+  const old = structuredClone(original)
+  const marker = Buffer.from('previous resource revision\n')
+  old.files.push({path: 'upgrade-fixture.txt', type: 'file', bytes: marker.length, mode: 0o644, sha256: createHash('sha256').update(marker).digest('hex')})
+  old.contentIdentity = bunReleaseContentIdentity(old)
+  const names = [old, original].map(metadata => `${metadata.version}-${metadata.contentIdentity}`)
+  for (const [index, metadata] of [old, original].entries()) {
+    const release = join(releases, names[index])
+    await cp(source, release, {recursive: true})
+    if (index === 0) await writeFile(join(release, 'upgrade-fixture.txt'), marker)
+    await writeFile(join(release, 'release.json'), JSON.stringify(metadata))
+  }
+  const activationPath = join(root, 'cli/activation.json')
+  let activeEnv
+  let binary
+  const invoke = async args => execute(binary, ['server', ...args, '--home', home], {env: activeEnv, timeout: 120_000, maxBuffer: 2 * 1024 * 1024})
+  try {
+    for (const [index, name] of names.entries()) {
+      await rm(join(root, 'cli/current'), {force: true})
+      await symlink(join('releases', name), join(root, 'cli/current'))
+      const release = join(releases, name)
+      activeEnv = {...env, OPENALICE_INSTALL_ROOT: root, OPENALICE_RELEASE_DIR: release, OPENALICE_APP_HOME: join(release, 'share/openalice')}
+      delete activeEnv.OPENALICE_RUNTIME_CONTENT_IDENTITY
+      delete activeEnv.OPENALICE_CONTENT_IDENTITY
+      binary = join(release, 'bin/openalice')
+      await writeFile(activationPath, JSON.stringify({schemaVersion: 1, activeRelease: name, previousRelease: index ? names[0] : null, productVersion: original.version, state: 'pending', activatedAt: new Date().toISOString()}))
+      await invoke(['start', '--port', env.OPENALICE_WEB_PORT, '--wait', '90'])
+      const status = JSON.parse((await invoke(['status', '--json'])).stdout)
+      if (status.provider?.contentIdentity !== [old, original][index].contentIdentity || status.pendingActivation) throw new Error('Native server did not activate the installed content')
+      if (JSON.parse(await readFile(activationPath, 'utf8')).state !== 'confirmed') throw new Error('Native activation remained pending')
+      await invoke(['stop', '--wait', '30'])
+    }
+  } finally {
+    if (binary) await invoke(['stop', '--wait', '30']).catch(() => undefined)
+  }
+  return {sameVersion: original.version, previous: old.contentIdentity, current: original.contentIdentity, confirmed: true}
+}

--- a/scripts/prepare-cli-dev-assets.mjs
+++ b/scripts/prepare-cli-dev-assets.mjs
@@ -10,6 +10,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { bunReleaseContentIdentity } from './bun-release-content-identity.mjs'
 import { CLI_RELEASE_TARGETS, cliExecutableName } from '../packages/cli/src/release-targets.mjs'
 
+import { readDevBrokerCatalog } from './dev-broker-binding.mjs'
+
 export { CLI_RELEASE_TARGETS }
 const PINNED_BUN_VERSION = readFileSync(new URL('../.bun-version', import.meta.url), 'utf8').trim()
 // PortableGit's complete file inventory exceeds child_process's 1 MiB default.
@@ -61,6 +63,18 @@ export function prepareCliDevAssets({ inputDir, outputDir, commit, version, inst
       platform,
       arch,
     })
+
+    const catalog = readDevBrokerCatalog(inputRoot, { commit, version, platform, arch }, immutableRoot)
+    const bindingPath = `${archiveName.slice(0, -'.tar.gz'.length)}/share/openalice/broker-pack-source.json`
+    const bindingBytes = execFileSync('tar', ['-xOzf', archivePath, bindingPath])
+    const binding = JSON.parse(bindingBytes.toString('utf8'))
+    const bindingEntry = metadata.files.find(entry => entry.path === 'share/openalice/broker-pack-source.json')
+    if (bindingEntry?.sha256 !== createHash('sha256').update(bindingBytes).digest('hex') || bindingEntry?.bytes !== bindingBytes.length) {
+      throw new Error('CLI content identity does not cover its broker catalog')
+    }
+    if (binding.schemaVersion !== 1 || binding.commit !== commit || JSON.stringify(binding.catalog) !== JSON.stringify(catalog)) {
+      throw new Error('CLI broker binding differs from published catalog')
+    }
 
     copyFileSync(archivePath, join(immutableRoot, archiveName))
     copyFileSync(checksumPath, join(immutableRoot, `${archiveName}.sha256`))

--- a/scripts/prepare-cli-dev-assets.spec.mjs
+++ b/scripts/prepare-cli-dev-assets.spec.mjs
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { cliExecutableName } from '../packages/cli/src/release-targets.mjs'
 import { bunReleaseContentIdentity } from './bun-release-content-identity.mjs'
+import { writeDevBrokerBinding } from './dev-broker-binding.mjs'
 import { prepareCliDevAssets } from './prepare-cli-dev-assets.mjs'
 
 const execFileAsync = promisify(execFile)
@@ -66,6 +67,13 @@ describe.skipIf(process.platform === 'win32')('CLI dev channel assets', () => {
       sha256: createHash('sha256').update('#!/usr/bin/env bash\n').digest('hex'),
     })
     expect(JSON.parse(await readFile(join(output, 'manifest.json'), 'utf8'))).toEqual(manifest)
+  })
+
+  it('rejects changed broker bytes before producing a channel receipt', async () => {
+    const root = await fixture()
+    await writeFile(join(root, 'input', `OpenAlice-Broker-alpaca-${version}-linux-x64.tgz`), 'broken')
+    expect(() => prepareCliDevAssets({ inputDir: join(root, 'input'), outputDir: join(root, 'output'), commit, version, installerPath: join(root, 'install') })).toThrow('Dev broker checksum mismatch')
+    await expect(access(join(root, 'output/manifest.json'))).rejects.toMatchObject({code: 'ENOENT'})
   })
 
   it('rejects a candidate whose sidecar does not match its bytes', async () => {
@@ -132,6 +140,19 @@ async function fixture({ tamperedIdentityTarget, largeWindowsMetadata = false } 
         sha256: createHash('sha256').update(executableBytes).digest('hex'),
       }],
     }
+    const packs = []
+    for (const engine of ['ccxt', 'alpaca', 'ibkr', 'leverup', 'longbridge'].filter(e => !(e === 'longbridge' && platform === 'win32' && arch === 'arm64'))) {
+      const file = `OpenAlice-Broker-${engine}-${version}-${platform}-${arch}.tgz`
+      const bytes = Buffer.from(`fixture-${engine}-${platform}-${arch}`)
+      await writeFile(join(input, file), bytes)
+      packs.push({engine, version, apiVersion: 1, file, entry: 'dist/index.js', size: bytes.length, sha256: createHash('sha256').update(bytes).digest('hex')})
+    }
+    await writeFile(join(input, `OpenAlice-Broker-Packs-${version}-${platform}-${arch}.json`), JSON.stringify({schemaVersion: 1, sourceCommit: commit, openAliceVersion: version, platform, arch, packs}))
+    const resources = join(releaseRoot, 'share/openalice')
+    await mkdir(resources, {recursive: true})
+    await writeDevBrokerBinding(resources, {inputDir: input, commit, version, platform, arch})
+    const binding = await readFile(join(resources, 'broker-pack-source.json'))
+    release.files.push({path: 'share/openalice/broker-pack-source.json', type: 'file', bytes: binding.length, mode: 0o644, sha256: createHash('sha256').update(binding).digest('hex')})
     release.contentIdentity = bunReleaseContentIdentity(release)
     if (tamperedIdentityTarget === `${platform}-${arch}`) {
       release.contentIdentity = release.contentIdentity === 'ffffffffffffffff'

--- a/scripts/verify-broker-packs.ts
+++ b/scripts/verify-broker-packs.ts
@@ -16,6 +16,7 @@ import {
 } from '../src/core/broker-packs.js'
 import {
   brokerPackCatalogFileName,
+  supportedBrokerPackEngines,
   type BrokerPackReleaseAsset,
   type BrokerPackReleaseCatalog,
 } from '../src/core/broker-pack-catalog.js'
@@ -27,7 +28,7 @@ const outDir = resolve(repoRoot, outputArg >= 0 ? process.argv[outputArg + 1] : 
 const catalogPath = resolve(outDir, brokerPackCatalogFileName(packageJson.version))
 const catalog = parseCatalog(JSON.parse(await readFile(catalogPath, 'utf8')))
 
-const expectedEngines = new Set<string>(INSTALLABLE_BROKER_ENGINES)
+const expectedEngines = new Set<string>(supportedBrokerPackEngines())
 const actualEngines = new Set(catalog.packs.map((asset) => asset.engine))
 if (catalog.packs.length !== expectedEngines.size || actualEngines.size !== expectedEngines.size) {
   throw new Error(`Broker Pack catalog must contain each engine exactly once; got ${catalog.packs.map((row) => row.engine).join(', ')}`)
@@ -46,6 +47,7 @@ try {
     const builder = resolve(tempRoot, 'build.ts')
     compiledProbe = resolve(tempRoot, process.platform === 'win32' ? 'probe.exe' : 'probe')
     await writeFile(probe, `
+if (process.arch !== ${JSON.stringify(process.arch)}) throw new Error('Compiled probe architecture mismatch');
 const m = await import(process.argv[2]);
 const engine = process.argv[3];
 if (m.BROKER_ENGINE !== engine || m.BROKER_PACK_API_VERSION !== 1) throw new Error('Invalid pack');
@@ -60,7 +62,7 @@ await broker.close();
 console.log('COMPILED_PACK_OK', engine);
 `)
     await writeFile(builder, `import {runtimeCompileOptions} from ${JSON.stringify(options)};
-const r=await Bun.build({entrypoints:[${JSON.stringify(probe)}],compile:{...runtimeCompileOptions,outfile:${JSON.stringify(compiledProbe)}}}); if(!r.success) throw new Error(String(r.logs));`)
+const r=await Bun.build({entrypoints:[${JSON.stringify(probe)}],compile:{...runtimeCompileOptions,target:${JSON.stringify(`bun-${process.platform === 'win32' ? 'windows' : process.platform}-${process.arch}`)},outfile:${JSON.stringify(compiledProbe)}}}); if(!r.success) throw new Error(String(r.logs));`)
     const result = spawnSync('bun', [builder], {cwd: tempRoot, encoding:'utf8', timeout:120_000})
     if (result.error || result.status !== 0) throw new Error(`Compiled probe build failed: ${result.error ?? result.stderr}`)
   }

--- a/src/core/broker-pack-catalog.ts
+++ b/src/core/broker-pack-catalog.ts
@@ -20,6 +20,7 @@ export interface BrokerPackReleaseCatalog {
   openAliceVersion: string
   platform: NodeJS.Platform
   arch: string
+  sourceCommit?: string
   generatedAt: string
   packs: BrokerPackReleaseAsset[]
 }
@@ -39,4 +40,11 @@ export function brokerPackArchiveFileName(
 
 function safeAssetPart(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]/g, '-')
+}
+
+
+/** Longbridge has no Windows ARM64 native binding. Other engines are portable. */
+export function supportedBrokerPackEngines(platform = process.platform, arch = process.arch): InstallableBrokerEngine[] {
+  return (['ccxt', 'alpaca', 'ibkr', 'leverup', 'longbridge'] as InstallableBrokerEngine[])
+    .filter(engine => !(engine === 'longbridge' && platform === 'win32' && arch === 'arm64'))
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { createMarketBarsTools } from './tool/market-bars.js'
 import {
   acquireOpenAliceRuntimeLocks,
   takeoverRequested,
+  RuntimeAlreadyRunningError,
   type OpenAliceRuntimeLock,
 } from '@traderalice/guardian-runtime'
 // The in-process AI loop (AgentCenter, then GenerateRouter + AgentWork) is gone
@@ -514,6 +515,6 @@ export async function runAliceEntrypoint(): Promise<void> {
 if (!(globalThis as { __OPENALICE_INTERNAL_ROLE_DISPATCH__?: boolean }).__OPENALICE_INTERNAL_ROLE_DISPATCH__) {
   runAliceEntrypoint().catch((err) => {
     console.error('fatal:', err)
-    process.exit(1)
+    process.exit(err instanceof RuntimeAlreadyRunningError ? err.exitCode : 1)
   })
 }

--- a/src/services/broker-packs/installer.spec.ts
+++ b/src/services/broker-packs/installer.spec.ts
@@ -19,11 +19,15 @@ let savedEnv: Record<string, string | undefined>
 beforeEach(async () => {
   savedEnv = {
     OPENALICE_HOME: process.env['OPENALICE_HOME'],
+    OPENALICE_APP_HOME: process.env['OPENALICE_APP_HOME'],
+    OPENALICE_BROKER_PACK_BASE_URL: process.env['OPENALICE_BROKER_PACK_BASE_URL'],
     OPENALICE_BROKER_PACK_CATALOG_URL: process.env['OPENALICE_BROKER_PACK_CATALOG_URL'],
     OPENALICE_BROKER_PACK_ALLOW_WORKSPACE: process.env['OPENALICE_BROKER_PACK_ALLOW_WORKSPACE'],
   }
   home = await mkdtemp(resolve(tmpdir(), 'openalice-broker-pack-home-'))
   fixture = await mkdtemp(resolve(tmpdir(), 'openalice-broker-pack-fixture-'))
+  delete process.env['OPENALICE_APP_HOME']
+  delete process.env['OPENALICE_BROKER_PACK_BASE_URL']
   process.env['OPENALICE_HOME'] = home
   process.env['OPENALICE_BROKER_PACK_ALLOW_WORKSPACE'] = '0'
 })
@@ -37,6 +41,7 @@ afterEach(async () => {
     if (value === undefined) delete process.env[key]
     else process.env[key] = value
   }
+  vi.unstubAllGlobals()
   vi.resetModules()
 })
 
@@ -143,6 +148,32 @@ async function seedCompatibleCcxtPack(version = '0.84.0-beta', apiVersion = 1) {
 }
 
 describe('broker-pack installer', () => {
+  it('updates same-version dev bytes from its immutable catalog and preserves the active pack on download failure', async () => {
+    const version = getCurrentVersion()
+    await seedCompatibleCcxtPack(version)
+    await publishCcxtPack()
+    const catalog = await (await fetch(process.env['OPENALICE_BROKER_PACK_CATALOG_URL']!)).json()
+    const commit = 'a'.repeat(40)
+    catalog.sourceCommit = commit
+    const resources = resolve(fixture, 'resources')
+    await mkdir(resources)
+    await writeFile(resolve(resources, 'broker-pack-source.json'), JSON.stringify({schemaVersion: 1, commit, catalog}))
+    delete process.env['OPENALICE_BROKER_PACK_CATALOG_URL']
+    process.env['OPENALICE_APP_HOME'] = resources
+    const fetchMock = vi.fn().mockRejectedValue(new Error('offline'))
+    vi.stubGlobal('fetch', fetchMock)
+    const { getBrokerPackLocalStatus, installBrokerPack } = await loadInstaller()
+    expect(await getBrokerPackLocalStatus('ccxt')).toMatchObject({installed: true, version, updateAvailable: true})
+    expect(fetchMock).not.toHaveBeenCalled()
+    await expect(installBrokerPack('ccxt')).rejects.toThrow('offline')
+    expect(await getBrokerPackLocalStatus('ccxt')).toMatchObject({installed: true, version, updateAvailable: true})
+    const bytes = await readFile(resolve(fixture, catalog.packs[0].file))
+    fetchMock.mockResolvedValue(new Response(bytes))
+    await installBrokerPack('ccxt')
+    expect(fetchMock).toHaveBeenLastCalledWith(`https://download.openalice.ai/cli/dev/releases/${commit}/${catalog.packs[0].file}`, expect.anything())
+    expect(await getBrokerPackLocalStatus('ccxt')).toMatchObject({installed: true, version, updateAvailable: false})
+  })
+
   it('distinguishes built-in, workspace, missing, and broken local status', async () => {
     const { brokerPackEngineRoot } = await import('../../core/broker-packs.js')
     const engineRoot = brokerPackEngineRoot('ccxt')

--- a/src/services/broker-packs/installer.ts
+++ b/src/services/broker-packs/installer.ts
@@ -9,6 +9,7 @@ import { basename, resolve, sep } from 'node:path'
 import * as tar from 'tar'
 import {
   BROKER_PACK_API_VERSION,
+  INSTALLABLE_BROKER_ENGINES,
   BROKER_PACK_SCHEMA_VERSION,
   brokerPackActivePath,
   brokerPackEngineRoot,
@@ -46,12 +47,21 @@ export async function getBrokerPackLocalStatus(engine: InstallableBrokerEngine |
   try {
     const active = await resolveActiveBrokerPack(engine)
     if (active) {
+      let bound: Awaited<ReturnType<typeof readBoundCatalog>>
+      try { bound = await readBoundCatalog() }
+      catch (error) {
+        return { engine, installed: true, source: 'downloaded', version: active.manifest.version,
+          reason: `Cannot check broker-pack update: ${error instanceof Error ? error.message : String(error)}` }
+      }
+      const expected = bound?.catalog.packs.find(asset => asset.engine === engine)
       return {
         engine,
         installed: true,
         source: 'downloaded',
         version: active.manifest.version,
-        updateAvailable: active.manifest.version !== getCurrentVersion(),
+        updateAvailable: expected
+          ? active.manifest.version !== expected.version || active.manifest.contentId !== expected.sha256.slice(0, 16)
+          : active.manifest.version !== getCurrentVersion(),
       }
     }
   } catch (err) {
@@ -81,8 +91,9 @@ export async function installBrokerPack(engine: InstallableBrokerEngine): Promis
 
   const workRoot = resolve(engineRoot, `.staging-${process.pid}-${Date.now()}`)
   try {
-    const catalogUrl = resolveCatalogUrl()
-    const catalog = await fetchCatalog(catalogUrl)
+    const bound = await readBoundCatalog()
+    const catalogUrl = bound?.url ?? resolveCatalogUrl()
+    const catalog = bound?.catalog ?? await fetchCatalog(catalogUrl)
     const asset = catalog.packs.find((row) => row.engine === engine)
     if (!asset) throw new Error(`No ${engine} broker pack is published for ${process.platform}-${process.arch}`)
     validateAsset(asset, getCurrentVersion())
@@ -150,6 +161,10 @@ async function fetchCatalog(url: string): Promise<BrokerPackReleaseCatalog> {
   const res = await fetch(url, { signal: AbortSignal.timeout(20_000) })
   if (!res.ok) throw new Error(`Broker-pack catalog request failed: HTTP ${res.status}`)
   const raw = await res.json() as Partial<BrokerPackReleaseCatalog>
+  return validateCatalog(raw)
+}
+
+function validateCatalog(raw: Partial<BrokerPackReleaseCatalog>): BrokerPackReleaseCatalog {
   const version = getCurrentVersion()
   if (
     raw.schemaVersion !== 1
@@ -160,10 +175,13 @@ async function fetchCatalog(url: string): Promise<BrokerPackReleaseCatalog> {
   ) {
     throw new Error(`Broker-pack catalog is incompatible with OpenAlice ${version} on ${process.platform}-${process.arch}`)
   }
+  for (const asset of raw.packs) validateAsset(asset, version)
+  if (new Set(raw.packs.map(asset => asset.engine)).size !== raw.packs.length) throw new Error('Duplicate broker-pack engine')
   return raw as BrokerPackReleaseCatalog
 }
 
 function validateAsset(asset: BrokerPackReleaseAsset, currentVersion: string): void {
+  if (!asset || !INSTALLABLE_BROKER_ENGINES.includes(asset.engine)) throw new Error('Invalid broker-pack engine')
   if (asset.version !== currentVersion) throw new Error(`Broker-pack asset targets OpenAlice ${asset.version}; expected ${currentVersion}`)
   if (asset.apiVersion !== BROKER_PACK_API_VERSION) throw new Error(`Broker-pack API ${asset.apiVersion} is unsupported`)
   if (!/^[A-Za-z0-9._-]+$/.test(asset.file) || basename(asset.file) !== asset.file) throw new Error('Invalid broker-pack asset name')
@@ -378,4 +396,21 @@ function isProcessAlive(pid: number): boolean {
   } catch (err) {
     return !isCode(err, 'ESRCH')
   }
+}
+
+
+/** Bound to the running archive, never to the mutable latest-dev pointer. */
+async function readBoundCatalog(): Promise<{ url: string; catalog: BrokerPackReleaseCatalog } | null> {
+  if (process.env['OPENALICE_BROKER_PACK_CATALOG_URL']?.trim() || process.env['OPENALICE_BROKER_PACK_BASE_URL']?.trim()) return null
+  const home = process.env['OPENALICE_APP_HOME']
+  if (!home) return null
+  let bytes: string
+  try { bytes = await readFile(resolve(home, 'broker-pack-source.json'), 'utf8') }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null; throw error }
+  const source = JSON.parse(bytes) as { schemaVersion?: number; commit?: string; catalog?: BrokerPackReleaseCatalog }
+  if (source.schemaVersion !== 1 || !/^[a-f0-9]{40}$/.test(source.commit ?? '') || source.catalog?.sourceCommit !== source.commit) {
+    throw new Error('Invalid bundled broker-pack source')
+  }
+  const catalog = validateCatalog(source.catalog!)
+  return { catalog, url: `https://download.openalice.ai/cli/dev/releases/${source.commit}/${brokerPackCatalogFileName(getCurrentVersion())}` }
 }


### PR DESCRIPTION
Native `server run/start` could leave a successful dev upgrade pending because its provider identity was never populated. Writer-lease contention was also treated as a broken binary and could roll back a good release. Separately, Broker Packs compared only product versions, leaving same-version dev fixes uninstalled.

Resolve native identity from release metadata, preserve exit code 75 for ownership conflicts, and read Linux process start identity through procfs before the conservative fallback. Keep the existing single-writer checks and rollback for genuine startup failures.

Bind each dev CLI archive to its commit-specific Broker Pack catalog. Publish and validate matching platform packs before channel activation, compare installed content hashes offline, and retain the prior pack if download/validation fails. Packs remain optional downloads. Windows ARM64 excludes Longbridge because upstream does not provide its native binding.

Validation:
- Full `pnpm test`: 778 files passed (6,925 tests passed); final focused regressions also passed after removing a duplicate test and tightening catalog coverage.
- Root TypeScript and Guardian package typecheck.
- `pnpm test:system:guardian`.
- `pnpm test:system:installer` on a disposable no-Node/Bun Linux host.
- `pnpm test:system:remote`, including real native Linux ARM64 runtime and TUI transfer acceptance.
- Native macOS ARM64 release smoke and Linux ARM64 Docker build smoke both exercised consecutive same-version resource revisions and confirmed activation.
- All five macOS ARM64 Broker Packs built and loaded both normally and from a compiled Bun probe.
- Dev asset preparation rejects corrupt pack bytes and validates that the CLI content manifest covers the matching catalog.

Windows and the other native release hosts remain trailing CI acceptance; no production account or remote runtime was changed during this repair. The historical stale-lease incident was not reproduced; procfs improves identity reliability while unknown ownership remains conservative.

Closes #1468.
