### PR TITLE
Prepare v0.93.1-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.93.0",
+  "version": "0.93.1-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.93.0",
+  "version": "0.93.1-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Prepares the accepted master source for the `v0.93.1-beta` release by synchronizing the root and distributed CLI package versions.

The promotion source was accepted in #1491. This PR changes only the two release-owned version fields.
