### PR TITLE
chore: prepare v0.93.0

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build optional Broker Packs on Windows
         run: pnpm broker-packs:build
-        timeout-minutes: 10
+        timeout-minutes: 20
 
       - name: Verify Broker Packs in compiled runtime
         run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.93.0-beta",
+  "version": "0.93.0",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.93.0-beta",
+  "version": "0.93.0",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Promote the accepted `v0.93.0-beta` product source to the stable `v0.93.0` version. The product changes are limited to the two authoritative version fields, so the stable build uses the exact beta-tested implementation.

The stable gate exposed that Windows Broker Pack construction can exceed its step's 10-minute timeout: all five packs built and four verified before GitHub killed the step at 9:59. The observed promotion run completed this same job in 13:30. This PR raises only that build-step timeout to 20 minutes; the workflow contract suite passes locally (10 files, 92 tests).

Beta evidence:
- Release: https://github.com/TraderAlice/OpenAlice/releases/tag/v0.93.0-beta
- Tag/source: `adfa27a4caf2c63bd39819d9084a4ca4ef3072b4`
- 55 GitHub assets and beta CDN manifest accepted
- Stable CDN manifest and update feeds remained byte-identical during beta publication

Stable publication will run the full synchronous source, desktop, N-1 upgrade, installer, npm, and distribution acceptance gates.
