### PR TITLE
feat(gui): consume streamed Workspace file references

### DIFF
--- a/docs/web-conversation-surface.md
+++ b/docs/web-conversation-surface.md
@@ -169,3 +169,24 @@ Quick Start exposes a TUI / GUI selector beside the runtime. GUI is available
 only with `web.freshSession`; `quick-chat` accepts `surface: webpi` and starts
 the structured host directly with the same Session runtime binding. Omission
 keeps the terminal default. The initial prompt is sent once after Web startup.
+
+## File references in GUI prose
+
+`useConversationFiles` consumes unified assistant progress and answer text in
+`WebSessionView`, outside every runtime/transport. It uses Connector Protocol's
+bracket parser; code, escaped brackets and incomplete references remain text.
+The read-only Workspace content endpoint checks realpath containment before
+returning metadata or bounded bytes. Missing references stay literal and retry
+briefly so a reference can precede a file write.
+
+The shared conversation renderer receives resolved hrefs and a click callback.
+Images/stickers stay in prose order; file cards open the existing workbench.
+New references automatically open a file tab once per turn/path, except
+`sticker/` references, which stay inline. The initial snapshot never opens
+historical references. Unmounting cancels resolution and pending opens. The
+consumer does not require a runtime-specific final channel or interpret
+Connector automation silence markers.
+
+Opening an existing file tab refreshes its content without duplicating the tab.
+On narrow screens the workbench takes the content width and its collapse control
+returns to the conversation. Sticker images retain transparent backgrounds.

--- a/src/webui/routes/workspace-content.spec.ts
+++ b/src/webui/routes/workspace-content.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, it } from 'vitest'
+import { mkdtemp, writeFile, symlink, rm, truncate } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createWorkspaceContentRoutes } from './workspace-content.js'
+const roots: string[] = []
+afterEach(async () => { await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))) })
+it('resolves metadata and bytes but rejects traversal, absent files and escaping symlinks', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'content-')); roots.push(root)
+  await writeFile(join(root, 'report.html'), '<script>alert(1)</script>')
+  const outside = await mkdtemp(join(tmpdir(), 'outside-')); roots.push(outside)
+  await writeFile(join(outside, 'secret.txt'), 'secret')
+  await symlink(outside, join(root, 'outside'))
+  const app = createWorkspaceContentRoutes(id => id === 'ws' ? root : undefined)
+  const get = (path: string, suffix = '') => app.request(`/ws/content?path=${encodeURIComponent(path)}${suffix}`)
+  expect(await (await get('report.html', '&metadata=1')).json()).toMatchObject({ path: 'report.html' })
+  const response = await get('report.html')
+  expect(response.headers.get('content-type')).toBe('application/octet-stream')
+  expect(response.headers.get('content-security-policy')).toContain('sandbox')
+  expect(await response.text()).toBe('<script>alert(1)</script>')
+  expect((await get('../secret.txt')).status).toBe(404)
+  expect((await get('missing.pdf')).status).toBe(404)
+  expect((await get('outside/secret.txt')).status).toBe(404)
+})
+
+it('serves image bytes and bounds content without blocking metadata', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'content-')); roots.push(root)
+  const app = createWorkspaceContentRoutes(() => root)
+  await writeFile(join(root, 'wave.png'), new Uint8Array([137, 80, 78, 71]))
+  const response = await app.request('/ws/content?path=wave.png')
+  expect(response.headers.get('content-type')).toBe('image/png')
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([137, 80, 78, 71]))
+  await writeFile(join(root, 'large.bin'), '')
+  await truncate(join(root, 'large.bin'), 17 * 1024 * 1024)
+  expect((await app.request('/ws/content?path=large.bin')).status).toBe(413)
+  expect((await app.request('/ws/content?path=large.bin&metadata=1')).status).toBe(200)
+})

