### PR TITLE
feat: add modular BTC and TSLA evidence monitor

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -29,6 +29,11 @@ the durable truth after it changes. Git history is the archive.
 
 ## Active
 
+- [[plans/market-evidence-monitor.md]] — Adds a read-only, modular BTC/TSLA
+  evidence monitor to the Market workspace, with explicit source health,
+  daily/intraday evidence, durable observations and alerts, deterministic demo
+  data, and a responsive web dashboard. The feature branch remains unmerged
+  pending Mac live-data acceptance.
 - [[plans/web-conversation-surface.md]] — Generalizes WebPi into one Web
   conversation surface: a neutral `WebSessionHost` with `pi-rpc`, `acp`,
   `claude-stream-json`, and `codex-app-server` transports, first-class

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ GitHub navigation.
 | [[docs/uta-live-testing.md]] | [UTA live testing](uta-live-testing.md) | Real broker/demo acceptance scenarios and trading invariants |
 | [[docs/ibkr-wire-protocol.md]] | [IBKR wire protocol](ibkr-wire-protocol.md) | TWS/Gateway inbound framing, payload-only decoder contract, failure isolation, and verification |
 | [[docs/market-data-architecture.md]] | [Market data architecture](market-data-architecture.md) | TraderHub/reference data, BarService K-lines, and the private provider compatibility layer |
+| [[docs/market-evidence-monitor.md]] | [Market evidence monitor](market-evidence-monitor.md) | Read-only BTC/TSLA evidence strategy, observations, alerts, and dashboard |
 
 Other files under `docs/images/` are README/product assets rather than owner
 guides.

--- a/docs/market-evidence-monitor.md
+++ b/docs/market-evidence-monitor.md
@@ -45,7 +45,12 @@ the last successful render visible.
 
 Every scan writes a receipt labelled `manual` or `scheduled`. A snapshot is
 written only when its semantic fingerprint changes; cache-hit text, fetch time
-and other transport mechanics do not create a new observation. Alerts are
+and other transport mechanics do not create a new observation. Continuously
+moving derivatives values are bucketed at decision scale, so insignificant
+last-decimal changes do not create observation noise while meaningful funding,
+positioning or basis changes remain visible. If a context provider becomes
+temporarily unavailable, the last valid values remain visible while source
+health clearly marks them as retained and unavailable/degraded. Alerts are
 deduplicated by asset, evidence state and latest attributed candle.
 
 Browser notifications are opt-in and work only while the dashboard is open.

--- a/docs/market-evidence-monitor.md
+++ b/docs/market-evidence-monitor.md
@@ -69,6 +69,24 @@ pnpm market-monitor:preview -- --check
 
 For real configured providers, run `pnpm dev`, choose **Market → Evidence
 Monitor**, and inspect every source-health row before using an interpretation.
+In a second terminal, the default acceptance command only checks the live page
+and read APIs:
+
+```bash
+pnpm market-monitor:acceptance
+```
+
+To exercise real scans for both assets and verify receipts, chart restoration,
+source attribution and semantic de-duplication consistency:
+
+```bash
+pnpm market-monitor:acceptance -- --scan
+```
+
+The command accepts `--base-url=http://127.0.0.1:<port>` when Guardian selected
+a non-default port, and writes `dist/market-monitor-acceptance.json`. Non-local
+URLs are rejected unless the caller explicitly adds `--allow-remote`.
+
 Mac/Electron acceptance must confirm desktop and narrow-window layout, live
 timestamps, the 1D/1H switch, persistence after restart and no duplicate scan
 records across a 24–72 hour observation window.

--- a/docs/market-evidence-monitor.md
+++ b/docs/market-evidence-monitor.md
@@ -23,6 +23,12 @@ never relabelled as intraday data.
 
 - `src/domain/market-monitor/analysis.ts` owns the first strategy
   (`evidence-chain-v1`), semantic fingerprints and observation evaluation.
+- `src/domain/market-monitor/strategy.ts` owns the strategy contract and
+  registry. A strategy declares a stable ID, version, required inputs, analysis
+  function and semantic fingerprint function.
+- `src/domain/market-monitor/context.ts` owns composable asset-context
+  providers. Multiple providers may support the same asset; one provider
+  failure becomes a source-health row without discarding successful modules.
 - `src/domain/market-monitor/service.ts` owns source orchestration, explicit
   fallback health, snapshot de-duplication and alert conditions.
 - `src/domain/market-monitor/store.ts` owns append-only JSONL observations,
@@ -33,8 +39,11 @@ never relabelled as intraday data.
 - `ui/src/pages/MarketEvidenceMonitorPage.tsx` owns the responsive dashboard,
   visible-page scheduling, 1D/1H switch, export and opt-in browser alerts.
 
-Adding another strategy should add a typed analysis implementation and select
-it through a registry; it should not embed rules in HTTP routes or React.
+Adding another strategy now means implementing `MarketMonitorStrategy` and
+registering it. It automatically appears in `GET /api/market-monitor/strategies`
+and the dashboard settings selector; HTTP routes and React do not need new
+decision rules. A new context source implements `MarketContextProvider` and may
+be composed with existing providers for BTC, TSLA or a future asset.
 
 ## Runtime Behaviour
 
@@ -52,6 +61,11 @@ positioning or basis changes remain visible. If a context provider becomes
 temporarily unavailable, the last valid values remain visible while source
 health clearly marks them as retained and unavailable/degraded. Alerts are
 deduplicated by asset, evidence state and latest attributed candle.
+
+Settings persist the active strategy ID. Observation histories, latest chart
+series and evaluation results remain separated by asset and strategy, so
+switching algorithms never mixes their evidence or accuracy records. Existing
+pre-registry settings and default-strategy chart files remain readable.
 
 Browser notifications are opt-in and work only while the dashboard is open.
 Native/background delivery is intentionally outside this increment.

--- a/docs/market-evidence-monitor.md
+++ b/docs/market-evidence-monitor.md
@@ -1,0 +1,74 @@
+# Market Evidence Monitor
+
+This guide owns the read-only BTC/TSLA evidence monitor, its persistence and
+the `/market/evidence` dashboard. Market-data provider selection and candle
+semantics remain owned by [[docs/market-data-architecture.md]].
+
+## Product Boundary
+
+The monitor organizes observable market evidence. It is not an execution
+strategy and never accesses accounts, approvals, credentials or order writes.
+Its initial asset registry contains:
+
+| Asset | Bar symbol | Context |
+|---|---|---|
+| BTC | `BTC-USD` | Deribit public funding, perpetual/futures and options summaries |
+| TSLA | `TSLA` | Configured OpenAlice equity/reference/news providers |
+
+Daily and hourly candles are separate attributed requests through BarService.
+If the hourly source fails, the UI reports it as unavailable; daily candles are
+never relabelled as intraday data.
+
+## Modules
+
+- `src/domain/market-monitor/analysis.ts` owns the first strategy
+  (`evidence-chain-v1`), semantic fingerprints and observation evaluation.
+- `src/domain/market-monitor/service.ts` owns source orchestration, explicit
+  fallback health, snapshot de-duplication and alert conditions.
+- `src/domain/market-monitor/store.ts` owns append-only JSONL observations,
+  alerts and scan receipts plus atomic settings writes under
+  `data/market-monitor/`.
+- `src/webui/routes/market-monitor.ts` exposes the read-only scan/history API
+  and validated settings updates.
+- `ui/src/pages/MarketEvidenceMonitorPage.tsx` owns the responsive dashboard,
+  visible-page scheduling, 1D/1H switch, export and opt-in browser alerts.
+
+Adding another strategy should add a typed analysis implementation and select
+it through a registry; it should not embed rules in HTTP routes or React.
+
+## Runtime Behaviour
+
+The page loads histories for both assets and source settings, refreshes the
+view while visible, and performs configured scheduled scans for enabled assets.
+Hidden pages pause polling and catch up after returning. A refresh error keeps
+the last successful render visible.
+
+Every scan writes a receipt labelled `manual` or `scheduled`. A snapshot is
+written only when its semantic fingerprint changes; cache-hit text, fetch time
+and other transport mechanics do not create a new observation. Alerts are
+deduplicated by asset, evidence state and latest attributed candle.
+
+Browser notifications are opt-in and work only while the dashboard is open.
+Native/background delivery is intentionally outside this increment.
+
+## Preview and Verification
+
+From the repository root:
+
+```bash
+pnpm market-monitor:preview
+```
+
+This builds deterministic demo data, starts the local web UI and opens
+`/market/evidence`. The amber `DEMO DATA · NOT LIVE` label distinguishes it
+from the real runtime. For a non-serving build check:
+
+```bash
+pnpm market-monitor:preview -- --check
+```
+
+For real configured providers, run `pnpm dev`, choose **Market → Evidence
+Monitor**, and inspect every source-health row before using an interpretation.
+Mac/Electron acceptance must confirm desktop and narrow-window layout, live
+timestamps, the 1D/1H switch, persistence after restart and no duplicate scan
+records across a 24–72 hour observation window.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "cli": "node packages/cli/bin/openalice.ts",
     "dev": "tsx scripts/guardian/dev.ts",
+    "market-monitor:preview": "node scripts/market-monitor-preview.mjs",
     "dev:onboarding": "tsx scripts/onboarding-test-dev.ts",
     "remote:ssh": "node packages/cli/bin/openalice.mjs ssh",
     "docker:build": "docker build --tag openalice:local .",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cli": "node packages/cli/bin/openalice.ts",
     "dev": "tsx scripts/guardian/dev.ts",
     "market-monitor:preview": "node scripts/market-monitor-preview.mjs",
+    "market-monitor:acceptance": "node scripts/market-monitor-live-smoke.mjs",
     "dev:onboarding": "tsx scripts/onboarding-test-dev.ts",
     "remote:ssh": "node packages/cli/bin/openalice.mjs ssh",
     "docker:build": "docker build --tag openalice:local .",

--- a/plans/market-evidence-monitor.md
+++ b/plans/market-evidence-monitor.md
@@ -42,6 +42,9 @@ present the result as a responsive dashboard with deterministic demo data.
 - The same live pass exposed a transient Deribit timeout. Context orchestration
   now retains the last valid values while recording the outage in source
   health, rather than replacing a useful dashboard state with empty fields.
+- Strategy and context collection are now runtime registries rather than
+  service conditionals. Multiple context modules may compose for one asset;
+  histories, chart series and evaluation remain isolated by strategy ID.
 
 ## Checklist
 
@@ -54,6 +57,10 @@ present the result as a responsive dashboard with deterministic demo data.
 - [x] Exercise the demo build and record live Mac acceptance as a residual gap.
 - [x] Commit and push the held feature branch without merging.
 - [x] Add and verify the Mac live-API acceptance command on the draft branch.
+- [x] Add strategy/provider registries, API discovery and dashboard selection.
+- [x] Isolate chart persistence, history and evaluation by strategy ID.
+- [x] Re-run demo/live acceptance for the modularity increment.
+- [ ] Publish the modularity increment to the draft pull request.
 - [ ] Verify decision-scale BTC fingerprinting with consecutive live scans.
 - [ ] Run the live command on macOS and observe scheduling for 24–72 hours.
 
@@ -72,7 +79,8 @@ present the result as a responsive dashboard with deterministic demo data.
 Verified in the managed Linux workspace on 2026-09-12:
 
 - Root and UI TypeScript checks passed.
-- Four focused files passed 12 tests.
+- Seven focused files passed 28 tests, including registry validation,
+  multi-provider failure isolation and cross-strategy history isolation.
 - The deterministic demo production build passed and reported
   `/market/evidence` ready.
 - The broader affected-test command reaches unrelated PTY, socket, installer,
@@ -85,6 +93,10 @@ Verified in the managed Linux workspace on 2026-09-12:
   BTC exercised healthy, timeout-with-retained-context and recovery states;
   TSLA exercised duplicate suppression and a meaningful new-news transition.
   Native macOS visual and long-window scheduling acceptance remains external.
+- The modular runtime pass discovered `evidence-chain-v1`,
+  `deribit-btc-v1` and `openalice-tsla-v1`, then completed BTC and TSLA scans.
+  Restricted workspace access left Deribit visibly unavailable without
+  interrupting BTC price evidence; TSLA fundamentals remained healthy.
 
 ## Completion
 

--- a/plans/market-evidence-monitor.md
+++ b/plans/market-evidence-monitor.md
@@ -33,6 +33,9 @@ present the result as a responsive dashboard with deterministic demo data.
   second navigation hierarchy.
 - Browser notifications are opt-in and only available while the dashboard is
   open. Native/background delivery is a later product increment.
+- Live acceptance is a separate, loopback-only smoke command. Its default mode
+  is read-only; explicit `--scan` performs two monitor scans per selected asset
+  and records a machine-readable receipt without touching trading routes.
 
 ## Checklist
 
@@ -44,6 +47,8 @@ present the result as a responsive dashboard with deterministic demo data.
 - [x] Add focused backend/UI tests and run owner typechecks.
 - [x] Exercise the demo build and record live Mac acceptance as a residual gap.
 - [x] Commit and push the held feature branch without merging.
+- [x] Add and verify the Mac live-API acceptance command on the draft branch.
+- [ ] Run the live command on macOS and observe scheduling for 24–72 hours.
 
 ## Verification
 
@@ -53,6 +58,8 @@ present the result as a responsive dashboard with deterministic demo data.
 - `pnpm test:changed` when the origin exposes a compatible `dev` base;
   otherwise explicit owner/path selection against `upstream/dev`
 - `pnpm -F open-alice-ui build:demo`
+- `pnpm market-monitor:acceptance -- --help`
+- `pnpm vitest run scripts/market-monitor-live-smoke.spec.ts`
 - Real `/market/evidence` demo route; Mac live-data acceptance remains external
 
 Verified in the managed Linux workspace on 2026-09-12:
@@ -65,6 +72,8 @@ Verified in the managed Linux workspace on 2026-09-12:
   and temporary-Git suites that require host capabilities unavailable in this
   workspace. No Market Monitor test failed; native Mac acceptance remains the
   final environment-specific check.
+- The live-acceptance helper and the original monitor closure pass five files
+  and 16 tests; its help/argument contract also passes under pnpm 11.
 
 ## Completion
 

--- a/plans/market-evidence-monitor.md
+++ b/plans/market-evidence-monitor.md
@@ -60,7 +60,7 @@ present the result as a responsive dashboard with deterministic demo data.
 - [x] Add strategy/provider registries, API discovery and dashboard selection.
 - [x] Isolate chart persistence, history and evaluation by strategy ID.
 - [x] Re-run demo/live acceptance for the modularity increment.
-- [ ] Publish the modularity increment to the draft pull request.
+- [x] Publish the modularity increment to the draft pull request.
 - [ ] Verify decision-scale BTC fingerprinting with consecutive live scans.
 - [ ] Run the live command on macOS and observe scheduling for 24–72 hours.
 

--- a/plans/market-evidence-monitor.md
+++ b/plans/market-evidence-monitor.md
@@ -1,0 +1,74 @@
+# Market Evidence Monitor
+
+Status: active — implementation complete on `feature/market-evidence-monitor`;
+live Mac acceptance remains.
+
+Related issues: none.
+
+Owner guides: [[docs/market-data-architecture.md]],
+[[docs/ui-interaction-and-motion.md]], [[docs/development-workflow.md]].
+
+## Scope
+
+Build a read-only evidence monitor for BTC and TSLA inside the existing Market
+web shell. Reuse BarService for attributed daily and hourly candles, compute
+observable price/volume evidence without claiming to know a market actor's
+intent, persist settings/observations/alerts under the OpenAlice data root, and
+present the result as a responsive dashboard with deterministic demo data.
+
+## Decisions
+
+- This is a Market product surface, not a second trading engine or account
+  service. It never submits, stages, approves, or cancels orders.
+- Strategy inputs and output types are isolated from HTTP and React so future
+  algorithms can be added behind one registry.
+- The first strategy is an evidence-chain interpretation of location,
+  effort/result, confirmation, invalidation, and competing explanations.
+- Daily and hourly bars remain separately attributed. Daily bars are never
+  relabelled as intraday data when the hourly source fails.
+- A semantic fingerprint excludes cache/transport mechanics so repeat scans do
+  not create duplicate observations or alerts.
+- The UI is one focused working view in the existing Market shell. On narrow
+  windows, controls wrap and evidence tables scroll instead of creating a
+  second navigation hierarchy.
+- Browser notifications are opt-in and only available while the dashboard is
+  open. Native/background delivery is a later product increment.
+
+## Checklist
+
+- [x] Add typed analysis, source-health, fingerprint and evaluation modules.
+- [x] Add file-backed settings, observation, receipt and alert storage.
+- [x] Add read-only HTTP routes and mount them in WebPlugin.
+- [x] Add Market navigation, route identity, API client and dashboard.
+- [x] Add deterministic demo handlers and fixtures.
+- [x] Add focused backend/UI tests and run owner typechecks.
+- [x] Exercise the demo build and record live Mac acceptance as a residual gap.
+- [x] Commit and push the held feature branch without merging.
+
+## Verification
+
+- `npx tsc --noEmit`
+- `cd ui && npx tsc -b`
+- Focused market-monitor backend and UI specs
+- `pnpm test:changed` when the origin exposes a compatible `dev` base;
+  otherwise explicit owner/path selection against `upstream/dev`
+- `pnpm -F open-alice-ui build:demo`
+- Real `/market/evidence` demo route; Mac live-data acceptance remains external
+
+Verified in the managed Linux workspace on 2026-09-12:
+
+- Root and UI TypeScript checks passed.
+- Four focused files passed 12 tests.
+- The deterministic demo production build passed and reported
+  `/market/evidence` ready.
+- The broader affected-test command reaches unrelated PTY, socket, installer,
+  and temporary-Git suites that require host capabilities unavailable in this
+  workspace. No Market Monitor test failed; native Mac acceptance remains the
+  final environment-specific check.
+
+## Completion
+
+The branch is complete when BTC and TSLA can be scanned read-only, duplicate
+snapshots are suppressed, source failure is visible without erasing the last
+good view, the 1D/1H dashboard and histories work in demo and production paths,
+all proportional tests pass, and the verified branch is pushed for Mac review.

--- a/plans/market-evidence-monitor.md
+++ b/plans/market-evidence-monitor.md
@@ -36,6 +36,12 @@ present the result as a responsive dashboard with deterministic demo data.
 - Live acceptance is a separate, loopback-only smoke command. Its default mode
   is read-only; explicit `--scan` performs two monitor scans per selected asset
   and records a machine-readable receipt without touching trading routes.
+- Live BTC acceptance showed raw derivatives decimals changing between
+  consecutive requests. Fingerprints therefore quantize those fields at
+  decision scale while snapshots retain the full observed values.
+- The same live pass exposed a transient Deribit timeout. Context orchestration
+  now retains the last valid values while recording the outage in source
+  health, rather than replacing a useful dashboard state with empty fields.
 
 ## Checklist
 
@@ -48,6 +54,7 @@ present the result as a responsive dashboard with deterministic demo data.
 - [x] Exercise the demo build and record live Mac acceptance as a residual gap.
 - [x] Commit and push the held feature branch without merging.
 - [x] Add and verify the Mac live-API acceptance command on the draft branch.
+- [ ] Verify decision-scale BTC fingerprinting with consecutive live scans.
 - [ ] Run the live command on macOS and observe scheduling for 24–72 hours.
 
 ## Verification
@@ -73,7 +80,11 @@ Verified in the managed Linux workspace on 2026-09-12:
   workspace. No Market Monitor test failed; native Mac acceptance remains the
   final environment-specific check.
 - The live-acceptance helper and the original monitor closure pass five files
-  and 16 tests; its help/argument contract also passes under pnpm 11.
+  and 18 tests; its help/argument contract also passes under pnpm 11.
+- A full isolated Linux runtime passed both read-only and live-scan acceptance.
+  BTC exercised healthy, timeout-with-retained-context and recovery states;
+  TSLA exercised duplicate suppression and a meaningful new-news transition.
+  Native macOS visual and long-window scheduling acceptance remains external.
 
 ## Completion
 

