### PR TITLE
chore: sync accepted v0.93.0-beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.92.1",
+  "version": "0.93.0-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.92.1",
+  "version": "0.93.0-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Synchronize the accepted `v0.93.0-beta` root product and distributed CLI version values back to `dev` after the beta release completed successfully.

Release: https://github.com/TraderAlice/OpenAlice/releases/tag/v0.93.0-beta
