### PR TITLE
feat: add discoverable market data and chart skill

### DIFF
--- a/default/skills/alice-analysis/SKILL.md
+++ b/default/skills/alice-analysis/SKILL.md
@@ -160,11 +160,7 @@ supported here).
 - For arbitrary/looping logic beyond these primitives, spawn a separate
   Auto-Quant workspace, not this tool.
 
-## Show a K-line in chat
+## Raw data and chart delivery
 
-Use `[[market/{barId}/{interval}]]` in reply prose, for example
-`[[market/yfinance|AAPL/1d]]`. Copy the exact barId from `alice market search-bars`;
-do not guess or rewrite its native symbol. This loads the latest 300 bars.
-GUI opens an interactive chart in the right panel; attachment-capable Connectors
-send a chart image in that position. Code examples stay literal. Unsupported
-sources or intervals report a failure rather than switching feeds.
+See the `market-data` skill for raw OHLCV reads and `[[market/{barId}/{interval}]]`
+references that display charts in GUI chat and supported Connectors.

--- a/default/skills/alice/SKILL.md
+++ b/default/skills/alice/SKILL.md
@@ -51,7 +51,8 @@ If a search for a non-US name comes up empty, check `alice market vendors`
 `alice rss` is an optional quick scan of collected subscription articles,
 with limited coverage. Command parameters are available in `alice rss --help`.
 
