### PR TITLE
chore: prepare v0.93.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1",
+  "version": "0.93.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1",
+  "version": "0.93.0-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Prepare the accepted release source for `v0.93.0-beta` by synchronizing the root product and distributed CLI package versions.

The source candidate was promoted through #1481 after the complete local and hosted beta acceptance gates passed. This PR intentionally changes only the two authoritative version fields and uses the bounded beta release-preparation lane.