--- a/scripts/market-monitor-live-smoke.mjs
+++ b/scripts/market-monitor-live-smoke.mjs
@@ -102,8 +102,18 @@ export async function runAcceptance(options, dependencies = {}) {
   const html = await page.text()
   if (!html.includes('id="root"')) throw new Error('market page did not return the OpenAlice application shell')
   const settings = await json(fetcher, options.baseUrl, '/api/market-monitor/settings')
-  if (!Array.isArray(settings.enabledAssets) || !Number.isFinite(settings.intervalMinutes)) {
+  const strategies = await json(fetcher, options.baseUrl, '/api/market-monitor/strategies')
+  const contextProviders = await json(fetcher, options.baseUrl, '/api/market-monitor/context-providers')
+  if (!Array.isArray(settings.enabledAssets) || !Number.isFinite(settings.intervalMinutes) || typeof settings.strategyId !== 'string') {
     throw new Error('monitor settings response is invalid')
+  }
+  if (!strategies.strategies?.some((strategy) => strategy.id === settings.strategyId)) {
+    throw new Error(`configured strategy is not registered: ${settings.strategyId}`)
+  }
+  for (const asset of options.assets) {
+    if (!contextProviders.providers?.some((provider) => provider.assets?.includes(asset))) {
+      throw new Error(`${asset}: no registered context provider`)
+    }
   }
 
   const assets = []
@@ -149,6 +159,11 @@ export async function runAcceptance(options, dependencies = {}) {
     platform: process.platform,
     arch: process.arch,
     node: process.version,
+    modules: {
+      strategyId: settings.strategyId,
+      strategies: strategies.strategies.map((strategy) => strategy.id),
+      contextProviders: contextProviders.providers.map((provider) => provider.id),
+    },
     assets,
   }
 }

--- a/scripts/market-monitor-live-smoke.mjs
+++ b/scripts/market-monitor-live-smoke.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const ASSETS = ['BTC', 'TSLA']
+const DEFAULT_BASE_URL = 'http://127.0.0.1:47331'
+const DEFAULT_OUTPUT = 'dist/market-monitor-acceptance.json'
+
+export function parseOptions(argv, env = process.env) {
+  const options = {
+    baseUrl: env.OPENALICE_MARKET_MONITOR_BASE_URL?.trim() || DEFAULT_BASE_URL,
+    output: DEFAULT_OUTPUT,
+    scan: false,
+    allowRemote: false,
+    assets: [...ASSETS],
+    help: false,
+  }
+  for (const arg of argv) {
+    if (arg === '--') continue
+    if (arg === '--scan') options.scan = true
+    else if (arg === '--allow-remote') options.allowRemote = true
+    else if (arg === '--help' || arg === '-h') options.help = true
+    else if (arg.startsWith('--base-url=')) options.baseUrl = arg.slice('--base-url='.length)
+    else if (arg.startsWith('--output=')) options.output = arg.slice('--output='.length)
+    else if (arg.startsWith('--asset=')) {
+      const asset = arg.slice('--asset='.length).toUpperCase()
+      if (!ASSETS.includes(asset)) throw new Error('--asset must be BTC or TSLA')
+      options.assets = [asset]
+    } else throw new Error(`unknown option: ${arg}`)
+  }
+  const url = new URL(options.baseUrl)
+  if (!['http:', 'https:'].includes(url.protocol)) throw new Error('--base-url must use http or https')
+  options.baseUrl = url.toString().replace(/\/$/, '')
+  if (!options.allowRemote && !isLoopbackHost(url.hostname)) {
+    throw new Error('remote acceptance requires --allow-remote; the default is loopback-only')
+  }
+  if (!options.output.trim()) throw new Error('--output must not be empty')
+  return options
+}
+
+export function isLoopbackHost(hostname) {
+  const value = hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  return value === 'localhost' || value === '::1' || /^127(?:\.\d{1,3}){3}$/.test(value)
+}
+
+export function validateSnapshot(asset, snapshot) {
+  if (!snapshot || snapshot.asset !== asset) throw new Error(`${asset}: response has the wrong asset`)
+  if (snapshot.strategyId !== 'evidence-chain-v1') throw new Error(`${asset}: unexpected strategy identity`)
+  if (!snapshot.fingerprint || !snapshot.hypothesis?.id) throw new Error(`${asset}: evidence identity is incomplete`)
+  if (!Number.isFinite(snapshot.metrics?.lastPrice)) throw new Error(`${asset}: last price is unavailable`)
+  if (!Array.isArray(snapshot.chart?.daily) || snapshot.chart.daily.length < 20) throw new Error(`${asset}: fewer than 20 daily bars were restored`)
+  if (!Array.isArray(snapshot.chart?.intraday)) throw new Error(`${asset}: intraday series is not explicit`)
+  const health = snapshot.sourceHealth
+  if (!Array.isArray(health) || !health.some((source) => source.id === 'daily-bars')) {
+    throw new Error(`${asset}: daily source attribution is missing`)
+  }
+  const hourly = health.find((source) => source.id === 'intraday-bars')
+  if (!hourly) throw new Error(`${asset}: hourly source attribution is missing`)
+  if (hourly.status === 'unavailable' && snapshot.chart.intraday.length !== 0) {
+    throw new Error(`${asset}: unavailable hourly data was replaced by another timeframe`)
+  }
+}
+
+export function validateScanPair(asset, first, second) {
+  validateSnapshot(asset, first?.snapshot)
+  validateSnapshot(asset, second?.snapshot)
+  for (const result of [first, second]) {
+    const expected = result.stored ? 'stored' : 'duplicate'
+    if (result.receipt?.asset !== asset || result.receipt?.outcome !== expected) {
+      throw new Error(`${asset}: scan receipt does not match its storage outcome`)
+    }
+  }
+  if (first.snapshot.fingerprint === second.snapshot.fingerprint && second.stored) {
+    throw new Error(`${asset}: identical semantic evidence created a duplicate observation`)
+  }
+}
+
+async function request(fetcher, baseUrl, path, init, timeoutMs = 45_000) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetcher(`${baseUrl}${path}`, { ...init, signal: controller.signal })
+    if (!response.ok) {
+      const detail = (await response.text()).slice(0, 500)
+      throw new Error(`${init?.method ?? 'GET'} ${path} returned ${response.status}: ${detail}`)
+    }
+    return response
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function json(fetcher, baseUrl, path, init) {
+  return request(fetcher, baseUrl, path, init).then((response) => response.json())
+}
+
+export async function runAcceptance(options, dependencies = {}) {
+  const fetcher = dependencies.fetcher ?? fetch
+  const startedAt = new Date().toISOString()
+  const page = await request(fetcher, options.baseUrl, '/market/evidence')
+  const html = await page.text()
+  if (!html.includes('id="root"')) throw new Error('market page did not return the OpenAlice application shell')
+  const settings = await json(fetcher, options.baseUrl, '/api/market-monitor/settings')
+  if (!Array.isArray(settings.enabledAssets) || !Number.isFinite(settings.intervalMinutes)) {
+    throw new Error('monitor settings response is invalid')
+  }
+
+  const assets = []
+  for (const asset of options.assets) {
+    const before = await json(fetcher, options.baseUrl, `/api/market-monitor/snapshots?asset=${asset}&limit=1000`)
+    let first = null
+    let second = null
+    if (options.scan) {
+      const init = { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ asset, trigger: 'manual' }) }
+      first = await json(fetcher, options.baseUrl, '/api/market-monitor/scan', init)
+      second = await json(fetcher, options.baseUrl, '/api/market-monitor/scan', init)
+      validateScanPair(asset, first, second)
+    }
+    const snapshots = await json(fetcher, options.baseUrl, `/api/market-monitor/snapshots?asset=${asset}&limit=1000`)
+    const receipts = await json(fetcher, options.baseUrl, `/api/market-monitor/receipts?asset=${asset}&limit=1000`)
+    const alerts = await json(fetcher, options.baseUrl, `/api/market-monitor/alerts?asset=${asset}&limit=1000`)
+    const evaluation = await json(fetcher, options.baseUrl, `/api/market-monitor/evaluation?asset=${asset}`)
+    const latest = snapshots.snapshots?.at(-1)
+    if (latest) validateSnapshot(asset, latest)
+    if (options.scan && (!latest || snapshots.count < before.count || receipts.count < 2)) {
+      throw new Error(`${asset}: persisted histories did not reflect the acceptance scans`)
+    }
+    assets.push({
+      asset,
+      beforeSnapshots: before.count,
+      afterSnapshots: snapshots.count,
+      receipts: receipts.count,
+      alerts: alerts.count,
+      evaluationSamples: evaluation.samples,
+      firstOutcome: first?.receipt?.outcome ?? null,
+      secondOutcome: second?.receipt?.outcome ?? null,
+      latestFingerprint: latest?.fingerprint ?? null,
+      sources: latest?.sourceHealth?.map(({ id, status, provider }) => ({ id, status, provider })) ?? [],
+    })
+  }
+  return {
+    schemaVersion: 1,
+    success: true,
+    mode: options.scan ? 'live-scan' : 'read-only',
+    baseUrl: options.baseUrl,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    assets,
+  }
+}
+
+export function helpText() {
+  return `Usage: pnpm market-monitor:acceptance -- [options]
+
+Checks a running OpenAlice Market Evidence Monitor.
+
+Options:
+  --scan                 Run two real read-only market scans per asset
+  --asset=BTC|TSLA       Limit acceptance to one asset
+  --base-url=<url>       OpenAlice Web endpoint (default ${DEFAULT_BASE_URL})
+  --output=<path>        Receipt path (default ${DEFAULT_OUTPUT})
+  --allow-remote         Permit a non-loopback endpoint
+  --help                 Show this message`
+}
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2))
+  if (options.help) {
+    console.log(helpText())
+    return
+  }
+  const report = await runAcceptance(options)
+  const output = resolve(options.output)
+  await mkdir(dirname(output), { recursive: true })
+  await writeFile(output, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  for (const asset of report.assets) {
+    console.log(`[market-monitor] ${asset.asset}: snapshots ${asset.beforeSnapshots} -> ${asset.afterSnapshots}; scans ${asset.firstOutcome ?? 'not run'} / ${asset.secondOutcome ?? 'not run'}`)
+  }
+  console.log(`[market-monitor] PASS (${report.mode}) -> ${output}`)
+}
+
+const entry = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null
+if (entry === import.meta.url) {
+  main().catch((error) => {
+    console.error(`[market-monitor] FAIL: ${error instanceof Error ? error.message : String(error)}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/market-monitor-live-smoke.spec.ts
+++ b/scripts/market-monitor-live-smoke.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { isLoopbackHost, parseOptions, validateScanPair, validateSnapshot } from './market-monitor-live-smoke.mjs'
+
+function snapshot(asset = 'BTC') {
+  const intraday: Array<Record<string, unknown>> = []
+  return {
+    asset,
+    strategyId: 'evidence-chain-v1',
+    fingerprint: 'evidence-a',
+    hypothesis: { id: 'balanced-range' },
+    metrics: { lastPrice: 100 },
+    chart: { daily: Array.from({ length: 20 }, () => ({})), intraday },
+    sourceHealth: [
+      { id: 'daily-bars', status: 'ok', provider: 'fixture' },
+      { id: 'intraday-bars', status: 'unavailable', provider: 'fixture' },
+    ],
+  }
+}
+
+describe('market monitor live acceptance', () => {
+  it('defaults to a loopback, read-only acceptance run', () => {
+    expect(parseOptions([], {})).toMatchObject({ baseUrl: 'http://127.0.0.1:47331', scan: false, assets: ['BTC', 'TSLA'] })
+    expect(isLoopbackHost('::1')).toBe(true)
+    expect(() => parseOptions(['--base-url=https://example.com'], {})).toThrow(/allow-remote/)
+  })
+
+  it('requires explicit and valid asset selection', () => {
+    expect(parseOptions(['--', '--scan', '--asset=tsla'], {})).toMatchObject({ scan: true, assets: ['TSLA'] })
+    expect(() => parseOptions(['--asset=ETH'], {})).toThrow(/BTC or TSLA/)
+  })
+
+  it('keeps an unavailable hourly source empty', () => {
+    expect(() => validateSnapshot('BTC', snapshot())).not.toThrow()
+    const invalid = snapshot()
+    invalid.chart.intraday.push({})
+    expect(() => validateSnapshot('BTC', invalid)).toThrow(/another timeframe/)
+  })
+
+  it('rejects duplicate semantic observations and inconsistent receipts', () => {
+    const first = { snapshot: snapshot(), stored: true, receipt: { asset: 'BTC', outcome: 'stored' } }
+    const duplicate = { snapshot: snapshot(), stored: false, receipt: { asset: 'BTC', outcome: 'duplicate' } }
+    expect(() => validateScanPair('BTC', first, duplicate)).not.toThrow()
+    expect(() => validateScanPair('BTC', first, { ...duplicate, stored: true, receipt: { asset: 'BTC', outcome: 'stored' } })).toThrow(/duplicate observation/)
+  })
+})

--- a/scripts/market-monitor-preview.mjs
+++ b/scripts/market-monitor-preview.mjs
@@ -1,0 +1,48 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { access, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const args = new Set(process.argv.slice(2))
+const checkOnly = args.has('--check')
+const noOpen = args.has('--no-open') || process.env['CI'] === 'true'
+const portArg = process.argv.find((value) => value.startsWith('--port='))
+const port = portArg?.slice('--port='.length) || '4173'
+const root = process.cwd()
+
+const build = spawnSync('pnpm', ['-F', 'open-alice-ui', 'build:demo'], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+})
+if (build.status !== 0) process.exit(build.status ?? 1)
+
+await access(resolve(root, 'ui/dist/index.html'))
+const assets = await readFile(resolve(root, 'ui/dist/index.html'), 'utf8')
+if (!assets.includes('/assets/')) throw new Error('Demo build did not produce an application bundle')
+
+if (checkOnly) {
+  console.log('Market Evidence Monitor demo build is ready at /market/evidence')
+  process.exit(0)
+}
+
+const url = `http://127.0.0.1:${port}/market/evidence`
+console.log(`Market Evidence Monitor: ${url}`)
+const server = spawn('pnpm', ['-F', 'open-alice-ui', 'preview', '--host', '127.0.0.1', '--port', port], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+})
+
+if (!noOpen) {
+  const opener = process.platform === 'darwin'
+    ? ['open', [url]]
+    : process.platform === 'win32'
+      ? ['cmd', ['/c', 'start', '', url]]
+      : ['xdg-open', [url]]
+  setTimeout(() => spawn(opener[0], opener[1], { stdio: 'ignore', detached: true }).unref(), 1200)
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.kill(signal))
+}
+server.on('exit', (code) => process.exit(code ?? 0))

--- a/src/domain/market-monitor/analysis.spec.ts
+++ b/src/domain/market-monitor/analysis.spec.ts
@@ -35,6 +35,23 @@ describe('market evidence analysis', () => {
     expect(a).toBe(b)
   })
 
+  it('buckets continuously moving derivatives fields at decision scale', () => {
+    const analysis = analyzeEvidence({ dailyBars: series(90, 86400000), intradayBars: series(48, 3600000), abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 })
+    const base = {
+      asset: 'BTC' as const, ...analysis,
+      context: { fundingRate: 0.00012341, openInterest: 100_010, annualizedBasisPercent: 4.21, optionOpenInterest: 50_001, putCallOpenInterestRatio: 0.751 },
+      sourceHealth: [],
+    }
+    expect(semanticFingerprint(base)).toBe(semanticFingerprint({
+      ...base,
+      context: { fundingRate: 0.00012349, openInterest: 100_020, annualizedBasisPercent: 4.27, optionOpenInterest: 50_002, putCallOpenInterestRatio: 0.752 },
+    }))
+    expect(semanticFingerprint(base)).not.toBe(semanticFingerprint({
+      ...base,
+      context: { ...base.context, openInterest: 102_000 },
+    }))
+  })
+
   it('evaluates only resolved directional hypotheses', () => {
     const make = (price: number, bias: 'bullish' | 'bearish' | 'neutral', capturedAt: string): MarketMonitorSnapshot => ({
       id: capturedAt, asset: 'BTC', capturedAt, trigger: 'manual', strategyId: 'evidence-chain-v1', fingerprint: capturedAt,

--- a/src/domain/market-monitor/analysis.spec.ts
+++ b/src/domain/market-monitor/analysis.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { OhlcvBar } from '../market-data/bars/index.js'
+import { analyzeEvidence, evaluateSnapshots, semanticFingerprint } from './analysis.js'
+import type { MarketMonitorSnapshot } from './types.js'
+
+function series(count: number, intervalMs: number, direction = 1): OhlcvBar[] {
+  const start = Date.parse('2026-01-01T00:00:00Z')
+  return Array.from({ length: count }, (_, index) => {
+    const close = 100 + direction * index * 0.8 + Math.sin(index / 5)
+    return { date: new Date(start + index * intervalMs).toISOString(), open: close - direction * 0.3, high: close + 0.7, low: close - 0.8, close, volume: 1000 + index * 4 }
+  })
+}
+
+describe('market evidence analysis', () => {
+  it('keeps daily, weekly and hourly evidence explicit', () => {
+    const result = analyzeEvidence({ dailyBars: series(90, 86400000), intradayBars: series(48, 3600000), abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 })
+    expect(result.metrics.lastPrice).toBeGreaterThan(100)
+    expect(result.metrics.intraday.available).toBe(true)
+    expect(result.evidence.map((item) => item.timeframe)).toEqual(expect.arrayContaining(['1D', '1W', '1H']))
+    expect(result.hypothesis.confirm.length).toBeGreaterThan(0)
+    expect(result.hypothesis.invalidate.length).toBeGreaterThan(0)
+  })
+
+  it('does not substitute daily candles when hourly data is absent', () => {
+    const result = analyzeEvidence({ dailyBars: series(90, 86400000), intradayBars: [], abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 })
+    expect(result.metrics.intraday).toMatchObject({ available: false, latestAt: null, abnormal: false })
+    expect(result.evidence.find((item) => item.id === 'intraday')?.observation).toContain('not substituted')
+  })
+
+  it('fingerprints semantic state rather than request mechanics', () => {
+    const analysis = analyzeEvidence({ dailyBars: series(90, 86400000), intradayBars: series(48, 3600000), abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 })
+    const base = { asset: 'BTC' as const, ...analysis, context: { fundingRate: 0.01 }, sourceHealth: [{ id: 'bars', label: 'Bars', status: 'ok' as const, provider: 'demo', asOf: analysis.metrics.lastBarAt, detail: 'cache miss' }] }
+    const a = semanticFingerprint(base)
+    const b = semanticFingerprint({ ...base, sourceHealth: [{ ...base.sourceHealth[0], detail: 'cache hit', asOf: '2026-12-31T00:00:00Z' }] })
+    expect(a).toBe(b)
+  })
+
+  it('evaluates only resolved directional hypotheses', () => {
+    const make = (price: number, bias: 'bullish' | 'bearish' | 'neutral', capturedAt: string): MarketMonitorSnapshot => ({
+      id: capturedAt, asset: 'BTC', capturedAt, trigger: 'manual', strategyId: 'evidence-chain-v1', fingerprint: capturedAt,
+      metrics: { lastPrice: price, lastBarAt: capturedAt, change1dPercent: null, change5dPercent: null, rangePosition60d: null, volumeRatio20d: null, weeklyChangePercent: null, intraday: { available: false, latestAt: null, latestChangePercent: null, fourHourChangePercent: null, volumeRatio: null, abnormal: false, note: '' } },
+      hypothesis: { id: bias === 'bullish' ? 'demand-control' : bias === 'bearish' ? 'supply-control' : 'balanced-range', label: bias, bias, confidence: 70, summary: '', confirm: [], invalidate: [], alternatives: [] },
+      evidence: [], context: {}, sourceHealth: [], chart: { daily: [], intraday: [], dailyMeta: { symbol: 'BTC', from: '', to: '', bars: 0 }, intradayMeta: null },
+    })
+    const result = evaluateSnapshots('BTC', [make(100, 'bullish', '2026-01-01'), make(110, 'neutral', '2026-01-02')])
+    expect(result.resolved).toBe(1)
+    expect(result.directionalAccuracy).toBe(100)
+  })
+})

--- a/src/domain/market-monitor/analysis.ts
+++ b/src/domain/market-monitor/analysis.ts
@@ -1,0 +1,221 @@
+import { createHash } from 'node:crypto'
+import type { OhlcvBar } from '../market-data/bars/index.js'
+import type {
+  EvidenceItem,
+  IntradayPulse,
+  MarketContext,
+  MarketHypothesis,
+  MarketMonitorAsset,
+  MarketMonitorEvaluation,
+  MarketMonitorMetrics,
+  MarketMonitorSnapshot,
+  SourceHealth,
+} from './types.js'
+
+const pct = (latest: number, prior: number): number | null =>
+  Number.isFinite(latest) && Number.isFinite(prior) && prior !== 0
+    ? ((latest / prior) - 1) * 100
+    : null
+
+const rounded = (value: number | null, digits = 2): number | null =>
+  value == null || !Number.isFinite(value) ? null : Number(value.toFixed(digits))
+
+function sortedBars(bars: OhlcvBar[]): OhlcvBar[] {
+  return bars
+    .filter((bar) => [bar.open, bar.high, bar.low, bar.close].every(Number.isFinite))
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date))
+}
+
+function mean(values: number[]): number | null {
+  const finite = values.filter(Number.isFinite)
+  return finite.length ? finite.reduce((sum, value) => sum + value, 0) / finite.length : null
+}
+
+function volumeRatio(bars: OhlcvBar[], lookback: number): number | null {
+  const latest = bars.at(-1)?.volume
+  const prior = bars.slice(-(lookback + 1), -1).map((bar) => bar.volume).filter((value): value is number => value != null && Number.isFinite(value))
+  const average = mean(prior)
+  return latest != null && average != null && average > 0 ? latest / average : null
+}
+
+function rangePosition(bars: OhlcvBar[], lookback: number): number | null {
+  const window = bars.slice(-lookback)
+  const latest = window.at(-1)
+  if (!latest || window.length < 2) return null
+  const low = Math.min(...window.map((bar) => bar.low))
+  const high = Math.max(...window.map((bar) => bar.high))
+  return high === low ? 0.5 : (latest.close - low) / (high - low)
+}
+
+function weeklyCloses(bars: OhlcvBar[]): number[] {
+  const groups = new Map<string, OhlcvBar>()
+  for (const bar of bars) {
+    const date = new Date(`${bar.date.slice(0, 10)}T00:00:00Z`)
+    if (Number.isNaN(date.getTime())) continue
+    const day = date.getUTCDay() || 7
+    date.setUTCDate(date.getUTCDate() - day + 1)
+    groups.set(date.toISOString().slice(0, 10), bar)
+  }
+  return [...groups.values()].sort((a, b) => a.date.localeCompare(b.date)).map((bar) => bar.close)
+}
+
+function intradayPulse(bars: OhlcvBar[], abnormalVolumeRatio: number, abnormalMovePercent: number): IntradayPulse {
+  const series = sortedBars(bars)
+  if (series.length < 2) {
+    return { available: false, latestAt: null, latestChangePercent: null, fourHourChangePercent: null, volumeRatio: null, abnormal: false, note: 'Hourly source unavailable; daily data was not substituted.' }
+  }
+  const latest = series.at(-1)!
+  const change = pct(latest.close, series.at(-2)!.close)
+  const fourHour = series.length >= 5 ? pct(latest.close, series.at(-5)!.close) : null
+  const ratio = volumeRatio(series, 20)
+  const abnormal = Math.abs(change ?? 0) >= abnormalMovePercent || (ratio ?? 0) >= abnormalVolumeRatio
+  return {
+    available: true,
+    latestAt: latest.date,
+    latestChangePercent: rounded(change),
+    fourHourChangePercent: rounded(fourHour),
+    volumeRatio: rounded(ratio),
+    abnormal,
+    note: abnormal ? 'The latest hourly move or volume is outside the configured normal band.' : 'No abnormal hourly move or volume expansion detected.',
+  }
+}
+
+export function analyzeEvidence(input: {
+  dailyBars: OhlcvBar[]
+  intradayBars: OhlcvBar[]
+  abnormalVolumeRatio: number
+  abnormalMovePercent: number
+}): { metrics: MarketMonitorMetrics; evidence: EvidenceItem[]; hypothesis: MarketHypothesis } {
+  const daily = sortedBars(input.dailyBars)
+  if (daily.length < 20) throw new Error('At least 20 daily bars are required for evidence analysis')
+  const latest = daily.at(-1)!
+  const change1d = pct(latest.close, daily.at(-2)!.close)
+  const change5d = daily.length >= 6 ? pct(latest.close, daily.at(-6)!.close) : null
+  const position = rangePosition(daily, 60)
+  const dailyVolumeRatio = volumeRatio(daily, 20)
+  const weekly = weeklyCloses(daily)
+  const weeklyChange = weekly.length >= 2 ? pct(weekly.at(-1)!, weekly.at(-2)!) : null
+  const pulse = intradayPulse(input.intradayBars, input.abnormalVolumeRatio, input.abnormalMovePercent)
+  const recent20 = daily.slice(-21, -1)
+  const priorHigh = Math.max(...recent20.map((bar) => bar.high))
+  const priorLow = Math.min(...recent20.map((bar) => bar.low))
+  const breakout = latest.close > priorHigh
+  const breakdown = latest.close < priorLow
+  const highEffort = (dailyVolumeRatio ?? 0) >= input.abnormalVolumeRatio
+  const smallResult = Math.abs(change1d ?? 0) < 0.6
+  const evidence: EvidenceItem[] = []
+
+  evidence.push({
+    id: 'location', label: 'Location in 60-day range', timeframe: '1D',
+    tone: position == null ? 'neutral' : position >= 0.72 ? 'positive' : position <= 0.28 ? 'negative' : 'neutral',
+    observation: position == null ? 'Range position unavailable.' : `Close is at ${Math.round(position * 100)}% of the 60-day range.`,
+    interpretation: 'Location changes how the same price/volume event should be interpreted.', weight: 2,
+  })
+  evidence.push({
+    id: 'structure', label: 'Twenty-day structure', timeframe: '1D',
+    tone: breakout ? 'positive' : breakdown ? 'negative' : 'neutral',
+    observation: breakout ? 'Close is above the prior 20-day high.' : breakdown ? 'Close is below the prior 20-day low.' : 'Close remains inside the prior 20-day range.',
+    interpretation: breakout ? 'Demand produced structural progress.' : breakdown ? 'Supply produced structural progress.' : 'The market still needs a confirmed range exit.', weight: 3,
+  })
+  evidence.push({
+    id: 'effort-result', label: 'Effort versus result', timeframe: '1D',
+    tone: highEffort && smallResult ? 'neutral' : (change1d ?? 0) > 0 ? 'positive' : (change1d ?? 0) < 0 ? 'negative' : 'neutral',
+    observation: `${rounded(dailyVolumeRatio) ?? '—'}× 20-day volume with ${rounded(change1d) ?? '—'}% price change.`,
+    interpretation: highEffort && smallResult ? 'High effort produced little displacement; absorption is possible and requires a test.' : 'Price displacement broadly matches the direction of effort.', weight: highEffort ? 3 : 1,
+  })
+  evidence.push({
+    id: 'weekly', label: 'Weekly follow-through', timeframe: '1W',
+    tone: (weeklyChange ?? 0) > 1 ? 'positive' : (weeklyChange ?? 0) < -1 ? 'negative' : 'neutral',
+    observation: `Latest calendar-week close is ${rounded(weeklyChange) ?? '—'}% from the previous week.`,
+    interpretation: 'Weekly direction provides context; it does not confirm a reversal by itself.', weight: 2,
+  })
+  evidence.push({
+    id: 'intraday', label: 'Intraday pulse', timeframe: '1H',
+    tone: !pulse.available ? 'neutral' : (pulse.fourHourChangePercent ?? 0) > 0.8 ? 'positive' : (pulse.fourHourChangePercent ?? 0) < -0.8 ? 'negative' : 'neutral',
+    observation: pulse.available ? `Latest hour ${pulse.latestChangePercent ?? '—'}%; rolling four hours ${pulse.fourHourChangePercent ?? '—'}%; volume ${pulse.volumeRatio ?? '—'}×.` : pulse.note,
+    interpretation: pulse.available ? pulse.note : 'Intraday confirmation remains unknown rather than inferred from daily candles.', weight: pulse.abnormal ? 2 : 1,
+  })
+
+  const score = evidence.reduce((sum, item) => sum + (item.tone === 'positive' ? item.weight : item.tone === 'negative' ? -item.weight : 0), 0)
+  const maxScore = evidence.reduce((sum, item) => sum + item.weight, 0)
+  const normalized = maxScore ? score / maxScore : 0
+  const bias = normalized >= 0.22 ? 'bullish' : normalized <= -0.22 ? 'bearish' : 'neutral'
+  const confidence = Math.round(Math.min(88, 50 + Math.abs(normalized) * 45 + (breakout || breakdown ? 5 : 0)))
+  const hypothesis: MarketHypothesis = bias === 'bullish' ? {
+    id: 'demand-control', label: 'Demand has provisional control', bias, confidence,
+    summary: 'Price structure and follow-through lean constructive, but the interpretation remains conditional on the next test.',
+    confirm: ['Hold above the prior 20-day range or reclaim it quickly after a test.', 'Pullbacks contract in volume and fail to make meaningful lower lows.', 'Hourly follow-through is supported by price progress, not only leverage or volume.'],
+    invalidate: ['Close back inside the broken range with expanding downside volume.', 'A lower high is followed by a decisive 20-day breakdown.', 'Weekly follow-through turns negative while the relative range position deteriorates.'],
+    alternatives: ['A false breakout returning to balance.', 'Short covering without durable spot demand.'],
+  } : bias === 'bearish' ? {
+    id: 'supply-control', label: 'Supply has provisional control', bias, confidence,
+    summary: 'Price structure and follow-through lean defensive, but a failed breakdown can still reverse the interpretation.',
+    confirm: ['Remain below the prior 20-day range after a weak retest.', 'Down moves expand in price result and volume.', 'Hourly rebounds fail before reclaiming the broken level.'],
+    invalidate: ['Rapidly reclaim the prior range and hold it on a quieter retest.', 'Downside volume expands without further price progress, followed by a higher low.', 'Weekly close reverses higher while range position improves.'],
+    alternatives: ['A spring-like failed breakdown.', 'Temporary liquidation without persistent supply.'],
+  } : {
+    id: 'balanced-range', label: 'Evidence remains balanced', bias, confidence,
+    summary: 'Neither side has produced enough structural progress. Treat directional stories as hypotheses until price leaves and tests the range.',
+    confirm: ['Continue rotating inside the prior 20-day range.', 'Volume expansion repeatedly produces limited net displacement.'],
+    invalidate: ['Close outside the range and hold through a subsequent test.', 'Daily and weekly follow-through align with abnormal intraday participation.'],
+    alternatives: ['Re-accumulation before an upside continuation.', 'Distribution before a downside continuation.'],
+  }
+
+  return {
+    metrics: {
+      lastPrice: latest.close,
+      lastBarAt: latest.date,
+      change1dPercent: rounded(change1d), change5dPercent: rounded(change5d),
+      rangePosition60d: rounded(position, 4), volumeRatio20d: rounded(dailyVolumeRatio),
+      weeklyChangePercent: rounded(weeklyChange), intraday: pulse,
+    }, evidence, hypothesis,
+  }
+}
+
+export function semanticFingerprint(input: {
+  asset: MarketMonitorAsset
+  metrics: MarketMonitorMetrics
+  hypothesis: MarketHypothesis
+  context: MarketContext
+  sourceHealth: SourceHealth[]
+}): string {
+  const semantic = {
+    asset: input.asset,
+    lastBarAt: input.metrics.lastBarAt,
+    lastPrice: rounded(input.metrics.lastPrice, 6),
+    intradayAt: input.metrics.intraday.latestAt,
+    intradayChange: input.metrics.intraday.latestChangePercent,
+    hypothesis: input.hypothesis.id,
+    confidence: input.hypothesis.confidence,
+    context: input.context,
+    // Freshness/fetch timestamps and cache mechanics are deliberately absent:
+    // the latest attributed candle already anchors market time. Only a real
+    // source-state/provider change should create another observation.
+    source: input.sourceHealth.map(({ id, status, provider }) => ({ id, status, provider })),
+  }
+  return createHash('sha256').update(JSON.stringify(semantic)).digest('hex').slice(0, 24)
+}
+
+export function evaluateSnapshots(asset: MarketMonitorAsset, snapshots: MarketMonitorSnapshot[]): MarketMonitorEvaluation {
+  const ordered = snapshots.slice().sort((a, b) => a.capturedAt.localeCompare(b.capturedAt))
+  const rows = ordered.map((snapshot, index) => {
+    const next = ordered[index + 1]
+    const change = next ? pct(next.metrics.lastPrice, snapshot.metrics.lastPrice) : null
+    const correct = change == null || snapshot.hypothesis.bias === 'neutral'
+      ? null
+      : snapshot.hypothesis.bias === 'bullish' ? change > 0 : change < 0
+    return {
+      capturedAt: snapshot.capturedAt, hypothesis: snapshot.hypothesis.bias,
+      confidence: snapshot.hypothesis.confidence, nextCapturedAt: next?.capturedAt ?? null,
+      forwardChangePercent: rounded(change), correct,
+    }
+  })
+  const resolved = rows.filter((row) => row.correct != null)
+  const changes = rows.map((row) => row.forwardChangePercent).filter((value): value is number => value != null)
+  return {
+    asset, samples: rows.length, resolved: resolved.length,
+    directionalAccuracy: resolved.length ? rounded(resolved.filter((row) => row.correct).length / resolved.length * 100) : null,
+    averageForwardChangePercent: rounded(mean(changes)), rows: rows.slice(-100),
+  }
+}

--- a/src/domain/market-monitor/analysis.ts
+++ b/src/domain/market-monitor/analysis.ts
@@ -20,6 +20,26 @@ const pct = (latest: number, prior: number): number | null =>
 const rounded = (value: number | null, digits = 2): number | null =>
   value == null || !Number.isFinite(value) ? null : Number(value.toFixed(digits))
 
+const significant = (value: number | null | undefined, digits: number): number | null | undefined =>
+  value == null || !Number.isFinite(value) ? value : Number(value.toPrecision(digits))
+
+function semanticContext(context: MarketContext): MarketContext {
+  return {
+    fundingRate: context.fundingRate == null ? context.fundingRate : rounded(context.fundingRate, 5),
+    openInterest: significant(context.openInterest, 3),
+    annualizedBasisPercent: context.annualizedBasisPercent == null ? context.annualizedBasisPercent : rounded(context.annualizedBasisPercent, 0),
+    optionOpenInterest: significant(context.optionOpenInterest, 3),
+    putCallOpenInterestRatio: context.putCallOpenInterestRatio == null ? context.putCallOpenInterestRatio : rounded(context.putCallOpenInterestRatio, 2),
+    marketCap: significant(context.marketCap, 4),
+    trailingPe: context.trailingPe == null ? context.trailingPe : rounded(context.trailingPe, 2),
+    forwardPe: context.forwardPe == null ? context.forwardPe : rounded(context.forwardPe, 2),
+    analystTargetMean: context.analystTargetMean == null ? context.analystTargetMean : rounded(context.analystTargetMean, 2),
+    shortPercentFloat: context.shortPercentFloat == null ? context.shortPercentFloat : rounded(context.shortPercentFloat, 4),
+    nextEarningsAt: context.nextEarningsAt,
+    recentNews: context.recentNews?.map(({ title, time, source }) => ({ title, time, source })),
+  }
+}
+
 function sortedBars(bars: OhlcvBar[]): OhlcvBar[] {
   return bars
     .filter((bar) => [bar.open, bar.high, bar.low, bar.close].every(Number.isFinite))
@@ -188,7 +208,10 @@ export function semanticFingerprint(input: {
     intradayChange: input.metrics.intraday.latestChangePercent,
     hypothesis: input.hypothesis.id,
     confidence: input.hypothesis.confidence,
-    context: input.context,
+    // Continuously moving derivatives fields are quantized to decision-scale
+    // buckets. A new headline or meaningful positioning/basis change is still
+    // semantic; a provider's last decimal ticking between two requests is not.
+    context: semanticContext(input.context),
     // Freshness/fetch timestamps and cache mechanics are deliberately absent:
     // the latest attributed candle already anchors market time. Only a real
     // source-state/provider change should create another observation.

--- a/src/domain/market-monitor/context.spec.ts
+++ b/src/domain/market-monitor/context.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MarketContextProviderRegistry } from './context.js'
+
+describe('market context provider registry', () => {
+  it('allows multiple independent providers for one asset', () => {
+    const providers = [
+      { manifest: { id: 'btc-a', label: 'A', assets: ['BTC'] as const, description: 'A' }, load: vi.fn() },
+      { manifest: { id: 'btc-b', label: 'B', assets: ['BTC'] as const, description: 'B' }, load: vi.fn() },
+    ]
+    const registry = new MarketContextProviderRegistry(providers.map((provider) => ({ ...provider, manifest: { ...provider.manifest, assets: [...provider.manifest.assets] } })))
+    expect(registry.forAsset('BTC').map((provider) => provider.manifest.id)).toEqual(['btc-a', 'btc-b'])
+  })
+
+  it('rejects duplicate module identities and uncovered assets', () => {
+    const provider = { manifest: { id: 'same', label: 'Same', assets: ['BTC'] as const, description: 'fixture' }, load: vi.fn() }
+    expect(() => new MarketContextProviderRegistry([
+      { ...provider, manifest: { ...provider.manifest, assets: [...provider.manifest.assets] } },
+      { ...provider, manifest: { ...provider.manifest, assets: [...provider.manifest.assets] } },
+    ])).toThrow(/Duplicate market context provider/)
+    const registry = new MarketContextProviderRegistry([{ ...provider, manifest: { ...provider.manifest, assets: [...provider.manifest.assets] } }])
+    expect(() => registry.forAsset('TSLA')).toThrow(/No market context provider/)
+  })
+
+  it('rejects ids that cannot be used as stable module identities', () => {
+    expect(() => new MarketContextProviderRegistry([{
+      manifest: { id: 'bad/provider', label: 'Bad', assets: ['BTC'], description: 'fixture' },
+      load: vi.fn(),
+    }])).toThrow(/Invalid market context provider id/)
+  })
+})

--- a/src/domain/market-monitor/context.ts
+++ b/src/domain/market-monitor/context.ts
@@ -1,0 +1,180 @@
+import type { EquityClientLike } from '../market-data/client/types.js'
+import type { ReferenceDataService } from '../market-data/reference/types.js'
+import type { INewsProvider } from '../news/types.js'
+import type {
+  MarketContext,
+  MarketContextProviderManifest,
+  MarketMonitorAsset,
+  SourceHealth,
+} from './types.js'
+
+export type MarketMonitorFetch = typeof fetch
+
+export interface MarketContextProviderResult {
+  context: MarketContext
+  health: SourceHealth[]
+}
+
+export interface MarketContextProvider {
+  manifest: MarketContextProviderManifest
+  load(input: { asset: MarketMonitorAsset; at: Date }): Promise<MarketContextProviderResult>
+}
+
+export interface MarketContextProviderDeps {
+  equityClient: EquityClientLike
+  reference: ReferenceDataService
+  newsProvider?: INewsProvider
+  fetcher?: MarketMonitorFetch
+}
+
+export class MarketContextProviderRegistry {
+  private readonly providers: MarketContextProvider[]
+  private readonly byId = new Map<string, MarketContextProvider>()
+
+  constructor(providers: MarketContextProvider[]) {
+    this.providers = [...providers]
+    for (const provider of providers) {
+      if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(provider.manifest.id)) {
+        throw new Error(`Invalid market context provider id: ${provider.manifest.id}`)
+      }
+      if (this.byId.has(provider.manifest.id)) throw new Error(`Duplicate market context provider: ${provider.manifest.id}`)
+      this.byId.set(provider.manifest.id, provider)
+    }
+  }
+
+  forAsset(asset: MarketMonitorAsset): MarketContextProvider[] {
+    const providers = this.providers.filter((provider) => provider.manifest.assets.includes(asset))
+    if (!providers.length) throw new Error(`No market context provider registered for ${asset}`)
+    return providers
+  }
+
+  list(): MarketContextProviderManifest[] {
+    return this.providers.map(({ manifest }) => ({ ...manifest, assets: [...manifest.assets] }))
+  }
+}
+
+function numberFrom(row: unknown, keys: string[]): number | null {
+  if (!row || typeof row !== 'object') return null
+  for (const key of keys) {
+    const value = (row as Record<string, unknown>)[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return null
+}
+
+function stringFrom(row: unknown, keys: string[]): string | null {
+  if (!row || typeof row !== 'object') return null
+  for (const key of keys) {
+    const value = (row as Record<string, unknown>)[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return null
+}
+
+async function fetchJson(fetcher: MarketMonitorFetch, url: string): Promise<unknown> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 6000)
+  try {
+    const response = await fetcher(url, { signal: controller.signal, headers: { Accept: 'application/json' } })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    return await response.json()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function bitcoinContext(fetcher: MarketMonitorFetch, at: Date): Promise<MarketContextProviderResult> {
+  const capturedAt = at.toISOString()
+  try {
+    const [futureResult, optionResult] = await Promise.allSettled([
+      fetchJson(fetcher, 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=future'),
+      fetchJson(fetcher, 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=option'),
+    ])
+    if (futureResult.status === 'rejected' && optionResult.status === 'rejected') throw futureResult.reason
+    const futureRaw = futureResult.status === 'fulfilled' ? futureResult.value : undefined
+    const optionRaw = optionResult.status === 'fulfilled' ? optionResult.value : undefined
+    const futures = ((futureRaw as { result?: unknown[] })?.result ?? []) as Array<Record<string, unknown>>
+    const options = ((optionRaw as { result?: unknown[] })?.result ?? []) as Array<Record<string, unknown>>
+    const perpetual = futures.find((row) => row.instrument_name === 'BTC-PERPETUAL')
+    const dated = futures
+      .map((row) => ({ row, expiry: Date.parse(String(row.instrument_name ?? '').split('-').at(-1) ?? '') }))
+      .filter(({ expiry }) => Number.isFinite(expiry) && expiry > at.getTime() + 3 * 86400000)
+      .sort((a, b) => a.expiry - b.expiry)[0]
+    const indexPrice = numberFrom(perpetual, ['underlying_price', 'index_price', 'estimated_delivery_price', 'mark_price'])
+    const futurePrice = numberFrom(dated?.row, ['mark_price', 'last'])
+    const days = dated ? (dated.expiry - at.getTime()) / 86400000 : null
+    const basis = indexPrice && futurePrice && days
+      ? ((futurePrice / indexPrice) - 1) * (365 / days) * 100
+      : null
+    let callOi = 0
+    let putOi = 0
+    for (const row of options) {
+      const oi = numberFrom(row, ['open_interest']) ?? 0
+      const name = String(row.instrument_name ?? '')
+      if (name.endsWith('-C')) callOi += oi
+      else if (name.endsWith('-P')) putOi += oi
+    }
+    return {
+      context: {
+        fundingRate: numberFrom(perpetual, ['funding_8h', 'current_funding']),
+        openInterest: numberFrom(perpetual, ['open_interest']),
+        annualizedBasisPercent: basis == null ? null : Number(basis.toFixed(2)),
+        optionOpenInterest: callOi + putOi || null,
+        putCallOpenInterestRatio: callOi > 0 ? Number((putOi / callOi).toFixed(2)) : null,
+      },
+      health: [{ id: 'btc-derivatives', label: 'BTC derivatives context', status: futureResult.status === 'fulfilled' && optionResult.status === 'fulfilled' ? 'ok' : 'degraded', provider: 'Deribit public API', asOf: capturedAt, detail: `Read-only derivatives context loaded${futureResult.status === 'rejected' ? '; futures unavailable' : ''}${optionResult.status === 'rejected' ? '; options unavailable' : ''}.` }],
+    }
+  } catch (error) {
+    return {
+      context: {},
+      health: [{ id: 'btc-derivatives', label: 'BTC derivatives context', status: 'unavailable', provider: 'Deribit public API', asOf: null, detail: error instanceof Error ? error.message : String(error) }],
+    }
+  }
+}
+
+async function teslaContext(deps: Pick<MarketContextProviderDeps, 'equityClient' | 'reference' | 'newsProvider'>, at: Date): Promise<MarketContextProviderResult> {
+  const [metrics, estimates, shares, calendar, news] = await Promise.allSettled([
+    deps.equityClient.getKeyMetrics({ symbol: 'TSLA' }),
+    deps.equityClient.getEstimateConsensus({ symbol: 'TSLA' }),
+    deps.equityClient.getShareStatistics({ symbol: 'TSLA' }),
+    deps.reference.calendar({ days: 90 }),
+    deps.newsProvider?.getNewsV2({ endTime: at, lookback: '7d', limit: 100 }) ?? Promise.resolve([]),
+  ])
+  const metric = metrics.status === 'fulfilled' ? metrics.value[0] : undefined
+  const estimate = estimates.status === 'fulfilled' ? estimates.value[0] : undefined
+  const share = shares.status === 'fulfilled' ? shares.value[0] : undefined
+  const earnings = calendar.status === 'fulfilled'
+    ? calendar.value.earnings.find((row) => String((row as { symbol?: unknown }).symbol ?? '').toUpperCase() === 'TSLA')
+    : undefined
+  const newsRows = news.status === 'fulfilled' ? news.value.filter((item) => `${item.title}\n${item.content}`.toUpperCase().includes('TSLA') || `${item.title}\n${item.content}`.toLowerCase().includes('tesla')).slice(-5).reverse() : []
+  const context: MarketContext = {
+    marketCap: numberFrom(metric, ['market_cap']),
+    trailingPe: numberFrom(metric, ['price_to_earnings', 'pe_ratio']),
+    forwardPe: numberFrom(metric, ['forward_pe', 'pe_forward']),
+    analystTargetMean: numberFrom(estimate, ['target_consensus', 'target_mean', 'target_price']),
+    shortPercentFloat: numberFrom(share, ['short_percent_of_float']),
+    nextEarningsAt: stringFrom(earnings, ['report_date', 'date']),
+    recentNews: newsRows.map((item) => ({ title: item.title, time: item.time.toISOString(), source: item.metadata.source ?? null })),
+  }
+  const coreOk = [context.marketCap, context.trailingPe, context.forwardPe, context.analystTargetMean, context.shortPercentFloat].some((value) => value != null)
+  const calendarOk = calendar.status === 'fulfilled'
+  const newsOk = Boolean(deps.newsProvider && news.status === 'fulfilled')
+  return { context, health: [
+    { id: 'tsla-reference', label: 'TSLA fundamentals and positioning', status: coreOk ? 'ok' : 'unavailable', provider: 'OpenAlice equity providers', asOf: coreOk ? at.toISOString() : null, detail: coreOk ? 'Valuation, analyst and short-interest fields loaded where supported.' : 'Configured equity providers returned no usable context.' },
+    { id: 'tsla-calendar-news', label: 'TSLA calendar and news', status: calendarOk && newsOk ? 'ok' : calendarOk || newsOk ? 'degraded' : 'unavailable', provider: 'OpenAlice reference/news', asOf: calendarOk || newsOk ? at.toISOString() : null, detail: `${context.nextEarningsAt ? 'Earnings date available' : 'No earnings date'}; ${context.recentNews?.length ?? 0} recent matching stories${!deps.newsProvider ? '; news collector not configured' : ''}.` },
+  ] }
+}
+
+export function createDefaultMarketContextProviderRegistry(deps: MarketContextProviderDeps): MarketContextProviderRegistry {
+  const fetcher = deps.fetcher ?? fetch
+  return new MarketContextProviderRegistry([
+    {
+      manifest: { id: 'deribit-btc-v1', label: 'BTC derivatives', assets: ['BTC'], description: 'Deribit public futures, perpetual and options summaries.' },
+      load: ({ at }) => bitcoinContext(fetcher, at),
+    },
+    {
+      manifest: { id: 'openalice-tsla-v1', label: 'TSLA reference', assets: ['TSLA'], description: 'Configured OpenAlice fundamentals, estimates, calendar and news providers.' },
+      load: ({ at }) => teslaContext(deps, at),
+    },
+  ])
+}

--- a/src/domain/market-monitor/service.spec.ts
+++ b/src/domain/market-monitor/service.spec.ts
@@ -66,4 +66,24 @@ describe('market monitor service', () => {
     expect(result.snapshot.chart.intraday).toEqual([])
     expect(result.snapshot.sourceHealth.find((source) => source.id === 'intraday-bars')?.status).toBe('unavailable')
   })
+
+  it('retains the last valid BTC context when Deribit is temporarily unavailable', async () => {
+    const store = memoryStore()
+    let unavailable = false
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      if (unavailable) throw new Error('temporary derivatives outage')
+      const isOption = String(input).includes('kind=option')
+      const result = isOption
+        ? [{ instrument_name: 'BTC-27SEP26-100000-C', open_interest: 25 }, { instrument_name: 'BTC-27SEP26-100000-P', open_interest: 10 }]
+        : [{ instrument_name: 'BTC-PERPETUAL', funding_8h: 0.0001, open_interest: 100_000, mark_price: 90_000 }]
+      return new Response(JSON.stringify({ result }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as typeof fetch
+    const service = createMarketMonitorService({ ...dependencies(), store, fetcher, now: () => new Date('2026-04-01T00:00:00Z') })
+    const first = await service.scan('BTC', 'manual')
+    unavailable = true
+    const second = await service.scan('BTC', 'scheduled')
+    expect(second.snapshot.context).toMatchObject({ fundingRate: first.snapshot.context.fundingRate, openInterest: first.snapshot.context.openInterest })
+    expect(second.snapshot.sourceHealth.find((source) => source.id === 'btc-derivatives')).toMatchObject({ status: 'unavailable' })
+    expect(second.snapshot.sourceHealth.find((source) => source.id === 'btc-derivatives')?.detail).toContain('Last valid context retained')
+  })
 })

--- a/src/domain/market-monitor/service.spec.ts
+++ b/src/domain/market-monitor/service.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BarService, OhlcvBar } from '../market-data/bars/index.js'
+import type { EquityClientLike } from '../market-data/client/types.js'
+import type { ReferenceDataService } from '../market-data/reference/types.js'
+import { createMarketMonitorService } from './service.js'
+import type { MarketMonitorStore } from './store.js'
+import { DEFAULT_MARKET_MONITOR_SETTINGS, type MarketMonitorAlert, type MarketMonitorReceipt, type MarketMonitorSnapshot } from './types.js'
+
+function bars(count: number, step: number): OhlcvBar[] {
+  return Array.from({ length: count }, (_, index) => ({ date: new Date(Date.parse('2026-01-01T00:00:00Z') + index * step).toISOString(), open: 100 + index, high: 102 + index, low: 99 + index, close: 101 + index, volume: 1000 + index }))
+}
+
+function memoryStore(): MarketMonitorStore & { data: { snapshots: MarketMonitorSnapshot[]; alerts: MarketMonitorAlert[]; receipts: MarketMonitorReceipt[] } } {
+  const data = { snapshots: [] as MarketMonitorSnapshot[], alerts: [] as MarketMonitorAlert[], receipts: [] as MarketMonitorReceipt[] }
+  let settings = { ...DEFAULT_MARKET_MONITOR_SETTINGS }
+  const series = new Map<string, MarketMonitorSnapshot['chart']>()
+  return {
+    data,
+    settings: async () => settings,
+    saveSettings: async (next) => { settings = next },
+    snapshots: async (asset, limit = 100) => data.snapshots.filter((row) => !asset || row.asset === asset).slice(-limit),
+    appendSnapshot: async (row) => { data.snapshots.push(row) },
+    alerts: async (asset, limit = 100) => data.alerts.filter((row) => !asset || row.asset === asset).slice(-limit),
+    appendAlert: async (row) => { data.alerts.push(row) },
+    receipts: async (asset, limit = 100) => data.receipts.filter((row) => !asset || row.asset === asset).slice(-limit),
+    appendReceipt: async (row) => { data.receipts.push(row) },
+    latestSeries: async (asset) => series.get(asset) ?? null,
+    saveLatestSeries: async (asset, chart) => { series.set(asset, chart) },
+  }
+}
+
+function dependencies(hourly = true) {
+  const daily = bars(90, 86400000)
+  const intraday = bars(48, 3600000)
+  const barService = { getBars: vi.fn(async (_ref, opts: { interval: string }) => {
+    if (opts.interval === '1h' && !hourly) throw new Error('hourly unavailable')
+    const rows = opts.interval === '1h' ? intraday : daily
+    return { bars: rows, meta: { symbol: 'TSLA', from: rows[0].date, to: rows.at(-1)!.date, bars: rows.length, source: 'vendor' as const, sourceId: 'yfinance', provider: 'yfinance', interval: opts.interval } }
+  }) } as unknown as BarService
+  const equityClient = {
+    getKeyMetrics: vi.fn(async () => [{ market_cap: 1e12, price_to_earnings: 80 }]),
+    getEstimateConsensus: vi.fn(async () => [{ target_consensus: 350 }]),
+    getShareStatistics: vi.fn(async () => [{ short_percent_of_float: 0.03 }]),
+  } as unknown as EquityClientLike
+  const reference = { calendar: vi.fn(async () => ({ earnings: [], ipos: [], dividends: [], window: { start: '2026-01-01', end: '2026-04-01' }, meta: { provider: 'test', asOf: '2026-01-01' } })) } as unknown as ReferenceDataService
+  return { barService, equityClient, reference }
+}
+
+describe('market monitor service', () => {
+  it('stores one semantic observation and records duplicate scan receipts', async () => {
+    const store = memoryStore()
+    const service = createMarketMonitorService({ ...dependencies(), store, now: () => new Date('2026-04-01T00:00:00Z') })
+    expect((await service.scan('TSLA', 'manual')).stored).toBe(true)
+    expect((await service.scan('TSLA', 'scheduled')).stored).toBe(false)
+    expect(store.data.snapshots).toHaveLength(1)
+    expect(store.data.snapshots[0].chart.daily).toEqual([])
+    expect((await service.snapshots('TSLA', 1))[0].chart.daily).toHaveLength(90)
+    expect(store.data.receipts.map((row) => [row.trigger, row.outcome])).toEqual([['manual', 'stored'], ['scheduled', 'duplicate']])
+  })
+
+  it('keeps an unavailable hourly source explicit instead of using daily bars', async () => {
+    const store = memoryStore()
+    const service = createMarketMonitorService({ ...dependencies(false), store, now: () => new Date('2026-04-01T00:00:00Z') })
+    const result = await service.scan('TSLA', 'manual')
+    expect(result.snapshot.metrics.intraday.available).toBe(false)
+    expect(result.snapshot.chart.intraday).toEqual([])
+    expect(result.snapshot.sourceHealth.find((source) => source.id === 'intraday-bars')?.status).toBe('unavailable')
+  })
+})

--- a/src/domain/market-monitor/service.spec.ts
+++ b/src/domain/market-monitor/service.spec.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import type { BarService, OhlcvBar } from '../market-data/bars/index.js'
 import type { EquityClientLike } from '../market-data/client/types.js'
 import type { ReferenceDataService } from '../market-data/reference/types.js'
+import { MarketContextProviderRegistry } from './context.js'
 import { createMarketMonitorService } from './service.js'
 import type { MarketMonitorStore } from './store.js'
+import { createMarketMonitorStrategyRegistry, evidenceChainV1Strategy } from './strategy.js'
 import { DEFAULT_MARKET_MONITOR_SETTINGS, type MarketMonitorAlert, type MarketMonitorReceipt, type MarketMonitorSnapshot } from './types.js'
 
 function bars(count: number, step: number): OhlcvBar[] {
@@ -24,8 +26,8 @@ function memoryStore(): MarketMonitorStore & { data: { snapshots: MarketMonitorS
     appendAlert: async (row) => { data.alerts.push(row) },
     receipts: async (asset, limit = 100) => data.receipts.filter((row) => !asset || row.asset === asset).slice(-limit),
     appendReceipt: async (row) => { data.receipts.push(row) },
-    latestSeries: async (asset) => series.get(asset) ?? null,
-    saveLatestSeries: async (asset, chart) => { series.set(asset, chart) },
+    latestSeries: async (asset, strategyId = 'evidence-chain-v1') => series.get(`${asset}:${strategyId}`) ?? null,
+    saveLatestSeries: async (asset, chart, strategyId = 'evidence-chain-v1') => { series.set(`${asset}:${strategyId}`, chart) },
   }
 }
 
@@ -84,6 +86,46 @@ describe('market monitor service', () => {
     const second = await service.scan('BTC', 'scheduled')
     expect(second.snapshot.context).toMatchObject({ fundingRate: first.snapshot.context.fundingRate, openInterest: first.snapshot.context.openInterest })
     expect(second.snapshot.sourceHealth.find((source) => source.id === 'btc-derivatives')).toMatchObject({ status: 'unavailable' })
-    expect(second.snapshot.sourceHealth.find((source) => source.id === 'btc-derivatives')?.detail).toContain('Last valid context retained')
+    expect(second.snapshot.sourceHealth.find((source) => source.id === 'btc-derivatives')?.detail).toContain('Last valid fields retained')
+  })
+
+  it('selects an injected strategy through persisted settings', async () => {
+    const store = memoryStore()
+    const analyze = vi.fn(evidenceChainV1Strategy.analyze)
+    const strategyRegistry = createMarketMonitorStrategyRegistry([{
+      manifest: { id: 'review-strategy-v1', label: 'Review strategy', version: 1, description: 'Test strategy module.', requiredData: ['daily-bars'] },
+      analyze,
+      fingerprint: evidenceChainV1Strategy.fingerprint,
+    }])
+    const service = createMarketMonitorService({ ...dependencies(), store, strategyRegistry, now: () => new Date('2026-04-01T00:00:00Z') })
+    await service.scan('TSLA', 'manual')
+    await service.saveSettings({ ...DEFAULT_MARKET_MONITOR_SETTINGS, strategyId: 'review-strategy-v1' })
+    const result = await service.scan('TSLA', 'manual')
+    expect(result.snapshot.strategyId).toBe('review-strategy-v1')
+    expect(analyze).toHaveBeenCalledOnce()
+    expect(service.strategies().map((strategy) => strategy.id)).toEqual(['evidence-chain-v1', 'review-strategy-v1'])
+    expect((await service.snapshots('TSLA', 1, 'evidence-chain-v1')).at(-1)?.chart.daily).toHaveLength(90)
+    expect((await service.snapshots('TSLA', 1, 'review-strategy-v1')).at(-1)?.chart.daily).toHaveLength(90)
+    expect((await service.evaluation('TSLA')).samples).toBe(1)
+  })
+
+  it('composes multiple context providers and isolates a provider failure', async () => {
+    const contextProviderRegistry = new MarketContextProviderRegistry([
+      {
+        manifest: { id: 'btc-positioning', label: 'BTC positioning', assets: ['BTC'], description: 'fixture' },
+        load: vi.fn(async () => ({ context: { fundingRate: 0.0001 }, health: [{ id: 'btc-positioning', label: 'BTC positioning', status: 'ok' as const, provider: 'fixture', asOf: '2026-04-01T00:00:00Z', detail: 'loaded' }] })),
+      },
+      {
+        manifest: { id: 'btc-onchain', label: 'BTC on-chain', assets: ['BTC'], description: 'fixture' },
+        load: vi.fn(async () => { throw new Error('on-chain unavailable') }),
+      },
+    ])
+    const service = createMarketMonitorService({ ...dependencies(), store: memoryStore(), contextProviderRegistry, now: () => new Date('2026-04-01T00:00:00Z') })
+    const result = await service.scan('BTC', 'manual')
+    expect(result.snapshot.context.fundingRate).toBe(0.0001)
+    expect(result.snapshot.sourceHealth).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'btc-positioning', status: 'ok' }),
+      expect.objectContaining({ id: 'context-provider:btc-onchain', status: 'unavailable' }),
+    ]))
   })
 })

--- a/src/domain/market-monitor/service.ts
+++ b/src/domain/market-monitor/service.ts
@@ -1,0 +1,278 @@
+import { randomUUID } from 'node:crypto'
+import type { EquityClientLike } from '../market-data/client/types.js'
+import type { BarMeta, BarService, BarsResult, OhlcvBar } from '../market-data/bars/index.js'
+import type { INewsProvider } from '../news/types.js'
+import type { ReferenceDataService } from '../market-data/reference/types.js'
+import { analyzeEvidence, evaluateSnapshots, semanticFingerprint } from './analysis.js'
+import { createMarketMonitorStore, type MarketMonitorStore } from './store.js'
+import {
+  MARKET_MONITOR_ASSET_CONFIG,
+  type MarketContext,
+  type MarketMonitorAlert,
+  type MarketMonitorAsset,
+  type MarketMonitorEvaluation,
+  type MarketMonitorReceipt,
+  type MarketMonitorScanResult,
+  type MarketMonitorSettings,
+  type MarketMonitorSnapshot,
+  type MarketMonitorTrigger,
+  type SourceHealth,
+} from './types.js'
+
+type FetchLike = typeof fetch
+
+export interface MarketMonitorServiceDeps {
+  barService: BarService
+  equityClient: EquityClientLike
+  reference: ReferenceDataService
+  newsProvider?: INewsProvider
+  store?: MarketMonitorStore
+  fetcher?: FetchLike
+  now?: () => Date
+}
+
+export interface MarketMonitorService {
+  settings(): Promise<MarketMonitorSettings>
+  saveSettings(settings: MarketMonitorSettings): Promise<void>
+  scan(asset: MarketMonitorAsset, trigger: MarketMonitorTrigger): Promise<MarketMonitorScanResult>
+  snapshots(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorSnapshot[]>
+  alerts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorAlert[]>
+  receipts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorReceipt[]>
+  evaluation(asset: MarketMonitorAsset): Promise<MarketMonitorEvaluation>
+}
+
+function compactBars(bars: OhlcvBar[], max: number): OhlcvBar[] {
+  return bars.slice(-max).map(({ date, open, high, low, close, volume }) => ({ date, open, high, low, close, volume }))
+}
+
+function numberFrom(row: unknown, keys: string[]): number | null {
+  if (!row || typeof row !== 'object') return null
+  for (const key of keys) {
+    const value = (row as Record<string, unknown>)[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return null
+}
+
+function stringFrom(row: unknown, keys: string[]): string | null {
+  if (!row || typeof row !== 'object') return null
+  for (const key of keys) {
+    const value = (row as Record<string, unknown>)[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return null
+}
+
+async function fetchJson(fetcher: FetchLike, url: string): Promise<unknown> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 6000)
+  try {
+    const response = await fetcher(url, { signal: controller.signal, headers: { Accept: 'application/json' } })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    return await response.json()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function loadBars(barService: BarService, asset: MarketMonitorAsset, interval: '1d' | '1h', count: number): Promise<{ result: BarsResult; fallback: boolean }> {
+  const config = MARKET_MONITOR_ASSET_CONFIG[asset]
+  try {
+    return { result: await barService.getBars({ symbol: config.symbol, assetClass: config.assetClass }, { interval, count }), fallback: false }
+  } catch (primaryError) {
+    try {
+      return { result: await barService.getBars({ barId: config.barId, assetClass: config.assetClass }, { interval, count }), fallback: true }
+    } catch {
+      throw primaryError
+    }
+  }
+}
+
+async function bitcoinContext(fetcher: FetchLike, at: Date): Promise<{ context: MarketContext; health: SourceHealth }> {
+  const capturedAt = at.toISOString()
+  try {
+    const [futureResult, optionResult] = await Promise.allSettled([
+      fetchJson(fetcher, 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=future'),
+      fetchJson(fetcher, 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=option'),
+    ])
+    if (futureResult.status === 'rejected' && optionResult.status === 'rejected') throw futureResult.reason
+    const futureRaw = futureResult.status === 'fulfilled' ? futureResult.value : undefined
+    const optionRaw = optionResult.status === 'fulfilled' ? optionResult.value : undefined
+    const futures = ((futureRaw as { result?: unknown[] })?.result ?? []) as Array<Record<string, unknown>>
+    const options = ((optionRaw as { result?: unknown[] })?.result ?? []) as Array<Record<string, unknown>>
+    const perpetual = futures.find((row) => row.instrument_name === 'BTC-PERPETUAL')
+    const dated = futures
+      .map((row) => ({ row, expiry: Date.parse(String(row.instrument_name ?? '').split('-').at(-1) ?? '') }))
+      .filter(({ expiry }) => Number.isFinite(expiry) && expiry > at.getTime() + 3 * 86400000)
+      .sort((a, b) => a.expiry - b.expiry)[0]
+    const indexPrice = numberFrom(perpetual, ['underlying_price', 'index_price', 'estimated_delivery_price', 'mark_price'])
+    const futurePrice = numberFrom(dated?.row, ['mark_price', 'last'])
+    const days = dated ? (dated.expiry - at.getTime()) / 86400000 : null
+    const basis = indexPrice && futurePrice && days
+      ? ((futurePrice / indexPrice) - 1) * (365 / days) * 100
+      : null
+    let callOi = 0
+    let putOi = 0
+    for (const row of options) {
+      const oi = numberFrom(row, ['open_interest']) ?? 0
+      const name = String(row.instrument_name ?? '')
+      if (name.endsWith('-C')) callOi += oi
+      else if (name.endsWith('-P')) putOi += oi
+    }
+    return {
+      context: {
+        fundingRate: numberFrom(perpetual, ['funding_8h', 'current_funding']),
+        openInterest: numberFrom(perpetual, ['open_interest']),
+        annualizedBasisPercent: basis == null ? null : Number(basis.toFixed(2)),
+        optionOpenInterest: callOi + putOi || null,
+        putCallOpenInterestRatio: callOi > 0 ? Number((putOi / callOi).toFixed(2)) : null,
+      },
+      health: { id: 'btc-derivatives', label: 'BTC derivatives context', status: futureResult.status === 'fulfilled' && optionResult.status === 'fulfilled' ? 'ok' : 'degraded', provider: 'Deribit public API', asOf: capturedAt, detail: `Read-only derivatives context loaded${futureResult.status === 'rejected' ? '; futures unavailable' : ''}${optionResult.status === 'rejected' ? '; options unavailable' : ''}.` },
+    }
+  } catch (error) {
+    return {
+      context: {},
+      health: { id: 'btc-derivatives', label: 'BTC derivatives context', status: 'unavailable', provider: 'Deribit public API', asOf: null, detail: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+async function teslaContext(deps: Pick<MarketMonitorServiceDeps, 'equityClient' | 'reference' | 'newsProvider'>, now: Date): Promise<{ context: MarketContext; health: SourceHealth[] }> {
+  const [metrics, estimates, shares, calendar, news] = await Promise.allSettled([
+    deps.equityClient.getKeyMetrics({ symbol: 'TSLA' }),
+    deps.equityClient.getEstimateConsensus({ symbol: 'TSLA' }),
+    deps.equityClient.getShareStatistics({ symbol: 'TSLA' }),
+    deps.reference.calendar({ days: 90 }),
+    deps.newsProvider?.getNewsV2({ endTime: now, lookback: '7d', limit: 100 }) ?? Promise.resolve([]),
+  ])
+  const metric = metrics.status === 'fulfilled' ? metrics.value[0] : undefined
+  const estimate = estimates.status === 'fulfilled' ? estimates.value[0] : undefined
+  const share = shares.status === 'fulfilled' ? shares.value[0] : undefined
+  const earnings = calendar.status === 'fulfilled'
+    ? calendar.value.earnings.find((row) => String((row as { symbol?: unknown }).symbol ?? '').toUpperCase() === 'TSLA')
+    : undefined
+  const newsRows = news.status === 'fulfilled' ? news.value.filter((item) => `${item.title}\n${item.content}`.toUpperCase().includes('TSLA') || `${item.title}\n${item.content}`.toLowerCase().includes('tesla')).slice(-5).reverse() : []
+  const context: MarketContext = {
+    marketCap: numberFrom(metric, ['market_cap']),
+    trailingPe: numberFrom(metric, ['price_to_earnings', 'pe_ratio']),
+    forwardPe: numberFrom(metric, ['forward_pe', 'pe_forward']),
+    analystTargetMean: numberFrom(estimate, ['target_consensus', 'target_mean', 'target_price']),
+    shortPercentFloat: numberFrom(share, ['short_percent_of_float']),
+    nextEarningsAt: stringFrom(earnings, ['report_date', 'date']),
+    recentNews: newsRows.map((item) => ({ title: item.title, time: item.time.toISOString(), source: item.metadata.source ?? null })),
+  }
+  const coreOk = [context.marketCap, context.trailingPe, context.forwardPe, context.analystTargetMean, context.shortPercentFloat].some((value) => value != null)
+  const calendarOk = calendar.status === 'fulfilled'
+  const newsOk = Boolean(deps.newsProvider && news.status === 'fulfilled')
+  return { context, health: [
+    { id: 'tsla-reference', label: 'TSLA fundamentals and positioning', status: coreOk ? 'ok' : 'unavailable', provider: 'OpenAlice equity providers', asOf: coreOk ? now.toISOString() : null, detail: coreOk ? 'Valuation, analyst and short-interest fields loaded where supported.' : 'Configured equity providers returned no usable context.' },
+    { id: 'tsla-calendar-news', label: 'TSLA calendar and news', status: calendarOk && newsOk ? 'ok' : calendarOk || newsOk ? 'degraded' : 'unavailable', provider: 'OpenAlice reference/news', asOf: calendarOk || newsOk ? now.toISOString() : null, detail: `${context.nextEarningsAt ? 'Earnings date available' : 'No earnings date'}; ${context.recentNews?.length ?? 0} recent matching stories${!deps.newsProvider ? '; news collector not configured' : ''}.` },
+  ] }
+}
+
+export function createMarketMonitorService(deps: MarketMonitorServiceDeps): MarketMonitorService {
+  const store = deps.store ?? createMarketMonitorStore()
+  const fetcher = deps.fetcher ?? fetch
+  const now = deps.now ?? (() => new Date())
+  return {
+    settings: () => store.settings(),
+    saveSettings: (settings) => store.saveSettings(settings),
+    async snapshots(asset, limit) {
+      const rows = await store.snapshots(asset, limit)
+      for (const target of asset ? [asset] : (['BTC', 'TSLA'] as MarketMonitorAsset[])) {
+        const index = rows.findLastIndex((row) => row.asset === target)
+        if (index < 0) continue
+        const chart = await store.latestSeries(target)
+        if (chart) rows[index] = { ...rows[index], chart }
+      }
+      return rows
+    },
+    alerts: (asset, limit) => store.alerts(asset, limit),
+    receipts: (asset, limit) => store.receipts(asset, limit),
+    async evaluation(asset) { return evaluateSnapshots(asset, await store.snapshots(asset, 1000)) },
+    async scan(asset, trigger) {
+      const requestedAt = now().toISOString()
+      const receiptBase = { id: randomUUID(), asset, requestedAt, trigger } as const
+      try {
+        const settings = await store.settings()
+        const daily = await loadBars(deps.barService, asset, '1d', 260)
+        let intraday: { result: BarsResult; fallback: boolean } | null = null
+        let intradayError: unknown
+        try { intraday = await loadBars(deps.barService, asset, '1h', 180) } catch (error) { intradayError = error }
+        const analysis = analyzeEvidence({
+          dailyBars: daily.result.bars, intradayBars: intraday?.result.bars ?? [],
+          abnormalMovePercent: settings.abnormalMovePercent,
+          abnormalVolumeRatio: settings.abnormalVolumeRatio,
+        })
+        const sourceHealth: SourceHealth[] = [
+          healthFromMeta('daily-bars', 'Daily OHLCV', daily.result.meta, daily.fallback),
+          intraday
+            ? healthFromMeta('intraday-bars', 'Hourly OHLCV', intraday.result.meta, intraday.fallback)
+            : { id: 'intraday-bars', label: 'Hourly OHLCV', status: 'unavailable', provider: 'OpenAlice BarService', asOf: null, detail: intradayError instanceof Error ? intradayError.message : 'Hourly source unavailable.' },
+        ]
+        let context: MarketContext
+        if (asset === 'BTC') {
+          const result = await bitcoinContext(fetcher, new Date(requestedAt))
+          context = result.context
+          sourceHealth.push(result.health)
+        } else {
+          const result = await teslaContext(deps, now())
+          context = result.context
+          sourceHealth.push(...result.health)
+        }
+        const fingerprint = semanticFingerprint({ asset, ...analysis, context, sourceHealth })
+        const snapshot: MarketMonitorSnapshot = {
+          id: randomUUID(), asset, capturedAt: requestedAt, trigger,
+          strategyId: 'evidence-chain-v1', fingerprint, ...analysis, context, sourceHealth,
+          chart: {
+            daily: compactBars(daily.result.bars, 260), intraday: compactBars(intraday?.result.bars ?? [], 180),
+            dailyMeta: daily.result.meta, intradayMeta: intraday?.result.meta ?? null,
+          },
+        }
+        const previous = (await store.snapshots(asset, 1)).at(-1)
+        const stored = previous?.fingerprint !== fingerprint
+        await store.saveLatestSeries(asset, snapshot.chart)
+        if (stored) {
+          await store.appendSnapshot({ ...snapshot, chart: { ...snapshot.chart, daily: [], intraday: [] } })
+        }
+        const alert = stored ? await maybeAlert(store, snapshot, previous, settings) : null
+        const receipt: MarketMonitorReceipt = { ...receiptBase, outcome: stored ? 'stored' : 'duplicate', snapshotId: stored ? snapshot.id : previous?.id }
+        await store.appendReceipt(receipt)
+        return { snapshot, stored, alert, receipt }
+      } catch (error) {
+        const receipt: MarketMonitorReceipt = { ...receiptBase, outcome: 'failed', error: error instanceof Error ? error.message : String(error) }
+        await store.appendReceipt(receipt)
+        throw error
+      }
+    },
+  }
+}
+
+function healthFromMeta(id: string, label: string, meta: BarMeta, fallback: boolean): SourceHealth {
+  const asOf = meta.freshness?.latestRecordAt ?? meta.to ?? null
+  const stale = meta.staleTradingDays != null && meta.staleTradingDays > 2
+  return {
+    id, label, status: stale || fallback ? 'degraded' : 'ok',
+    provider: meta.sourceId ?? meta.provider ?? 'OpenAlice BarService', asOf,
+    detail: `${fallback ? 'Configured source failed; explicit Yahoo fallback used. ' : ''}${stale ? `${meta.staleTradingDays} weekday(s) behind the request anchor.` : `${meta.bars} attributed bars.`}`,
+  }
+}
+
+async function maybeAlert(store: MarketMonitorStore, snapshot: MarketMonitorSnapshot, previous: MarketMonitorSnapshot | undefined, settings: MarketMonitorSettings): Promise<MarketMonitorAlert | null> {
+  const changed = previous && previous.hypothesis.id !== snapshot.hypothesis.id
+  const strong = snapshot.hypothesis.bias !== 'neutral' && snapshot.hypothesis.confidence >= settings.alertConfidence
+  const abnormal = snapshot.metrics.intraday.abnormal
+  if (!changed && !(strong && abnormal)) return null
+  const alerts = await store.alerts(snapshot.asset, 20)
+  const fingerprint = `${snapshot.asset}:${snapshot.hypothesis.id}:${snapshot.metrics.intraday.latestAt ?? snapshot.metrics.lastBarAt}`
+  if (alerts.some((alert) => alert.fingerprint === fingerprint)) return null
+  const alert: MarketMonitorAlert = {
+    id: randomUUID(), asset: snapshot.asset, createdAt: snapshot.capturedAt, snapshotId: snapshot.id,
+    severity: strong && abnormal ? 'warning' : 'info',
+    title: changed ? `${snapshot.asset} evidence state changed` : `${snapshot.asset} abnormal intraday confirmation`,
+    message: `${snapshot.hypothesis.label} · ${snapshot.hypothesis.confidence}% confidence. ${snapshot.metrics.intraday.note}`,
+    fingerprint,
+  }
+  await store.appendAlert(alert)
+  return alert
+}

--- a/src/domain/market-monitor/service.ts
+++ b/src/domain/market-monitor/service.ts
@@ -3,11 +3,21 @@ import type { EquityClientLike } from '../market-data/client/types.js'
 import type { BarMeta, BarService, BarsResult, OhlcvBar } from '../market-data/bars/index.js'
 import type { INewsProvider } from '../news/types.js'
 import type { ReferenceDataService } from '../market-data/reference/types.js'
-import { analyzeEvidence, evaluateSnapshots, semanticFingerprint } from './analysis.js'
+import { evaluateSnapshots } from './analysis.js'
+import {
+  createDefaultMarketContextProviderRegistry,
+  type MarketContextProviderRegistry,
+  type MarketMonitorFetch,
+} from './context.js'
 import { createMarketMonitorStore, type MarketMonitorStore } from './store.js'
+import {
+  createMarketMonitorStrategyRegistry,
+  type MarketMonitorStrategyRegistry,
+} from './strategy.js'
 import {
   MARKET_MONITOR_ASSET_CONFIG,
   type MarketContext,
+  type MarketContextProviderManifest,
   type MarketMonitorAlert,
   type MarketMonitorAsset,
   type MarketMonitorEvaluation,
@@ -15,11 +25,10 @@ import {
   type MarketMonitorScanResult,
   type MarketMonitorSettings,
   type MarketMonitorSnapshot,
+  type MarketMonitorStrategyManifest,
   type MarketMonitorTrigger,
   type SourceHealth,
 } from './types.js'
-
-type FetchLike = typeof fetch
 
 export interface MarketMonitorServiceDeps {
   barService: BarService
@@ -27,7 +36,9 @@ export interface MarketMonitorServiceDeps {
   reference: ReferenceDataService
   newsProvider?: INewsProvider
   store?: MarketMonitorStore
-  fetcher?: FetchLike
+  fetcher?: MarketMonitorFetch
+  strategyRegistry?: MarketMonitorStrategyRegistry
+  contextProviderRegistry?: MarketContextProviderRegistry
   now?: () => Date
 }
 
@@ -35,32 +46,16 @@ export interface MarketMonitorService {
   settings(): Promise<MarketMonitorSettings>
   saveSettings(settings: MarketMonitorSettings): Promise<void>
   scan(asset: MarketMonitorAsset, trigger: MarketMonitorTrigger): Promise<MarketMonitorScanResult>
-  snapshots(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorSnapshot[]>
+  snapshots(asset?: MarketMonitorAsset, limit?: number, strategyId?: string): Promise<MarketMonitorSnapshot[]>
   alerts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorAlert[]>
   receipts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorReceipt[]>
   evaluation(asset: MarketMonitorAsset): Promise<MarketMonitorEvaluation>
+  strategies(): MarketMonitorStrategyManifest[]
+  contextProviders(): MarketContextProviderManifest[]
 }
 
 function compactBars(bars: OhlcvBar[], max: number): OhlcvBar[] {
   return bars.slice(-max).map(({ date, open, high, low, close, volume }) => ({ date, open, high, low, close, volume }))
-}
-
-function numberFrom(row: unknown, keys: string[]): number | null {
-  if (!row || typeof row !== 'object') return null
-  for (const key of keys) {
-    const value = (row as Record<string, unknown>)[key]
-    if (typeof value === 'number' && Number.isFinite(value)) return value
-  }
-  return null
-}
-
-function stringFrom(row: unknown, keys: string[]): string | null {
-  if (!row || typeof row !== 'object') return null
-  for (const key of keys) {
-    const value = (row as Record<string, unknown>)[key]
-    if (typeof value === 'string' && value.trim()) return value
-  }
-  return null
 }
 
 function retainPreviousContext(current: MarketContext, previous: MarketContext | undefined): { context: MarketContext; retained: boolean } {
@@ -89,18 +84,6 @@ function retainPreviousContext(current: MarketContext, previous: MarketContext |
   return { context: merged, retained }
 }
 
-async function fetchJson(fetcher: FetchLike, url: string): Promise<unknown> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 6000)
-  try {
-    const response = await fetcher(url, { signal: controller.signal, headers: { Accept: 'application/json' } })
-    if (!response.ok) throw new Error(`HTTP ${response.status}`)
-    return await response.json()
-  } finally {
-    clearTimeout(timer)
-  }
-}
-
 async function loadBars(barService: BarService, asset: MarketMonitorAsset, interval: '1d' | '1h', count: number): Promise<{ result: BarsResult; fallback: boolean }> {
   const config = MARKET_MONITOR_ASSET_CONFIG[asset]
   try {
@@ -114,118 +97,64 @@ async function loadBars(barService: BarService, asset: MarketMonitorAsset, inter
   }
 }
 
-async function bitcoinContext(fetcher: FetchLike, at: Date): Promise<{ context: MarketContext; health: SourceHealth }> {
-  const capturedAt = at.toISOString()
-  try {
-    const [futureResult, optionResult] = await Promise.allSettled([
-      fetchJson(fetcher, 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=future'),
-      fetchJson(fetcher, 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=option'),
-    ])
-    if (futureResult.status === 'rejected' && optionResult.status === 'rejected') throw futureResult.reason
-    const futureRaw = futureResult.status === 'fulfilled' ? futureResult.value : undefined
-    const optionRaw = optionResult.status === 'fulfilled' ? optionResult.value : undefined
-    const futures = ((futureRaw as { result?: unknown[] })?.result ?? []) as Array<Record<string, unknown>>
-    const options = ((optionRaw as { result?: unknown[] })?.result ?? []) as Array<Record<string, unknown>>
-    const perpetual = futures.find((row) => row.instrument_name === 'BTC-PERPETUAL')
-    const dated = futures
-      .map((row) => ({ row, expiry: Date.parse(String(row.instrument_name ?? '').split('-').at(-1) ?? '') }))
-      .filter(({ expiry }) => Number.isFinite(expiry) && expiry > at.getTime() + 3 * 86400000)
-      .sort((a, b) => a.expiry - b.expiry)[0]
-    const indexPrice = numberFrom(perpetual, ['underlying_price', 'index_price', 'estimated_delivery_price', 'mark_price'])
-    const futurePrice = numberFrom(dated?.row, ['mark_price', 'last'])
-    const days = dated ? (dated.expiry - at.getTime()) / 86400000 : null
-    const basis = indexPrice && futurePrice && days
-      ? ((futurePrice / indexPrice) - 1) * (365 / days) * 100
-      : null
-    let callOi = 0
-    let putOi = 0
-    for (const row of options) {
-      const oi = numberFrom(row, ['open_interest']) ?? 0
-      const name = String(row.instrument_name ?? '')
-      if (name.endsWith('-C')) callOi += oi
-      else if (name.endsWith('-P')) putOi += oi
-    }
-    return {
-      context: {
-        fundingRate: numberFrom(perpetual, ['funding_8h', 'current_funding']),
-        openInterest: numberFrom(perpetual, ['open_interest']),
-        annualizedBasisPercent: basis == null ? null : Number(basis.toFixed(2)),
-        optionOpenInterest: callOi + putOi || null,
-        putCallOpenInterestRatio: callOi > 0 ? Number((putOi / callOi).toFixed(2)) : null,
-      },
-      health: { id: 'btc-derivatives', label: 'BTC derivatives context', status: futureResult.status === 'fulfilled' && optionResult.status === 'fulfilled' ? 'ok' : 'degraded', provider: 'Deribit public API', asOf: capturedAt, detail: `Read-only derivatives context loaded${futureResult.status === 'rejected' ? '; futures unavailable' : ''}${optionResult.status === 'rejected' ? '; options unavailable' : ''}.` },
-    }
-  } catch (error) {
-    return {
-      context: {},
-      health: { id: 'btc-derivatives', label: 'BTC derivatives context', status: 'unavailable', provider: 'Deribit public API', asOf: null, detail: error instanceof Error ? error.message : String(error) },
-    }
-  }
-}
-
-async function teslaContext(deps: Pick<MarketMonitorServiceDeps, 'equityClient' | 'reference' | 'newsProvider'>, now: Date): Promise<{ context: MarketContext; health: SourceHealth[] }> {
-  const [metrics, estimates, shares, calendar, news] = await Promise.allSettled([
-    deps.equityClient.getKeyMetrics({ symbol: 'TSLA' }),
-    deps.equityClient.getEstimateConsensus({ symbol: 'TSLA' }),
-    deps.equityClient.getShareStatistics({ symbol: 'TSLA' }),
-    deps.reference.calendar({ days: 90 }),
-    deps.newsProvider?.getNewsV2({ endTime: now, lookback: '7d', limit: 100 }) ?? Promise.resolve([]),
-  ])
-  const metric = metrics.status === 'fulfilled' ? metrics.value[0] : undefined
-  const estimate = estimates.status === 'fulfilled' ? estimates.value[0] : undefined
-  const share = shares.status === 'fulfilled' ? shares.value[0] : undefined
-  const earnings = calendar.status === 'fulfilled'
-    ? calendar.value.earnings.find((row) => String((row as { symbol?: unknown }).symbol ?? '').toUpperCase() === 'TSLA')
-    : undefined
-  const newsRows = news.status === 'fulfilled' ? news.value.filter((item) => `${item.title}\n${item.content}`.toUpperCase().includes('TSLA') || `${item.title}\n${item.content}`.toLowerCase().includes('tesla')).slice(-5).reverse() : []
-  const context: MarketContext = {
-    marketCap: numberFrom(metric, ['market_cap']),
-    trailingPe: numberFrom(metric, ['price_to_earnings', 'pe_ratio']),
-    forwardPe: numberFrom(metric, ['forward_pe', 'pe_forward']),
-    analystTargetMean: numberFrom(estimate, ['target_consensus', 'target_mean', 'target_price']),
-    shortPercentFloat: numberFrom(share, ['short_percent_of_float']),
-    nextEarningsAt: stringFrom(earnings, ['report_date', 'date']),
-    recentNews: newsRows.map((item) => ({ title: item.title, time: item.time.toISOString(), source: item.metadata.source ?? null })),
-  }
-  const coreOk = [context.marketCap, context.trailingPe, context.forwardPe, context.analystTargetMean, context.shortPercentFloat].some((value) => value != null)
-  const calendarOk = calendar.status === 'fulfilled'
-  const newsOk = Boolean(deps.newsProvider && news.status === 'fulfilled')
-  return { context, health: [
-    { id: 'tsla-reference', label: 'TSLA fundamentals and positioning', status: coreOk ? 'ok' : 'unavailable', provider: 'OpenAlice equity providers', asOf: coreOk ? now.toISOString() : null, detail: coreOk ? 'Valuation, analyst and short-interest fields loaded where supported.' : 'Configured equity providers returned no usable context.' },
-    { id: 'tsla-calendar-news', label: 'TSLA calendar and news', status: calendarOk && newsOk ? 'ok' : calendarOk || newsOk ? 'degraded' : 'unavailable', provider: 'OpenAlice reference/news', asOf: calendarOk || newsOk ? now.toISOString() : null, detail: `${context.nextEarningsAt ? 'Earnings date available' : 'No earnings date'}; ${context.recentNews?.length ?? 0} recent matching stories${!deps.newsProvider ? '; news collector not configured' : ''}.` },
-  ] }
-}
-
 export function createMarketMonitorService(deps: MarketMonitorServiceDeps): MarketMonitorService {
   const store = deps.store ?? createMarketMonitorStore()
-  const fetcher = deps.fetcher ?? fetch
   const now = deps.now ?? (() => new Date())
+  const strategyRegistry = deps.strategyRegistry ?? createMarketMonitorStrategyRegistry()
+  const contextProviderRegistry = deps.contextProviderRegistry ?? createDefaultMarketContextProviderRegistry({
+    equityClient: deps.equityClient,
+    reference: deps.reference,
+    ...(deps.newsProvider ? { newsProvider: deps.newsProvider } : {}),
+    ...(deps.fetcher ? { fetcher: deps.fetcher } : {}),
+  })
+  const loadSettings = async (): Promise<MarketMonitorSettings> => {
+    const settings = await store.settings()
+    return strategyRegistry.has(settings.strategyId)
+      ? settings
+      : { ...settings, strategyId: strategyRegistry.list()[0]!.id }
+  }
   return {
-    settings: () => store.settings(),
-    saveSettings: (settings) => store.saveSettings(settings),
-    async snapshots(asset, limit) {
-      const rows = await store.snapshots(asset, limit)
-      for (const target of asset ? [asset] : (['BTC', 'TSLA'] as MarketMonitorAsset[])) {
-        const index = rows.findLastIndex((row) => row.asset === target)
-        if (index < 0) continue
-        const chart = await store.latestSeries(target)
-        if (chart) rows[index] = { ...rows[index], chart }
+    settings: loadSettings,
+    async saveSettings(settings) {
+      strategyRegistry.get(settings.strategyId)
+      await store.saveSettings(settings)
+    },
+    strategies: () => strategyRegistry.list(),
+    contextProviders: () => contextProviderRegistry.list(),
+    async snapshots(asset, limit, strategyId) {
+      if (strategyId) strategyRegistry.get(strategyId)
+      const boundedLimit = Math.max(1, Math.min(1000, limit ?? 100))
+      const candidates = await store.snapshots(asset, strategyId ? 1000 : boundedLimit)
+      const rows = candidates
+        .filter((row) => !strategyId || row.strategyId === strategyId)
+        .slice(-boundedLimit)
+      const latestBySeries = new Map<string, number>()
+      rows.forEach((row, index) => latestBySeries.set(`${row.asset}:${row.strategyId}`, index))
+      for (const index of latestBySeries.values()) {
+        const row = rows[index]!
+        const chart = await store.latestSeries(row.asset, row.strategyId)
+        if (chart) rows[index] = { ...row, chart }
       }
       return rows
     },
     alerts: (asset, limit) => store.alerts(asset, limit),
     receipts: (asset, limit) => store.receipts(asset, limit),
-    async evaluation(asset) { return evaluateSnapshots(asset, await store.snapshots(asset, 1000)) },
+    async evaluation(asset) {
+      const settings = await loadSettings()
+      const rows = (await store.snapshots(asset, 1000)).filter((row) => row.strategyId === settings.strategyId)
+      return evaluateSnapshots(asset, rows)
+    },
     async scan(asset, trigger) {
       const requestedAt = now().toISOString()
       const receiptBase = { id: randomUUID(), asset, requestedAt, trigger } as const
       try {
-        const settings = await store.settings()
+        const settings = await loadSettings()
+        const strategy = strategyRegistry.get(settings.strategyId)
         const daily = await loadBars(deps.barService, asset, '1d', 260)
         let intraday: { result: BarsResult; fallback: boolean } | null = null
         let intradayError: unknown
         try { intraday = await loadBars(deps.barService, asset, '1h', 180) } catch (error) { intradayError = error }
-        const analysis = analyzeEvidence({
+        const analysis = strategy.analyze({
           dailyBars: daily.result.bars, intradayBars: intraday?.result.bars ?? [],
           abnormalMovePercent: settings.abnormalMovePercent,
           abnormalVolumeRatio: settings.abnormalVolumeRatio,
@@ -236,39 +165,48 @@ export function createMarketMonitorService(deps: MarketMonitorServiceDeps): Mark
             ? healthFromMeta('intraday-bars', 'Hourly OHLCV', intraday.result.meta, intraday.fallback)
             : { id: 'intraday-bars', label: 'Hourly OHLCV', status: 'unavailable', provider: 'OpenAlice BarService', asOf: null, detail: intradayError instanceof Error ? intradayError.message : 'Hourly source unavailable.' },
         ]
-        const previous = (await store.snapshots(asset, 1)).at(-1)
+        const previous = (await store.snapshots(asset, 1000)).filter((row) => row.strategyId === strategy.manifest.id).at(-1)
         const previousCapturedAt = previous?.capturedAt ?? 'an earlier scan'
-        let context: MarketContext
-        if (asset === 'BTC') {
-          const result = await bitcoinContext(fetcher, new Date(requestedAt))
-          const fallback = result.health.status !== 'ok'
-            ? retainPreviousContext(result.context, previous?.context)
-            : { context: result.context, retained: false }
-          context = fallback.context
-          sourceHealth.push(fallback.retained
-            ? { ...result.health, detail: `${result.health.detail} Last valid context retained from ${previousCapturedAt}.` }
-            : result.health)
-        } else {
-          const result = await teslaContext(deps, now())
-          const fallback = result.health.some((source) => source.status !== 'ok')
-            ? retainPreviousContext(result.context, previous?.context)
-            : { context: result.context, retained: false }
-          context = fallback.context
-          sourceHealth.push(...result.health.map((source) => fallback.retained && source.status !== 'ok'
-            ? { ...source, detail: `${source.detail} Last valid fields retained from ${previousCapturedAt}.` }
-            : source))
+        const providers = contextProviderRegistry.forAsset(asset)
+        const contextResults = await Promise.all(providers.map(async (provider) => {
+          try {
+            return await provider.load({ asset, at: new Date(requestedAt) })
+          } catch (error) {
+            return {
+              context: {},
+              health: [{
+                id: `context-provider:${provider.manifest.id}`,
+                label: provider.manifest.label,
+                status: 'unavailable' as const,
+                provider: provider.manifest.id,
+                asOf: null,
+                detail: error instanceof Error ? error.message : String(error),
+              }],
+            }
+          }
+        }))
+        const contextResult = {
+          context: Object.assign({}, ...contextResults.map((result) => result.context)) as MarketContext,
+          health: contextResults.flatMap((result) => result.health),
         }
-        const fingerprint = semanticFingerprint({ asset, ...analysis, context, sourceHealth })
+        const fallback = contextResult.health.some((source) => source.status !== 'ok')
+          ? retainPreviousContext(contextResult.context, previous?.context)
+          : { context: contextResult.context, retained: false }
+        const context: MarketContext = fallback.context
+        sourceHealth.push(...contextResult.health.map((source) => fallback.retained && source.status !== 'ok'
+          ? { ...source, detail: `${source.detail} Last valid fields retained from ${previousCapturedAt}.` }
+          : source))
+        const fingerprint = strategy.fingerprint({ asset, ...analysis, context, sourceHealth })
         const snapshot: MarketMonitorSnapshot = {
           id: randomUUID(), asset, capturedAt: requestedAt, trigger,
-          strategyId: 'evidence-chain-v1', fingerprint, ...analysis, context, sourceHealth,
+          strategyId: strategy.manifest.id, fingerprint, ...analysis, context, sourceHealth,
           chart: {
             daily: compactBars(daily.result.bars, 260), intraday: compactBars(intraday?.result.bars ?? [], 180),
             dailyMeta: daily.result.meta, intradayMeta: intraday?.result.meta ?? null,
           },
         }
         const stored = previous?.fingerprint !== fingerprint
-        await store.saveLatestSeries(asset, snapshot.chart)
+        await store.saveLatestSeries(asset, snapshot.chart, snapshot.strategyId)
         if (stored) {
           await store.appendSnapshot({ ...snapshot, chart: { ...snapshot.chart, daily: [], intraday: [] } })
         }

--- a/src/domain/market-monitor/service.ts
+++ b/src/domain/market-monitor/service.ts
@@ -63,6 +63,32 @@ function stringFrom(row: unknown, keys: string[]): string | null {
   return null
 }
 
+function retainPreviousContext(current: MarketContext, previous: MarketContext | undefined): { context: MarketContext; retained: boolean } {
+  if (!previous) return { context: current, retained: false }
+  const merged: MarketContext = { ...previous, ...current }
+  let retained = false
+  const numeric = [
+    'fundingRate', 'openInterest', 'annualizedBasisPercent', 'optionOpenInterest',
+    'putCallOpenInterestRatio', 'marketCap', 'trailingPe', 'forwardPe',
+    'analystTargetMean', 'shortPercentFloat',
+  ] as const
+  for (const key of numeric) {
+    if (current[key] == null && previous[key] != null) {
+      merged[key] = previous[key]
+      retained = true
+    }
+  }
+  if (current.nextEarningsAt == null && previous.nextEarningsAt != null) {
+    merged.nextEarningsAt = previous.nextEarningsAt
+    retained = true
+  }
+  if (!current.recentNews?.length && previous.recentNews?.length) {
+    merged.recentNews = previous.recentNews
+    retained = true
+  }
+  return { context: merged, retained }
+}
+
 async function fetchJson(fetcher: FetchLike, url: string): Promise<unknown> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), 6000)
@@ -210,15 +236,27 @@ export function createMarketMonitorService(deps: MarketMonitorServiceDeps): Mark
             ? healthFromMeta('intraday-bars', 'Hourly OHLCV', intraday.result.meta, intraday.fallback)
             : { id: 'intraday-bars', label: 'Hourly OHLCV', status: 'unavailable', provider: 'OpenAlice BarService', asOf: null, detail: intradayError instanceof Error ? intradayError.message : 'Hourly source unavailable.' },
         ]
+        const previous = (await store.snapshots(asset, 1)).at(-1)
+        const previousCapturedAt = previous?.capturedAt ?? 'an earlier scan'
         let context: MarketContext
         if (asset === 'BTC') {
           const result = await bitcoinContext(fetcher, new Date(requestedAt))
-          context = result.context
-          sourceHealth.push(result.health)
+          const fallback = result.health.status !== 'ok'
+            ? retainPreviousContext(result.context, previous?.context)
+            : { context: result.context, retained: false }
+          context = fallback.context
+          sourceHealth.push(fallback.retained
+            ? { ...result.health, detail: `${result.health.detail} Last valid context retained from ${previousCapturedAt}.` }
+            : result.health)
         } else {
           const result = await teslaContext(deps, now())
-          context = result.context
-          sourceHealth.push(...result.health)
+          const fallback = result.health.some((source) => source.status !== 'ok')
+            ? retainPreviousContext(result.context, previous?.context)
+            : { context: result.context, retained: false }
+          context = fallback.context
+          sourceHealth.push(...result.health.map((source) => fallback.retained && source.status !== 'ok'
+            ? { ...source, detail: `${source.detail} Last valid fields retained from ${previousCapturedAt}.` }
+            : source))
         }
         const fingerprint = semanticFingerprint({ asset, ...analysis, context, sourceHealth })
         const snapshot: MarketMonitorSnapshot = {
@@ -229,7 +267,6 @@ export function createMarketMonitorService(deps: MarketMonitorServiceDeps): Mark
             dailyMeta: daily.result.meta, intradayMeta: intraday?.result.meta ?? null,
           },
         }
-        const previous = (await store.snapshots(asset, 1)).at(-1)
         const stored = previous?.fingerprint !== fingerprint
         await store.saveLatestSeries(asset, snapshot.chart)
         if (stored) {

--- a/src/domain/market-monitor/store.ts
+++ b/src/domain/market-monitor/store.ts
@@ -1,0 +1,102 @@
+import { appendFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { dataPath } from '../../core/paths.js'
+import type {
+  MarketMonitorAlert,
+  MarketMonitorAsset,
+  MarketMonitorReceipt,
+  MarketMonitorSettings,
+  MarketMonitorSnapshot,
+} from './types.js'
+import { DEFAULT_MARKET_MONITOR_SETTINGS } from './types.js'
+
+const ROOT = dataPath('market-monitor')
+const SETTINGS_FILE = `${ROOT}/settings.json`
+const SNAPSHOTS_FILE = `${ROOT}/observations.jsonl`
+const ALERTS_FILE = `${ROOT}/alerts.jsonl`
+const RECEIPTS_FILE = `${ROOT}/receipts.jsonl`
+
+async function ensureParent(file: string): Promise<void> {
+  await mkdir(dirname(file), { recursive: true })
+}
+
+async function appendJsonLine(file: string, value: unknown): Promise<void> {
+  await ensureParent(file)
+  await appendFile(file, `${JSON.stringify(value)}\n`, 'utf8')
+}
+
+async function readJsonLines<T>(file: string): Promise<T[]> {
+  try {
+    const text = await readFile(file, 'utf8')
+    return text.split('\n').filter(Boolean).flatMap((line) => {
+      try { return [JSON.parse(line) as T] } catch { return [] }
+    })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+}
+
+export interface MarketMonitorStore {
+  settings(): Promise<MarketMonitorSettings>
+  saveSettings(settings: MarketMonitorSettings): Promise<void>
+  snapshots(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorSnapshot[]>
+  appendSnapshot(snapshot: MarketMonitorSnapshot): Promise<void>
+  alerts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorAlert[]>
+  appendAlert(alert: MarketMonitorAlert): Promise<void>
+  receipts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorReceipt[]>
+  appendReceipt(receipt: MarketMonitorReceipt): Promise<void>
+  latestSeries(asset: MarketMonitorAsset): Promise<MarketMonitorSnapshot['chart'] | null>
+  saveLatestSeries(asset: MarketMonitorAsset, chart: MarketMonitorSnapshot['chart']): Promise<void>
+}
+
+export function createMarketMonitorStore(): MarketMonitorStore {
+  return {
+    async settings() {
+      try {
+        const saved = JSON.parse(await readFile(SETTINGS_FILE, 'utf8')) as Partial<MarketMonitorSettings>
+        return { ...DEFAULT_MARKET_MONITOR_SETTINGS, ...saved }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) {
+          return { ...DEFAULT_MARKET_MONITOR_SETTINGS }
+        }
+        throw error
+      }
+    },
+    async saveSettings(settings) {
+      await ensureParent(SETTINGS_FILE)
+      const temp = `${SETTINGS_FILE}.${process.pid}.tmp`
+      await writeFile(temp, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
+      await rename(temp, SETTINGS_FILE)
+    },
+    async snapshots(asset, limit = 100) {
+      const rows = await readJsonLines<MarketMonitorSnapshot>(SNAPSHOTS_FILE)
+      return rows.filter((row) => !asset || row.asset === asset).slice(-Math.max(1, Math.min(1000, limit)))
+    },
+    appendSnapshot: (snapshot) => appendJsonLine(SNAPSHOTS_FILE, snapshot),
+    async alerts(asset, limit = 100) {
+      const rows = await readJsonLines<MarketMonitorAlert>(ALERTS_FILE)
+      return rows.filter((row) => !asset || row.asset === asset).slice(-Math.max(1, Math.min(1000, limit)))
+    },
+    appendAlert: (alert) => appendJsonLine(ALERTS_FILE, alert),
+    async receipts(asset, limit = 100) {
+      const rows = await readJsonLines<MarketMonitorReceipt>(RECEIPTS_FILE)
+      return rows.filter((row) => !asset || row.asset === asset).slice(-Math.max(1, Math.min(1000, limit)))
+    },
+    appendReceipt: (receipt) => appendJsonLine(RECEIPTS_FILE, receipt),
+    async latestSeries(asset) {
+      try { return JSON.parse(await readFile(`${ROOT}/series-${asset.toLowerCase()}.json`, 'utf8')) as MarketMonitorSnapshot['chart'] }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) return null
+        throw error
+      }
+    },
+    async saveLatestSeries(asset, chart) {
+      const file = `${ROOT}/series-${asset.toLowerCase()}.json`
+      await ensureParent(file)
+      const temp = `${file}.${process.pid}.tmp`
+      await writeFile(temp, `${JSON.stringify(chart)}\n`, 'utf8')
+      await rename(temp, file)
+    },
+  }
+}

--- a/src/domain/market-monitor/store.ts
+++ b/src/domain/market-monitor/store.ts
@@ -8,13 +8,26 @@ import type {
   MarketMonitorSettings,
   MarketMonitorSnapshot,
 } from './types.js'
-import { DEFAULT_MARKET_MONITOR_SETTINGS } from './types.js'
+import { DEFAULT_MARKET_MONITOR_SETTINGS, DEFAULT_MARKET_MONITOR_STRATEGY_ID } from './types.js'
 
 const ROOT = dataPath('market-monitor')
 const SETTINGS_FILE = `${ROOT}/settings.json`
 const SNAPSHOTS_FILE = `${ROOT}/observations.jsonl`
 const ALERTS_FILE = `${ROOT}/alerts.jsonl`
 const RECEIPTS_FILE = `${ROOT}/receipts.jsonl`
+
+function seriesFile(asset: MarketMonitorAsset, strategyId: string): string {
+  const safeStrategy = strategyId.replace(/[^a-zA-Z0-9._-]/g, '_')
+  return `${ROOT}/series-${asset.toLowerCase()}-${safeStrategy}.json`
+}
+
+async function readSeriesFile(file: string): Promise<MarketMonitorSnapshot['chart'] | null> {
+  try { return JSON.parse(await readFile(file, 'utf8')) as MarketMonitorSnapshot['chart'] }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) return null
+    throw error
+  }
+}
 
 async function ensureParent(file: string): Promise<void> {
   await mkdir(dirname(file), { recursive: true })
@@ -46,8 +59,8 @@ export interface MarketMonitorStore {
   appendAlert(alert: MarketMonitorAlert): Promise<void>
   receipts(asset?: MarketMonitorAsset, limit?: number): Promise<MarketMonitorReceipt[]>
   appendReceipt(receipt: MarketMonitorReceipt): Promise<void>
-  latestSeries(asset: MarketMonitorAsset): Promise<MarketMonitorSnapshot['chart'] | null>
-  saveLatestSeries(asset: MarketMonitorAsset, chart: MarketMonitorSnapshot['chart']): Promise<void>
+  latestSeries(asset: MarketMonitorAsset, strategyId?: string): Promise<MarketMonitorSnapshot['chart'] | null>
+  saveLatestSeries(asset: MarketMonitorAsset, chart: MarketMonitorSnapshot['chart'], strategyId?: string): Promise<void>
 }
 
 export function createMarketMonitorStore(): MarketMonitorStore {
@@ -84,15 +97,13 @@ export function createMarketMonitorStore(): MarketMonitorStore {
       return rows.filter((row) => !asset || row.asset === asset).slice(-Math.max(1, Math.min(1000, limit)))
     },
     appendReceipt: (receipt) => appendJsonLine(RECEIPTS_FILE, receipt),
-    async latestSeries(asset) {
-      try { return JSON.parse(await readFile(`${ROOT}/series-${asset.toLowerCase()}.json`, 'utf8')) as MarketMonitorSnapshot['chart'] }
-      catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT' || error instanceof SyntaxError) return null
-        throw error
-      }
+    async latestSeries(asset, strategyId = DEFAULT_MARKET_MONITOR_STRATEGY_ID) {
+      const current = await readSeriesFile(seriesFile(asset, strategyId))
+      if (current || strategyId !== DEFAULT_MARKET_MONITOR_STRATEGY_ID) return current
+      return readSeriesFile(`${ROOT}/series-${asset.toLowerCase()}.json`)
     },
-    async saveLatestSeries(asset, chart) {
-      const file = `${ROOT}/series-${asset.toLowerCase()}.json`
+    async saveLatestSeries(asset, chart, strategyId = DEFAULT_MARKET_MONITOR_STRATEGY_ID) {
+      const file = seriesFile(asset, strategyId)
       await ensureParent(file)
       const temp = `${file}.${process.pid}.tmp`
       await writeFile(temp, `${JSON.stringify(chart)}\n`, 'utf8')

--- a/src/domain/market-monitor/strategy.spec.ts
+++ b/src/domain/market-monitor/strategy.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { MarketMonitorStrategyRegistry, evidenceChainV1Strategy } from './strategy.js'
+
+describe('market monitor strategy registry', () => {
+  it('rejects duplicate identities and protects manifest arrays from mutation', () => {
+    expect(() => new MarketMonitorStrategyRegistry([evidenceChainV1Strategy, evidenceChainV1Strategy])).toThrow(/Duplicate/)
+    const registry = new MarketMonitorStrategyRegistry([evidenceChainV1Strategy])
+    const listed = registry.list()
+    listed[0]!.requiredData.length = 0
+    expect(registry.get('evidence-chain-v1').manifest.requiredData).toHaveLength(3)
+  })
+
+  it('rejects an unknown strategy instead of silently falling back', () => {
+    const registry = new MarketMonitorStrategyRegistry([evidenceChainV1Strategy])
+    expect(() => registry.get('unknown')).toThrow(/Unknown market monitor strategy/)
+  })
+
+  it('rejects ids that cannot be used as stable persistence keys', () => {
+    expect(() => new MarketMonitorStrategyRegistry([{
+      ...evidenceChainV1Strategy,
+      manifest: { ...evidenceChainV1Strategy.manifest, id: 'bad/strategy' },
+    }])).toThrow(/Invalid market monitor strategy id/)
+  })
+})

--- a/src/domain/market-monitor/strategy.ts
+++ b/src/domain/market-monitor/strategy.ts
@@ -1,0 +1,82 @@
+import type { OhlcvBar } from '../market-data/bars/index.js'
+import { analyzeEvidence, semanticFingerprint } from './analysis.js'
+import {
+  DEFAULT_MARKET_MONITOR_STRATEGY_ID,
+  type EvidenceItem,
+  type MarketContext,
+  type MarketHypothesis,
+  type MarketMonitorAsset,
+  type MarketMonitorMetrics,
+  type MarketMonitorStrategyManifest,
+  type SourceHealth,
+} from './types.js'
+
+export interface MarketMonitorStrategyInput {
+  dailyBars: OhlcvBar[]
+  intradayBars: OhlcvBar[]
+  abnormalVolumeRatio: number
+  abnormalMovePercent: number
+}
+
+export interface MarketMonitorStrategyOutput {
+  metrics: MarketMonitorMetrics
+  evidence: EvidenceItem[]
+  hypothesis: MarketHypothesis
+}
+
+export interface MarketMonitorFingerprintInput extends MarketMonitorStrategyOutput {
+  asset: MarketMonitorAsset
+  context: MarketContext
+  sourceHealth: SourceHealth[]
+}
+
+export interface MarketMonitorStrategy {
+  manifest: MarketMonitorStrategyManifest
+  analyze(input: MarketMonitorStrategyInput): MarketMonitorStrategyOutput
+  fingerprint(input: MarketMonitorFingerprintInput): string
+}
+
+export class MarketMonitorStrategyRegistry {
+  private readonly byId = new Map<string, MarketMonitorStrategy>()
+
+  constructor(strategies: MarketMonitorStrategy[]) {
+    for (const strategy of strategies) {
+      if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(strategy.manifest.id)) {
+        throw new Error(`Invalid market monitor strategy id: ${strategy.manifest.id}`)
+      }
+      if (this.byId.has(strategy.manifest.id)) throw new Error(`Duplicate market monitor strategy: ${strategy.manifest.id}`)
+      this.byId.set(strategy.manifest.id, strategy)
+    }
+    if (!this.byId.size) throw new Error('At least one market monitor strategy is required')
+  }
+
+  get(id: string): MarketMonitorStrategy {
+    const strategy = this.byId.get(id)
+    if (!strategy) throw new Error(`Unknown market monitor strategy: ${id}`)
+    return strategy
+  }
+
+  has(id: string): boolean {
+    return this.byId.has(id)
+  }
+
+  list(): MarketMonitorStrategyManifest[] {
+    return [...this.byId.values()].map(({ manifest }) => ({ ...manifest, requiredData: [...manifest.requiredData] }))
+  }
+}
+
+export const evidenceChainV1Strategy: MarketMonitorStrategy = {
+  manifest: {
+    id: DEFAULT_MARKET_MONITOR_STRATEGY_ID,
+    label: 'Evidence chain',
+    version: 1,
+    description: 'Location, structure, effort/result, weekly follow-through and an independent hourly test.',
+    requiredData: ['daily-bars', 'hourly-bars', 'asset-context'],
+  },
+  analyze: analyzeEvidence,
+  fingerprint: semanticFingerprint,
+}
+
+export function createMarketMonitorStrategyRegistry(additional: MarketMonitorStrategy[] = []): MarketMonitorStrategyRegistry {
+  return new MarketMonitorStrategyRegistry([evidenceChainV1Strategy, ...additional])
+}

--- a/src/domain/market-monitor/types.ts
+++ b/src/domain/market-monitor/types.ts
@@ -1,0 +1,167 @@
+import type { BarMeta, OhlcvBar } from '../market-data/bars/index.js'
+
+export const MARKET_MONITOR_ASSETS = ['BTC', 'TSLA'] as const
+export type MarketMonitorAsset = typeof MARKET_MONITOR_ASSETS[number]
+export type MarketMonitorTrigger = 'manual' | 'scheduled'
+export type EvidenceTone = 'positive' | 'negative' | 'neutral'
+
+export interface MarketMonitorAssetConfig {
+  asset: MarketMonitorAsset
+  label: string
+  symbol: string
+  assetClass: 'crypto' | 'equity'
+  barId: string
+}
+
+export const MARKET_MONITOR_ASSET_CONFIG: Record<MarketMonitorAsset, MarketMonitorAssetConfig> = {
+  BTC: { asset: 'BTC', label: 'Bitcoin', symbol: 'BTC-USD', assetClass: 'crypto', barId: 'yfinance|BTC-USD' },
+  TSLA: { asset: 'TSLA', label: 'Tesla', symbol: 'TSLA', assetClass: 'equity', barId: 'yfinance|TSLA' },
+}
+
+export interface MarketMonitorSettings {
+  enabledAssets: MarketMonitorAsset[]
+  intervalMinutes: number
+  notifications: boolean
+  alertConfidence: number
+  abnormalVolumeRatio: number
+  abnormalMovePercent: number
+}
+
+export const DEFAULT_MARKET_MONITOR_SETTINGS: MarketMonitorSettings = {
+  enabledAssets: ['BTC', 'TSLA'],
+  intervalMinutes: 15,
+  notifications: false,
+  alertConfidence: 68,
+  abnormalVolumeRatio: 1.8,
+  abnormalMovePercent: 1.5,
+}
+
+export interface SourceHealth {
+  id: string
+  label: string
+  status: 'ok' | 'degraded' | 'unavailable'
+  provider: string
+  asOf: string | null
+  detail: string
+}
+
+export interface EvidenceItem {
+  id: string
+  label: string
+  timeframe: '1D' | '1W' | '1H'
+  tone: EvidenceTone
+  observation: string
+  interpretation: string
+  weight: number
+}
+
+export interface MarketHypothesis {
+  id: 'demand-control' | 'supply-control' | 'balanced-range'
+  label: string
+  bias: 'bullish' | 'bearish' | 'neutral'
+  confidence: number
+  summary: string
+  confirm: string[]
+  invalidate: string[]
+  alternatives: string[]
+}
+
+export interface IntradayPulse {
+  available: boolean
+  latestAt: string | null
+  latestChangePercent: number | null
+  fourHourChangePercent: number | null
+  volumeRatio: number | null
+  abnormal: boolean
+  note: string
+}
+
+export interface MarketMonitorMetrics {
+  lastPrice: number
+  lastBarAt: string
+  change1dPercent: number | null
+  change5dPercent: number | null
+  rangePosition60d: number | null
+  volumeRatio20d: number | null
+  weeklyChangePercent: number | null
+  intraday: IntradayPulse
+}
+
+export interface MarketContext {
+  fundingRate?: number | null
+  openInterest?: number | null
+  annualizedBasisPercent?: number | null
+  optionOpenInterest?: number | null
+  putCallOpenInterestRatio?: number | null
+  marketCap?: number | null
+  trailingPe?: number | null
+  forwardPe?: number | null
+  analystTargetMean?: number | null
+  shortPercentFloat?: number | null
+  nextEarningsAt?: string | null
+  recentNews?: Array<{ title: string; time: string; source: string | null }>
+}
+
+export interface MarketMonitorSnapshot {
+  id: string
+  asset: MarketMonitorAsset
+  capturedAt: string
+  trigger: MarketMonitorTrigger
+  strategyId: 'evidence-chain-v1'
+  fingerprint: string
+  metrics: MarketMonitorMetrics
+  hypothesis: MarketHypothesis
+  evidence: EvidenceItem[]
+  context: MarketContext
+  sourceHealth: SourceHealth[]
+  chart: {
+    daily: OhlcvBar[]
+    intraday: OhlcvBar[]
+    dailyMeta: BarMeta
+    intradayMeta: BarMeta | null
+  }
+}
+
+export interface MarketMonitorAlert {
+  id: string
+  asset: MarketMonitorAsset
+  createdAt: string
+  snapshotId: string
+  severity: 'info' | 'warning'
+  title: string
+  message: string
+  fingerprint: string
+}
+
+export interface MarketMonitorReceipt {
+  id: string
+  asset: MarketMonitorAsset
+  requestedAt: string
+  trigger: MarketMonitorTrigger
+  outcome: 'stored' | 'duplicate' | 'failed'
+  snapshotId?: string
+  error?: string
+}
+
+export interface MarketMonitorScanResult {
+  snapshot: MarketMonitorSnapshot
+  stored: boolean
+  alert: MarketMonitorAlert | null
+  receipt: MarketMonitorReceipt
+}
+
+export interface MarketMonitorEvaluation {
+  asset: MarketMonitorAsset
+  samples: number
+  resolved: number
+  directionalAccuracy: number | null
+  averageForwardChangePercent: number | null
+  rows: Array<{
+    capturedAt: string
+    hypothesis: MarketHypothesis['bias']
+    confidence: number
+    nextCapturedAt: string | null
+    forwardChangePercent: number | null
+    correct: boolean | null
+  }>
+}

--- a/src/domain/market-monitor/types.ts
+++ b/src/domain/market-monitor/types.ts
@@ -4,6 +4,9 @@ export const MARKET_MONITOR_ASSETS = ['BTC', 'TSLA'] as const
 export type MarketMonitorAsset = typeof MARKET_MONITOR_ASSETS[number]
 export type MarketMonitorTrigger = 'manual' | 'scheduled'
 export type EvidenceTone = 'positive' | 'negative' | 'neutral'
+export type MarketMonitorStrategyId = string
+
+export const DEFAULT_MARKET_MONITOR_STRATEGY_ID = 'evidence-chain-v1'
 
 export interface MarketMonitorAssetConfig {
   asset: MarketMonitorAsset
@@ -20,6 +23,7 @@ export const MARKET_MONITOR_ASSET_CONFIG: Record<MarketMonitorAsset, MarketMonit
 
 export interface MarketMonitorSettings {
   enabledAssets: MarketMonitorAsset[]
+  strategyId: MarketMonitorStrategyId
   intervalMinutes: number
   notifications: boolean
   alertConfidence: number
@@ -29,11 +33,27 @@ export interface MarketMonitorSettings {
 
 export const DEFAULT_MARKET_MONITOR_SETTINGS: MarketMonitorSettings = {
   enabledAssets: ['BTC', 'TSLA'],
+  strategyId: DEFAULT_MARKET_MONITOR_STRATEGY_ID,
   intervalMinutes: 15,
   notifications: false,
   alertConfidence: 68,
   abnormalVolumeRatio: 1.8,
   abnormalMovePercent: 1.5,
+}
+
+export interface MarketMonitorStrategyManifest {
+  id: MarketMonitorStrategyId
+  label: string
+  version: number
+  description: string
+  requiredData: Array<'daily-bars' | 'hourly-bars' | 'asset-context'>
+}
+
+export interface MarketContextProviderManifest {
+  id: string
+  label: string
+  assets: MarketMonitorAsset[]
+  description: string
 }
 
 export interface SourceHealth {
@@ -107,7 +127,7 @@ export interface MarketMonitorSnapshot {
   asset: MarketMonitorAsset
   capturedAt: string
   trigger: MarketMonitorTrigger
-  strategyId: 'evidence-chain-v1'
+  strategyId: MarketMonitorStrategyId
   fingerprint: string
   metrics: MarketMonitorMetrics
   hypothesis: MarketHypothesis

--- a/src/webui/plugin.ts
+++ b/src/webui/plugin.ts
@@ -24,6 +24,7 @@ import { createAgentRuntimeLogRoutes } from './routes/agent-runtime.js'
 import { createOfficeRoutes } from './routes/office.js'
 import { createNewsRoutes } from './routes/news.js'
 import { createMarketRoutes } from './routes/market.js'
+import { createMarketMonitorRoutes } from './routes/market-monitor.js'
 import { createBarsRoutes } from './routes/bars.js'
 import { createReferenceRoutes } from './routes/reference.js'
 import { createInboxRoutes } from './routes/inbox.js'
@@ -268,6 +269,7 @@ export class WebPlugin implements Plugin {
     app.route('/api/agent-status', createAgentStatusRoutes(ctx))
     app.route('/api/news', createNewsRoutes(ctx))
     app.route('/api/market', createMarketRoutes(ctx))
+    app.route('/api/market-monitor', createMarketMonitorRoutes(ctx))
     app.route('/api/bars', createBarsRoutes(ctx))
     app.route('/api/reference', createReferenceRoutes(ctx))
     app.route('/api/inbox', createInboxRoutes({ inboxStore: ctx.inboxStore, resolveWorkspace: id => this.workspaceService?.registry.get(id) }))

--- a/src/webui/routes/market-monitor.spec.ts
+++ b/src/webui/routes/market-monitor.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { EngineContext } from '../../core/types.js'
+import type { MarketMonitorService } from '../../domain/market-monitor/service.js'
+import { DEFAULT_MARKET_MONITOR_SETTINGS } from '../../domain/market-monitor/types.js'
+import { createMarketMonitorRoutes } from './market-monitor.js'
+
+function service(): MarketMonitorService {
+  return {
+    settings: vi.fn(async () => DEFAULT_MARKET_MONITOR_SETTINGS),
+    saveSettings: vi.fn(async () => undefined),
+    scan: vi.fn(async () => ({ snapshot: {} as never, stored: true, alert: null, receipt: {} as never })),
+    snapshots: vi.fn(async () => []), alerts: vi.fn(async () => []), receipts: vi.fn(async () => []),
+    evaluation: vi.fn(async (asset) => ({ asset, samples: 0, resolved: 0, directionalAccuracy: null, averageForwardChangePercent: null, rows: [] })),
+  }
+}
+
+describe('market monitor routes', () => {
+  it('validates scan identity and preserves trigger provenance', async () => {
+    const fake = service()
+    const app = createMarketMonitorRoutes({} as EngineContext, fake)
+    expect((await app.request('/scan', { method: 'POST', body: JSON.stringify({ asset: 'ETH' }), headers: { 'Content-Type': 'application/json' } })).status).toBe(400)
+    expect((await app.request('/scan', { method: 'POST', body: JSON.stringify({ asset: 'BTC', trigger: 'scheduled' }), headers: { 'Content-Type': 'application/json' } })).status).toBe(200)
+    expect(fake.scan).toHaveBeenCalledWith('BTC', 'scheduled')
+  })
+
+  it('rejects unsafe settings rather than coercing them', async () => {
+    const fake = service()
+    const app = createMarketMonitorRoutes({} as EngineContext, fake)
+    const response = await app.request('/settings', { method: 'PUT', body: JSON.stringify({ ...DEFAULT_MARKET_MONITOR_SETTINGS, intervalMinutes: 0 }), headers: { 'Content-Type': 'application/json' } })
+    expect(response.status).toBe(400)
+    expect(fake.saveSettings).not.toHaveBeenCalled()
+  })
+
+  it('provides bounded histories and evaluation', async () => {
+    const fake = service()
+    const app = createMarketMonitorRoutes({} as EngineContext, fake)
+    expect((await app.request('/snapshots?asset=TSLA&limit=99999')).status).toBe(200)
+    expect(fake.snapshots).toHaveBeenCalledWith('TSLA', 1000)
+    expect((await app.request('/evaluation?asset=BTC')).status).toBe(200)
+  })
+})

--- a/src/webui/routes/market-monitor.spec.ts
+++ b/src/webui/routes/market-monitor.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { EngineContext } from '../../core/types.js'
 import type { MarketMonitorService } from '../../domain/market-monitor/service.js'
-import { DEFAULT_MARKET_MONITOR_SETTINGS } from '../../domain/market-monitor/types.js'
+import { DEFAULT_MARKET_MONITOR_SETTINGS, type MarketContextProviderManifest, type MarketMonitorStrategyManifest } from '../../domain/market-monitor/types.js'
 import { createMarketMonitorRoutes } from './market-monitor.js'
 
 function service(): MarketMonitorService {
@@ -11,6 +11,8 @@ function service(): MarketMonitorService {
     scan: vi.fn(async () => ({ snapshot: {} as never, stored: true, alert: null, receipt: {} as never })),
     snapshots: vi.fn(async () => []), alerts: vi.fn(async () => []), receipts: vi.fn(async () => []),
     evaluation: vi.fn(async (asset) => ({ asset, samples: 0, resolved: 0, directionalAccuracy: null, averageForwardChangePercent: null, rows: [] })),
+    strategies: vi.fn((): MarketMonitorStrategyManifest[] => [{ id: 'evidence-chain-v1', label: 'Evidence chain', version: 1, description: 'fixture', requiredData: ['daily-bars', 'hourly-bars', 'asset-context'] }]),
+    contextProviders: vi.fn((): MarketContextProviderManifest[] => [{ id: 'fixture-context', label: 'Fixture', assets: ['BTC', 'TSLA'], description: 'fixture' }]),
   }
 }
 
@@ -31,11 +33,23 @@ describe('market monitor routes', () => {
     expect(fake.saveSettings).not.toHaveBeenCalled()
   })
 
+  it('lists modules and rejects an unregistered strategy', async () => {
+    const fake = service()
+    const app = createMarketMonitorRoutes({} as EngineContext, fake)
+    expect((await app.request('/strategies')).status).toBe(200)
+    expect((await app.request('/context-providers')).status).toBe(200)
+    const response = await app.request('/settings', { method: 'PUT', body: JSON.stringify({ ...DEFAULT_MARKET_MONITOR_SETTINGS, strategyId: 'unknown' }), headers: { 'Content-Type': 'application/json' } })
+    expect(response.status).toBe(400)
+    expect(fake.saveSettings).not.toHaveBeenCalled()
+  })
+
   it('provides bounded histories and evaluation', async () => {
     const fake = service()
     const app = createMarketMonitorRoutes({} as EngineContext, fake)
     expect((await app.request('/snapshots?asset=TSLA&limit=99999')).status).toBe(200)
-    expect(fake.snapshots).toHaveBeenCalledWith('TSLA', 1000)
+    expect(fake.snapshots).toHaveBeenCalledWith('TSLA', 1000, undefined)
+    expect((await app.request('/snapshots?asset=BTC&strategyId=evidence-chain-v1')).status).toBe(200)
+    expect(fake.snapshots).toHaveBeenCalledWith('BTC', 100, 'evidence-chain-v1')
     expect((await app.request('/evaluation?asset=BTC')).status).toBe(200)
   })
 })

--- a/src/webui/routes/market-monitor.ts
+++ b/src/webui/routes/market-monitor.ts
@@ -7,6 +7,7 @@ import { DEFAULT_MARKET_MONITOR_SETTINGS, MARKET_MONITOR_ASSETS, type MarketMoni
 const assetSchema = z.enum(MARKET_MONITOR_ASSETS)
 const settingsSchema = z.object({
   enabledAssets: z.array(assetSchema).min(1),
+  strategyId: z.string().trim().min(1).default(DEFAULT_MARKET_MONITOR_SETTINGS.strategyId),
   intervalMinutes: z.number().int().min(1).max(1440),
   notifications: z.boolean(),
   alertConfidence: z.number().int().min(50).max(95),
@@ -35,10 +36,17 @@ export function createMarketMonitorRoutes(ctx: EngineContext, provided?: MarketM
 
   app.get('/settings', async (c) => c.json(await service.settings()))
 
+  app.get('/strategies', (c) => c.json({ strategies: service.strategies() }))
+
+  app.get('/context-providers', (c) => c.json({ providers: service.contextProviders() }))
+
   app.put('/settings', async (c) => {
     const body = await c.req.json().catch(() => null)
     const parsed = settingsSchema.safeParse(body)
     if (!parsed.success) return c.json({ error: 'Invalid monitor settings', issues: parsed.error.issues }, 400)
+    if (!service.strategies().some((strategy) => strategy.id === parsed.data.strategyId)) {
+      return c.json({ error: 'Unknown monitor strategy' }, 400)
+    }
     await service.saveSettings(parsed.data)
     return c.json(parsed.data)
   })
@@ -58,7 +66,11 @@ export function createMarketMonitorRoutes(ctx: EngineContext, provided?: MarketM
     const raw = c.req.query('asset')
     const asset = assetFrom(raw)
     if (raw && !asset) return c.json({ error: 'asset must be BTC or TSLA' }, 400)
-    const snapshots = await service.snapshots(asset, limitFrom(c.req.query('limit')))
+    const strategyId = c.req.query('strategyId')
+    if (strategyId && !service.strategies().some((strategy) => strategy.id === strategyId)) {
+      return c.json({ error: 'Unknown monitor strategy' }, 400)
+    }
+    const snapshots = await service.snapshots(asset, limitFrom(c.req.query('limit')), strategyId)
     return c.json({ snapshots, count: snapshots.length })
   })
 

--- a/src/webui/routes/market-monitor.ts
+++ b/src/webui/routes/market-monitor.ts
@@ -1,0 +1,90 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { EngineContext } from '../../core/types.js'
+import { createMarketMonitorService, type MarketMonitorService } from '../../domain/market-monitor/service.js'
+import { DEFAULT_MARKET_MONITOR_SETTINGS, MARKET_MONITOR_ASSETS, type MarketMonitorAsset } from '../../domain/market-monitor/types.js'
+
+const assetSchema = z.enum(MARKET_MONITOR_ASSETS)
+const settingsSchema = z.object({
+  enabledAssets: z.array(assetSchema).min(1),
+  intervalMinutes: z.number().int().min(1).max(1440),
+  notifications: z.boolean(),
+  alertConfidence: z.number().int().min(50).max(95),
+  abnormalVolumeRatio: z.number().min(1).max(10),
+  abnormalMovePercent: z.number().min(0.1).max(25),
+})
+
+function limitFrom(raw: string | undefined): number {
+  const value = Number(raw ?? 100)
+  return Number.isFinite(value) ? Math.max(1, Math.min(1000, Math.trunc(value))) : 100
+}
+
+function assetFrom(raw: string | undefined): MarketMonitorAsset | undefined {
+  const parsed = assetSchema.safeParse(raw)
+  return parsed.success ? parsed.data : undefined
+}
+
+export function createMarketMonitorRoutes(ctx: EngineContext, provided?: MarketMonitorService): Hono {
+  const app = new Hono()
+  const service = provided ?? createMarketMonitorService({
+    barService: ctx.barService,
+    equityClient: ctx.equityClient,
+    reference: ctx.reference,
+    ...(ctx.newsProvider ? { newsProvider: ctx.newsProvider } : {}),
+  })
+
+  app.get('/settings', async (c) => c.json(await service.settings()))
+
+  app.put('/settings', async (c) => {
+    const body = await c.req.json().catch(() => null)
+    const parsed = settingsSchema.safeParse(body)
+    if (!parsed.success) return c.json({ error: 'Invalid monitor settings', issues: parsed.error.issues }, 400)
+    await service.saveSettings(parsed.data)
+    return c.json(parsed.data)
+  })
+
+  app.post('/scan', async (c) => {
+    const body = await c.req.json().catch(() => null)
+    const parsed = z.object({ asset: assetSchema, trigger: z.enum(['manual', 'scheduled']).default('manual') }).safeParse(body)
+    if (!parsed.success) return c.json({ error: 'asset must be BTC or TSLA' }, 400)
+    try {
+      return c.json(await service.scan(parsed.data.asset, parsed.data.trigger))
+    } catch (error) {
+      return c.json({ error: error instanceof Error ? error.message : String(error) }, 502)
+    }
+  })
+
+  app.get('/snapshots', async (c) => {
+    const raw = c.req.query('asset')
+    const asset = assetFrom(raw)
+    if (raw && !asset) return c.json({ error: 'asset must be BTC or TSLA' }, 400)
+    const snapshots = await service.snapshots(asset, limitFrom(c.req.query('limit')))
+    return c.json({ snapshots, count: snapshots.length })
+  })
+
+  app.get('/alerts', async (c) => {
+    const raw = c.req.query('asset')
+    const asset = assetFrom(raw)
+    if (raw && !asset) return c.json({ error: 'asset must be BTC or TSLA' }, 400)
+    const alerts = await service.alerts(asset, limitFrom(c.req.query('limit')))
+    return c.json({ alerts, count: alerts.length })
+  })
+
+  app.get('/receipts', async (c) => {
+    const raw = c.req.query('asset')
+    const asset = assetFrom(raw)
+    if (raw && !asset) return c.json({ error: 'asset must be BTC or TSLA' }, 400)
+    const receipts = await service.receipts(asset, limitFrom(c.req.query('limit')))
+    return c.json({ receipts, count: receipts.length })
+  })
+
+  app.get('/evaluation', async (c) => {
+    const asset = assetFrom(c.req.query('asset'))
+    if (!asset) return c.json({ error: 'asset must be BTC or TSLA' }, 400)
+    return c.json(await service.evaluation(asset))
+  })
+
+  app.get('/defaults', (c) => c.json(DEFAULT_MARKET_MONITOR_SETTINGS))
+
+  return app
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -11,6 +11,7 @@ import { toolsApi } from './tools'
 import { agentStatusApi } from './agentStatus'
 import { newsApi } from './news'
 import { marketApi } from './market'
+import { marketMonitorApi } from './market-monitor'
 import { inboxApi } from './inbox'
 import { entitiesApi } from './entities'
 import { versionApi } from './version'
@@ -33,6 +34,7 @@ export const api = {
   agentStatus: agentStatusApi,
   news: newsApi,
   market: marketApi,
+  marketMonitor: marketMonitorApi,
   inbox: inboxApi,
   entities: entitiesApi,
   version: versionApi,

--- a/ui/src/api/market-monitor.ts
+++ b/ui/src/api/market-monitor.ts
@@ -6,11 +6,27 @@ export type MonitorTrigger = 'manual' | 'scheduled'
 
 export interface MonitorSettings {
   enabledAssets: MonitorAsset[]
+  strategyId: string
   intervalMinutes: number
   notifications: boolean
   alertConfidence: number
   abnormalVolumeRatio: number
   abnormalMovePercent: number
+}
+
+export interface MonitorStrategy {
+  id: string
+  label: string
+  version: number
+  description: string
+  requiredData: Array<'daily-bars' | 'hourly-bars' | 'asset-context'>
+}
+
+export interface MonitorContextProvider {
+  id: string
+  label: string
+  assets: MonitorAsset[]
+  description: string
 }
 
 export interface SourceHealth {
@@ -37,7 +53,7 @@ export interface MonitorSnapshot {
   asset: MonitorAsset
   capturedAt: string
   trigger: MonitorTrigger
-  strategyId: 'evidence-chain-v1'
+  strategyId: string
   fingerprint: string
   metrics: {
     lastPrice: number
@@ -117,17 +133,20 @@ export interface MonitorEvaluation {
   }>
 }
 
-function query(asset?: MonitorAsset, limit = 100): string {
+function query(asset?: MonitorAsset, limit = 100, strategyId?: string): string {
   const params = new URLSearchParams({ limit: String(limit) })
   if (asset) params.set('asset', asset)
+  if (strategyId) params.set('strategyId', strategyId)
   return params.toString()
 }
 
 export const marketMonitorApi = {
   settings: () => fetchJson<MonitorSettings>('/api/market-monitor/settings'),
+  strategies: () => fetchJson<{ strategies: MonitorStrategy[] }>('/api/market-monitor/strategies'),
+  contextProviders: () => fetchJson<{ providers: MonitorContextProvider[] }>('/api/market-monitor/context-providers'),
   saveSettings: (settings: MonitorSettings) => fetchJson<MonitorSettings>('/api/market-monitor/settings', { method: 'PUT', headers, body: JSON.stringify(settings) }),
   scan: (asset: MonitorAsset, trigger: MonitorTrigger = 'manual') => fetchJson<ScanResult>('/api/market-monitor/scan', { method: 'POST', headers, body: JSON.stringify({ asset, trigger }) }),
-  snapshots: (asset?: MonitorAsset, limit = 100) => fetchJson<{ snapshots: MonitorSnapshot[]; count: number }>(`/api/market-monitor/snapshots?${query(asset, limit)}`),
+  snapshots: (asset?: MonitorAsset, limit = 100, strategyId?: string) => fetchJson<{ snapshots: MonitorSnapshot[]; count: number }>(`/api/market-monitor/snapshots?${query(asset, limit, strategyId)}`),
   alerts: (asset?: MonitorAsset, limit = 100) => fetchJson<{ alerts: MonitorAlert[]; count: number }>(`/api/market-monitor/alerts?${query(asset, limit)}`),
   receipts: (asset?: MonitorAsset, limit = 100) => fetchJson<{ receipts: MonitorReceipt[]; count: number }>(`/api/market-monitor/receipts?${query(asset, limit)}`),
   evaluation: (asset: MonitorAsset) => fetchJson<MonitorEvaluation>(`/api/market-monitor/evaluation?asset=${asset}`),

--- a/ui/src/api/market-monitor.ts
+++ b/ui/src/api/market-monitor.ts
@@ -1,0 +1,134 @@
+import { fetchJson, headers } from './client'
+import type { BarMeta, HistoricalBar } from './market'
+
+export type MonitorAsset = 'BTC' | 'TSLA'
+export type MonitorTrigger = 'manual' | 'scheduled'
+
+export interface MonitorSettings {
+  enabledAssets: MonitorAsset[]
+  intervalMinutes: number
+  notifications: boolean
+  alertConfidence: number
+  abnormalVolumeRatio: number
+  abnormalMovePercent: number
+}
+
+export interface SourceHealth {
+  id: string
+  label: string
+  status: 'ok' | 'degraded' | 'unavailable'
+  provider: string
+  asOf: string | null
+  detail: string
+}
+
+export interface EvidenceItem {
+  id: string
+  label: string
+  timeframe: '1D' | '1W' | '1H'
+  tone: 'positive' | 'negative' | 'neutral'
+  observation: string
+  interpretation: string
+  weight: number
+}
+
+export interface MonitorSnapshot {
+  id: string
+  asset: MonitorAsset
+  capturedAt: string
+  trigger: MonitorTrigger
+  strategyId: 'evidence-chain-v1'
+  fingerprint: string
+  metrics: {
+    lastPrice: number
+    lastBarAt: string
+    change1dPercent: number | null
+    change5dPercent: number | null
+    rangePosition60d: number | null
+    volumeRatio20d: number | null
+    weeklyChangePercent: number | null
+    intraday: {
+      available: boolean
+      latestAt: string | null
+      latestChangePercent: number | null
+      fourHourChangePercent: number | null
+      volumeRatio: number | null
+      abnormal: boolean
+      note: string
+    }
+  }
+  hypothesis: {
+    id: 'demand-control' | 'supply-control' | 'balanced-range'
+    label: string
+    bias: 'bullish' | 'bearish' | 'neutral'
+    confidence: number
+    summary: string
+    confirm: string[]
+    invalidate: string[]
+    alternatives: string[]
+  }
+  evidence: EvidenceItem[]
+  context: Record<string, unknown> & { recentNews?: Array<{ title: string; time: string; source: string | null }> }
+  sourceHealth: SourceHealth[]
+  chart: { daily: HistoricalBar[]; intraday: HistoricalBar[]; dailyMeta: BarMeta; intradayMeta: BarMeta | null }
+}
+
+export interface MonitorAlert {
+  id: string
+  asset: MonitorAsset
+  createdAt: string
+  snapshotId: string
+  severity: 'info' | 'warning'
+  title: string
+  message: string
+  fingerprint: string
+}
+
+export interface MonitorReceipt {
+  id: string
+  asset: MonitorAsset
+  requestedAt: string
+  trigger: MonitorTrigger
+  outcome: 'stored' | 'duplicate' | 'failed'
+  snapshotId?: string
+  error?: string
+}
+
+export interface ScanResult {
+  snapshot: MonitorSnapshot
+  stored: boolean
+  alert: MonitorAlert | null
+  receipt: MonitorReceipt
+}
+
+export interface MonitorEvaluation {
+  asset: MonitorAsset
+  samples: number
+  resolved: number
+  directionalAccuracy: number | null
+  averageForwardChangePercent: number | null
+  rows: Array<{
+    capturedAt: string
+    hypothesis: 'bullish' | 'bearish' | 'neutral'
+    confidence: number
+    nextCapturedAt: string | null
+    forwardChangePercent: number | null
+    correct: boolean | null
+  }>
+}
+
+function query(asset?: MonitorAsset, limit = 100): string {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (asset) params.set('asset', asset)
+  return params.toString()
+}
+
+export const marketMonitorApi = {
+  settings: () => fetchJson<MonitorSettings>('/api/market-monitor/settings'),
+  saveSettings: (settings: MonitorSettings) => fetchJson<MonitorSettings>('/api/market-monitor/settings', { method: 'PUT', headers, body: JSON.stringify(settings) }),
+  scan: (asset: MonitorAsset, trigger: MonitorTrigger = 'manual') => fetchJson<ScanResult>('/api/market-monitor/scan', { method: 'POST', headers, body: JSON.stringify({ asset, trigger }) }),
+  snapshots: (asset?: MonitorAsset, limit = 100) => fetchJson<{ snapshots: MonitorSnapshot[]; count: number }>(`/api/market-monitor/snapshots?${query(asset, limit)}`),
+  alerts: (asset?: MonitorAsset, limit = 100) => fetchJson<{ alerts: MonitorAlert[]; count: number }>(`/api/market-monitor/alerts?${query(asset, limit)}`),
+  receipts: (asset?: MonitorAsset, limit = 100) => fetchJson<{ receipts: MonitorReceipt[]; count: number }>(`/api/market-monitor/receipts?${query(asset, limit)}`),
+  evaluation: (asset: MonitorAsset) => fetchJson<MonitorEvaluation>(`/api/market-monitor/evaluation?asset=${asset}`),
+}

--- a/ui/src/components/MarketSidebar.tsx
+++ b/ui/src/components/MarketSidebar.tsx
@@ -217,6 +217,11 @@ export function MarketSidebar({ onNavigate }: { onNavigate?: () => void }) {
         </MarketSection>
         <MarketSection label={t('market.analyticsSection')}>
           <SidebarRow
+            label="Evidence Monitor"
+            active={isFocused('market-monitor')}
+            onClick={() => openOrFocus({ kind: 'market-monitor', params: {} })}
+          />
+          <SidebarRow
             label={t('market.boardMovers')}
             active={focusedSpec?.kind === 'market-board' && focusedSpec.params.board === 'movers'}
             onClick={() => openOrFocus({ kind: 'market-board', params: { board: 'movers' } })}

--- a/ui/src/demo/fixtures/market-monitor.ts
+++ b/ui/src/demo/fixtures/market-monitor.ts
@@ -1,0 +1,80 @@
+import type { HistoricalBar } from '../../api/market'
+import type { MonitorAsset, MonitorSnapshot } from '../../api/market-monitor'
+
+function bars(asset: MonitorAsset, interval: '1D' | '1H'): HistoricalBar[] {
+  const count = interval === '1D' ? 150 : 96
+  const base = asset === 'BTC' ? 104_000 : 338
+  const step = interval === '1D' ? 86400000 : 3600000
+  const end = Date.parse(interval === '1D' ? '2026-09-11T00:00:00Z' : '2026-09-12T12:00:00Z')
+  return Array.from({ length: count }, (_, index) => {
+    const trend = asset === 'BTC' ? index * 95 : index * 0.18
+    const wave = Math.sin(index / (interval === '1D' ? 6 : 4)) * base * (interval === '1D' ? 0.018 : 0.004)
+    const close = base + trend + wave
+    const previous = index ? base + (index - 1) * (asset === 'BTC' ? 95 : 0.18) + Math.sin((index - 1) / (interval === '1D' ? 6 : 4)) * base * (interval === '1D' ? 0.018 : 0.004) : close * 0.998
+    const band = close * (interval === '1D' ? 0.009 : 0.002)
+    return {
+      date: new Date(end - (count - index - 1) * step).toISOString(),
+      open: previous,
+      high: Math.max(previous, close) + band,
+      low: Math.min(previous, close) - band,
+      close,
+      volume: (asset === 'BTC' ? 32_000 : 88_000_000) * (1 + Math.sin(index / 5) * 0.2),
+    }
+  })
+}
+
+export function demoMonitorSnapshot(asset: MonitorAsset, sequence = 0): MonitorSnapshot {
+  const daily = bars(asset, '1D')
+  const intraday = bars(asset, '1H')
+  const last = daily.at(-1)!
+  const bullish = asset === 'BTC'
+  return {
+    id: `demo-${asset.toLowerCase()}-${sequence}`,
+    asset,
+    capturedAt: new Date(Date.parse('2026-09-12T12:05:00Z') + sequence * 900000).toISOString(),
+    trigger: sequence ? 'scheduled' : 'manual',
+    strategyId: 'evidence-chain-v1',
+    fingerprint: `demo-${asset}-${sequence}`,
+    metrics: {
+      lastPrice: last.close,
+      lastBarAt: last.date,
+      change1dPercent: bullish ? 1.34 : -0.62,
+      change5dPercent: bullish ? 3.82 : 1.15,
+      rangePosition60d: bullish ? 0.82 : 0.56,
+      volumeRatio20d: bullish ? 1.42 : 0.94,
+      weeklyChangePercent: bullish ? 2.75 : -0.45,
+      intraday: { available: true, latestAt: intraday.at(-1)!.date, latestChangePercent: bullish ? 0.36 : -0.18, fourHourChangePercent: bullish ? 0.94 : -0.71, volumeRatio: bullish ? 1.31 : 1.08, abnormal: false, note: 'No abnormal hourly move or volume expansion detected.' },
+    },
+    hypothesis: bullish ? {
+      id: 'demand-control', label: 'Demand has provisional control', bias: 'bullish', confidence: 74,
+      summary: 'Price structure and follow-through lean constructive, but the interpretation remains conditional on the next test.',
+      confirm: ['Hold above the prior 20-day range.', 'Pullbacks contract in volume and preserve a higher low.', 'Hourly follow-through produces price progress.'],
+      invalidate: ['Return inside the range on expanding downside volume.', 'A lower high is followed by a decisive breakdown.'],
+      alternatives: ['A false breakout returning to balance.', 'Short covering without durable spot demand.'],
+    } : {
+      id: 'balanced-range', label: 'Evidence remains balanced', bias: 'neutral', confidence: 56,
+      summary: 'Neither side has produced enough structural progress. Directional stories remain provisional.',
+      confirm: ['Continue rotating inside the prior 20-day range.', 'Volume expansion produces limited displacement.'],
+      invalidate: ['Close outside the range and hold through a subsequent test.', 'Daily and weekly follow-through align.'],
+      alternatives: ['Re-accumulation before continuation.', 'Distribution before a downside move.'],
+    },
+    evidence: [
+      { id: 'location', label: 'Location in 60-day range', timeframe: '1D', tone: bullish ? 'positive' : 'neutral', observation: `Close is at ${bullish ? 82 : 56}% of the 60-day range.`, interpretation: 'Location changes how the same price/volume event should be interpreted.', weight: 2 },
+      { id: 'structure', label: 'Twenty-day structure', timeframe: '1D', tone: bullish ? 'positive' : 'neutral', observation: bullish ? 'Close is above the prior 20-day high.' : 'Close remains inside the prior 20-day range.', interpretation: bullish ? 'Demand produced structural progress.' : 'The market still needs a confirmed range exit.', weight: 3 },
+      { id: 'effort-result', label: 'Effort versus result', timeframe: '1D', tone: bullish ? 'positive' : 'neutral', observation: `${bullish ? 1.42 : 0.94}× volume with ${bullish ? 1.34 : -0.62}% price change.`, interpretation: 'Price displacement is compared with observed trading effort.', weight: 2 },
+      { id: 'weekly', label: 'Weekly follow-through', timeframe: '1W', tone: bullish ? 'positive' : 'neutral', observation: `Latest week is ${bullish ? 2.75 : -0.45}% from the previous week.`, interpretation: 'Weekly direction provides context rather than a standalone signal.', weight: 2 },
+      { id: 'intraday', label: 'Intraday pulse', timeframe: '1H', tone: bullish ? 'positive' : 'neutral', observation: `Latest hour ${bullish ? 0.36 : -0.18}%; rolling four hours ${bullish ? 0.94 : -0.71}%.`, interpretation: 'No abnormal hourly expansion detected.', weight: 1 },
+    ],
+    context: asset === 'BTC' ? { fundingRate: 0.00012, openInterest: 812_500_000, annualizedBasisPercent: 5.7, optionOpenInterest: 198_400, putCallOpenInterestRatio: 0.78 } : { marketCap: 1_087_000_000_000, trailingPe: 186.4, forwardPe: 98.6, analystTargetMean: 352.5, shortPercentFloat: 2.74, nextEarningsAt: '2026-10-21', recentNews: [{ title: 'Tesla delivery expectations remain in focus', time: '2026-09-12T09:00:00Z', source: 'Demo Wire' }] },
+    sourceHealth: [
+      { id: 'daily-bars', label: 'Daily OHLCV', status: 'ok', provider: 'demo/yfinance', asOf: last.date, detail: 'Deterministic attributed demo bars.' },
+      { id: 'intraday-bars', label: 'Hourly OHLCV', status: 'ok', provider: 'demo/yfinance', asOf: intraday.at(-1)!.date, detail: 'Deterministic attributed hourly demo bars.' },
+      { id: 'context', label: `${asset} context`, status: 'ok', provider: asset === 'BTC' ? 'demo/Deribit' : 'demo/OpenAlice reference', asOf: '2026-09-12T12:00:00Z', detail: 'Static context for UI acceptance; not live.' },
+    ],
+    chart: {
+      daily, intraday,
+      dailyMeta: { symbol: asset === 'BTC' ? 'BTC-USD' : 'TSLA', from: daily[0].date, to: last.date, bars: daily.length, source: 'vendor', sourceId: 'demo/yfinance', barId: `demo|${asset}`, provider: 'demo', barCapability: 'delayed' },
+      intradayMeta: { symbol: asset === 'BTC' ? 'BTC-USD' : 'TSLA', from: intraday[0].date, to: intraday.at(-1)!.date, bars: intraday.length, source: 'vendor', sourceId: 'demo/yfinance', barId: `demo|${asset}`, provider: 'demo', barCapability: 'delayed' },
+    },
+  }
+}

--- a/ui/src/demo/handlers/index.ts
+++ b/ui/src/demo/handlers/index.ts
@@ -8,6 +8,7 @@ import { issuesHandlers } from './issues'
 import { wikilinkHandlers } from './wikilink'
 import { toolsSimulatorHandlers } from './toolsSimulator'
 import { marketHandlers } from './market'
+import { marketMonitorHandlers } from './market-monitor'
 import { configKeysHandlers } from './configKeys'
 import { agentStatusHandlers } from './agentStatus'
 import { agentConversationHandlers } from './agentConversations'
@@ -37,6 +38,7 @@ export const handlers = [
   ...wikilinkHandlers,
   ...toolsSimulatorHandlers,
   ...marketHandlers,
+  ...marketMonitorHandlers,
   ...configKeysHandlers,
   ...agentStatusHandlers,
   ...agentConversationHandlers,

--- a/ui/src/demo/handlers/market-monitor.ts
+++ b/ui/src/demo/handlers/market-monitor.ts
@@ -1,0 +1,31 @@
+import { http, HttpResponse } from 'msw'
+import type { MonitorAlert, MonitorAsset, MonitorSettings } from '../../api/market-monitor'
+import { demoMonitorSnapshot } from '../fixtures/market-monitor'
+
+let settings: MonitorSettings = { enabledAssets: ['BTC', 'TSLA'], intervalMinutes: 15, notifications: false, alertConfidence: 68, abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 }
+const snapshots: Record<MonitorAsset, ReturnType<typeof demoMonitorSnapshot>[]> = { BTC: [demoMonitorSnapshot('BTC')], TSLA: [demoMonitorSnapshot('TSLA')] }
+const alerts: MonitorAlert[] = []
+
+export const marketMonitorHandlers = [
+  http.get('/api/market-monitor/settings', () => HttpResponse.json(settings)),
+  http.put('/api/market-monitor/settings', async ({ request }) => {
+    settings = await request.json() as MonitorSettings
+    return HttpResponse.json(settings)
+  }),
+  http.post('/api/market-monitor/scan', async ({ request }) => {
+    const body = await request.json() as { asset: MonitorAsset; trigger: 'manual' | 'scheduled' }
+    const previous = snapshots[body.asset].at(-1)!
+    return HttpResponse.json({ snapshot: previous, stored: false, alert: null, receipt: { id: `demo-receipt-${Date.now()}`, asset: body.asset, requestedAt: new Date().toISOString(), trigger: body.trigger, outcome: 'duplicate', snapshotId: previous.id } })
+  }),
+  http.get('/api/market-monitor/snapshots', ({ request }) => {
+    const asset = new URL(request.url).searchParams.get('asset') as MonitorAsset | null
+    const rows = asset ? snapshots[asset] : [...snapshots.BTC, ...snapshots.TSLA]
+    return HttpResponse.json({ snapshots: rows, count: rows.length })
+  }),
+  http.get('/api/market-monitor/alerts', () => HttpResponse.json({ alerts, count: alerts.length })),
+  http.get('/api/market-monitor/receipts', () => HttpResponse.json({ receipts: [], count: 0 })),
+  http.get('/api/market-monitor/evaluation', ({ request }) => {
+    const asset = (new URL(request.url).searchParams.get('asset') ?? 'BTC') as MonitorAsset
+    return HttpResponse.json({ asset, samples: 1, resolved: 0, directionalAccuracy: null, averageForwardChangePercent: null, rows: [{ capturedAt: snapshots[asset][0].capturedAt, hypothesis: snapshots[asset][0].hypothesis.bias, confidence: snapshots[asset][0].hypothesis.confidence, nextCapturedAt: null, forwardChangePercent: null, correct: null }] })
+  }),
+]

--- a/ui/src/demo/handlers/market-monitor.ts
+++ b/ui/src/demo/handlers/market-monitor.ts
@@ -2,12 +2,17 @@ import { http, HttpResponse } from 'msw'
 import type { MonitorAlert, MonitorAsset, MonitorSettings } from '../../api/market-monitor'
 import { demoMonitorSnapshot } from '../fixtures/market-monitor'
 
-let settings: MonitorSettings = { enabledAssets: ['BTC', 'TSLA'], intervalMinutes: 15, notifications: false, alertConfidence: 68, abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 }
+let settings: MonitorSettings = { enabledAssets: ['BTC', 'TSLA'], strategyId: 'evidence-chain-v1', intervalMinutes: 15, notifications: false, alertConfidence: 68, abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 }
 const snapshots: Record<MonitorAsset, ReturnType<typeof demoMonitorSnapshot>[]> = { BTC: [demoMonitorSnapshot('BTC')], TSLA: [demoMonitorSnapshot('TSLA')] }
 const alerts: MonitorAlert[] = []
 
 export const marketMonitorHandlers = [
   http.get('/api/market-monitor/settings', () => HttpResponse.json(settings)),
+  http.get('/api/market-monitor/strategies', () => HttpResponse.json({ strategies: [{ id: 'evidence-chain-v1', label: 'Evidence chain', version: 1, description: 'Location, structure, effort/result and confirmation.', requiredData: ['daily-bars', 'hourly-bars', 'asset-context'] }] })),
+  http.get('/api/market-monitor/context-providers', () => HttpResponse.json({ providers: [
+    { id: 'deribit-btc-v1', label: 'BTC derivatives', assets: ['BTC'], description: 'Deterministic Deribit context.' },
+    { id: 'openalice-tsla-v1', label: 'TSLA reference', assets: ['TSLA'], description: 'Deterministic OpenAlice reference context.' },
+  ] })),
   http.put('/api/market-monitor/settings', async ({ request }) => {
     settings = await request.json() as MonitorSettings
     return HttpResponse.json(settings)

--- a/ui/src/pages/MarketEvidenceMonitorPage.spec.tsx
+++ b/ui/src/pages/MarketEvidenceMonitorPage.spec.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { demoMonitorSnapshot } from '../demo/fixtures/market-monitor'
+import { MarketEvidenceMonitorPage } from './MarketEvidenceMonitorPage'
+
+const mocks = vi.hoisted(() => ({
+  settings: vi.fn(), snapshots: vi.fn(), alerts: vi.fn(), evaluation: vi.fn(), scan: vi.fn(), saveSettings: vi.fn(),
+}))
+vi.mock('../api', () => ({ api: { marketMonitor: mocks } }))
+
+beforeEach(() => {
+  window.localStorage.clear()
+  const settings = { enabledAssets: ['BTC', 'TSLA'], intervalMinutes: 15, notifications: false, alertConfidence: 68, abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 }
+  mocks.settings.mockResolvedValue(settings)
+  mocks.snapshots.mockImplementation(async (asset: 'BTC' | 'TSLA') => ({ snapshots: [demoMonitorSnapshot(asset)], count: 1 }))
+  mocks.alerts.mockResolvedValue({ alerts: [], count: 0 })
+  mocks.evaluation.mockImplementation(async (asset: 'BTC' | 'TSLA') => ({ asset, samples: 1, resolved: 0, directionalAccuracy: null, averageForwardChangePercent: null, rows: [] }))
+  mocks.scan.mockResolvedValue({ snapshot: demoMonitorSnapshot('BTC'), stored: false, alert: null, receipt: {} })
+  mocks.saveSettings.mockImplementation(async (value) => value)
+})
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+it('shows attributed BTC evidence and switches to the independent hourly series', async () => {
+  render(<MarketEvidenceMonitorPage />)
+  expect((await screen.findAllByText('Demand has provisional control')).length).toBeGreaterThan(0)
+  expect(screen.getAllByText('demo/yfinance').length).toBeGreaterThan(0)
+  fireEvent.click(screen.getByRole('button', { name: '1H' }))
+  expect(screen.getByRole('button', { name: '1H' }).getAttribute('aria-pressed')).toBe('true')
+  expect(screen.getByRole('img', { name: /Price path ending/ })).toBeTruthy()
+})
+
+it('switches from BTC to TSLA without losing the other asset history', async () => {
+  render(<MarketEvidenceMonitorPage />)
+  await screen.findAllByText('Demand has provisional control')
+  fireEvent.click(screen.getByRole('tab', { name: /TSLA/ }))
+  expect((await screen.findAllByText('Evidence remains balanced')).length).toBeGreaterThan(0)
+  expect(screen.getByText('Trailing P/E')).toBeTruthy()
+  expect(mocks.snapshots).toHaveBeenCalledWith('BTC', 120)
+  expect(mocks.snapshots).toHaveBeenCalledWith('TSLA', 120)
+})
+
+it('keeps the rendered snapshot when a background refresh fails', async () => {
+  render(<MarketEvidenceMonitorPage />)
+  await screen.findAllByText('Demand has provisional control')
+  mocks.scan.mockRejectedValueOnce(new Error('offline'))
+  fireEvent.click(screen.getByRole('button', { name: /Scan now/ }))
+  await waitFor(() => expect(screen.getByText(/last successful view is retained/i)).toBeTruthy())
+  expect(screen.getAllByText('Demand has provisional control').length).toBeGreaterThan(0)
+})

--- a/ui/src/pages/MarketEvidenceMonitorPage.spec.tsx
+++ b/ui/src/pages/MarketEvidenceMonitorPage.spec.tsx
@@ -6,14 +6,15 @@ import { demoMonitorSnapshot } from '../demo/fixtures/market-monitor'
 import { MarketEvidenceMonitorPage } from './MarketEvidenceMonitorPage'
 
 const mocks = vi.hoisted(() => ({
-  settings: vi.fn(), snapshots: vi.fn(), alerts: vi.fn(), evaluation: vi.fn(), scan: vi.fn(), saveSettings: vi.fn(),
+  settings: vi.fn(), strategies: vi.fn(), snapshots: vi.fn(), alerts: vi.fn(), evaluation: vi.fn(), scan: vi.fn(), saveSettings: vi.fn(),
 }))
 vi.mock('../api', () => ({ api: { marketMonitor: mocks } }))
 
 beforeEach(() => {
   window.localStorage.clear()
-  const settings = { enabledAssets: ['BTC', 'TSLA'], intervalMinutes: 15, notifications: false, alertConfidence: 68, abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 }
+  const settings = { enabledAssets: ['BTC', 'TSLA'], strategyId: 'evidence-chain-v1', intervalMinutes: 15, notifications: false, alertConfidence: 68, abnormalVolumeRatio: 1.8, abnormalMovePercent: 1.5 }
   mocks.settings.mockResolvedValue(settings)
+  mocks.strategies.mockResolvedValue({ strategies: [{ id: 'evidence-chain-v1', label: 'Evidence chain', version: 1, description: 'fixture', requiredData: ['daily-bars', 'hourly-bars', 'asset-context'] }] })
   mocks.snapshots.mockImplementation(async (asset: 'BTC' | 'TSLA') => ({ snapshots: [demoMonitorSnapshot(asset)], count: 1 }))
   mocks.alerts.mockResolvedValue({ alerts: [], count: 0 })
   mocks.evaluation.mockImplementation(async (asset: 'BTC' | 'TSLA') => ({ asset, samples: 1, resolved: 0, directionalAccuracy: null, averageForwardChangePercent: null, rows: [] }))
@@ -37,8 +38,8 @@ it('switches from BTC to TSLA without losing the other asset history', async () 
   fireEvent.click(screen.getByRole('tab', { name: /TSLA/ }))
   expect((await screen.findAllByText('Evidence remains balanced')).length).toBeGreaterThan(0)
   expect(screen.getByText('Trailing P/E')).toBeTruthy()
-  expect(mocks.snapshots).toHaveBeenCalledWith('BTC', 120)
-  expect(mocks.snapshots).toHaveBeenCalledWith('TSLA', 120)
+  expect(mocks.snapshots).toHaveBeenCalledWith('BTC', 120, 'evidence-chain-v1')
+  expect(mocks.snapshots).toHaveBeenCalledWith('TSLA', 120, 'evidence-chain-v1')
 })
 
 it('keeps the rendered snapshot when a background refresh fails', async () => {
@@ -48,4 +49,12 @@ it('keeps the rendered snapshot when a background refresh fails', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Scan now/ }))
   await waitFor(() => expect(screen.getByText(/last successful view is retained/i)).toBeTruthy())
   expect(screen.getAllByText('Demand has provisional control').length).toBeGreaterThan(0)
+})
+
+it('renders the registered strategy in monitor settings', async () => {
+  render(<MarketEvidenceMonitorPage />)
+  await screen.findAllByText('Demand has provisional control')
+  fireEvent.click(screen.getByRole('button', { name: 'Monitor settings' }))
+  expect((screen.getByRole('combobox', { name: 'Strategy' }) as HTMLSelectElement).value).toBe('evidence-chain-v1')
+  expect(screen.getByRole('option', { name: 'Evidence chain v1' })).toBeTruthy()
 })

--- a/ui/src/pages/MarketEvidenceMonitorPage.tsx
+++ b/ui/src/pages/MarketEvidenceMonitorPage.tsx
@@ -7,6 +7,7 @@ import type {
   MonitorEvaluation,
   MonitorSettings,
   MonitorSnapshot,
+  MonitorStrategy,
 } from '../api/market-monitor'
 import type { HistoricalBar } from '../api/market'
 import { PageHeader } from '../components/PageHeader'
@@ -17,6 +18,7 @@ import { cn } from '../lib/utils'
 const ASSETS: MonitorAsset[] = ['BTC', 'TSLA']
 const DEFAULT_SETTINGS: MonitorSettings = {
   enabledAssets: ASSETS,
+  strategyId: 'evidence-chain-v1',
   intervalMinutes: 15,
   notifications: false,
   alertConfidence: 68,
@@ -55,6 +57,7 @@ export function MarketEvidenceMonitorPage({ visible = true }: { visible?: boolea
   const [asset, setAsset] = usePersistedAsset()
   const [timeframe, setTimeframe] = useState<Timeframe>('1D')
   const [settings, setSettings] = useState<MonitorSettings>(DEFAULT_SETTINGS)
+  const [strategies, setStrategies] = useState<MonitorStrategy[]>([])
   const [history, setHistory] = useState<Record<MonitorAsset, MonitorSnapshot[]>>({ BTC: [], TSLA: [] })
   const [alerts, setAlerts] = useState<MonitorAlert[]>([])
   const [evaluation, setEvaluation] = useState<MonitorEvaluation | null>(null)
@@ -81,13 +84,17 @@ export function MarketEvidenceMonitorPage({ visible = true }: { visible?: boolea
 
   const loadState = useCallback(async (initial = false) => {
     try {
-      const [nextSettings, btc, tsla, nextAlerts] = await Promise.all([
+      const [nextSettings, nextStrategies] = await Promise.all([
         api.marketMonitor.settings(),
-        api.marketMonitor.snapshots('BTC', 120),
-        api.marketMonitor.snapshots('TSLA', 120),
+        api.marketMonitor.strategies(),
+      ])
+      const [btc, tsla, nextAlerts] = await Promise.all([
+        api.marketMonitor.snapshots('BTC', 120, nextSettings.strategyId),
+        api.marketMonitor.snapshots('TSLA', 120, nextSettings.strategyId),
         api.marketMonitor.alerts(undefined, 100),
       ])
       setSettings(nextSettings)
+      setStrategies(nextStrategies.strategies)
       setHistory({ BTC: btc.snapshots, TSLA: tsla.snapshots })
       setAlerts(nextAlerts.alerts)
       notifyNewAlerts(nextAlerts.alerts, nextSettings.notifications)
@@ -171,6 +178,10 @@ export function MarketEvidenceMonitorPage({ visible = true }: { visible?: boolea
     }
     const saved = await api.marketMonitor.saveSettings(next)
     setSettings(saved)
+    setHistory((current) => ({
+      BTC: current.BTC.filter((row) => row.strategyId === saved.strategyId),
+      TSLA: current.TSLA.filter((row) => row.strategyId === saved.strategyId),
+    }))
   }
 
   const exportData = (format: 'json' | 'csv') => {
@@ -190,7 +201,7 @@ export function MarketEvidenceMonitorPage({ visible = true }: { visible?: boolea
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <PageHeader
         title="Evidence Monitor"
-        description="BTC + TSLA · read-only evidence chain · facts, hypotheses, confirmation and invalidation"
+        description={`BTC + TSLA · ${strategies.find((strategy) => strategy.id === settings.strategyId)?.label ?? settings.strategyId} · facts, hypotheses, confirmation and invalidation`}
         live={{ lastUpdated: snapshot ? new Date(snapshot.capturedAt) : null, label: snapshot ? `scanned ${formatDate(snapshot.capturedAt)}` : 'waiting for first scan', hideDot: !snapshot }}
         right={<div className="flex items-center gap-1.5">
           {import.meta.env.VITE_DEMO_MODE && <span className="rounded-sm border border-warning/50 bg-warning/10 px-2 py-1 text-[10px] font-semibold tracking-wide text-warning">DEMO DATA · NOT LIVE</span>}
@@ -201,7 +212,7 @@ export function MarketEvidenceMonitorPage({ visible = true }: { visible?: boolea
 
       {refreshError && <div role="status" className="mx-4 mt-2 flex items-center justify-between border-l-2 border-warning bg-warning/5 px-3 py-2 text-xs text-muted-foreground md:mx-6"><span>Refresh failed; the last successful view is retained. {refreshError}</span><Button variant="ghost" size="sm" onClick={() => void loadState(false)}>Retry</Button></div>}
 
-      {settingsOpen && <SettingsPanel settings={settings} onSave={saveSettings} onClose={() => setSettingsOpen(false)} />}
+      {settingsOpen && <SettingsPanel settings={settings} strategies={strategies} onSave={saveSettings} onClose={() => setSettingsOpen(false)} />}
 
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border/60 px-4 py-3 md:px-6">
         <div role="tablist" aria-label="Monitored asset" className="inline-flex rounded-md border border-border bg-muted/35 p-0.5">
@@ -309,11 +320,11 @@ function HistoryPanel({ snapshots, evaluation, alerts }: { snapshots: MonitorSna
   return <Panel title="Observation history" trailing={evaluation ? <span className="text-[11px] text-muted-foreground">{evaluation.resolved} resolved · accuracy {evaluation.directionalAccuracy == null ? '—' : `${formatNumber(evaluation.directionalAccuracy)}%`}</span> : undefined}><div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(280px,0.6fr)]"><div className="overflow-x-auto"><table className="w-full min-w-[560px] text-xs"><thead className="border-b border-border text-left text-[11px] text-muted-foreground"><tr><th className="pb-2 font-medium">Captured</th><th className="pb-2 font-medium">Price</th><th className="pb-2 font-medium">Hypothesis</th><th className="pb-2 text-right font-medium">Confidence</th><th className="pb-2 text-right font-medium">Trigger</th></tr></thead><tbody>{snapshots.slice(-12).reverse().map((row) => <tr key={row.id} className="border-b border-border/50"><td className="py-2.5 text-muted-foreground">{formatDate(row.capturedAt)}</td><td className="py-2.5 tabular-nums">{formatNumber(row.metrics.lastPrice)}</td><td className="py-2.5">{row.hypothesis.label}</td><td className="py-2.5 text-right tabular-nums">{row.hypothesis.confidence}%</td><td className="py-2.5 text-right text-muted-foreground">{row.trigger}</td></tr>)}</tbody></table></div><div><div className="mb-2 flex items-center gap-2 text-[11px] font-semibold text-muted-foreground"><Bell className="size-3.5" />Recent alerts</div>{alerts.length ? <ul className="space-y-2">{alerts.slice(-6).reverse().map((alert) => <li key={alert.id} className="border-l-2 border-warning pl-2 text-xs"><div className="font-medium">{alert.title}</div><div className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{alert.message}</div></li>)}</ul> : <p className="text-xs text-muted-foreground">No alert conditions recorded.</p>}</div></div></Panel>
 }
 
-function SettingsPanel({ settings, onSave, onClose }: { settings: MonitorSettings; onSave: (settings: MonitorSettings) => Promise<void>; onClose: () => void }) {
+function SettingsPanel({ settings, strategies, onSave, onClose }: { settings: MonitorSettings; strategies: MonitorStrategy[]; onSave: (settings: MonitorSettings) => Promise<void>; onClose: () => void }) {
   const [draft, setDraft] = useState(settings)
   const [saving, setSaving] = useState(false)
   const commit = async () => { setSaving(true); try { await onSave(draft); onClose() } finally { setSaving(false) } }
-  return <div className="shrink-0 border-b border-border bg-muted/20 px-4 py-3 md:px-6"><div className="mx-auto grid max-w-[980px] gap-3 md:grid-cols-5"><label className="text-[11px] text-muted-foreground">Scan interval (min)<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={1} max={1440} value={draft.intervalMinutes} onChange={(event) => setDraft({ ...draft, intervalMinutes: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Alert confidence<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={50} max={95} value={draft.alertConfidence} onChange={(event) => setDraft({ ...draft, alertConfidence: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Volume ratio<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={1} max={10} step={0.1} value={draft.abnormalVolumeRatio} onChange={(event) => setDraft({ ...draft, abnormalVolumeRatio: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Hourly move %<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={0.1} max={25} step={0.1} value={draft.abnormalMovePercent} onChange={(event) => setDraft({ ...draft, abnormalMovePercent: Number(event.target.value) })} /></label><div className="flex items-end justify-between gap-2"><label className="flex items-center gap-2 pb-1.5 text-xs"><input type="checkbox" checked={draft.notifications} onChange={(event) => setDraft({ ...draft, notifications: event.target.checked })} />Browser alerts</label><div className="flex gap-1"><Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button><Button size="sm" onClick={() => void commit()} disabled={saving}>{saving ? 'Saving…' : 'Save'}</Button></div></div></div></div>
+  return <div className="shrink-0 border-b border-border bg-muted/20 px-4 py-3 md:px-6"><div className="mx-auto grid max-w-[1160px] gap-3 md:grid-cols-6"><label className="text-[11px] text-muted-foreground">Strategy<select className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" value={draft.strategyId} onChange={(event) => setDraft({ ...draft, strategyId: event.target.value })}>{strategies.map((strategy) => <option key={strategy.id} value={strategy.id}>{strategy.label} v{strategy.version}</option>)}</select></label><label className="text-[11px] text-muted-foreground">Scan interval (min)<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={1} max={1440} value={draft.intervalMinutes} onChange={(event) => setDraft({ ...draft, intervalMinutes: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Alert confidence<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={50} max={95} value={draft.alertConfidence} onChange={(event) => setDraft({ ...draft, alertConfidence: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Volume ratio<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={1} max={10} step={0.1} value={draft.abnormalVolumeRatio} onChange={(event) => setDraft({ ...draft, abnormalVolumeRatio: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Hourly move %<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={0.1} max={25} step={0.1} value={draft.abnormalMovePercent} onChange={(event) => setDraft({ ...draft, abnormalMovePercent: Number(event.target.value) })} /></label><div className="flex items-end justify-between gap-2"><label className="flex items-center gap-2 pb-1.5 text-xs"><input type="checkbox" checked={draft.notifications} onChange={(event) => setDraft({ ...draft, notifications: event.target.checked })} />Browser alerts</label><div className="flex gap-1"><Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button><Button size="sm" onClick={() => void commit()} disabled={saving}>{saving ? 'Saving…' : 'Save'}</Button></div></div></div></div>
 }
 
 function MonitorSkeleton() {

--- a/ui/src/pages/MarketEvidenceMonitorPage.tsx
+++ b/ui/src/pages/MarketEvidenceMonitorPage.tsx
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Bell, Download, RefreshCw, Settings2 } from 'lucide-react'
+import { api } from '../api'
+import type {
+  MonitorAlert,
+  MonitorAsset,
+  MonitorEvaluation,
+  MonitorSettings,
+  MonitorSnapshot,
+} from '../api/market-monitor'
+import type { HistoricalBar } from '../api/market'
+import { PageHeader } from '../components/PageHeader'
+import { Button } from '../components/ui/button'
+import { EmptyState, Skeleton } from '../components/StateViews'
+import { cn } from '../lib/utils'
+
+const ASSETS: MonitorAsset[] = ['BTC', 'TSLA']
+const DEFAULT_SETTINGS: MonitorSettings = {
+  enabledAssets: ASSETS,
+  intervalMinutes: 15,
+  notifications: false,
+  alertConfidence: 68,
+  abnormalVolumeRatio: 1.8,
+  abnormalMovePercent: 1.5,
+}
+
+type Timeframe = '1D' | '1H'
+
+function formatNumber(value: unknown, digits = 2): string {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? new Intl.NumberFormat(undefined, { maximumFractionDigits: digits }).format(value)
+    : '—'
+}
+
+function formatPercent(value: number | null | undefined): string {
+  return value == null ? '—' : `${value > 0 ? '+' : ''}${formatNumber(value)}%`
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+function usePersistedAsset(): [MonitorAsset, (asset: MonitorAsset) => void] {
+  const [asset, setAssetState] = useState<MonitorAsset>(() => window.localStorage.getItem('market-monitor.asset') === 'TSLA' ? 'TSLA' : 'BTC')
+  const setAsset = (next: MonitorAsset) => {
+    window.localStorage.setItem('market-monitor.asset', next)
+    setAssetState(next)
+  }
+  return [asset, setAsset]
+}
+
+export function MarketEvidenceMonitorPage({ visible = true }: { visible?: boolean }) {
+  const [asset, setAsset] = usePersistedAsset()
+  const [timeframe, setTimeframe] = useState<Timeframe>('1D')
+  const [settings, setSettings] = useState<MonitorSettings>(DEFAULT_SETTINGS)
+  const [history, setHistory] = useState<Record<MonitorAsset, MonitorSnapshot[]>>({ BTC: [], TSLA: [] })
+  const [alerts, setAlerts] = useState<MonitorAlert[]>([])
+  const [evaluation, setEvaluation] = useState<MonitorEvaluation | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [scanning, setScanning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshError, setRefreshError] = useState<string | null>(null)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const seenAlerts = useRef<Set<string> | null>(null)
+  const lastScheduledAt = useRef(Date.now())
+  const snapshots = history[asset]
+  const snapshot = snapshots.at(-1) ?? null
+
+  const notifyNewAlerts = useCallback((next: MonitorAlert[], allowNotifications: boolean) => {
+    if (!seenAlerts.current) {
+      seenAlerts.current = new Set(next.map((item) => item.id))
+      return
+    }
+    const fresh = next.filter((item) => !seenAlerts.current!.has(item.id))
+    next.forEach((item) => seenAlerts.current!.add(item.id))
+    if (!allowNotifications || typeof Notification === 'undefined' || Notification.permission !== 'granted') return
+    fresh.forEach((item) => new Notification(item.title, { body: item.message, tag: item.fingerprint }))
+  }, [])
+
+  const loadState = useCallback(async (initial = false) => {
+    try {
+      const [nextSettings, btc, tsla, nextAlerts] = await Promise.all([
+        api.marketMonitor.settings(),
+        api.marketMonitor.snapshots('BTC', 120),
+        api.marketMonitor.snapshots('TSLA', 120),
+        api.marketMonitor.alerts(undefined, 100),
+      ])
+      setSettings(nextSettings)
+      setHistory({ BTC: btc.snapshots, TSLA: tsla.snapshots })
+      setAlerts(nextAlerts.alerts)
+      notifyNewAlerts(nextAlerts.alerts, nextSettings.notifications)
+      setRefreshError(null)
+      if (initial) setError(null)
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause)
+      if (initial) setError(message)
+      else setRefreshError(message)
+    } finally {
+      if (initial) setLoading(false)
+    }
+  }, [notifyNewAlerts])
+
+  const scan = useCallback(async (target: MonitorAsset, trigger: 'manual' | 'scheduled') => {
+    setScanning(true)
+    try {
+      const result = await api.marketMonitor.scan(target, trigger)
+      setHistory((current) => {
+        const rows = current[target]
+        const next = result.stored ? [...rows.filter((row) => row.id !== result.snapshot.id), result.snapshot].slice(-120) : rows.length ? rows : [result.snapshot]
+        return { ...current, [target]: next }
+      })
+      if (result.alert) {
+        setAlerts((current) => [...current.filter((item) => item.id !== result.alert!.id), result.alert!].slice(-100))
+        notifyNewAlerts([result.alert], settings.notifications)
+      }
+      setError(null)
+      setRefreshError(null)
+      return result
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause)
+      if (!history[target].length) setError(message)
+      else setRefreshError(message)
+      return null
+    } finally {
+      setScanning(false)
+    }
+  }, [history, notifyNewAlerts, settings.notifications])
+
+  useEffect(() => { void loadState(true) }, [loadState])
+
+  useEffect(() => {
+    if (!loading && !snapshot && visible && !error) void scan(asset, 'manual')
+  }, [asset, error, loading, scan, snapshot, visible])
+
+  useEffect(() => {
+    if (!visible) return
+    void api.marketMonitor.evaluation(asset).then(setEvaluation).catch(() => setEvaluation(null))
+  }, [asset, snapshots.length, visible])
+
+  useEffect(() => {
+    if (!visible) return
+    const refresh = window.setInterval(() => { if (document.visibilityState === 'visible') void loadState(false) }, 30_000)
+    return () => window.clearInterval(refresh)
+  }, [loadState, visible])
+
+  useEffect(() => {
+    if (!visible) return
+    const cadence = Math.max(1, settings.intervalMinutes) * 60_000
+    const scheduled = window.setInterval(() => {
+      if (document.visibilityState !== 'visible') return
+      lastScheduledAt.current = Date.now()
+      settings.enabledAssets.forEach((target) => { void scan(target, 'scheduled') })
+    }, cadence)
+    const catchUp = () => {
+      if (document.visibilityState === 'visible' && Date.now() - lastScheduledAt.current >= cadence) {
+        lastScheduledAt.current = Date.now()
+        settings.enabledAssets.forEach((target) => { void scan(target, 'scheduled') })
+        void loadState(false)
+      }
+    }
+    document.addEventListener('visibilitychange', catchUp)
+    return () => { window.clearInterval(scheduled); document.removeEventListener('visibilitychange', catchUp) }
+  }, [loadState, scan, settings.enabledAssets, settings.intervalMinutes, visible])
+
+  const saveSettings = async (next: MonitorSettings) => {
+    if (next.notifications && typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      const permission = await Notification.requestPermission()
+      next = { ...next, notifications: permission === 'granted' }
+    }
+    const saved = await api.marketMonitor.saveSettings(next)
+    setSettings(saved)
+  }
+
+  const exportData = (format: 'json' | 'csv') => {
+    const rows = history[asset]
+    const content = format === 'json'
+      ? `${JSON.stringify(rows, null, 2)}\n`
+      : ['capturedAt,asset,price,bias,confidence,change1dPercent,change5dPercent,volumeRatio20d', ...rows.map((row) => [row.capturedAt, row.asset, row.metrics.lastPrice, row.hypothesis.bias, row.hypothesis.confidence, row.metrics.change1dPercent ?? '', row.metrics.change5dPercent ?? '', row.metrics.volumeRatio20d ?? ''].join(','))].join('\n')
+    const url = URL.createObjectURL(new Blob([content], { type: format === 'json' ? 'application/json' : 'text/csv' }))
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `market-evidence-${asset.toLowerCase()}.${format}`
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <PageHeader
+        title="Evidence Monitor"
+        description="BTC + TSLA · read-only evidence chain · facts, hypotheses, confirmation and invalidation"
+        live={{ lastUpdated: snapshot ? new Date(snapshot.capturedAt) : null, label: snapshot ? `scanned ${formatDate(snapshot.capturedAt)}` : 'waiting for first scan', hideDot: !snapshot }}
+        right={<div className="flex items-center gap-1.5">
+          {import.meta.env.VITE_DEMO_MODE && <span className="rounded-sm border border-warning/50 bg-warning/10 px-2 py-1 text-[10px] font-semibold tracking-wide text-warning">DEMO DATA · NOT LIVE</span>}
+          <Button variant="ghost" size="sm" onClick={() => setSettingsOpen((value) => !value)} aria-label="Monitor settings"><Settings2 className="size-4" /></Button>
+          <Button size="sm" onClick={() => void scan(asset, 'manual')} disabled={scanning}><RefreshCw className={cn('size-3.5', scanning && 'animate-spin')} />Scan now</Button>
+        </div>}
+      />
+
+      {refreshError && <div role="status" className="mx-4 mt-2 flex items-center justify-between border-l-2 border-warning bg-warning/5 px-3 py-2 text-xs text-muted-foreground md:mx-6"><span>Refresh failed; the last successful view is retained. {refreshError}</span><Button variant="ghost" size="sm" onClick={() => void loadState(false)}>Retry</Button></div>}
+
+      {settingsOpen && <SettingsPanel settings={settings} onSave={saveSettings} onClose={() => setSettingsOpen(false)} />}
+
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border/60 px-4 py-3 md:px-6">
+        <div role="tablist" aria-label="Monitored asset" className="inline-flex rounded-md border border-border bg-muted/35 p-0.5">
+          {ASSETS.map((item) => <button key={item} role="tab" aria-selected={asset === item} onClick={() => setAsset(item)} className={cn('rounded-[5px] px-4 py-1.5 text-xs font-semibold transition-colors', asset === item ? 'bg-background text-foreground shadow-xs' : 'text-muted-foreground hover:text-foreground')}>{item}<span className="ml-1.5 font-normal text-muted-foreground">{item === 'BTC' ? 'Bitcoin' : 'Tesla'}</span></button>)}
+        </div>
+        <div className="flex items-center gap-2">
+          <div role="group" aria-label="Chart timeframe" className="inline-flex rounded-md border border-border p-0.5">
+            {(['1D', '1H'] as const).map((item) => <button key={item} aria-pressed={timeframe === item} onClick={() => setTimeframe(item)} className={cn('rounded px-2.5 py-1 text-[11px]', timeframe === item ? 'bg-muted font-semibold text-foreground' : 'text-muted-foreground')}>{item}</button>)}
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => exportData('csv')} disabled={!snapshots.length}><Download className="size-3.5" />CSV</Button>
+          <Button variant="ghost" size="sm" onClick={() => exportData('json')} disabled={!snapshots.length}>JSON</Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 md:px-6">
+        {loading && !snapshot ? <MonitorSkeleton /> : error && !snapshot ? <div><EmptyState title="Evidence monitor unavailable" description={error} /><div className="-mt-9 flex justify-center pb-10"><Button onClick={() => void scan(asset, 'manual')}>Retry scan</Button></div></div> : snapshot ? (
+          <div className="mx-auto flex max-w-[1320px] flex-col gap-4 pb-8">
+            <Overview snapshot={snapshot} timeframe={timeframe} />
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(300px,0.7fr)]">
+              <EvidenceTable snapshot={snapshot} />
+              <HypothesisPanel snapshot={snapshot} />
+            </div>
+            <div className="grid gap-4 xl:grid-cols-2">
+              <ContextPanel snapshot={snapshot} />
+              <SourcePanel snapshot={snapshot} />
+            </div>
+            <HistoryPanel snapshots={snapshots} evaluation={evaluation} alerts={alerts.filter((item) => item.asset === asset)} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function Panel({ title, trailing, children }: { title: string; trailing?: React.ReactNode; children: React.ReactNode }) {
+  return <section className="min-w-0 border-t border-border pt-3"><div className="mb-3 flex items-center justify-between gap-3"><h3 className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">{title}</h3>{trailing}</div>{children}</section>
+}
+
+function Overview({ snapshot, timeframe }: { snapshot: MonitorSnapshot; timeframe: Timeframe }) {
+  const bars = timeframe === '1D' ? snapshot.chart.daily : snapshot.chart.intraday
+  return <Panel title={`${snapshot.asset} market state`} trailing={<span className="text-[11px] text-muted-foreground">{timeframe === '1D' ? snapshot.chart.dailyMeta.sourceId : snapshot.chart.intradayMeta?.sourceId ?? 'hourly unavailable'} · {formatDate(timeframe === '1D' ? snapshot.metrics.lastBarAt : snapshot.metrics.intraday.latestAt)}</span>}>
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1.65fr)_minmax(300px,0.85fr)]">
+      <div className="min-h-[260px] border-y border-border/60 py-3"><PriceChart bars={bars} unavailable={timeframe === '1H' && !snapshot.metrics.intraday.available} /></div>
+      <div className="grid grid-cols-2 gap-x-5 gap-y-4 content-start">
+        <Metric label="Last price" value={snapshot.asset === 'BTC' ? `$${formatNumber(snapshot.metrics.lastPrice, 0)}` : `$${formatNumber(snapshot.metrics.lastPrice)}`} />
+        <Metric label="1-day change" value={formatPercent(snapshot.metrics.change1dPercent)} tone={snapshot.metrics.change1dPercent} />
+        <Metric label="5-day change" value={formatPercent(snapshot.metrics.change5dPercent)} tone={snapshot.metrics.change5dPercent} />
+        <Metric label="Weekly follow-through" value={formatPercent(snapshot.metrics.weeklyChangePercent)} tone={snapshot.metrics.weeklyChangePercent} />
+        <Metric label="60-day range" value={snapshot.metrics.rangePosition60d == null ? '—' : `${Math.round(snapshot.metrics.rangePosition60d * 100)}%`} />
+        <Metric label="20-day volume" value={snapshot.metrics.volumeRatio20d == null ? '—' : `${formatNumber(snapshot.metrics.volumeRatio20d)}×`} />
+        <Metric label="Latest hour" value={formatPercent(snapshot.metrics.intraday.latestChangePercent)} tone={snapshot.metrics.intraday.latestChangePercent} />
+        <Metric label="Rolling 4 hours" value={formatPercent(snapshot.metrics.intraday.fourHourChangePercent)} tone={snapshot.metrics.intraday.fourHourChangePercent} />
+      </div>
+    </div>
+  </Panel>
+}
+
+function PriceChart({ bars, unavailable }: { bars: HistoricalBar[]; unavailable: boolean }) {
+  const points = useMemo(() => {
+    const rows = bars.slice(-120)
+    if (rows.length < 2) return ''
+    const min = Math.min(...rows.map((row) => row.close))
+    const max = Math.max(...rows.map((row) => row.close))
+    const spread = max - min || 1
+    return rows.map((row, index) => `${(index / (rows.length - 1)) * 100},${92 - ((row.close - min) / spread) * 80}`).join(' ')
+  }, [bars])
+  if (unavailable || !points) return <div className="flex h-[230px] items-center justify-center text-sm text-muted-foreground">No attributed hourly series. Daily bars are not substituted.</div>
+  const latest = bars.at(-1)!
+  const first = bars[Math.max(0, bars.length - 120)]
+  const up = latest.close >= first.close
+  return <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="h-[230px] w-full" role="img" aria-label={`Price path ending ${formatNumber(latest.close)}`}>
+    {[20, 40, 60, 80].map((y) => <line key={y} x1="0" x2="100" y1={y} y2={y} vectorEffect="non-scaling-stroke" className="stroke-border/60" />)}
+    <polyline points={points} fill="none" vectorEffect="non-scaling-stroke" strokeWidth="1.75" className={up ? 'stroke-success' : 'stroke-destructive'} />
+  </svg>
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone?: number | null }) {
+  return <div><div className="mb-1 text-[11px] text-muted-foreground">{label}</div><div className={cn('text-lg font-semibold tabular-nums', tone != null && tone > 0 && 'text-success', tone != null && tone < 0 && 'text-destructive')}>{value}</div></div>
+}
+
+function EvidenceTable({ snapshot }: { snapshot: MonitorSnapshot }) {
+  return <Panel title="Evidence chain"><div className="overflow-x-auto"><table className="w-full min-w-[660px] text-left text-xs"><thead className="border-b border-border text-[11px] text-muted-foreground"><tr><th className="pb-2 pr-3 font-medium">Signal</th><th className="pb-2 pr-3 font-medium">Frame</th><th className="pb-2 pr-3 font-medium">Observed fact</th><th className="pb-2 font-medium">Interpretation</th></tr></thead><tbody>{snapshot.evidence.map((item) => <tr key={item.id} className="border-b border-border/50 align-top"><td className="py-3 pr-3 font-medium"><span className={cn('mr-2 inline-block size-1.5 rounded-full', item.tone === 'positive' ? 'bg-success' : item.tone === 'negative' ? 'bg-destructive' : 'bg-muted-foreground')} />{item.label}</td><td className="py-3 pr-3 font-mono text-muted-foreground">{item.timeframe}</td><td className="py-3 pr-4 leading-5">{item.observation}</td><td className="py-3 leading-5 text-muted-foreground">{item.interpretation}</td></tr>)}</tbody></table></div></Panel>
+}
+
+function HypothesisPanel({ snapshot }: { snapshot: MonitorSnapshot }) {
+  const hypothesis = snapshot.hypothesis
+  return <Panel title="Current hypothesis" trailing={<span className={cn('text-xs font-semibold tabular-nums', hypothesis.bias === 'bullish' ? 'text-success' : hypothesis.bias === 'bearish' ? 'text-destructive' : 'text-muted-foreground')}>{hypothesis.confidence}%</span>}><h4 className="text-lg font-semibold">{hypothesis.label}</h4><p className="mt-2 text-xs leading-5 text-muted-foreground">{hypothesis.summary}</p><ConditionList title="Confirmation" rows={hypothesis.confirm} tone="positive" /><ConditionList title="Invalidation" rows={hypothesis.invalidate} tone="negative" /><ConditionList title="Competing explanations" rows={hypothesis.alternatives} tone="neutral" /></Panel>
+}
+
+function ConditionList({ title, rows, tone }: { title: string; rows: string[]; tone: 'positive' | 'negative' | 'neutral' }) {
+  return <div className="mt-4"><div className="mb-1.5 text-[11px] font-semibold text-muted-foreground">{title}</div><ul className="space-y-1.5 text-xs leading-5">{rows.map((row) => <li key={row} className="flex gap-2"><span className={cn('mt-2 size-1 shrink-0 rounded-full', tone === 'positive' ? 'bg-success' : tone === 'negative' ? 'bg-destructive' : 'bg-muted-foreground')} /><span>{row}</span></li>)}</ul></div>
+}
+
+function ContextPanel({ snapshot }: { snapshot: MonitorSnapshot }) {
+  const labels: Record<string, string> = { fundingRate: 'Funding rate', openInterest: 'Perpetual OI', annualizedBasisPercent: 'Annualized basis', optionOpenInterest: 'Options OI', putCallOpenInterestRatio: 'Put/call OI', marketCap: 'Market cap', trailingPe: 'Trailing P/E', forwardPe: 'Forward P/E', analystTargetMean: 'Analyst target', shortPercentFloat: 'Short % float', nextEarningsAt: 'Next earnings' }
+  const rows = Object.entries(labels).filter(([key]) => snapshot.context[key] != null)
+  return <Panel title={`${snapshot.asset} context`}><dl className="grid grid-cols-2 gap-x-5 gap-y-3">{rows.length ? rows.map(([key, label]) => <div key={key}><dt className="text-[11px] text-muted-foreground">{label}</dt><dd className="mt-1 text-sm font-medium tabular-nums">{key.toLowerCase().includes('percent') || key === 'annualizedBasisPercent' ? `${formatNumber(snapshot.context[key])}%` : key.endsWith('At') ? formatDate(String(snapshot.context[key])) : formatNumber(snapshot.context[key])}</dd></div>) : <p className="col-span-2 text-xs text-muted-foreground">Context source unavailable. Price/volume evidence remains usable and explicitly attributed.</p>}</dl>{snapshot.context.recentNews?.length ? <div className="mt-4 border-t border-border/60 pt-3"><div className="mb-2 text-[11px] font-semibold text-muted-foreground">Recent matching news</div><ul className="space-y-2">{snapshot.context.recentNews.map((item) => <li key={`${item.time}:${item.title}`} className="text-xs"><span className="text-muted-foreground">{formatDate(item.time)} · {item.source ?? 'unknown'}</span><div className="mt-0.5 line-clamp-2">{item.title}</div></li>)}</ul></div> : null}</Panel>
+}
+
+function SourcePanel({ snapshot }: { snapshot: MonitorSnapshot }) {
+  return <Panel title="Source health"><div className="space-y-3">{snapshot.sourceHealth.map((source) => <div key={source.id} className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2"><span className={cn('mt-1.5 size-2 rounded-full', source.status === 'ok' ? 'bg-success' : source.status === 'degraded' ? 'bg-warning' : 'bg-destructive')} /><div><div className="flex flex-wrap items-baseline justify-between gap-2"><span className="text-xs font-medium">{source.label}</span><span className="text-[10px] text-muted-foreground">{source.provider}</span></div><p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{source.detail}</p><div className="mt-0.5 text-[10px] text-muted-foreground/70">As of {formatDate(source.asOf)}</div></div></div>)}</div></Panel>
+}
+
+function HistoryPanel({ snapshots, evaluation, alerts }: { snapshots: MonitorSnapshot[]; evaluation: MonitorEvaluation | null; alerts: MonitorAlert[] }) {
+  return <Panel title="Observation history" trailing={evaluation ? <span className="text-[11px] text-muted-foreground">{evaluation.resolved} resolved · accuracy {evaluation.directionalAccuracy == null ? '—' : `${formatNumber(evaluation.directionalAccuracy)}%`}</span> : undefined}><div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(280px,0.6fr)]"><div className="overflow-x-auto"><table className="w-full min-w-[560px] text-xs"><thead className="border-b border-border text-left text-[11px] text-muted-foreground"><tr><th className="pb-2 font-medium">Captured</th><th className="pb-2 font-medium">Price</th><th className="pb-2 font-medium">Hypothesis</th><th className="pb-2 text-right font-medium">Confidence</th><th className="pb-2 text-right font-medium">Trigger</th></tr></thead><tbody>{snapshots.slice(-12).reverse().map((row) => <tr key={row.id} className="border-b border-border/50"><td className="py-2.5 text-muted-foreground">{formatDate(row.capturedAt)}</td><td className="py-2.5 tabular-nums">{formatNumber(row.metrics.lastPrice)}</td><td className="py-2.5">{row.hypothesis.label}</td><td className="py-2.5 text-right tabular-nums">{row.hypothesis.confidence}%</td><td className="py-2.5 text-right text-muted-foreground">{row.trigger}</td></tr>)}</tbody></table></div><div><div className="mb-2 flex items-center gap-2 text-[11px] font-semibold text-muted-foreground"><Bell className="size-3.5" />Recent alerts</div>{alerts.length ? <ul className="space-y-2">{alerts.slice(-6).reverse().map((alert) => <li key={alert.id} className="border-l-2 border-warning pl-2 text-xs"><div className="font-medium">{alert.title}</div><div className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{alert.message}</div></li>)}</ul> : <p className="text-xs text-muted-foreground">No alert conditions recorded.</p>}</div></div></Panel>
+}
+
+function SettingsPanel({ settings, onSave, onClose }: { settings: MonitorSettings; onSave: (settings: MonitorSettings) => Promise<void>; onClose: () => void }) {
+  const [draft, setDraft] = useState(settings)
+  const [saving, setSaving] = useState(false)
+  const commit = async () => { setSaving(true); try { await onSave(draft); onClose() } finally { setSaving(false) } }
+  return <div className="shrink-0 border-b border-border bg-muted/20 px-4 py-3 md:px-6"><div className="mx-auto grid max-w-[980px] gap-3 md:grid-cols-5"><label className="text-[11px] text-muted-foreground">Scan interval (min)<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={1} max={1440} value={draft.intervalMinutes} onChange={(event) => setDraft({ ...draft, intervalMinutes: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Alert confidence<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={50} max={95} value={draft.alertConfidence} onChange={(event) => setDraft({ ...draft, alertConfidence: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Volume ratio<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={1} max={10} step={0.1} value={draft.abnormalVolumeRatio} onChange={(event) => setDraft({ ...draft, abnormalVolumeRatio: Number(event.target.value) })} /></label><label className="text-[11px] text-muted-foreground">Hourly move %<input className="mt-1 w-full rounded border border-border bg-background px-2 py-1.5 text-xs text-foreground" type="number" min={0.1} max={25} step={0.1} value={draft.abnormalMovePercent} onChange={(event) => setDraft({ ...draft, abnormalMovePercent: Number(event.target.value) })} /></label><div className="flex items-end justify-between gap-2"><label className="flex items-center gap-2 pb-1.5 text-xs"><input type="checkbox" checked={draft.notifications} onChange={(event) => setDraft({ ...draft, notifications: event.target.checked })} />Browser alerts</label><div className="flex gap-1"><Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button><Button size="sm" onClick={() => void commit()} disabled={saving}>{saving ? 'Saving…' : 'Save'}</Button></div></div></div></div>
+}
+
+function MonitorSkeleton() {
+  return <div className="mx-auto w-full max-w-[1320px] space-y-4"><Skeleton className="h-72 w-full" /><div className="grid gap-4 xl:grid-cols-2"><Skeleton className="h-80" /><Skeleton className="h-80" /></div></div>
+}

--- a/ui/src/tabs/UrlAdopter.tsx
+++ b/ui/src/tabs/UrlAdopter.tsx
@@ -75,6 +75,7 @@ export function UrlAdopter() {
         />
         <Route path="/news" element={<Navigate to="/market/news" replace />} />
         <Route path="/market" element={<AdoptTraderStatic spec={{ kind: 'market-list', params: {} }} />} />
+        <Route path="/market/evidence" element={<AdoptTraderStatic spec={{ kind: 'market-monitor', params: {} }} />} />
         <Route path="/market/rotation" element={<AdoptTraderStatic spec={{ kind: 'market-rotation', params: {} }} />} />
         <Route path="/market/news" element={<AdoptNewsSelection />} />
         {/* Static `boards` segment outranks /market/:assetClass/:symbol in
@@ -513,6 +514,7 @@ function specToSection(spec: ViewSpec): ActivitySection {
     case 'office':             return 'office'
     case 'news':
     case 'market-list':
+    case 'market-monitor':
     case 'market-rotation':
     case 'market-board':
     case 'market-detail':      return 'market'

--- a/ui/src/tabs/registry.tsx
+++ b/ui/src/tabs/registry.tsx
@@ -14,6 +14,7 @@ import { TrackedIssueDetailPage } from '../pages/TrackedIssueDetailPage'
 import { OfficePage } from '../pages/OfficePage'
 import { NewsPage } from '../pages/NewsPage'
 import { MarketPage } from '../pages/MarketPage'
+import { MarketEvidenceMonitorPage } from '../pages/MarketEvidenceMonitorPage'
 import { MarketRotationPage } from '../pages/MarketRotationPage'
 import { MarketBoardPage } from '../pages/MarketBoardPage'
 import { MARKET_BOARD_TITLES } from '../pages/market-board-titles'
@@ -233,6 +234,15 @@ const marketListModule: ViewModule<'market-list'> = {
   toUrl: () => '/market',
   shell: 'market',
   Component: () => <MarketPage />,
+}
+
+const marketMonitorModule: ViewModule<'market-monitor'> = {
+  kind: 'market-monitor',
+  title: () => 'Evidence Monitor',
+  toUrl: () => '/market/evidence',
+  shell: 'market',
+  lifecycle: 'keep-mounted',
+  Component: ({ visible }) => <MarketEvidenceMonitorPage visible={visible} />,
 }
 
 const marketRotationModule: ViewModule<'market-rotation'> = {
@@ -602,6 +612,7 @@ const VIEWS = {
   office: officeModule,
   news: newsModule,
   'market-list': marketListModule,
+  'market-monitor': marketMonitorModule,
   'market-rotation': marketRotationModule,
   'market-board': marketBoardModule,
   'market-detail': marketDetailModule,

--- a/ui/src/tabs/types.ts
+++ b/ui/src/tabs/types.ts
@@ -41,6 +41,7 @@ export type ViewSpec =
   | { kind: 'office';         params: Record<string, never> }
   | { kind: 'news';           params: { category?: string; view?: string } }
   | { kind: 'market-list';    params: Record<string, never> }
+  | { kind: 'market-monitor'; params: Record<string, never> }
   | { kind: 'market-rotation'; params: Record<string, never> }
   | { kind: 'market-board';   params: { board: 'movers' | 'calendar' | 'macro' | 'term-structure' | 'global-macro' | 'shipping' | 'fed' } }
   | { kind: 'market-detail';  params: { assetClass: 'equity' | 'crypto' | 'currency' | 'commodity'; symbol: string; source?: string } }


### PR DESCRIPTION
## Summary

- add a read-only, modular Market Evidence Monitor for BTC and TSLA
- reuse OpenAlice BarService for separately attributed daily/hourly bars with explicit fallback health
- add evidence-chain analysis, competing hypotheses, confirmation/invalidation, semantic de-duplication, evaluation, alerts and scan receipts
- add a responsive `/market/evidence` dashboard with deterministic demo data, CSV/JSON export and opt-in browser notifications
- persist compact observations while storing only the latest chart series separately
- add a loopback-only live acceptance command with a read-only default and explicit `--scan` mode
- quantize continuously moving derivatives values at decision scale and retain last valid context through provider outages

## Product boundary

This increment never reads trading accounts and never submits, stages, approves or cancels orders. It organizes observable evidence; it does not claim to identify a market actor's intent.

## Verification

- `pnpm exec tsc --noEmit`
- `cd ui && pnpm exec tsc -b`
- monitor plus live-acceptance closure: 18/18 passed
- `pnpm market-monitor:preview -- --check`
- `pnpm market-monitor:acceptance -- --help`
- full production build completed successfully
- isolated Linux runtime passed read-only and live-scan acceptance for BTC and TSLA
- live BTC exercised healthy, timeout-with-retained-context and recovery transitions
- live TSLA exercised duplicate suppression and a meaningful new-news transition

The broader host-dependent suites reach PTY, Unix-socket, installer and temporary-Git tests that cannot run in the managed container. No Market Monitor test failed. Native desktop/narrow-window and long-window scheduling acceptance remain to be performed on macOS before this draft is marked ready.

## macOS acceptance

1. Run `pnpm dev`.
2. In a second terminal, run `pnpm market-monitor:acceptance` for read-only checks.
3. Run `pnpm market-monitor:acceptance -- --scan` to exercise BTC and TSLA evidence scans.
4. Inspect `dist/market-monitor-acceptance.json`, then observe scheduling and alert de-duplication for 24–72 hours.

## Review state

Draft only. Do not merge until macOS live-data acceptance and the planned 24–72 hour duplicate/alert observation pass are complete.