--- a/src/webui/routes/workspace-content.ts
+++ b/src/webui/routes/workspace-content.ts
@@ -1,0 +1,25 @@
+import { Hono } from 'hono'
+import { readFile, stat } from 'node:fs/promises'
+import { resolveInboxFile } from '../../core/inbox-files.js'
+
+/** Read-only Workspace projection; the consumer owns rendering and delivery. */
+export function createWorkspaceContentRoutes(root: (id: string) => string | undefined) {
+  const app = new Hono()
+  app.get('/:id/content', async c => {
+    const path = c.req.query('path') ?? ''
+    const file = await resolveInboxFile(root(c.req.param('id')), path)
+    if (!file) return c.json({ error: 'file_not_found' }, 404)
+    const info = await stat(file)
+    if (c.req.query('metadata') === '1') return c.json({ path, size: info.size, modified: info.mtimeMs })
+    if (info.size > 16 * 1024 * 1024) return c.json({ error: 'file_too_large' }, 413)
+    const media: Record<string, string> = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', webp: 'image/webp', gif: 'image/gif', pdf: 'application/pdf' }
+    const type = media[path.split('.').pop()?.toLowerCase() ?? '']
+    c.header('Content-Type', type ?? 'application/octet-stream')
+    c.header('X-Content-Type-Options', 'nosniff')
+    c.header('Content-Security-Policy', "sandbox; default-src 'none'")
+    c.header('Cache-Control', 'no-store')
+    c.header('Content-Disposition', `${type ? 'inline' : 'attachment'}; filename*=UTF-8''${encodeURIComponent(path.split('/').pop()!)}`)
+    return c.body(await readFile(file))
+  })
+  return app
+}

--- a/src/webui/routes/workspaces.ts
+++ b/src/webui/routes/workspaces.ts
@@ -1,3 +1,4 @@
+import { createWorkspaceContentRoutes } from './workspace-content.js';
 import { createStickerRoutes } from './stickers.js';
 import { prepareProjectWorkspaces, readProjectWorkspaceSetup } from '../../workspaces/project-workspace-setup.js';
 /**
@@ -1693,6 +1694,8 @@ export function createWorkspaceRoutes(
       resumable: identity.lifecycle !== 'retired' && Boolean(identity.agentSessionId),
     });
   });
+
+  app.route('/', createWorkspaceContentRoutes(id => svc.registry.get(id)?.dir));
 
   app.get('/:id/file', async (c) => {
     const id = c.req.param('id');

--- a/src/workspaces/session-registry.spec.ts
+++ b/src/workspaces/session-registry.spec.ts
@@ -50,6 +50,14 @@ function rec(over: Partial<SessionRecord> = {}): SessionRecord {
 }
 
 describe('SessionRegistry persistence', () => {
+  it('serializes overlapping writes to the same workspace', async () => {
+    const reg = await SessionRegistry.load(root, noopLogger)
+    await reg.create(rec())
+    await Promise.all(Array.from({ length: 20 }, (_, i) => reg.create(rec({ id: `codex-concurrent-${i}`, resumeId: `resume-concurrent-${i}`, state: 'paused' }))))
+    const restored = await SessionRegistry.load(root, noopLogger)
+    expect(restored.listFor(WS)).toHaveLength(21)
+  })
+
   it('round-trips native and fallback titles across a reload', async () => {
     const reg = await SessionRegistry.load(root, noopLogger)
     await reg.create(rec({

--- a/src/workspaces/session-registry.ts
+++ b/src/workspaces/session-registry.ts
@@ -111,6 +111,7 @@ export class SessionRegistry {
   private readonly byWs = new Map<string, Map<string, SessionRecord>>();
   /** wsId set of workspaces whose file has been loaded (or known-absent). */
   private readonly loaded = new Set<string>();
