### PR TITLE
feat(connector): support reply media on Discord, Slack and Feishu

### DIFF
--- a/docs/connector-service.md
+++ b/docs/connector-service.md
@@ -48,8 +48,8 @@ categories.
   through the existing attachment safety path, and posts a directed
   artifact delivery back to that Connector only. Cancel does not enqueue.
   First-version pull does not change Inbox read state. Discord and Slack
-  keep `/inbox` as a placeholder and reject artifact delivery as
-  unimplemented. `/uta` is the same shape: Telegram renders the review
+  keep `/inbox` as a placeholder; all four adapters support directed artifact
+  delivery, independently of whether they expose file-pull controls. `/uta` is the same shape: Telegram renders the review
   panel; Discord and Slack reply with a placeholder. Connector never
   talks to UTA. Push and reject stay Alice-owned wallet writes, gated
   by the current trading mode. Callback data carries only page-local
@@ -221,6 +221,28 @@ Telegram sends PNG/JPEG/WebP images as photos and `sticker/*.png` or
 Files must satisfy Telegram's media requirements; no implicit image conversion
 occurs. Inbox artifact pulls remain documents. The old unreleased `file:` syntax
 is replaced directly, not maintained as a second syntax.
+
+The same `sendOwnerFile(attachment, presentation)` adapter interface handles
+reply files on Telegram, Discord, Slack, and Feishu/Lark. Core never branches
+on platform IDs. Discord sends local stickers and images as uploaded image
+attachments, not native sticker IDs. Slack uses `filesUploadV2` in the owner's
+DM and lets Slack preview image uploads. Feishu uploads images with
+`im.image.create` (`image_type: message`) and sends an `image_key` message;
+local stickers use this same image path. Ordinary files use its file upload
+and `file_key` message path. Directed Inbox artifacts default to files on every
+adapter, without adding another Inbox summary.
+
+Slack requires `files:write` in addition to its existing owner-DM permissions.
+Feishu requires image/file resource upload permission (`im:resource`) and bot
+message sending permission. Existing installations may need updated app scopes.
+No adapter converts image bytes or creates server-wide emoji/sticker resources.
+Reply media support does not itself enable private chat ingress or advertise
+the `desk` capability.
+
+Official API references:
+- [Discord message files and sticker IDs](https://docs.discord.com/developers/resources/message)
+- [Slack SDK file uploads](https://docs.slack.dev/tools/node-slack-sdk/web-api/)
+- [Feishu image upload](https://open.feishu.cn/document/server-docs/im-v1/image/create)
 
 Progress never uploads files. Events for a conversation are serialized;
 concurrent/repeated message IDs share one delivery attempt, including uncertain

--- a/services/connector/src/adapters/discord.ts
+++ b/services/connector/src/adapters/discord.ts
@@ -1,6 +1,7 @@
 import type { Client } from 'discord.js'
 import type {
   ConnectorAdapterConfig,
+  ConnectorArtifactDelivery,
   ConnectorAdapterHealth,
   InboxNotification,
 } from '@traderalice/connector-protocol'
@@ -18,6 +19,7 @@ import {
   AdapterHealthTracker,
   classifyNetworkStartFailure,
   decodeInboxAttachments,
+  decodeConnectorAttachment,
   formatInboxNotification,
 } from './shared.js'
 
@@ -125,8 +127,25 @@ export class DiscordConnectorAdapter implements ConnectorAdapter {
     }
   }
 
-  async deliverArtifact(): Promise<void> {
-    throw new Error('Inbox file delivery is not implemented for Discord yet.')
+  async deliverArtifact(delivery: ConnectorArtifactDelivery): Promise<void> {
+    await this.sendOwnerFile(delivery.attachment)
+  }
+
+  async sendOwnerFile(attachment: ConnectorArtifactDelivery['attachment'],
+    _presentation: import('../core/reply-directives.js').ReplyMedia = 'file'): Promise<void> {
+    if (!this.client?.isReady()) throw new Error('Discord client is not ready')
+    if (!this.ownerUserId) throw new Error('Discord owner is not linked')
+    this.tracker.attempt()
+    try {
+      const file = decodeConnectorAttachment(attachment)
+      const user = await this.client.users.fetch(this.ownerUserId)
+      // Local stickers are image attachments; native Discord stickers require registered IDs.
+      await user.send({ files: [{ attachment: file.content, name: file.filename }] })
+      this.tracker.success(this.ownerUserId)
+    } catch (error) {
+      this.tracker.degraded(error)
+      throw error
+    }
   }
 
   async sendOwnerText(text: string): Promise<void> {

--- a/services/connector/src/adapters/feishu.ts
+++ b/services/connector/src/adapters/feishu.ts
@@ -19,6 +19,7 @@ import {
   AdapterHealthTracker,
   classifyNetworkStartFailure,
   decodeInboxAttachments,
+  decodeConnectorAttachment,
   formatAdapterError,
   formatInboxNotification,
   formatPlainInboxNotification,
@@ -116,6 +117,11 @@ interface FeishuImClient {
         params: { receive_id_type: 'chat_id' | 'open_id' }
         data: { receive_id: string; msg_type: string; content: string }
       }) => Promise<{ code?: number; msg?: string } | null | undefined>
+    }
+    image: {
+      create: (payload: {
+        data: { image_type: 'message'; image: Buffer }
+      }) => Promise<{ image_key?: string; data?: { image_key?: string } } | null | undefined>
     }
     file: {
       create: (payload: {
@@ -250,8 +256,31 @@ export class FeishuConnectorAdapter implements ConnectorAdapter {
     }
   }
 
-  async deliverArtifact(): Promise<void> {
-    throw new Error('Inbox file delivery is not implemented for Feishu yet.')
+  async deliverArtifact(delivery: ConnectorArtifactDelivery): Promise<void> {
+    await this.sendOwnerFile(delivery.attachment)
+  }
+
+  async sendOwnerFile(attachment: ConnectorArtifactDelivery['attachment'],
+    presentation: import('../core/reply-directives.js').ReplyMedia = 'file'): Promise<void> {
+    this.assertReady()
+    this.tracker.attempt()
+    try {
+      const file = decodeConnectorAttachment(attachment)
+      if (presentation === 'image' || presentation === 'sticker') {
+        const uploaded = await this.client!.im.image.create({
+          data: { image_type: 'message', image: file.content },
+        })
+        const imageKey = uploaded?.image_key ?? uploaded?.data?.image_key
+        if (!imageKey) throw new Error('Feishu image upload did not return an image_key')
+        await this.createMessage('image', JSON.stringify({ image_key: imageKey }))
+      } else {
+        await this.sendFile(file.filename, file.content)
+      }
+      this.tracker.success(this.ownerUserId)
+    } catch (error) {
+      this.tracker.degraded(error)
+      throw error
+    }
   }
 
   async sendOwnerText(text: string): Promise<void> {

--- a/services/connector/src/adapters/reply-media.spec.ts
+++ b/services/connector/src/adapters/reply-media.spec.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it, vi } from 'vitest'
+import { DiscordConnectorAdapter } from './discord.js'
+import { SlackConnectorAdapter } from './slack.js'
+import { FeishuConnectorAdapter } from './feishu.js'
+
+const bytes = Buffer.from('media-fixture')
+const attachment = {
+  filename: 'wave.png', mediaType: 'image/png', sizeBytes: bytes.length,
+  contentBase64: bytes.toString('base64'),
+  contentSha256: createHash('sha256').update(bytes).digest('hex'),
+}
+
+function setup(platform: 'discord' | 'slack' | 'feishu') {
+  const send = vi.fn(async () => ({ code: 0 }))
+  const upload = vi.fn(async () => ({ image_key: 'img_1', file_key: 'file_1' }))
+  const adapter = platform === 'discord' ? new DiscordConnectorAdapter()
+    : platform === 'slack' ? new SlackConnectorAdapter() : new FeishuConnectorAdapter()
+  Object.assign(adapter, {
+    ownerUserId: 'owner', chatId: 'dm', sessionReady: true,
+    ...(platform === 'discord' ? { client: {
+      isReady: () => true, users: { fetch: vi.fn(async () => ({ send })) },
+    } } : platform === 'slack' ? { web: {
+      conversations: { open: vi.fn(async () => ({ channel: { id: 'dm' } })) },
+      filesUploadV2: upload,
+    } } : { client: { im: {
+      image: { create: upload }, file: { create: upload }, message: { create: send },
+    } } }),
+  })
+  return { adapter, send, upload }
+}
+
+describe.each(['discord', 'slack', 'feishu'] as const)('%s reply media', platform => {
+  it.each(['file', 'image', 'sticker'] as const)('delivers %s to the linked owner without changing bytes', async presentation => {
+    const { adapter, send, upload } = setup(platform)
+    await adapter.sendOwnerFile(attachment, presentation)
+    if (platform === 'discord') {
+      expect(send).toHaveBeenCalledWith({ files: [{ attachment: bytes, name: 'wave.png' }] })
+    } else if (platform === 'slack') {
+      expect(upload).toHaveBeenCalledWith({ channel_id: 'dm', file: bytes, filename: 'wave.png' })
+    } else {
+      expect(upload).toHaveBeenCalledWith({ data: presentation === 'file'
+        ? { file_type: 'stream', file_name: 'wave.png', file: bytes }
+        : { image_type: 'message', image: bytes } })
+      expect(send).toHaveBeenCalledWith({
+        params: { receive_id_type: 'chat_id' },
+        data: { receive_id: 'dm', msg_type: presentation === 'file' ? 'file' : 'image',
+          content: JSON.stringify(presentation === 'file' ? { file_key: 'file_1' } : { image_key: 'img_1' }) },
+      })
+    }
+    expect(adapter.health().status).toBe('healthy')
+  })
+
+  it('delivers directed artifacts as files without an Inbox summary', async () => {
+    const { adapter, send, upload } = setup(platform)
+    await adapter.deliverArtifact({
+      requestId: 'request', connectorId: platform, entryId: 'entry', docIndex: 0, attachment,
+    })
+    if (platform === 'discord') expect(send.mock.calls[0]).toEqual([{ files: [{ attachment: bytes, name: 'wave.png' }] }])
+    else if (platform === 'slack') expect(upload).toHaveBeenCalledTimes(1)
+    else expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ msg_type: 'file' }),
+    }))
+  })
+
+  it('rejects an unlinked owner before uploading', async () => {
+    const { adapter, send, upload } = setup(platform)
+    Object.assign(adapter, { ownerUserId: undefined })
+    await expect(adapter.sendOwnerFile(attachment, 'sticker')).rejects.toThrow('not linked')
+    expect(send).not.toHaveBeenCalled()
+    expect(upload).not.toHaveBeenCalled()
+  })
+
+  it('reports upload failure and degraded health', async () => {
+    const { adapter, send, upload } = setup(platform)
+    const endpoint = platform === 'discord' ? send : upload
+    endpoint.mockRejectedValueOnce(new Error('upload denied'))
+    await expect(adapter.sendOwnerFile(attachment, 'sticker')).rejects.toThrow('upload denied')
+    expect(adapter.health().status).toBe('degraded')
+  })
+
+  it('rejects corrupt media before uploading', async () => {
+    const { adapter, send, upload } = setup(platform)
+    await expect(adapter.sendOwnerFile({ ...attachment, contentSha256: '0'.repeat(64) })).rejects.toThrow()
+    expect(send).not.toHaveBeenCalled()
+    expect(upload).not.toHaveBeenCalled()
+  })
+})
+
+it('does not send a Feishu message when upload returns no image key', async () => {
+  const { adapter, send, upload } = setup('feishu')
+  upload.mockResolvedValueOnce({} as Awaited<ReturnType<typeof upload>>)
+  await expect(adapter.sendOwnerFile(attachment, 'image')).rejects.toThrow('image_key')
+  expect(send).not.toHaveBeenCalled()
+})

--- a/services/connector/src/adapters/slack.ts
+++ b/services/connector/src/adapters/slack.ts
@@ -2,6 +2,7 @@ import type { SocketModeClient } from '@slack/socket-mode'
 import type { WebClient } from '@slack/web-api'
 import type {
   ConnectorAdapterConfig,
+  ConnectorArtifactDelivery,
   ConnectorAdapterHealth,
   InboxNotification,
 } from '@traderalice/connector-protocol'
@@ -19,6 +20,7 @@ import {
   AdapterHealthTracker,
   classifyNetworkStartFailure,
   decodeInboxAttachments,
+  decodeConnectorAttachment,
   formatInboxNotification,
 } from './shared.js'
 
@@ -133,8 +135,28 @@ export class SlackConnectorAdapter implements ConnectorAdapter {
     }
   }
 
