### PR TITLE
Sync accepted v0.93.1-beta version to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-alice",
-  "version": "0.93.0",
+  "version": "0.93.1-beta",
   "description": "File-based trading agent engine",
   "type": "module",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traderalice/openalice-cli",
-  "version": "0.93.0",
+  "version": "0.93.1-beta",
   "description": "OpenAlice local runtime and remote connection CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Synchronizes the accepted `v0.93.1-beta` root and distributed CLI version values back to `dev` after the public release completed successfully.

Release: https://github.com/TraderAlice/OpenAlice/releases/tag/v0.93.1-beta
