### PR TITLE
Choose TUI or GUI from Quick Start

### DIFF
--- a/docs/web-conversation-surface.md
+++ b/docs/web-conversation-surface.md
@@ -164,3 +164,8 @@ turn is running. A deliberate PTY disposal must not trigger browser reconnect.
 Web shutdown waits for child termination, including the SIGKILL fallback, before
 another writer may start. The UI renders background occupancy without attaching
 a terminal to a headless Session.
+
+Quick Start exposes a TUI / GUI selector beside the runtime. GUI is available
+only with `web.freshSession`; `quick-chat` accepts `surface: webpi` and starts
+the structured host directly with the same Session runtime binding. Omission
+keeps the terminal default. The initial prompt is sent once after Web startup.

--- a/src/webui/routes/workspaces-quickchat.spec.ts
+++ b/src/webui/routes/workspaces-quickchat.spec.ts
@@ -257,6 +257,7 @@ function build(opts: {
     rememberAutoPredictionDefaultWorkspace,
   });
   return {
+    svc,
     app,
     opencode,
     spawn,
@@ -566,6 +567,28 @@ describe('GET /credentials — Quick Chat launch metadata', () => {
 });
 
 describe('POST /quick-chat — native auth and explicit credential overrides', () => {
+  it('starts GUI directly without spawning a terminal and forwards the prompt', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({});
+    const { app, svc, opencode, spawn } = build();
+    (opencode.capabilities as any).web = { wire: 'acp', freshSession: true };
+    (opencode as any).composeWebCommand = vi.fn();
+    svc.startWebSession = vi.fn(async () => ({} as any));
+    (svc as any).web = { prompt: vi.fn(async () => ({})) } as any;
+    const r = await quickChat(app, { prompt: 'GUI hello', agent: 'opencode', surface: 'webpi' });
+    expect(r.status).toBe(201);
+    expect(r.body.session.surface).toBe('webpi');
+    expect(spawn).not.toHaveBeenCalled();
+    expect(svc.startWebSession).toHaveBeenCalledOnce();
+    expect(svc.web.prompt).toHaveBeenCalledWith(r.body.session.sessionId, 'GUI hello');
+  });
+
+  it('rejects GUI for a runtime without fresh Web support before spawning', async () => {
+    const { app, spawn } = build();
+    const r = await quickChat(app, { prompt: 'hello', agent: 'shell', surface: 'webpi' });
+    expect(r.status).toBe(400);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it('opencode + empty vault → native launch without injection', async () => {
     vi.mocked(readCredentials).mockResolvedValue({});
     const { app, opencode, spawn } = build();

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -242,6 +242,7 @@ function redactLaunchCommand(argv: readonly string[]): readonly string[] {
 
 /** The 201 body both `/:id/sessions/spawn` and `/quick-chat` return. */
 interface SpawnedSessionBody {
+  readonly surface?: 'terminal' | 'webpi';
   readonly sessionId: string;
   readonly wsId: string;
   readonly name: string;
@@ -339,6 +340,7 @@ export function createWorkspaceRoutes(
       /** Product-level conversation id. Resolved to a native id only here. */
       readonly resumeId?: string;
       readonly initialPrompt?: string;
+      readonly surface?: 'terminal' | 'webpi';
       readonly title?: string;
       readonly sourceRunId?: string;
       readonly credentialSource?: 'native';
@@ -410,6 +412,10 @@ export function createWorkspaceRoutes(
       return { ok: false, status: 400, body: { error: 'unknown_agent', message: `no adapter: ${agentId}` } };
     }
     const adapter = svc.resolveAdapter(meta, agentId);
+    if (opts.surface === 'webpi' && (!adapter.capabilities.web?.freshSession || !adapter.composeWebCommand)) {
+      return { ok: false, status: 400, body: { error: 'unsupported_surface', message: 'This runtime cannot start a fresh GUI session' } };
+    }
+
     if (requestedIdentity && requestedIdentity.agent !== adapter.id) {
       return { ok: false, status: 400, body: { error: 'resume_wrong_agent' } };
     }
@@ -503,7 +509,7 @@ export function createWorkspaceRoutes(
           ? { metadata: sessionMetadata(opts.createdBy) }
           : {}),
         state: 'running',
-        surface: 'terminal',
+        surface: opts.surface ?? 'terminal',
         ...(fallbackTitle ? { fallbackTitle } : {}),
         ...(opts.sourceRunId ? { sourceRunId: opts.sourceRunId } : {}),
       });
@@ -523,6 +529,14 @@ export function createWorkspaceRoutes(
           agent: adapter.id,
           sessionRecordId: record.id,
         })
+      }
+      if (opts.surface === 'webpi') {
+        operationLease?.release();
+        releaseClaim();
+        const snapshot = await svc.startWebSession(meta, record);
+        if (initialPrompt) await svc.web.prompt(record.id, initialPrompt);
+        releaseClaim();
+        return { ok: true, session: { sessionId: record.id, wsId: id, name: record.name, agent: adapter.id, resumeId: record.resumeId, pid: snapshot.pid ?? 0, startedAt: snapshot.startedAt, title: sessionPreferredTitle(record) ?? null, surface: 'webpi' } };
       }
       const ctx: SessionFactoryContext = {
         ...(resume !== undefined ? { resume } : {}),
@@ -560,7 +574,7 @@ export function createWorkspaceRoutes(
         resumeId: identity.resumeId,
         agent: adapter.id,
         sessionRecordId: record.id,
-        surface: 'terminal',
+        surface: opts.surface ?? 'terminal',
         cause: { kind: 'ui' },
       })
       releaseClaim();
@@ -579,11 +593,12 @@ export function createWorkspaceRoutes(
       };
     } catch (err) {
       releaseClaim();
+      if (opts.surface === 'webpi') await svc.web.stop(record.id, 'GUI launch failed').catch(() => undefined);
       await svc.sessionCoordinator.transition({
         wsId: id,
         resumeId: record.resumeId,
         state: 'paused',
-        surface: 'terminal',
+        surface: opts.surface ?? 'terminal',
       }).catch(() => undefined);
       launcherLogger.error('workspace.session_spawn_failed', { id, err });
       await svc.recordAgentRuntime?.('runtime.spawn_failed', {
@@ -591,7 +606,7 @@ export function createWorkspaceRoutes(
         resumeId: record.resumeId,
         agent: adapter.id,
         sessionRecordId: record.id,
-        surface: 'terminal',
+        surface: opts.surface ?? 'terminal',
         cause: { kind: 'ui' },
         error: (err as Error).message,
       })
@@ -2002,6 +2017,7 @@ export function createWorkspaceRoutes(
   // Workspace template; the native Coding Agent remains the worker.
   // Body: { prompt, agent?, targetWsId?, template? }
   app.post('/quick-chat', async (c) => {
+    let surface: 'terminal' | 'webpi' | undefined;
     let prompt: string;
     let agentId: string | undefined;
     let credentialSource: 'native' | undefined;
@@ -2013,6 +2029,8 @@ export function createWorkspaceRoutes(
     try {
       const body = await safeJson(c);
       const fields = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+      if (fields['surface'] !== undefined && fields['surface'] !== 'terminal' && fields['surface'] !== 'webpi') return c.json({ error: 'invalid_surface' }, 400);
+      surface = fields['surface'] as typeof surface;
       const seed = parseSeedPrompt(fields['prompt']);
       if (seed === null) return c.json({ error: 'prompt_required' }, 400);
       if ('error' in seed) return c.json(seed, 400);
@@ -2139,6 +2157,7 @@ export function createWorkspaceRoutes(
     }
 
     const spawn = await spawnInteractiveSession(meta, {
+      surface,
       ...(agentId !== undefined ? { agentId } : {}),
       ...(credentialSource !== undefined ? { credentialSource } : {}),
       ...(credentialSlug !== undefined ? { credentialSlug } : {}),

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -1295,8 +1295,10 @@ export async function quickChat(
   model?: string | null,
   reasoningEffort?: ModelReasoningEffort,
   credentialSource?: 'native',
+      surface?: 'terminal' | 'webpi',
 ): Promise<QuickChatResult> {
   const body: Record<string, unknown> = { prompt };
+  if (surface) body['surface'] = surface;
   if (credentialSource !== undefined) body['credentialSource'] = credentialSource;
   if (agent !== undefined) body['agent'] = agent;
   if (credentialSlug !== undefined) body['credentialSlug'] = credentialSlug;

--- a/ui/src/contexts/WorkspacesContext.tsx
+++ b/ui/src/contexts/WorkspacesContext.tsx
@@ -439,6 +439,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
       model?: string | null,
       reasoningEffort?: import('../api').ModelReasoningEffort,
       credentialSource?: 'native',
+      surface?: 'terminal' | 'webpi',
     ): Promise<string> => {
       await ensureTerminalAppearancePublished()
       const { workspace, session } = await apiQuickChat(
@@ -450,6 +451,7 @@ export function WorkspacesProvider({ children }: { children: ReactNode }) {
         model,
         reasoningEffort,
         credentialSource,
+        surface,
       )
       const nowIso = new Date().toISOString()
       const newRecord: SessionRecord = {

--- a/ui/src/contexts/workspaces-context.ts
+++ b/ui/src/contexts/workspaces-context.ts
@@ -70,6 +70,7 @@ export interface WorkspacesContextValue {
     model?: string | null,
     reasoningEffort?: import('../api').ModelReasoningEffort,
     credentialSource?: 'native',
+      surface?: 'terminal' | 'webpi',
   ): Promise<string>
   pauseSession(wsId: string, sessionId: string): Promise<void>
   resumeSession(wsId: string, sessionId: string, source?: WorkspaceSource): Promise<void>

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1323,6 +1323,7 @@ export const workspacesHandlers = [
   // is multi-runtime.
   http.post('/api/workspaces/quick-chat', async ({ request }) => {
     const body = (await request.json().catch(() => null)) as {
+      surface?: unknown
       prompt?: unknown
       agent?: unknown
       targetWsId?: unknown
@@ -1355,7 +1356,8 @@ export const workspacesHandlers = [
     const prefix = ({ claude: 'c', codex: 'x', grok: 'g', omp: 'om', opencode: 'o', pi: 'p' } as Record<string, string>)[agent]
       ?? agent.slice(0, 1)
     const name = `${prefix}${ws.sessions.filter((session) => session.agent === agent).length + 1}`
-    const surface = agent in demoWebCapabilities ? 'webpi' as const : 'terminal' as const
+    if (body?.surface === 'webpi' && !(agent in demoWebCapabilities)) return HttpResponse.json({ error: 'unsupported_surface' }, { status: 400 })
+    const surface = body?.surface === 'terminal' ? 'terminal' as const : agent in demoWebCapabilities ? 'webpi' as const : 'terminal' as const
     const record: SessionRecord = {
       id: sessionId,
       wsId: ws.id,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1450,6 +1450,7 @@ export const en = {
     resumeError: 'Could not resume this manager conversation.',
   },
   chatLanding: {
+    uiMode: 'UI mode',
     heading: 'What should Alice work on?',
     subheading: 'Research, analysis, and trading workflows in the selected Workspace.',
     targetHeading: 'New session in this workspace',

--- a/ui/src/i18n/locales/ja.ts
+++ b/ui/src/i18n/locales/ja.ts
@@ -1425,6 +1425,7 @@ export const ja: Resources = {
     resumeError: 'この管理者会話を再開できませんでした。',
   },
   chatLanding: {
+    uiMode: 'UI モード',
     heading: 'Alice に何を任せますか？',
     subheading: '選択した Workspace で調査、分析、取引を進めます。',
     targetHeading: 'このワークスペースで新規セッション',

--- a/ui/src/i18n/locales/zh-Hant.ts
+++ b/ui/src/i18n/locales/zh-Hant.ts
@@ -1432,6 +1432,7 @@ export const zhHant: Resources = {
     resumeError: '無法恢復這段主管對話。',
   },
   chatLanding: {
+    uiMode: 'UI 模式',
     heading: '先讓 Alice 處理什麼？',
     subheading: '在選定的 Workspace 中進行研究、分析與交易工作。',
     targetHeading: '在此工作區新增對話',

--- a/ui/src/i18n/locales/zh.ts
+++ b/ui/src/i18n/locales/zh.ts
@@ -1423,6 +1423,7 @@ export const zh: Resources = {
     resumeError: '无法恢复这段主管对话。',
   },
   chatLanding: {
+    uiMode: 'UI 模式',
     heading: '先让 Alice 处理什么？',
     subheading: '在选定的 Workspace 中开展研究、分析和交易工作。',
     targetHeading: '在此工作区中新建对话',

--- a/ui/src/pages/ChatLandingPage.render.spec.tsx
+++ b/ui/src/pages/ChatLandingPage.render.spec.tsx
@@ -508,6 +508,22 @@ describe('ChatLandingPage workflow starters', () => {
 })
 
 describe('ChatLandingPage keyboard submission', () => {
+  it('offers GUI for a capable runtime and passes the selected surface', async () => {
+    mocks.useWorkspaces.mockImplementation(() => ({
+      ...context([chatWorkspace()]),
+      agents: [{ ...piAgent, capabilities: { ...piAgent.capabilities, web: { wire: 'pi-rpc', freshSession: true } } }],
+    }))
+    render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
+    await screen.findByRole('button', { name: 'Model and reasoning' })
+    fireEvent.click(screen.getByRole('button', { name: 'UI mode: TUI' }))
+    fireEvent.click(await screen.findByRole('menuitemradio', { name: 'GUI' }))
+    const composer = screen.getByPlaceholderText('Describe the task, question, or decision…')
+    fireEvent.change(composer, { target: { value: 'GUI hello' } })
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' })
+    await waitFor(() => expect(mocks.quickChat).toHaveBeenCalled())
+    expect(mocks.quickChat.mock.calls[0]?.[8]).toBe('webpi')
+  })
+
   it('does not submit when Enter confirms an IME composition candidate', async () => {
     render(<ChatLandingPage spec={{ params: { targetWsId: 'chat-1' } }} />)
 
@@ -528,6 +544,7 @@ describe('ChatLandingPage keyboard submission', () => {
       undefined,
       undefined,
       'native',
+      'terminal',
     ))
   })
 
@@ -607,6 +624,7 @@ describe('ChatLandingPage keyboard submission', () => {
       undefined,
       undefined,
       'native',
+      'terminal',
     ))
     expect(mocks.probeAgentRuntimeReadiness).not.toHaveBeenCalled()
     expect(screen.queryByText('The runtime reported an error: 429: balance exhausted')).toBeNull()
@@ -675,6 +693,7 @@ describe('ChatLandingPage keyboard submission', () => {
       undefined,
       undefined,
       undefined,
+      'terminal',
     ))
   })
 
@@ -703,6 +722,7 @@ describe('ChatLandingPage keyboard submission', () => {
       'gemini-3.1-pro-preview',
       'high',
       'native',
+      'terminal',
     ))
   })
 })
@@ -757,6 +777,7 @@ describe('ChatLandingPage AI source disclosure', () => {
       undefined,
       undefined,
       'native',
+      'terminal',
     ))
   })
 
@@ -817,6 +838,7 @@ describe('ChatLandingPage AI source disclosure', () => {
       'deepseek-v4-flash',
       'high',
       undefined,
+      'terminal',
     ))
   })
 
@@ -891,6 +913,7 @@ describe('ChatLandingPage AI source disclosure', () => {
       'gpt-5.6-sol',
       undefined,
       'native',
+      'terminal',
     ))
   })
 
@@ -1002,6 +1025,7 @@ describe('Workspace embedded composer', () => {
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
     await waitFor(() => expect(mocks.quickChat).toHaveBeenCalledWith(
       'Inspect existing research', 'pi', undefined, target.id, 'auto-quant-v2', undefined, undefined, undefined,
+      'terminal',
     ))
   })
 })

--- a/ui/src/pages/ChatLandingPage.tsx
+++ b/ui/src/pages/ChatLandingPage.tsx
@@ -348,7 +348,10 @@ export function HarnessLandingPage({
     managedWorkspaceLaunch: mode === 'chat' && credentialWorkspace !== null && credentialWorkspace !== undefined,
   })
   const effectiveAgent = launchConfig.effectiveAgent
+  const [uiMode, setUiMode] = useState<'terminal' | 'webpi'>('terminal')
   const selectedInfo = launchConfig.selectedAgent
+  const supportsGui = Boolean(selectedInfo?.capabilities.web?.freshSession)
+  const surface = supportsGui ? uiMode : 'terminal'
   const installHint = selectedInfo ? installHintFor(selectedInfo.id) : undefined
   const exampleGroups = mode === 'chat'
     ? chatLandingExampleGroups((key) => t(key as never), project?.product)
@@ -411,6 +414,7 @@ export function HarnessLandingPage({
         launchConfig.launchModel,
         launchConfig.launchReasoningEffort,
         launchConfig.accessMode === 'native' ? 'native' : undefined,
+        surface,
       )
       void recordSuccessfulUse(effectiveAgent).catch(() => undefined)
       if (mode === 'chat') launchPreferences.adoptRecentChatWorkspace(workspaceId)
@@ -569,6 +573,19 @@ export function HarnessLandingPage({
                 menuPlacement="up"
                 toolbar
               />
+              <DropdownMenu>
+                <DropdownMenuTrigger render={<Button variant="ghost" size="sm" aria-label={`${t('chatLanding.uiMode')}: ${surface === 'webpi' ? 'GUI' : 'TUI'}`} disabled={launching} />}>
+                  <LayoutGrid size={14} aria-hidden />
+                  <span>{surface === 'webpi' ? 'GUI' : 'TUI'}</span><ChevronDown size={14} aria-hidden />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="top" align="start">
+                  <DropdownMenuRadioGroup value={surface} onValueChange={value => setUiMode(value as 'terminal' | 'webpi')}>
+                    <DropdownMenuRadioItem value="terminal" closeOnClick>TUI</DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="webpi" disabled={!supportsGui} closeOnClick>GUI</DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
             </>}
             controls={<>
                   <AgentLaunchSelectors


### PR DESCRIPTION
## Summary
Quick Start now offers TUI / GUI beside the runtime selector. The choice follows the existing credential, model, and effort selection into Session creation. GUI starts the structured Web host directly and submits the initial prompt once, without creating a throwaway terminal.

GUI is enabled only for runtimes advertising fresh Web sessions; unsupported requests fail before spawning. The shared Harness landing composer also exposes this control. The menu uses shared keyboard-accessible primitives, wraps at narrow widths, and preserves TUI as the default. Demo requests honor the selected surface.

## Verification
- Root and UI TypeScript checks passed.
- Targeted Quick Chat route tests: 41 passed; composer tests: 25 passed.
- Full hermetic suite: 785 files passed; 6,943 tests passed, 4 skipped.
- Real local Codex GUI launch with native account / gpt-5.6-sol: HTTP 201, Web Session created without a PTY, assistant replied GUI_READY. Test session paused afterward.
- Real and demo Quick Start at 390px: selectable GUI, no horizontal overflow; desktop selector inspected.