+  private readonly writes = new Map<string, Promise<void>>();
 
   private constructor(
     private readonly dir: string,
@@ -315,6 +316,14 @@ export class SessionRegistry {
   }
 
   private async flush(wsId: string): Promise<void> {
+    const previous = this.writes.get(wsId) ?? Promise.resolve();
+    const pending = previous.catch(() => {}).then(() => this.writeSnapshot(wsId));
+    this.writes.set(wsId, pending);
+    try { await pending; }
+    finally { if (this.writes.get(wsId) === pending) this.writes.delete(wsId); }
+  }
+
+  private async writeSnapshot(wsId: string): Promise<void> {
     const records = this.byWs.get(wsId);
     if (!records) return;
     const payload: FileShape = {

--- a/ui/src/components/MarkdownContent.tsx
+++ b/ui/src/components/MarkdownContent.tsx
@@ -62,7 +62,7 @@ function createWikilinkExtension(opts: { codeSpanWikilinks: boolean; fileHrefs?:
         if (!href) return escapeHtml(token.raw)
         const attributes = `href="${escapeHtml(href)}" data-file-path="${escapeHtml(name)}"`
         if (/\.(png|jpe?g|webp|gif)$/i.test(name)) {
-          return `<a class="markdown-file-image" ${attributes}><img src="${escapeHtml(href)}" alt="${escapeHtml(name)}" loading="lazy" /></a>`
+          return `<a class="markdown-file-image${name.startsWith('sticker/') ? ' is-sticker' : ''}" ${attributes}><img src="${escapeHtml(href)}" alt="${escapeHtml(name)}" loading="lazy" /></a>`
         }
         const filename = name.split('/').pop() ?? name
         const extension = filename.split('.').pop()?.toUpperCase() ?? 'FILE'

--- a/ui/src/components/conversation/ConversationTranscript.tsx
+++ b/ui/src/components/conversation/ConversationTranscript.tsx
@@ -6,9 +6,13 @@ import { MessageActions } from './MessageActions'
 
 export function ConversationTranscriptItem({
   item,
+  fileHrefs,
+  onFileReference,
   working,
   latest = false,
 }: {
+  readonly fileHrefs?: Record<string, string>
+  readonly onFileReference?: (path: string) => void
   readonly item: ConversationItem
   readonly working: boolean
   readonly latest?: boolean
@@ -39,10 +43,10 @@ export function ConversationTranscriptItem({
     <article className={`conversation-message is-assistant is-turn${latest ? ' is-latest' : ''}`}>
       <div className="conversation-message-body">
         {item.progress.map((text, index) => (
-          <div key={index} className="conversation-progress-text"><MarkdownContent text={text} /></div>
+          <div key={index} className="conversation-progress-text"><MarkdownContent text={text} fileHrefs={fileHrefs} onFileReference={onFileReference} /></div>
         ))}
         {item.activity && <ConversationActivityGroup activity={item.activity} working={working} />}
-        {item.final && <div className="conversation-final-text"><MarkdownContent text={item.final} /></div>}
+        {item.final && <div className="conversation-final-text"><MarkdownContent text={item.final} fileHrefs={fileHrefs} onFileReference={onFileReference} /></div>}
       </div>
       {!working && item.final && <MessageActions text={item.final} />}
     </article>

--- a/ui/src/components/conversation/ConversationView.tsx
+++ b/ui/src/components/conversation/ConversationView.tsx
@@ -8,6 +8,8 @@ import type { ConversationItem } from './types'
 import './conversation.css'
 
 export interface ConversationViewProps {
+  readonly fileHrefs?: Record<string, string>
+  readonly onFileReference?: (path: string) => void
   readonly items: readonly ConversationItem[]
   readonly revision: number
   readonly busy: boolean
@@ -87,7 +89,7 @@ export function ConversationView(props: ConversationViewProps) {
       setFollowing(followingRef.current)
     }}>
       {props.items.length === 0 && !error && <div className="conversation-empty">{props.empty}</div>}
-      {props.items.map((item, index) => <ConversationTranscriptItem key={item.key} item={item} latest={index === props.items.length - 1} working={props.busy && index === props.items.length - 1} />)}
+      {props.items.map((item, index) => <ConversationTranscriptItem key={item.key} fileHrefs={props.fileHrefs} onFileReference={props.onFileReference} item={item} latest={index === props.items.length - 1} working={props.busy && index === props.items.length - 1} />)}
       {error && <div className="conversation-error" role="alert">
         <strong>Could not continue</strong><span>{error}</span>
         {props.retry && <button type="button" onClick={() => { setActionError(null); props.retry?.() }}>Retry</button>}

--- a/ui/src/components/harness/HarnessWorkbench.spec.tsx
+++ b/ui/src/components/harness/HarnessWorkbench.spec.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, afterEach, expect, it, vi } from 'vitest'
 import { HarnessWorkbench } from './HarnessWorkbench'
 import { useHarnessWorkbench as store } from '../../live/harness-workbench'
@@ -41,4 +41,14 @@ it('closes the addressed background tab without changing the selected document',
   fireEvent.click(screen.getByRole('button', { name: 'Close Files' }))
   expect(screen.getByRole('tab', { name: 'README.md' }).getAttribute('aria-selected')).toBe('true')
   expect(screen.queryByRole('tab', { name: 'Files' })).toBeNull()
+})
+
+it('reopening a file refreshes its preview without adding another tab', () => {
+  const tab = { kind: 'file' as const, id: 'file:report.md', path: 'report.md' }
+  store.getState().openTab('a', tab)
+  render(<HarnessWorkbench source="chat" spec={{ kind: 'workspace', params: { wsId: 'a' } }}>Conversation</HarnessWorkbench>)
+  const previous = screen.getByText('Document content')
+  act(() => store.getState().openTab('a', tab))
+  expect(screen.getByText('Document content')).not.toBe(previous)
+  expect(screen.getAllByRole('tab', { name: 'report.md' })).toHaveLength(1)
 })

--- a/ui/src/components/harness/HarnessWorkbench.tsx
+++ b/ui/src/components/harness/HarnessWorkbench.tsx
@@ -13,7 +13,7 @@ import { FilesPanel } from '../workspace/FilesPanel'
 import { FileContentView } from '../FileContentView'
 import { useWorkspaceSessionData } from '../../hooks/useWorkspaceData'
 import { useWorkspaces } from '../../contexts/workspaces-context'
-import { agentSupportsWeb } from '../workspace/api'
+import { agentSupportsWeb, workspaceContentHref } from '../workspace/api'
 import { useWorkbenchFile } from '../../hooks/useWorkbenchFile'
 import { HarnessSurfacePage } from '../../pages/HarnessSurfacePage'
 import { PageContentLayout } from '../PageTopBar'
@@ -125,11 +125,18 @@ function WorkPanel({ wsId, source, onCollapse }: { wsId: string; source: Workspa
             if (current) patch(wsId, { tabs: current.tabs.map((item) => item.id === tab.id ? { ...item, title: new URL(url).host } : item) })
           }} />
         : tab.kind === 'studio' && source !== 'chat' ? <HarnessSurfacePage workspaceId={wsId} source={source} embedded />
-          : tab.kind === 'file' ? <WorkFile wsId={wsId} path={tab.path} /> : null}
+          : tab.kind === 'file' ? <WorkFile key={`${tab.id}:${tab.revision ?? 0}`} wsId={wsId} path={tab.path} /> : null}
     </TabsContent>)}
   </Tabs>
 }
 function WorkFile({ wsId, path }: { wsId: string; path: string }) {
+  const href = workspaceContentHref(wsId, path)
+  if (/\.(png|jpe?g|gif|webp)$/i.test(path)) return <div className="h-full overflow-auto p-5"><img src={href} alt={path} className="max-w-full h-auto" /><a href={href} download className="block mt-4 text-sm underline">{path}</a></div>
+  if (/\.pdf$/i.test(path)) return <iframe src={href} title={path} className="h-full w-full border-0" />
+  if (/\.[^/.]+$/.test(path) && !/\.(md|markdown|html?|txt|log|csv|json|ya?ml|toml|ini|conf|cfg|env|ts|tsx|js|jsx|mjs|cjs|css|scss|sql|py|rb|rs|go|java|c|cpp|h|sh|bash|zsh|xml|svg)$/i.test(path)) return <a href={href} download className="block p-5 underline">Download {path}</a>
+  return <WorkTextFile wsId={wsId} path={path} />
+}
+function WorkTextFile({ wsId, path }: { wsId: string; path: string }) {
   const result = useWorkbenchFile(wsId, path)
   return <div className="h-full overflow-auto p-5"><div className="mb-5 break-all text-xs text-muted-foreground">{path}</div>{result ? <FileContentView path={path} result={result} /> : <div role="status">Loading…</div>}</div>
 }

--- a/ui/src/components/harness/workbench.css
+++ b/ui/src/components/harness/workbench.css
@@ -13,7 +13,7 @@
 .harness-work .oa-topbar { flex-wrap:wrap; height:auto; min-height:40px; padding:6px; }
 .harness-work .oa-topbar-actions { flex-wrap:wrap; }
 @container (max-width: 720px) {
-  .harness-workbench.is-open [data-panel]:has(> .harness-conversation) { display:none; }
+  .harness-workbench.is-open [data-panel]:has(> .harness-conversation) { display:none!important; }
   .harness-workbench.is-open [data-panel]:has(> .harness-work) { flex:1!important; }
   .harness-divider { display:none; }
 }

--- a/ui/src/components/workspace/WebSessionView.tsx
+++ b/ui/src/components/workspace/WebSessionView.tsx
@@ -1,4 +1,6 @@
-import { useMemo, type ReactNode } from 'react'
+import { useConversationFiles } from '../../hooks/useConversationFiles'
+import { useHarnessWorkbench } from '../../live/harness-workbench'
+import { useCallback, useMemo, type ReactNode } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { PageTopBar } from '../PageTopBar'
 import { ConversationView } from '../conversation/ConversationView'
@@ -33,6 +35,8 @@ export function WebSessionView(props: Props) {
 function WebSession({ wsId, sessionId, agent, agents, label, headerActions, onSessionLost }: Props) {
   const session = useWebConversation(wsId, sessionId)
   const { snapshot, busy, requests } = session
+  const openFile = useCallback((path: string) => useHarnessWorkbench.getState().openTab(wsId, { id: `file:${path}`, kind: 'file', path }), [wsId])
+  const files = useConversationFiles(wsId, session.items, !!snapshot && snapshot.phase !== 'starting', openFile)
   const agentId = snapshot?.agent ?? agent ?? 'agent'
   const agentLabel = agents?.find((entry) => entry.id === agentId)?.displayName ?? fallbackAgentLabel(agentId)
   const activeRequest = useMemo(() => requests[0] ? presentRequest(requests[0]) : null, [requests])
@@ -47,6 +51,7 @@ function WebSession({ wsId, sessionId, agent, agents, label, headerActions, onSe
       </span>}
     </PageTopBar>
     <ConversationView
+      {...files}
       items={session.items}
       revision={snapshot?.revision ?? 0}
       busy={busy}

--- a/ui/src/components/workspace/api.ts
+++ b/ui/src/components/workspace/api.ts
@@ -1979,3 +1979,8 @@ export async function testAgentConfig(
     return { ok: false, error: `HTTP ${res.status}` };
   }
 }
+
+/** Read-only content URL, also forwarded through the desktop app protocol. */
+export function workspaceContentHref(wsId: string, path: string) {
+  return `/api/workspaces/${encodeURIComponent(wsId)}/content?path=${encodeURIComponent(path)}`
+}

--- a/ui/src/demo/fixtures/web-session.ts
+++ b/ui/src/demo/fixtures/web-session.ts
@@ -339,7 +339,7 @@ export function demoWebFollowUp(agent: string, message: string): readonly WebCon
         },
         {
           type: 'text',
-          text: `This is the real **Web conversation surface** for ${label} backed by recorded demo data. The public preview does not call a live model, so this reply is simulated; install OpenAlice locally to continue the research with your own runtime and data sources.`,
+          text: `This is the real **Web conversation surface** for ${label} backed by recorded demo data. The public preview does not call a live model, so this reply is simulated; install OpenAlice locally to continue the research with your own runtime and data sources.\n\nWorkspace guidance: [[AGENTS.md]]`,
         },
       ],
     },

--- a/ui/src/demo/handlers/workspaces.ts
+++ b/ui/src/demo/handlers/workspaces.ts
@@ -1068,6 +1068,14 @@ export const workspacesHandlers = [
     }
     return HttpResponse.json(listing)
   }),
