### PR TITLE
fix(gui): preserve literal sent user prose

### DIFF
--- a/docs/web-conversation-surface.md
+++ b/docs/web-conversation-surface.md
@@ -190,3 +190,7 @@ Connector automation silence markers.
 Opening an existing file tab refreshes its content without duplicating the tab.
 On narrow screens the workbench takes the content width and its collapse control
 returns to the conversation. Sticker images retain transparent backgrounds.
+
+User prose is displayed as plain text, preserving line breaks and literal syntax.
+It does not re-enter Markdown or Workspace reference parsing after submission;
+structured content retains its presentation independently of prose.

--- a/ui/src/components/conversation/ConversationTranscript.spec.tsx
+++ b/ui/src/components/conversation/ConversationTranscript.spec.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { ConversationTranscriptItem } from './ConversationTranscript'
+afterEach(cleanup)
+it('keeps sent prose literal without turning syntax into links or blocks', () => {
+  const text = '第一行\n[[reports/demo.md]] **bold** [link](https://example.com) <b>literal</b>'
+  const { container } = render(<ConversationTranscriptItem working={false} item={{ kind: 'user', key: 'user', content: [{ kind: 'markdown', text }] }} />)
+  const body = container.querySelector('.conversation-message-body')!
+  expect(body.textContent).toBe(text)
+  expect(body.querySelector('a, strong, b, .markdown-file-card')).toBeNull()
+})
+it('continues to render assistant Markdown', () => {
+  const { container } = render(<ConversationTranscriptItem working={false} item={{ kind: 'assistant-turn', key: 'assistant', progress: [], final: '**bold**', activity: null }} />)
+  expect(container.querySelector('strong')?.textContent).toBe('bold')
+})

--- a/ui/src/components/conversation/ConversationTranscript.tsx
+++ b/ui/src/components/conversation/ConversationTranscript.tsx
@@ -20,7 +20,7 @@ export function ConversationTranscriptItem({
   if (item.kind === 'user') {
     return (
       <article className={`conversation-message is-user${latest ? ' is-latest' : ''}`}>
-        <div className="conversation-message-body"><ConversationContentView content={item.content} /></div>
+        <div className="conversation-message-body"><ConversationContentView content={item.content} plainText /></div>
         {item.content.some(block => block.kind === 'markdown') && <MessageActions text={item.content.flatMap(block => block.kind === 'markdown' ? [block.text] : []).join('\n\n')} />}
       </article>
     )
@@ -164,10 +164,11 @@ function ConversationReasoning({ notes, label }: { readonly notes: readonly stri
 }
 
 
-export function ConversationContentView({ content }: { readonly content: ConversationContent }): ReactElement {
+export function ConversationContentView({ content, plainText = false }: { readonly content: ConversationContent; readonly plainText?: boolean }): ReactElement {
   return <div className="conversation-content-parts">{content.map((block, index) => {
+    if (block.kind === 'markdown' && plainText) return <div key={index} className="whitespace-pre-wrap break-words">{block.text}</div>
     if (block.kind === 'markdown') return <MarkdownContent key={index} text={block.text} />
-    if (block.kind === 'disclosure') return <details key={index} className="conversation-detail"><summary>{block.label}</summary><ConversationContentView content={block.content} /></details>
+    if (block.kind === 'disclosure') return <details key={index} className="conversation-detail"><summary>{block.label}</summary><ConversationContentView content={block.content} plainText={plainText} /></details>
     return <pre key={index} className="conversation-unknown">{block.text}</pre>
   })}</div>
 }


### PR DESCRIPTION
Sent user prose now preserves literal syntax and line breaks instead of reinterpreting Markdown and double-bracket references as links or attachment blocks. This changes display only; structured content and assistant rendering keep their existing paths.

Validated with UI typecheck, six conversation tests, and the real Codex GUI route: user references remain literal with zero links while assistant file cards and both images still render.