-  async deliverArtifact(): Promise<void> {
-    throw new Error('Inbox file delivery is not implemented for Slack yet.')
+  async deliverArtifact(delivery: ConnectorArtifactDelivery): Promise<void> {
+    await this.sendOwnerFile(delivery.attachment)
+  }
+
+  async sendOwnerFile(attachment: ConnectorArtifactDelivery['attachment'],
+    _presentation: import('../core/reply-directives.js').ReplyMedia = 'file'): Promise<void> {
+    if (!this.web) throw new Error('Slack client is not ready')
+    if (!this.ownerUserId) throw new Error('Slack owner is not linked')
+    this.tracker.attempt()
+    try {
+      const file = decodeConnectorAttachment(attachment)
+      // Slack previews uploaded images, including local stickers.
+      await this.web.filesUploadV2({
+        channel_id: await this.openOwnerDm(),
+        file: file.content,
+        filename: file.filename,
+      })
+      this.tracker.success(this.ownerUserId)
+    } catch (error) {
+      this.tracker.degraded(error)
+      throw error
+    }
   }
 
   async sendOwnerText(text: string): Promise<void> {


### PR DESCRIPTION
## Change
Resolved reply file references previously remained literal on Discord, Slack, and Feishu because only Telegram implemented sendOwnerFile. Implement the shared interface for the other built-in adapters and directed artifact delivery without an Inbox re-summary.

Discord and Slack upload original files (local stickers render as images rather than native sticker resources). Feishu uses image upload/image_key for images and stickers, and file upload/file_key for documents. Core parsing, owner routing, ordered text/media delivery and unresolved-reference behavior remain shared. Document official API references, scope requirements and the distinction between media support and desk ingress.

## Validation
- Connector service suite: 18 files, 151 tests passed, including 22 new media cases.
- Connector service typecheck and build passed.
- Isolated Connector process smoke passed.
- Real Discord/Slack/Feishu recipient delivery and client rendering have not been verified; platform scopes and appearance remain live acceptance items.
