### PR TITLE
chore: sync accepted v0.93.0 release

### DIFF
--- a/.github/workflows/desktop-package-smoke.yml
+++ b/.github/workflows/desktop-package-smoke.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build optional Broker Packs on Windows
         run: pnpm broker-packs:build
-        timeout-minutes: 10
+        timeout-minutes: 20
 
       - name: Verify Broker Packs in compiled runtime
         run: pnpm exec tsx scripts/verify-broker-packs.ts --compiled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.93.0-beta",
+  "version": "0.93.0",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.93.0-beta",
+  "version": "0.93.0",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Synchronize the accepted `v0.93.0` root product and distributed CLI versions back to `dev` after stable publication.

This also carries the release-proven Windows Broker Pack build timeout adjustment from 10 to 20 minutes. The stable gate showed the build can legitimately take 12-14 minutes on hosted Windows runners; the corrected gate completed successfully, including compiled-runtime and N-1 upgrade checks. The workflow contract suite passes locally (10 files, 92 tests).

Release: https://github.com/TraderAlice/OpenAlice/releases/tag/v0.93.0