+  http.get('/api/workspaces/:id/content', ({ request }) => {
+    const url = new URL(request.url)
+    const path = url.searchParams.get('path') ?? ''
+    const content = demoWorkspaceFiles[path]
+    if (content == null) return HttpResponse.json({ error: 'file_not_found' }, { status: 404 })
+    if (url.searchParams.get('metadata') === '1') return HttpResponse.json({ path, size: content.length })
+    return new HttpResponse(content, { headers: { 'Content-Type': 'application/octet-stream' } })
+  }),
   http.get('/api/workspaces/:id/file', ({ request }) => {
     const url = new URL(request.url)
     const path = url.searchParams.get('path') ?? ''

--- a/ui/src/hooks/useConversationFiles.spec.tsx
+++ b/ui/src/hooks/useConversationFiles.spec.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { conversationReferences, useConversationFiles } from './useConversationFiles'
+import type { ConversationItem } from '../components/conversation/types'
+const turn = (text: string, key = 'turn'): ConversationItem[] => [{ kind: 'assistant-turn', key, progress: [], final: text, activity: null }]
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.useRealTimers() })
+function available() {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => ({ ok: true, json: async () => ({ path: new URL(url, 'http://localhost').searchParams.get('path') }) })))
+}
+it('only consumes visible assistant prose with complete, non-code references', () => {
+  expect(conversationReferences(turn('[[a.pdf]] `[[code.pdf]]` \\[[escaped.pdf]] [[unfinished'))).toEqual([{ path: 'a.pdf', key: '["turn","a.pdf"]' }])
+})
+it('renders history without opening; opens live files once and leaves stickers inline', async () => {
+  available()
+  const open = vi.fn()
+  const { result, rerender } = renderHook(({ items }) => useConversationFiles('ws', items, true, open), { initialProps: { items: turn('[[old.pdf]]') } })
+  await waitFor(() => expect(result.current.fileHrefs['old.pdf']).toBeTruthy())
+  expect(open).not.toHaveBeenCalled()
+  rerender({ items: turn('[[old.pdf]] [[new.pdf]] [[sticker/wave.png]]') })
+  await waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+  expect(open).toHaveBeenCalledWith('new.pdf')
+  rerender({ items: turn('[[old.pdf]] [[new.pdf]] [[sticker/wave.png]] More text [[new.pdf]]') })
+  await waitFor(() => expect(result.current.fileHrefs['sticker/wave.png']).toBeTruthy())
+  expect(open).toHaveBeenCalledTimes(1)
+})
+it('ignores late results when the consumer unmounts', async () => {
+  let finish!: (value: unknown) => void
+  vi.stubGlobal('fetch', vi.fn(() => new Promise(resolve => { finish = resolve })))
+  const open = vi.fn()
+  const { rerender, unmount } = renderHook(({ items }) => useConversationFiles('ws', items, true, open), { initialProps: { items: turn('') } })
+  rerender({ items: turn('[[late.pdf]]') })
+  unmount()
+  await act(async () => finish({ ok: true, json: async () => ({ path: 'late.pdf' }) }))
+  expect(open).not.toHaveBeenCalled()
+})
+it('retries a file that is written after the reference arrives', async () => {
+  vi.useFakeTimers()
+  const open = vi.fn()
+  let exists = false
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: exists, json: async () => ({ path: 'late.pdf' }) })))
+  const { rerender } = renderHook(({ items }) => useConversationFiles('ws', items, true, open), { initialProps: { items: turn('') } })
+  await act(async () => {})
+  rerender({ items: turn('[[late.pdf]]') })
+  await act(async () => {})
+  expect(open).not.toHaveBeenCalled()
+  exists = true
+  await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+  expect(open).toHaveBeenCalledWith('late.pdf')
+})

