### PR TITLE
feat(alpaca): add permission-gated single-leg options trading

### DIFF
--- a/docs/broker-packs.md
+++ b/docs/broker-packs.md
@@ -296,11 +296,21 @@ extended-hours flags are rejected. Venue minimums and increments still apply.
 Contract details expose the asset's minimum size and increments when supplied.
 Notional orders retain cash quantity separately from filled base quantity.
 
-Options are a **read-only** capability in this pack. `alice-uta contract
+Options support **single-leg trading** when the account reports a positive
+`options_trading_level`. Permission is refreshed before entry/amendment; Alpaca
+validates strategy approval and collateral. Orders accept whole contract
+quantities, per-unit premium prices, MKT/LMT/STP/STP LMT and DAY/GTC. Cash
+notional, trailing, attached exits and extended hours are refused. Close and
+amend routes preserve the OCC symbol, rather than matching the underlying.
+Position quantities are positive contract counts with direction in `side`;
+Alpaca's signed short quantities must not be passed through and signed again.
+Multi-leg strategies and explicit exercise are not implemented.
+
+For research, `alice-uta contract
 option-contracts` exposes paginated definitions and dated open interest;
 `option-chain` exposes paginated snapshots with feed provenance and individual
 trade/quote timestamps. `contract expand` requires an expiry for concrete
-Alpaca option leaves. Option place/modify/close operations remain refused.
+Alpaca option leaves. Option historical bars are not exposed by this pack.
 The default snapshot feed is `indicative`: trades are delayed and quotes are
 modified, not executable OPRA. Explicit OPRA requests preserve entitlement
 errors instead of silently changing feeds. Missing IV/Greeks/OI stay missing.

--- a/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/AlpacaBroker.ts
@@ -2,7 +2,7 @@
  * AlpacaBroker — IBroker adapter for Alpaca
  *
  * Direct implementation against @alpacahq/alpaca-trade-api SDK.
- * Supports equities and spot crypto trading, plus read-only options research.
+ * Supports equities, spot crypto and permission-gated single-leg options trading.
  * Native keys are stock tickers, slash crypto pairs, or OCC option symbols.
  *
  * Takes IBKR Order objects, reads relevant fields, ignores the rest.
@@ -147,6 +147,8 @@ export class AlpacaBroker implements IBroker {
   /** symbol → asset, derived from `catalog` for O(1) name/exchange joins on
    *  position & order rows (issue #340). Rebuilt whenever the catalog loads. */
   private catalogBySymbol: Map<string, AlpacaAssetRaw> | null = null
+  /** Venue permissions, populated at connect and refreshed on account reads/writes. */
+  private optionsTradingLevel = 0
 
   constructor(config: AlpacaBrokerConfig) {
     this.config = config
@@ -178,6 +180,7 @@ export class AlpacaBroker implements IBroker {
     for (let attempt = 1; attempt <= AlpacaBroker.MAX_INIT_RETRIES; attempt++) {
       try {
         const account = await this.client.getAccount() as AlpacaBrokerRaw
+        this.optionsTradingLevel = account.options_trading_level ?? 0
         console.log(
           `AlpacaBroker[${this.id}]: connected (paper=${this.config.paper}, equity=$${parseFloat(account.equity).toFixed(2)})`,
         )
@@ -281,8 +284,31 @@ export class AlpacaBroker implements IBroker {
       if (asset?.price_increment) details.minTick = Number(asset.price_increment)
       if (asset?.min_order_size) details.minSize = new Decimal(asset.min_order_size)
       if (asset?.min_trade_increment) details.sizeIncrement = new Decimal(asset.min_trade_increment)
-    } else if (details.contract.secType === 'OPT') details.orderTypes = ''
+    } else if (details.contract.secType === 'OPT') {
+      details.orderTypes = this.optionsTradingLevel > 0 ? 'MKT,LMT,STP,STP LMT' : ''
+      details.minSize = new Decimal(1)
+      details.sizeIncrement = new Decimal(1)
+    }
     return details
+  }
+
+  /** Validate only fields this adapter can faithfully send. Alpaca remains the
+   * authority for strategy approval, collateral and opening/closing exposure. */
+  private validateOptionOrder(order: Partial<Order>, tpsl?: TpSlParams, amendment = false): string | undefined {
+    if ((!amendment || order.orderType) && !['MKT', 'LMT', 'STP', 'STP LMT'].includes(order.orderType ?? '')) return 'Alpaca single-leg options support MKT, LMT, STP and STP LMT only.'
+    if ((!amendment || order.tif) && !['DAY', 'GTC'].includes(order.tif ?? 'DAY')) return 'Alpaca options require DAY or GTC time in force.'
+    if (order.parentId || order.ocaGroup || order.goodTillDate || (order.trailStopPrice != null && !order.trailStopPrice.equals(UNSET_DECIMAL))) return 'Alpaca options do not support parent/OCA, GTD or trailing-stop fields.'
+    const qty = order.totalQuantity
+    if ((!amendment || (qty != null && !qty.equals(UNSET_DECIMAL))) && (!qty || qty.equals(UNSET_DECIMAL) || !qty.isFinite() || !qty.isInteger() || qty.lte(0))) return 'Alpaca options require a positive whole number of contracts.'
+    if (order.cashQty != null && !order.cashQty.equals(UNSET_DECIMAL)) return 'Alpaca options do not support cash-notional orders.'
+    if (tpsl || order.outsideRth || (order.trailingPercent != null && !order.trailingPercent.equals(UNSET_DECIMAL))) return 'Alpaca options do not support attached TP/SL, trailing or extended-hours orders.'
+  }
+
+  private async optionPermissionError(): Promise<string | undefined> {
+    const account = await this.client.getAccount() as AlpacaBrokerRaw
+    this.optionsTradingLevel = account.options_trading_level ?? 0
+    if (this.optionsTradingLevel < 1) return `Alpaca options trading is disabled for this account (options_trading_level=${this.optionsTradingLevel}). Enable options approval in Alpaca.`
+    if (account.trading_blocked || account.account_blocked) return 'Alpaca reports that this account is blocked for trading.'
   }
 
   // ---- Trading operations ----
@@ -293,7 +319,10 @@ export class AlpacaBroker implements IBroker {
       return { success: false, error: 'Cannot resolve contract to Alpaca symbol' }
     }
 
-    if (this.contractFor(symbol).secType === 'OPT') return { success: false, error: 'Alpaca options are read-only; options orders are not enabled.' }
+    if (this.contractFor(symbol).secType === 'OPT') {
+      const error = this.validateOptionOrder(order, tpsl)
+      if (error) return { success: false, error }
+    }
     if (this.contractFor(symbol).secType === 'CRYPTO') {
       if (!['MKT', 'LMT', 'STP LMT'].includes(order.orderType)) return { success: false, error: 'Alpaca crypto supports MKT, LMT and STP LMT only.' }
       if (!['GTC', 'IOC'].includes(order.tif)) return { success: false, error: 'Alpaca crypto requires GTC or IOC time in force.' }
@@ -301,6 +330,10 @@ export class AlpacaBroker implements IBroker {
     }
 
     try {
+      if (this.contractFor(symbol).secType === 'OPT') {
+        const error = await this.optionPermissionError()
+        if (error) return { success: false, error }
+      }
       const alpacaOrder: Record<string, unknown> = {
         symbol,
         side: order.action.toLowerCase(), // BUY → buy, SELL → sell
@@ -374,7 +407,13 @@ export class AlpacaBroker implements IBroker {
     try {
       const existing = await this.client.getOrder(orderId) as AlpacaOrderRaw
       const contract = this.contractFor(existing.symbol, existing.asset_class)
-      if (contract.secType === 'OPT') return { success: false, error: 'Alpaca options are read-only.' }
+      if (contract.secType === 'OPT') {
+        const error = this.validateOptionOrder(changes, undefined, true)
+        if (error) return { success: false, error }
+        if (changes.orderType && ibkrOrderTypeToAlpaca(changes.orderType) !== existing.type) return { success: false, error: 'Alpaca cannot replace the order type; cancel and submit a new order.' }
+        const permissionError = await this.optionPermissionError()
+        if (permissionError) return { success: false, error: permissionError }
+      }
       if (contract.secType === 'CRYPTO') {
         if (changes.tif && !['GTC', 'IOC'].includes(changes.tif)) return { success: false, error: 'Alpaca crypto requires GTC or IOC time in force.' }
         if (changes.trailingPercent != null && !changes.trailingPercent.equals(UNSET_DECIMAL)) return { success: false, error: 'Alpaca crypto does not support trailing orders.' }
@@ -415,13 +454,12 @@ export class AlpacaBroker implements IBroker {
       return { success: false, error: 'Cannot resolve contract to Alpaca symbol' }
     }
 
-    if (this.contractFor(symbol).secType === 'OPT') return { success: false, error: 'Alpaca options are read-only.' }
-
     // Partial close → reverse market order
     if (quantity != null) {
       const positions = await this.getPositions()
-      const pos = positions.find(p => p.contract.symbol === symbol)
+      const pos = positions.find(p => this.getNativeKey(p.contract) === symbol)
       if (!pos) return { success: false, error: `No position for ${symbol}` }
+      if (!quantity.isFinite() || quantity.lte(0) || quantity.gt(new Decimal(pos.quantity).abs())) return { success: false, error: 'Close quantity must be positive and cannot exceed the position.' }
 
       const order = new Order()
       order.action = pos.side === 'long' ? 'SELL' : 'BUY'
@@ -454,6 +492,8 @@ export class AlpacaBroker implements IBroker {
         this.client.getAccount() as Promise<AlpacaBrokerRaw>,
         this.client.getPositions() as Promise<AlpacaPositionRaw[]>,
       ])
+
+      this.optionsTradingLevel = account.options_trading_level ?? 0
 
       // Alpaca account API doesn't provide unrealizedPnL — aggregate from positions with Decimal
       const unrealizedPnL = positions.reduce(
@@ -501,7 +541,8 @@ export class AlpacaBroker implements IBroker {
         contract: this.contractFor(p.symbol, p.asset_class),
         currency: 'USD',
         side: p.side === 'long' ? 'long' as const : 'short' as const,
-        quantity: new Decimal(p.qty),
+        // UTA carries direction in side; Alpaca encodes shorts in qty too.
+        quantity: new Decimal(p.qty).abs(),
         avgCost: new Decimal(p.avg_entry_price).toString(),
         marketPrice: new Decimal(p.current_price).toString(),
         // Pass-through: Alpaca's API already provides multiplier-applied
@@ -657,7 +698,7 @@ export class AlpacaBroker implements IBroker {
 
   getCapabilities(): AccountCapabilities {
     return {
-      supportedSecTypes: ['STK', 'CRYPTO'],
+      supportedSecTypes: ['STK', 'CRYPTO', ...(this.optionsTradingLevel > 0 ? ['OPT'] : [])],
       supportedOrderTypes: ['MKT', 'LMT', 'STP', 'STP LMT', 'TRAIL'],
       historicalBars: { supported: true, quality: 'iex', qualityBySecType: { CRYPTO: 'realtime' } },
     }
@@ -718,7 +759,7 @@ export class AlpacaBroker implements IBroker {
       const contract = makeContract(row.symbol, 'us_option')
       contract.multiplier = row.multiplier ?? row.size
       return contract
-    }), hint: 'Alpaca options are read-only. Use option-chain for feed-labelled snapshots and option-contracts for open interest with observation dates.' }
+    }), hint: 'Single-leg options trading requires Alpaca account approval; quantities are whole contracts and prices are per unit of the underlying. Use option-chain for feed-labelled snapshots and option-contracts for open interest with observation dates.' }
   }
 
   async getOrderBook(contract: Contract, limit = 20): Promise<Record<string, unknown>> {

--- a/services/uta/src/domain/trading/brokers/alpaca/alpaca-multi-asset.spec.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/alpaca-multi-asset.spec.ts
@@ -48,13 +48,11 @@ describe('Alpaca multi-asset identities and writes', () => {
     expect((await broker.placeOrder(contract, order)).success).toBe(true)
     expect(createOrder).toHaveBeenCalledWith(expect.objectContaining({ symbol: 'BTC/USD', qty: '0.00012345', time_in_force: 'gtc' }))
   })
-  it('keeps option local identity and multiplier while rejecting trading', async () => {
+  it('keeps option local identity and multiplier', async () => {
     const broker = new AlpacaBroker(config)
     const contract = broker.resolveNativeKey('SPY260918C00600000')
     expect(contract).toMatchObject({ symbol: 'SPY', localSymbol: 'SPY260918C00600000', secType: 'OPT', strike: 600, multiplier: '100', right: 'C', lastTradeDateOrContractMonth: '20260918' })
     expect(broker.getNativeKey(contract)).toBe('SPY260918C00600000')
-    expect((await broker.placeOrder(contract, new Order())).error).toMatch(/read-only/)
-    expect((await broker.closePosition(contract)).error).toMatch(/read-only/)
   })
 })
 
@@ -108,9 +106,92 @@ describe('Alpaca close and amendment boundaries', () => {
     const broker = new AlpacaBroker(config)
     const replaceOrder = vi.fn()
     const getOrder = vi.fn().mockResolvedValueOnce({ symbol: 'SPY260918C00600000', asset_class: 'us_option' }).mockResolvedValueOnce({ symbol: 'BTCUSD', asset_class: 'crypto' })
-    Object.assign(broker, { client: { getOrder, replaceOrder } })
-    expect((await broker.modifyOrder('option', { tif: 'DAY' })).error).toMatch(/read-only/)
+    Object.assign(broker, { client: { getOrder, replaceOrder, getAccount: async () => ({ options_trading_level: 0 }) } })
+    expect((await broker.modifyOrder('option', { tif: 'DAY' })).error).toMatch(/disabled/)
     expect((await broker.modifyOrder('crypto', { tif: 'DAY' })).error).toMatch(/GTC or IOC/)
     expect(replaceOrder).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('Alpaca single-leg options execution', () => {
+  const symbol = 'SPY260918C00600000'
+  const order = () => Object.assign(new Order(), { action: 'BUY', orderType: 'LMT', tif: 'DAY', totalQuantity: new Decimal(1), lmtPrice: new Decimal('1.25') })
+  function setup(level = 2) {
+    const broker = new AlpacaBroker(config)
+    const client = {
+      getAccount: vi.fn().mockResolvedValue({ options_trading_level: level }),
+      createOrder: vi.fn().mockResolvedValue({ id: 'entry', status: 'new' }),
+      getOrder: vi.fn().mockResolvedValue({ symbol, asset_class: 'us_option', type: 'limit' }),
+      replaceOrder: vi.fn().mockResolvedValue({ id: 'replacement', status: 'new' }),
+      closePosition: vi.fn().mockResolvedValue({ id: 'exit', status: 'new' }),
+    }
+    Object.assign(broker, { client })
+    return { broker, client, contract: broker.resolveNativeKey(symbol) }
+  }
+  it('sends OCC identity, contract quantity and per-unit price and advertises approved options', async () => {
+    const { broker, client, contract } = setup()
+    expect(broker.getCapabilities().supportedSecTypes).not.toContain('OPT')
+    expect((await broker.placeOrder(contract, order())).success).toBe(true)
+    expect(client.createOrder).toHaveBeenCalledWith({ symbol, side: 'buy', type: 'limit', time_in_force: 'day', qty: '1', limit_price: '1.25' })
+    expect(broker.getCapabilities().supportedSecTypes).toContain('OPT')
+    expect((await broker.getContractDetails(contract))?.orderTypes).toBe('MKT,LMT,STP,STP LMT')
+  })
+  it('refreshes permissions and preserves venue rejection reasons', async () => {
+    const { broker, client, contract } = setup(0)
+    expect((await broker.placeOrder(contract, order())).error).toMatch(/options_trading_level=0/)
+    expect(client.createOrder).not.toHaveBeenCalled()
+    client.getAccount.mockResolvedValue({ options_trading_level: 1 })
+    client.createOrder.mockRejectedValue({ response: { data: { message: 'insufficient options approval level' } } })
+    expect((await broker.placeOrder(contract, order())).error).toContain('insufficient options approval level')
+  })
+  it.each([
+    { totalQuantity: new Decimal('0.5') }, { totalQuantity: new Decimal(0) },
+    { totalQuantity: new Decimal(-1) }, { cashQty: new Decimal(100) },
+    { tif: 'IOC' }, { outsideRth: true }, { orderType: 'TRAIL' },
+    { trailingPercent: new Decimal(1) }, { parentId: 1 }, { ocaGroup: 'group' },
+    { trailStopPrice: new Decimal(1) }, { goodTillDate: '20260918' },
+  ])('rejects unsupported option fields before dispatch: %j', async changes => {
+    const { broker, client, contract } = setup()
+    expect((await broker.placeOrder(contract, Object.assign(order(), changes))).success).toBe(false)
+    expect(client.createOrder).not.toHaveBeenCalled()
+  })
+  it('fails closed when the account lookup fails or reports a block', async () => {
+    const { broker, client, contract } = setup()
+    client.getAccount.mockRejectedValueOnce(new Error('account unavailable'))
+    expect((await broker.placeOrder(contract, order())).error).toContain('account unavailable')
+    client.getAccount.mockResolvedValueOnce({ options_trading_level: 2, trading_blocked: true } as never)
+    expect((await broker.placeOrder(contract, order())).error).toContain('blocked')
+    expect(client.createOrder).not.toHaveBeenCalled()
+  })
+  it.each(['C', 'P'])('keeps long/short %s positions in contract units', async right => {
+    const { broker } = setup()
+    const localSymbol = `SPY260918${right}00600000`
+    const raw = (side: string, qty: string) => ({ symbol: localSymbol, asset_class: 'us_option', side, qty, avg_entry_price: '2', current_price: '3', market_value: side === 'long' ? '600' : '-600', unrealized_pl: side === 'long' ? '200' : '-200' })
+    Object.assign(broker, { client: { getPositions: async () => [raw('long', '2'), raw('short', '-2')] } })
+    const positions = await broker.getPositions()
+    expect(positions.map(p => ({ side: p.side, qty: p.quantity.toString(), value: p.marketValue, pnl: p.unrealizedPnL }))).toEqual([
+      { side: 'long', qty: '2', value: '600', pnl: '200' },
+      { side: 'short', qty: '2', value: '600', pnl: '-200' },
+    ])
+    for (const p of positions) expect(p.contract).toMatchObject({ secType: 'OPT', localSymbol, multiplier: '100', right })
+  })
+  it('rejects bracket attachment and applies whole-contract checks to replacements', async () => {
+    const { broker, client, contract } = setup()
+    expect((await broker.placeOrder(contract, order(), { takeProfit: { price: '2' } })).success).toBe(false)
+    expect((await broker.modifyOrder('entry', { totalQuantity: new Decimal('0.5') })).success).toBe(false)
+    expect((await broker.modifyOrder('entry', { orderType: 'MKT' })).success).toBe(false)
+    expect(client.replaceOrder).not.toHaveBeenCalled()
+    expect((await broker.modifyOrder('entry', { totalQuantity: new Decimal(2), lmtPrice: new Decimal('1.15'), tif: 'GTC' })).orderId).toBe('replacement')
+    expect(client.replaceOrder).toHaveBeenCalledWith('entry', { qty: '2', limit_price: '1.15', time_in_force: 'gtc' })
+  })
+  it('closes the precise option rather than matching the underlying; never over-closes', async () => {
+    const { broker, client, contract } = setup()
+    vi.spyOn(broker, 'getPositions').mockResolvedValue([{ contract, side: 'long', quantity: '2' } as never])
+    expect((await broker.closePosition(contract, new Decimal(3))).success).toBe(false)
+    expect((await broker.closePosition(contract, new Decimal(1))).success).toBe(true)
+    expect(client.createOrder).toHaveBeenCalledWith({ symbol, side: 'sell', type: 'market', time_in_force: 'day', qty: '1' })
+    expect((await broker.closePosition(contract)).orderId).toBe('exit')
+    expect(client.closePosition).toHaveBeenCalledWith(symbol)
   })
 })

--- a/services/uta/src/domain/trading/brokers/alpaca/alpaca-types.ts
+++ b/services/uta/src/domain/trading/brokers/alpaca/alpaca-types.ts
@@ -9,6 +9,10 @@ export interface AlpacaBrokerConfig {
 // ==================== Alpaca SDK raw shapes ====================
 
 export interface AlpacaBrokerRaw {
+  options_approved_level?: number
+  options_trading_level?: number
+  trading_blocked?: boolean
+  account_blocked?: boolean
   cash: string
   portfolio_value: string
   equity: string


### PR DESCRIPTION
Alpaca already exposes option contracts and snapshots, but the adapter rejected every option write and omitted OPT from account capabilities. This connects single-leg orders to the existing UTA staging/approval path, advertises OPT for approved accounts, refreshes venue permissions before entry/amendment, and validates whole contract quantities and supported order fields.

Partial closes now match the OCC native key rather than the underlying symbol and reject quantities exceeding the position. Position reads normalize Alpaca's signed short quantity into UTA's positive quantity plus side convention, avoiding double-signing on downstream recomputation. Multi-leg orders, exercise instructions and option history remain outside this change.

Validation:
- Alpaca pack and UTA service typechecks passed; compiled Bun pack import smoke passed.
- UTA owner suite: 58 files / 1055 tests passed, including call/put and long/short position-unit cases.
- UTA integration: 15 tests passed.
- Full hermetic baseline: 778 files, 6936 passed, 4 skipped; subsequent option-only validation and position normalization changes passed the UTA owner suite.
- Isolated remote native runtime loaded the built pack. Actual alice-uta CLI discovered a tradable SPY option, staged/committed/submitted one paper limit order, listed the correct OCC identity and contract units, and cancelled it. Venue verification confirmed Cancelled, zero open orders and unchanged pre-existing position quantities. Test runtime stopped and copied credentials removed; main remote runtime remains unchanged and healthy in Pro mode.

**Integration decision (2026-09-18):** Maintainer explicitly approved merging now and completing the market-open paper exercise afterward. Synced with current dev without conflicts; reran the UTA owner suite (58 files / 1,055 tests), UTA integration (15 tests), and UTA service plus Alpaca pack typechecks successfully.

**Remaining venue acceptance:** The earlier paper account reported trading level 3. Market-closed testing proved placement/query/cancellation but the venue rejected replacement while the order was `accepted`. Successful replacement, fills, partial/full closes, and remaining applicable S1–S14 scenarios are not yet verified. This merge does not claim those scenarios passed or that an existing remote Broker Pack was upgraded.

Order rules checked against https://docs.alpaca.markets/us/docs/options-trading (whole qty, no notional, DAY/GTC, market/limit/stop/stop_limit, no extended hours).

