### PR TITLE
feat(desktop): integrate Windows native title bar controls

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -59,6 +59,7 @@ import { existingOwnerSmokeMode, resolveExistingOwnerStartup } from './existing-
 import { inspectPreviousUpdateAttempt, recordUpdateAttempt } from './update-attempt.js'
 import { childIsRunning, stopChild } from './child-shutdown.js'
 import { exitDesktopProcess } from './app-exit.js'
+import { configureWindowChrome, windowChromeOptions } from './window-chrome.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -1007,10 +1008,7 @@ app.whenReady().then(async () => {
     width: 1280,
     height: 800,
     title: 'OpenAlice',
-    ...(process.platform === 'darwin' ? {
-      titleBarStyle: 'hidden' as const,
-      trafficLightPosition: { x: 16, y: 15 },
-    } : {}),
+    ...windowChromeOptions(),
     webPreferences: {
       preload: resolve(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -1021,6 +1019,7 @@ app.whenReady().then(async () => {
       sandbox: false,
     },
   })
+  configureWindowChrome(win)
   win.webContents.on('preload-error', (_event, preloadPath, error) => {
     console.error(`[guardian] renderer preload failed path=${preloadPath}: ${error.message}`)
   })

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -126,7 +126,11 @@ ipcRenderer.on('openalice:updater:status', (_event, raw: unknown) => {
 })
 
 const api = {
-  windowChrome: { platform: process.platform },
+  windowChrome: {
+    platform: process.platform,
+    setTheme: (theme: { color: string; symbolColor: string }) =>
+      process.platform === 'win32' ? ipcRenderer.invoke('openalice:window-chrome:theme', theme) : Promise.resolve(),
+  },
   runtime: {
     info: () => ipcRenderer.invoke('openalice:runtime:info'),
   },

--- a/apps/desktop/src/window-chrome.spec.ts
+++ b/apps/desktop/src/window-chrome.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { BrowserWindow } from 'electron'
+
+const electron = vi.hoisted(() => ({ ipcMain: { handle: vi.fn(), removeHandler: vi.fn() }, nativeTheme: { shouldUseDarkColors: false } }))
+vi.mock('electron', () => electron)
+import { configureWindowChrome, windowChromeOptions } from './window-chrome.js'
+
+beforeEach(() => { vi.clearAllMocks(); electron.nativeTheme.shouldUseDarkColors = false })
+
+describe('native window chrome', () => {
+  it('retains platform-native controls without making a frameless window', () => {
+    expect(windowChromeOptions('win32')).toMatchObject({ titleBarStyle: 'hidden', titleBarOverlay: { height: 44, color: '#faf9f6' } })
+    expect(windowChromeOptions('win32')).not.toHaveProperty('frame')
+    expect(windowChromeOptions('darwin')).toEqual({ titleBarStyle: 'hidden', trafficLightPosition: { x: 16, y: 15 } })
+    expect(windowChromeOptions('linux')).toEqual({})
+    electron.nativeTheme.shouldUseDarkColors = true
+    expect(windowChromeOptions('win32')).toMatchObject({ titleBarOverlay: { color: '#181818' } })
+  })
+  it('accepts only color updates from this window\'s application main frame and cleans up', () => {
+    const mainFrame = { url: 'app://openalice/quick-start' }
+    const webContents = { mainFrame }
+    const win = { webContents, setTitleBarOverlay: vi.fn(), isDestroyed: () => false, once: vi.fn() }
+    configureWindowChrome(win as unknown as BrowserWindow, 'win32')
+    const handler = electron.ipcMain.handle.mock.calls[0][1]
+    const theme = { color: '#faf9f6', symbolColor: '#252629' }
+    handler({ sender: {}, senderFrame: mainFrame }, theme)
+    handler({ sender: webContents, senderFrame: {} }, theme)
+    handler({ sender: webContents, senderFrame: mainFrame }, { color: 'url(bad)', symbolColor: '#252629' })
+    expect(win.setTitleBarOverlay).not.toHaveBeenCalled()
+    handler({ sender: webContents, senderFrame: mainFrame }, theme)
+    expect(win.setTitleBarOverlay).toHaveBeenCalledWith({ ...theme, height: 44 })
+    mainFrame.url = 'https://example.com/'
+    handler({ sender: webContents, senderFrame: mainFrame }, theme)
+    expect(win.setTitleBarOverlay).toHaveBeenCalledTimes(1)
+    win.once.mock.calls[0][1]()
+    expect(electron.ipcMain.removeHandler).toHaveBeenCalledWith('openalice:window-chrome:theme')
+  })
+  it('does not register Windows IPC on other platforms', () => {
+    configureWindowChrome({} as BrowserWindow, 'darwin')
+    expect(electron.ipcMain.handle).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/window-chrome.ts
+++ b/apps/desktop/src/window-chrome.ts
@@ -1,0 +1,32 @@
+import { ipcMain, nativeTheme, type BrowserWindow, type BrowserWindowConstructorOptions } from 'electron'
+
+export function windowChromeOptions(platform = process.platform): BrowserWindowConstructorOptions {
+  if (platform === 'darwin') return { titleBarStyle: 'hidden', trafficLightPosition: { x: 16, y: 15 } }
+  if (platform !== 'win32') return {}
+  return {
+    minWidth: 400,
+    minHeight: 320,
+    titleBarStyle: 'hidden',
+    titleBarOverlay: {
+      height: 44,
+      color: nativeTheme.shouldUseDarkColors ? '#181818' : '#faf9f6',
+      symbolColor: nativeTheme.shouldUseDarkColors ? '#eeeeee' : '#252629',
+    },
+  }
+}
+
+/** Color-only bridge: window operations and caption hit testing stay native. */
+export function configureWindowChrome(win: BrowserWindow, platform = process.platform): void {
+  if (platform !== 'win32') return
+  const channel = 'openalice:window-chrome:theme'
+  ipcMain.handle(channel, (event, input: unknown) => {
+    if (event.sender !== win.webContents || event.senderFrame !== win.webContents.mainFrame) return
+    if (!event.senderFrame?.url.startsWith('app://openalice/')) return
+    if (!input || typeof input !== 'object') return
+    const { color, symbolColor } = input as Record<string, unknown>
+    const hex = /^#[0-9a-f]{6}$/i
+    if (typeof color !== 'string' || !hex.test(color) || typeof symbolColor !== 'string' || !hex.test(symbolColor)) return
+    if (!win.isDestroyed()) win.setTitleBarOverlay({ color, symbolColor, height: 44 })
+  })
+  win.once('closed', () => ipcMain.removeHandler(channel))
+}

--- a/docs/ui-interaction-and-motion.md
+++ b/docs/ui-interaction-and-motion.md
@@ -69,7 +69,20 @@ native-control space; its compact width is 88px. Below 768px the mobile context
 bar reserves that same left inset, and the navigation drawer reserves 44px at
 the top. Header whitespace is draggable; controls remain interactive. The
 preload's read-only `windowChrome.platform` selects this shell treatment.
-Browser and other desktop platforms retain their existing window chrome.
+Windows Electron uses native Window Controls Overlay in the same 44px header
+band. `useWindowsChrome` measures the shared page, navigation, work-panel and
+banner rows against the overlay's reported CSS-pixel rectangle; only rows
+intersecting native controls reserve horizontal space. Geometry changes cover
+resize, display scaling, maximization and fullscreen, without imitating native
+caption buttons or Snap Layouts. Very narrow split toolbars move below the
+caption band instead of overflowing into its controls. Loading and disconnected
+screens retain a draggable caption region without mounting the authenticated
+App. App palette/surface colors update the native
+overlay through a validated color-only preload bridge. Edge drawers reserve
+the caption band's height, and header controls remain non-draggable.
+Browser and Linux retain their existing window chrome. Windows native visual
+and Snap/high-DPI acceptance requires a Windows runtime; Mac geometry tests
+and browser layout checks do not replace that gate.
 
 The activity rail's utility items, groups, and visibility are user-arranged from
 Settings → Activity bar and stored in `data/ui-layout.json`. The three Harnesses

--- a/ui/src/auth/AuthGate.tsx
+++ b/ui/src/auth/AuthGate.tsx
@@ -16,6 +16,7 @@ import { getBackendConnection, type BackendConnection } from './backendConnectio
 import { LoginPage, NoTokenPage } from './LoginPage'
 import { Spinner } from '../components/StateViews'
 import { Button } from '../components/ui/button'
+import { useWindowsChrome } from '../hooks/useWindowsChrome'
 
 function remoteTargetLabel(connection: Extract<BackendConnection, { kind: 'remote' }>): string {
   return connection.sshPort === 22
@@ -117,6 +118,7 @@ export function BackendUnavailableScreen({
 }
 
 export function AuthGate({ children }: { children: ReactNode }) {
+  useWindowsChrome()
   const { state, backendUnavailable, refresh } = useAuth()
   const connection = getBackendConnection()
 

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -53,7 +53,7 @@ export function UpdateBanner() {
   }
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2 bg-primary-muted/30 border-b border-primary/40 text-[12px] text-foreground">
+    <div data-desktop-banner className="flex items-center gap-3 px-4 py-2 bg-primary-muted/30 border-b border-primary/40 text-[12px] text-foreground">
       <span className="shrink-0">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />

--- a/ui/src/demo/DemoBanner.tsx
+++ b/ui/src/demo/DemoBanner.tsx
@@ -6,7 +6,7 @@ export function DemoBanner(): ReactElement {
   const { t } = useTranslation()
 
   return (
-    <div className="oa-demo-banner flex min-h-9 items-center gap-2 border-b px-2 py-1 text-[12px] leading-[18px] text-foreground sm:gap-3 sm:px-3">
+    <div data-desktop-banner className="oa-demo-banner flex min-h-9 items-center gap-2 border-b px-2 py-1 text-[12px] leading-[18px] text-foreground sm:gap-3 sm:px-3">
       <span className="inline-flex h-6 shrink-0 items-center px-1 text-[11px] leading-[15px] font-medium text-warning">
         {t('demoBanner.badge')}
       </span>

--- a/ui/src/hooks/useWindowsChrome.spec.tsx
+++ b/ui/src/hooks/useWindowsChrome.spec.tsx
@@ -1,0 +1,72 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { useWindowsChrome } from './useWindowsChrome'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  delete (navigator as unknown as Record<string, unknown>).windowControlsOverlay
+  delete (window as unknown as Record<string, unknown>).openAlice
+  document.body.innerHTML = ''
+  document.documentElement.removeAttribute('style')
+})
+
+it('updates actual header insets, theme and fullscreen state, then releases observers', async () => {
+  let pending: FrameRequestCallback | undefined
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => { pending = callback; return 1 })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  const disconnect = vi.fn()
+  vi.stubGlobal('ResizeObserver', class { observe() {} unobserve() {} disconnect = disconnect })
+  const overlay = Object.assign(new EventTarget(), {
+    visible: true,
+    getTitlebarAreaRect: () => new DOMRect(0, 0, 862, 44),
+  })
+  Object.defineProperty(navigator, 'windowControlsOverlay', { configurable: true, value: overlay })
+  const setTheme = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(window, 'openAlice', { configurable: true, value: { windowChrome: { platform: 'win32', setTheme } } })
+  document.documentElement.style.setProperty('--foreground', '#eeeeee')
+  const top = document.createElement('div')
+  top.className = 'oa-topbar'
+  top.style.backgroundColor = 'rgb(24, 24, 24)'
+  let topRect = new DOMRect(260, 0, 740, 44)
+  top.getBoundingClientRect = () => topRect
+  document.body.append(top)
+  const view = renderHook(useWindowsChrome)
+  expect(top.style.getPropertyValue('--caption-right')).toBe('138px')
+  expect(top.hasAttribute('data-caption-row')).toBe(true)
+  expect(setTheme).toHaveBeenLastCalledWith({ color: '#181818', symbolColor: '#eeeeee' })
+  const flush = async () => {
+    await act(async () => { await Promise.resolve(); const callback = pending; pending = undefined; callback?.(0) })
+  }
+  overlay.visible = false
+  overlay.dispatchEvent(new Event('geometrychange'))
+  await flush()
+  expect(top.style.getPropertyValue('--caption-right')).toBe('0px')
+  expect(top.hasAttribute('data-caption-row')).toBe(false)
+  expect(document.documentElement.style.getPropertyValue('--desktop-caption-height')).toBe('0px')
+  overlay.visible = true
+  top.style.backgroundColor = 'rgb(250, 249, 246)'
+  document.documentElement.style.setProperty('--foreground', '#252629')
+  overlay.dispatchEvent(new Event('geometrychange'))
+  await flush()
+  expect(top.style.getPropertyValue('--caption-right')).toBe('138px')
+  expect(setTheme).toHaveBeenLastCalledWith({ color: '#faf9f6', symbolColor: '#252629' })
+  topRect = new DOMRect(850, 0, 150, 44)
+  overlay.dispatchEvent(new Event('geometrychange'))
+  await flush()
+  expect(top.hasAttribute('data-caption-stacked')).toBe(true)
+  top.setAttribute('inert', '')
+  await flush()
+  expect(top.hasAttribute('data-caption-row')).toBe(false)
+  expect(document.querySelector<HTMLElement>('.oa-windows-chrome-fallback')?.hidden).toBe(false)
+  view.unmount()
+  expect(disconnect).toHaveBeenCalled()
+  expect(top.style.getPropertyValue('--caption-right')).toBe('')
+  expect(document.documentElement.dataset.windowChrome).toBeUndefined()
+  expect(document.querySelector('.oa-windows-chrome-fallback')).toBeNull()
+})
+
+it('leaves ordinary browser chrome untouched', () => {
+  renderHook(useWindowsChrome)
+  expect(document.documentElement.dataset.windowChrome).toBeUndefined()
+})

--- a/ui/src/hooks/useWindowsChrome.ts
+++ b/ui/src/hooks/useWindowsChrome.ts
@@ -1,0 +1,110 @@
+import { useLayoutEffect } from 'react'
+import { captionInsets, opaqueHex, type ChromeRect } from '../lib/window-chrome'
+
+interface WindowControlsOverlay extends EventTarget {
+  visible: boolean
+  getTitlebarAreaRect(): DOMRect
+}
+
+const headers = '.oa-topbar, .oa-activity-brand, .harness-work-toolbar, [data-testid="mobile-context-bar"], [data-desktop-banner]'
+
+/** Measure shared header primitives, never page-specific buttons. Native
+ * geometry handles Windows scaling, maximization, RTL and fullscreen. */
+export function useWindowsChrome(): void {
+  useLayoutEffect(() => {
+    const chrome = window.openAlice?.windowChrome
+    if (chrome?.platform !== 'win32') return
+    const root = document.documentElement
+    root.dataset.windowChrome = 'windows'
+    const overlay = (navigator as Navigator & { windowControlsOverlay?: WindowControlsOverlay }).windowControlsOverlay
+    let frame = 0
+    let lastTheme = ''
+    const observed = new Set<HTMLElement>()
+    // Loading/login/reconnection screens have no page header. Keep their
+    // window movable without mounting App or starting its backend effects.
+    const fallback = document.createElement('div')
+    fallback.className = 'oa-windows-chrome-fallback'
+    fallback.setAttribute('aria-hidden', 'true')
+    document.body.append(fallback)
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update)
+    }
+    const resize = new ResizeObserver(schedule)
+    function update() {
+      frame = 0
+      const reported = overlay?.visible ? overlay.getTitlebarAreaRect() : null
+      const safe: ChromeRect | null = overlay && !overlay.visible ? null
+        : reported && reported.width > 0 && reported.height > 0 ? reported
+          : { x: 0, y: 0, width: Math.max(0, window.innerWidth - 138), height: 44 }
+      root.style.setProperty('--desktop-caption-height', `${safe ? safe.y + safe.height : 0}px`)
+      const current = new Set(document.querySelectorAll<HTMLElement>(headers))
+      let captionSurface: HTMLElement | undefined
+      let hasHeader = false
+      for (const element of current) {
+        if (!observed.has(element)) { observed.add(element); resize.observe(element) }
+        const rect = element.getBoundingClientRect()
+        const inset = captionInsets(rect, element.closest('[inert], [aria-hidden="true"]') ? null : safe)
+        hasHeader ||= inset.caption
+        element.style.setProperty('--caption-left', `${inset.left}px`)
+        element.style.setProperty('--caption-right', `${inset.right}px`)
+        element.toggleAttribute('data-caption-row', inset.caption)
+        // A very narrow split pane cannot fit controls beside native captions.
+        // Put that toolbar below the caption band instead of overlapping it.
+        element.toggleAttribute('data-caption-stacked', inset.caption && inset.left + inset.right > 0 && rect.width - inset.left - inset.right < 160)
+        if (inset.right > 0 || inset.left > 0) captionSurface = element
+      }
+      for (const element of observed) {
+        if (!current.has(element)) { resize.unobserve(element); observed.delete(element) }
+      }
+      fallback.hidden = hasHeader || !safe
+      if (safe) {
+        fallback.style.left = `${safe.x}px`
+        fallback.style.top = `${safe.y}px`
+        fallback.style.width = `${safe.width}px`
+        fallback.style.height = `${safe.height}px`
+      }
+      // Use the surface behind the caption buttons (work panels use sidebar
+      // material), rather than assuming that the OS and app themes agree.
+      let surface: HTMLElement | null = captionSurface ?? document.body
+      let color: string | null = null
+      while (surface && !color) {
+        color = opaqueHex(getComputedStyle(surface).backgroundColor)
+        surface = surface.parentElement
+      }
+      const style = getComputedStyle(root)
+      color ??= opaqueHex(style.getPropertyValue('--background').trim())
+      const symbolColor = opaqueHex(style.getPropertyValue('--foreground').trim())
+      if (color && symbolColor && `${color}:${symbolColor}` !== lastTheme) {
+        lastTheme = `${color}:${symbolColor}`
+        void chrome?.setTheme?.({ color, symbolColor }).catch(() => { lastTheme = '' })
+      }
+    }
+    const mutations = new MutationObserver(schedule)
+    mutations.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['inert', 'aria-hidden'] })
+    const theme = new MutationObserver(schedule)
+    theme.observe(root, { attributes: true, attributeFilter: ['data-palette', 'data-ui-style'] })
+    resize.observe(document.body)
+    overlay?.addEventListener('geometrychange', schedule)
+    window.addEventListener('resize', schedule)
+    document.addEventListener('scroll', schedule, true)
+    update()
+    return () => {
+      cancelAnimationFrame(frame)
+      resize.disconnect()
+      mutations.disconnect()
+      theme.disconnect()
+      fallback.remove()
+      overlay?.removeEventListener('geometrychange', schedule)
+      window.removeEventListener('resize', schedule)
+      document.removeEventListener('scroll', schedule, true)
+      delete root.dataset.windowChrome
+      root.style.removeProperty('--desktop-caption-height')
+      for (const element of observed) {
+        element.style.removeProperty('--caption-left')
+        element.style.removeProperty('--caption-right')
+        element.removeAttribute('data-caption-row')
+        element.removeAttribute('data-caption-stacked')
+      }
+    }
+  }, [])
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -761,6 +761,35 @@ body {
 /* One chrome row for navigator and working view. Body descriptions are not
    toolbar content. Layout owns the header slot; pages retain their actions. */
 .oa-topbar-host { container-type: inline-size; }
+/* Windows keeps native caption controls. Only header rows intersecting their
+   actual geometry reserve space; nested toolbars keep their normal density. */
+.oa-windows-chrome-fallback {
+  position: fixed;
+  z-index: 101;
+  -webkit-app-region: drag;
+}
+:root[data-window-chrome="windows"] [data-caption-row] {
+  min-height: max(44px, var(--desktop-caption-height, 44px));
+  height: auto;
+  flex-shrink: 0;
+  padding-left: max(12px, calc(var(--caption-left, 0px) + 8px));
+  padding-right: max(12px, calc(var(--caption-right, 0px) + 8px));
+  -webkit-app-region: drag;
+}
+:root[data-window-chrome="windows"] [data-caption-stacked] {
+  padding: calc(var(--desktop-caption-height, 44px) + 4px) 12px 4px;
+}
+:root[data-window-chrome="windows"] [data-caption-row] :is(button, a, input, textarea, select, [role="button"], [role="tab"], [role="tablist"], [role="separator"], [contenteditable="true"]),
+:root[data-window-chrome="windows"] [data-caption-row] :is(.oa-topbar-actions, .oa-topbar-leading) {
+  -webkit-app-region: no-drag;
+}
+/* Portaled edge drawers also stay below the native caption controls. */
+:root[data-window-chrome="windows"] [data-slot="sheet-content"]:is([data-side="left"], [data-side="right"], [data-side="top"]) {
+  padding-top: max(16px, var(--desktop-caption-height, 44px));
+}
+:root[data-window-chrome="windows"] [data-slot="sheet-content"] [data-slot="sheet-close"] {
+  top: calc(var(--desktop-caption-height, 44px) + 8px);
+}
 /* macOS owns the traffic lights; the existing navigation and page headers
    share their row. Browser windows keep their original geometry. */
 .oa-desktop-mac .oa-topbar,

--- a/ui/src/lib/window-chrome.spec.ts
+++ b/ui/src/lib/window-chrome.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { captionInsets, opaqueHex } from './window-chrome'
+
+describe('captionInsets', () => {
+  const safe = { x: 0, y: 0, width: 1142, height: 44 }
+  it('reserves only the rightmost split panel, not the conversation or lower toolbar', () => {
+    expect(captionInsets({ x: 260, y: 0, width: 500, height: 44 }, safe)).toEqual({ left: 0, right: 0, caption: true })
+    expect(captionInsets({ x: 760, y: 0, width: 520, height: 44 }, safe)).toEqual({ left: 0, right: 138, caption: true })
+    expect(captionInsets({ x: 760, y: 44, width: 520, height: 44 }, safe)).toEqual({ left: 0, right: 0, caption: false })
+  })
+  it('uses reported geometry for narrow/high-DPI windows and left-side controls', () => {
+    expect(captionInsets({ x: 0, y: 0, width: 600, height: 48 }, { x: 0, y: 0, width: 450, height: 44 }).right).toBe(150)
+    expect(captionInsets({ x: 0, y: 0, width: 600, height: 44 }, { x: 138, y: 0, width: 462, height: 44 }).left).toBe(138)
+  })
+  it('releases caption space in fullscreen or for hidden headers', () => {
+    expect(captionInsets({ x: 0, y: 0, width: 1280, height: 44 }, null)).toEqual({ left: 0, right: 0, caption: false })
+    expect(captionInsets({ x: 0, y: 0, width: 0, height: 0 }, safe).caption).toBe(false)
+  })
+})
+
+it('uses opaque surface colors and skips transparent layers', () => {
+  expect(opaqueHex('rgb(250, 249, 246)')).toBe('#faf9f6')
+  expect(opaqueHex('rgba(0, 0, 0, 0)')).toBeNull()
+  expect(opaqueHex('rgba(20, 30, 40, 0.4)')).toBeNull()
+  expect(opaqueHex('#eeeeee')).toBe('#eeeeee')
+})

--- a/ui/src/lib/window-chrome.ts
+++ b/ui/src/lib/window-chrome.ts
@@ -1,0 +1,21 @@
+export interface ChromeRect { x: number; y: number; width: number; height: number }
+
+/** All coordinates are CSS pixels, as supplied by Window Controls Overlay.
+ * Only a header intersecting the caption band needs to yield horizontal space. */
+export function captionInsets(rect: ChromeRect, safe: ChromeRect | null) {
+  if (!safe || rect.width <= 0 || rect.height <= 0 || rect.y >= safe.y + safe.height || rect.y + rect.height <= safe.y) {
+    return { left: 0, right: 0, caption: false }
+  }
+  return {
+    left: Math.min(rect.width, Math.max(0, safe.x - rect.x)),
+    right: Math.min(rect.width, Math.max(0, rect.x + rect.width - safe.x - safe.width)),
+    caption: true,
+  }
+}
+
+export function opaqueHex(value: string): string | null {
+  if (/^#[0-9a-f]{6}$/i.test(value)) return value
+  const rgb = value.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)$/)
+  if (!rgb || (rgb[4] !== undefined && Number(rgb[4]) !== 1)) return null
+  return '#' + rgb.slice(1, 4).map((n) => Math.min(255, Number(n)).toString(16).padStart(2, '0')).join('')
+}

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -28,7 +28,10 @@ interface Window {
    * sync with apps/desktop/src/preload.ts; never expose raw ipcRenderer.
    */
   readonly openAlice?: {
-    readonly windowChrome?: { readonly platform: string }
+    readonly windowChrome?: {
+      readonly platform: string
+      setTheme?(theme: { color: string; symbolColor: string }): Promise<void>
+    }
     readonly runtime: {
       info(): Promise<{
         mode: 'electron-dev' | 'electron-packaged'


### PR DESCRIPTION
Windows currently places a separate system title bar above OpenAlice. Enable Electron's native Window Controls Overlay in the existing 44px header band, preserving native minimize/maximize/close behavior and the standard window frame.

The shared chrome adapter measures page headers, split-panel toolbars, mobile navigation and banners against the native overlay's CSS-pixel safe rectangle. Only intersecting rows reserve space; very narrow panels move their toolbar below the caption band. Geometry changes release space in fullscreen and recalculate after resizing/scaling. Edge drawers retain caption clearance, and loading/reconnection screens keep a draggable region without mounting the authenticated App. App surface and palette colors update the native controls through a validated, main-frame-only color bridge. macOS options and Linux/browser behavior remain unchanged.

Validation:
- Full hermetic suite: 785 files passed; 6,940 tests passed, 4 skipped.
- Final focused geometry/bridge/auth checks: 4 files, 10 tests passed.
- Root, UI and desktop typechecks; complete Electron build; final UI production build passed.
- Mac Electron PTY/CLI smoke passed.
- Temporary, untracked browser geometry fixture exercised desktop page headers, split panels, light/dark themes, mobile navigation and a 400px viewport without horizontal overflow. This fixture was not a Windows screenshot and is not part of the product.

The maintainer explicitly authorized implementation without Windows hardware and requested no new CI workflow. No workflow was added. Windows native rendering, Snap Layouts, multi-monitor DPI and packaged Windows acceptance remain unverified; no Windows installer was executed on this Mac.