--- a/ui/src/hooks/useConversationFiles.ts
+++ b/ui/src/hooks/useConversationFiles.ts
@@ -1,0 +1,57 @@
+import { workspaceContentHref } from '../components/workspace/api'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { parseContentReferences } from '@traderalice/connector-protocol'
+import type { ConversationItem } from '../components/conversation/types'
+
+export function conversationReferences(items: readonly ConversationItem[]) {
+  return items.flatMap(item => item.kind === 'assistant-turn'
+    ? [...item.progress, item.final ?? ''].flatMap(text => parseContentReferences(text).references.map(ref => ({
+      path: ref.path, key: JSON.stringify([item.key, ref.path]),
+    }))) : [])
+}
+
+/** One mounted Session. Presentation consumes prose; no runtime protocol semantics. */
+export function useConversationFiles(wsId: string, items: readonly ConversationItem[], ready: boolean, open: (path: string) => void) {
+  const references = useMemo(() => conversationReferences(items), [items])
+  const signature = JSON.stringify(references)
+  const baseline = useRef(false)
+  const consumed = useRef(new Set<string>())
+  const [fileHrefs, setFileHrefs] = useState<Record<string, string>>({})
+  useEffect(() => {
+    if (!ready) return
+    const refs = JSON.parse(signature) as ReturnType<typeof conversationReferences>
+    if (!baseline.current) {
+      refs.forEach(ref => consumed.current.add(ref.key))
+      baseline.current = true
+    }
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const controller = new AbortController()
+    let attempts = 0
+    async function resolve() {
+      const paths = [...new Set(refs.map(ref => ref.path))]
+      const available = await Promise.all(paths.map(async path => {
+        const href = workspaceContentHref(wsId, path)
+        try {
+          const response = await fetch(`${href}&metadata=1`, { signal: controller.signal })
+          if (!response.ok) return null
+          const metadata = await response.json() as { path?: string }
+          return metadata.path === path ? [path, href] as const : null
+        } catch { return null }
+      }))
+      if (cancelled) return
+      const hrefs = Object.fromEntries(available.filter(entry => entry !== null))
+      setFileHrefs(hrefs)
+      for (const ref of refs) {
+        if (!hrefs[ref.path] || consumed.current.has(ref.key)) continue
+        consumed.current.add(ref.key)
+        if (!ref.path.startsWith('sticker/')) open(ref.path)
+      }
+      // A reference can precede its tool's file write. Retry without a render loop.
+      if (available.some(entry => entry === null) && ++attempts < 30) timer = setTimeout(() => void resolve(), 2000)
+    }
+    void resolve()
+    return () => { cancelled = true; controller.abort(); clearTimeout(timer) }
+  }, [wsId, signature, ready, open])
+  return { fileHrefs, onFileReference: open }
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1874,3 +1874,5 @@ html[lang="ja"] .oa-onboarding-title {
 }
 .markdown-content a.markdown-file-card:hover { border-color: var(--muted-foreground); }
 .markdown-content a[data-file-path]:focus-visible { outline: 2px solid var(--ring); outline-offset: 3px; }
+
+.markdown-content a.markdown-file-image.is-sticker img { border: 0; border-radius: 0; background: transparent; }

--- a/ui/src/live/harness-workbench.ts
+++ b/ui/src/live/harness-workbench.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 
-export type WorkTab = { id: string; kind: 'files' | 'studio' | 'browser'; title?: string } | { id: string; kind: 'file'; path: string }
+export type WorkTab = { id: string; kind: 'files' | 'studio' | 'browser'; title?: string } | { id: string; kind: 'file'; path: string; revision?: number }
 export interface WorkbenchState {
   tabs: WorkTab[]
   active: string | null
@@ -21,7 +21,7 @@ export const useHarnessWorkbench = create<Store>((set) => ({
   patch: (id, update) => set((s) => ({ workspaces: { ...s.workspaces, [id]: { ...(s.workspaces[id] ?? empty), ...update } } })),
   openTab: (id, tab) => set((s) => {
     const state = s.workspaces[id] ?? empty
-    return { workspaces: { ...s.workspaces, [id]: { ...state, width: !state.tabs.length && tab.kind === 'studio' ? 62 : state.width, tabs: state.tabs.some((t) => t.id === tab.id) ? state.tabs : [...state.tabs, tab], active: tab.id, open: true } } }
+    return { workspaces: { ...s.workspaces, [id]: { ...state, width: !state.tabs.length && tab.kind === 'studio' ? 62 : state.width, tabs: state.tabs.some((t) => t.id === tab.id) ? state.tabs.map(t => t.id === tab.id && t.kind === 'file' ? { ...t, revision: (t.revision ?? 0) + 1 } : t) : [...state.tabs, tab], active: tab.id, open: true } } }
   }),
   closeTab: (id, tabId) => set((s) => {
     const state = s.workspaces[id] ?? empty


### PR DESCRIPTION
GUI assistant replies now consume Workspace file references through one runtime-neutral `useConversationFiles` hook. Complete references resolve as the text arrives: stickers/images render in place and new ordinary files open the existing workbench. Initial history never opens tabs; repeated stream chunks do not steal focus; missing files remain literal and retry briefly. Code and escaped syntax keep the shared Connector Protocol semantics.

Workspace content uses a read-only, realpath-contained endpoint with bounded delivery. Workbench images/PDFs preview directly, other binary formats download, and reopening a file refreshes the same tab. Narrow layouts now correctly hide the conversation panel when showing a file. Live verification also exposed a SessionRegistry same-temp-file write race during GUI launch; per-workspace flush serialization and a regression test fix it.

Validation: root and UI typechecks; full hermetic suite (787 files, 6,951 passed, 4 skipped), plus final targeted workbench refresh tests. Real isolated Codex GUI verified report auto-open, inline 512px source sticker/image, literal missing path, no auto-open on history, manual preview and 390px full-width panel. Demo GUI verified the same hook on a subsequent simulated reply. Packaged Electron was not re-run; the endpoint uses the existing app-protocol forwarding path.
