### PR TITLE
Render Inbox attachments as blocks and images inline

### DIFF
--- a/docs/inbox-content.md
+++ b/docs/inbox-content.md
@@ -31,7 +31,9 @@ untouched. There is no legacy authoring or dual-read contract.
   lazy preview. It discards responses from an earlier selection. Summary-only
   consumers use `resolveFiles: false`. Inbox and Office share this projection.
 - `MarkdownContent` renders available file references in their original position
-  using exact-case paths. The shared Dialog owns focus, keyboard dismissal and
+  using exact-case paths. Documents use compact file blocks; images render in place
+  within 256px width and 512px height, preserving aspect ratio without upscaling.
+  Both remain keyboard-accessible preview links. The shared Dialog owns focus, keyboard dismissal and
   responsive previews. There is no separate Inbox attachment section.
 - Connector notifications carry the body unchanged. The existing bounded
   adapter upload / Telegram on-demand file controls derive their files from it.

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -59,7 +59,14 @@ function createWikilinkExtension(opts: { codeSpanWikilinks: boolean; fileHrefs?:
       const name = token.text as string
       if (opts.fileHrefs && isFileReference(name)) {
         const href = opts.fileHrefs[name]
-        return href ? `<a href="${escapeHtml(href)}" data-file-path="${escapeHtml(name)}">${escapeHtml(name)}</a>` : escapeHtml(token.raw)
+        if (!href) return escapeHtml(token.raw)
+        const attributes = `href="${escapeHtml(href)}" data-file-path="${escapeHtml(name)}"`
+        if (/\.(png|jpe?g|webp|gif)$/i.test(name)) {
+          return `<a class="markdown-file-image" ${attributes}><img src="${escapeHtml(href)}" alt="${escapeHtml(name)}" loading="lazy" /></a>`
+        }
+        const filename = name.split('/').pop() ?? name
+        const extension = filename.split('.').pop()?.toUpperCase() ?? 'FILE'
+        return `<a class="markdown-file-card" ${attributes}><span class="markdown-file-type">${escapeHtml(extension)}</span><span class="markdown-file-label"><strong>${escapeHtml(filename)}</strong><span>${escapeHtml(name)}</span></span><span aria-hidden="true">↗</span></a>`
       }
       const key = name.toLowerCase()
       return `<a class="wikilink" data-entity="${escapeHtml(key)}">${escapeHtml(name)}</a>`

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1778,3 +1778,41 @@ html[lang="ja"] .oa-onboarding-title {
 @media (prefers-reduced-motion: reduce) {
   .oa-collapsible-panel { transition: none; }
 }
+
+/* Resolved Workspace files retain their position in the Markdown body. */
+.markdown-content a.markdown-file-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: fit-content;
+  max-width: 100%;
+  margin: 12px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--muted);
+  color: var(--foreground);
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.markdown-file-type {
+  flex: none;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+}
+.markdown-file-label { display: grid; min-width: 0; }
+.markdown-file-label > span { color: var(--muted-foreground); font-size: 12px; }
+.markdown-content a.markdown-file-image { display: block; width: fit-content; max-width: 100%; }
+.markdown-content a.markdown-file-image img {
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: min(256px, 100%);
+  max-height: 512px;
+  object-fit: contain;
+  margin: 12px 0;
+}
+.markdown-content a.markdown-file-card:hover { border-color: var(--muted-foreground); }
+.markdown-content a[data-file-path]:focus-visible { outline: 2px solid var(--ring); outline-offset: 3px; }


### PR DESCRIPTION
## Summary
Render resolved Inbox attachments as compact file blocks in their original Markdown position. Images display directly, capped at 256px wide and 512px high with proportional downscaling, no upscaling, and a narrow-screen width bound. Both keep their existing preview interaction and keyboard focus indication.

## Verification
- Complete workspace build and root/UI typechecks passed.
- Full hermetic suite: 782 files passed; 6,931 tests passed, 4 skipped.
- Real local Project `/inbox`: file block opens the report, Escape closes preview, image renders at 256px outer width, and 390px viewport has no horizontal overflow.
- Synced current dev, including its Connector Protocol dependency/build fix.
