### PR TITLE
feat(skills): document reply files and clarify Inbox semantics

### DIFF
--- a/default/alice-harness.json
+++ b/default/alice-harness.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Alice Project-provided Skills file bundle"
 }

--- a/default/skills/alice/references/collaboration.md
+++ b/default/skills/alice/references/collaboration.md
@@ -9,7 +9,7 @@ keep using their native file, search, and Git tools inside any resolved path.
 |---|---|---|
 | `peer` | Active Workspace discovery, absolute paths, Session directory | File reading or research |
 | `conversation` | Ordinary Agent-to-Agent requests and replies | Human notification |
-| `inbox` | Human-facing report delivery and follow-up | General peer chat |
+| `inbox` | Outward-facing human notifications, reports and follow-up | General peer chat or file storage |
 | `issue` | Durable work, ownership, scheduling, Activity | Ad-hoc questions |
 | `provenance` | Artifact-to-Session attribution | Guessing intent |
 | `signature` | The current Session's safe `@resumeId` | Runtime-native ids |
@@ -96,11 +96,18 @@ There is no unsolicited Agent-to-Agent completion notification bus. Inbox
 notifies the human; `await`, `read`, and `collect` retrieve direct Agent replies.
 Do not build shell sleep loops.
 
-## Deliver and read reports
+## Notify the human and deliver reports
 