-**Raw K-lines** use the same BarService as the Market chart:
+**Raw K-lines** use the same BarService as the Market chart. The `market-data`
+skill covers source discovery, raw data and chart references in replies:
 
 ```bash
 alice market search-bars --query AAPL

--- a/default/skills/market-data/SKILL.md
+++ b/default/skills/market-data/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: market-data
+description: >
+  Use for price history, OHLCV/K-lines, market-data source discovery, or showing
+  a candlestick chart in a conversation. Fetch data for local analysis or share
+  a chart using OpenAlice market references.
+---
+
+# Market data and charts
+
+OpenAlice's Market UI and `alice market` share the same K-line service.
+Workspace shells already select their Alice Project. Outside a Workspace, use
+`openalice exec --project <key> alice market ...`.
+
+## Find and read a series
+
+```bash
+alice market search-bars --query AAPL
+alice market bars --bar-id 'yfinance|AAPL' --interval 1d --count 300 --output bars.json
+```
+
+Copy an exact `barId` from search results. It identifies a source as well as an
+instrument: two feeds for the same symbol are different series. Do not rewrite
+native symbols or guess broker account IDs. If source discovery is empty,
+`alice market vendors` shows configured vendor availability.
+
+The result contains `bars` (OHLCV) and `meta`. Use the file in local Python,
+JavaScript or shell analysis; omit `--output` for stdout. Existing output files
+are not overwritten. `alice market bars --help` lists window options and an
+explicit `--asset-class` hint for vendor lookups that cannot resolve the class.
+The `alice-analysis` skill covers optional formula and snapshot shortcuts.
+
+Check the returned coverage and freshness metadata, especially the earliest
+and latest records, fetch time and possible delay. The age of the last bar is
+not measured feed latency; market closures and bar boundaries matter. Do not
+present a delayed or historical observation as a live quote.
+
+## Show a chart in a reply
+
+Write a market reference directly in reply prose when a chart helps:
+
+[[market/yfinance|AAPL/1d]]
+
+The syntax is `[[market/{barId}/{interval}]]`. Copy the discovered barId intact,
+including any slash in its symbol; the final slash separates the interval.
+Intervals are `1m`, `5m`, `15m`, `30m`, `1h`, `4h`, `1d`, `1w` (availability
+varies by source). The reference requests the latest 300 bars, not a saved
+snapshot of an earlier analysis.
+
+GUI chat displays a card and opens the interactive chart in the right panel.
+Supported Connectors such as Telegram send a chart image at that position in
+the reply, preserving surrounding text order. Put the reference outside code
+when you want it rendered; code examples remain literal. Failed references do
+not silently switch feeds. There is no need to generate or attach a chart file.
+
+For broker quotes, contracts, positions or orders, use `alice-uta` instead.
+A market reference only displays data; it does not place a trade.

--- a/docs/workspace-agent-guidance.md
+++ b/docs/workspace-agent-guidance.md
@@ -42,7 +42,8 @@ One concept has one primary owner:
 | Delegating quantitative research from Chat to AutoQuant | `delegate-autoquant` |
 | Issue file shape, ownership, schedules, headless delivery | `self-scheduling` |
 | Low-frequency market/fundamental/macro data | `traderhub` |
-| Quantitative K-line panels and source choice | `alice-analysis` |
+| K-line discovery, raw OHLCV, freshness and reply chart references | `market-data` |
+| Optional quantitative formulas and snapshots | `alice-analysis` |
 | Broker accounts/contracts/quotes and trading writes | `alice-uta` |
 
 Other instructions may route to that owner but should not copy its manual.

--- a/src/workspaces/alice-harness-assets.spec.ts
+++ b/src/workspaces/alice-harness-assets.spec.ts
@@ -42,3 +42,16 @@ it('restores an excluded file-delivery projection without enabling the CLI', asy
   await injectAliceHarnessSkills(dir, true, { ...config, skills: { 'file-delivery': true } })
   for (const root of ['.agents', '.claude']) expect(await readFile(join(dir, root, 'skills/file-delivery/SKILL.md'), 'utf8')).toBe('# file-delivery')
 })
+
+it('projects market-data into both mirrors and supports exclusion and restoration', async () => {
+  const dir = join(paths.root, 'market-workspace')
+  const config = { schemaVersion: 1 as const, cli: {}, skills: { 'market-data': false } }
+  await injectAliceHarnessSkills(dir, true, config)
+  for (const root of ['.agents', '.claude']) {
+    await expect(readFile(join(dir, root, 'skills/market-data/SKILL.md'))).rejects.toMatchObject({ code: 'ENOENT' })
+  }
+  await injectAliceHarnessSkills(dir, true, { ...config, skills: { 'market-data': true } })
+  for (const root of ['.agents', '.claude']) {
+    expect(await readFile(join(dir, root, 'skills/market-data/SKILL.md'), 'utf8')).toBe('# market-data')
+  }
+})

--- a/src/workspaces/alice-harness-policy.ts
+++ b/src/workspaces/alice-harness-policy.ts
@@ -5,7 +5,7 @@ import { CLI_EXPORTS } from '../server/cli-commands.js'
 
 export const ALICE_HARNESS_CONFIG_PATH = '.alice/alice-harness-config.json'
 export const ALICE_HARNESS_VERSION_PATH = '.alice/alice-harness-version.json'
-export const ALICE_HARNESS_SKILLS = ['alice', 'alice-analysis', 'alice-uta', 'traderhub', 'self-scheduling', 'file-delivery'] as const
+export const ALICE_HARNESS_SKILLS = ['alice', 'market-data', 'alice-analysis', 'alice-uta', 'traderhub', 'self-scheduling', 'file-delivery'] as const
 export const LEGACY_ALICE_HARNESS_SKILLS = [...ALICE_HARNESS_SKILLS, 'alice-workspace']
 export const aliceHarnessConfigSchema = z.object({
   schemaVersion: z.literal(1),


### PR DESCRIPTION
Adds a discoverable English `market-data` skill for source discovery, raw OHLCV reads, freshness interpretation, and inline market chart delivery. Previously chart delivery was buried in the calculator manual. The new skill is part of Project-managed Harness injection and supports Workspace exclusion/restoration and both runtime mirrors. Existing manuals route to its single owner.

Validation: 17 changed test files / 284 tests passed; root TypeScript check passed; real bundled-source injection into a temporary Workspace verified both mirrors and content-derived Harness version.