-Inbox is the outbound human delivery surface. A normal attended Chat reply
-already reaches the user; scheduled/headless work must push explicitly when its
-result deserves human attention.
+Inbox is OpenAlice's outward-facing notification and reporting surface for the
+human. Use it for alerts, findings, reports or requests for attention that need
+a separate delivery record. It is not the Workspace's file store or a general
+Agent-to-Agent message channel.
+
+A normal conversation reply already reaches the user. For attachments in a
+Connector reply, use `[[reports/summary.pdf]]` as described in `file-delivery`;
+no Inbox entry is required just to send a file. Use Inbox when a separate
+notification/report handoff is intended, including unattended work whose result
+needs human attention.
 
 ```bash
 alice inbox push \

--- a/default/skills/file-delivery/SKILL.md
+++ b/default/skills/file-delivery/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: file-delivery
+description: Send Workspace files as attachments in a Connector conversation reply using [[relative/path.ext]]. Use when the user wants a file, image, or report sent in the current chat, or when distinguishing reply attachments from an Inbox notification.
+---
+
+# Send files in a reply
+
+In a Connector conversation, include a file's Workspace-relative path in double
+brackets in the final reply. Create or verify the file first. For example:
+
+```text
+Here is the report.
+[[reports/summary.pdf]]
+The chart shows the comparison.
+[[reports/chart.png]]
+```
+
+Write the actual references outside code spans or code fences. The Connector
+uploads resolved files at their position in the reply, preserving the order of
+text and attachments. This does not create an Inbox entry.
+
+- Paths refer to the replying Session's Workspace. For a file from a peer
+  Workspace, copy it into this Workspace before referencing it.
+- Use the path and extension directly: no `file:` prefix, absolute path,
+  `..`, or `|label` suffix. Missing, unreadable or unsupported references stay
+  as literal text; writing a reference alone is not proof of delivery.
+- The current reply limit is five unique files, each at most 1 MiB. Files retain
+  their bytes. Telegram sends PNG/JPEG/WebP as photos and other supported files
+  as documents. `sticker/*.png` and `sticker/*.webp` use sticker delivery; follow
+  the installed sticker Skill for the available pack and usage.
+
+This syntax is interpreted by Connectors that support attachments. Do not
+assume a terminal or another chat surface will upload it. To discuss the syntax
+without sending a file, put the reference in inline code or a code fence.
+
+## When to use Inbox
+
+Inbox is OpenAlice's outward-facing notification and reporting surface for the
+human: alerts, findings, reports, or requests for attention that deserve their
+own delivery record. Use `alice inbox push` for that purpose; the `alice` Skill's
+collaboration reference describes its current commands.
+
+A file requested in the current conversation can be sent directly in the reply.
+It does not need an Inbox entry merely because it is a file. Files and Git hold
+the work; Inbox communicates it to the human; peer conversations carry
+Agent-to-Agent handoffs. Avoid duplicating a reply into Inbox unless a separate
+notification or report handoff is intended.

--- a/default/skills/self-scheduling/SKILL.md
+++ b/default/skills/self-scheduling/SKILL.md
@@ -258,11 +258,10 @@ conversation.** Write What as a
 **complete, standalone instruction**, as if handing the job to a fresh teammate
 who has only this workspace's files. Say exactly what to read, do, and produce.
 
-**Decide what it outputs — and decide on purpose.** A headless run that does real
-work and surfaces nothing has vanished. So:
+Decide whether the run should notify the human or simply update its work:
 
 - If the run produces something the user should see — a brief, a finding, a
-  result — **push it to the Inbox**, the only channel a headless run has:
+  result — use **Inbox for an outward-facing notification or report**:
   `alice inbox push --comments "…"` (attach files with repeatable
   `--doc <path>`; run `alice --help` for the flags). A report pushed
   during a scheduled run is automatically linked back to the issue that
@@ -271,9 +270,11 @@ work and surfaces nothing has vanished. So:
   changed), **exit silently — that is the correct outcome**, not a failure.
   Don't manufacture noise.
 
-The Agent Runtime returning a reply only means the scheduler received the run's
-control-plane result. It does **not** mean the user saw it. Put the Inbox command
-inside What whenever human delivery is part of completion.
+A Connector-backed Issue may deliver its reply directly to the connected chat;
+other headless runs need not have a chat recipient. Do not assume every runtime
+reply is delivered. Put an Inbox push in What when a separate notification or
+report is part of completion, and avoid duplicating a reply that already serves
+that purpose. Inbox is a human delivery record, not storage for every run result.
 
 Put **conditions inside `what`**, not in the schedule — there is no condition
 field. For "ping me only if X", write: "check X; if it holds, push an alert;

--- a/docs/alice-harness.md
+++ b/docs/alice-harness.md
@@ -25,7 +25,7 @@ accepted and available revisions separately.
 ## Ownership
 
 Alice Harness owns complete trees for `alice`, `alice-analysis`, `alice-uta`,
-`traderhub`, and `self-scheduling`, plus removal/reconciliation of legacy
+`traderhub`, `self-scheduling`, and `file-delivery`, plus removal/reconciliation of legacy
 `alice-workspace` copies. `.agents/skills` is primary and `.claude/skills` is its
 runtime mirror; old `.pi/skills` duplicates are included only for reconciliation.
 Template-declared instructions, README and other bundled Skills remain template

--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -192,6 +192,10 @@ Load-bearing paths:
 
 ## Reply attachments
 
+The Project-owned `file-delivery` Skill teaches this reply path separately from
+Inbox notifications and reports. It follows Alice Harness injection preferences
+and upgrades; optional sticker-pack guidance remains owned by the sticker pack.
+
 A final reply may include `[[reports/chart.png]]`. Paths are relative to
 its source Workspace. Ordinary `[[name]]` references remain text; inline/fenced
 code and escaped brackets are literal, including examples of `[[no-reply]]`.

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -37,7 +37,8 @@ One concept has one primary owner:
 
 | Concept | Owner |
 |---|---|
-| Inbox, Issue collaboration, provenance, peer questions, Session nametags | `alice` (collaboration reference) |
+| Human notifications/reports through Inbox, Issue collaboration, provenance, peer questions, Session nametags | `alice` (collaboration reference) |
+| Connector reply file attachments (`[[relative/path.ext]]`) | `file-delivery` |
 | Delegating quantitative research from Chat to AutoQuant | `delegate-autoquant` |
 | Issue file shape, ownership, schedules, headless delivery | `self-scheduling` |
 | Low-frequency market/fundamental/macro data | `traderhub` |

--- a/src/server/cli-commands.ts
+++ b/src/server/cli-commands.ts
@@ -138,7 +138,7 @@ const BASE_EXPORTS: Record<string, CliExport> = {
     groupDescriptions: {
       peer: 'Discover active desks, their Sessions, and absolute filesystem locations',
       conversation: 'Send ordinary Agent-to-Agent requests and retrieve their replies',
-      inbox: 'Deliver reports to the human Inbox or inspect and follow up on deliveries',
+      inbox: 'Send outward-facing notifications and reports to the human Inbox; inspect and follow up on deliveries',
       issue: 'Read the shared work board and manage this Workspace\'s durable work',
       provenance: 'Trace business artifacts to attributable product Sessions',
       signature: 'Show this Session\'s safe product identity',

--- a/src/tool/inbox-push.ts
+++ b/src/tool/inbox-push.ts
@@ -32,11 +32,13 @@ export const inboxPushFactory: WorkspaceToolFactory = {
   build(ctx: WorkspaceToolContext) {
     return tool({
       description: [
-        "Push an update to the user's inbox from this workspace.",
+        "Send an outward-facing notification or report to the human Inbox from this workspace.",
         'Use this when you have something the user should see —',
         'a finished analysis (point to the report file via `docs`),',
         'a question back to the user (write it as `comments`),',
         'a blocked task that needs input, or a status check-in.',
+        'Use a normal conversation reply for in-chat responses; reply attachments do not require an Inbox entry.',
+        'Inbox is not a file store or a general Agent-to-Agent channel.',
         '',
         '`docs` are paths relative to this workspace root. Each one',
         'is rendered live in the inbox UI when the user opens the',

--- a/src/tool/inbox-read.ts
+++ b/src/tool/inbox-read.ts
@@ -1,5 +1,5 @@
 /**
- * inbox_read — workspace's inbound view of the user's inbox.
+ * inbox_read — view of the human's notification and reporting history.
  *
  * The read counterpart to {@link inboxPushFactory}. inbox_push is the
  * outbound channel (workspace → user); this is the agent looking *back*
@@ -43,7 +43,7 @@ export const inboxReadFactory: WorkspaceToolFactory = {
   build(ctx: WorkspaceToolContext) {
     return tool({
       description: [
-        "Read recent entries from the user's inbox — the push log workspaces post finished work and questions to.",
+        "Read the human Inbox notification and reporting history — what Workspaces have surfaced to the user.",
         '',
         'Use this to recall what you already reported, or to see the broader stream of what every workspace has surfaced to the user.',
         '',

--- a/src/workspaces/alice-harness-assets.spec.ts
+++ b/src/workspaces/alice-harness-assets.spec.ts
@@ -33,3 +33,12 @@ it('keeps CLI switches separate from Skill inclusion and creates both runtime co
   expect(await readFile(join(dir, '.claude/skills/alice/SKILL.md'), 'utf8')).toBe('# alice')
   await expect(readFile(join(dir, '.agents/skills/traderhub/SKILL.md'))).rejects.toMatchObject({ code: 'ENOENT' })
 })
+
+it('restores an excluded file-delivery projection without enabling the CLI', async () => {
+  const dir = join(paths.root, 'workspace')
+  const config = { schemaVersion: 1 as const, cli: { alice: { enabled: false } }, skills: { 'file-delivery': false } }
+  await injectAliceHarnessSkills(dir, true, config)
+  for (const root of ['.agents', '.claude']) await expect(readFile(join(dir, root, 'skills/file-delivery/SKILL.md'))).rejects.toMatchObject({ code: 'ENOENT' })
+  await injectAliceHarnessSkills(dir, true, { ...config, skills: { 'file-delivery': true } })
+  for (const root of ['.agents', '.claude']) expect(await readFile(join(dir, root, 'skills/file-delivery/SKILL.md'), 'utf8')).toBe('# file-delivery')
+})

--- a/src/workspaces/alice-harness-policy.ts
+++ b/src/workspaces/alice-harness-policy.ts
@@ -5,7 +5,7 @@ import { CLI_EXPORTS } from '../server/cli-commands.js'
 
 export const ALICE_HARNESS_CONFIG_PATH = '.alice/alice-harness-config.json'
 export const ALICE_HARNESS_VERSION_PATH = '.alice/alice-harness-version.json'
-export const ALICE_HARNESS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'self-scheduling'] as const
+export const ALICE_HARNESS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'self-scheduling', 'file-delivery'] as const
 export const LEGACY_ALICE_HARNESS_SKILLS = [...ALICE_HARNESS_SKILLS, 'alice-workspace']
 export const aliceHarnessConfigSchema = z.object({
   schemaVersion: z.literal(1),

--- a/src/workspaces/context-injector.spec.ts
+++ b/src/workspaces/context-injector.spec.ts
@@ -127,7 +127,7 @@ describe('injectWorkspaceContext — skills', () => {
       wsId: 'ws-abc',
       dir,
     });
-    for (const name of ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'scan-value-chain']) {
+    for (const name of ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'file-delivery', 'scan-value-chain']) {
       expect(existsSync(join(dir, '.claude/skills', name, 'SKILL.md')), name).toBe(true);
       expect(existsSync(join(dir, '.agents/skills', name, 'SKILL.md')), name).toBe(true);
     }


### PR DESCRIPTION
Add an English `file-delivery` Skill for sending Workspace files in Connector replies through `[[relative/path.ext]]`. It explains ordered text/attachment delivery, literal examples, source-Workspace paths, current upload limits, and the separate optional sticker Skill. Register it in the Project-owned Alice Harness bundle so new tool-bearing Workspaces receive primary and Claude mirror copies and existing Workspaces can install/update/remove/restore it through the normal injection controls. Bump the file bundle to 1.0.3.

Clarify Inbox as the human-facing notification and reporting surface in the collaboration guide, scheduling Skill, live CLI help and tool descriptions. Remove the outdated claim that Inbox is the only headless delivery channel; Connector-backed Issue replies can already reach chat. This changes guidance, not Inbox syntax or delivery behavior.

Validation: Skill validator; root TypeScript; 295 changed-closure tests; explicit CLI shim and Connector parser tests. Real source-catalog probe reports `1.0.3+137e6a1bee172f48` and the new Skill. Context injection tests exercise real bundled files in both runtime directories; inclusion tests verify exclude/restore independently of CLI switches. No unsolicited Connector messages were sent and no existing Workspace copies were overwritten.
